### PR TITLE
refactor(iota-types): replace node CheckpointCommitment with SDK type

### DIFF
--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -456,7 +456,7 @@ async fn sync_end_of_epoch_checkpoint(
         Some(EndOfEpochData {
             next_epoch_committee: new_committee.committee().voting_rights.clone(),
             next_epoch_protocol_version: ProtocolVersion::MIN,
-            epoch_commitments: vec![ECMHLiveObjectSetDigest::default().into()],
+            epoch_commitments: vec![ECMHLiveObjectSetDigest::default().into_commitment()],
             // Do not simulate supply changes in tests.
             // We would need to build this checkpoint after the below execution of advance_epoch to
             // obtain this number from the SystemEpochInfoEvent.

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -6,7 +6,7 @@ use std::{sync::Arc, time::Duration};
 
 use iota_config::node::ExpensiveSafetyCheckConfig;
 use iota_metrics::spawn_monitored_task;
-use iota_sdk_types::gas::GasCostSummary;
+use iota_sdk_types::{CheckpointCommitment, gas::GasCostSummary};
 use iota_swarm_config::test_utils::{CommitteeFixture, empty_contents};
 use iota_types::{
     committee::ProtocolVersion,
@@ -456,7 +456,9 @@ async fn sync_end_of_epoch_checkpoint(
         Some(EndOfEpochData {
             next_epoch_committee: new_committee.committee().voting_rights.clone(),
             next_epoch_protocol_version: ProtocolVersion::MIN,
-            epoch_commitments: vec![ECMHLiveObjectSetDigest::default().into_commitment()],
+            epoch_commitments: vec![CheckpointCommitment::EcmhLiveObjectSet {
+                digest: ECMHLiveObjectSetDigest::default().digest,
+            }],
             // Do not simulate supply changes in tests.
             // We would need to build this checkpoint after the below execution of advance_epoch to
             // obtain this number from the SystemEpochInfoEvent.

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1659,7 +1659,7 @@ impl CheckpointBuilder {
                 self.metrics.highest_accumulated_epoch.set(epoch as i64);
                 info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
 
-                let epoch_commitments = vec![root_state_digest.into()];
+                let epoch_commitments = vec![root_state_digest.into_commitment()];
 
                 Some(EndOfEpochData {
                     next_epoch_committee: committee.voting_rights,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1659,7 +1659,9 @@ impl CheckpointBuilder {
                 self.metrics.highest_accumulated_epoch.set(epoch as i64);
                 info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
 
-                let epoch_commitments = vec![root_state_digest.into_commitment()];
+                let epoch_commitments = vec![CheckpointCommitment::EcmhLiveObjectSet {
+                    digest: root_state_digest.digest,
+                }];
 
                 Some(EndOfEpochData {
                     next_epoch_committee: committee.voting_rights,

--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -121,9 +121,10 @@ ChangedObject:
 CheckpointCommitment:
   ENUM:
     0:
-      ECMHLiveObjectSetDigest:
-        NEWTYPE:
-          TYPENAME: ECMHLiveObjectSetDigest
+      EcmhLiveObjectSet:
+        STRUCT:
+          - digest:
+              TYPENAME: Digest
 CheckpointContents:
   ENUM:
     0:
@@ -278,10 +279,6 @@ DeleteKind:
       Wrap: UNIT
 Digest:
   NEWTYPESTRUCT: BYTES
-ECMHLiveObjectSetDigest:
-  STRUCT:
-    - digest:
-        TYPENAME: Digest
 EmptySignInfo:
   STRUCT: []
 EndOfEpochData:

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -191,8 +191,7 @@ impl Epoch {
         })?;
 
         let digest = commitments.into_iter().next().map(|commitment| {
-            let EpochCommitment::ECMHLiveObjectSetDigest(digest) = commitment;
-            Base58::encode(digest.digest.into_inner())
+            Base58::encode(commitment.as_ecmh_live_object_set_digest().into_inner())
         });
 
         Ok(digest)

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -191,7 +191,10 @@ impl Epoch {
         })?;
 
         let digest = commitments.into_iter().next().map(|commitment| {
-            Base58::encode(commitment.as_ecmh_live_object_set_digest().into_inner())
+            let EpochCommitment::EcmhLiveObjectSet { digest } = commitment else {
+                panic!("a new CheckpointCommitment variant was added and must be handled")
+            };
+            Base58::encode(digest.into_inner())
         });
 
         Ok(digest)

--- a/crates/iota-json-rpc-types/src/iota_checkpoint.rs
+++ b/crates/iota-json-rpc-types/src/iota_checkpoint.rs
@@ -249,14 +249,25 @@ impl<'de> DeserializeAs<'de, CheckpointCommitment> for CheckpointCommitmentSchem
 impl From<CheckpointCommitmentSchema> for CheckpointCommitment {
     fn from(iota_commitment: CheckpointCommitmentSchema) -> Self {
         match iota_commitment {
-            CheckpointCommitmentSchema::ECMHLiveObjectSetDigest(digest) => digest.into_commitment(),
+            CheckpointCommitmentSchema::ECMHLiveObjectSetDigest(digest) => {
+                CheckpointCommitment::EcmhLiveObjectSet {
+                    digest: digest.digest,
+                }
+            }
         }
     }
 }
 
 impl From<CheckpointCommitment> for CheckpointCommitmentSchema {
     fn from(commitment: CheckpointCommitment) -> Self {
-        CheckpointCommitmentSchema::ECMHLiveObjectSetDigest(commitment.into())
+        match commitment {
+            CheckpointCommitment::EcmhLiveObjectSet { digest } => {
+                CheckpointCommitmentSchema::ECMHLiveObjectSetDigest(ECMHLiveObjectSetDigest {
+                    digest,
+                })
+            }
+            _ => unimplemented!("a new CheckpointCommitment variant was added and must be handled"),
+        }
     }
 }
 

--- a/crates/iota-json-rpc-types/src/iota_checkpoint.rs
+++ b/crates/iota-json-rpc-types/src/iota_checkpoint.rs
@@ -249,20 +249,14 @@ impl<'de> DeserializeAs<'de, CheckpointCommitment> for CheckpointCommitmentSchem
 impl From<CheckpointCommitmentSchema> for CheckpointCommitment {
     fn from(iota_commitment: CheckpointCommitmentSchema) -> Self {
         match iota_commitment {
-            CheckpointCommitmentSchema::ECMHLiveObjectSetDigest(digest) => {
-                CheckpointCommitment::ECMHLiveObjectSetDigest(digest)
-            }
+            CheckpointCommitmentSchema::ECMHLiveObjectSetDigest(digest) => digest.into_commitment(),
         }
     }
 }
 
 impl From<CheckpointCommitment> for CheckpointCommitmentSchema {
     fn from(commitment: CheckpointCommitment) -> Self {
-        match commitment {
-            CheckpointCommitment::ECMHLiveObjectSetDigest(digest) => {
-                CheckpointCommitmentSchema::ECMHLiveObjectSetDigest(digest)
-            }
-        }
+        CheckpointCommitmentSchema::ECMHLiveObjectSetDigest(commitment.into())
     }
 }
 

--- a/crates/iota-snapshot/src/uploader.rs
+++ b/crates/iota-snapshot/src/uploader.rs
@@ -12,6 +12,7 @@ use iota_core::{
     checkpoints::CheckpointStore,
     db_checkpoint_handler::{STATE_SNAPSHOT_COMPLETED_MARKER, SUCCESS_MARKER},
 };
+use iota_sdk_types::CheckpointCommitment;
 use iota_storage::{
     FileCompression,
     object_store::util::{
@@ -148,13 +149,16 @@ impl StateSnapshotUploader {
                     .get_epoch_state_commitments(*epoch)
                     .expect("Expected last checkpoint of epoch to have end of epoch data")
                     .expect("Expected end of epoch data to be present");
-                let state_hash_commitment: ECMHLiveObjectSetDigest = commitments
+                let CheckpointCommitment::EcmhLiveObjectSet { digest } = *commitments
                     .last()
                     .expect("Expected at least one commitment")
-                    .clone()
-                    .into();
+                else {
+                    unimplemented!(
+                        "A new CheckpointCommitment variant was added and must be handled"
+                    )
+                };
                 state_snapshot_writer
-                    .write(*epoch, db, state_hash_commitment)
+                    .write(*epoch, db, ECMHLiveObjectSetDigest { digest })
                     .await?;
                 info!("State snapshot creation successful for epoch: {}", *epoch);
                 // Records the on-chain start timestamp of this epoch (= timestamp of the

--- a/crates/iota-snapshot/src/uploader.rs
+++ b/crates/iota-snapshot/src/uploader.rs
@@ -19,7 +19,7 @@ use iota_storage::{
         find_missing_epochs_dirs, path_to_filesystem, put, run_manifest_update_loop,
     },
 };
-use iota_types::messages_checkpoint::CheckpointCommitment::ECMHLiveObjectSetDigest;
+use iota_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use object_store::DynObjectStore;
 use prometheus::{
     IntCounter, IntGauge, Registry, register_int_counter_with_registry,
@@ -148,10 +148,11 @@ impl StateSnapshotUploader {
                     .get_epoch_state_commitments(*epoch)
                     .expect("Expected last checkpoint of epoch to have end of epoch data")
                     .expect("Expected end of epoch data to be present");
-                let ECMHLiveObjectSetDigest(state_hash_commitment) = commitments
+                let state_hash_commitment: ECMHLiveObjectSetDigest = commitments
                     .last()
                     .expect("Expected at least one commitment")
-                    .clone();
+                    .clone()
+                    .into();
                 state_snapshot_writer
                     .write(*epoch, db, state_hash_commitment)
                     .await?;

--- a/crates/iota-snapshot/src/uploader.rs
+++ b/crates/iota-snapshot/src/uploader.rs
@@ -154,7 +154,7 @@ impl StateSnapshotUploader {
                     .expect("Expected at least one commitment")
                 else {
                     unimplemented!(
-                        "A new CheckpointCommitment variant was added and must be handled"
+                        "a new CheckpointCommitment variant was added and must be handled"
                     )
                 };
                 state_snapshot_writer

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -62,7 +62,7 @@ use iota_types::{
     committee::QUORUM_THRESHOLD,
     crypto::AuthorityPublicKeyBytes,
     global_state_hash::GlobalStateHash,
-    messages_checkpoint::{CheckpointCommitment, ECMHLiveObjectSetDigest},
+    messages_checkpoint::ECMHLiveObjectSetDigest,
     messages_grpc::{
         LayoutGenerationOption, ObjectInfoRequest, ObjectInfoRequestKind, ObjectInfoResponse,
         TransactionInfoRequest, TransactionStatus,
@@ -938,26 +938,23 @@ pub async fn download_formal_snapshot(
                 digest commitment. If restoring from mainnet, `--epoch` must be > 20, \
                 and for testnet, `--epoch` must be > 12.",
             );
-        match commitment {
-            CheckpointCommitment::ECMHLiveObjectSetDigest(consensus_digest) => {
-                let local_digest: ECMHLiveObjectSetDigest = root_global_state_hash.digest().into();
-                assert_eq!(
-                    *consensus_digest, local_digest,
-                    "End of epoch {} root state digest {} does not match \
-                    local root state hash {} computed from snapshot data",
-                    epoch, consensus_digest.digest, local_digest.digest,
-                );
-                let progress_bar = m.add(
-                    ProgressBar::new(1).with_style(
-                        ProgressStyle::with_template(
-                            "[{elapsed_precise}] {wide_bar} Verifying snapshot contents against root state hash ({msg})",
-                        )
-                        .unwrap(),
-                    ),
-                );
-                progress_bar.finish_with_message("Verification complete");
-            }
-        };
+        let consensus_digest: ECMHLiveObjectSetDigest = commitment.clone().into();
+        let local_digest: ECMHLiveObjectSetDigest = root_global_state_hash.digest().into();
+        assert_eq!(
+            consensus_digest, local_digest,
+            "End of epoch {} root state digest {} does not match \
+            local root state hash {} computed from snapshot data",
+            epoch, consensus_digest.digest, local_digest.digest,
+        );
+        let progress_bar = m.add(
+            ProgressBar::new(1).with_style(
+                ProgressStyle::with_template(
+                    "[{elapsed_precise}] {wide_bar} Verifying snapshot contents against root state hash ({msg})",
+                )
+                .unwrap(),
+            ),
+        );
+        progress_bar.finish_with_message("Verification complete");
     } else {
         m.println(
             "WARNING: Skipping snapshot verification! \

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -62,7 +62,7 @@ use iota_types::{
     committee::QUORUM_THRESHOLD,
     crypto::AuthorityPublicKeyBytes,
     global_state_hash::GlobalStateHash,
-    messages_checkpoint::ECMHLiveObjectSetDigest,
+    messages_checkpoint::{CheckpointCommitment, ECMHLiveObjectSetDigest},
     messages_grpc::{
         LayoutGenerationOption, ObjectInfoRequest, ObjectInfoRequestKind, ObjectInfoResponse,
         TransactionInfoRequest, TransactionStatus,
@@ -938,23 +938,29 @@ pub async fn download_formal_snapshot(
                 digest commitment. If restoring from mainnet, `--epoch` must be > 20, \
                 and for testnet, `--epoch` must be > 12.",
             );
-        let consensus_digest: ECMHLiveObjectSetDigest = commitment.clone().into();
-        let local_digest: ECMHLiveObjectSetDigest = root_global_state_hash.digest().into();
-        assert_eq!(
-            consensus_digest, local_digest,
-            "End of epoch {} root state digest {} does not match \
-            local root state hash {} computed from snapshot data",
-            epoch, consensus_digest.digest, local_digest.digest,
-        );
-        let progress_bar = m.add(
-            ProgressBar::new(1).with_style(
-                ProgressStyle::with_template(
-                    "[{elapsed_precise}] {wide_bar} Verifying snapshot contents against root state hash ({msg})",
-                )
-                .unwrap(),
-            ),
-        );
-        progress_bar.finish_with_message("Verification complete");
+        match commitment {
+            CheckpointCommitment::EcmhLiveObjectSet {
+                digest: consensus_digest,
+            } => {
+                let local_digest: ECMHLiveObjectSetDigest = root_global_state_hash.digest().into();
+                assert_eq!(
+                    *consensus_digest, local_digest.digest,
+                    "End of epoch {} root state digest {} does not match \
+                    local root state hash {} computed from snapshot data",
+                    epoch, consensus_digest, local_digest.digest,
+                );
+                let progress_bar = m.add(
+                    ProgressBar::new(1).with_style(
+                        ProgressStyle::with_template(
+                            "[{elapsed_precise}] {wide_bar} Verifying snapshot contents against root state hash ({msg})",
+                        )
+                        .unwrap(),
+                    ),
+                );
+                progress_bar.finish_with_message("Verification complete");
+            }
+            _ => unimplemented!("a new CheckpointCommitment variant was added and must be handled"),
+        };
     } else {
         m.println(
             "WARNING: Skipping snapshot verification! \

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -14,11 +14,10 @@ use fastcrypto::traits::ToFromBytes;
 use iota_sdk_types::{
     address::Address,
     checkpoint::{
-        CheckpointCommitment, CheckpointContents, CheckpointData, CheckpointSummary,
-        CheckpointTransaction, CheckpointTransactionInfo, EndOfEpochData, SignedCheckpointSummary,
+        CheckpointContents, CheckpointData, CheckpointSummary, CheckpointTransaction,
+        CheckpointTransactionInfo, EndOfEpochData, SignedCheckpointSummary,
     },
     crypto::{Bls12381PublicKey, Bls12381Signature, UserSignature},
-    digest::Digest,
     move_core::{Identifier, StructTag, TypeParseError, TypeTag},
     object::Object,
     transaction::SignedTransaction,
@@ -245,11 +244,7 @@ impl From<crate::messages_checkpoint::EndOfEpochData> for EndOfEpochData {
                 })
                 .collect(),
             next_epoch_protocol_version: value.next_epoch_protocol_version.as_u64(),
-            epoch_commitments: value
-                .epoch_commitments
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            epoch_commitments: value.epoch_commitments,
             epoch_supply_change: value.epoch_supply_change,
         }
     }
@@ -264,37 +259,8 @@ impl From<EndOfEpochData> for crate::messages_checkpoint::EndOfEpochData {
                 .map(|v| (v.public_key.into(), v.stake))
                 .collect(),
             next_epoch_protocol_version: value.next_epoch_protocol_version.into(),
-            epoch_commitments: value
-                .epoch_commitments
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            epoch_commitments: value.epoch_commitments,
             epoch_supply_change: value.epoch_supply_change,
-        }
-    }
-}
-
-impl From<crate::messages_checkpoint::CheckpointCommitment> for CheckpointCommitment {
-    fn from(value: crate::messages_checkpoint::CheckpointCommitment) -> Self {
-        let crate::messages_checkpoint::CheckpointCommitment::ECMHLiveObjectSetDigest(digest) =
-            value;
-        Self::EcmhLiveObjectSet {
-            digest: Digest::new(digest.digest.into_inner()),
-        }
-    }
-}
-
-impl From<CheckpointCommitment> for crate::messages_checkpoint::CheckpointCommitment {
-    fn from(value: CheckpointCommitment) -> Self {
-        match value {
-            CheckpointCommitment::EcmhLiveObjectSet { digest } => {
-                Self::ECMHLiveObjectSetDigest(crate::messages_checkpoint::ECMHLiveObjectSetDigest {
-                    digest: crate::digests::Digest::new(digest.into_inner()),
-                })
-            }
-            _ => unimplemented!(
-                "a new CheckpointCommitment enum variant was added and needs to be handled"
-            ),
         }
     }
 }
@@ -311,11 +277,7 @@ impl TryFrom<crate::messages_checkpoint::CheckpointSummary> for CheckpointSummar
             previous_digest: value.previous_digest,
             epoch_rolling_gas_cost_summary: value.epoch_rolling_gas_cost_summary,
             timestamp_ms: value.timestamp_ms,
-            checkpoint_commitments: value
-                .checkpoint_commitments
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            checkpoint_commitments: value.checkpoint_commitments,
             end_of_epoch_data: value.end_of_epoch_data.map(Into::into),
             version_specific_data: value.version_specific_data,
         }
@@ -335,11 +297,7 @@ impl TryFrom<CheckpointSummary> for crate::messages_checkpoint::CheckpointSummar
             previous_digest: value.previous_digest,
             epoch_rolling_gas_cost_summary: value.epoch_rolling_gas_cost_summary,
             timestamp_ms: value.timestamp_ms,
-            checkpoint_commitments: value
-                .checkpoint_commitments
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            checkpoint_commitments: value.checkpoint_commitments,
             end_of_epoch_data: value.end_of_epoch_data.map(Into::into),
             version_specific_data: value.version_specific_data,
         }

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -98,28 +98,10 @@ pub struct ECMHLiveObjectSetDigest {
     pub digest: Digest,
 }
 
-impl ECMHLiveObjectSetDigest {
-    /// Wrap this digest in the [`CheckpointCommitment`] variant that carries
-    /// it.
-    pub fn into_commitment(self) -> CheckpointCommitment {
-        CheckpointCommitment::EcmhLiveObjectSet {
-            digest: iota_sdk_types::Digest::new(self.digest.into_inner()),
-        }
-    }
-}
-
 impl From<fastcrypto::hash::Digest<32>> for ECMHLiveObjectSetDigest {
     fn from(digest: fastcrypto::hash::Digest<32>) -> Self {
         Self {
             digest: Digest::new(digest.digest),
-        }
-    }
-}
-
-impl From<CheckpointCommitment> for ECMHLiveObjectSetDigest {
-    fn from(commitment: CheckpointCommitment) -> Self {
-        Self {
-            digest: Digest::new(commitment.as_ecmh_live_object_set_digest().into_inner()),
         }
     }
 }

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -99,7 +99,8 @@ pub struct ECMHLiveObjectSetDigest {
 }
 
 impl ECMHLiveObjectSetDigest {
-    /// Wrap this digest in the [`CheckpointCommitment`] variant that carries it.
+    /// Wrap this digest in the [`CheckpointCommitment`] variant that carries
+    /// it.
     pub fn into_commitment(self) -> CheckpointCommitment {
         CheckpointCommitment::EcmhLiveObjectSet {
             digest: iota_sdk_types::Digest::new(self.digest.into_inner()),

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -89,11 +89,22 @@ pub struct CheckpointResponse {
 
 // The constituent parts of checkpoints, signed and certified
 
+pub use iota_sdk_types::checkpoint::CheckpointCommitment;
+
 /// The Sha256 digest of an EllipticCurveMultisetHash committing to the live
 /// object set.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ECMHLiveObjectSetDigest {
     pub digest: Digest,
+}
+
+impl ECMHLiveObjectSetDigest {
+    /// Wrap this digest in the [`CheckpointCommitment`] variant that carries it.
+    pub fn into_commitment(self) -> CheckpointCommitment {
+        CheckpointCommitment::EcmhLiveObjectSet {
+            digest: iota_sdk_types::Digest::new(self.digest.into_inner()),
+        }
+    }
 }
 
 impl From<fastcrypto::hash::Digest<32>> for ECMHLiveObjectSetDigest {
@@ -104,21 +115,17 @@ impl From<fastcrypto::hash::Digest<32>> for ECMHLiveObjectSetDigest {
     }
 }
 
-impl Default for ECMHLiveObjectSetDigest {
-    fn default() -> Self {
-        GlobalStateHash::default().digest().into()
+impl From<CheckpointCommitment> for ECMHLiveObjectSetDigest {
+    fn from(commitment: CheckpointCommitment) -> Self {
+        Self {
+            digest: Digest::new(commitment.as_ecmh_live_object_set_digest().into_inner()),
+        }
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum CheckpointCommitment {
-    ECMHLiveObjectSetDigest(ECMHLiveObjectSetDigest),
-    // Other commitment types (e.g. merkle roots) go here.
-}
-
-impl From<ECMHLiveObjectSetDigest> for CheckpointCommitment {
-    fn from(d: ECMHLiveObjectSetDigest) -> Self {
-        Self::ECMHLiveObjectSetDigest(d)
+impl Default for ECMHLiveObjectSetDigest {
+    fn default() -> Self {
+        GlobalStateHash::default().digest().into()
     }
 }
 


### PR DESCRIPTION
## Why

Continues the effort to remove duplicated checkpoint-family types from `iota-types` and adopt their canonical `iota_sdk_types` counterparts (cf. `Object` #11718). This is **PR 1 of the checkpoint-family track** — `CheckpointCommitment` is a leaf type, depended on by `EndOfEpochData` and `CheckpointSummary`.

## What

- Drop the node `enum CheckpointCommitment` and re-export `iota_sdk_types::checkpoint::CheckpointCommitment` in its place. It is BCS-identical (enum variant 0 + 32-byte digest), so the wire format does not change.
- Delete the now-redundant `CheckpointCommitment` `From`/`TryFrom` impls from `iota_sdk_types_conversions.rs`, and simplify the `EndOfEpochData`/`CheckpointSummary` conversions whose `commitments` fields are now the same type on both sides (the `.map(Into::into)` became a no-op).
- Keep `ECMHLiveObjectSetDigest` node-side — it's a standalone digest wrapper used by the snapshot writer and global-state hasher, and its `Default` pulls in the node-only `GlobalStateHash`. No conversion helpers are added to it: because `iota-types`' `Digest` is already a re-export of `iota_sdk_types::Digest`, its `.digest` field plugs straight into the SDK `EcmhLiveObjectSet { digest }` variant.
- Update the construction/match sites in `iota-core`, `iota-tool`, `iota-snapshot`, `iota-graphql-rpc`, and the `iota-json-rpc-types` schema wrappers to build/destructure the SDK variant directly. Since the SDK enum is `#[non_exhaustive]`, each match keeps an explicit catch-all arm that panics if a future variant is added. The JSON-RPC schema wrappers are unchanged on the wire — they still (de)serialize through `ECMHLiveObjectSetDigest`.

## Test plan

- `cargo check` across `iota-types`, `iota-core`, `iota-indexer`, `iota-json-rpc-types`, `iota-graphql-rpc`, `iota-grpc-server`, `iota-snapshot`, `iota-tool`.
- `cargo clippy --all-targets` on the touched crates — clean.
- `cargo nextest run -p iota-types -p iota-json-rpc-types` — 243 passed.
- BCS format snapshot test passes; the snapshot diff reflects only the Rust-level variant rename (`ECMHLiveObjectSetDigest` newtype → `EcmhLiveObjectSet { digest }`), not a wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
