### PR TITLE
feat(graphql): add archival fallback for checkpoint queries

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.move
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL checkpoint queries under pruning, with no historical
+// fallback configured. Covers:
+// - top-level `Query.checkpoints` after pruning
+// - paginating with a cursor that points below the pruning watermark
+// - `Query.checkpoint(sequenceNumber)` for both pruned and unpruned seqs
+// - nested `Epoch.checkpoints` on a fully-pruned epoch and on the current one
+
+//# init --protocol-version 12 --addresses Test=0x0 --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public entry fun noop() {}
+}
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: top-level checkpoints, defaults.
+# After waiting for pruning, only unpruned checkpoints come back.
+# `hasPreviousPage` must be `false` because we clamp `absolute_lo_incl` to the
+# pruning watermark.
+{
+  checkpoints {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql
+# B: top-level checkpoints with `first: 2`.
+# `hasNextPage` should be `true` (more unpruned data above), `hasPreviousPage`
+# should be `false` (we're at the bottom of the reachable range).
+{
+  checkpoints(first: 2) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":2}
+# C: paginate forward from a cursor below the pruning watermark.
+# `c` is the view-at checkpoint, `s` is the cursor's sequence number. A cursor
+# below the watermark means the referenced data has been pruned -- the request
+# is rejected with DATA_PRUNED, telling the client to retry from scratch.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":42}
+# C2: cursor above the upper bound (viewed_at is 9, but cursor seq is 42).
+# The cursor contradicts its own `checkpoint_viewed_at`, so it's malformed --
+# return BAD_USER_INPUT.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":7}
+# D: paginate forward from a cursor sitting at the lower bound (s=7, the
+# lowest unpruned seq). The boundary is in-range, so the page returns the
+# items strictly above it.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql
+# E: Query.checkpoint(seq) for a pruned seq.
+# Should resolve to `null` -- the DataLoader can't find the row in either
+# Postgres or the (absent) fallback.
+{
+  pruned: checkpoint(id: { sequenceNumber: 0 }) {
+    sequenceNumber
+  }
+}
+
+//# run-graphql
+# F: Query.checkpoint(seq) for an unpruned seq -- resolves to the row.
+{
+  unpruned: checkpoint(id: { sequenceNumber: 7 }) {
+    sequenceNumber
+  }
+}
+
+//# run-graphql
+# G: nested Epoch.checkpoints on a fully-pruned epoch.
+# Epoch 0's range is entirely below the watermark; without a fallback we have
+# no way to serve any of its checkpoints. `epochId` resolves, the
+# `checkpoints` sub-field errors with DATA_PRUNED.
+{
+  epoch(id: 0) {
+    epochId
+    checkpoints {
+      pageInfo { hasPreviousPage hasNextPage }
+      nodes { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql
+# H: nested Epoch.checkpoints on the unpruned epoch -- paginates normally.
+{
+  epoch(id: 3) {
+    epochId
+    checkpoints {
+      pageInfo { hasPreviousPage hasNextPage }
+      nodes { sequenceNumber }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.snap
@@ -1,0 +1,231 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 20 tasks
+
+task 1, lines 13-16:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3374400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 18:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, line 20:
+//# advance-epoch
+Epoch advanced: 0
+
+task 4, line 22:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 5, line 24:
+//# advance-epoch
+Epoch advanced: 1
+
+task 6, line 26:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 7, line 28:
+//# advance-epoch
+Epoch advanced: 2
+
+task 8, line 30:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 9, line 32:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 10, line 34:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 11, lines 36-46:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 12, lines 48-57:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 13, lines 59-69:
+//# run-graphql --cursors {"c":9,"s":2}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: `after` cursor (seq 2) is below the available range 7..=9",
+      "locations": [
+        {
+          "line": 6,
+          "column": 3
+        }
+      ],
+      "path": [
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 14, lines 71-80:
+//# run-graphql --cursors {"c":9,"s":42}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "`after` cursor (seq 42) is above the available range 7..=9",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 15, lines 82-91:
+//# run-graphql --cursors {"c":9,"s":7}
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 16, lines 93-101:
+//# run-graphql
+Response: {
+  "data": {
+    "pruned": null
+  }
+}
+
+task 17, lines 103-109:
+//# run-graphql
+Response: {
+  "data": {
+    "unpruned": {
+      "sequenceNumber": 7
+    }
+  }
+}
+
+task 18, lines 111-124:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "epochId": 0
+    }
+  },
+  "errors": [
+    {
+      "message": "Requested data has been pruned: all checkpoints in the requested range have been pruned",
+      "locations": [
+        {
+          "line": 8,
+          "column": 5
+        }
+      ],
+      "path": [
+        "epoch",
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 19, lines 126-136:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 7
+          },
+          {
+            "sequenceNumber": 8
+          },
+          {
+            "sequenceNumber": 9
+          }
+        ],
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        }
+      },
+      "epochId": 3
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/src/error.rs
+++ b/crates/iota-graphql-rpc/src/error.rs
@@ -14,6 +14,7 @@ use iota_names::error::IotaNamesError;
 pub(crate) mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
     pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
+    pub const DATA_PRUNED: &str = "DATA_PRUNED";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";
     pub const REQUEST_TIMEOUT: &str = "REQUEST_TIMEOUT";
     pub const UNKNOWN: &str = "UNKNOWN";
@@ -77,6 +78,8 @@ pub enum Error {
     // Catch-all for client-fault errors
     #[error("{0}")]
     Client(String),
+    #[error("Requested data has been pruned: {0}")]
+    DataPruned(String),
     #[error("Internal error occurred while processing request: {0}")]
     Internal(String),
     #[error(transparent)]
@@ -96,6 +99,9 @@ impl ErrorExtensions for Error {
             | Error::Client(_) => {
                 e.set("code", code::BAD_USER_INPUT);
             }
+            Error::DataPruned(_) => {
+                e.set("code", code::DATA_PRUNED);
+            }
             Error::Internal(_) => {
                 e.set("code", code::INTERNAL_SERVER_ERROR);
             }
@@ -114,7 +120,10 @@ impl ErrorExtensions for Error {
 
 impl From<IndexerError> for Error {
     fn from(e: IndexerError) -> Self {
-        Error::Internal(e.to_string())
+        match e {
+            IndexerError::DataPruned(msg) => Error::DataPruned(msg),
+            _ => Error::Internal(e.to_string()),
+        }
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    ops::RangeInclusive,
+};
 
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
@@ -417,36 +420,9 @@ impl Checkpoint {
             ));
         }
 
-        // Reject cursors outside the available range. Below the lower bound means data
-        // was pruned in the middle of pagination; above the upper bound means the
-        // cursor is malformed.
-        let validate_cursor = |name: &str, cursor: Option<&Cursor>| -> Result<Option<u64>, Error> {
-            let Some(cursor) = cursor else {
-                return Ok(None);
-            };
-            let seq = cursor.sequence_number;
-            if seq < absolute_lo_incl {
-                return Err(Error::DataPruned(format!(
-                    "`{name}` cursor (seq {seq}) is below the available range {available_range:?}"
-                )));
-            }
-            if seq > absolute_hi_incl {
-                return Err(Error::Client(format!(
-                    "`{name}` cursor (seq {seq}) is above the available range {available_range:?}"
-                )));
-            }
-            Ok(Some(seq))
-        };
-        // Narrow the range using cursors, keeping in mind cursors are exclusive.
-        let page_lo_incl = validate_cursor("after", page.after())?
-            .map_or(absolute_lo_incl, |s| s.saturating_add(1));
-        let page_hi_incl = validate_cursor("before", page.before())?
-            .map_or(absolute_hi_incl, |s| s.saturating_sub(1));
-
-        let page_range = page_lo_incl..=page_hi_incl;
-        if page_range.is_empty() {
+        let Some(page_range) = page.narrow_to_available_range(&available_range)? else {
             return Ok(Connection::new(false, false));
-        }
+        };
 
         // Take `limit` sequence numbers from the appropriate end of the page range.
         let limit = page.limit();
@@ -515,6 +491,63 @@ impl Checkpointed for Cursor {
 }
 
 impl ScanLimited for Cursor {}
+
+impl Page<Cursor> {
+    /// Narrow page range to the `available` range and return the inclusive
+    /// range this page should cover, or `None` if the range is empty.
+    ///
+    /// A cursor below `available.start()` returns `Error::DataPruned` (the
+    /// data was pruned since the cursor was issued). A cursor above
+    /// `available.end()` returns `Error::Client` (the cursor is malformed).
+    /// When `after > before` the range is empty and no error is returned.
+    fn narrow_to_available_range(
+        &self,
+        available: &RangeInclusive<u64>,
+    ) -> Result<Option<RangeInclusive<u64>>, Error> {
+        let lo = *available.start();
+        let hi = *available.end();
+
+        let after = self.after().map(|c| c.sequence_number);
+        let before = self.before().map(|c| c.sequence_number);
+
+        // If `after > before`, the range is empty; skip cursor validation.
+        if let (Some(after), Some(before)) = (after, before) {
+            if after > before {
+                return Ok(None);
+            }
+        }
+
+        let ensure_in_available_range = |name: &str, seq: u64| -> Result<(), Error> {
+            if seq < lo {
+                return Err(Error::DataPruned(format!(
+                    "`{name}` cursor (seq {seq}) is below the available range {available:?}"
+                )));
+            }
+            if seq > hi {
+                return Err(Error::Client(format!(
+                    "`{name}` cursor (seq {seq}) is above the available range {available:?}"
+                )));
+            }
+            Ok(())
+        };
+        if let Some(seq) = after {
+            ensure_in_available_range("after", seq)?;
+        }
+        if let Some(seq) = before {
+            ensure_in_available_range("before", seq)?;
+        }
+
+        // Cursors are exclusive.
+        let page_lo = after.map(|seq| seq.saturating_add(1)).unwrap_or(lo);
+        let page_hi = before.map(|seq| seq.saturating_sub(1)).unwrap_or(hi);
+        let range = page_lo..=page_hi;
+        if range.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(range))
+        }
+    }
+}
 
 impl Loader<SeqNumKey> for Db {
     type Value = Checkpoint;

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
@@ -11,7 +11,9 @@ use async_graphql::{
 };
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
-use iota_indexer::{models::checkpoints::StoredCheckpoint, schema::checkpoints};
+use iota_indexer::{
+    models::checkpoints::StoredCheckpoint, pruning::CommitterTables, schema::checkpoints,
+};
 use iota_types::messages_checkpoint::CheckpointDigest;
 use serde::{Deserialize, Serialize};
 
@@ -373,6 +375,9 @@ impl Checkpoint {
     ///
     /// If the `Page<Cursor>` is set, then this function will defer to the
     /// `checkpoint_viewed_at` in the cursor if they are consistent.
+    ///
+    /// Specifying cursor or requesting epoch from the pruned range will result
+    /// in an error.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
@@ -386,37 +391,73 @@ impl Checkpoint {
             return Ok(Connection::new(false, false));
         }
 
-        let Some((absolute_lo_incl, absolute_hi_incl)) =
+        let Some((mut absolute_lo_incl, absolute_hi_incl)) =
             Self::pagination_range(db, filter, checkpoint_viewed_at).await?
         else {
             return Ok(Connection::new(false, false));
         };
 
-        // Narrow by the page's cursors, keeping in mind cursors are exclusive.
-        let page_lo_incl = match page.after() {
-            Some(cursor) => absolute_lo_incl.max(cursor.sequence_number.saturating_add(1)),
-            None => absolute_lo_incl,
-        };
-        let page_hi_incl = match page.before() {
-            Some(cursor) => absolute_hi_incl.min(cursor.sequence_number.saturating_sub(1)),
-            None => absolute_hi_incl,
-        };
+        // Without a fallback, anything below the pruning watermark is unreachable
+        if !db.inner.is_fallback_enabled() {
+            if let Some(lowest_unpruned_cp) = db
+                .inner
+                .watermark_cache()
+                .get_lowest_available_cp_for_tables(&[CommitterTables::Checkpoints])
+                .map(|w| w as u64)
+            {
+                absolute_lo_incl = absolute_lo_incl.max(lowest_unpruned_cp);
+            }
+        }
 
-        if page_lo_incl > page_hi_incl {
+        let available_range = absolute_lo_incl..=absolute_hi_incl;
+
+        if available_range.is_empty() {
+            return Err(Error::DataPruned(
+                "all checkpoints in the requested range have been pruned".into(),
+            ));
+        }
+
+        // Reject cursors outside the available range. Below the lower bound means data
+        // was pruned in the middle of pagination; above the upper bound means the
+        // cursor is malformed.
+        let validate_cursor = |name: &str, cursor: Option<&Cursor>| -> Result<Option<u64>, Error> {
+            let Some(cursor) = cursor else {
+                return Ok(None);
+            };
+            let seq = cursor.sequence_number;
+            if seq < absolute_lo_incl {
+                return Err(Error::DataPruned(format!(
+                    "`{name}` cursor (seq {seq}) is below the available range {available_range:?}"
+                )));
+            }
+            if seq > absolute_hi_incl {
+                return Err(Error::Client(format!(
+                    "`{name}` cursor (seq {seq}) is above the available range {available_range:?}"
+                )));
+            }
+            Ok(Some(seq))
+        };
+        // Narrow the range using cursors, keeping in mind cursors are exclusive.
+        let page_lo_incl = validate_cursor("after", page.after())?
+            .map_or(absolute_lo_incl, |s| s.saturating_add(1));
+        let page_hi_incl = validate_cursor("before", page.before())?
+            .map_or(absolute_hi_incl, |s| s.saturating_sub(1));
+
+        let page_range = page_lo_incl..=page_hi_incl;
+        if page_range.is_empty() {
             return Ok(Connection::new(false, false));
         }
 
-        // Take `limit` sequence numbers from the appropriate end of [lo, hi].
+        // Take `limit` sequence numbers from the appropriate end of the page range.
         let limit = page.limit();
         let picked_seqs: Vec<u64> = if page.is_from_front() {
-            (page_lo_incl..=page_hi_incl).take(limit).collect()
+            page_range.take(limit).collect()
         } else {
-            (page_lo_incl..=page_hi_incl).rev().take(limit).collect()
+            page_range.rev().take(limit).collect()
         };
-        let expected_count = picked_seqs.len();
         let mut all_rows: Vec<StoredCheckpoint> = db
             .inner
-            .get_stored_checkpoints_by_seqs_with_fallback(picked_seqs)
+            .get_stored_checkpoints_by_seqs_with_fallback(picked_seqs.clone())
             .await
             .map_err(|err| Error::Internal(format!("Failed to fetch checkpoints: {err}")))?
             .into_iter()
@@ -424,19 +465,22 @@ impl Checkpoint {
             .collect();
         all_rows.sort_by_key(|s| s.sequence_number);
 
-        if all_rows.is_empty() {
-            return Err(Error::Internal(
-                "checkpoints in the requested page have been pruned and are not available in fallback storage".into(),
-            ));
+        // We validated the available range earlier, unpruned range should be present in
+        // the DB, rest should be present in fallback KV if configured. In such case we
+        // expect all checkpoints to be returned.
+        if all_rows.len() < picked_seqs.len() {
+            let picked: BTreeSet<u64> = picked_seqs.iter().copied().collect();
+            let returned: BTreeSet<u64> =
+                all_rows.iter().map(|r| r.sequence_number as u64).collect();
+            let misses: Vec<u64> = picked.difference(&returned).copied().collect();
+            return Err(Error::Internal(format!(
+                "checkpoints {misses:?} expected to be available but not found"
+            )));
         }
 
         let fetched_lo = all_rows.first().expect("checked non-empty").sequence_number as u64;
         let fetched_hi = all_rows.last().expect("checked non-empty").sequence_number as u64;
-
-        // Pruning progresses from the `lo` side. Too few rows returned -> no usable
-        // previous page.
-        let fully_unpruned_page = all_rows.len() == expected_count;
-        let has_prev = fully_unpruned_page && fetched_lo > absolute_lo_incl;
+        let has_prev = fetched_lo > absolute_lo_incl;
         let has_next = fetched_hi < absolute_hi_incl;
 
         let mut conn = Connection::new(has_prev, has_next);
@@ -521,13 +565,7 @@ impl Loader<DigestKey> for Db {
     type Error = Error;
 
     async fn load(&self, keys: &[DigestKey]) -> Result<HashMap<DigestKey, Checkpoint>, Error> {
-        let digests: Vec<CheckpointDigest> = keys
-            .iter()
-            .map(|key| {
-                CheckpointDigest::from_bytes(key.digest.to_vec())
-                    .map_err(|e| Error::Internal(format!("Invalid CheckpointDigest: {e}")))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let digests: Vec<CheckpointDigest> = keys.iter().map(|key| key.digest.into()).collect();
 
         let rows = self
             .inner

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
@@ -19,11 +19,11 @@ use crate::{
     config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::Checkpointed,
-    data::{self, Conn, DataLoader, Db, DbConnection, QueryExecutor},
+    data::{Conn, DataLoader, Db, DbConnection, QueryExecutor},
     error::Error,
     types::{
         base64::Base64,
-        cursor::{self, Page, Paginated, ScanLimited, Target},
+        cursor::{self, Page, ScanLimited, Target},
         date_time::DateTime,
         digest::Digest,
         epoch::Epoch,
@@ -71,7 +71,6 @@ pub(crate) struct Checkpoint {
 }
 
 pub(crate) type Cursor = cursor::JsonCursor<CheckpointCursor>;
-type Query<ST, GB> = data::Query<ST, checkpoints::table, GB>;
 
 /// The cursor returned for each `Checkpoint` in a connection's page of results.
 /// The `checkpoint_viewed_at` will set the consistent upper bound for
@@ -322,6 +321,44 @@ impl Checkpoint {
         Ok(stored as u64)
     }
 
+    /// Returns the inclusive `[lo, hi]` checkpoint sequence-number range to
+    /// paginate over, given the `checkpoint_viewed_at` and optional `epoch`
+    /// filter. Returns `None` when `filter` targets an epoch that does not
+    /// exist.
+    ///
+    /// The `epochs` table is never pruned but an in-progress epoch's
+    /// `last_checkpoint_id` is NULL - in that case the upper bound is
+    /// capped at `checkpoint_viewed_at`.
+    async fn pagination_range(
+        db: &Db,
+        filter: Option<u64>,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Option<(u64, u64)>, Error> {
+        let Some(epoch) = filter else {
+            return Ok(Some((0, checkpoint_viewed_at)));
+        };
+
+        let row: Option<(i64, Option<i64>)> = db
+            .execute(move |conn| {
+                use iota_indexer::schema::epochs::dsl as e;
+                conn.first(move || {
+                    e::epochs
+                        .select((e::first_checkpoint_id, e::last_checkpoint_id))
+                        .filter(e::epoch.eq(epoch as i64))
+                })
+                .optional()
+            })
+            .await
+            .map_err(|err| Error::Internal(format!("Failed to fetch epoch range: {err}")))?;
+
+        Ok(row.map(|(first, last)| {
+            let hi = last
+                .map(|l| std::cmp::min(l as u64, checkpoint_viewed_at))
+                .unwrap_or(checkpoint_viewed_at);
+            (first as u64, hi)
+        }))
+    }
+
     /// Query the database for a `page` of checkpoints. The Page uses the
     /// checkpoint sequence number of the stored checkpoint and the
     /// checkpoint at which this was viewed at as the cursor, and
@@ -342,31 +379,68 @@ impl Checkpoint {
         filter: Option<u64>,
         checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, Checkpoint>, Error> {
-        use checkpoints::dsl;
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredCheckpoint, _, _, _>(
-                    conn,
-                    checkpoint_viewed_at,
-                    move || {
-                        let mut query = dsl::checkpoints.into_boxed();
-                        query = query.filter(dsl::sequence_number.le(checkpoint_viewed_at as i64));
-                        if let Some(epoch) = filter {
-                            query = query.filter(dsl::epoch.eq(epoch as i64));
-                        }
-                        query
-                    },
-                )
-            })
-            .await?;
+        if page.limit() == 0 {
+            return Ok(Connection::new(false, false));
+        }
 
-        // The "checkpoint viewed at" sets a consistent upper bound for the nested
-        // queries.
-        let mut conn = Connection::new(prev, next);
-        for stored in results {
+        let Some((absolute_lo_incl, absolute_hi_incl)) =
+            Self::pagination_range(db, filter, checkpoint_viewed_at).await?
+        else {
+            return Ok(Connection::new(false, false));
+        };
+
+        // Narrow by the page's cursors, keeping in mind cursors are exclusive.
+        let page_lo_incl = match page.after() {
+            Some(cursor) => absolute_lo_incl.max(cursor.sequence_number.saturating_add(1)),
+            None => absolute_lo_incl,
+        };
+        let page_hi_incl = match page.before() {
+            Some(cursor) => absolute_hi_incl.min(cursor.sequence_number.saturating_sub(1)),
+            None => absolute_hi_incl,
+        };
+
+        if page_lo_incl > page_hi_incl {
+            return Ok(Connection::new(false, false));
+        }
+
+        // Take `limit` sequence numbers from the appropriate end of [lo, hi].
+        let limit = page.limit();
+        let picked_seqs: Vec<u64> = if page.is_from_front() {
+            (page_lo_incl..=page_hi_incl).take(limit).collect()
+        } else {
+            (page_lo_incl..=page_hi_incl).rev().take(limit).collect()
+        };
+        let expected_count = picked_seqs.len();
+        let mut all_rows: Vec<StoredCheckpoint> = db
+            .inner
+            .get_stored_checkpoints_by_seqs_with_fallback(picked_seqs)
+            .await
+            .map_err(|err| Error::Internal(format!("Failed to fetch checkpoints: {err}")))?
+            .into_iter()
+            .flatten()
+            .collect();
+        all_rows.sort_by_key(|s| s.sequence_number);
+
+        if all_rows.is_empty() {
+            return Err(Error::Internal(
+                "checkpoints in the requested page have been pruned and are not available in fallback storage".into(),
+            ));
+        }
+
+        let fetched_lo = all_rows.first().expect("checked non-empty").sequence_number as u64;
+        let fetched_hi = all_rows.last().expect("checked non-empty").sequence_number as u64;
+
+        // Pruning progresses from the `lo` side. Too few rows returned -> no usable
+        // previous page.
+        let fully_unpruned_page = all_rows.len() == expected_count;
+        let has_prev = fully_unpruned_page && fetched_lo > absolute_lo_incl;
+        let has_next = fetched_hi < absolute_hi_incl;
+
+        let mut conn = Connection::new(has_prev, has_next);
+        for stored in all_rows {
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
             conn.edges.push(Edge::new(
                 cursor,
@@ -378,27 +452,6 @@ impl Checkpoint {
         }
 
         Ok(conn)
-    }
-}
-
-impl Paginated<Cursor> for StoredCheckpoint {
-    type Source = checkpoints::table;
-
-    fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.ge(cursor.sequence_number as i64))
-    }
-
-    fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.le(cursor.sequence_number as i64))
-    }
-
-    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
-        use checkpoints::dsl;
-        if asc {
-            query.order(dsl::sequence_number)
-        } else {
-            query.order(dsl::sequence_number.desc())
-        }
     }
 }
 
@@ -424,30 +477,23 @@ impl Loader<SeqNumKey> for Db {
     type Error = Error;
 
     async fn load(&self, keys: &[SeqNumKey]) -> Result<HashMap<SeqNumKey, Checkpoint>, Error> {
-        use checkpoints::dsl;
-
-        let checkpoint_ids: BTreeSet<_> = keys
+        // Drop keys querying for a checkpoint after their own consistency cursor.
+        let seqs: Vec<u64> = keys
             .iter()
-            .filter_map(|key| {
-                // Filter out keys querying for checkpoints after their own consistency cursor.
-                (key.checkpoint_viewed_at >= key.sequence_number)
-                    .then_some(key.sequence_number as i64)
-            })
+            .filter(|key| key.checkpoint_viewed_at >= key.sequence_number)
+            .map(|key| key.sequence_number)
             .collect();
 
-        let checkpoints: Vec<StoredCheckpoint> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    dsl::checkpoints
-                        .filter(dsl::sequence_number.eq_any(checkpoint_ids.iter().cloned()))
-                })
-            })
+        let rows = self
+            .inner
+            .get_stored_checkpoints_by_seqs_with_fallback(seqs.clone())
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoints: {e}")))?;
 
-        let checkpoint_id_to_stored: BTreeMap<_, _> = checkpoints
+        let checkpoint_id_to_stored: BTreeMap<u64, StoredCheckpoint> = seqs
             .into_iter()
-            .map(|stored| (stored.sequence_number as u64, stored))
+            .zip(rows)
+            .filter_map(|(seq, row)| row.map(|stored| (seq, stored)))
             .collect();
 
         Ok(keys
@@ -475,22 +521,24 @@ impl Loader<DigestKey> for Db {
     type Error = Error;
 
     async fn load(&self, keys: &[DigestKey]) -> Result<HashMap<DigestKey, Checkpoint>, Error> {
-        use checkpoints::dsl;
-
-        let digests: BTreeSet<_> = keys.iter().map(|key| key.digest.to_vec()).collect();
-
-        let checkpoints: Vec<StoredCheckpoint> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    dsl::checkpoints.filter(dsl::checkpoint_digest.eq_any(digests.iter().cloned()))
-                })
+        let digests: Vec<CheckpointDigest> = keys
+            .iter()
+            .map(|key| {
+                CheckpointDigest::from_bytes(key.digest.to_vec())
+                    .map_err(|e| Error::Internal(format!("Invalid CheckpointDigest: {e}")))
             })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let rows = self
+            .inner
+            .get_stored_checkpoints_by_digests_with_fallback(digests.clone())
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoints: {e}")))?;
 
-        let checkpoint_id_to_stored: BTreeMap<_, _> = checkpoints
+        let checkpoint_id_to_stored: BTreeMap<Vec<u8>, StoredCheckpoint> = digests
             .into_iter()
-            .map(|stored| (stored.checkpoint_digest.clone(), stored))
+            .zip(rows)
+            .filter_map(|(digest, row)| row.map(|stored| (digest.inner().to_vec(), stored)))
             .collect();
 
         Ok(keys

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -507,39 +507,36 @@ impl Page<Cursor> {
         let lo = *available.start();
         let hi = *available.end();
 
-        let after = self.after().map(|c| c.sequence_number);
-        let before = self.before().map(|c| c.sequence_number);
+        let after = self.after().map(|c| ("after", c.sequence_number));
+        let before = self.before().map(|c| ("before", c.sequence_number));
 
         // If `after > before`, the range is empty; skip cursor validation.
-        if let (Some(after), Some(before)) = (after, before) {
-            if after > before {
+        if let (Some((_, after_seq)), Some((_, before_seq))) = (after, before) {
+            if after_seq > before_seq {
                 return Ok(None);
             }
         }
 
-        let ensure_in_available_range = |name: &str, seq: u64| -> Result<(), Error> {
+        // Since `after <= before`, it's enough to check if the smaller cursor is below
+        // `lo`. Analogously for `hi`.
+        if let Some((name, seq)) = after.or(before) {
             if seq < lo {
                 return Err(Error::DataPruned(format!(
                     "`{name}` cursor (seq {seq}) is below the available range {available:?}"
                 )));
             }
+        }
+        if let Some((name, seq)) = before.or(after) {
             if seq > hi {
                 return Err(Error::Client(format!(
                     "`{name}` cursor (seq {seq}) is above the available range {available:?}"
                 )));
             }
-            Ok(())
-        };
-        if let Some(seq) = after {
-            ensure_in_available_range("after", seq)?;
-        }
-        if let Some(seq) = before {
-            ensure_in_available_range("before", seq)?;
         }
 
         // Cursors are exclusive.
-        let page_lo = after.map(|seq| seq.saturating_add(1)).unwrap_or(lo);
-        let page_hi = before.map(|seq| seq.saturating_sub(1)).unwrap_or(hi);
+        let page_lo = after.map(|(_, seq)| seq.saturating_add(1)).unwrap_or(lo);
+        let page_hi = before.map(|(_, seq)| seq.saturating_sub(1)).unwrap_or(hi);
         let range = page_lo..=page_hi;
         if range.is_empty() {
             Ok(None)

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -21,7 +21,7 @@ use iota_types::{
     event::EventID,
     full_checkpoint_content::CheckpointTransaction,
     messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest, CheckpointSequenceNumber,
     },
     object::Object,
 };
@@ -266,6 +266,60 @@ impl HistoricalFallbackReader {
             .collect();
 
         Ok(checkpoints)
+    }
+
+    /// Fetches multiple checkpoints by their digests from the historical
+    /// fallback storage. The returned vector has the same length as `digests`
+    /// and preserves its order; missing entries become `None`.
+    ///
+    /// # NOTE
+    /// As with [`Self::checkpoints`], `StoredCheckpoint.successful_tx_num` is
+    /// hardcoded to 0 in fallback-returned data.
+    pub(crate) async fn checkpoints_by_digests(
+        &self,
+        digests: Vec<CheckpointDigest>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let summaries = self
+            .client
+            .multi_get_checkpoints_summaries_by_digests(&digests)
+            .await?;
+
+        let mut seqs_for_contents: Vec<CheckpointSequenceNumber> = summaries
+            .iter()
+            .filter_map(|s| s.as_ref().map(|s| s.sequence_number))
+            .collect();
+        seqs_for_contents.sort_unstable();
+        seqs_for_contents.dedup();
+
+        if seqs_for_contents.is_empty() {
+            return Ok(vec![None; digests.len()]);
+        }
+
+        let contents = self
+            .client
+            .multi_get_checkpoints_contents(&seqs_for_contents)
+            .await?;
+        let content_by_seq: HashMap<CheckpointSequenceNumber, CheckpointContents> =
+            seqs_for_contents
+                .iter()
+                .zip(contents)
+                .filter_map(|(seq, content)| content.map(|c| (*seq, c)))
+                .collect();
+
+        let result = summaries
+            .into_iter()
+            .map(|summary| {
+                let summary = summary?;
+                let content = content_by_seq.get(&summary.sequence_number)?.clone();
+                Some(StoredCheckpoint::from((summary, content)))
+            })
+            .collect();
+
+        Ok(result)
     }
 
     /// Fetches all events belonging to the provided transaction digest.

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -273,8 +273,9 @@ impl HistoricalFallbackReader {
     /// and preserves its order; missing entries become `None`.
     ///
     /// # NOTE
-    /// As with [`Self::checkpoints`], `StoredCheckpoint.successful_tx_num` is
-    /// hardcoded to 0 in fallback-returned data.
+    /// As with [`checkpoints`](Self::checkpoints),
+    /// `StoredCheckpoint.successful_tx_num` is hardcoded to 0 in
+    /// fallback-returned data.
     pub(crate) async fn checkpoints_by_digests(
         &self,
         digests: Vec<CheckpointDigest>,

--- a/crates/iota-indexer/src/pruning/mod.rs
+++ b/crates/iota-indexer/src/pruning/mod.rs
@@ -4,3 +4,5 @@
 
 pub mod pruner;
 pub mod watermark_task;
+
+pub use crate::ingestion::common::persist::CommitterTables;

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -208,6 +208,13 @@ impl IndexerReader {
         self.fallback.as_ref()
     }
 
+    /// Returns `true` if a historical fallback reader is configured on this
+    /// `IndexerReader`. Callers can use this to decide whether pruned-range
+    /// reads will be served by the fallback.
+    pub fn is_fallback_enabled(&self) -> bool {
+        self.fallback.is_some()
+    }
+
     /// Accesses the watermark cache.
     pub fn watermark_cache(&self) -> &WatermarkCache {
         &self.watermark_cache

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -800,6 +800,87 @@ impl IndexerReader {
             .collect()
     }
 
+    /// Fetches a batch of checkpoints by sequence number. Each requested seq
+    /// resolves to `Some(StoredCheckpoint)` if it lives in Postgres or in the
+    /// historical fallback (when enabled), or to `None` otherwise. The
+    /// returned vector has the same length as `seqs` and preserves its order.
+    pub async fn get_stored_checkpoints_by_seqs_with_fallback(
+        &self,
+        seqs: Vec<CheckpointSequenceNumber>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if seqs.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let db_rows = self.db().multi_get_checkpoints_by_seqs(&seqs).await?;
+        let mut by_seq: HashMap<CheckpointSequenceNumber, StoredCheckpoint> = db_rows
+            .into_iter()
+            .map(|c| (c.sequence_number as u64, c))
+            .collect();
+
+        let missing: Vec<CheckpointSequenceNumber> = seqs
+            .iter()
+            .copied()
+            .filter(|s| !by_seq.contains_key(s))
+            .collect();
+        if !missing.is_empty() {
+            if let Some(fallback) = self.fallback_reader() {
+                for stored in fallback.checkpoints(missing).await?.into_iter().flatten() {
+                    by_seq.insert(stored.sequence_number as u64, stored);
+                }
+            }
+        }
+
+        Ok(seqs.into_iter().map(|s| by_seq.get(&s).cloned()).collect())
+    }
+
+    /// Fetches a batch of checkpoints by digest. Each requested digest
+    /// resolves to `Some(StoredCheckpoint)` if it lives in Postgres or in the
+    /// historical fallback (when enabled), or to `None` otherwise. The
+    /// returned vector has the same length as `digests` and preserves its
+    /// order.
+    pub async fn get_stored_checkpoints_by_digests_with_fallback(
+        &self,
+        digests: Vec<CheckpointDigest>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let digest_bytes: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
+        let db_rows = self
+            .db()
+            .multi_get_checkpoints_by_digests(&digest_bytes)
+            .await?;
+        let mut by_digest: HashMap<Vec<u8>, StoredCheckpoint> = db_rows
+            .into_iter()
+            .map(|c| (c.checkpoint_digest.clone(), c))
+            .collect();
+
+        let missing: Vec<CheckpointDigest> = digests
+            .iter()
+            .filter(|d| !by_digest.contains_key(d.inner().as_slice()))
+            .copied()
+            .collect();
+        if !missing.is_empty() {
+            if let Some(fallback) = self.fallback_reader() {
+                for stored in fallback
+                    .checkpoints_by_digests(missing)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                {
+                    by_digest.insert(stored.checkpoint_digest.clone(), stored);
+                }
+            }
+        }
+
+        Ok(digests
+            .into_iter()
+            .map(|d| by_digest.get(d.inner().as_slice()).cloned())
+            .collect())
+    }
+
     /// Fetches multiple transactions from the database.
     ///
     ///  Retrieval order:
@@ -2922,6 +3003,42 @@ impl<'a> DBReader<'a> {
         }
 
         Ok(checkpoint)
+    }
+
+    /// Fetches from the `checkpoints` table by sequence numbers list.
+    /// Pruned/missing seqs are simply absent from the result.
+    async fn multi_get_checkpoints_by_seqs(
+        &self,
+        seqs: &[CheckpointSequenceNumber],
+    ) -> IndexerResult<Vec<StoredCheckpoint>> {
+        if seqs.is_empty() {
+            return Ok(vec![]);
+        }
+        let seqs_i64: Vec<i64> = seqs.iter().map(|s| *s as i64).collect();
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            checkpoints::dsl::checkpoints
+                .filter(checkpoints::sequence_number.eq_any(seqs_i64))
+                .load::<StoredCheckpoint>(conn)
+        })
+    }
+
+    /// Fetches from the `checkpoints` table by digests list.
+    /// Pruned/missing digests are simply absent from the result.
+    async fn multi_get_checkpoints_by_digests(
+        &self,
+        digests: &[Vec<u8>],
+    ) -> IndexerResult<Vec<StoredCheckpoint>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+        let digests = digests.to_vec();
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            checkpoints::dsl::checkpoints
+                .filter(checkpoints::checkpoint_digest.eq_any(digests))
+                .load::<StoredCheckpoint>(conn)
+        })
     }
 
     async fn get_checkpoints(


### PR DESCRIPTION
# Description of change

Makes the GraphQL `Query.checkpoint(id)` and `Query.checkpoints(...)` resolvers fall back to the historical fallback storage when reading checkpoints whose rows have been pruned from Postgres.

### New loaders

- **`IndexerReader::get_stored_checkpoints_by_seqs_with_fallback`** — reads checkpoints by their sequence numbers from Postgres, falls back to historical fallback storage if needed. 
- **`IndexerReader::get_stored_checkpoints_by_digests_with_fallback`** — same as above but with "digest" key.


-------


- **`DBReader::multi_get_checkpoints_by_seqs`** — internal helper; runs one Diesel query to load checkpoint rows for a list of sequence numbers.
- **`DBReader::multi_get_checkpoints_by_digests`** — internal helper; runs one Diesel query to load checkpoint rows for a list of digests.


----------


- **`HistoricalFallbackReader::checkpoints_by_digests`** — reads a batch of checkpoints from the historical fallback storage by their digests (analogous to already existing `checkpoints` function)

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11934

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

**Setup:** 10 checkpoints across 4 epochs (epoch 0: cps 0–2, epoch 1: cps 3–4, epoch 2: cps 5–6, epoch 3: cps 7–9). With `--epochs-to-keep 1` and `--wait-for-checkpoint-pruned 6`, cps 0–6 are pruned and cps 7–9 remain. No historical fallback configured.

| # | Input | Expected |
  |---|---|---|
  | **A** | `checkpoints { ... }` (defaults) | nodes `[7, 8, 9]`, `hasPreviousPage = false`, `hasNextPage = false` — the reachable range is `[7, 9]` and fits in one page |
  | **B** | `checkpoints(first: 2) { ... }` | nodes `[7, 8]`, `hasPreviousPage = false`, `hasNextPage = true` — at the lower bound, more above |
  | **C** | `checkpoints(first: 2, after: cursor{c: 9, s: 2})` | error `DATA_PRUNED` — cursor's seq is below the pruning watermark |
  | **C2** | `checkpoints(first: 2, after: cursor{c: 9, s: 42})` | error `BAD_USER_INPUT` — cursor's seq is above its own `checkpoint_viewed_at` (malformed) |
  | **D** | `checkpoints(first: 2, after: cursor{c: 9, s: 7})` | nodes `[8, 9]`, `hasPreviousPage = true`, `hasNextPage = false` — cursor at the lower boundary is in-range |
  | **E** | `checkpoint(id: { sequenceNumber: 0 })` | `null` — pruned, no fallback to consult |
  | **F** | `checkpoint(id: { sequenceNumber: 7 })` | `{ sequenceNumber: 7 }` — unpruned, resolves |
  | **G** | `epoch(id: 0) { epochId, checkpoints { ... } }` | `epochId: 0`; `checkpoints` errors `DATA_PRUNED` — epoch 0's range is entirely below the watermark |
  | **H** | `epoch(id: 3) { epochId, checkpoints { ... } }` | `epochId: 3`; nodes `[7, 8, 9]`, both flags `false` — unpruned epoch paginates normally |



### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.



### Release Notes

- [x] GraphQL: checkpoint queries (`Query.checkpoint`, `Query.checkpoints`, `Epoch.checkpoints`) can now read pruned checkpoints from the fallback KV store when it is configured.
