### PR TITLE
refactor(iota-types): remove unused SignableBytes trait

### DIFF
--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -1411,13 +1411,6 @@ pub trait Signable<W> {
     fn write(&self, writer: &mut W);
 }
 
-pub trait SignableBytes
-where
-    Self: Sized,
-{
-    fn from_signable_bytes(bytes: &[u8]) -> Result<Self, Error>;
-}
-
 /// Activate the blanket implementation of `Signable` based on serde and BCS.
 /// * We use `serde_name` to extract a seed from the name of structs and enums.
 /// * We use `BCS` to generate canonical bytes suitable for hashing and signing.
@@ -1481,39 +1474,12 @@ where
     }
 }
 
-impl SignableBytes for crate::move_authenticator::MoveAuthenticator {
-    fn from_signable_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let name = "MoveAuthenticator";
-        let name_byte_len = format!("{name}::").bytes().len();
-        let inner = bcs::from_bytes(
-            bytes
-                .get(name_byte_len..)
-                .ok_or_else(|| anyhow!("Failed to deserialize to {name}."))?,
-        )?;
-        Ok(Self::from_inner(inner))
-    }
-}
-
 impl<W> Signable<W> for EpochId
 where
     W: std::io::Write,
 {
     fn write(&self, writer: &mut W) {
         bcs::serialize_into(writer, &self).expect("Message serialization should not fail");
-    }
-}
-
-impl<T> SignableBytes for T
-where
-    T: bcs_signable::BcsSignable,
-{
-    fn from_signable_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        // Remove name tag before deserialization using BCS
-        let name = serde_name::trace_name::<Self>().expect("Self should be a struct or an enum");
-        let name_byte_len = format!("{name}::").bytes().len();
-        Ok(bcs::from_bytes(bytes.get(name_byte_len..).ok_or_else(
-            || anyhow!("Failed to deserialize to {name}."),
-        )?)?)
     }
 }
 

--- a/crates/iota-types/src/move_authenticator.rs
+++ b/crates/iota-types/src/move_authenticator.rs
@@ -47,12 +47,6 @@ impl MoveAuthenticator {
         }
     }
 
-    /// Constructs a `MoveAuthenticator` from a deserialized
-    /// [`MoveAuthenticatorInner`].
-    pub(crate) fn from_inner(inner: MoveAuthenticatorInner) -> Self {
-        Self { inner }
-    }
-
     /// Computes the digest of the MoveAuthenticator.
     pub fn digest(&self) -> MoveAuthenticatorDigest {
         MoveAuthenticatorDigest::new(default_hash(self))
@@ -480,9 +474,9 @@ mod tests {
         assert!(MoveAuthenticator::from_bytes(&[flag]).is_err());
     }
 
-    // ---- Signable / SignableBytes round-trip tests ----
+    // ---- Signable (write) format tests ----
 
-    use crate::crypto::{Signable, SignableBytes};
+    use crate::crypto::Signable;
 
     /// Helper: produce the signable bytes for a MoveAuthenticator (the
     /// `"MoveAuthenticator::" ++ BCS(inner)` format).
@@ -490,15 +484,6 @@ mod tests {
         let mut buf = Vec::new();
         auth.write(&mut buf);
         buf
-    }
-
-    #[test]
-    fn signable_round_trip() {
-        let auth = make_simple_authenticator();
-        let bytes = signable_bytes(&auth);
-        let decoded = MoveAuthenticator::from_signable_bytes(&bytes)
-            .expect("round-trip via signable bytes should succeed");
-        assert_eq!(auth, decoded);
     }
 
     #[test]
@@ -520,33 +505,6 @@ mod tests {
         let payload = &bytes[tag_len..];
         let expected_bcs = bcs::to_bytes(&auth.inner).expect("BCS serialization should not fail");
         assert_eq!(payload, expected_bcs.as_slice());
-    }
-
-    #[test]
-    fn from_signable_bytes_rejects_empty() {
-        assert!(MoveAuthenticator::from_signable_bytes(&[]).is_err());
-    }
-
-    #[test]
-    fn from_signable_bytes_rejects_short_input() {
-        // Shorter than the name tag — should fail, not panic.
-        assert!(MoveAuthenticator::from_signable_bytes(b"Move").is_err());
-    }
-
-    #[test]
-    fn from_signable_bytes_rejects_tag_only() {
-        // Exact tag with no BCS payload.
-        assert!(MoveAuthenticator::from_signable_bytes(b"MoveAuthenticator::").is_err());
-    }
-
-    #[test]
-    fn from_signable_bytes_rejects_corrupt_payload() {
-        let auth = make_simple_authenticator();
-        let mut bytes = signable_bytes(&auth);
-        // Truncate the BCS payload so it is incomplete.
-        let tag_len = "MoveAuthenticator::".len();
-        bytes.truncate(tag_len + 1);
-        assert!(MoveAuthenticator::from_signable_bytes(&bytes).is_err());
     }
 
     #[test]

--- a/crates/iota-types/src/unit_tests/crypto_tests.rs
+++ b/crates/iota-types/src/unit_tests/crypto_tests.rs
@@ -5,7 +5,6 @@
 use proptest::{collection, prelude::*};
 
 use super::*;
-use crate::crypto::bcs_signable_test::Foo;
 
 #[test]
 fn serde_keypair() {
@@ -110,13 +109,6 @@ proptest! {
         let _key_pair = get_key_pair_from_bytes::<AuthorityKeyPair>(&bytes);
         let _key_pair = get_key_pair_from_bytes::<NetworkKeyPair>(&bytes);
         let _key_pair = get_key_pair_from_bytes::<AccountKeyPair>(&bytes);
-    }
-
-    #[test]
-    fn test_from_signable_bytes(
-        bytes in collection::vec(any::<u8>(), 0..1024)
-    ){
-        let _foo = Foo::from_signable_bytes(&bytes);
     }
 
     #[test]


### PR DESCRIPTION
# Description of change

The `SignableBytes` trait in `iota-types::crypto` is the BCS-decode counterpart to `Signable`'s write/encode side, exposing `from_signable_bytes(&[u8]) -> Result<Self>`. A search of the repo shows it has **no production call sites** — `from_signable_bytes` was only ever invoked from tests. The encode side (`Signable::write`) is used in production (signing checkpoints, effects, transactions, …); the decode side is not wired into any live code path.

This PR removes the dead trait and its only consumers:

- the `SignableBytes` trait definition,
- its blanket impl over `T: BcsSignable`,
- the manual `SignableBytes for MoveAuthenticator` impl,
- the now-orphaned `MoveAuthenticator::from_inner` helper (its sole caller was the removed impl), and
- the test-only call sites in `move_authenticator.rs` and `crypto_tests.rs`.

The `Signable` (write) machinery and the `bcs_signable_test` fixtures (`Foo`/`Bar`) are still used elsewhere (e.g. `base_types_tests.rs`, `messages_tests.rs`, and the verification-obligation tests) and are left untouched. The remaining `MoveAuthenticator` `signable_bytes_*` tests, which exercise the write-side format, are kept.

## Links to any relevant issues

N/A

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check -p iota-types --tests` is clean (no new warnings), and `cargo nextest run -p iota-types --lib move_authenticator crypto` passes (21 tests). The only removed tests are those that exercised the deleted `from_signable_bytes` path.