### PR TITLE
fix(iota-data-ingestion): configure remote store timeouts

### DIFF
--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -68,6 +68,8 @@ struct IndexerConfig {
     remote_store_url: Option<RemoteStoreUrl>,
     #[serde(default = "default_remote_read_batch_size")]
     remote_read_batch_size: usize,
+    #[serde(default = "default_remote_read_timeout")]
+    remote_read_timeout: u64,
     #[serde(default = "default_metrics_host")]
     metrics_host: String,
     #[serde(default = "default_metrics_port")]
@@ -84,6 +86,15 @@ fn default_metrics_port() -> u16 {
 
 fn default_remote_read_batch_size() -> usize {
     100
+}
+
+/// Returns the default remote read timeout in seconds.
+///
+/// This targets primarily the hybrid historical store.
+///
+/// The default value is 120 seconds.
+fn default_remote_read_timeout() -> u64 {
+    120
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -299,6 +310,7 @@ async fn main() -> Result<()> {
 
     let reader_options = ReaderOptions {
         batch_size: config.remote_read_batch_size,
+        timeout_secs: config.remote_read_timeout,
         ..Default::default()
     };
 

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -68,8 +68,8 @@ struct IndexerConfig {
     remote_store_url: Option<RemoteStoreUrl>,
     #[serde(default = "default_remote_read_batch_size")]
     remote_read_batch_size: usize,
-    #[serde(default = "default_remote_read_timeout")]
-    remote_read_timeout: u64,
+    #[serde(default = "default_remote_read_timeout_secs")]
+    remote_read_timeout_secs: u64,
     #[serde(default = "default_metrics_host")]
     metrics_host: String,
     #[serde(default = "default_metrics_port")]
@@ -93,7 +93,7 @@ fn default_remote_read_batch_size() -> usize {
 /// This targets primarily the hybrid historical store.
 ///
 /// The default value is 120 seconds.
-fn default_remote_read_timeout() -> u64 {
+fn default_remote_read_timeout_secs() -> u64 {
     120
 }
 
@@ -310,7 +310,7 @@ async fn main() -> Result<()> {
 
     let reader_options = ReaderOptions {
         batch_size: config.remote_read_batch_size,
-        timeout_secs: config.remote_read_timeout,
+        timeout_secs: config.remote_read_timeout_secs,
         ..Default::default()
     };
 


### PR DESCRIPTION
# Description of change

This PR fixes the inability of providing custom timeout value, usually used by historical checkpoint store for downloading checkpoints.

## Links to any relevant issues

fixes #11991 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran the iota-data-ingestion workers using hybrid checkpoint store on devnet syncing the genesis checkpoint.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.

