### PR TITLE
upstream(iota-json-rpc): pair checkpoint summaries with their own contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6527,6 +6527,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "prometheus",
+ "roaring",
  "serde",
  "serde_json",
  "signature 1.6.4",

--- a/crates/iota-json-rpc/Cargo.toml
+++ b/crates/iota-json-rpc/Cargo.toml
@@ -66,6 +66,7 @@ typed-store.workspace = true
 # external dependencies
 expect-test.workspace = true
 mockall.workspace = true
+roaring.workspace = true
 
 # internal dependencies
 telemetry-subscribers.workspace = true

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -33,16 +33,13 @@ use iota_storage::key_value_store::TransactionKeyValueStore;
 use iota_types::{
     base_types::{SequenceNumber, TransactionDigest},
     collection_types::VecMap,
-    crypto::AggregateAuthoritySignature,
     display::DisplayVersionUpdatedEvent,
     effects::{
         TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt, TransactionEvents,
     },
     error::IotaError,
     iota_serde::BigInt,
-    messages_checkpoint::{
-        CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, CheckpointTimestamp,
-    },
+    messages_checkpoint::{CheckpointSequenceNumber, CheckpointTimestamp},
     object::{MoveObjectExt, Object, ObjectRead, PastObjectRead},
     transaction::{Transaction, TransactionDataAPI},
 };
@@ -160,37 +157,32 @@ impl ReadApi {
         let verified_checkpoints = transaction_kv_store
             .multi_get_checkpoints_summaries(&checkpoint_numbers)
             .await?;
-
-        let checkpoint_summaries_and_signatures: Vec<(
-            CheckpointSummary,
-            AggregateAuthoritySignature,
-        )> = verified_checkpoints
-            .into_iter()
-            .flatten()
-            .map(|check| {
-                (
-                    check.clone().into_summary_and_sequence().1,
-                    check.get_validator_signature(),
-                )
-            })
-            .collect();
-
         let checkpoint_contents = transaction_kv_store
             .multi_get_checkpoints_contents(&checkpoint_numbers)
             .await?;
-        let contents: Vec<CheckpointContents> = checkpoint_contents.into_iter().flatten().collect();
 
-        let mut checkpoints: Vec<Checkpoint> = vec![];
-
-        for (summary_and_sig, content) in checkpoint_summaries_and_signatures
-            .into_iter()
-            .zip(contents)
+        // Summaries and contents are resolved from separate tables, and
+        // checkpoint pruning can delete a checkpoint's contents while leaving
+        // its sequence-addressable summary in place. Pair each summary with
+        // the contents for the *same* sequence number by zipping the two
+        // `Option` vectors index-by-index. Independently dropping the `None`s
+        // and zipping the dense remainders would shift later contents onto
+        // earlier summaries, yielding response rows whose summary and
+        // transaction list describe different checkpoints.
+        debug_assert_eq!(verified_checkpoints.len(), checkpoint_contents.len());
+        let mut checkpoints = Vec::with_capacity(checkpoint_numbers.len());
+        for (maybe_summary, maybe_contents) in
+            verified_checkpoints.into_iter().zip(checkpoint_contents)
         {
-            checkpoints.push(Checkpoint::from((
-                summary_and_sig.0,
-                content,
-                summary_and_sig.1,
-            )));
+            // Skip any sequence number whose summary or contents are
+            // unavailable (e.g. pruned) rather than pairing it with another
+            // checkpoint's data.
+            let (Some(summary), Some(contents)) = (maybe_summary, maybe_contents) else {
+                continue;
+            };
+            let signature = summary.auth_sig().signature.clone();
+            let summary = summary.into_summary_and_sequence().1;
+            checkpoints.push(Checkpoint::from((summary, contents, signature)));
         }
 
         Ok(checkpoints)
@@ -1473,7 +1465,34 @@ impl PackageStore for ReadApi {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use iota_protocol_config::ProtocolConfig;
+    use iota_sdk_types::gas::GasCostSummary;
+    use iota_storage::{
+        key_value_store::{
+            KVStoreCheckpointData, KVStoreTransactionData, TransactionKeyValueStoreTrait,
+        },
+        key_value_store_metrics::KeyValueStoreMetrics,
+    };
+    use iota_types::{
+        base_types::ExecutionDigests,
+        crypto::AuthorityStrongQuorumSignInfo,
+        digests::TransactionEffectsDigest,
+        effects::TransactionEvents,
+        error::IotaResult,
+        message_envelope::Envelope,
+        messages_checkpoint::{
+            CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest, CheckpointSummary,
+        },
+        object::Object,
+        storage::ObjectKey,
+    };
+    use mockall::mock;
+    use roaring::RoaringBitmap;
+
     use super::*;
+    use crate::authority_state::MockStateRead;
 
     #[test]
     fn test_calculate_checkpoint_numbers() {
@@ -1551,5 +1570,169 @@ mod tests {
             calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
 
         assert_eq!(checkpoint_numbers, (0..=15).rev().collect::<Vec<_>>());
+    }
+
+    mock! {
+        CheckpointKvStore {}
+        #[async_trait]
+        impl TransactionKeyValueStoreTrait for CheckpointKvStore {
+            async fn multi_get(
+                &self,
+                transactions: &[TransactionDigest],
+                effects: &[TransactionDigest],
+            ) -> IotaResult<KVStoreTransactionData>;
+
+            async fn multi_get_checkpoints(
+                &self,
+                checkpoint_summaries: &[CheckpointSequenceNumber],
+                checkpoint_contents: &[CheckpointSequenceNumber],
+                checkpoint_summaries_by_digest: &[CheckpointDigest],
+            ) -> IotaResult<KVStoreCheckpointData>;
+
+            async fn get_transaction_perpetual_checkpoint(
+                &self,
+                digest: TransactionDigest,
+            ) -> IotaResult<Option<CheckpointSequenceNumber>>;
+
+            async fn get_object(
+                &self,
+                object_id: ObjectId,
+                version: SequenceNumber,
+            ) -> IotaResult<Option<Object>>;
+
+            async fn multi_get_objects(
+                &self,
+                object_keys: &[ObjectKey],
+            ) -> IotaResult<Vec<Option<Object>>>;
+
+            async fn multi_get_transactions_perpetual_checkpoints(
+                &self,
+                digests: &[TransactionDigest],
+            ) -> IotaResult<Vec<Option<CheckpointSequenceNumber>>>;
+
+            async fn multi_get_events_by_tx_digests(
+                &self,
+                digests: &[TransactionDigest],
+            ) -> IotaResult<Vec<Option<TransactionEvents>>>;
+        }
+    }
+
+    // Builds `CheckpointContents` whose single transaction digest uniquely
+    // encodes `seq`, so a returned `Checkpoint` can be traced back to the
+    // sequence number whose contents it actually carries.
+    fn test_checkpoint_contents(seq: CheckpointSequenceNumber) -> CheckpointContents {
+        let mut tx = [0u8; 32];
+        tx[0] = 0xA;
+        tx[1..9].copy_from_slice(&seq.to_le_bytes());
+        let mut fx = [0u8; 32];
+        fx[0] = 0xE;
+        fx[1..9].copy_from_slice(&seq.to_le_bytes());
+        CheckpointContents::new_with_digests_only_for_tests([ExecutionDigests::new(
+            TransactionDigest::new(tx),
+            TransactionEffectsDigest::new(fx),
+        )])
+    }
+
+    // Builds a certified summary for `seq`. The aggregate signature is a
+    // placeholder; `get_checkpoints_internal` never verifies it.
+    fn test_certified_summary(
+        seq: CheckpointSequenceNumber,
+        contents: &CheckpointContents,
+    ) -> CertifiedCheckpointSummary {
+        let summary = CheckpointSummary::new(
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
+            0,
+            seq,
+            seq,
+            contents,
+            None,
+            GasCostSummary::default(),
+            None,
+            0,
+            Vec::new(),
+        );
+        let auth_sig = AuthorityStrongQuorumSignInfo {
+            epoch: 0,
+            signature: Default::default(),
+            signers_map: RoaringBitmap::new(),
+        };
+        Envelope::new_from_data_and_sig(summary, auth_sig)
+    }
+
+    // Regression test for a pruning-induced misalignment: when a checkpoint's
+    // contents are pruned but its sequence-addressable summary survives,
+    // `get_checkpoints_internal` must not pair that summary (or any later one)
+    // with a different checkpoint's contents.
+    #[tokio::test]
+    async fn test_get_checkpoints_internal_preserves_alignment_across_pruned_contents() {
+        let max_checkpoint: CheckpointSequenceNumber = 13;
+        // Contents for this sequence are pruned while its summary remains. It
+        // sits in the interior of the requested range to show that alignment is
+        // preserved regardless of where the hole falls.
+        let pruned_seq: CheckpointSequenceNumber = 11;
+
+        let mut all_contents: HashMap<CheckpointSequenceNumber, CheckpointContents> =
+            HashMap::new();
+        for seq in 0..=max_checkpoint {
+            all_contents.insert(seq, test_checkpoint_contents(seq));
+        }
+
+        let mut mock_state = MockStateRead::new();
+        mock_state
+            .expect_get_latest_checkpoint_sequence_number()
+            .returning(move || Ok(max_checkpoint));
+
+        let store_contents = all_contents.clone();
+        let mut mock_kv = MockCheckpointKvStore::new();
+        mock_kv.expect_multi_get_checkpoints().times(2).returning(
+            move |summaries, contents, _by_digest| {
+                // Summaries survive pruning for every requested sequence.
+                let summaries = summaries
+                    .iter()
+                    .map(|seq| Some(test_certified_summary(*seq, &store_contents[seq])))
+                    .collect();
+                // Contents are missing for the pruned sequence only.
+                let contents = contents
+                    .iter()
+                    .map(|seq| (*seq != pruned_seq).then(|| store_contents[seq].clone()))
+                    .collect();
+                Ok((summaries, contents, vec![]))
+            },
+        );
+
+        let state: Arc<dyn StateRead> = Arc::new(mock_state);
+        let kv_store = Arc::new(TransactionKeyValueStore::new(
+            "test",
+            KeyValueStoreMetrics::new_for_tests(),
+            Arc::new(mock_kv),
+        ));
+
+        // cursor = 9, ascending, limit 4 => requested sequences [10, 11, 12, 13].
+        let checkpoints = ReadApi::get_checkpoints_internal(state, kv_store, Some(9), 4, false)
+            .await
+            .unwrap();
+
+        // The pruned sequence is omitted; every other sequence is returned once.
+        assert_eq!(
+            checkpoints
+                .iter()
+                .map(|c| c.sequence_number)
+                .collect::<Vec<_>>(),
+            vec![10, 12, 13],
+        );
+
+        // Crucially, each returned checkpoint still carries the transactions of
+        // its own sequence number rather than a neighbor's.
+        for checkpoint in &checkpoints {
+            let expected: Vec<TransactionDigest> = all_contents[&checkpoint.sequence_number]
+                .iter()
+                .map(|digests| digests.transaction)
+                .collect();
+            assert_eq!(
+                checkpoint.transactions, expected,
+                "checkpoint {} was paired with another checkpoint's contents",
+                checkpoint.sequence_number,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description of change

- Port of upstream PR: [MystenLabs/sui#26964](https://github.com/MystenLabs/sui/pull/26964)
- Description:

`ReadApi::get_checkpoints_internal` fetched checkpoint summaries and contents into two `Option` vectors aligned by sequence number, then flattened each side independently before zipping the dense remainders back together. Checkpoint pruning deletes a checkpoint's contents while leaving its sequence-addressable summary in `certified_checkpoints`, so `multi_get_checkpoints` returns `Some(summary)` with `None` contents for a pruned sequence. Independently dropping the `None`s shifted every later content one slot to the left, so a summary could be paired with a different checkpoint's transaction list. Because `Checkpoint::from` copies those transactions verbatim, `iota_getCheckpoints` could return rows whose sequence number, digest, and signature described one checkpoint while the transaction list came from another.

This zips the two `Option` vectors index-by-index and only constructs a `Checkpoint` when both the summary and its contents are present; any sequence whose contents are unavailable (e.g. pruned) is skipped rather than paired with a neighbor's data. This preserves the existing "return available checkpoints, skip missing ones" behavior while keeping every response row bound to its own sequence number.

## Links to any relevant issues

N/A

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Added a regression test (`test_get_checkpoints_internal_preserves_alignment_across_pruned_contents`) that prunes the contents of an interior sequence and asserts the surviving checkpoints are returned aligned, each carrying its own transaction digests. Verified the test fails against the pre-fix flatten-then-zip logic and passes with the fix. Run with `cargo nextest run -p iota-json-rpc test_get_checkpoints_internal_preserves_alignment_across_pruned_contents`.