### PR TITLE
feat(consensus): wire the sliding-window leader schedule behind a protocol flag

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1310,6 +1310,7 @@
                 "consensus_block_restrictions": false,
                 "consensus_commit_transactions_only_for_traversed_headers": false,
                 "consensus_distributed_vote_scoring_strategy": false,
+                "consensus_enable_sliding_window_leader_schedule": false,
                 "consensus_fast_commit_sync": false,
                 "consensus_linearize_subdag_v2": false,
                 "consensus_median_timestamp_with_checkpoint_enforcement": false,
@@ -1477,7 +1478,9 @@
                 "consensus_bad_nodes_stake_threshold": {
                   "u64": "20"
                 },
+                "consensus_commits_per_schedule": null,
                 "consensus_gc_depth": null,
+                "consensus_leader_schedule_window_size": null,
                 "consensus_max_acknowledgments_per_block": null,
                 "consensus_max_num_transactions_in_block": {
                   "u64": "512"

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -528,6 +528,13 @@ struct FeatureFlags {
     // Conflicts are resolved deterministically post-consensus using persistent locks.
     #[serde(skip_serializing_if = "is_false")]
     enable_white_flag_flow: bool,
+
+    // If true, the Starfish leader schedule scores reputation over a sliding
+    // window and rebuilds the swap table every `consensus_commits_per_schedule`
+    // commits with a uniform base election; when false, V2 snapshot scoring +
+    // stake-weighted base election is used.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_enable_sliding_window_leader_schedule: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1395,6 +1402,16 @@ pub struct ProtocolConfig {
     // `fun native_sender_authenticator_function_info_v1<F>(): &Option<F>`
     // `fun native_sponsor_authenticator_function_info_v1<F>(): &Option<F>`
     auth_context_authenticator_function_info_v1_cost_base: Option<u64>,
+
+    /// Number of committed subdags between leader-schedule recomputations — the
+    /// rotation cadence (formerly the `CONSENSUS_COMMITS_PER_SCHEDULE` const).
+    /// When unset, defaults to 300.
+    consensus_commits_per_schedule: Option<u32>,
+
+    /// Number of committed subdags the sliding-window leader scorer aggregates
+    /// over (the scoring depth). When unset, defaults to 600. Consulted only
+    /// when `consensus_enable_sliding_window_leader_schedule` is set.
+    consensus_leader_schedule_window_size: Option<u32>,
 }
 
 // feature flags
@@ -1784,6 +1801,30 @@ impl ProtocolConfig {
 
     pub fn enable_white_flag_flow(&self) -> bool {
         self.feature_flags.enable_white_flag_flow
+    }
+
+    pub fn commits_per_schedule(&self) -> u64 {
+        if cfg!(msim) {
+            // Exercise faster leader-schedule rotation in simtests.
+            min(10, self.consensus_commits_per_schedule.unwrap_or(300)) as u64
+        } else {
+            self.consensus_commits_per_schedule.unwrap_or(300) as u64
+        }
+    }
+
+    pub fn leader_schedule_window_size(&self) -> u32 {
+        self.consensus_leader_schedule_window_size.unwrap_or(600)
+    }
+
+    pub fn consensus_enable_sliding_window_leader_schedule(&self) -> bool {
+        let res = self
+            .feature_flags
+            .consensus_enable_sliding_window_leader_schedule;
+        assert!(
+            !res || self.leader_schedule_window_size() as u64 >= self.commits_per_schedule(),
+            "consensus_enable_sliding_window_leader_schedule requires window_size >= commits_per_schedule"
+        );
+        res
     }
 }
 
@@ -2385,6 +2426,10 @@ impl ProtocolConfig {
             auth_context_replace_cost_base: None,
             auth_context_replace_cost_per_byte: None,
             auth_context_authenticator_function_info_v1_cost_base: None,
+
+            consensus_commits_per_schedule: None,
+
+            consensus_leader_schedule_window_size: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -3179,6 +3224,19 @@ impl ProtocolConfig {
 
     pub fn set_enable_white_flag_flow_for_testing(&mut self, val: bool) {
         self.feature_flags.enable_white_flag_flow = val;
+    }
+
+    pub fn set_commits_per_schedule_for_testing(&mut self, val: u32) {
+        self.consensus_commits_per_schedule = Some(val);
+    }
+
+    pub fn set_leader_schedule_window_size_for_testing(&mut self, val: u32) {
+        self.consensus_leader_schedule_window_size = Some(val);
+    }
+
+    pub fn set_consensus_enable_sliding_window_leader_schedule_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .consensus_enable_sliding_window_leader_schedule = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1403,9 +1403,8 @@ pub struct ProtocolConfig {
     // `fun native_sponsor_authenticator_function_info_v1<F>(): &Option<F>`
     auth_context_authenticator_function_info_v1_cost_base: Option<u64>,
 
-    /// Number of committed subdags between leader-schedule recomputations
-    /// (formerly the `CONSENSUS_COMMITS_PER_SCHEDULE` const). When unset,
-    /// defaults to 300.
+    /// Number of committed subdags between leader-schedule recomputations.
+    /// When unset, defaults to 300.
     consensus_commits_per_schedule: Option<u32>,
 
     /// Number of committed subdags the sliding-window leader scorer aggregates

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1803,12 +1803,17 @@ impl ProtocolConfig {
     }
 
     pub fn commits_per_schedule(&self) -> u64 {
-        if cfg!(msim) {
+        let commits_per_schedule = if cfg!(msim) {
             // Exercise faster leader-schedule rotation in simtests.
             min(10, self.consensus_commits_per_schedule.unwrap_or(300)) as u64
         } else {
             self.consensus_commits_per_schedule.unwrap_or(300) as u64
-        }
+        };
+        assert!(
+            commits_per_schedule > 0,
+            "consensus_commits_per_schedule must be greater than 0"
+        );
+        commits_per_schedule
     }
 
     pub fn leader_schedule_window_size(&self) -> u32 {

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1403,9 +1403,9 @@ pub struct ProtocolConfig {
     // `fun native_sponsor_authenticator_function_info_v1<F>(): &Option<F>`
     auth_context_authenticator_function_info_v1_cost_base: Option<u64>,
 
-    /// Number of committed subdags between leader-schedule recomputations — the
-    /// rotation cadence (formerly the `CONSENSUS_COMMITS_PER_SCHEDULE` const).
-    /// When unset, defaults to 300.
+    /// Number of committed subdags between leader-schedule recomputations
+    /// (formerly the `CONSENSUS_COMMITS_PER_SCHEDULE` const). When unset,
+    /// defaults to 300.
     consensus_commits_per_schedule: Option<u32>,
 
     /// Number of committed subdags the sliding-window leader scorer aggregates

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -929,6 +929,23 @@ pub(crate) enum Decision {
 
 /// The status of a leader slot from the direct and indirect commit rules.
 ///
+/// A leader slot advances through three nested levels — every finalized leader
+/// is resolved, and every resolved leader is decided:
+///
+/// - **Decided** — commit-vs-skip is answered: `Skip`, or `Commit` with any
+///   metastate (including `Pending`). Convertible to a `DecidedLeader`.
+/// - **Resolved** — the outcome is fully pinned: `Skip`, or `Commit` with a
+///   settled (non-`Pending`) metastate, so sequencing can proceed past it
+///   (`is_resolved`). `Commit(Pending)` is decided but not resolved — the
+///   indirect rule upgrades its metastate on a later commit pass.
+/// - **Finalized** — a resolved leader the committer has processed as part of a
+///   contiguous, rotation-boundary-respecting prefix (its `last_finalized`
+///   boundary has advanced past the leader). Permanent; Decided and Resolved
+///   are provisional and recomputed on every commit pass — before finalization
+///   a slot's outcome can still flip between `Commit` and `Skip`.
+///
+/// `Undecided` is none of these: the slot has no commit-vs-skip decision yet.
+///
 /// `Commit(_, Some(Optimistic), strong_voters)` carries the r+1 authorities
 /// whose strong votes attest data availability for the leader and its
 /// acknowledgments; the linearizer feeds them to the per-ref ack tracker.
@@ -961,9 +978,11 @@ impl LeaderStatus {
         }
     }
 
-    /// True when sequencing can proceed past this leader. `Commit(Pending)`
-    /// and `Undecided` are non-final.
-    pub(crate) fn is_final(&self) -> bool {
+    /// True when this leader is resolved: its outcome is fully pinned -- a
+    /// `Skip`, or a `Commit` with a settled (non-`Pending`) metastate -- so
+    /// sequencing can proceed past it. `Commit(Pending)` is decided but not
+    /// yet resolved; `Undecided` is neither.
+    pub(crate) fn is_resolved(&self) -> bool {
         match self {
             Self::Commit(_, Some(CommitMetastate::Pending), _) => false,
             Self::Commit(..) | Self::Skip(_) => true,

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -717,7 +717,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // Fetch the maximum to satisfy all requirements
         let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
         let gc_depth = inner.context.protocol_config.gc_depth();
-        let leader_schedule_window = crate::leader_schedule::CONSENSUS_COMMITS_PER_SCHEDULE as u32;
+        let leader_schedule_window = inner.context.protocol_config.commits_per_schedule() as u32;
         // Get block refs from recent commits stored during fast sync
         // TODO: The commits might not yet stored, but only fetched and pending
         // processing.

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -38,6 +38,7 @@ use crate::{
     header_synchronizer::HeaderSynchronizerHandle,
     misbehavior_store::MisbehaviorStore,
     network::{NetworkClient, SerializedTransactionsV2},
+    sliding_window_schedule::SlidingWindowSchedule,
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
 
@@ -731,6 +732,26 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 commits_since_schedule_update,
                 max(leader_schedule_window, max(cached_rounds, gc_depth * 2)),
             );
+            // When the sliding-window leader schedule is enabled, recovery replays
+            // the scorer over `replay_start..=last`; fetch enough commits to cover
+            // that range so the replayed window matches a fully-synced node
+            // (otherwise the recovered leader schedule could diverge).
+            let num_commits = if inner
+                .context
+                .protocol_config
+                .consensus_enable_sliding_window_leader_schedule()
+            {
+                let window = inner.context.protocol_config.leader_schedule_window_size();
+                let replay_start = SlidingWindowSchedule::replay_start(last_commit_index, window);
+                max(
+                    num_commits,
+                    last_commit_index
+                        .saturating_sub(replay_start)
+                        .saturating_add(1),
+                )
+            } else {
+                num_commits
+            };
             let block_refs = dag_state.get_block_refs_for_recent_commits(num_commits);
             (commits_since_schedule_update, block_refs)
         };

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -735,7 +735,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             // When the sliding-window leader schedule is enabled, recovery replays
             // the scorer over `replay_start..=last`; fetch enough commits to cover
             // that range so the replayed window matches a fully-synced node
-            // (otherwise the recovered leader schedule could diverge).
             let num_commits = if inner
                 .context
                 .protocol_config

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3049,6 +3049,21 @@ mod test {
                 .commits_until_leader_schedule_update(cores[0].core.dag_state.clone()),
             "commits_until_leader_schedule_update must be restart-invariant"
         );
+
+        // The recovered swap table must match the live one exactly, not just
+        // the rotation count. It is rebuilt with the rotation boundary as its
+        // seed, so equal-scoring authorities shuffle into the same good/bad
+        // split on both sides.
+        let restarted_table = restarted.core.leader_schedule.leader_swap_table.read();
+        let live_table = cores[0].core.leader_schedule.leader_swap_table.read();
+        assert_eq!(
+            restarted_table.good_nodes, live_table.good_nodes,
+            "recovered good_nodes must match the live node"
+        );
+        assert_eq!(
+            restarted_table.bad_nodes, live_table.bad_nodes,
+            "recovered bad_nodes must match the live node"
+        );
     }
 
     #[rstest]

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -85,9 +85,9 @@ pub(crate) struct Core {
     /// to note that this does not signify that the leader has been
     /// persisted yet as it still has to go through CommitObserver and
     /// persist the commit in store. On recovery/restart
-    /// the last_decided_leader will be set to the last_commit leader in dag
+    /// the last_finalized_leader will be set to the last_commit leader in dag
     /// state.
-    last_decided_leader: Slot,
+    last_finalized_leader: Slot,
     /// The consensus leader schedule to be used to resolve the leader for a
     /// given round.
     leader_schedule: Arc<LeaderSchedule>,
@@ -209,7 +209,7 @@ impl Core {
         sync_last_known_own_block: bool,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
     ) -> Self {
-        let last_decided_leader = dag_state.read().last_commit_leader();
+        let last_finalized_leader = dag_state.read().last_commit_leader();
         let committer = UniversalCommitterBuilder::new(
             context.clone(),
             leader_schedule.clone(),
@@ -251,7 +251,7 @@ impl Core {
             context,
             last_signaled_round,
             last_included_ancestors,
-            last_decided_leader,
+            last_finalized_leader,
             leader_schedule,
             transaction_consumer,
             block_manager,
@@ -713,8 +713,8 @@ impl Core {
         // 6. Reinitialize BlockManager
         self.block_manager.reinitialize();
 
-        // 7. Update last_decided_leader to match the new DAG state
-        self.last_decided_leader = last_commit_leader;
+        // 7. Update last_finalized_leader to match the new DAG state
+        self.last_finalized_leader = last_commit_leader;
 
         // 8. Reinitialize CommitObserver with recovery (uses recover_and_send_commits)
         self.commit_observer.reinitialize(last_commit_index);
@@ -1253,19 +1253,21 @@ impl Core {
             // Always try to process the synced commits first. If there are certified
             // commits to process then the decided leaders and the commits will be returned.
 
-            let mut decided_leaders = self.committer.try_decide(self.last_decided_leader);
+            let mut decided_leaders = self.committer.try_decide(self.last_finalized_leader);
 
-            // Truncate the decided leaders to fit the commit schedule limit.
+            // Drop leaders past the next rotation boundary; they are re-decided next
+            // pass under the new schedule. This pins each committed leader to the
+            // schedule at its position — the dropped tail stays provisional.
             if decided_leaders.len() >= commits_until_update {
                 let _ = decided_leaders.split_off(commits_until_update);
             }
 
             // If the decided leaders list is empty then just break the loop.
-            let Some(last_decided) = decided_leaders.last().cloned() else {
+            let Some(last_finalized) = decided_leaders.last().cloned() else {
                 break;
             };
 
-            self.last_decided_leader = last_decided.slot();
+            self.last_finalized_leader = last_finalized.slot();
 
             let sequenced_leaders = decided_leaders
                 .into_iter()
@@ -1281,7 +1283,7 @@ impl Core {
                 .metrics
                 .node_metrics
                 .last_decided_leader_round
-                .set(self.last_decided_leader.round as i64);
+                .set(self.last_finalized_leader.round as i64);
 
             // It's possible to reach this point as the decided leaders might all of them be
             // "Skip" decisions. In this case there is no leader to commit and

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2979,16 +2979,16 @@ mod test {
     /// mid-interval commit, flushes, then rebuilds authority 0 from the same
     /// store via the real recovery path (`DagState::new` +
     /// `LeaderSchedule::from_store`) and asserts the rotation count is
-    /// restart-invariant.
+    /// restart-invariant: a recovered node resumes with the same
+    /// commits-until-next-rotation as one that never restarted.
     ///
-    /// On the sliding-window path the scorer persists its last *scored* commit,
-    /// which lags the last *fed* commit by `MAX_PENDING_COMMITS = 3`; on
-    /// restart `DagState::new` rebuilds the rotation-counting scoring subdag
-    /// from `commit_range.end() + 1`, so a buggy node recovers 3 extra
-    /// scoring subdags and rotates 3 commits early. V2 persists the last
-    /// *fed* commit (no lag), so it stays restart-invariant. Both
-    /// assertions are live-vs-restarted equality (never a hard-coded
-    /// value), so the test is fix-agnostic.
+    /// On the sliding-window path the scorer's scored frontier lags the
+    /// rotation boundary by `MAX_PENDING_COMMITS = 3`, while recovery rebuilds
+    /// the rotation-counting scoring subdag from the persisted
+    /// `commit_range.end() + 1`. The count stays invariant because the
+    /// persisted end is the rotation boundary (the last committed index), not
+    /// the lagging frontier. The assertions compare live vs. restarted directly
+    /// (no hard-coded count) and run for both the sliding-window and V2 paths.
     #[rstest]
     #[case::sliding_window(true)]
     #[case::v2(false)]

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2978,12 +2978,12 @@ mod test {
     /// Drives a real 4-core network past one leader-schedule rotation to a
     /// mid-interval commit, flushes, then rebuilds authority 0 from the same
     /// store via the real recovery path (`DagState::new` +
-    /// `LeaderSchedule::from_store`) and asserts the rotation cadence is
+    /// `LeaderSchedule::from_store`) and asserts the rotation count is
     /// restart-invariant.
     ///
     /// On the sliding-window path the scorer persists its last *scored* commit,
     /// which lags the last *fed* commit by `MAX_PENDING_COMMITS = 3`; on
-    /// restart `DagState::new` rebuilds the cadence-counting scoring subdag
+    /// restart `DagState::new` rebuilds the rotation-counting scoring subdag
     /// from `commit_range.end() + 1`, so a buggy node recovers 3 extra
     /// scoring subdags and rotates 3 commits early. V2 persists the last
     /// *fed* commit (no lag), so it stays restart-invariant. Both
@@ -2993,7 +2993,7 @@ mod test {
     #[case::sliding_window(true)]
     #[case::v2(false)]
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_leader_schedule_restart_invariant_cadence(#[case] enable_sliding_window: bool) {
+    async fn test_leader_schedule_restart_invariant_rotation(#[case] enable_sliding_window: bool) {
         telemetry_subscribers::init_for_testing();
         let default_params = Parameters::default();
 
@@ -3002,8 +3002,9 @@ mod test {
             context
                 .protocol_config
                 .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
-            // Pin the cadence small and keep `window_size >= commits_per_schedule`
-            // (a protocol-config invariant the flag getter asserts).
+            // Pin the rotation interval small and keep `window_size >=
+            // commits_per_schedule` (a protocol-config invariant the flag
+            // getter asserts).
             context
                 .protocol_config
                 .set_commits_per_schedule_for_testing(10);
@@ -3029,7 +3030,7 @@ mod test {
             Some(cores[0].store.clone()),
         );
 
-        // Root cause: the cadence count is restart-invariant.
+        // Root cause: the rotation count is restart-invariant.
         assert_eq!(
             restarted.core.dag_state.read().scoring_subdags_count(),
             cores[0].core.dag_state.read().scoring_subdags_count(),

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1326,6 +1326,8 @@ impl Core {
                 );
                 dag_state.add_scoring_subdags(subdags.iter().map(|s| s.base.clone()).collect());
             }
+            self.leader_schedule
+                .feed_committed_subdags(subdags.iter().map(|s| s.base.clone()));
 
             committed_sub_dags.extend(subdags);
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1786,12 +1786,12 @@ impl CoreSignalsReceivers {
 /// corresponding stakes. The method returns the cores and their respective
 /// signal receivers are returned in `AuthorityIndex` order asc.
 #[cfg(test)]
-pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<CoreTextFixture> {
+pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<CoreTestFixture> {
     let mut cores = Vec::new();
 
     for index in 0..authorities.len() {
         let own_index = AuthorityIndex::new_for_test(index as u8);
-        let core = CoreTextFixture::new(
+        let core = CoreTestFixture::new(
             context.clone(),
             authorities.clone(),
             own_index,
@@ -1805,7 +1805,7 @@ pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<Cor
 }
 
 #[cfg(test)]
-pub(crate) struct CoreTextFixture {
+pub(crate) struct CoreTestFixture {
     pub core: Core,
     pub signal_receivers: CoreSignalsReceivers,
     pub block_receiver: broadcast::Receiver<VerifiedBlock>,
@@ -1814,7 +1814,7 @@ pub(crate) struct CoreTextFixture {
 }
 
 #[cfg(test)]
-impl CoreTextFixture {
+impl CoreTestFixture {
     fn new(
         context: Context,
         authorities: Vec<Stake>,
@@ -2461,7 +2461,7 @@ mod test {
             "test assumes consensus_fast_commit_sync is enabled at max version"
         );
 
-        let fixture = CoreTextFixture::new(
+        let fixture = CoreTestFixture::new(
             context.clone(),
             vec![1; 4],
             AuthorityIndex::new_for_test(0),
@@ -2496,7 +2496,7 @@ mod test {
         context_off
             .protocol_config
             .set_consensus_fast_commit_sync_for_testing(false);
-        let fixture_off = CoreTextFixture::new(
+        let fixture_off = CoreTestFixture::new(
             context_off,
             vec![1; 4],
             AuthorityIndex::new_for_test(0),
@@ -2881,7 +2881,7 @@ mod test {
     /// authorities, so the resulting leader schedule is independent of RNG
     /// seed and topology.
     async fn gossip_one_round(
-        cores: &mut [CoreTextFixture],
+        cores: &mut [CoreTestFixture],
         round: u32,
         last_round_block_headers: &[VerifiedBlockHeader],
         min_block_delay: Duration,
@@ -2933,11 +2933,11 @@ mod test {
     /// Drives the gossip network until `cores[0]` has performed at least one
     /// leader-schedule rotation and then sits mid-interval: its scoring-subdag
     /// count is strictly between 0 and `num_commits_per_schedule` (10 here,
-    /// matching `CoreTextFixture`'s `with_num_commits_per_schedule(10)`). It
+    /// matching `CoreTestFixture`'s `with_num_commits_per_schedule(10)`). It
     /// loops until that state holds rather than running a fixed number of
     /// gossip rounds, because the number of commits per round is not fixed.
     async fn drive_to_post_rotation_mid_interval(
-        cores: &mut [CoreTextFixture],
+        cores: &mut [CoreTestFixture],
         min_block_delay: Duration,
     ) {
         const NUM_COMMITS_PER_SCHEDULE: u64 = 10;
@@ -3022,7 +3022,7 @@ mod test {
         // Flush so the persisted `CommitInfo` reaches the store, then restart the
         // node by rebuilding it from the same store via the real recovery path.
         cores[0].core.dag_state.write().flush();
-        let restarted = CoreTextFixture::new(
+        let restarted = CoreTestFixture::new(
             context,
             vec![1, 1, 1, 1],
             AuthorityIndex::new_for_test(0),
@@ -3094,7 +3094,7 @@ mod test {
                 commit_only_for_traversed_headers,
             );
         let own_index = AuthorityIndex::new_for_test(0);
-        let core_fixture_own = CoreTextFixture::new(
+        let core_fixture_own = CoreTestFixture::new(
             context.clone(),
             vec![1; committee_size],
             own_index,
@@ -3112,7 +3112,7 @@ mod test {
             .dag_state_cached_rounds;
         // One authority will try to catch up, so it does not create any block
         let catch_up_index = AuthorityIndex::new_for_test((committee_size - 1) as u8);
-        let core_fixture_catch_up = CoreTextFixture::new(
+        let core_fixture_catch_up = CoreTestFixture::new(
             context.clone(),
             vec![1; committee_size],
             catch_up_index,
@@ -3317,7 +3317,7 @@ mod test {
         });
 
         let authority_index = AuthorityIndex::new_for_test(0);
-        let core = CoreTextFixture::new(
+        let core = CoreTestFixture::new(
             context,
             vec![1, 1, 1, 1],
             authority_index,
@@ -3956,7 +3956,7 @@ mod test {
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(true);
-        let fixture = CoreTextFixture::new(
+        let fixture = CoreTestFixture::new(
             context,
             vec![1; 4],
             AuthorityIndex::new_for_test(0),

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2931,10 +2931,11 @@ mod test {
     }
 
     /// Drives the gossip network until `cores[0]` has performed at least one
-    /// leader-schedule rotation and then sits mid-interval (its scoring-subdag
-    /// count is in `1..num_commits_per_schedule`). This avoids hard-coding a
-    /// round count, which would be brittle to the network's exact commit rate.
-    /// `num_commits_per_schedule` is 10 here (pinned by `CoreTextFixture`).
+    /// leader-schedule rotation and then sits mid-interval: its scoring-subdag
+    /// count is strictly between 0 and `num_commits_per_schedule` (10 here,
+    /// matching `CoreTextFixture`'s `with_num_commits_per_schedule(10)`). It
+    /// loops until that state holds rather than running a fixed number of
+    /// gossip rounds, because the number of commits per round is not fixed.
     async fn drive_to_post_rotation_mid_interval(
         cores: &mut [CoreTextFixture],
         min_block_delay: Duration,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2808,69 +2808,17 @@ mod test {
         // create the cores and their signals for all the authorities
         let mut cores = create_cores(context, vec![1, 1, 1, 1]);
 
-        // Now iterate over a few rounds and ensure the corresponding signals are
-        // created while network advances
+        // Advance the gossip network round by round; `gossip_one_round` asserts
+        // each round is healthy and fully connected.
         let mut last_round_block_headers = Vec::new();
         for round in 1..=30 {
-            let mut this_round_block_headers = Vec::new();
-
-            // Wait for min block delay to allow blocks to be proposed.
-            sleep(default_params.min_block_delay).await;
-
-            for core_fixture in &mut cores {
-                // add the blocks from last round
-                // this will trigger a block creation for the round and a signal should be
-                // emitted
-                core_fixture
-                    .core
-                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
-                    .unwrap();
-
-                // A "new round" signal should be received given that all the blocks of previous
-                // round have been processed
-                let new_round = receive(
-                    Duration::from_secs(1),
-                    core_fixture.signal_receivers.new_round_receiver(),
-                )
-                .await;
-                assert_eq!(new_round, round);
-
-                // Check that a new block has been proposed.
-                let verified_block = tokio::time::timeout(
-                    Duration::from_secs(1),
-                    core_fixture.block_receiver.recv(),
-                )
-                .await
-                .unwrap()
-                .unwrap();
-                assert_eq!(verified_block.round(), round);
-                assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
-
-                // append the new block to this round blocks
-                this_round_block_headers
-                    .push(core_fixture.core.last_proposed_block_header().clone());
-
-                let block_header = core_fixture.core.last_proposed_block_header();
-
-                // ensure that produced block is referring to the blocks of last_round
-                assert_eq!(
-                    block_header.ancestors().len(),
-                    core_fixture.core.context.committee.size()
-                );
-                for ancestor in block_header.ancestors() {
-                    if block_header.round() > 1 {
-                        // don't bother with round 1 block which just contains the genesis blocks.
-                        assert!(
-                            last_round_block_headers
-                                .iter()
-                                .any(|block_header| block_header.reference() == *ancestor),
-                            "Reference from previous round should be added"
-                        );
-                    }
-                }
-            }
-
-            last_round_block_headers = this_round_block_headers;
+            last_round_block_headers = gossip_one_round(
+                &mut cores,
+                round,
+                &last_round_block_headers,
+                default_params.min_block_delay,
+            )
+            .await;
         }
 
         for core_fixture in cores {

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1795,6 +1795,7 @@ pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<Cor
             own_index,
             false,
             false,
+            None,
         );
         cores.push(core);
     }
@@ -1818,6 +1819,7 @@ impl CoreTextFixture {
         own_index: AuthorityIndex,
         sync_last_known_own_block: bool,
         with_rocksdb: bool,
+        store: Option<Arc<dyn Store>>,
     ) -> Self {
         let (committee, mut signers) = local_committee_and_keys(0, authorities);
         let mut context = context;
@@ -1829,11 +1831,15 @@ impl CoreTextFixture {
             .set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
         let context = Arc::new(context);
-        let store: Arc<dyn Store> = if !with_rocksdb {
-            Arc::new(MemStore::new())
-        } else {
-            let store_path = context.parameters.db_path.as_path().to_str().unwrap();
-            Arc::new(RocksDBStore::new(store_path))
+        // Reuse an existing store to model a restart (recovery from persisted
+        // state); otherwise start from a fresh one.
+        let store: Arc<dyn Store> = match store {
+            Some(store) => store,
+            None if !with_rocksdb => Arc::new(MemStore::new()),
+            None => {
+                let store_path = context.parameters.db_path.as_path().to_str().unwrap();
+                Arc::new(RocksDBStore::new(store_path))
+            }
         };
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
@@ -2459,6 +2465,7 @@ mod test {
             AuthorityIndex::new_for_test(0),
             false,
             false,
+            None,
         );
         let core = &fixture.core;
 
@@ -2493,6 +2500,7 @@ mod test {
             AuthorityIndex::new_for_test(0),
             false,
             false,
+            None,
         );
         assert_eq!(
             fixture_off.core.min_ancestor_round(1000),
@@ -2915,6 +2923,180 @@ mod test {
         }
     }
 
+    /// Drives a fully-connected gossip network forward by one block-round:
+    /// feeds the previous round's proposed headers to every core (which
+    /// runs the real `try_commit`) and returns the headers proposed this
+    /// round, to be used as ancestors for the next round. A uniform,
+    /// fully-connected DAG keeps the reputation scores equal across all
+    /// authorities, so the resulting leader schedule is independent of RNG
+    /// seed and topology.
+    async fn gossip_one_round(
+        cores: &mut [CoreTextFixture],
+        round: u32,
+        last_round_block_headers: &[VerifiedBlockHeader],
+        min_block_delay: Duration,
+    ) -> Vec<VerifiedBlockHeader> {
+        let mut this_round_block_headers = Vec::new();
+        // Wait for min block delay to allow blocks to be proposed.
+        sleep(min_block_delay).await;
+        for core_fixture in cores.iter_mut() {
+            core_fixture
+                .core
+                .add_block_headers(last_round_block_headers.to_vec(), DataSource::Test)
+                .unwrap();
+            // Feeding the previous round's blocks advances this core a round and
+            // triggers a proposal; assert the round signal and a healthy,
+            // fully-connected proposed block.
+            let new_round = receive(
+                Duration::from_secs(1),
+                core_fixture.signal_receivers.new_round_receiver(),
+            )
+            .await;
+            assert_eq!(new_round, round);
+            let proposed_block =
+                tokio::time::timeout(Duration::from_secs(1), core_fixture.block_receiver.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(proposed_block.round(), round);
+            assert_eq!(proposed_block.author(), core_fixture.core.context.own_index);
+            let block_header = core_fixture.core.last_proposed_block_header().clone();
+            assert_eq!(
+                block_header.ancestors().len(),
+                core_fixture.core.context.committee.size()
+            );
+            if round > 1 {
+                for ancestor in block_header.ancestors() {
+                    assert!(
+                        last_round_block_headers
+                            .iter()
+                            .any(|bh| bh.reference() == *ancestor),
+                        "reference from previous round should be added"
+                    );
+                }
+            }
+            this_round_block_headers.push(block_header);
+        }
+        this_round_block_headers
+    }
+
+    /// Drives the gossip network until `cores[0]` has performed at least one
+    /// leader-schedule rotation and then sits mid-interval (its scoring-subdag
+    /// count is in `1..num_commits_per_schedule`). This avoids hard-coding a
+    /// round count, which would be brittle to the network's exact commit rate.
+    /// `num_commits_per_schedule` is 10 here (pinned by `CoreTextFixture`).
+    async fn drive_to_post_rotation_mid_interval(
+        cores: &mut [CoreTextFixture],
+        min_block_delay: Duration,
+    ) {
+        const NUM_COMMITS_PER_SCHEDULE: u64 = 10;
+        let mut round = 0u32;
+        let mut last_round_block_headers = Vec::new();
+        let mut rotated = false;
+        loop {
+            round += 1;
+            assert!(
+                round <= 60,
+                "network did not reach a post-rotation mid-interval state within 60 rounds"
+            );
+            last_round_block_headers =
+                gossip_one_round(cores, round, &last_round_block_headers, min_block_delay).await;
+
+            // A rotation has occurred once the in-effect swap table carries
+            // persisted reputation scores (a non-empty commit range).
+            if cores[0]
+                .core
+                .leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range
+                != crate::commit::CommitRange::default()
+            {
+                rotated = true;
+            }
+
+            let count = cores[0].core.dag_state.read().scoring_subdags_count() as u64;
+            if rotated && count > 0 && count < NUM_COMMITS_PER_SCHEDULE {
+                break;
+            }
+        }
+    }
+
+    /// Drives a real 4-core network past one leader-schedule rotation to a
+    /// mid-interval commit, flushes, then rebuilds authority 0 from the same
+    /// store via the real recovery path (`DagState::new` +
+    /// `LeaderSchedule::from_store`) and asserts the rotation cadence is
+    /// restart-invariant.
+    ///
+    /// On the sliding-window path the scorer persists its last *scored* commit,
+    /// which lags the last *fed* commit by `MAX_PENDING_COMMITS = 3`; on
+    /// restart `DagState::new` rebuilds the cadence-counting scoring subdag
+    /// from `commit_range.end() + 1`, so a buggy node recovers 3 extra
+    /// scoring subdags and rotates 3 commits early. V2 persists the last
+    /// *fed* commit (no lag), so it stays restart-invariant. Both
+    /// assertions are live-vs-restarted equality (never a hard-coded
+    /// value), so the test is fix-agnostic.
+    #[rstest]
+    #[case::sliding_window(true)]
+    #[case::v2(false)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_leader_schedule_restart_invariant_cadence(#[case] enable_sliding_window: bool) {
+        telemetry_subscribers::init_for_testing();
+        let default_params = Parameters::default();
+
+        let (mut context, _) = Context::new_for_test(4);
+        if enable_sliding_window {
+            context
+                .protocol_config
+                .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+            // Pin the cadence small and keep `window_size >= commits_per_schedule`
+            // (a protocol-config invariant the flag getter asserts).
+            context
+                .protocol_config
+                .set_commits_per_schedule_for_testing(10);
+            context
+                .protocol_config
+                .set_leader_schedule_window_size_for_testing(20);
+        }
+
+        // Drive a real 4-core network until it has done >= 1 rotation and sits
+        // mid-interval, persisting a real `CommitInfo`.
+        let mut cores = create_cores(context.clone(), vec![1, 1, 1, 1]);
+        drive_to_post_rotation_mid_interval(&mut cores, default_params.min_block_delay).await;
+
+        // Flush so the persisted `CommitInfo` reaches the store, then restart the
+        // node by rebuilding it from the same store via the real recovery path.
+        cores[0].core.dag_state.write().flush();
+        let restarted = CoreTextFixture::new(
+            context,
+            vec![1, 1, 1, 1],
+            AuthorityIndex::new_for_test(0),
+            false,
+            false,
+            Some(cores[0].store.clone()),
+        );
+
+        // Root cause: the cadence count is restart-invariant.
+        assert_eq!(
+            restarted.core.dag_state.read().scoring_subdags_count(),
+            cores[0].core.dag_state.read().scoring_subdags_count(),
+            "scoring_subdags_count must be restart-invariant"
+        );
+        // The same fact, as commits-until-next-rotation.
+        assert_eq!(
+            restarted
+                .core
+                .leader_schedule
+                .commits_until_leader_schedule_update(restarted.core.dag_state.clone()),
+            cores[0]
+                .core
+                .leader_schedule
+                .commits_until_leader_schedule_update(cores[0].core.dag_state.clone()),
+            "commits_until_leader_schedule_update must be restart-invariant"
+        );
+    }
+
     #[rstest]
     #[case(true, true)]
     #[case(true, false)]
@@ -2964,6 +3146,7 @@ mod test {
             own_index,
             true,
             false,
+            None,
         );
         // create a DAG of 2*gc_depth rounds
         let mut dag_builder = DagBuilder::new(Arc::new(context.clone()));
@@ -2981,6 +3164,7 @@ mod test {
             catch_up_index,
             true,
             true,
+            None,
         );
         let active_authorities = (0..(committee_size - 1) as u8)
             .map(AuthorityIndex::new_for_test)
@@ -3179,7 +3363,14 @@ mod test {
         });
 
         let authority_index = AuthorityIndex::new_for_test(0);
-        let core = CoreTextFixture::new(context, vec![1, 1, 1, 1], authority_index, true, false);
+        let core = CoreTextFixture::new(
+            context,
+            vec![1, 1, 1, 1],
+            authority_index,
+            true,
+            false,
+            None,
+        );
         let store = core.store.clone();
         let mut core = core.core;
 
@@ -3817,6 +4008,7 @@ mod test {
             AuthorityIndex::new_for_test(0),
             false,
             false,
+            None,
         );
 
         let leader = AuthorityIndex::new_for_test(1);

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1912,7 +1912,7 @@ mod test {
             BlockHeaderDigest, TestBlockHeader, TransactionsCommitment, genesis_block_headers,
             genesis_blocks,
         },
-        commit::CommitAPI,
+        commit::{CommitAPI, CommitRange},
         leader_scoring::ReputationScores,
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
@@ -2938,14 +2938,16 @@ mod test {
         min_block_delay: Duration,
     ) {
         const NUM_COMMITS_PER_SCHEDULE: u64 = 10;
+        // Generous safety ceiling; the loop actually breaks dynamically below.
+        const MAX_ROUNDS: u32 = 6 * NUM_COMMITS_PER_SCHEDULE as u32;
         let mut round = 0u32;
         let mut last_round_block_headers = Vec::new();
         let mut rotated = false;
         loop {
             round += 1;
             assert!(
-                round <= 60,
-                "network did not reach a post-rotation mid-interval state within 60 rounds"
+                round <= MAX_ROUNDS,
+                "network did not reach a post-rotation mid-interval state within {MAX_ROUNDS} rounds"
             );
             last_round_block_headers =
                 gossip_one_round(cores, round, &last_round_block_headers, min_block_delay).await;
@@ -2959,7 +2961,7 @@ mod test {
                 .read()
                 .reputation_scores
                 .commit_range
-                != crate::commit::CommitRange::default()
+                != CommitRange::default()
             {
                 rotated = true;
             }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -228,8 +228,14 @@ pub(crate) struct DagState {
     /// Rounds for latest blocks traversed by linearizer per authority.
     last_committed_rounds: Vec<Round>,
 
-    /// The committed subdags that have been scored but scores have not been
-    /// used for leader schedule yet.
+    /// Committed subdags scored since the last leader-schedule rotation, not
+    /// yet applied to the schedule. The V2 path computes its reputation
+    /// scores from these; the sliding-window path takes scores from the
+    /// window scorer instead, so there this serves only as the rotation
+    /// counter (`scoring_subdags_count`) and the just-rotated edge
+    /// (`is_scoring_subdag_empty`). Once V2 is removed it can be dropped
+    /// entirely, both roles replaced by a single recovered `u32` holding the
+    /// last rotation boundary index.
     scoring_subdag: ScoringSubdag,
 
     /// Commit votes pending to be included in new blocks. Ordered by

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -30,7 +30,7 @@ use crate::{
         VerifiedTransactions, genesis_blocks,
     },
     commit::{
-        CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRef, CommitVote,
+        CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRange, CommitRef, CommitVote,
         GENESIS_COMMIT_INDEX, SubDagBase, TrustedCommit, load_pending_subdag_from_store,
     },
     context::Context,
@@ -535,31 +535,36 @@ impl DagState {
     }
 
     fn rebuild_scoring_subdag_from_store(&mut self) {
-        let Some(last_commit) = self.last_commit.as_ref() else {
+        let Some(last_commit_index) = self.last_commit.as_ref().map(|c| c.index()) else {
             return;
         };
 
         let commit_recovery_start_index = self.last_commit_info_index().saturating_add(1);
 
-        if commit_recovery_start_index > last_commit.index() {
+        if commit_recovery_start_index > last_commit_index {
             return;
         }
 
-        let commits = self
-            .store
-            .scan_commits((commit_recovery_start_index..=last_commit.index()).into())
-            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
-
-        let mut unscored_subdags = Vec::with_capacity(commits.len());
-        for commit in commits {
-            let pending_subdag =
-                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]);
-            unscored_subdags.push(pending_subdag.base);
-        }
+        let unscored_subdags =
+            self.scan_subdag_bases((commit_recovery_start_index..=last_commit_index).into());
 
         if !unscored_subdags.is_empty() {
             self.scoring_subdag.add_subdags(unscored_subdags);
         }
+    }
+
+    /// Scans committed subdags in `range` from the store and returns their
+    /// `SubDagBase`s (leader + headers), used to replay scoring state on
+    /// restart.
+    pub(crate) fn scan_subdag_bases(&self, range: CommitRange) -> Vec<SubDagBase> {
+        let commits = self
+            .store
+            .scan_commits(range)
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
+        commits
+            .into_iter()
+            .map(|commit| load_pending_subdag_from_store(self.store.as_ref(), commit, vec![]).base)
+            .collect()
     }
 
     /// Accepts a block header into DagState and keeps it in memory.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -267,9 +267,8 @@ pub(crate) struct DagState {
     /// the next dag state flush. This is okay because we can recover
     /// reputation scores & last_committed_rounds from the commits as
     /// needed.
-    /// The index in CommitRef correspond to the first index of the next
-    /// scheduler window, while the reputation scores in CommitInfoare for
-    /// the previous window.
+    /// The `CommitRef` is the boundary commit — the last commit of the window
+    /// that just closed — so recovery resumes from its index + 1.
     commit_info_to_write: Vec<(CommitRef, CommitInfo)>,
 
     /// Misbehavior scoring metrics (in-memory + persisted buckets).

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -330,11 +330,9 @@ impl LeaderSchedule {
         commit_index: CommitIndex,
         reputation_scores_desc: &[(AuthorityIndex, u64)],
     ) {
-        // Determine the commit range for these scores. Reputation scores are
-        // attached to the *first* commit after a schedule update, so commit_index
-        // - 1 is the boundary of the window that just closed; the commit_range
-        // below is the committed interval ending there, though on the
-        // sliding-window path the scores summarize a deeper window.
+        // Reputation scores are attached to the *first* commit after a schedule
+        // update, so commit_index - 1 is the last commit of the window that just
+        // closed; the commit_range below is the committed interval ending there.
         let range_end = commit_index.saturating_sub(1);
         if range_end == GENESIS_COMMIT_INDEX {
             return;

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -285,9 +285,20 @@ impl LeaderSchedule {
             // spans many rotation intervals, so consecutive rebuilds have
             // overlapping commit ranges. Skip `range_validation` (it requires
             // contiguous, equal-length ranges), as the fast-sync path does.
-            let reputation_scores = sliding_window.lock().reputation_scores();
-            let seed = reputation_scores.commit_range.end();
-            let table = LeaderSwapTable::new(self.context.clone(), seed, reputation_scores.clone());
+            //
+            // The scorer's range ends at its last *scored* commit, which lags this
+            // rotation boundary by `MAX_PENDING_COMMITS`. Persist the boundary as
+            // the range end so recovery resumes the scoring subdag from the same
+            // commit a never-restarted node would, keeping the rotation cadence
+            // restart-invariant (as the V2 path already does).
+            let window_scores = sliding_window.lock().reputation_scores();
+            let boundary = dag_state_write_lock.last_commit_index();
+            let reputation_scores = ReputationScores::new(
+                CommitRange::new(window_scores.commit_range.start()..=boundary),
+                window_scores.scores_per_authority,
+            );
+            let table =
+                LeaderSwapTable::new(self.context.clone(), boundary, reputation_scores.clone());
             self.persist_scores(dag_state_write_lock, reputation_scores);
             self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
             return;
@@ -1110,8 +1121,9 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Feed the first 6 commits, then rebuild: scores come from the sliding
-        // window (commits 1..=3 are scored, given the 3-commit lookback), not from
-        // a ScoringSubdag snapshot.
+        // window (commits 1..=3 are scored, given the 3-commit lookback), not a
+        // ScoringSubdag snapshot. The range is tagged to the rotation boundary
+        // (last committed index = 6), not the last scored commit.
         leader_schedule.feed_committed_subdags(commits[..6].iter().map(|(s, _)| s.base.clone()));
         {
             let mut ds = dag_state.write();
@@ -1124,10 +1136,10 @@ mod tests {
             .reputation_scores
             .commit_range
             .clone();
-        assert_eq!(range, (1..=3).into());
+        assert_eq!(range, (1..=6).into());
 
-        // Feed 3 more and rebuild again. The new window range (1..=6) overlaps the
-        // previous one (1..=3) — V2's range_validation would reject that, so this
+        // Feed 3 more and rebuild again. The new range (1..=9) overlaps the
+        // previous one (1..=6) — V2's range_validation would reject that, so this
         // not panicking confirms the sliding-window path skips it.
         leader_schedule.feed_committed_subdags(commits[6..].iter().map(|(s, _)| s.base.clone()));
         {
@@ -1141,7 +1153,7 @@ mod tests {
             .reputation_scores
             .commit_range
             .clone();
-        assert_eq!(range, (1..=6).into());
+        assert_eq!(range, (1..=9).into());
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -424,9 +424,8 @@ impl LeaderSchedule {
 
     /// Rebuilds the sliding-window scorer (when enabled) by replaying the last
     /// `window_size` committed subdags from storage, so the running aggregate
-    /// is current after a restart or fast-sync. The in-effect swap table is
-    /// recovered separately from `CommitInfo`. Returns without effect on the V2
-    /// path (no scorer).
+    /// is current after a restart or fast-sync. Does not recover the in-effect
+    /// swap table. Returns without effect on the V2 path (no scorer).
     fn recover_sliding_window(&self, dag_state: &RwLock<DagState>) {
         let Some(sliding_window) = &self.sliding_window else {
             return;

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -419,8 +419,9 @@ impl LeaderSchedule {
             .unwrap()
     }
 
-    /// Feeds newly committed subdags to the sliding-window scorer when enabled;
-    /// a no-op on the V2 path.
+    /// Feeds newly committed subdags to the sliding-window scorer when enabled.
+    /// Called on every commit; returns without effect on the V2 path (no
+    /// scorer).
     pub(crate) fn feed_committed_subdags(&self, subdags: impl IntoIterator<Item = SubDagBase>) {
         if let Some(sliding_window) = &self.sliding_window {
             let mut scorer = sliding_window.lock();
@@ -433,7 +434,8 @@ impl LeaderSchedule {
     /// Rebuilds the sliding-window scorer (when enabled) by replaying the last
     /// `window_size` committed subdags from storage, so the running aggregate
     /// is current after a restart or fast-sync. The in-effect swap table is
-    /// recovered separately from `CommitInfo`. A no-op on the V2 path.
+    /// recovered separately from `CommitInfo`. Returns without effect on the V2
+    /// path (no scorer).
     fn recover_sliding_window(&self, dag_state: &RwLock<DagState>) {
         let Some(sliding_window) = &self.sliding_window else {
             return;

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -51,14 +51,6 @@ fn recover_leader_swap_table(
     )
 }
 
-/// The window where the schedule change takes place in consensus. It
-/// represents number of committed sub dags.
-/// TODO: move this to protocol config
-#[cfg(not(msim))]
-pub(crate) const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 300;
-#[cfg(msim)]
-pub(crate) const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 10;
-
 /// The `LeaderSchedule` is responsible for producing the leader schedule across
 /// an epoch. The leader schedule is subject to change periodically based on
 /// calculated `ReputationScores` of the authorities.
@@ -71,9 +63,10 @@ pub(crate) struct LeaderSchedule {
 
 impl LeaderSchedule {
     pub(crate) fn new(context: Arc<Context>, leader_swap_table: LeaderSwapTable) -> Self {
+        let num_commits_per_schedule = context.protocol_config.commits_per_schedule();
         Self {
             context,
-            num_commits_per_schedule: CONSENSUS_COMMITS_PER_SCHEDULE,
+            num_commits_per_schedule,
             leader_swap_table: Arc::new(RwLock::new(leader_swap_table)),
         }
     }

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -188,6 +188,8 @@ impl LeaderSchedule {
         }
     }
 
+    /// Stake-weighted base election. `offset` selects among multiple leaders in
+    /// a round; with one leader per round today it is always 0.
     pub(crate) fn elect_leader_stake_based(&self, round: u32, offset: u32) -> AuthorityIndex {
         assert!((offset as usize) < self.context.committee.size());
 
@@ -391,8 +393,8 @@ impl LeaderSchedule {
 
     /// Uniform (non-stake-weighted) base election, used when the sliding-window
     /// leader schedule is enabled. Round-seeded so all authorities draw the
-    /// same candidate for a given round; `offset` selects within the
-    /// shuffle.
+    /// same candidate for a given round. `offset` selects among multiple
+    /// leaders in a round; with one leader per round today it is always 0.
     pub(crate) fn elect_leader_uniform(&self, round: u32, offset: u32) -> AuthorityIndex {
         assert!((offset as usize) < self.context.committee.size());
         let mut seed_bytes = [0u8; 32];

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -281,22 +281,29 @@ impl LeaderSchedule {
             .start_timer();
 
         if let Some(sliding_window) = &self.sliding_window {
-            // Sliding-window path: scores come from the running window, which
-            // spans many rotation intervals, so consecutive rebuilds have
-            // overlapping commit ranges. Skip `range_validation` (it requires
-            // contiguous, equal-length ranges), as the fast-sync path does.
+            // commit_range is the committed interval this update closes: the last
+            // `num_commits_per_schedule` commits, ending at the boundary L — the
+            // same shape the V2 path tags. Its end (L) is the recovery anchor; a
+            // restarted node resumes the scoring subdag from L+1, the commit a
+            // never-restarted node would. The scores are aggregated over a deeper
+            // window (window_size) whose scored frontier lags L by
+            // MAX_PENDING_COMMITS; that depth and lag are the scorer's concern,
+            // rebuilt on restart by replaying window_size + MAX_PENDING_COMMITS
+            // commits (see recover_sliding_window / replay_start), not encoded in
+            // this range.
             //
-            // The scorer's range ends at its last *scored* commit, which lags this
-            // rotation boundary by `MAX_PENDING_COMMITS`. Persist the boundary as
-            // the range end so recovery resumes the scoring subdag from the same
-            // commit a never-restarted node would, keeping the rotation cadence
-            // restart-invariant (as the V2 path already does).
-            let window_scores = sliding_window.lock().reputation_scores();
+            // Skip `range_validation` (it requires contiguous, equal-length
+            // ranges): after fast-sync the committed range can jump, so the strict
+            // check would panic — as the fast-sync path also skips it.
+            let scores = sliding_window
+                .lock()
+                .reputation_scores()
+                .scores_per_authority;
             let boundary = dag_state_write_lock.last_commit_index();
-            let reputation_scores = ReputationScores::new(
-                CommitRange::new(window_scores.commit_range.start()..=boundary),
-                window_scores.scores_per_authority,
-            );
+            let interval = self.num_commits_per_schedule as u32;
+            let start = boundary.saturating_sub(interval).saturating_add(1);
+            let reputation_scores =
+                ReputationScores::new(CommitRange::new(start..=boundary), scores);
             let table =
                 LeaderSwapTable::new(self.context.clone(), boundary, reputation_scores.clone());
             self.persist_scores(dag_state_write_lock, reputation_scores);

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -8,16 +8,17 @@ use std::{
     sync::Arc,
 };
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 use starfish_config::{AuthorityIndex, Stake};
 
 use crate::{
     CommitIndex, Round,
-    commit::{CommitInfo, CommitRange, CommitRef, GENESIS_COMMIT_INDEX},
+    commit::{CommitInfo, CommitRange, CommitRef, GENESIS_COMMIT_INDEX, SubDagBase},
     context::Context,
     dag_state::DagState,
     leader_scoring::ReputationScores,
+    sliding_window_schedule::SlidingWindowSchedule,
 };
 
 /// Calculates the seed index for leader swap table initialization.
@@ -59,15 +60,30 @@ pub(crate) struct LeaderSchedule {
     pub leader_swap_table: Arc<RwLock<LeaderSwapTable>>,
     context: Arc<Context>,
     num_commits_per_schedule: u64,
+    /// When set (the `consensus_enable_sliding_window_leader_schedule` flag is
+    /// on), reputation scores are sourced from this sliding-window scorer
+    /// instead of the `ScoringSubdag` snapshot, and the base election is
+    /// uniform. `None` runs the V2 path.
+    sliding_window: Option<Arc<Mutex<SlidingWindowSchedule>>>,
 }
 
 impl LeaderSchedule {
     pub(crate) fn new(context: Arc<Context>, leader_swap_table: LeaderSwapTable) -> Self {
         let num_commits_per_schedule = context.protocol_config.commits_per_schedule();
+        let sliding_window = context
+            .protocol_config
+            .consensus_enable_sliding_window_leader_schedule()
+            .then(|| {
+                Arc::new(Mutex::new(SlidingWindowSchedule::new(
+                    context.clone(),
+                    context.protocol_config.leader_schedule_window_size(),
+                )))
+            });
         Self {
             context,
             num_commits_per_schedule,
             leader_swap_table: Arc::new(RwLock::new(leader_swap_table)),
+            sliding_window,
         }
     }
 
@@ -89,7 +105,9 @@ impl LeaderSchedule {
         );
 
         // create the schedule
-        Self::new(context, leader_swap_table)
+        let schedule = Self::new(context, leader_swap_table);
+        schedule.recover_sliding_window(&dag_state);
+        schedule
     }
 
     /// Reinitializes the leader schedule from stored commit info.
@@ -103,8 +121,11 @@ impl LeaderSchedule {
             dag_state.read().scoring_subdags_count(),
         );
 
-        let mut write = self.leader_swap_table.write();
-        *write = leader_swap_table;
+        {
+            let mut write = self.leader_swap_table.write();
+            *write = leader_swap_table;
+        }
+        self.recover_sliding_window(dag_state);
     }
 
     pub(crate) fn commits_until_leader_schedule_update(
@@ -156,7 +177,11 @@ impl LeaderSchedule {
                 let table = self.leader_swap_table.read();
                 table.swap(leader, round, leader_offset).unwrap_or(leader)
             } else {
-                let leader = self.elect_leader_stake_based(round, leader_offset);
+                let leader = if self.sliding_window.is_some() {
+                    self.elect_leader_uniform(round, leader_offset)
+                } else {
+                    self.elect_leader_stake_based(round, leader_offset)
+                };
                 let table = self.leader_swap_table.read();
                 table.swap(leader, round, leader_offset).unwrap_or(leader)
             }
@@ -254,6 +279,20 @@ impl LeaderSchedule {
             .scope_processing_time
             .with_label_values(&["LeaderSchedule::update_leader_schedule"])
             .start_timer();
+
+        if let Some(sliding_window) = &self.sliding_window {
+            // Sliding-window path: scores come from the running window, which
+            // spans many rotation intervals, so consecutive rebuilds have
+            // overlapping commit ranges. Skip `range_validation` (it requires
+            // contiguous, equal-length ranges), as the fast-sync path does.
+            let reputation_scores = sliding_window.lock().reputation_scores();
+            let seed = reputation_scores.commit_range.end();
+            let table = LeaderSwapTable::new(self.context.clone(), seed, reputation_scores.clone());
+            self.persist_scores(dag_state_write_lock, reputation_scores);
+            self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
+            return;
+        }
+
         let (reputation_scores, last_commit_index) = {
             let reputation_scores = dag_state_write_lock.calculate_scoring_subdag_scores();
             let last_commit_index = dag_state_write_lock.scoring_subdag_commit_range();
@@ -346,6 +385,60 @@ impl LeaderSchedule {
         let mut old = self.leader_swap_table.write();
         self.range_validation(&table, &old);
         self.apply_reputation_scores_inner(&mut old, table);
+    }
+
+    /// Uniform (non-stake-weighted) base election, used when the sliding-window
+    /// leader schedule is enabled. Round-seeded so all authorities draw the
+    /// same candidate for a given round; `offset` selects within the
+    /// shuffle.
+    pub(crate) fn elect_leader_uniform(&self, round: u32, offset: u32) -> AuthorityIndex {
+        assert!((offset as usize) < self.context.committee.size());
+        let mut seed_bytes = [0u8; 32];
+        seed_bytes[32 - 4..].copy_from_slice(&round.to_le_bytes());
+        let mut rng = StdRng::from_seed(seed_bytes);
+        let choices = self
+            .context
+            .committee
+            .authorities()
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        *choices
+            .choose_multiple(&mut rng, self.context.committee.size())
+            .nth(offset as usize)
+            .unwrap()
+    }
+
+    /// Feeds newly committed subdags to the sliding-window scorer when enabled;
+    /// a no-op on the V2 path.
+    pub(crate) fn feed_committed_subdags(&self, subdags: impl IntoIterator<Item = SubDagBase>) {
+        if let Some(sliding_window) = &self.sliding_window {
+            let mut scorer = sliding_window.lock();
+            for subdag in subdags {
+                scorer.add_commit(subdag);
+            }
+        }
+    }
+
+    /// Rebuilds the sliding-window scorer (when enabled) by replaying the last
+    /// `window_size` committed subdags from storage, so the running aggregate
+    /// is current after a restart or fast-sync. The in-effect swap table is
+    /// recovered separately from `CommitInfo`. A no-op on the V2 path.
+    fn recover_sliding_window(&self, dag_state: &RwLock<DagState>) {
+        let Some(sliding_window) = &self.sliding_window else {
+            return;
+        };
+        let window_size = self.context.protocol_config.leader_schedule_window_size();
+        let subdags = {
+            let dag_state = dag_state.read();
+            let last_commit_index = dag_state.last_commit_index();
+            let start = SlidingWindowSchedule::replay_start(last_commit_index, window_size);
+            dag_state.scan_subdag_bases((start..=last_commit_index).into())
+        };
+        let mut fresh = SlidingWindowSchedule::new(self.context.clone(), window_size);
+        for subdag in subdags {
+            fresh.add_commit(subdag);
+        }
+        *sliding_window.lock() = fresh;
     }
 }
 
@@ -637,6 +730,29 @@ mod tests {
         assert_ne!(
             leader_schedule.elect_leader_stake_based(1, 1),
             leader_schedule.elect_leader_stake_based(1, 2)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_elect_leader_uniform() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
+        let size = context.committee.size();
+
+        // For a fixed round, varying the offset across the whole committee yields
+        // a permutation of all authorities — the uniform draw covers everyone.
+        let round = 7;
+        let mut leaders = (0..size as u32)
+            .map(|offset| leader_schedule.elect_leader_uniform(round, offset))
+            .collect::<Vec<_>>();
+        leaders.sort();
+        leaders.dedup();
+        assert_eq!(leaders.len(), size);
+
+        // Deterministic: same (round, offset) always elects the same leader.
+        assert_eq!(
+            leader_schedule.elect_leader_uniform(round, 0),
+            leader_schedule.elect_leader_uniform(round, 0)
         );
     }
 

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -280,21 +280,18 @@ impl LeaderSchedule {
             .with_label_values(&["LeaderSchedule::update_leader_schedule"])
             .start_timer();
 
-        if let Some(sliding_window) = &self.sliding_window {
-            // commit_range is the committed interval this update closes: the last
-            // `num_commits_per_schedule` commits, ending at the boundary L — the
-            // same shape the V2 path tags. Its end (L) is the recovery anchor; a
-            // restarted node resumes the scoring subdag from L+1, the commit a
-            // never-restarted node would. The scores are aggregated over a deeper
-            // window (window_size) whose scored frontier lags L by
-            // MAX_PENDING_COMMITS; that depth and lag are the scorer's concern,
-            // rebuilt on restart by replaying window_size + MAX_PENDING_COMMITS
-            // commits (see recover_sliding_window / replay_start), not encoded in
-            // this range.
-            //
-            // Skip `range_validation` (it requires contiguous, equal-length
-            // ranges): after fast-sync the committed range can jump, so the strict
-            // check would panic — as the fast-sync path also skips it.
+        // Both paths feed the same swap table and go through range_validation and
+        // persist below; they differ only in where the scores and commit_range
+        // come from.
+        //
+        // Sliding-window: scores are the running-window aggregate; commit_range is
+        // the committed interval ending at the boundary L — the same shape V2
+        // produces, so it satisfies the shared range_validation. Its end (L) is
+        // the recovery anchor (a restarted node resumes the scoring subdag from
+        // L+1). The window's scored frontier lags L by MAX_PENDING_COMMITS.
+        //
+        // V2: scores and commit_range both come from the ScoringSubdag snapshot.
+        let (reputation_scores, boundary) = if let Some(sliding_window) = &self.sliding_window {
             let scores = sliding_window
                 .lock()
                 .reputation_scores()
@@ -302,30 +299,19 @@ impl LeaderSchedule {
             let boundary = dag_state_write_lock.last_commit_index();
             let interval = self.num_commits_per_schedule as u32;
             let start = boundary.saturating_sub(interval).saturating_add(1);
-            let reputation_scores =
-                ReputationScores::new(CommitRange::new(start..=boundary), scores);
-            let table =
-                LeaderSwapTable::new(self.context.clone(), boundary, reputation_scores.clone());
-            self.persist_scores(dag_state_write_lock, reputation_scores);
-            self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
-            return;
-        }
-
-        let (reputation_scores, last_commit_index) = {
+            (
+                ReputationScores::new(CommitRange::new(start..=boundary), scores),
+                boundary,
+            )
+        } else {
             let reputation_scores = dag_state_write_lock.calculate_scoring_subdag_scores();
-            let last_commit_index = dag_state_write_lock.scoring_subdag_commit_range();
-            (reputation_scores, last_commit_index)
+            let boundary = dag_state_write_lock.scoring_subdag_commit_range();
+            (reputation_scores, boundary)
         };
-        let table = LeaderSwapTable::new(
-            self.context.clone(),
-            last_commit_index,
-            reputation_scores.clone(),
-        );
+        let table = LeaderSwapTable::new(self.context.clone(), boundary, reputation_scores.clone());
         self.persist_scores(dag_state_write_lock, reputation_scores);
-        {
-            self.range_validation(&table, &self.leader_swap_table.read());
-            self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
-        }
+        self.range_validation(&table, &self.leader_swap_table.read());
+        self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
     }
 
     /// Updates the leader schedule from reputation scores stored in a commit.
@@ -1116,7 +1102,8 @@ mod tests {
             .protocol_config
             .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
         let context = Arc::new(context);
-        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
+            .with_num_commits_per_schedule(3);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             Arc::new(MemStore::new()),
@@ -1131,8 +1118,9 @@ mod tests {
 
         // Feed the first 6 commits, then rebuild: scores come from the sliding
         // window (commits 1..=3 are scored, given the 3-commit lookback), not a
-        // ScoringSubdag snapshot. The range is tagged to the rotation boundary
-        // (last committed index = 6), not the last scored commit.
+        // ScoringSubdag snapshot. commit_range is the committed interval ending at
+        // the boundary — with num_commits_per_schedule = 3 and last committed
+        // index 6, that is 4..=6.
         leader_schedule.feed_committed_subdags(commits[..6].iter().map(|(s, _)| s.base.clone()));
         {
             let mut ds = dag_state.write();
@@ -1145,11 +1133,11 @@ mod tests {
             .reputation_scores
             .commit_range
             .clone();
-        assert_eq!(range, (1..=6).into());
+        assert_eq!(range, (4..=6).into());
 
-        // Feed 3 more and rebuild again. The new range (1..=9) overlaps the
-        // previous one (1..=6) — V2's range_validation would reject that, so this
-        // not panicking confirms the sliding-window path skips it.
+        // Feed 3 more and rebuild again. The committed-interval ranges are
+        // contiguous and equal-size (4..=6 then 7..=9), so range_validation — now
+        // shared with the V2 path — accepts them.
         leader_schedule.feed_committed_subdags(commits[6..].iter().map(|(s, _)| s.base.clone()));
         {
             let mut ds = dag_state.write();
@@ -1162,7 +1150,7 @@ mod tests {
             .reputation_scores
             .commit_range
             .clone();
-        assert_eq!(range, (1..=9).into());
+        assert_eq!(range, (7..=9).into());
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -222,9 +222,8 @@ impl LeaderSchedule {
         let new_commit_range = &new_table.reputation_scores.commit_range;
 
         // Unless LeaderSchedule is brand new and using the default commit range
-        // of CommitRange(0..0) all future LeaderSwapTables should be calculated
-        // from a CommitRange of equal length and immediately following the
-        // preceding commit range of the old swap table.
+        // of CommitRange(0..0), every LeaderSwapTable should carry a CommitRange
+        // of equal length, immediately following the old table's range.
         if *old_commit_range != CommitRange::default() {
             assert!(
                 old_commit_range.is_next_range(new_commit_range)
@@ -287,8 +286,8 @@ impl LeaderSchedule {
         // Sliding-window: scores are the running-window aggregate; commit_range is
         // the committed interval ending at the boundary L — the same shape V2
         // produces, so it satisfies the shared range_validation. Its end (L) is
-        // the recovery anchor (a restarted node resumes the scoring subdag from
-        // L+1). The window's scored frontier lags L by MAX_PENDING_COMMITS.
+        // where a restarted node resumes the scoring subdag (from L+1). The
+        // window's scored frontier lags L by MAX_PENDING_COMMITS.
         //
         // V2: scores and commit_range both come from the ScoringSubdag snapshot.
         let (reputation_scores, boundary) = if let Some(sliding_window) = &self.sliding_window {
@@ -331,10 +330,11 @@ impl LeaderSchedule {
         commit_index: CommitIndex,
         reputation_scores_desc: &[(AuthorityIndex, u64)],
     ) {
-        // Determine the commit range for these scores.
-        // Reputation scores are attached to the *first* commit after a schedule
-        // update, so the scores correspond to the previous window ending at
-        // commit_index - 1.
+        // Determine the commit range for these scores. Reputation scores are
+        // attached to the *first* commit after a schedule update, so commit_index
+        // - 1 is the boundary of the window that just closed; the commit_range
+        // below is the committed interval ending there, though on the
+        // sliding-window path the scores summarize a deeper window.
         let range_end = commit_index.saturating_sub(1);
         if range_end == GENESIS_COMMIT_INDEX {
             return;

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -1090,6 +1090,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_leader_schedule_sliding_window() {
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=9).build();
+        let commits = dag_builder
+            .get_sub_dag_and_commits(1..=9)
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        // Feed the first 6 commits, then rebuild: scores come from the sliding
+        // window (commits 1..=3 are scored, given the 3-commit lookback), not from
+        // a ScoringSubdag snapshot.
+        leader_schedule.feed_committed_subdags(commits[..6].iter().map(|(s, _)| s.base.clone()));
+        {
+            let mut ds = dag_state.write();
+            ds.set_last_commit(commits[5].1.clone());
+            leader_schedule.update_leader_schedule(&mut ds);
+        }
+        let range = leader_schedule
+            .leader_swap_table
+            .read()
+            .reputation_scores
+            .commit_range
+            .clone();
+        assert_eq!(range, (1..=3).into());
+
+        // Feed 3 more and rebuild again. The new window range (1..=6) overlaps the
+        // previous one (1..=3) — V2's range_validation would reject that, so this
+        // not panicking confirms the sliding-window path skips it.
+        leader_schedule.feed_committed_subdags(commits[6..].iter().map(|(s, _)| s.base.clone()));
+        {
+            let mut ds = dag_state.write();
+            ds.set_last_commit(commits[8].1.clone());
+            leader_schedule.update_leader_schedule(&mut ds);
+        }
+        let range = leader_schedule
+            .leader_swap_table
+            .read()
+            .reputation_scores
+            .commit_range
+            .clone();
+        assert_eq!(range, (1..=6).into());
+    }
+
+    #[tokio::test]
     async fn test_leader_swap_table() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -23,7 +23,11 @@ use crate::{
 pub(crate) struct ReputationScores {
     /// Score per authority. Vec index is the `AuthorityIndex`.
     pub(crate) scores_per_authority: Vec<u64>,
-    // The range of commits these scores were calculated from.
+    /// The range of commits these scores were calculated from. Exception: on
+    /// the sliding-window path the *persisted* range is the committed
+    /// interval ending at the rotation boundary,
+    /// whereas the scores are aggregated over a deeper window ending
+    /// `MAX_PENDING_COMMITS` commits earlier.
     pub(crate) commit_range: CommitRange,
 }
 

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 use tracing::instrument;
 
 use crate::{
-    block_header::{BlockHeaderAPI, BlockRef, Round},
+    block_header::{BlockHeaderAPI, BlockRef},
     commit::{CommitRange, SubDagBase},
     context::Context,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -242,26 +242,6 @@ impl ScoringSubdag {
     }
 }
 
-/// Walks `[c_minus_2, c_minus_1, c]` in order, returning every commit up to and
-/// **including** the first whose leader round is strictly greater than `upper`.
-/// Callers pass strictly increasing leader rounds, so the scan always stops on
-/// a commit above `upper` rather than running off the end.
-fn scan_until_leader_round_above<'a>(
-    c_minus_2: &'a SubDagBase,
-    c_minus_1: &'a SubDagBase,
-    c: &'a SubDagBase,
-    upper: Round,
-) -> Vec<&'a SubDagBase> {
-    let mut out = Vec::with_capacity(3);
-    for cmt in [c_minus_2, c_minus_1, c] {
-        out.push(cmt);
-        if cmt.leader.round > upper {
-            break;
-        }
-    }
-    out
-}
-
 /// Compute the per-commit score contribution for the new commit `c`, scoring
 /// the oldest of the 3 pending commits (`c_minus_3`). Returns per-authority
 /// score deltas indexed by `AuthorityIndex`.
@@ -270,14 +250,11 @@ fn scan_until_leader_round_above<'a>(
 /// for each authority A, `contribution[A]` is the sum of stake of authorities
 /// whose round-(r+2) blocks strongly link to A's round-(r+1) voting block,
 /// where A's voting block strongly links to `c_minus_3`'s leader block (round
-/// r).
+/// r). The round-(r+1) and round-(r+2) blocks are collected from all three
+/// commits following `c_minus_3` (`c_minus_2`, `c_minus_1`, `c`).
 ///
-/// Equivocation: if A has multiple voting blocks at r+1 within the lookback
-/// window, `contribution[A] = 0`.
-///
-/// Assumes consecutive commits have strictly increasing leader rounds
-/// (`c_minus_3 < c_minus_2 < c_minus_1 < c`), which the driving schedule
-/// maintains by construction.
+/// Equivocation: if A has multiple voting blocks at r+1 within that window,
+/// `contribution[A] = 0`.
 pub(crate) fn compute_per_commit_contribution(
     context: &Context,
     c_minus_3: &SubDagBase,
@@ -294,9 +271,8 @@ pub(crate) fn compute_per_commit_contribution(
     // Voting blocks at round r+1 that strongly link to the leader block, grouped by
     // author. Multiple blocks per author indicates equivocation in the lookback
     // window.
-    let voting_commits = scan_until_leader_round_above(c_minus_2, c_minus_1, c, vote_round);
     let mut voting_blocks_by_author: BTreeMap<AuthorityIndex, Vec<BlockRef>> = BTreeMap::new();
-    for commit in &voting_commits {
+    for commit in [c_minus_2, c_minus_1, c] {
         for header in &commit.headers {
             if header.round() != vote_round {
                 continue;
@@ -312,9 +288,8 @@ pub(crate) fn compute_per_commit_contribution(
     }
 
     // Round-(r+2) certifying blocks, with their ancestor lists.
-    let certifying_commits = scan_until_leader_round_above(c_minus_2, c_minus_1, c, certify_round);
     let mut certifying_blocks: Vec<(AuthorityIndex, &[BlockRef])> = Vec::new();
-    for commit in &certifying_commits {
+    for commit in [c_minus_2, c_minus_1, c] {
         for header in &commit.headers {
             if header.round() == certify_round {
                 certifying_blocks.push((header.author(), header.ancestors()));
@@ -347,7 +322,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_header::{BlockHeaderDigest, TestBlockHeader, VerifiedBlockHeader},
+        block_header::{BlockHeaderDigest, Round, TestBlockHeader, VerifiedBlockHeader},
         commit::{CommitDigest, CommitRef},
         test_dag_builder::DagBuilder,
     };

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -79,15 +79,15 @@ impl SlidingWindowSchedule {
 
     /// Earliest commit index a caller must replay through [`Self::add_commit`]
     /// to rebuild the window state as of `last_commit_index`.
+    ///
+    /// Replays a full window: the window slides by adding new and subtracting
+    /// evicted per-commit contributions, so recovery must rebuild those
+    /// per-commit entries — the aggregate sum alone cannot evict. The extra
+    /// `MAX_PENDING_COMMITS` starts the replay three commits before the window
+    /// so the lookback buffer (`pending_commits`) is refilled and the first
+    /// in-window commit scores identically to live operation. The swap table in
+    /// effect at restart is not recovered by this replay.
     pub(crate) fn replay_start(last_commit_index: CommitIndex, window_size: u32) -> CommitIndex {
-        // Replays a full window, not just the latest commit: the window slides by
-        // adding new and subtracting evicted per-commit contributions, so recovery
-        // must rebuild those per-commit entries — the aggregate sum alone cannot
-        // evict. The extra `MAX_PENDING_COMMITS` starts the replay three commits
-        // before the window so the lookback buffer (`pending_commits`) is refilled
-        // and the first in-window commit scores identically to live operation. The
-        // swap table in effect at restart is recovered separately, from the scores
-        // persisted in `CommitInfo`, not by this replay.
         last_commit_index
             .saturating_sub(window_size + MAX_PENDING_COMMITS as u32)
             .max(1)

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -20,7 +20,8 @@
 //! `consensus_enable_sliding_window_leader_schedule`), the leader schedule
 //! feeds each committed subdag to [`SlidingWindowSchedule::add_commit`] in
 //! consecutive index order and rebuilds the `LeaderSwapTable` from
-//! [`SlidingWindowSchedule::reputation_scores`] at its usual cadence.
+//! [`SlidingWindowSchedule::reputation_scores`] every `commits_per_schedule`
+//! commits.
 //!
 //! On a restart or fast-sync the in-memory window starts empty and is rebuilt
 //! from storage: [`SlidingWindowSchedule::replay_start`] gives the earliest
@@ -82,8 +83,11 @@ impl SlidingWindowSchedule {
         // Replays a full window, not just the latest commit: the window slides by
         // adding new and subtracting evicted per-commit contributions, so recovery
         // must rebuild those per-commit entries — the aggregate sum alone cannot
-        // evict. The swap table in effect at restart is recovered separately, from
-        // the scores persisted in `CommitInfo`, not by this replay.
+        // evict. The extra `MAX_PENDING_COMMITS` starts the replay three commits
+        // before the window so the lookback buffer (`pending_commits`) is refilled
+        // and the first in-window commit scores identically to live operation. The
+        // swap table in effect at restart is recovered separately, from the scores
+        // persisted in `CommitInfo`, not by this replay.
         last_commit_index
             .saturating_sub(window_size + MAX_PENDING_COMMITS as u32)
             .max(1)
@@ -101,8 +105,11 @@ impl SlidingWindowSchedule {
             return;
         }
 
-        // Steady state: 3 commits already pending; this is the 4th. The scored
-        // commit is c_minus_3 (the oldest pending).
+        // Steady state: the window now holds four consecutive commits. We score
+        // the OLDEST of the four, c_minus_3: its leader is at round r, and the
+        // r+1 votes and r+2 certifiers that score it live in the three newer
+        // commits. So a commit is scored only once the third commit after it is
+        // committed; the just-fed c merely unlocks scoring c_minus_3.
         let c_minus_3 = &self.pending_commits[0];
         let c_minus_2 = &self.pending_commits[1];
         let c_minus_1 = &self.pending_commits[2];
@@ -137,8 +144,11 @@ impl SlidingWindowSchedule {
     }
 
     /// Current running aggregate as [`ReputationScores`], tagged with the
-    /// commit range of the scored commits in the window. Returns all-zero
-    /// scores over the empty range until the first commit is scored.
+    /// commit range of the scored commits in the window. The range ends at
+    /// the last *scored* commit, which trails the last fed commit by
+    /// `MAX_PENDING_COMMITS` (a commit is scored only once the third commit
+    /// after it arrives). Returns all-zero scores over the empty range
+    /// until the first commit is scored.
     pub(crate) fn reputation_scores(&self) -> ReputationScores {
         let commit_range = match (self.scores_entries.front(), self.scores_entries.back()) {
             (Some((first, _)), Some((last, _))) => CommitRange::new(*first..=*last),

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -14,12 +14,12 @@
 //! The sliding window is an alternative *score source* for the existing swap
 //! table; it does not select leaders itself.
 //!
-//! # Intended usage
+//! # Usage
 //!
-//! This scorer is not yet wired into the leader schedule (hence the
-//! `expect(dead_code)` below). Once wired, the leader schedule feeds each
-//! committed subdag to [`SlidingWindowSchedule::add_commit`] in consecutive
-//! index order and rebuilds the `LeaderSwapTable` from
+//! When the sliding-window leader schedule is enabled (protocol flag
+//! `consensus_enable_sliding_window_leader_schedule`), the leader schedule
+//! feeds each committed subdag to [`SlidingWindowSchedule::add_commit`] in
+//! consecutive index order and rebuilds the `LeaderSwapTable` from
 //! [`SlidingWindowSchedule::reputation_scores`] at its usual cadence.
 //!
 //! On a restart or fast-sync the in-memory window starts empty and is rebuilt

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -29,11 +29,6 @@
 //! [`SlidingWindowSchedule::add_commit`] to repopulate the window before any
 //! scores are read.
 
-#![cfg_attr(
-    not(test),
-    expect(dead_code, reason = "not yet wired into the leader schedule")
-)]
-
 use std::{collections::VecDeque, sync::Arc};
 
 use crate::{

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -655,7 +655,7 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
 }
 
 #[tokio::test]
-async fn leader_status_is_final_classification() {
+async fn leader_status_is_resolved_classification() {
     let (context, dag_state) = test_context_with_flag(true);
     let refs = build_v2_layers(&context, &dag_state, None, 1);
     let block = dag_state
@@ -665,17 +665,18 @@ async fn leader_status_is_final_classification() {
 
     let slot = Slot::new(3, AuthorityIndex::from(0u8));
     assert!(
-        !LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending), vec![]).is_final()
+        !LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending), vec![]).is_resolved()
     );
     assert!(
-        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic), vec![]).is_final()
+        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic), vec![])
+            .is_resolved()
     );
     assert!(
-        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard), vec![]).is_final()
+        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard), vec![]).is_resolved()
     );
-    assert!(LeaderStatus::Commit(block, None, vec![]).is_final());
-    assert!(LeaderStatus::Skip(slot).is_final());
-    assert!(!LeaderStatus::Undecided(slot).is_final());
+    assert!(LeaderStatus::Commit(block, None, vec![]).is_resolved());
+    assert!(LeaderStatus::Skip(slot).is_resolved());
+    assert!(!LeaderStatus::Undecided(slot).is_resolved());
 }
 
 fn build_universal_committer(

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -27,8 +27,8 @@ async fn direct_commit() {
     let decision_round_wave_0_pipeline_1 = committer.committers[1].certifying_round(0);
     build_dag(context, dag_state, None, decision_round_wave_0_pipeline_1);
 
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 1);
 
@@ -56,8 +56,8 @@ async fn idempotence() {
     build_dag(context, dag_state, None, certifying_round_pipeline_1_wave_0);
 
     // Commit one leader.
-    let last_decided = Slot::new(0, 0);
-    let first_sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let first_sequence = committer.try_decide(last_finalized);
     assert_eq!(first_sequence.len(), 1);
     tracing::info!("Commit sequence: {first_sequence:#?}");
 
@@ -73,7 +73,7 @@ async fn idempotence() {
 
     // Ensure that if try_commit is called again with the same last decided leader
     // input the commit decision will be the same.
-    let first_sequence = committer.try_decide(last_decided);
+    let first_sequence = committer.try_decide(last_finalized);
 
     assert_eq!(first_sequence.len(), 1);
     if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
@@ -88,8 +88,8 @@ async fn idempotence() {
 
     // Ensure we don't commit the same leader again once last decided has been
     // updated.
-    let last_decided = Slot::new(first_sequence[0].round(), first_sequence[0].authority());
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(first_sequence[0].round(), first_sequence[0].authority());
+    let sequence = committer.try_decide(last_finalized);
     assert!(sequence.is_empty());
 }
 
@@ -99,7 +99,7 @@ async fn multiple_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
     let wave_length = WAVE_LENGTH;
 
-    let mut last_decided = Slot::new(0, 0);
+    let mut last_finalized = Slot::new(0, 0);
     let mut ancestors = None;
     for n in 1..=10 {
         // Build the dag up to the decision round for each pipeline's wave starting
@@ -118,7 +118,7 @@ async fn multiple_direct_commit() {
         ));
 
         // Because of pipelining we are committing a leader every round.
-        let sequence = committer.try_decide(last_decided);
+        let sequence = committer.try_decide(last_finalized);
         tracing::info!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), 1);
@@ -135,7 +135,7 @@ async fn multiple_direct_commit() {
         // Update the last decided leader so only one new leader is committed as
         // each new wave is completed.
         let last = sequence.into_iter().next_back().unwrap();
-        last_decided = Slot::new(last.round(), last.authority());
+        last_finalized = Slot::new(last.round(), last.authority());
     }
 }
 
@@ -153,8 +153,8 @@ async fn direct_commit_late_call() {
 
     build_dag(context, dag_state, None, certifying_round);
 
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), n);
@@ -184,8 +184,8 @@ async fn no_genesis_commit() {
     for r in 0..certifying_round_pipeline_0_wave_0 {
         ancestors = Some(build_dag(context.clone(), dag_state.clone(), ancestors, r));
 
-        let last_decided = Slot::new(0, 0);
-        let sequence = committer.try_decide(last_decided);
+        let last_finalized = Slot::new(0, 0);
+        let sequence = committer.try_decide(last_finalized);
         assert!(sequence.is_empty());
     }
 }
@@ -228,8 +228,8 @@ async fn direct_skip_no_leader() {
 
     // Ensure no blocks are committed because there are 2f+1 blame (non-votes) for
     // the missing leader.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 1);
@@ -302,8 +302,8 @@ async fn direct_skip_enough_blame() {
 
     // Ensure the leader is skipped because there are 2f+1 blame (non-votes) for
     // the wave 0 leader of pipeline 1.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 1);
@@ -408,8 +408,8 @@ async fn indirect_commit() {
     );
 
     // Ensure we commit the first leaders.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 5);
 
@@ -489,8 +489,8 @@ async fn indirect_skip() {
 
     // Ensure we commit the first 3 leaders, skip the 4th, and commit the last 2
     // leaders.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 7);
 
@@ -567,8 +567,8 @@ async fn undecided() {
     );
 
     // Ensure no blocks are committed.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     assert!(sequence.is_empty());
 }
 
@@ -725,8 +725,8 @@ async fn test_byzantine_validator() {
 
     // Expect a successful direct commit of A12 and leaders at rounds 1 ~ 11 as
     // pipelining is enabled.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
@@ -748,15 +748,15 @@ async fn test_byzantine_validator() {
 
     // Ensure B13 is marked as undecided as there is <2f+1 blame and <2f+1 certs
     let last_sequenced = sequence.last().unwrap();
-    let last_decided = Slot::new(last_sequenced.round(), last_sequenced.authority());
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(last_sequenced.round(), last_sequenced.authority());
+    let sequence = committer.try_decide(last_finalized);
     assert!(sequence.is_empty());
 
     // Now build an additional 3 dag layers on top of the existing dag so a commit
     // decision can be made about leader A16 and then an indirect decision can be
     // made about B13
     build_dag(context, dag_state, Some(references_round_15), 18);
-    let sequence = committer.try_decide(last_decided);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 4);
 

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -53,8 +53,8 @@ async fn test_randomized_dag_all_direct_commit() {
             "Running test with committee size {num_authorities} & {NUM_ROUNDS} rounds in the DAG..."
         );
 
-        let last_decided = Slot::new(0, 0);
-        let sequence = authority.committer.try_decide(last_decided);
+        let last_finalized = Slot::new(0, 0);
+        let sequence = authority.committer.try_decide(last_finalized);
         tracing::debug!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), (NUM_ROUNDS - 2) as usize);
@@ -79,7 +79,7 @@ async fn test_randomized_dag_all_direct_commit() {
 ///
 /// Blocks will randomly be fed through BlockManager and after each accepted
 /// block we will try_decide() and if there is a committed sequence we will
-/// update last_decided and continue. We do this from the perspective of two
+/// update last_finalized and continue. We do this from the perspective of two
 /// different authorities who receive the blocks in different orders and ensure
 /// the resulting sequence is the same for both authorities. The resulting
 /// sequence will include Commit & Skip decisions and potentially will stop
@@ -116,7 +116,7 @@ async fn test_randomized_dag_and_decision_sequence() {
         all_blocks.shuffle(&mut random_test_setup.seeded_rng);
 
         let mut sequenced_leaders_1 = vec![];
-        let mut last_decided = Slot::new(0, 0);
+        let mut last_finalized = Slot::new(0, 0);
         let mut i = 0;
         let mut seen_so_far = vec![];
         while i < all_blocks.len() {
@@ -128,12 +128,12 @@ async fn test_randomized_dag_and_decision_sequence() {
             let _ = authority_1
                 .block_manager
                 .try_accept_block_headers(chunk.to_vec(), DataSource::Test);
-            let sequence = authority_1.committer.try_decide(last_decided);
+            let sequence = authority_1.committer.try_decide(last_finalized);
 
             if !sequence.is_empty() {
                 sequenced_leaders_1.extend(sequence.clone());
                 let leader_status = sequence.last().unwrap();
-                last_decided = Slot::new(leader_status.round(), leader_status.authority());
+                last_finalized = Slot::new(leader_status.round(), leader_status.authority());
             }
 
             i += chunk_size;
@@ -158,7 +158,7 @@ async fn test_randomized_dag_and_decision_sequence() {
         all_blocks.shuffle(&mut random_test_setup.seeded_rng);
 
         let mut sequenced_leaders_2 = vec![];
-        let mut last_decided = Slot::new(0, 0);
+        let mut last_finalized = Slot::new(0, 0);
         let mut i = 0;
         let mut seen_so_far = vec![];
         while i < all_blocks.len() {
@@ -171,12 +171,12 @@ async fn test_randomized_dag_and_decision_sequence() {
             let _ = authority_2
                 .block_manager
                 .try_accept_block_headers(chunk.to_vec(), DataSource::Test);
-            let sequence = authority_2.committer.try_decide(last_decided);
+            let sequence = authority_2.committer.try_decide(last_finalized);
 
             if !sequence.is_empty() {
                 sequenced_leaders_2.extend(sequence.clone());
                 let leader_status = sequence.last().unwrap();
-                last_decided = Slot::new(leader_status.round(), leader_status.authority());
+                last_finalized = Slot::new(leader_status.round(), leader_status.authority());
             }
             // Evaluate the seen blocks so far
             let (suspended, missing) = evaluate_block_headers(&seen_so_far);

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -43,12 +43,12 @@ async fn direct_commit() {
 
     // Genesis cert will not be included in commit sequence, marking it as last
     // decided
-    let last_decided = Slot::new(0, 0);
+    let last_finalized = Slot::new(0, 0);
 
     // The universal committer should mark the potential leaders in leader round 6
     // as undecided because there is no way to get enough certificates for
     // leaders of leader round 6 without completing wave (6-7-8).
-    let sequence = test_setup.committer.try_decide(last_decided);
+    let sequence = test_setup.committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     // The decided leaders should be all from round 1 to round 5
     assert_eq!(sequence.len(), 5);
@@ -80,8 +80,8 @@ async fn idempotence() {
     );
 
     // Commit one leader.
-    let last_decided = Slot::new(0, 0);
-    let first_sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let first_sequence = committer.try_decide(last_finalized);
     assert_eq!(first_sequence.len(), 1);
 
     if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
@@ -96,7 +96,7 @@ async fn idempotence() {
 
     // Ensure that if try_commit is called again with the same last decided leader
     // input the commit decision will be the same.
-    let first_sequence = committer.try_decide(last_decided);
+    let first_sequence = committer.try_decide(last_finalized);
 
     assert_eq!(first_sequence.len(), 1);
     if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
@@ -121,12 +121,12 @@ async fn idempotence() {
     // Ensure we don't commit the same leader of round 1 again if we mark it as the
     // last decided.
     let leader_status_first_leader = first_sequence.last().unwrap();
-    let last_decided = Slot::new(
+    let last_finalized = Slot::new(
         leader_status_first_leader.round(),
         leader_status_first_leader.authority(),
     );
     let round_5 = 5;
-    let second_sequence = committer.try_decide(last_decided);
+    let second_sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {second_sequence:#?}");
 
     // Expect that all leaders between round 2 and round 5 are committed.
@@ -146,7 +146,7 @@ async fn multiple_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
 
     let mut ancestors = None;
-    let mut last_decided = Slot::new(0, 0);
+    let mut last_finalized = Slot::new(0, 0);
     for n in 1..=10 {
         // Build the DAG up to the certifying round for leader blocks of authority 1,
         // i.e. full DAG is built with chunks of 3 rounds
@@ -161,7 +161,7 @@ async fn multiple_direct_commit() {
 
         // After every 3 rounds, try commit all leaders in between
         let leader_round = committer.committers[0].leader_round(n);
-        let sequence = committer.try_decide(last_decided);
+        let sequence = committer.try_decide(last_finalized);
         tracing::info!("Commit sequence: {sequence:#?}");
         assert_eq!(sequence.len(), 3);
         if let DecidedLeader::Commit(ref block, _, _) = sequence[2] {
@@ -174,7 +174,7 @@ async fn multiple_direct_commit() {
         // Update the last decided leader so only one new leader is committed as
         // each new wave is completed.
         let leader_status = sequence.last().unwrap();
-        last_decided = Slot::new(leader_status.round(), leader_status.authority());
+        last_finalized = Slot::new(leader_status.round(), leader_status.authority());
     }
 }
 
@@ -189,8 +189,8 @@ async fn direct_commit_late_call() {
     let certifying_round_wave_10 = committer.committers[0].certifying_round(10);
     build_dag(context, dag_state, None, certifying_round_wave_10);
 
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     // With 11 full non-intersecting waves completed, excluding genesis in wave 0 as
@@ -267,8 +267,8 @@ async fn direct_skip_no_leader_votes() {
     // committer.
     assert_eq!(committer.committers.len(), 3);
 
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     // Only leader for slot B1 should be decided, specifically, skipped
     assert_eq!(sequence.len(), 1);
     if let DecidedLeader::Skip(leader) = sequence[0] {
@@ -385,8 +385,8 @@ async fn indirect_commit() {
 
     // Ensure we indirectly commit the leader of round 3 via the directly committed
     // leader of round 6.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 6);
 
@@ -463,8 +463,8 @@ async fn indirect_skip() {
 
     // Ensure we indirectly skip the leader of round 4 via the directly committed
     // leader of round 7.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 7);
 
@@ -545,8 +545,8 @@ async fn undecided() {
 
     // Ensure we indirectly commit the leader of round3 via the directly committed
     // leader of round 6.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert!(sequence.is_empty());
 }
@@ -694,8 +694,8 @@ async fn test_byzantine_direct_commit() {
     // all of these blocks also have good votes for leader A12 through A, B, D.
 
     // Expect a successful direct commit of A12 and all leaders at previous rounds.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -42,14 +42,14 @@ pub(crate) struct UniversalCommitter {
 impl UniversalCommitter {
     /// Try to decide part of the dag. This function is idempotent and returns
     /// an ordered list of decided leaders.
-    #[tracing::instrument(skip_all, fields(last_decided = %last_decided))]
-    pub(crate) fn try_decide(&self, last_decided: Slot) -> Vec<DecidedLeader> {
+    #[tracing::instrument(skip_all, fields(last_finalized = %last_finalized))]
+    pub(crate) fn try_decide(&self, last_finalized: Slot) -> Vec<DecidedLeader> {
         let highest_accepted_round = self.dag_state.read().highest_accepted_round();
 
         // Try to decide as many leaders as possible, starting with the highest round.
         let mut leaders: VecDeque<(LeaderStatus, Decision)> = VecDeque::new();
 
-        let last_round = last_decided.round + 1;
+        let last_round = last_finalized.round + 1;
 
         // try to commit a leader up to the highest_accepted_round - 2. There is no
         // reason to try and iterate on higher rounds as in order to make a direct
@@ -63,9 +63,9 @@ impl UniversalCommitter {
                     continue;
                 };
 
-                // now that we reached the last committed leader we can stop the commit rule
-                if slot == last_decided {
-                    tracing::debug!("Reached last committed {slot}, now exit");
+                // now that we reached the last finalized leader we can stop the commit rule
+                if slot == last_finalized {
+                    tracing::debug!("Reached last finalized {slot}, now exit");
                     break 'outer;
                 }
 
@@ -75,11 +75,11 @@ impl UniversalCommitter {
                 let mut decision = Decision::Direct;
                 tracing::debug!("Outcome of direct rule: {status}");
 
-                // If the direct result is not final (Commit(Pending) or
+                // If the direct result is not resolved (Commit(Pending) or
                 // Undecided), run the indirect rule. For Pending, a
                 // committed anchor's path can upgrade the metastate; for
                 // Undecided, indirect may resolve the slot entirely.
-                if !status.is_final() {
+                if !status.is_resolved() {
                     let indirect = committer
                         .try_indirect_decide(status.clone(), leaders.iter().map(|(x, _)| x));
                     if indirect != status {
@@ -98,20 +98,21 @@ impl UniversalCommitter {
             }
         }
 
-        // The decided sequence is the longest prefix of final decisions.
-        // Commit(Pending) is decided but non-final — sequencing stops until
-        // the metastate is upgraded on a subsequent commit pass.
+        // The decided sequence is the longest prefix where every leader is
+        // resolved. Commit(Pending) is decided but not resolved — its metastate
+        // is still pending — so sequencing stops there until a later commit pass
+        // upgrades it.
         let mut decided_leaders = Vec::new();
         for (leader, decision) in leaders {
             if leader.round() == GENESIS_ROUND {
                 continue;
             }
-            if !leader.is_final() {
+            if !leader.is_resolved() {
                 break;
             }
             let decided_leader = leader
                 .into_decided_leader()
-                .expect("is_final implies decided");
+                .expect("is_resolved implies a DecidedLeader");
             Self::update_metrics(&self.context, &decided_leader, decision);
             decided_leaders.push(decided_leader);
         }


### PR DESCRIPTION
# Description of change

Wires the sliding-window leader scorer so it can drive the leader schedule,
behind a default-off protocol flag (`consensus_enable_sliding_window_leader_schedule`).
With the flag off — the default everywhere — behavior is byte-for-byte the
existing V2 path, so nothing changes on the network until a future protocol
version enables it.

When the flag is on:

- `CONSENSUS_COMMITS_PER_SCHEDULE` (how often the schedule rotates) becomes a
  version-gated `consensus_commits_per_schedule` param (default 300), and a new
  `consensus_leader_schedule_window_size` param (default 600) sets the scoring
  depth — decoupling how often the schedule rotates from how many commits the
  reputation scores aggregate over. The flag getter asserts the invariant
  `window_size >= commits_per_schedule`.
- `LeaderSchedule` feeds each committed subdag to the scorer and, every
  `commits_per_schedule` commits, rebuilds the `LeaderSwapTable` from the
  scorer's `reputation_scores()` (the running-window aggregate) instead of the
  `ScoringSubdag` snapshot. The rebuilt scores are tagged with the committed
  interval ending at the rotation boundary — the same shape V2 produces — so
  both paths now go through the *same* `range_validation` and persist the
  scores to `CommitInfo`.
- The per-round base election is uniform instead of stake-weighted.
- Restart and fast-sync recover the scorer by replaying the last window from
  storage (fast-sync fetches enough commits to cover that range); the in-effect
  swap table is recovered from `CommitInfo` as before.

Selection still uses the swap table (good/bad, swap bad→good) — only the score
source and the base draw change.

## Restart-invariance

The scorer's scored frontier lags the rotation boundary by `MAX_PENDING_COMMITS`
(3) commits. Persisting that lagging frontier as the `CommitInfo` range end made
a restarted node rebuild extra scoring subdags and rotate the schedule early,
diverging from a node that ran continuously. We persist the rotation boundary
(the last committed index) as the range end — matching V2 — so a restarted node
resumes its scoring subdag from the same commit a never-restarted node would.
`test_leader_schedule_restart_invariant_rotation` drives a real 4-core network
past a rotation to a mid-interval commit, restarts authority 0 through the real
recovery path, and asserts — for both flag states — that the
commits-until-next-rotation and the recovered swap table's good/bad nodes are
identical live-vs-restarted (the boundary is also the swap-table seed, so
recovery reproduces the same selection, not just the same count).

## Incidental cleanups

- Renamed `last_decided_leader` → `last_finalized_leader` and clarified the
  decided / resolved / finalized leader terminology across `Core` and the
  committer.
- Dropped the round-keyed `scan_until_leader_round_above` from per-commit
  scoring; the r+1 / r+2 blocks are collected from the three commits following
  the scored commit.
- Fixed the pre-existing `CoreTextFixture` → `CoreTestFixture` typo in the
  consensus test harness.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
