### PR TITLE
upstream(core): Add assertion to detect missing tx keys during checkpoint building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5757,6 +5757,7 @@ dependencies = [
  "object_store 0.13.1",
  "once_cell",
  "parking_lot 0.12.3",
+ "pin-project-lite",
  "pprof",
  "pretty_assertions",
  "prometheus",

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -38,6 +38,7 @@ num_cpus.workspace = true
 object_store.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
+pin-project-lite.workspace = true
 prometheus.workspace = true
 quinn-proto = "0.11.14"
 rand.workspace = true

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5821,7 +5821,7 @@ impl RandomnessRoundReceiver {
             tokio::select! {
                 maybe_recv = self.randomness_rx.recv() => {
                     if let Some((epoch, round, bytes)) = maybe_recv {
-                        self.handle_new_randomness(epoch, round, bytes);
+                        self.handle_new_randomness(epoch, round, bytes).await;
                     } else {
                         break;
                     }
@@ -5833,7 +5833,9 @@ impl RandomnessRoundReceiver {
     }
 
     #[instrument(level = "debug", skip_all, fields(?epoch, ?round))]
-    fn handle_new_randomness(&self, epoch: EpochId, round: RandomnessRound, bytes: Vec<u8>) {
+    async fn handle_new_randomness(&self, epoch: EpochId, round: RandomnessRound, bytes: Vec<u8>) {
+        fail_point_async!("randomness-delay");
+
         let epoch_store = self.authority_state.load_epoch_store_one_call_per_task();
         if epoch_store.epoch() != epoch {
             warn!(

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -10,9 +10,12 @@ mod metrics;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs::File,
+    future::Future,
     io::Write,
     path::Path,
+    pin::Pin,
     sync::{Arc, Weak},
+    task::{Context, Poll},
     time::{Duration, SystemTime},
 };
 
@@ -50,6 +53,7 @@ use iota_types::{
 use itertools::Itertools;
 use nonempty::NonEmpty;
 use parking_lot::Mutex;
+use pin_project_lite::pin_project;
 use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -1132,29 +1136,17 @@ impl CheckpointBuilder {
         let _scope = monitored_scope("CheckpointBuilder::make_checkpoint");
         let last_details = pendings.last().unwrap().details().clone();
 
-        // Keeps track of the effects that are already included in the current
-        // checkpoint. This is used when there are multiple pending checkpoints
-        // to create a single checkpoint because in such scenarios, dependencies
-        // of a transaction may in earlier created checkpoints, or in earlier
-        // pending checkpoints.
-        let mut effects_in_current_checkpoint = BTreeSet::new();
-
         // Stores the transactions that should be included in the checkpoint.
         // Transactions will be recorded in the checkpoint in this order.
-        let mut sorted_tx_effects_included_in_checkpoint = Vec::new();
-        let mut all_roots = HashSet::new();
-        for pending_checkpoint in pendings.into_iter() {
-            let pending = pending_checkpoint.into_v1();
-            debug!(
-                checkpoint_commit_height = pending.details.checkpoint_height,
-                "Resolving checkpoint transactions for pending checkpoint.",
-            );
-            let (root_digests, txn_in_checkpoint) = self
-                .resolve_checkpoint_transactions(pending.roots, &mut effects_in_current_checkpoint)
-                .await?;
-            sorted_tx_effects_included_in_checkpoint.extend(txn_in_checkpoint);
-            all_roots.extend(root_digests);
-        }
+        let highest_executed_sequence = self
+            .store
+            .get_highest_executed_checkpoint_seq_number()
+            .expect("db error")
+            .unwrap_or(0);
+
+        let (poll_count, result) = poll_count(self.resolve_checkpoint_transactions(pendings)).await;
+        let (sorted_tx_effects_included_in_checkpoint, all_roots) = result?;
+
         let new_checkpoints = self
             .create_checkpoints(
                 sorted_tx_effects_included_in_checkpoint,
@@ -1163,97 +1155,126 @@ impl CheckpointBuilder {
             )
             .await?;
         let highest_sequence = *new_checkpoints.last().0.sequence_number();
+        if highest_sequence <= highest_executed_sequence && poll_count > 1 {
+            debug_fatal!(
+                "resolve_checkpoint_transactions should be instantaneous when executed checkpoint is ahead of checkpoint builder"
+            );
+        }
+
         self.write_checkpoints(last_details.checkpoint_height, new_checkpoints)
             .await?;
         Ok(highest_sequence)
     }
 
-    // Given the root transactions of a pending checkpoint, resolve the transactions
-    // should be included in the checkpoint, and return them in the order they
-    // should be included in the checkpoint. `effects_in_current_checkpoint`
-    // tracks the transactions that already exist in the current checkpoint.
+    // Given the root transactions of the pending checkpoints, resolve the
+    // transactions that should be included in the checkpoint, and return them in
+    // the order they should be included in the checkpoint, together with all the
+    // resolved roots.
     #[instrument(level = "debug", skip_all)]
     async fn resolve_checkpoint_transactions(
         &self,
-        roots: Vec<TransactionKey>,
-        effects_in_current_checkpoint: &mut BTreeSet<TransactionDigest>,
-    ) -> IotaResult<(Vec<TransactionDigest>, Vec<TransactionEffects>)> {
+        pending_checkpoints: Vec<PendingCheckpoint>,
+    ) -> IotaResult<(Vec<TransactionEffects>, HashSet<TransactionDigest>)> {
         let _scope = monitored_scope("CheckpointBuilder::resolve_checkpoint_transactions");
 
-        self.metrics
-            .checkpoint_roots_count
-            .inc_by(roots.len() as u64);
+        // Keeps track of the effects that are already included in the current
+        // checkpoint. This is used when there are multiple pending checkpoints
+        // to create a single checkpoint because in such scenarios, dependencies
+        // of a transaction may in earlier created checkpoints, or in earlier
+        // pending checkpoints.
+        let mut effects_in_current_checkpoint = BTreeSet::new();
 
-        let root_digests = self
-            .epoch_store
-            .notify_read_executed_digests(&roots)
-            .in_monitored_scope("CheckpointNotifyDigests")
-            .await?;
-        let root_effects = self
-            .effects_store
-            .try_notify_read_executed_effects(&root_digests)
-            .in_monitored_scope("CheckpointNotifyRead")
-            .await?;
+        let mut tx_effects = Vec::new();
+        let mut tx_roots = HashSet::new();
 
-        let consensus_commit_prologue = {
-            // If the roots contains consensus commit prologue transaction, we want to
-            // extract it, and put it to the front of the checkpoint.
+        for pending_checkpoint in pending_checkpoints.into_iter() {
+            let pending = pending_checkpoint.into_v1();
+            debug!(
+                checkpoint_commit_height = pending.details.checkpoint_height,
+                roots = ?pending.roots,
+                "Resolving checkpoint transactions for pending checkpoint.",
+            );
 
-            let consensus_commit_prologue = self
-                .extract_consensus_commit_prologue(&root_digests, &root_effects)
+            let roots = &pending.roots;
+
+            self.metrics
+                .checkpoint_roots_count
+                .inc_by(roots.len() as u64);
+
+            let root_digests = self
+                .epoch_store
+                .notify_read_executed_digests(roots)
+                .in_monitored_scope("CheckpointNotifyDigests")
+                .await?;
+            let root_effects = self
+                .effects_store
+                .try_notify_read_executed_effects(&root_digests)
+                .in_monitored_scope("CheckpointNotifyRead")
                 .await?;
 
-            // Get the un-included dependencies of the consensus commit prologue. We should
-            // expect no other dependencies that haven't been included in any
-            // previous checkpoints.
-            if let Some((ccp_digest, ccp_effects)) = &consensus_commit_prologue {
-                let unsorted_ccp = self.complete_checkpoint_effects(
-                    vec![ccp_effects.clone()],
-                    effects_in_current_checkpoint,
-                )?;
+            let consensus_commit_prologue = {
+                // If the roots contains consensus commit prologue transaction, we want to
+                // extract it, and put it to the front of the checkpoint.
 
-                // No other dependencies of this consensus commit prologue that haven't been
-                // included in any previous checkpoint.
-                if unsorted_ccp.len() != 1 {
-                    fatal!(
-                        "Expected 1 consensus commit prologue, got {:?}",
-                        unsorted_ccp
-                            .iter()
-                            .map(|e| e.transaction_digest())
-                            .collect::<Vec<_>>()
-                    );
+                let consensus_commit_prologue = self
+                    .extract_consensus_commit_prologue(&root_digests, &root_effects)
+                    .await?;
+
+                // Get the un-included dependencies of the consensus commit prologue. We should
+                // expect no other dependencies that haven't been included in
+                // any previous checkpoints.
+                if let Some((ccp_digest, ccp_effects)) = &consensus_commit_prologue {
+                    let unsorted_ccp = self.complete_checkpoint_effects(
+                        vec![ccp_effects.clone()],
+                        &mut effects_in_current_checkpoint,
+                    )?;
+
+                    // No other dependencies of this consensus commit prologue that haven't been
+                    // included in any previous checkpoint.
+                    if unsorted_ccp.len() != 1 {
+                        fatal!(
+                            "Expected 1 consensus commit prologue, got {:?}",
+                            unsorted_ccp
+                                .iter()
+                                .map(|e| e.transaction_digest())
+                                .collect::<Vec<_>>()
+                        );
+                    }
+                    assert_eq!(unsorted_ccp.len(), 1);
+                    assert_eq!(unsorted_ccp[0].transaction_digest(), ccp_digest);
                 }
-                assert_eq!(unsorted_ccp.len(), 1);
-                assert_eq!(unsorted_ccp[0].transaction_digest(), ccp_digest);
+                consensus_commit_prologue
+            };
+
+            let unsorted =
+                self.complete_checkpoint_effects(root_effects, &mut effects_in_current_checkpoint)?;
+
+            let _scope = monitored_scope("CheckpointBuilder::causal_sort");
+            let mut sorted: Vec<TransactionEffects> = Vec::with_capacity(unsorted.len() + 1);
+            if let Some((_ccp_digest, ccp_effects)) = consensus_commit_prologue {
+                #[cfg(debug_assertions)]
+                {
+                    // When consensus_commit_prologue is extracted, it should not be included in the
+                    // `unsorted`.
+                    for tx in unsorted.iter() {
+                        assert!(tx.transaction_digest() != &_ccp_digest);
+                    }
+                }
+                sorted.push(ccp_effects);
             }
-            consensus_commit_prologue
-        };
+            sorted.extend(CausalOrder::causal_sort(unsorted));
 
-        let unsorted =
-            self.complete_checkpoint_effects(root_effects, effects_in_current_checkpoint)?;
-
-        let _scope = monitored_scope("CheckpointBuilder::causal_sort");
-        let mut sorted: Vec<TransactionEffects> = Vec::with_capacity(unsorted.len() + 1);
-        if let Some((_ccp_digest, ccp_effects)) = consensus_commit_prologue {
-            #[cfg(debug_assertions)]
+            #[cfg(msim)]
             {
-                // When consensus_commit_prologue is extracted, it should not be included in the
-                // `unsorted`.
-                for tx in unsorted.iter() {
-                    assert!(tx.transaction_digest() != &_ccp_digest);
-                }
+                // Check consensus commit prologue invariants in sim test.
+                self.expensive_consensus_commit_prologue_invariants_check(&root_digests, &sorted);
             }
-            sorted.push(ccp_effects);
-        }
-        sorted.extend(CausalOrder::causal_sort(unsorted));
 
-        #[cfg(msim)]
-        {
-            // Check consensus commit prologue invariants in sim test.
-            self.expensive_consensus_commit_prologue_invariants_check(&root_digests, &sorted);
+            tx_effects.extend(sorted);
+            tx_roots.extend(root_digests);
         }
 
-        Ok((root_digests, sorted))
+        Ok((tx_effects, tx_roots))
     }
 
     // This function is used to extract the consensus commit prologue digest and
@@ -2713,6 +2734,41 @@ impl CheckpointServiceNotify for CheckpointServiceNoop {
     fn notify_checkpoint(&self) -> IotaResult {
         Ok(())
     }
+}
+
+pin_project! {
+    pub struct PollCounter<Fut> {
+        #[pin]
+        future: Fut,
+        count: usize,
+    }
+}
+
+impl<Fut> PollCounter<Fut> {
+    pub fn new(future: Fut) -> Self {
+        Self { future, count: 0 }
+    }
+
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+impl<Fut: Future> Future for PollCounter<Fut> {
+    type Output = (usize, Fut::Output);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        *this.count += 1;
+        match this.future.poll(cx) {
+            Poll::Ready(output) => Poll::Ready((*this.count, output)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn poll_count<Fut>(future: Fut) -> PollCounter<Fut> {
+    PollCounter::new(future)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.51.5, v1.52.3)
- Port commit:
  - [MystenLabs/sui@aaa6edef](https://github.com/MystenLabs/sui/commit/aaa6edef4f1eb714af5d6301cdc267de1f55a533)
- Description:

**The core fix is already present in this fork.** Our `commit_certificate` path
already inserts the tx key after execution via `insert_tx_key_and_digest` (which
bundles the executed-in-epoch insert with the guarded `transaction_key_to_digest`
insert and notifies `executed_digests_notify_read`). This PR therefore ports only the detection/test scaffolding.

## Links to any relevant issues

Part of #11885

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes