### PR TITLE
refactor(consensus): remove dead v29 flag-off branches from the consensus runtime

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4341,15 +4341,9 @@ impl AuthorityPerEpochStore {
         // sees no new inbound traffic (e.g. one that restarted) can stay Pending
         // forever -- deferring all randomness-using transactions and blocking
         // epoch close.
-        //
-        // This changes when `advance_dkg` runs relative to consensus, so it is
-        // gated behind a protocol flag: every validator must flip the behavior
-        // at the same protocol-upgrade boundary, otherwise a mixed-version
-        // network could resolve DKG on different commits and diverge.
-        let dkg_pending = self.protocol_config.always_advance_dkg_to_resolution()
-            && randomness_manager
-                .as_ref()
-                .is_some_and(|rm| rm.dkg_status() == DkgStatus::Pending);
+        let dkg_pending = randomness_manager
+            .as_ref()
+            .is_some_and(|rm| rm.dkg_status() == DkgStatus::Pending);
         if randomness_state_updated || dkg_pending {
             if let Some(randomness_manager) = randomness_manager.as_mut() {
                 randomness_manager

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1608,13 +1608,7 @@ impl CheckpointBuilder {
                         "Decrease of checkpoint timestamp, possibly due to epoch change. Sequence: {}, previous: {}, current: {}",
                         sequence_number, last_checkpoint.timestamp_ms, timestamp_ms,
                     );
-                    if self
-                        .epoch_store
-                        .protocol_config()
-                        .consensus_median_timestamp_with_checkpoint_enforcement()
-                    {
-                        timestamp_ms = last_checkpoint.timestamp_ms;
-                    }
+                    timestamp_ms = last_checkpoint.timestamp_ms;
                 }
             }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1557,19 +1557,11 @@ impl ProtocolConfig {
     }
 
     pub fn max_acknowledgments_per_block(&self, committee_size: usize) -> usize {
-        if self.consensus_block_restrictions() {
-            2 * committee_size
-        } else {
-            self.consensus_max_acknowledgments_per_block_or_default() as usize
-        }
+        2 * committee_size
     }
 
     pub fn max_commit_votes_per_block(&self, committee_size: usize) -> usize {
-        if self.consensus_block_restrictions() {
-            committee_size
-        } else {
-            100
-        }
+        committee_size
     }
 
     pub fn variant_nodes(&self) -> bool {

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -140,13 +140,8 @@ pub struct Parameters {
     pub commit_sync_gap_threshold: u32,
 
     /// Enable FastCommitSyncer for faster recovery from large commit gaps.
-    /// This is a local node configuration that works in conjunction with the
-    /// protocol-level consensus_fast_commit_sync feature flag. Both must be
-    /// enabled for FastCommitSyncer to run. The protocol flag controls
-    /// whether gRPC endpoints are available, while this local flag controls
-    /// whether this specific node creates and runs the FastCommitSyncer.
     /// Enabled by default; operators can disable it locally if bugs are
-    /// discovered, without affecting protocol-level endpoint availability.
+    /// discovered.
     #[serde(default = "Parameters::default_enable_fast_commit_syncer")]
     pub enable_fast_commit_syncer: bool,
 

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -1167,8 +1167,7 @@ pub(crate) mod tests {
         let stable_work_duration_time = Duration::from_secs(30);
 
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(true);
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
 
         let temp_dirs: Vec<TempDir> = (0..NUM_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())
@@ -1616,8 +1615,7 @@ pub(crate) mod tests {
         let stable_work_duration_time = Duration::from_secs(30);
 
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(true);
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
 
         let temp_dirs: Vec<TempDir> = (0..NUM_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -529,18 +529,15 @@ pub(crate) mod tests {
         transaction::NoopTransactionVerifier,
     };
 
-    #[rstest]
     #[tokio::test]
-    async fn test_authority_start_and_stop(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_authority_start_and_stop() {
         let (committee, keypairs) = local_committee_and_keys(0, vec![1]);
         let registry = Registry::new();
 
         let temp_dir = TempDir::new().unwrap();
         let parameters = Parameters {
             db_path: temp_dir.keep(),
-            enable_fast_commit_syncer: consensus_fast_commit_sync,
+            enable_fast_commit_syncer: true,
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};
@@ -552,8 +549,7 @@ pub(crate) mod tests {
         let (sender, _receiver) = unbounded_channel("consensus_output");
         let commit_consumer = CommitConsumer::new(sender, 0);
 
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
 
         let authority = ConsensusAuthority::start(
             0,
@@ -582,18 +578,14 @@ pub(crate) mod tests {
     /// with the rest of the committee.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_restart_authority_committee(
-        #[values(4, 6)] num_of_authorities: usize,
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_restart_authority_committee(#[values(4, 6)] num_of_authorities: usize) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
         let (committee, keypairs) =
             local_committee_and_keys(0, vec![1; num_of_authorities].to_vec());
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
 
         let temp_dirs = (0..num_of_authorities)
             .map(|_| TempDir::new().unwrap())
@@ -612,7 +604,6 @@ pub(crate) mod tests {
                 keypairs.clone(),
                 boot_counters[index],
                 protocol_config.clone(),
-                consensus_fast_commit_sync,
             )
             .await;
             boot_counters[index] += 1;
@@ -707,7 +698,6 @@ pub(crate) mod tests {
             keypairs.clone(),
             boot_counters[stopped_authority_index],
             protocol_config.clone(),
-            consensus_fast_commit_sync,
         )
         .await;
         boot_counters[stopped_authority_index] += 1;
@@ -793,16 +783,12 @@ pub(crate) mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_small_committee(
-        #[values(1, 2, 3)] num_authorities: usize,
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_small_committee(#[values(1, 2, 3)] num_authorities: usize) {
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; num_authorities]);
-        let mut protocol_config: ProtocolConfig = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        let protocol_config: ProtocolConfig = ProtocolConfig::get_for_max_version_UNSAFE();
 
         let temp_dirs = (0..num_authorities)
             .map(|_| TempDir::new().unwrap())
@@ -820,7 +806,6 @@ pub(crate) mod tests {
                 keypairs.clone(),
                 boot_counters[index],
                 protocol_config.clone(),
-                consensus_fast_commit_sync,
             )
             .await;
             boot_counters[index] += 1;
@@ -883,7 +868,6 @@ pub(crate) mod tests {
             keypairs.clone(),
             boot_counters[index],
             protocol_config.clone(),
-            consensus_fast_commit_sync,
         )
         .await;
         boot_counters[index] += 1;
@@ -899,11 +883,8 @@ pub(crate) mod tests {
 
     /// This test checks that an authority can recover from amnesia
     /// successfully.
-    #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_amnesia_recovery_success(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_amnesia_recovery_success() {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
@@ -915,8 +896,7 @@ pub(crate) mod tests {
         let mut temp_dirs = BTreeMap::new();
         let mut boot_counters = [0; NUM_OF_AUTHORITIES];
 
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
 
         for (index, _authority_info) in committee.authorities() {
             let dir = TempDir::new().unwrap();
@@ -927,7 +907,6 @@ pub(crate) mod tests {
                 keypairs.clone(),
                 boot_counters[index],
                 protocol_config.clone(),
-                consensus_fast_commit_sync,
             )
             .await;
             assert!(
@@ -999,7 +978,6 @@ pub(crate) mod tests {
             keypairs.clone(),
             boot_counters[index_1],
             protocol_config.clone(),
-            consensus_fast_commit_sync,
         )
         .await;
         assert!(
@@ -1039,7 +1017,6 @@ pub(crate) mod tests {
             keypairs,
             boot_counters[index_2],
             protocol_config.clone(),
-            consensus_fast_commit_sync,
         )
         .await;
         assert!(
@@ -1083,7 +1060,6 @@ pub(crate) mod tests {
         keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
         boot_counter: u64,
         protocol_config: ProtocolConfig,
-        consensus_fast_commit_sync: bool,
     ) -> (
         ConsensusAuthority,
         UnboundedReceiver<CommittedSubDag>,
@@ -1098,7 +1074,7 @@ pub(crate) mod tests {
             commit_sync_parallel_fetches: 2,
             commit_sync_batch_size: 10,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
-            enable_fast_commit_syncer: consensus_fast_commit_sync,
+            enable_fast_commit_syncer: true,
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -188,6 +188,19 @@ impl ConsensusAuthority {
 
         let fast_sync_ongoing = dag_state.read().fast_sync_ongoing();
 
+        // A node that was mid-fast-sync (fast_sync_ongoing persisted) cannot recover
+        // without the fast commit syncer: DagState recovery is skipped expecting the
+        // syncer to reinitialize, the core thread stays in fast-sync mode awaiting
+        // subdags that never arrive, and eviction keeps using the fast-sync strategy
+        // because nothing clears the flag. Refuse to start rather than hang in this
+        // unrecoverable partial state.
+        assert!(
+            !fast_sync_ongoing || context.parameters.enable_fast_commit_syncer,
+            "Consensus DB has fast_sync_ongoing set but enable_fast_commit_syncer is disabled: \
+             no fast commit syncer will run to finish recovery. Re-enable \
+             enable_fast_commit_syncer, or delete this epoch's consensus DB, before restarting."
+        );
+
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
         let core = Core::new(

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -537,7 +537,10 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::{
-        CommitConsumerMonitor, CommittedSubDag, block_header::GENESIS_ROUND, commit::CommitIndex,
+        CommitConsumerMonitor, CommittedSubDag,
+        block_header::GENESIS_ROUND,
+        commit::CommitIndex,
+        storage::{Store, WriteBatch},
         transaction::NoopTransactionVerifier,
     };
 
@@ -583,6 +586,108 @@ pub(crate) mod tests {
         assert_eq!(authority.context().committee.size(), 1);
 
         authority.stop().await;
+    }
+
+    /// Disabling the fast commit syncer locally (protocol flag still on) is a
+    /// supported operator escape hatch: the node must start and run on the
+    /// regular commit syncer alone.
+    #[tokio::test]
+    async fn starts_with_fast_commit_syncer_disabled() {
+        let (committee, keypairs) = local_committee_and_keys(0, vec![1]);
+        let registry = Registry::new();
+
+        let temp_dir = TempDir::new().unwrap();
+        let parameters = Parameters {
+            db_path: temp_dir.keep(),
+            enable_fast_commit_syncer: false,
+            ..Default::default()
+        };
+        let txn_verifier = NoopTransactionVerifier {};
+
+        let own_index = committee.to_authority_index(0).unwrap();
+        let protocol_keypair = keypairs[own_index].1.clone();
+        let network_keypair = keypairs[own_index].0.clone();
+
+        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let commit_consumer = CommitConsumer::new(sender, 0);
+
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+
+        let authority = ConsensusAuthority::start(
+            0,
+            own_index,
+            committee,
+            parameters,
+            protocol_config,
+            protocol_keypair,
+            network_keypair,
+            Arc::new(Clock::default()),
+            Arc::new(txn_verifier),
+            commit_consumer,
+            registry,
+            0,
+        )
+        .await;
+
+        assert_eq!(authority.context().own_index, own_index);
+        authority.stop().await;
+    }
+
+    /// A node interrupted mid-fast-sync (durable `fast_sync_ongoing` flag set)
+    /// that restarts with the fast commit syncer disabled has no way to finish
+    /// recovery, so startup must fail loudly instead of hanging silently.
+    #[tokio::test]
+    #[should_panic(expected = "fast_sync_ongoing set but enable_fast_commit_syncer is disabled")]
+    async fn refuses_to_start_when_fast_sync_interrupted_and_syncer_disabled() {
+        let (committee, keypairs) = local_committee_and_keys(0, vec![1]);
+        let registry = Registry::new();
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.keep();
+
+        // Seed the durable flag as if the node had crashed mid-fast-sync.
+        {
+            let store = RocksDBStore::new(db_path.to_str().unwrap());
+            store
+                .write(WriteBatch {
+                    fast_commit_sync_flag: Some(true),
+                    ..Default::default()
+                })
+                .unwrap();
+            assert!(store.read_fast_sync_ongoing().unwrap());
+        }
+
+        let parameters = Parameters {
+            db_path,
+            enable_fast_commit_syncer: false,
+            ..Default::default()
+        };
+        let txn_verifier = NoopTransactionVerifier {};
+
+        let own_index = committee.to_authority_index(0).unwrap();
+        let protocol_keypair = keypairs[own_index].1.clone();
+        let network_keypair = keypairs[own_index].0.clone();
+
+        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let commit_consumer = CommitConsumer::new(sender, 0);
+
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+
+        let _authority = ConsensusAuthority::start(
+            0,
+            own_index,
+            committee,
+            parameters,
+            protocol_config,
+            protocol_keypair,
+            network_keypair,
+            Arc::new(Clock::default()),
+            Arc::new(txn_verifier),
+            commit_consumer,
+            registry,
+            0,
+        )
+        .await;
     }
 
     /// This test checks that an authority can be restarted and still get synced

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -234,22 +234,18 @@ impl ConsensusAuthority {
         // and the header synchronizer both read it to pause their
         // dispatch loops while fast sync is active, avoiding overlapping
         // ancestor fetches. Only created when fast sync will actually run;
-        // `None` keeps the gate a no-op on deployments (e.g. mainnet today)
-        // where fast sync is disabled.
+        // `None` keeps the gate a no-op when an operator disables fast sync
+        // via the local `enable_fast_commit_syncer` config.
         //
         // Seeded from the durable `DagState::fast_sync_ongoing` flag so a
         // restart mid-fast-sync starts in the paused state, without
         // waiting for fast sync's first schedule-loop tick to set it.
         // Afterwards fast sync owns the atomic; the durable flag is not
         // reactive enough for runtime gating.
-        let fast_sync_active: Option<Arc<AtomicBool>> =
-            if context.protocol_config.consensus_fast_commit_sync()
-                && context.parameters.enable_fast_commit_syncer
-            {
-                Some(Arc::new(AtomicBool::new(fast_sync_ongoing)))
-            } else {
-                None
-            };
+        let fast_sync_active: Option<Arc<AtomicBool>> = context
+            .parameters
+            .enable_fast_commit_syncer
+            .then(|| Arc::new(AtomicBool::new(fast_sync_ongoing)));
 
         let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
@@ -281,10 +277,8 @@ impl ConsensusAuthority {
         )
         .start();
 
-        // FastCommitSyncer is enabled when both the protocol-level flag and the local
-        // config flag are enabled. The protocol flag also controls gRPC endpoint
-        // availability, while the local flag allows operators to disable the
-        // syncer without a protocol upgrade.
+        // FastCommitSyncer runs when the local `enable_fast_commit_syncer`
+        // config flag is enabled, letting operators disable the syncer.
         let fast_commit_syncer_handle = fast_sync_active.as_ref().map(|flag| {
             FastCommitSyncer::new(
                 context.clone(),

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -111,9 +111,8 @@ impl ConsensusAuthority {
         );
         info!("Consensus parameters: {:?}", parameters);
         info!(
-            "Protocol consensus flags: starfish_speed={} fast_commit_sync={}",
+            "Protocol consensus flags: starfish_speed={}",
             protocol_config.consensus_starfish_speed(),
-            protocol_config.consensus_fast_commit_sync(),
         );
         info!("Consensus committee: {:?}", committee);
         let context = Arc::new(Context::new(
@@ -537,7 +536,6 @@ pub(crate) mod tests {
         let temp_dir = TempDir::new().unwrap();
         let parameters = Parameters {
             db_path: temp_dir.keep(),
-            enable_fast_commit_syncer: true,
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -390,7 +390,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             let shard: ShardWithProof =
                 bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
 
-            if let Err(e) = check_shard_version_matches_flags(&shard) {
+            if let Err(e) = check_shard_version(&shard) {
                 self.context
                     .metrics
                     .node_metrics
@@ -664,10 +664,10 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 /// variant. The variant is uniform across the network within an epoch, so a
 /// legacy `V1` shard implies either a malicious peer or a misconfigured upgrade
 /// path.
-pub(crate) fn check_shard_version_matches_flags(shard: &ShardWithProof) -> ConsensusResult<()> {
+pub(crate) fn check_shard_version(shard: &ShardWithProof) -> ConsensusResult<()> {
     match shard {
         ShardWithProof::V2(_) => Ok(()),
-        ShardWithProof::V1(_) => Err(ConsensusError::WrongShardVersionForFlags { actual: "V1" }),
+        ShardWithProof::V1(_) => Err(ConsensusError::WrongShardVersion { actual: "V1" }),
     }
 }
 
@@ -1434,20 +1434,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let mut result = Vec::new();
         for (opt_serialized_tx, gen_ref) in store_transactions.into_iter().chain(dag_transactions) {
             if let Some(serialized_tx) = opt_serialized_tx {
-                let serialized =
-                    if let GenericTransactionRef::TransactionRef(transaction_ref) = gen_ref {
-                        bcs::to_bytes(&SerializedTransactionsV2 {
-                            transaction_ref,
-                            serialized_transactions: serialized_tx,
-                        })
-                        .map_err(ConsensusError::SerializationFailure)?
-                    } else {
-                        return Err(ConsensusError::TransactionRefVariantMismatch {
-                            protocol_flag_enabled: true,
-                            expected_variant: "TransactionRef",
-                            received_variant: gen_ref.variant_name(),
-                        });
-                    };
+                let transaction_ref = gen_ref.expect_transaction_ref()?;
+                let serialized = bcs::to_bytes(&SerializedTransactionsV2 {
+                    transaction_ref,
+                    serialized_transactions: serialized_tx,
+                })
+                .map_err(ConsensusError::SerializationFailure)?;
                 result.push(Bytes::from(serialized));
             }
         }
@@ -4133,8 +4125,8 @@ mod tests {
     }
 
     #[test]
-    fn check_shard_version_matches_flags_when_fast_commit_sync_enabled() {
-        use super::check_shard_version_matches_flags;
+    fn check_shard_version_rejects_v1() {
+        use super::check_shard_version;
         use crate::{
             block_header::{ShardWithProof, ShardWithProofV1},
             error::ConsensusError,
@@ -4147,10 +4139,10 @@ mod tests {
             proof: vec![],
             block_ref: BlockRef::default(),
         });
-        let result = check_shard_version_matches_flags(&shard_v1);
+        let result = check_shard_version(&shard_v1);
         assert!(matches!(
             result,
-            Err(ConsensusError::WrongShardVersionForFlags { actual: "V1" })
+            Err(ConsensusError::WrongShardVersion { actual: "V1" })
         ));
 
         // V2 — accepted (positive control).
@@ -4160,6 +4152,6 @@ mod tests {
             BlockRef::default(),
             TransactionsCommitment::default(),
         );
-        check_shard_version_matches_flags(&shard_v2).unwrap();
+        check_shard_version(&shard_v2).unwrap();
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -667,10 +667,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 pub(crate) fn check_shard_version_matches_flags(shard: &ShardWithProof) -> ConsensusResult<()> {
     match shard {
         ShardWithProof::V2(_) => Ok(()),
-        ShardWithProof::V1(_) => Err(ConsensusError::WrongShardVersionForFlags {
-            actual: "V1",
-            fast_commit_sync: true,
-        }),
+        ShardWithProof::V1(_) => Err(ConsensusError::WrongShardVersionForFlags { actual: "V1" }),
     }
 }
 
@@ -4153,10 +4150,7 @@ mod tests {
         let result = check_shard_version_matches_flags(&shard_v1);
         assert!(matches!(
             result,
-            Err(ConsensusError::WrongShardVersionForFlags {
-                actual: "V1",
-                fast_commit_sync: true,
-            })
+            Err(ConsensusError::WrongShardVersionForFlags { actual: "V1" })
         ));
 
         // V2 — accepted (positive control).

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1728,7 +1728,7 @@ mod tests {
         network::{
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
-            SerializedTransactionsV1, SerializedTransactionsV2, TransactionFetchMode,
+            SerializedTransactionsV2, TransactionFetchMode,
         },
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
@@ -1801,14 +1801,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribed_block_bundle_wrong_peer(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let (mut context, _keys) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+    async fn test_handle_subscribed_block_bundle_wrong_peer() {
+        let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
@@ -1901,14 +1895,8 @@ mod tests {
     /// it cannot grow shard/transaction state.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribed_block_bundle_drops_far_future(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let (mut context, _keys) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+    async fn test_handle_subscribed_block_bundle_drops_far_future() {
+        let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
@@ -1993,14 +1981,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribed_block_bundle_wrong_transaction_commitment(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let (mut context, _keys) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+    async fn test_handle_subscribed_block_bundle_wrong_transaction_commitment() {
+        let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
@@ -2117,15 +2099,9 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribed_block_bundle_with_bad_headers(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_handle_subscribed_block_bundle_with_bad_headers() {
         let committee_size = 4;
-        let (mut context, _keys) = Context::new_for_test(committee_size);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        let (context, _keys) = Context::new_for_test(committee_size);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
@@ -2539,17 +2515,11 @@ mod tests {
     }
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribed_block_bundle_with_additional_headers(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_handle_subscribed_block_bundle_with_additional_headers() {
         // GIVEN
         let rounds = 10;
         let validators = 10;
-        let (mut context, key_pairs) = Context::new_for_test(validators);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        let (context, key_pairs) = Context::new_for_test(validators);
         let context = Arc::new(context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
             context.clone(),
@@ -2709,17 +2679,11 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribe_bundle_without_additional_headers(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_handle_subscribe_bundle_without_additional_headers() {
         // GIVEN
         let rounds = 10;
         let validators = 10;
-        let (mut context, key_pairs) = Context::new_for_test(validators);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        let (context, key_pairs) = Context::new_for_test(validators);
         let context = Arc::new(context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
             context.clone(),
@@ -2893,19 +2857,13 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_handle_subscribe_block_bundles_request(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_handle_subscribe_block_bundles_request() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
         let rounds = 10;
         let validators = 4;
         let to_whom_authority = AuthorityIndex::new_for_test(1);
-        let (mut context, key_pairs) = Context::new_for_test(validators);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        let (context, key_pairs) = Context::new_for_test(validators);
         let context = Arc::new(context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
             context.clone(),
@@ -3547,15 +3505,11 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_handle_fetch_commits(#[values(false, true)] consensus_fast_commit_sync: bool) {
+    async fn test_handle_fetch_commits() {
         // GIVEN
         let rounds = 15;
         let validators = 4;
-        let (mut context, key_pairs) = Context::new_for_test(validators);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        let (context, key_pairs) = Context::new_for_test(validators);
         let context = Arc::new(context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
             context.clone(),
@@ -3768,23 +3722,20 @@ mod tests {
         );
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn test_handle_fetch_transactions(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_handle_fetch_transactions() {
         // GIVEN
         let rounds = 10;
         let validators = 4;
         let (mut context, key_pairs) = Context::new_for_test(validators);
         context
             .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+            .set_consensus_fast_commit_sync_for_testing(true);
         let context = Context {
             parameters: Parameters {
                 max_transactions_per_transaction_sync_fetch: 20,
                 max_transactions_per_commit_sync_fetch: 10,
-                enable_fast_commit_syncer: consensus_fast_commit_sync,
+                enable_fast_commit_syncer: true,
                 ..context.parameters
             },
             ..context
@@ -3891,26 +3842,18 @@ mod tests {
 
         let mut block_refs_to_request_first_batch: Vec<GenericTransactionRef> = (1..=rounds)
             .flat_map(|round| {
-                all_block_headers[round as usize].iter().map(|bh| {
-                    if consensus_fast_commit_sync {
-                        GenericTransactionRef::TransactionRef(bh.transaction_ref())
-                    } else {
-                        GenericTransactionRef::from(bh.reference())
-                    }
-                })
+                all_block_headers[round as usize]
+                    .iter()
+                    .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
             })
             .collect();
 
         let mut block_refs_to_request_second_batch: Vec<GenericTransactionRef> = (rounds + 1
             ..=2 * rounds)
             .flat_map(|round| {
-                all_block_headers[round as usize].iter().map(|bh| {
-                    if consensus_fast_commit_sync {
-                        GenericTransactionRef::TransactionRef(bh.transaction_ref())
-                    } else {
-                        GenericTransactionRef::from(bh.reference())
-                    }
-                })
+                all_block_headers[round as usize]
+                    .iter()
+                    .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
             })
             .collect();
 
@@ -3939,55 +3882,28 @@ mod tests {
 
         // Check the correctness of the received transactions
         for (i, serialized_transactions_bytes) in serialized_transactions.iter().enumerate() {
-            if consensus_fast_commit_sync {
-                // Deserialize V2 format with TransactionRef
-                let deserialized: SerializedTransactionsV2 =
-                    bcs::from_bytes(serialized_transactions_bytes)
-                        .expect("deserialization should succeed");
-                let transaction_ref = deserialized.transaction_ref;
+            let deserialized: SerializedTransactionsV2 =
+                bcs::from_bytes(serialized_transactions_bytes)
+                    .expect("deserialization should succeed");
+            let transaction_ref = deserialized.transaction_ref;
 
-                // Verify it matches the expected ref
-                assert_eq!(
-                    GenericTransactionRef::TransactionRef(transaction_ref),
-                    block_refs_to_request_first_batch[i]
-                );
+            // Verify it matches the expected ref
+            assert_eq!(
+                GenericTransactionRef::TransactionRef(transaction_ref),
+                block_refs_to_request_first_batch[i]
+            );
 
-                let serialized_transactions = deserialized.serialized_transactions;
-                // Verify the transaction commitment matches
-                assert_eq!(
-                    transaction_ref.transactions_commitment,
-                    TransactionsCommitment::compute_transactions_commitment(
-                        &serialized_transactions,
-                        &context,
-                        &mut encoder
-                    )
-                    .unwrap()
-                );
-            } else {
-                // Deserialize V1 format with BlockRef
-                let deserialized: SerializedTransactionsV1 =
-                    bcs::from_bytes(serialized_transactions_bytes)
-                        .expect("deserialization should succeed");
-                let block_ref = deserialized.block_ref;
-                assert_eq!(
-                    GenericTransactionRef::from(block_ref),
-                    block_refs_to_request_first_batch[i]
-                );
-                let serialized_transactions = deserialized.serialized_transactions;
-                let block_header = all_block_headers[block_ref.round as usize]
-                    .iter()
-                    .find(|header| header.reference() == block_ref)
-                    .expect("We expect to find the header with such block_ref");
-                assert_eq!(
-                    block_header.transactions_commitment(),
-                    TransactionsCommitment::compute_transactions_commitment(
-                        &serialized_transactions,
-                        &context,
-                        &mut encoder
-                    )
-                    .unwrap()
-                );
-            }
+            let serialized_transactions = deserialized.serialized_transactions;
+            // Verify the transaction commitment matches
+            assert_eq!(
+                transaction_ref.transactions_commitment,
+                TransactionsCommitment::compute_transactions_commitment(
+                    &serialized_transactions,
+                    &context,
+                    &mut encoder
+                )
+                .unwrap()
+            );
         }
 
         block_refs_to_request_second_batch.truncate(
@@ -4118,14 +4034,11 @@ mod tests {
         // Also write all block headers to the store so below-GC refs can be found
         let all_headers: Vec<VerifiedBlockHeader> = dag_builder.block_headers(1..=rounds);
         store
-            .write(
-                WriteBatch {
-                    block_headers: all_headers,
-                    fast_commit_sync_flag: Some(false),
-                    ..WriteBatch::default()
-                },
-                context.clone(),
-            )
+            .write(WriteBatch {
+                block_headers: all_headers,
+                fast_commit_sync_flag: Some(false),
+                ..WriteBatch::default()
+            })
             .expect("Failed to write block headers to store");
 
         // Set last_solid_subdag_base so gc_round_for_last_solid_commit() is ~10.
@@ -4225,20 +4138,19 @@ mod tests {
     #[test]
     fn check_shard_version_matches_flags_when_fast_commit_sync_enabled() {
         use super::check_shard_version_matches_flags;
-        use crate::{block_header::ShardWithProof, error::ConsensusError};
-        let mut config = iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE();
-        config.set_consensus_fast_commit_sync_for_testing(true);
+        use crate::{
+            block_header::{ShardWithProof, ShardWithProofV1},
+            error::ConsensusError,
+        };
 
-        // V1 reaching a flag-ON receiver — the case the wire-format dispatch
-        // does not catch on its own.
-        let shard_v1 = ShardWithProof::new(
-            vec![],
-            vec![],
-            BlockRef::default(),
-            TransactionsCommitment::default(),
-            false,
-        );
-        let result = check_shard_version_matches_flags(&shard_v1, &config);
+        // A legacy V1 shard reaching the receiver is rejected.
+        let shard_v1 = ShardWithProof::V1(ShardWithProofV1 {
+            shard: vec![],
+            transaction_commitment: TransactionsCommitment::default(),
+            proof: vec![],
+            block_ref: BlockRef::default(),
+        });
+        let result = check_shard_version_matches_flags(&shard_v1);
         assert!(matches!(
             result,
             Err(ConsensusError::WrongShardVersionForFlags {
@@ -4247,14 +4159,13 @@ mod tests {
             })
         ));
 
-        // V2 with flag ON — accepted (positive control).
+        // V2 — accepted (positive control).
         let shard_v2 = ShardWithProof::new(
             vec![],
             vec![],
             BlockRef::default(),
             TransactionsCommitment::default(),
-            true,
         );
-        check_shard_version_matches_flags(&shard_v2, &config).unwrap();
+        check_shard_version_matches_flags(&shard_v2).unwrap();
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -25,8 +25,8 @@ use crate::{
     CommitIndex, Round, VerifiedBlockHeader,
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, ShardWithProof,
-        ShardWithProofAPI, ShardWithProofV1, SignedBlockHeader, TransactionsCommitment,
-        VerifiedBlock, VerifiedOwnShard, VerifiedTransactions,
+        ShardWithProofAPI, SignedBlockHeader, TransactionsCommitment, VerifiedBlock,
+        VerifiedOwnShard, VerifiedTransactions,
     },
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
@@ -42,8 +42,8 @@ use crate::{
     misbehavior_store::MisbehaviorStore,
     network::{
         BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
-        SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactionsV1,
-        SerializedTransactionsV2, TransactionFetchMode,
+        SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactionsV2,
+        TransactionFetchMode,
     },
     shard_reconstructor::TransactionMessage,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -257,7 +257,6 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 proof_for_shard,
                 block_ref,
                 transaction_commitment,
-                self.context.protocol_config.consensus_fast_commit_sync(),
             ))
         } else {
             None
@@ -389,21 +388,9 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         let mut verified_shards: Vec<ShardWithProof> = vec![];
         for serialized_shard in &serialized_shards {
             let shard: ShardWithProof =
-                if !self.context.protocol_config.consensus_fast_commit_sync() {
-                    // For backward compatibility, we still support ShardWithProofV1 during the
-                    // epoch during which nodes are upgraded to a new software version. Peers
-                    // running an old version will still send ShardWithProofV1 without the enum
-                    // wrapping. We can remove this support after we are sure
-                    // all peers have been updated to send versioned ShardWithProof.
-                    let shard_v1: ShardWithProofV1 = bcs::from_bytes(serialized_shard)
-                        .map_err(ConsensusError::MalformedShard)?;
-                    ShardWithProof::V1(shard_v1)
-                } else {
-                    bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?
-                };
+                bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
 
-            if let Err(e) = check_shard_version_matches_flags(&shard, &self.context.protocol_config)
-            {
+            if let Err(e) = check_shard_version_matches_flags(&shard) {
                 self.context
                     .metrics
                     .node_metrics
@@ -673,32 +660,18 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
     }
 }
 
-/// Rejects a deserialized `ShardWithProof` whose variant does not match the
-/// local protocol-flag configuration. The flag is uniform across the network
-/// within an epoch, so any mismatch implies either a malicious peer or a
-/// misconfigured upgrade path. In the flag-OFF (raw V1 wire form) branch the
-/// check is a tautology — the deserializer always produces V1 — but it is
-/// called there for symmetry.
-pub(crate) fn check_shard_version_matches_flags(
-    shard: &ShardWithProof,
-    protocol_config: &iota_protocol_config::ProtocolConfig,
-) -> ConsensusResult<()> {
-    let fast_commit_sync = protocol_config.consensus_fast_commit_sync();
-    let variant_matches_flags = matches!(
-        (shard, fast_commit_sync),
-        (ShardWithProof::V1(_), false) | (ShardWithProof::V2(_), true)
-    );
-    if !variant_matches_flags {
-        let actual = match shard {
-            ShardWithProof::V1(_) => "V1",
-            ShardWithProof::V2(_) => "V2",
-        };
-        return Err(ConsensusError::WrongShardVersionForFlags {
-            actual,
-            fast_commit_sync,
-        });
+/// Rejects a deserialized `ShardWithProof` that is not the current `V2`
+/// variant. The variant is uniform across the network within an epoch, so a
+/// legacy `V1` shard implies either a malicious peer or a misconfigured upgrade
+/// path.
+pub(crate) fn check_shard_version_matches_flags(shard: &ShardWithProof) -> ConsensusResult<()> {
+    match shard {
+        ShardWithProof::V2(_) => Ok(()),
+        ShardWithProof::V1(_) => Err(ConsensusError::WrongShardVersionForFlags {
+            actual: "V1",
+            fast_commit_sync: true,
+        }),
     }
-    Ok(())
 }
 
 #[async_trait]
@@ -743,11 +716,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         )?;
         let block_ref = verified_block.reference();
         let transaction_ref = verified_block.transaction_ref();
-        let gen_transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
-            GenericTransactionRef::from(transaction_ref)
-        } else {
-            GenericTransactionRef::from(block_ref)
-        };
+        let gen_transaction_ref = GenericTransactionRef::from(transaction_ref);
         // 2. Record timestamp drift metric (NEW mode - no waiting or rejection)
         let now = self.context.clock.timestamp_utc_ms();
         let forward_time_drift =
@@ -908,24 +877,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // 12. Add our shard from the received block and its proof to the dag_state
         // only if it contains transactions and the block is not far-future.
         if let Some(shard_for_core) = shard_for_core.filter(|_| !primary_block_far_future) {
-            let serialized_shard_for_core: Bytes = match shard_for_core {
-                // For backward compatibility, we still support ShardWithProofV1 during the
-                // epoch during which nodes are upgraded to a new software version. Because of
-                // peers running an old version will still need to send
-                // ShardWithProofV1 without the enum wrapping. We can remove this
-                // support after we are sure all peers have been updated to send
-                // versioned ShardWithProof.
-                ShardWithProof::V1(shard_v1)
-                    if !self.context.protocol_config.consensus_fast_commit_sync() =>
-                {
-                    bcs::to_bytes(&shard_v1)
-                        .map_err(ConsensusError::SerializationFailure)?
-                        .into()
-                }
-                _ => bcs::to_bytes(&shard_for_core)
-                    .map_err(ConsensusError::SerializationFailure)?
-                    .into(),
-            };
+            let serialized_shard_for_core: Bytes = bcs::to_bytes(&shard_for_core)
+                .map_err(ConsensusError::SerializationFailure)?
+                .into();
             let shard_for_core = VerifiedOwnShard {
                 serialized_shard: serialized_shard_for_core,
                 gen_transaction_ref,
@@ -1218,15 +1172,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             });
         }
 
-        // TODO: This gate can be removed once consensus_fast_commit_sync is enabled on
-        // all networks. Fast commit sync type is controlled by the client, so
-        // we need to validate that the protocol supports it before processing.
-        if matches!(commit_sync_type, CommitSyncType::Fast)
-            && !self.context.protocol_config.consensus_fast_commit_sync()
-        {
-            return Err(ConsensusError::FastCommitSyncNotEnabled);
-        }
-
         // Bound the range based on sync type.
         let batch_size = commit_sync_type.commit_sync_batch_size(&self.context);
         let inclusive_bound = commit_range
@@ -1341,14 +1286,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
     ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
         fail_point_async!("consensus-rpc-response");
 
-        // TODO: This gate can be removed once consensus_fast_commit_sync is enabled on
-        // all networks. This endpoint is gated by the
-        // consensus_fast_commit_sync feature flag as it is more expensive than
-        // just fetching commits or headers.
-        if !self.context.protocol_config.consensus_fast_commit_sync() {
-            return Err(ConsensusError::FastCommitSyncNotEnabled);
-        }
-
         let (commits, certifier_block_headers) = self
             .handle_fetch_commits(peer, commit_range, CommitSyncType::Fast)
             .await?;
@@ -1437,14 +1374,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // Apply truncation based on fetch mode
         match fetch_mode {
             TransactionFetchMode::FastCommitSync => {
-                // TODO: This gate can be removed once consensus_fast_commit_sync is enabled on
-                // all networks. FastCommitSync mode is controlled by the
-                // client, so we need to validate that the protocol supports it
-                // before processing. No truncation for fast commit sync - all
-                // transactions referenced by commits must be fetched.
-                if !self.context.protocol_config.consensus_fast_commit_sync() {
-                    return Err(ConsensusError::FastCommitSyncNotEnabled);
-                }
+                // No truncation for fast commit sync - all transactions
+                // referenced by commits must be fetched.
             }
             TransactionFetchMode::TransactionSync => {
                 let max_transactions = max(
@@ -1506,33 +1437,20 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let mut result = Vec::new();
         for (opt_serialized_tx, gen_ref) in store_transactions.into_iter().chain(dag_transactions) {
             if let Some(serialized_tx) = opt_serialized_tx {
-                let serialized = if !self.context.protocol_config.consensus_fast_commit_sync() {
-                    if let GenericTransactionRef::BlockRef(block_ref) = gen_ref {
-                        bcs::to_bytes(&SerializedTransactionsV1 {
-                            block_ref,
+                let serialized =
+                    if let GenericTransactionRef::TransactionRef(transaction_ref) = gen_ref {
+                        bcs::to_bytes(&SerializedTransactionsV2 {
+                            transaction_ref,
                             serialized_transactions: serialized_tx,
                         })
                         .map_err(ConsensusError::SerializationFailure)?
                     } else {
                         return Err(ConsensusError::TransactionRefVariantMismatch {
-                            protocol_flag_enabled: false,
-                            expected_variant: "BlockRef",
+                            protocol_flag_enabled: true,
+                            expected_variant: "TransactionRef",
                             received_variant: gen_ref.variant_name(),
                         });
-                    }
-                } else if let GenericTransactionRef::TransactionRef(transaction_ref) = gen_ref {
-                    bcs::to_bytes(&SerializedTransactionsV2 {
-                        transaction_ref,
-                        serialized_transactions: serialized_tx,
-                    })
-                    .map_err(ConsensusError::SerializationFailure)?
-                } else {
-                    return Err(ConsensusError::TransactionRefVariantMismatch {
-                        protocol_flag_enabled: true,
-                        expected_variant: "TransactionRef",
-                        received_variant: gen_ref.variant_name(),
-                    });
-                };
+                    };
                 result.push(Bytes::from(serialized));
             }
         }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1681,7 +1681,6 @@ mod tests {
     use futures::StreamExt;
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::{Mutex, RwLock};
-    use rstest::rstest;
     use starfish_config::{AuthorityIndex, Parameters};
     use tokio::{
         sync::{broadcast, mpsc},
@@ -1788,7 +1787,6 @@ mod tests {
         }
     }
 
-    #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_wrong_peer() {
         let (context, _keys) = Context::new_for_test(4);
@@ -1882,7 +1880,6 @@ mod tests {
     /// A signed far-future bundle is dropped at ingress: the block is counted,
     /// not forwarded to the core, and not sent to the shard reconstructor, so
     /// it cannot grow shard/transaction state.
-    #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_drops_far_future() {
         let (context, _keys) = Context::new_for_test(4);
@@ -1968,7 +1965,6 @@ mod tests {
         );
     }
 
-    #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_wrong_transaction_commitment() {
         let (context, _keys) = Context::new_for_test(4);
@@ -2086,7 +2082,6 @@ mod tests {
         assert_eq!(counts.faulty_blocks_unprovable, 2);
     }
 
-    #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_with_bad_headers() {
         let committee_size = 4;
@@ -2502,7 +2497,6 @@ mod tests {
             unimplemented!("Unimplemented")
         }
     }
-    #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_with_additional_headers() {
         // GIVEN
@@ -2666,7 +2660,6 @@ mod tests {
         }
     }
 
-    #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribe_bundle_without_additional_headers() {
         // GIVEN
@@ -2844,7 +2837,6 @@ mod tests {
         assert_eq!(received, None);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_handle_subscribe_block_bundles_request() {
         telemetry_subscribers::init_for_testing();
@@ -3492,7 +3484,6 @@ mod tests {
         );
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_handle_fetch_commits() {
         // GIVEN
@@ -3716,10 +3707,7 @@ mod tests {
         // GIVEN
         let rounds = 10;
         let validators = 4;
-        let (mut context, key_pairs) = Context::new_for_test(validators);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
+        let (context, key_pairs) = Context::new_for_test(validators);
         let context = Context {
             parameters: Parameters {
                 max_transactions_per_transaction_sync_fetch: 20,

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -776,34 +776,22 @@ pub(crate) enum ShardWithProof {
 }
 
 impl ShardWithProof {
-    /// Creates a new ShardWithProof instance based on the protocol flag.
-    /// If `consensus_fast_commit_sync` is true, creates V2 variant, otherwise
-    /// V1.
+    /// Creates a new ShardWithProof.
     pub(crate) fn new(
         shard: Shard,
         proof: MerkleProofBytes,
         block_ref: BlockRef,
         transaction_commitment: TransactionsCommitment,
-        consensus_fast_commit_sync: bool,
     ) -> Self {
-        if consensus_fast_commit_sync {
-            ShardWithProof::V2(ShardWithProofV2 {
-                shard,
-                proof,
-                transaction_ref: TransactionRef {
-                    round: block_ref.round,
-                    author: block_ref.author,
-                    transactions_commitment: transaction_commitment,
-                },
-            })
-        } else {
-            ShardWithProof::V1(ShardWithProofV1 {
-                shard,
-                transaction_commitment,
-                proof,
-                block_ref,
-            })
-        }
+        ShardWithProof::V2(ShardWithProofV2 {
+            shard,
+            proof,
+            transaction_ref: TransactionRef {
+                round: block_ref.round,
+                author: block_ref.author,
+                transactions_commitment: transaction_commitment,
+            },
+        })
     }
 }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -738,8 +738,7 @@ impl AsRef<[u8]> for BlockHeaderDigest {
 pub struct TransactionsCommitment(pub(crate) [u8; starfish_config::DIGEST_LENGTH]);
 pub type MerkleProofBytes = Vec<u8>;
 
-/// Used when the protocol flag `consensus_fast_commit_sync` is disabled.
-/// Contains block reference and separate transaction commitment field.
+/// Legacy shard format retained for deserialization and enum-tag stability.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub(crate) struct ShardWithProofV1 {
     pub(crate) shard: Shard,
@@ -748,8 +747,7 @@ pub(crate) struct ShardWithProofV1 {
     pub(crate) block_ref: BlockRef,
 }
 
-/// Used when the protocol flag `consensus_fast_commit_sync` is enabled.
-/// Contains transaction reference which includes the transaction commitment.
+/// Current shard format using a transaction reference.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub(crate) struct ShardWithProofV2 {
     pub(crate) shard: Shard,
@@ -1299,10 +1297,10 @@ pub struct VerifiedTransactions {
     transaction_ref: TransactionRef,
 
     /// Digest of the block this transaction batch belongs to.
-    /// Present (`Some`) whenever the block header is available at
-    /// construction time, regardless of the `consensus_fast_commit_sync` flag.
-    /// `None` only when transactions were received without an accompanying
-    /// block header (e.g., fast sync or store loading via TransactionRef).
+    /// Present (`Some`) whenever the block header is available at construction
+    /// time. `None` only when transactions were received without an
+    /// accompanying block header (e.g., fast sync or store loading via
+    /// TransactionRef).
     block_digest: Option<BlockHeaderDigest>,
 
     /// The serialized bytes of the transactions.

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -1234,10 +1234,7 @@ mod tests {
     async fn gc_eviction_accepts_header_with_only_old_missing_ancestors() {
         use gc_eviction_helpers::*;
 
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
@@ -1460,10 +1457,7 @@ mod tests {
     async fn gc_eviction_does_not_suspend_old_block_transactions() {
         use gc_eviction_helpers::*;
 
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
@@ -1543,10 +1537,7 @@ mod tests {
     async fn gc_eviction_drops_suspended_transactions_below_floor() {
         use gc_eviction_helpers::*;
 
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
@@ -1577,10 +1568,7 @@ mod tests {
     async fn gc_eviction_sweep_is_idempotent_when_floor_unchanged() {
         use gc_eviction_helpers::*;
 
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
@@ -1644,10 +1632,7 @@ mod tests {
     async fn gc_eviction_filters_stale_unsuspended_headers() {
         use gc_eviction_helpers::*;
 
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -1093,7 +1093,7 @@ mod tests {
         let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
 
         // Create a DAG with 2 rounds
-        let mut dag_builder = DagBuilder::new(context.clone());
+        let mut dag_builder = DagBuilder::new(context);
         dag_builder.layers(1..=2).build();
 
         let round_1_headers = dag_builder

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -1609,17 +1609,15 @@ mod tests {
         assert_eq!(block_manager.last_gc_floor_applied, first_floor);
     }
 
-    /// With the `consensus_block_restrictions` flag off, the sweep is fully
-    /// disabled: no eviction, no floor advance, no filtering of low-round
-    /// ancestors.
+    /// Accepting a header advances the applied gc floor to the commit's gc
+    /// floor: the sweep runs on every accept, so a header whose only missing
+    /// ancestor is below that floor is accepted (not suspended) and the floor
+    /// is recorded as applied.
     #[tokio::test]
-    async fn gc_eviction_disabled_when_flag_off() {
+    async fn gc_eviction_advances_applied_floor_on_accept() {
         use gc_eviction_helpers::*;
 
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(false);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let gc_depth = context.protocol_config.gc_depth();
 
@@ -1630,20 +1628,19 @@ mod tests {
 
         let mut block_manager = BlockManager::new(context, dag_state.clone());
 
-        // A header with a missing ancestor far below the would-be gc_floor
-        // should still be suspended (legacy behavior).
         let gc_floor = dag_state.read().gc_round_for_last_commit();
         assert!(gc_floor > 0);
         let old_ancestor = block_ref(gc_floor.saturating_sub(10), 0);
         let h = header(gc_floor + 50, 1, vec![old_ancestor]);
 
-        let (accepted, missing) = block_manager.try_accept_block_headers(vec![h], DataSource::Test);
+        let (accepted, missing) =
+            block_manager.try_accept_block_headers(vec![h.clone()], DataSource::Test);
+        assert_eq!(accepted, vec![h]);
         assert!(
-            accepted.is_empty(),
-            "header should be suspended when flag off"
+            missing.is_empty(),
+            "old ancestor below gc_floor should not be reported as missing"
         );
-        assert_eq!(missing, BTreeSet::from([old_ancestor]));
-        assert_eq!(block_manager.last_gc_floor_applied, 0);
+        assert_eq!(block_manager.last_gc_floor_applied, gc_floor);
     }
 
     /// A header suspended at an earlier (lower) gc_floor must not be promoted

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -1147,13 +1147,7 @@ mod tests {
         let has_transactions_results = dag_state.read().contains_transactions(
             round_2_blocks
                 .iter()
-                .map(|b| {
-                    if context.protocol_config.consensus_fast_commit_sync() {
-                        GenericTransactionRef::TransactionRef(b.transaction_ref())
-                    } else {
-                        GenericTransactionRef::BlockRef(b.reference())
-                    }
-                })
+                .map(|b| GenericTransactionRef::TransactionRef(b.transaction_ref()))
                 .collect(),
         );
 
@@ -1234,10 +1228,8 @@ mod tests {
         }
     }
 
-    /// With the `consensus_block_restrictions` flag on and a non-zero gc_floor,
-    /// an incoming header whose only missing ancestor is below the floor is
-    /// accepted directly, not suspended, and is not registered for
-    /// fetching.
+    /// An incoming header whose only missing ancestor is below a non-zero GC
+    /// floor is accepted directly and is not registered for fetching.
     #[tokio::test]
     async fn gc_eviction_accepts_header_with_only_old_missing_ancestors() {
         use gc_eviction_helpers::*;

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -151,11 +151,6 @@ impl BlockManager {
     /// Cheap when the floor has not advanced since the last call: a single
     /// read-locked field access on `DagState` and a comparison.
     fn maybe_evict_below_gc_floor(&mut self) -> Vec<VerifiedBlockHeader> {
-        // Gated on `consensus_block_restrictions`. Off the flag, BlockManager
-        // retains its original "fetch every missing ancestor forever" behavior.
-        if !self.context.protocol_config.consensus_block_restrictions() {
-            return vec![];
-        }
         let gc_floor = self.dag_state.read().gc_round_for_last_commit();
         if gc_floor <= self.last_gc_floor_applied {
             return vec![];
@@ -357,17 +352,11 @@ impl BlockManager {
         }
 
         if let Some(blocks) = blocks {
-            // Mirrors the gate in `filter_out_already_processed_and_sort`: when
-            // the `consensus_block_restrictions` flag is on, a block at or below the GC
-            // floor cannot be sequenced and its header is dropped on arrival.
-            // Suspending its transactions would leave them stranded until the
-            // floor advanced again, allowing the map to grow between sweeps.
-            let gc_filter_round: Option<Round> =
-                if self.context.protocol_config.consensus_block_restrictions() {
-                    Some(self.last_gc_floor_applied)
-                } else {
-                    None
-                };
+            // Mirrors the drop in `filter_out_already_processed_and_sort`: a block
+            // at or below the GC floor cannot be sequenced and its header is dropped
+            // on arrival. Suspending its transactions would leave them stranded
+            // until the floor advanced again, letting the map grow between sweeps.
+            let gc_filter_round = self.last_gc_floor_applied;
             let mut accepted_transactions_from_blocks = vec![];
             for block in blocks {
                 if block_refs_to_be_accepted.contains(&block.reference())
@@ -375,7 +364,7 @@ impl BlockManager {
                 {
                     accepted_transactions_from_blocks.push(block.verified_transactions);
                 } else if block.verified_transactions.has_transactions()
-                    && gc_filter_round.is_none_or(|f| block.round() > f)
+                    && block.round() > gc_filter_round
                 {
                     // optimization to avoid suspending 0 set verified transactions.
                     self.suspended_transactions
@@ -543,23 +532,16 @@ impl BlockManager {
         incoming_headers: Vec<VerifiedBlockHeader>,
         present_header_and_ancestor_refs_in_dag_state: &BTreeSet<BlockRef>,
     ) -> BTreeMap<VerifiedBlockHeader, BTreeSet<BlockRef>> {
-        // Off the `consensus_block_restrictions` flag, every absent ancestor is treated
-        // as missing (legacy behavior). With the flag on, ancestors at or below
-        // the GC floor cannot affect any not-yet-sequenced block and are
-        // skipped.
-        let gc_filter_round: Option<Round> =
-            if self.context.protocol_config.consensus_block_restrictions() {
-                Some(self.last_gc_floor_applied)
-            } else {
-                None
-            };
+        // Ancestors at or below the GC floor cannot affect any not-yet-sequenced
+        // block and are skipped.
+        let gc_filter_round = self.last_gc_floor_applied;
         let mut missing_ancestors = BTreeMap::new();
         for incoming_header in incoming_headers {
             let ancestors: &[BlockRef] = incoming_header.ancestors();
             let mut missing_ancestors_set = BTreeSet::new();
             for ancestor in ancestors {
                 let found = present_header_and_ancestor_refs_in_dag_state.contains(ancestor);
-                let below_gc = gc_filter_round.is_some_and(|f| ancestor.round <= f);
+                let below_gc = ancestor.round <= gc_filter_round;
                 if !found && !below_gc {
                     missing_ancestors_set.insert(*ancestor);
                 }
@@ -576,19 +558,13 @@ impl BlockManager {
         present_header_and_ancestor_refs_in_dag_state: &BTreeSet<BlockRef>,
         source: DataSource,
     ) -> Vec<VerifiedBlockHeader> {
-        let gc_filter_round: Option<Round> =
-            if self.context.protocol_config.consensus_block_restrictions() {
-                Some(self.last_gc_floor_applied)
-            } else {
-                None
-            };
+        let gc_filter_round = self.last_gc_floor_applied;
         let mut filtered = block_headers
             .into_iter()
             .filter_map(|block_header| {
-                // With the `consensus_block_restrictions` flag on, drop incoming headers whose
-                // own round is at or below the GC floor; nothing they carry can
-                // be sequenced anymore.
-                if gc_filter_round.is_some_and(|f| block_header.round() <= f) {
+                // Drop incoming headers whose own round is at or below the GC
+                // floor; nothing they carry can be sequenced anymore.
+                if block_header.round() <= gc_filter_round {
                     self.context
                         .metrics
                         .node_metrics

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -169,28 +169,25 @@ impl BlockVerifier for SignedBlockVerifier {
                 quorum: committee.quorum_threshold(),
             });
         }
-        let block_restrictions = self.context.protocol_config.consensus_block_restrictions();
-        if block_restrictions {
-            let max_acknowledgments = self
-                .context
-                .protocol_config
-                .max_acknowledgments_per_block(committee.size());
-            if block.acknowledgments().len() > max_acknowledgments {
-                return Err(ConsensusError::TooManyAcknowledgments {
-                    count: block.acknowledgments().len(),
-                    max: max_acknowledgments,
-                });
-            }
-            let max_commit_votes = self
-                .context
-                .protocol_config
-                .max_commit_votes_per_block(committee.size());
-            if block.commit_votes().len() > max_commit_votes {
-                return Err(ConsensusError::TooManyCommitVotes {
-                    count: block.commit_votes().len(),
-                    max: max_commit_votes,
-                });
-            }
+        let max_acknowledgments = self
+            .context
+            .protocol_config
+            .max_acknowledgments_per_block(committee.size());
+        if block.acknowledgments().len() > max_acknowledgments {
+            return Err(ConsensusError::TooManyAcknowledgments {
+                count: block.acknowledgments().len(),
+                max: max_acknowledgments,
+            });
+        }
+        let max_commit_votes = self
+            .context
+            .protocol_config
+            .max_commit_votes_per_block(committee.size());
+        if block.commit_votes().len() > max_commit_votes {
+            return Err(ConsensusError::TooManyCommitVotes {
+                count: block.commit_votes().len(),
+                max: max_commit_votes,
+            });
         }
         let gc_depth = self.context.protocol_config.gc_depth();
         let min_ref_round = self.context.min_ref_round(block.round());
@@ -199,25 +196,21 @@ impl BlockVerifier for SignedBlockVerifier {
                 &[acknowledgment.author],
                 committee,
             )?;
-            if block_restrictions {
-                if acknowledgment.round >= block.round() {
-                    return Err(ConsensusError::InvalidAcknowledgmentRound {
-                        acknowledgment: acknowledgment.round,
-                        block: block.round(),
-                    });
-                }
-                if acknowledgment.round < min_ref_round {
-                    return Err(ConsensusError::AcknowledgmentRoundTooOld {
-                        acknowledgment: acknowledgment.round,
-                        block: block.round(),
-                        gc_depth,
-                    });
-                }
+            if acknowledgment.round >= block.round() {
+                return Err(ConsensusError::InvalidAcknowledgmentRound {
+                    acknowledgment: acknowledgment.round,
+                    block: block.round(),
+                });
+            }
+            if acknowledgment.round < min_ref_round {
+                return Err(ConsensusError::AcknowledgmentRoundTooOld {
+                    acknowledgment: acknowledgment.round,
+                    block: block.round(),
+                    gc_depth,
+                });
             }
         }
 
-        let check_ancestor_lower_bound =
-            block_restrictions && self.context.protocol_config.consensus_fast_commit_sync();
         let mut seen_ancestors = vec![false; committee.size()];
         let mut parent_stakes = 0;
         for (i, ancestor) in block.ancestors().iter().enumerate() {
@@ -240,7 +233,7 @@ impl BlockVerifier for SignedBlockVerifier {
             // Skip the gc_depth lower bound for the author's own ancestor
             // (i == 0): the proposer always includes its last proposed block
             // regardless of gap so a recovered node can catch up.
-            if check_ancestor_lower_bound && i > 0 && ancestor.round < min_ref_round {
+            if i > 0 && ancestor.round < min_ref_round {
                 return Err(ConsensusError::AncestorRoundTooOld {
                     ancestor: ancestor.round,
                     block: block.round(),

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -444,10 +444,7 @@ pub(crate) mod test {
 
     #[tokio::test]
     async fn test_verify_block() {
-        let (mut context, keypairs) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(true);
+        let (context, keypairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let authority_2_protocol_keypair = &keypairs[2].1;
         let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
@@ -702,17 +699,10 @@ pub(crate) mod test {
     async fn test_verify_block_round_gap() {
         let (mut context, keypairs) = Context::new_for_test(4);
         // Small gc_depth so we can construct violations without huge round
-        // numbers. consensus_fast_commit_sync must be on for the ancestor
-        // lower-bound check to fire.
+        // numbers.
         context
             .protocol_config
             .set_consensus_gc_depth_for_testing(5);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(true);
         let context = Arc::new(context);
         let authority_2_protocol_keypair = &keypairs[2].1;
         let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
@@ -805,9 +795,6 @@ pub(crate) mod test {
         // V1 block reaching a flag-on receiver -> WrongBlockHeaderVersionForFlag.
         {
             let (mut context, keypairs) = Context::new_for_test(4);
-            context
-                .protocol_config
-                .set_consensus_fast_commit_sync_for_testing(true);
             context
                 .protocol_config
                 .set_consensus_starfish_speed_for_testing(true);

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -104,8 +104,8 @@ pub(crate) enum Commit {
 }
 
 impl Commit {
-    /// Create a new commit. The variant (V1, V2, or V3) is determined by the
-    /// consensus_fast_commit_sync and consensus_starfish_speed protocol flags.
+    /// Create a new commit. The variant (V2 or V3) is determined by the
+    /// consensus_starfish_speed protocol flag.
     pub(crate) fn new(
         context: &Arc<Context>,
         index: CommitIndex,
@@ -141,15 +141,15 @@ impl Commit {
                 reputation_scores_desc,
                 is_optimistic,
             })
-        } else if context.protocol_config.consensus_fast_commit_sync() {
-            debug!("Creating CommitV2 as consensus_fast_commit_sync is enabled");
+        } else {
+            debug!("Creating CommitV2");
             // Extract TransactionRefs from GenericTransactionRef
             let transaction_refs: Vec<TransactionRef> = committed_transactions
                 .into_iter()
                 .map(|gen_ref| match gen_ref {
                     GenericTransactionRef::TransactionRef(tr) => tr,
                     GenericTransactionRef::BlockRef(_) => {
-                        panic!("Expected TransactionRef when consensus_fast_commit_sync is enabled")
+                        panic!("Expected TransactionRef")
                     }
                 })
                 .collect();
@@ -162,26 +162,6 @@ impl Commit {
                 block_headers: blocks,
                 committed_transactions: transaction_refs,
                 reputation_scores_desc,
-            })
-        } else {
-            debug!("Creating CommitV1 as consensus_fast_commit_sync is disabled");
-            // Extract BlockRefs from GenericTransactionRef
-            let block_refs: Vec<BlockRef> = committed_transactions
-                .into_iter()
-                .map(|gen_ref| match gen_ref {
-                    GenericTransactionRef::BlockRef(br) => br,
-                    GenericTransactionRef::TransactionRef(_) => {
-                        panic!("Expected BlockRef when consensus_fast_commit_sync is disabled")
-                    }
-                })
-                .collect();
-            Commit::V1(CommitV1 {
-                index,
-                previous_digest,
-                timestamp_ms,
-                leader,
-                blocks,
-                committed_transactions: block_refs,
             })
         }
     }
@@ -1356,12 +1336,9 @@ mod tests {
         let leader_ref = leader_block.reference();
         let commit_index = 1;
 
-        // Convert BlockRefs to GenericTransactionRefs based on protocol flag
-        let generic_committed_transactions = convert_block_refs_to_generic_transaction_refs(
-            &context,
-            store.as_ref(),
-            &first_round_references,
-        );
+        // Convert BlockRefs to GenericTransactionRefs.
+        let generic_committed_transactions =
+            convert_block_refs_to_generic_transaction_refs(store.as_ref(), &first_round_references);
 
         let commit = TrustedCommit::new_for_test(
             &context,
@@ -1459,12 +1436,9 @@ mod tests {
         let leader_ref = leader_block.reference();
         let commit_index = 1;
 
-        // Convert BlockRefs to GenericTransactionRefs based on protocol flag
-        let generic_committed_transactions = convert_block_refs_to_generic_transaction_refs(
-            &context,
-            store.as_ref(),
-            &first_round_references,
-        );
+        // Convert BlockRefs to GenericTransactionRefs.
+        let generic_committed_transactions =
+            convert_block_refs_to_generic_transaction_refs(store.as_ref(), &first_round_references);
 
         let commit = TrustedCommit::new_for_test(
             &context,

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -1293,7 +1293,6 @@ mod tests {
                 WriteBatch::default()
                     .block_headers(first_round_headers)
                     .transactions(first_round_transactions),
-                context.clone(),
             )
             .unwrap();
         blocks.append(&mut first_round_references.clone());
@@ -1316,7 +1315,6 @@ mod tests {
                         WriteBatch::default()
                             .block_headers(vec![block.verified_block_header.clone()])
                             .transactions(vec![block.verified_transactions.clone()]),
-                        context.clone(),
                     )
                     .unwrap();
                 new_ancestors.push(block.reference());
@@ -1393,10 +1391,7 @@ mod tests {
             .map(|block| (block.reference(), block))
             .unzip();
         store
-            .write(
-                WriteBatch::default().block_headers(first_round_headers),
-                context.clone(),
-            )
+            .write(WriteBatch::default().block_headers(first_round_headers))
             .unwrap();
         blocks.append(&mut first_round_references.clone());
 
@@ -1414,10 +1409,7 @@ mod tests {
                         .build(),
                 );
                 store
-                    .write(
-                        WriteBatch::default().block_headers(vec![block.clone()]),
-                        context.clone(),
-                    )
+                    .write(WriteBatch::default().block_headers(vec![block.clone()]))
                     .unwrap();
                 new_ancestors.push(block.reference());
                 blocks.push(block.reference());

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -222,7 +222,6 @@ mod tests {
     use std::sync::Arc;
 
     use parking_lot::RwLock;
-    use rstest::rstest;
 
     use super::*;
     use crate::{
@@ -531,7 +530,6 @@ mod tests {
     }
 
     /// Tests the happy path where a single sub-dag is successfully committed.
-    #[rstest]
     #[tokio::test]
     async fn test_happy_path_commit() {
         let setup = Arc::new(TestSetup::new(3));
@@ -554,7 +552,6 @@ mod tests {
         assert!(commit_solidifier.pending_subdags.is_empty());
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_missing_blocks() {
         let setup = Arc::new(TestSetup::new(3));
@@ -586,7 +583,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 0);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_commit_after_missing_blocks_arrive() {
         let setup = Arc::new(TestSetup::new(3));
@@ -627,7 +623,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 1);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_multiple_subdags_in_order() {
         let setup = Arc::new(TestSetup::new(4));
@@ -656,7 +651,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 2);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_out_of_order_subdags() {
         let setup = Arc::new(TestSetup::new(4));
@@ -693,7 +687,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 2);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_empty_subdag_commit() {
         let setup = Arc::new(TestSetup::new(2));
@@ -706,7 +699,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 0);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_duplicate_subdag_commit() {
         let setup = Arc::new(TestSetup::new(3));
@@ -730,7 +722,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 1);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_out_of_order_commit_calls() {
         let setup = Arc::new(TestSetup::new(4));
@@ -769,7 +760,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 2);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_all_missing_refs_are_collected() {
         telemetry_subscribers::init_for_testing();
@@ -846,7 +836,6 @@ mod tests {
         assert!(commit_solidifier.pending_subdags.is_empty());
     }
 
-    #[rstest]
     #[tokio::test]
     #[should_panic(expected = "Duplicate missing blockref detected")]
     async fn test_duplicate_missing_refs_panic() {
@@ -894,7 +883,6 @@ mod tests {
         commit_solidifier.try_get_solid_sub_dags(&[subdag1, subdag2, subdag3]);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_gaps_in_subdags_sequence() {
         let setup = Arc::new(TestSetup::new(5));
@@ -961,7 +949,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 3); // Unchanged
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_set_last_committed_index() {
         let setup = Arc::new(TestSetup::new(3));
@@ -983,7 +970,6 @@ mod tests {
         assert_eq!(commit_solidifier.last_solid_committed_index, 0);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_get_missing_transaction_data() {
         let setup = Arc::new(TestSetup::new(4));

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -244,12 +244,8 @@ mod tests {
     impl TestSetup {
         /// Creates a new test setup with a full DAG containing the specified
         /// number of rounds
-        fn new(num_rounds: u32, consensus_fast_commit_sync: bool) -> Self {
-            let (mut context, _) = Context::new_for_test(2);
-            context
-                .protocol_config
-                .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-            context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        fn new(num_rounds: u32) -> Self {
+            let (context, _) = Context::new_for_test(2);
             let context = Arc::new(context);
             let dag_state = Arc::new(RwLock::new(DagState::new(
                 context.clone(),
@@ -431,40 +427,21 @@ mod tests {
         }
 
         fn with_committed_refs_from_round(mut self, round: u32) -> Self {
-            let consensus_fast_commit_sync = self
-                .setup
-                .context
-                .protocol_config
-                .consensus_fast_commit_sync();
             let refs = if round == 0 {
-                if consensus_fast_commit_sync {
-                    genesis_blocks(&self.setup.context)
-                        .iter()
-                        .map(|b| {
-                            GenericTransactionRef::TransactionRef(
-                                b.verified_block_header.transaction_ref(),
-                            )
-                        })
-                        .collect()
-                } else {
-                    genesis_blocks(&self.setup.context)
-                        .iter()
-                        .map(|b| GenericTransactionRef::from(b.reference()))
-                        .collect()
-                }
-            } else if consensus_fast_commit_sync {
-                self.setup
-                    .dag_builder
-                    .block_headers(round..=round)
+                genesis_blocks(&self.setup.context)
                     .iter()
-                    .map(|b| GenericTransactionRef::TransactionRef(b.transaction_ref()))
+                    .map(|b| {
+                        GenericTransactionRef::TransactionRef(
+                            b.verified_block_header.transaction_ref(),
+                        )
+                    })
                     .collect()
             } else {
                 self.setup
                     .dag_builder
                     .block_headers(round..=round)
                     .iter()
-                    .map(|b| GenericTransactionRef::from(b.reference()))
+                    .map(|b| GenericTransactionRef::TransactionRef(b.transaction_ref()))
                     .collect()
             };
             self.committed_refs = refs;
@@ -556,8 +533,8 @@ mod tests {
     /// Tests the happy path where a single sub-dag is successfully committed.
     #[rstest]
     #[tokio::test]
-    async fn test_happy_path_commit(#[values(false, true)] consensus_fast_commit_sync: bool) {
-        let setup = Arc::new(TestSetup::new(3, consensus_fast_commit_sync));
+    async fn test_happy_path_commit() {
+        let setup = Arc::new(TestSetup::new(3));
         let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag = SubDagBuilder::new(setup, 1)
@@ -579,21 +556,17 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_missing_blocks(#[values(false, true)] consensus_fast_commit_sync: bool) {
-        let setup = Arc::new(TestSetup::new(3, consensus_fast_commit_sync));
+    async fn test_missing_blocks() {
+        let setup = Arc::new(TestSetup::new(3));
         let (mut commit_solidifier, _selective_dag_state) = setup
             .create_selective_commit_solidifier(
                 vec![1, 2, 3],
                 vec![(1, 0)], // Exclude the first transaction from round 1
             );
 
-        let committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(1..=1)[0].reference())
-        };
+        let committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
+        );
 
         let subdag = SubDagBuilder::new(setup, 1)
             .leader(3, 0)
@@ -615,23 +588,17 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_commit_after_missing_blocks_arrive(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let setup = Arc::new(TestSetup::new(3, consensus_fast_commit_sync));
+    async fn test_commit_after_missing_blocks_arrive() {
+        let setup = Arc::new(TestSetup::new(3));
         let (mut commit_solidifier, selective_dag_state) = setup
             .create_selective_commit_solidifier(
                 vec![1, 2, 3],
                 vec![(1, 0)], // Exclude the first transactions from round 1
             );
 
-        let committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(1..=1)[0].reference())
-        };
+        let committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
+        );
 
         let subdag = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -662,10 +629,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_multiple_subdags_in_order(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let setup = Arc::new(TestSetup::new(4, consensus_fast_commit_sync));
+    async fn test_multiple_subdags_in_order() {
+        let setup = Arc::new(TestSetup::new(4));
         let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
@@ -693,8 +658,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_out_of_order_subdags(#[values(false, true)] consensus_fast_commit_sync: bool) {
-        let setup = Arc::new(TestSetup::new(4, consensus_fast_commit_sync));
+    async fn test_out_of_order_subdags() {
+        let setup = Arc::new(TestSetup::new(4));
         let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
@@ -730,8 +695,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_empty_subdag_commit(#[values(false, true)] consensus_fast_commit_sync: bool) {
-        let setup = Arc::new(TestSetup::new(2, consensus_fast_commit_sync));
+    async fn test_empty_subdag_commit() {
+        let setup = Arc::new(TestSetup::new(2));
         let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[]);
@@ -743,8 +708,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_duplicate_subdag_commit(#[values(false, true)] consensus_fast_commit_sync: bool) {
-        let setup = Arc::new(TestSetup::new(3, consensus_fast_commit_sync));
+    async fn test_duplicate_subdag_commit() {
+        let setup = Arc::new(TestSetup::new(3));
         let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup, 1)
@@ -767,10 +732,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_out_of_order_commit_calls(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let setup = Arc::new(TestSetup::new(4, consensus_fast_commit_sync));
+    async fn test_out_of_order_commit_calls() {
+        let setup = Arc::new(TestSetup::new(4));
         let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
@@ -808,12 +771,10 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_all_missing_refs_are_collected(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_all_missing_refs_are_collected() {
         telemetry_subscribers::init_for_testing();
 
-        let setup = Arc::new(TestSetup::new(4, consensus_fast_commit_sync));
+        let setup = Arc::new(TestSetup::new(4));
         let (mut commit_solidifier, selective_dag_state) = setup
             .create_selective_commit_solidifier(
                 vec![1, 2, 3, 4],
@@ -829,13 +790,9 @@ mod tests {
             .with_committed_refs(vec![]) // No committed refs
             .build();
 
-        let subdag2_committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(1..=1)[0].reference())
-        };
+        let subdag2_committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
+        );
 
         let subdag2 = SubDagBuilder::new(setup.clone(), 2)
             .leader(3, 0)
@@ -843,13 +800,9 @@ mod tests {
             .with_committed_refs(vec![subdag2_committed_ref])
             .build();
 
-        let subdag3_committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(2..=2)[0].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(2..=2)[0].reference())
-        };
+        let subdag3_committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(2..=2)[0].transaction_ref(),
+        );
 
         let subdag3 = SubDagBuilder::new(setup.clone(), 3)
             .leader(4, 0)
@@ -896,10 +849,8 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[should_panic(expected = "Duplicate missing blockref detected")]
-    async fn test_duplicate_missing_refs_panic(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let setup = Arc::new(TestSetup::new(4, consensus_fast_commit_sync));
+    async fn test_duplicate_missing_refs_panic() {
+        let setup = Arc::new(TestSetup::new(4));
         let (mut commit_solidifier, _selective_dag_state) = setup
             .create_selective_commit_solidifier(
                 vec![1, 2, 3, 4],
@@ -915,13 +866,9 @@ mod tests {
             .with_committed_refs(vec![])
             .build();
 
-        let subdag2_committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(1..=1)[0].reference())
-        };
+        let subdag2_committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
+        );
 
         let subdag2 = SubDagBuilder::new(setup.clone(), 2)
             .leader(3, 0)
@@ -934,13 +881,7 @@ mod tests {
             &setup.dag_builder.block_headers(2..=2)[0],
         ]
         .iter()
-        .map(|header| {
-            if consensus_fast_commit_sync {
-                GenericTransactionRef::TransactionRef(header.transaction_ref())
-            } else {
-                GenericTransactionRef::from(header.reference())
-            }
-        })
+        .map(|header| GenericTransactionRef::TransactionRef(header.transaction_ref()))
         .collect::<Vec<_>>();
 
         let subdag3 = SubDagBuilder::new(setup, 2) // Same index as subdag2
@@ -955,10 +896,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_gaps_in_subdags_sequence(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let setup = Arc::new(TestSetup::new(5, consensus_fast_commit_sync));
+    async fn test_gaps_in_subdags_sequence() {
+        let setup = Arc::new(TestSetup::new(5));
         let (mut commit_solidifier, selective_dag_state) = setup
             .create_selective_commit_solidifier(
                 vec![1, 2, 3, 4, 5],
@@ -977,13 +916,9 @@ mod tests {
             .with_committed_refs(vec![])
             .build();
 
-        let subdag3_committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(1..=1)[0].reference())
-        };
+        let subdag3_committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
+        );
 
         let subdag3 = SubDagBuilder::new(setup.clone(), 3)
             .leader(4, 0)
@@ -994,13 +929,9 @@ mod tests {
             .with_committed_refs(vec![subdag3_committed_ref])
             .build();
 
-        let subdag5_committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(3..=3)[0].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(3..=3)[0].reference())
-        };
+        let subdag5_committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(3..=3)[0].transaction_ref(),
+        );
 
         let subdag5 = SubDagBuilder::new(setup.clone(), 5) // Gap: missing index 4
             .leader(5, 0)
@@ -1032,10 +963,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_set_last_committed_index(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let setup = Arc::new(TestSetup::new(3, consensus_fast_commit_sync));
+    async fn test_set_last_committed_index() {
+        let setup = Arc::new(TestSetup::new(3));
         let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
 
         // Initially should be 0
@@ -1056,10 +985,8 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_missing_transaction_data(
-        #[values(false, true)] consensus_fast_commit_sync: bool,
-    ) {
-        let setup = Arc::new(TestSetup::new(4, consensus_fast_commit_sync));
+    async fn test_get_missing_transaction_data() {
+        let setup = Arc::new(TestSetup::new(4));
         let (mut commit_solidifier, selective_dag_state) = setup
             .create_selective_commit_solidifier(
                 vec![1, 2, 3, 4],
@@ -1068,13 +995,9 @@ mod tests {
             );
 
         // Create subdags that reference the missing transactions
-        let subdag1_committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(1..=1)[0].reference())
-        };
+        let subdag1_committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(1..=1)[0].transaction_ref(),
+        );
 
         let subdag1 = SubDagBuilder::new(setup.clone(), 1)
             .leader(3, 0)
@@ -1082,13 +1005,9 @@ mod tests {
             .with_committed_refs(vec![subdag1_committed_ref])
             .build();
 
-        let subdag2_committed_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::TransactionRef(
-                setup.dag_builder.block_headers(2..=2)[1].transaction_ref(),
-            )
-        } else {
-            GenericTransactionRef::from(setup.dag_builder.block_headers(2..=2)[1].reference())
-        };
+        let subdag2_committed_ref = GenericTransactionRef::TransactionRef(
+            setup.dag_builder.block_headers(2..=2)[1].transaction_ref(),
+        );
 
         let subdag2 = SubDagBuilder::new(setup.clone(), 2)
             .leader(4, 0)

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -315,11 +315,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             || self.inner.sync_type.should_schedule(
                 gap,
                 self.inner.context.parameters.commit_sync_gap_threshold,
-                self.inner
-                    .context
-                    .protocol_config
-                    .consensus_fast_commit_sync()
-                    && self.inner.context.parameters.enable_fast_commit_syncer,
+                self.inner.context.parameters.enable_fast_commit_syncer,
             );
 
         if should_schedule {
@@ -562,7 +558,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .commit_sync_fetch_once_latency
             .with_label_values(&[inner.sync_type.as_str()])
             .start_timer();
-        assert!(inner.context.protocol_config.consensus_fast_commit_sync());
 
         // 1. Fetch commits, voting headers, and transactions in the commit range from
         //    the target authority. Each transaction is serialized as

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1003,7 +1003,6 @@ mod tests {
 
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(true);
         protocol_config.set_gc_depth_for_testing(5);
         // Shrink the leader-schedule rotation window — which also bounds the
         // fast-sync reinitialization fetch window — well below TARGET_GAP. With the
@@ -1343,8 +1342,7 @@ mod tests {
         let stable_work_duration = Duration::from_secs(10);
 
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(true);
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
 
         let temp_dirs: Vec<TempDir> = (0..NUM_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -110,15 +110,12 @@ impl CommitSyncType {
         &self,
         gap: u32,
         commit_sync_gap_threshold: u32,
-        consensus_fast_commit_sync: bool,
+        fast_commit_sync_enabled: bool,
     ) -> bool {
         match self {
-            // Fast syncer requires consensus_fast_commit_sync to be enabled
-            CommitSyncType::Fast => consensus_fast_commit_sync && gap > commit_sync_gap_threshold,
-            // Regular syncer handles all gaps when consensus_fast_commit_sync is disabled,
-            // otherwise only handles small gaps
+            CommitSyncType::Fast => fast_commit_sync_enabled && gap > commit_sync_gap_threshold,
             CommitSyncType::Regular => {
-                !consensus_fast_commit_sync || gap <= commit_sync_gap_threshold
+                !fast_commit_sync_enabled || gap <= commit_sync_gap_threshold
             }
         }
     }
@@ -187,9 +184,7 @@ pub(crate) struct Inner<C: NetworkClient> {
     pub(crate) header_synchronizer: Arc<HeaderSynchronizerHandle>,
     pub(crate) misbehavior_store: Arc<MisbehaviorStore>,
     pub(crate) sync_type: CommitSyncType,
-    /// Present only when `FastCommitSyncer` is constructed (both the
-    /// protocol flag `consensus_fast_commit_sync` and the local flag
-    /// `enable_fast_commit_syncer` are on). The atomic is seeded at
+    /// Present only when `FastCommitSyncer` is enabled. The atomic is seeded at
     /// startup from the durable `DagState::fast_sync_ongoing()` flag so
     /// that a restart during fast sync correctly pauses regular syncing
     /// before fast sync's own loop has had a chance to run. After
@@ -406,8 +401,7 @@ pub(crate) fn verify_commits(
     Ok((trusted_commits, verified_voting_headers))
 }
 
-/// Verifies transactions against their transaction refs and returns a map of
-/// BlockRef to VerifiedTransactions.
+/// Verifies transactions and returns them keyed by transaction reference.
 pub(crate) fn verify_transactions_with_transactions_refs(
     context: &Arc<Context>,
     peer: AuthorityIndex,
@@ -417,16 +411,7 @@ pub(crate) fn verify_transactions_with_transactions_refs(
     let mut encoder = create_encoder(context);
     let size_limit = serialized_transactions_size_limit(context);
     for (committed_transactions_ref, inner_serialized_transactions) in serialized_transactions {
-        let transaction_ref = match committed_transactions_ref {
-            GenericTransactionRef::TransactionRef(tx_ref) => tx_ref,
-            _ => {
-                return Err(ConsensusError::TransactionRefVariantMismatch {
-                    protocol_flag_enabled: true,
-                    expected_variant: "TransactionRef",
-                    received_variant: "BlockRef",
-                });
-            }
-        };
+        let transaction_ref = committed_transactions_ref.expect_transaction_ref()?;
         // Bound the peer-supplied payload before erasure-encoding it.
         if inner_serialized_transactions.len() > size_limit {
             return Err(ConsensusError::SerializedTransactionsTooLarge {

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -246,7 +246,6 @@ pub(crate) fn check_commit_version_matches_flags(
         };
         return Err(ConsensusError::WrongCommitVersionForFlags {
             actual,
-            fast_commit_sync: true,
             starfish_speed,
         });
     }
@@ -861,14 +860,12 @@ mod tests {
         let result = run_verify(commit, starfish_speed_on);
         let Err(ConsensusError::WrongCommitVersionForFlags {
             actual,
-            fast_commit_sync,
             starfish_speed,
         }) = result
         else {
             panic!("expected WrongCommitVersionForFlags, got {result:?}");
         };
         assert_eq!(actual, expected_variant);
-        assert!(fast_commit_sync);
         assert_eq!(starfish_speed, starfish_speed_on);
     }
 

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -64,7 +64,7 @@ use crate::{
     misbehavior_store::MisbehaviorStore,
     network::NetworkClient,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
-    transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI, TransactionRef},
+    transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI},
 };
 
 /// Allowed multiplicity of commit vote headers per authority in a
@@ -233,11 +233,10 @@ pub(crate) fn check_commit_version_matches_flags(
     commit: &Commit,
     protocol_config: &iota_protocol_config::ProtocolConfig,
 ) -> ConsensusResult<()> {
-    let fast_commit_sync = protocol_config.consensus_fast_commit_sync();
     let starfish_speed = protocol_config.consensus_starfish_speed();
     let variant_matches_flags = matches!(
-        (commit, fast_commit_sync, starfish_speed),
-        (Commit::V1(_), false, false) | (Commit::V2(_), true, false) | (Commit::V3(_), true, true)
+        (commit, starfish_speed),
+        (Commit::V2(_), false) | (Commit::V3(_), true)
     );
     if !variant_matches_flags {
         let actual = match commit {
@@ -247,7 +246,7 @@ pub(crate) fn check_commit_version_matches_flags(
         };
         return Err(ConsensusError::WrongCommitVersionForFlags {
             actual,
-            fast_commit_sync,
+            fast_commit_sync: true,
             starfish_speed,
         });
     }
@@ -406,77 +405,6 @@ pub(crate) fn verify_commits(
         .map(|((_d, c), s)| TrustedCommit::new_trusted(c, s))
         .collect();
     Ok((trusted_commits, verified_voting_headers))
-}
-
-/// Verifies transactions against their block headers and returns a map of
-/// BlockRef to VerifiedTransactions.
-pub(crate) fn verify_transactions_with_headers(
-    context: Arc<Context>,
-    peer: AuthorityIndex,
-    serialized_transactions: BTreeMap<GenericTransactionRef, Bytes>,
-    block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
-) -> ConsensusResult<BTreeMap<GenericTransactionRef, VerifiedTransactions>> {
-    let mut verified_transactions_map = BTreeMap::new();
-    let mut encoder = create_encoder(&context);
-    let size_limit = serialized_transactions_size_limit(&context);
-    for (committed_transactions_ref, inner_serialized_transactions) in serialized_transactions {
-        let block_ref = match committed_transactions_ref {
-            GenericTransactionRef::BlockRef(br) => br,
-            _ => {
-                return Err(ConsensusError::TransactionRefVariantMismatch {
-                    protocol_flag_enabled: false,
-                    expected_variant: "BlockRef",
-                    received_variant: "TransactionRef",
-                });
-            }
-        };
-        // Bound the peer-supplied payload before erasure-encoding it.
-        if inner_serialized_transactions.len() > size_limit {
-            return Err(ConsensusError::SerializedTransactionsTooLarge {
-                size: inner_serialized_transactions.len(),
-                limit: size_limit,
-            });
-        }
-        // Step 1: Get the block header and verify that the transactions commitment
-        // matches. This ensures the transactions we received are exactly
-        // the ones that were included in the block when it was created.
-        let block_header = block_headers
-            .get(&block_ref)
-            .ok_or(ConsensusError::MissingBlockHeader { block_ref })?;
-
-        if block_header.transactions_commitment()
-            != TransactionsCommitment::compute_transactions_commitment(
-                &inner_serialized_transactions,
-                &context,
-                &mut encoder,
-            )?
-        {
-            return Err(ConsensusError::TransactionCommitmentFailure {
-                round: block_ref.round,
-                author: block_ref.author,
-                peer,
-            });
-        }
-
-        // Step 2: Deserialize the actual transactions vector.
-        let transactions: Vec<Transaction> = bcs::from_bytes(&inner_serialized_transactions)
-            .map_err(ConsensusError::MalformedTransactions)?;
-
-        // Step 3: Create a VerifiedTransactions instance and insert into map
-        let verified_transactions = VerifiedTransactions::new(
-            transactions,
-            TransactionRef::new(block_ref, block_header.transactions_commitment()),
-            Some(block_ref.digest),
-            inner_serialized_transactions,
-        );
-
-        verified_transactions_map.insert(
-            GenericTransactionRef::BlockRef(block_ref),
-            verified_transactions,
-        );
-    }
-
-    Ok(verified_transactions_map)
 }
 
 /// Verifies transactions against their transaction refs and returns a map of

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -819,21 +819,15 @@ mod tests {
         block_header::BlockHeaderDigest,
         block_verifier::NoopBlockVerifier,
         commit::{CommitV1, CommitV2, CommitV3},
+        transaction_ref::TransactionRef,
     };
 
     /// Builds a single-commit byte stream from `commit` and runs it through
     /// `verify_commits` with the two protocol flags set as specified. The
     /// version check fires before the index check, so the default commit
     /// index of 0 is fine here.
-    fn run_verify(
-        commit: Commit,
-        fast_commit_sync_on: bool,
-        starfish_speed_on: bool,
-    ) -> ConsensusResult<()> {
+    fn run_verify(commit: Commit, starfish_speed_on: bool) -> ConsensusResult<()> {
         let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(fast_commit_sync_on);
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(starfish_speed_on);
@@ -854,20 +848,17 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case::v1_with_fast_on(Commit::V1(CommitV1::default()), true, false, "V1")]
-    #[case::v1_with_starfish_on(Commit::V1(CommitV1::default()), true, true, "V1")]
-    #[case::v2_with_fast_off(Commit::V2(CommitV2::default()), false, false, "V2")]
-    #[case::v2_with_starfish_on(Commit::V2(CommitV2::default()), true, true, "V2")]
-    #[case::v3_with_fast_off(Commit::V3(CommitV3::default()), false, false, "V3")]
-    #[case::v3_with_starfish_off(Commit::V3(CommitV3::default()), true, false, "V3")]
+    #[case::v1_with_starfish_off(Commit::V1(CommitV1::default()), false, "V1")]
+    #[case::v1_with_starfish_on(Commit::V1(CommitV1::default()), true, "V1")]
+    #[case::v2_with_starfish_on(Commit::V2(CommitV2::default()), true, "V2")]
+    #[case::v3_with_starfish_off(Commit::V3(CommitV3::default()), false, "V3")]
     #[tokio::test]
     async fn verify_commits_rejects_wrong_version(
         #[case] commit: Commit,
-        #[case] fast_commit_sync_on: bool,
         #[case] starfish_speed_on: bool,
         #[case] expected_variant: &'static str,
     ) {
-        let result = run_verify(commit, fast_commit_sync_on, starfish_speed_on);
+        let result = run_verify(commit, starfish_speed_on);
         let Err(ConsensusError::WrongCommitVersionForFlags {
             actual,
             fast_commit_sync,
@@ -877,16 +868,13 @@ mod tests {
             panic!("expected WrongCommitVersionForFlags, got {result:?}");
         };
         assert_eq!(actual, expected_variant);
-        assert_eq!(fast_commit_sync, fast_commit_sync_on);
+        assert!(fast_commit_sync);
         assert_eq!(starfish_speed, starfish_speed_on);
     }
 
     #[tokio::test]
     async fn verify_commits_rejects_out_of_range_authority_index() {
         let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(false);
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(false);

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -20,11 +20,10 @@ use tokio::{
     task::JoinSet,
     time::{MissedTickBehavior, sleep},
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     CommitConsumerMonitor, CommitIndex,
-    block_header::BlockRef,
     block_verifier::BlockVerifier,
     commit::{CertifiedCommit, CertifiedCommits, CommitAPI as _, CommitRange},
     commit_syncer::{
@@ -32,8 +31,7 @@ use crate::{
         fast::{FastSyncPauseSource, paused_by_fast_sync},
         fetch_loop as shared_fetch_loop, handle_fetch_join_error, requeue_partial_range,
         schedule_commit_ranges, try_start_fetches as shared_try_start_fetches,
-        verify_fetched_headers, verify_transactions_with_headers,
-        verify_transactions_with_transactions_refs,
+        verify_fetched_headers, verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -42,7 +40,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     header_synchronizer::HeaderSynchronizerHandle,
     misbehavior_store::MisbehaviorStore,
-    network::{NetworkClient, SerializedTransactionsV1, SerializedTransactionsV2},
+    network::{NetworkClient, SerializedTransactionsV2},
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
 };
 
@@ -164,11 +162,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
         if !self.inner.sync_type.should_schedule(
             gap,
             self.inner.context.parameters.commit_sync_gap_threshold,
-            self.inner
-                .context
-                .protocol_config
-                .consensus_fast_commit_sync()
-                && self.inner.context.parameters.enable_fast_commit_syncer,
+            self.inner.context.parameters.enable_fast_commit_syncer,
         ) {
             return;
         }
@@ -354,22 +348,8 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
 
                 // Collect available transactions from VerifiedTransactions
                 for verified_txns in certified_commit.transactions() {
-                    let gen_tx_ref = if self
-                        .inner
-                        .context
-                        .protocol_config
-                        .consensus_fast_commit_sync()
-                    {
-                        GenericTransactionRef::TransactionRef(verified_txns.transaction_ref())
-                    } else {
-                        let Some(block_ref) = verified_txns.block_ref() else {
-                            error!(
-                                "block_ref unavailable for transactions in non-transaction-ref path"
-                            );
-                            continue;
-                        };
-                        GenericTransactionRef::BlockRef(block_ref)
-                    };
+                    let gen_tx_ref =
+                        GenericTransactionRef::TransactionRef(verified_txns.transaction_ref());
                     available_transactions.insert(gen_tx_ref);
                 }
             }
@@ -535,7 +515,6 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             .commit_sync_fetch_once_latency
             .with_label_values(&[inner.sync_type.as_str()])
             .start_timer();
-        let consensus_fast_commit_sync = inner.context.protocol_config.consensus_fast_commit_sync();
 
         // 1. Fetch commits in the commit range from the target authority.
         let (serialized_commits, serialized_voting_block_headers) = inner
@@ -565,7 +544,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             .expect("Spawn blocking should not fail")?;
 
         // 3. Fetch block headers referenced by the commits, from the same authority.
-        let mut block_refs: Vec<_> = commits
+        let block_refs: Vec<_> = commits
             .iter()
             .flat_map(|c| c.block_headers())
             .cloned()
@@ -576,36 +555,6 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             .iter()
             .flat_map(|c| c.committed_transactions())
             .collect();
-
-        if !consensus_fast_commit_sync {
-            // 3b. Identify which committed transaction blocks are NOT in the committed
-            // blocks list and add them to block_refs so they get fetched together.
-            // If consensus_fast_commit_sync is true, then we fetch these transactions
-            // separately without fetching headers, so in this case we don't need to do
-            // anything here
-            let block_refs_set: BTreeSet<_> = block_refs.iter().cloned().collect();
-            let missing_tx_header_refs: ConsensusResult<Vec<BlockRef>> = committed_tx_refs
-                .iter()
-                .filter_map(|tx_ref| match tx_ref {
-                    GenericTransactionRef::BlockRef(br) => {
-                        if !block_refs_set.contains(br) {
-                            Some(Ok(*br))
-                        } else {
-                            None
-                        }
-                    }
-                    _ => Some(Err(ConsensusError::TransactionRefVariantMismatch {
-                        protocol_flag_enabled: false,
-                        expected_variant: "BlockRef",
-                        received_variant: "TransactionRef",
-                    })),
-                })
-                .collect();
-            let missing_tx_header_refs = missing_tx_header_refs?;
-
-            // Merge missing transaction headers into the main block_refs list
-            block_refs.extend(missing_tx_header_refs);
-        }
 
         let num_chunks = block_refs
             .len()
@@ -696,58 +645,26 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         // Deserialize to extract BlockRef and build a map directly
                         let mut result = BTreeMap::new();
                         for serialized_bytes in serialized_transactions {
-                            let (committed_transaction_ref, serialized_transactions) =
-                                if !consensus_fast_commit_sync {
-                                    let serialized_tx: SerializedTransactionsV1 =
-                                        bcs::from_bytes(&serialized_bytes)
-                                            .map_err(ConsensusError::MalformedTransactions)?;
+                            let serialized_tx: SerializedTransactionsV2 =
+                                bcs::from_bytes(&serialized_bytes)
+                                    .map_err(ConsensusError::MalformedTransactions)?;
 
-                                    // 11. Verify the returned transactions match the requested
-                                    //     block refs.
-                                    let committed_transaction_ref =
-                                        GenericTransactionRef::BlockRef(serialized_tx.block_ref);
-                                    if !requested_block_refs_set
-                                        .contains(&committed_transaction_ref)
-                                    {
-                                        return Err(
-                                            ConsensusError::UnexpectedTransactionForCommit {
-                                                peer: target_authority,
-                                                received: committed_transaction_ref,
-                                            },
-                                        );
-                                    }
-                                    (
-                                        committed_transaction_ref,
-                                        serialized_tx.serialized_transactions,
-                                    )
-                                } else {
-                                    let serialized_tx: SerializedTransactionsV2 =
-                                        bcs::from_bytes(&serialized_bytes)
-                                            .map_err(ConsensusError::MalformedTransactions)?;
+                            // 11. Verify the returned transactions match the requested transaction
+                            //     refs.
+                            let committed_transaction_ref = GenericTransactionRef::TransactionRef(
+                                serialized_tx.transaction_ref,
+                            );
+                            if !requested_block_refs_set.contains(&committed_transaction_ref) {
+                                return Err(ConsensusError::UnexpectedTransactionForCommit {
+                                    peer: target_authority,
+                                    received: committed_transaction_ref,
+                                });
+                            }
 
-                                    // 11. Verify the returned transactions match the requested
-                                    //     transaction refs.
-                                    let committed_transaction_ref =
-                                        GenericTransactionRef::TransactionRef(
-                                            serialized_tx.transaction_ref,
-                                        );
-                                    if !requested_block_refs_set
-                                        .contains(&committed_transaction_ref)
-                                    {
-                                        return Err(
-                                            ConsensusError::UnexpectedTransactionForCommit {
-                                                peer: target_authority,
-                                                received: committed_transaction_ref,
-                                            },
-                                        );
-                                    }
-                                    (
-                                        committed_transaction_ref,
-                                        serialized_tx.serialized_transactions,
-                                    )
-                                };
-
-                            result.insert(committed_transaction_ref, serialized_transactions);
+                            result.insert(
+                                committed_transaction_ref,
+                                serialized_tx.serialized_transactions,
+                            );
                         }
 
                         Ok::<BTreeMap<GenericTransactionRef, Bytes>, ConsensusError>(result)
@@ -778,38 +695,20 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
 
         // 13. Verify transactions
         let mut transactions_map = if !fetched_transactions.is_empty() {
-            if !inner.context.protocol_config.consensus_fast_commit_sync() {
-                Handle::current()
-                    .spawn_blocking({
-                        let context = inner.context.clone();
-                        let fetched_block_headers_clone = fetched_block_headers.clone();
-                        move || {
-                            verify_transactions_with_headers(
-                                context,
-                                target_authority,
-                                fetched_transactions,
-                                fetched_block_headers_clone,
-                            )
-                        }
-                    })
-                    .await
-                    .expect("Spawn blocking should not fail")?
-            } else {
-                Handle::current()
-                    .spawn_blocking({
-                        let context = inner.context.clone();
+            Handle::current()
+                .spawn_blocking({
+                    let context = inner.context.clone();
 
-                        move || {
-                            verify_transactions_with_transactions_refs(
-                                &context,
-                                target_authority,
-                                fetched_transactions,
-                            )
-                        }
-                    })
-                    .await
-                    .expect("Spawn blocking should not fail")?
-            }
+                    move || {
+                        verify_transactions_with_transactions_refs(
+                            &context,
+                            target_authority,
+                            fetched_transactions,
+                        )
+                    }
+                })
+                .await
+                .expect("Spawn blocking should not fail")?
         } else {
             BTreeMap::new()
         };

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -600,28 +600,22 @@ impl CordialKnowledge {
             msgs.push(ConnectionKnowledgeMessage::NewHeader { block_ref });
         }
 
-        // 3) The block_author now acknowledges previously known transactions
-        // Use the provided transaction commitments to create the proper
-        // GenericTransactionRef variant
-        let consensus_fast_commit_sync = self.context.protocol_config.consensus_fast_commit_sync();
+        // 3) The block_author now acknowledges previously known transactions,
+        // using the provided transaction commitments.
         for (acknowledgment, &transactions_commitment) in header
             .acknowledgments()
             .iter()
             .zip(ack_transactions_commitments.iter())
         {
-            let gen_tx_ref = if consensus_fast_commit_sync {
-                if let Some(transactions_commitment) = transactions_commitment {
-                    GenericTransactionRef::TransactionRef(crate::transaction_ref::TransactionRef {
-                        round: acknowledgment.round,
-                        author: acknowledgment.author,
-                        transactions_commitment,
-                    })
-                } else {
-                    continue;
-                }
-            } else {
-                GenericTransactionRef::BlockRef(*acknowledgment)
+            let Some(transactions_commitment) = transactions_commitment else {
+                continue;
             };
+            let gen_tx_ref =
+                GenericTransactionRef::TransactionRef(crate::transaction_ref::TransactionRef {
+                    round: acknowledgment.round,
+                    author: acknowledgment.author,
+                    transactions_commitment,
+                });
 
             vec_knowledge_msgs[block_author]
                 .push(ConnectionKnowledgeMessage::RemoveShard { gen_tx_ref });

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1279,18 +1279,9 @@ mod tests {
                     dag_state
                         .write()
                         .accept_block_header(verified_block_header, DataSource::Test);
-                    let gen_transaction_ref =
-                        if context.protocol_config.consensus_fast_commit_sync() {
-                            GenericTransactionRef::TransactionRef(
-                                verified_transactions.transaction_ref(),
-                            )
-                        } else {
-                            GenericTransactionRef::BlockRef(
-                                verified_transactions.block_ref().expect(
-                                    "block_ref must be present in non-transaction-ref path",
-                                ),
-                            )
-                        };
+                    let gen_transaction_ref = GenericTransactionRef::TransactionRef(
+                        verified_transactions.transaction_ref(),
+                    );
                     let shard_for_core = VerifiedOwnShard {
                         serialized_shard: Bytes::from([0u8; 32].to_vec()), /* put some dummy
                                                                             * shard data */
@@ -1312,15 +1303,8 @@ mod tests {
                 dag_state
                     .write()
                     .accept_block_header(verified_block_header, DataSource::Test);
-                let gen_transaction_ref = if context.protocol_config.consensus_fast_commit_sync() {
-                    GenericTransactionRef::TransactionRef(verified_transactions.transaction_ref())
-                } else {
-                    GenericTransactionRef::BlockRef(
-                        verified_transactions
-                            .block_ref()
-                            .expect("block_ref must be present in non-transaction-ref path"),
-                    )
-                };
+                let gen_transaction_ref =
+                    GenericTransactionRef::TransactionRef(verified_transactions.transaction_ref());
                 let shard_for_core = VerifiedOwnShard {
                     serialized_shard: Bytes::from([0u8; 32].to_vec()), // put some dummy shard data
                     gen_transaction_ref,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2920,7 +2920,7 @@ mod test {
     #[tokio::test]
     #[serial]
     async fn test_sequenced_transactions_no_headers() {
-        test_sequenced_transactions_no_headers_impl(true, true).await;
+        test_sequenced_transactions_no_headers_impl(true).await;
     }
 
     #[tokio::test]
@@ -2929,20 +2929,13 @@ mod test {
         expected = "consensus_fast_commit_sync requires consensus_commit_transactions_only_for_traversed_headers to be enabled"
     )]
     async fn test_sequenced_transactions_no_headers_invalid_config() {
-        test_sequenced_transactions_no_headers_impl(false, true).await;
+        test_sequenced_transactions_no_headers_impl(false).await;
     }
 
-    async fn test_sequenced_transactions_no_headers_impl(
-        commit_only_for_traversed_headers: bool,
-        consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_sequenced_transactions_no_headers_impl(commit_only_for_traversed_headers: bool) {
         telemetry_subscribers::init_for_testing();
         let committee_size = 10;
         let (mut context, _key_pairs) = Context::new_for_test(committee_size);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         context
             .protocol_config
             .set_consensus_commit_transactions_only_for_traversed_headers_for_testing(
@@ -3712,10 +3705,7 @@ mod test {
 
     #[tokio::test]
     async fn test_compute_strong_vote() {
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context, store)));
@@ -3778,9 +3768,6 @@ mod test {
     #[tokio::test]
     async fn test_has_strong_vote_quorum() {
         let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(true);

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1436,9 +1436,8 @@ impl Core {
     }
 
     /// Returns true when Core should propose at the current clock round. As a
-    /// side effect, when proposal is greenlit under
-    /// `consensus_block_restrictions`, refreshes `DagState`'s last-known
-    /// quorum commit index to enable eviction for commit votes
+    /// side effect, when proposal is greenlit, refreshes `DagState`'s
+    /// last-known quorum commit index to enable eviction for commit votes.
     pub(crate) fn should_propose(&self) -> bool {
         let (clock_round, last_proposed_round, local_commit_index, local_commit_round) = {
             let dag_state = self.dag_state.read();

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1476,28 +1476,26 @@ impl Core {
             return false;
         }
 
-        // Under `consensus_block_restrictions`, skip if the candidate round
-        // does not exceed an approximation of the quorum commit round. Blocks
-        // at or below it cannot improve the commit rule.
-        if self.context.protocol_config.consensus_block_restrictions() {
-            let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
-            let approx_quorum_round =
-                local_commit_round + quorum_commit_index.saturating_sub(local_commit_index);
-            if clock_round <= approx_quorum_round {
-                return self.skip_proposal(
-                    clock_round,
-                    SkipProposalReason::BehindQuorumCommitRound {
-                        approx_quorum: approx_quorum_round,
-                    },
-                );
-            }
-
-            // We are about to propose: refresh DagState's known quorum commit
-            // index so the eviction of `pending_commit_votes` is bounded.
-            self.dag_state
-                .write()
-                .set_last_known_quorum_commit_index(quorum_commit_index);
+        // Skip if the candidate round does not exceed an approximation of the
+        // quorum commit round. Blocks at or below it cannot improve the commit
+        // rule.
+        let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
+        let approx_quorum_round =
+            local_commit_round + quorum_commit_index.saturating_sub(local_commit_index);
+        if clock_round <= approx_quorum_round {
+            return self.skip_proposal(
+                clock_round,
+                SkipProposalReason::BehindQuorumCommitRound {
+                    approx_quorum: approx_quorum_round,
+                },
+            );
         }
+
+        // We are about to propose: refresh DagState's known quorum commit
+        // index so the eviction of `pending_commit_votes` is bounded.
+        self.dag_state
+            .write()
+            .set_last_known_quorum_commit_index(quorum_commit_index);
 
         true
     }

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1934,7 +1934,6 @@ mod test {
     use futures::{StreamExt, stream::FuturesUnordered};
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use iota_protocol_config::ProtocolConfig;
-    use rstest::rstest;
     use serial_test::serial;
     use starfish_config::{AuthorityIndex, Parameters};
     use tokio::time::sleep;
@@ -1956,17 +1955,10 @@ mod test {
 
     /// Recover Core and continue proposing from the last round which forms a
     /// quorum.
-    #[rstest]
     #[tokio::test]
-    async fn test_core_recover_from_store_for_full_round(
-        #[values(true, false)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_core_recover_from_store_for_full_round() {
         telemetry_subscribers::init_for_testing();
-        let (mut context, mut key_pairs) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -1983,17 +1975,11 @@ mod test {
         // able to commit transactions up to round 2.
         for block in dag_builder.block_headers(1..=2) {
             if block.author() == context.own_index {
-                let generic_ref = if consensus_fast_commit_sync {
-                    // When consensus_fast_commit_sync is enabled, create TransactionRef variant
-                    GenericTransactionRef::TransactionRef(TransactionRef {
-                        round: block.round(),
-                        author: block.author(),
-                        transactions_commitment: block.transactions_commitment(),
-                    })
-                } else {
-                    // When disabled, use BlockRef variant
-                    GenericTransactionRef::from(block.reference())
-                };
+                let generic_ref = GenericTransactionRef::TransactionRef(TransactionRef {
+                    round: block.round(),
+                    author: block.author(),
+                    transactions_commitment: block.transactions_commitment(),
+                });
                 let subscription =
                     transaction_consumer.subscribe_for_block_status_testing(generic_ref);
                 block_status_subscriptions.push(subscription);
@@ -2006,7 +1992,6 @@ mod test {
                 WriteBatch::default()
                     .block_headers(dag_builder.block_headers(1..=num_rounds))
                     .transactions(dag_builder.transactions(1..=num_rounds)),
-                context.clone(),
             )
             .expect("We should expect a successful storing of headers");
 
@@ -2137,7 +2122,6 @@ mod test {
                 WriteBatch::default()
                     .block_headers(block_headers)
                     .transactions(block_transactions),
-                context.clone(),
             )
             .expect("Storage error");
 
@@ -2477,25 +2461,17 @@ mod test {
     /// Validates `min_ancestor_round`, the helper driving
     /// `ancestors_to_propose`'s drop-too-old filter.
     ///
-    /// Three properties are checked:
+    /// Two properties are checked:
     ///   1. `saturating_sub` clamps small `clock_round`s to `0`, so the
     ///      strict-`<` filter in `ancestors_to_propose` self-disables there and
     ///      genesis/quorum-round ancestors can never be accidentally dropped.
     ///   2. Well above `gc_depth`, the helper returns `clock_round - gc_depth`
     ///      (matching `Context::min_ref_round` and the verifier's bound).
-    ///   3. When the `consensus_fast_commit_sync` protocol flag is off the
-    ///      helper returns `GENESIS_ROUND = 0` unconditionally — the filter
-    ///      becomes a no-op, preserving backwards compatibility on networks
-    ///      without the flag.
     #[tokio::test]
     async fn test_min_ancestor_round() {
         telemetry_subscribers::init_for_testing();
         let (context, _) = Context::new_for_test(4);
         let gc_depth = context.protocol_config.gc_depth();
-        assert!(
-            context.protocol_config.consensus_fast_commit_sync(),
-            "test assumes consensus_fast_commit_sync is enabled at max version"
-        );
 
         let fixture = CoreTextFixture::new(
             context.clone(),
@@ -2524,27 +2500,6 @@ mod test {
                 "min_ancestor_round({clock_round}) should be clock_round - gc_depth (gc_depth={gc_depth})",
             );
         }
-
-        // (3) Flag off → no-op. Build a fresh fixture with the flag disabled
-        // and confirm the helper returns GENESIS_ROUND for a round well
-        // above gc_depth (where otherwise the bound would be non-zero).
-        let mut context_off = context;
-        context_off
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(false);
-        let fixture_off = CoreTextFixture::new(
-            context_off,
-            vec![1; 4],
-            AuthorityIndex::new_for_test(0),
-            false,
-            false,
-        )
-        .await;
-        assert_eq!(
-            fixture_off.core.min_ancestor_round(1000),
-            GENESIS_ROUND,
-            "flag-off should return GENESIS_ROUND regardless of clock_round"
-        );
     }
 
     #[tokio::test]
@@ -2963,21 +2918,10 @@ mod test {
         }
     }
 
-    #[rstest]
-    #[case(true, true)]
-    #[case(true, false)]
-    #[case(false, false)]
     #[tokio::test]
     #[serial]
-    async fn test_sequenced_transactions_no_headers(
-        #[case] commit_only_for_traversed_headers: bool,
-        #[case] consensus_fast_commit_sync: bool,
-    ) {
-        test_sequenced_transactions_no_headers_impl(
-            commit_only_for_traversed_headers,
-            consensus_fast_commit_sync,
-        )
-        .await;
+    async fn test_sequenced_transactions_no_headers() {
+        test_sequenced_transactions_no_headers_impl(true, true).await;
     }
 
     #[tokio::test]
@@ -3005,6 +2949,9 @@ mod test {
             .set_consensus_commit_transactions_only_for_traversed_headers_for_testing(
                 commit_only_for_traversed_headers,
             );
+        // Enforce the protocol-config invariant before exercising the pipeline:
+        // fast commit sync requires committing only for traversed headers.
+        assert!(context.protocol_config.consensus_fast_commit_sync());
         let own_index = AuthorityIndex::new_for_test(0);
         let core_fixture_own = CoreTextFixture::new(
             context.clone(),
@@ -3168,13 +3115,7 @@ mod test {
         let missing_verified_transactions: Vec<_> = all_sequenced_transactions
             .into_iter()
             .filter(|tx| {
-                let generic_ref = if consensus_fast_commit_sync {
-                    GenericTransactionRef::TransactionRef(tx.transaction_ref())
-                } else {
-                    GenericTransactionRef::BlockRef(
-                        tx.block_ref().expect("block_ref should be set in test"),
-                    )
-                };
+                let generic_ref = GenericTransactionRef::TransactionRef(tx.transaction_ref());
                 missing_transactions.contains_key(&generic_ref)
             })
             .collect();
@@ -3640,17 +3581,10 @@ mod test {
         *receiver.borrow_and_update()
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn test_commit_and_notify_for_block_status(
-        #[values(true, false)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_commit_and_notify_for_block_status() {
         telemetry_subscribers::init_for_testing();
-        let (mut context, mut key_pairs) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        let (context, mut key_pairs) = Context::new_for_test(4);
 
         let context = Arc::new(context);
 
@@ -3668,17 +3602,11 @@ mod test {
         // able to commit transactions up to round 4.
         for block in dag_builder.block_headers(1..=4) {
             if block.author() == context.own_index {
-                let generic_ref = if consensus_fast_commit_sync {
-                    // When consensus_fast_commit_sync is enabled, create TransactionRef variant
-                    GenericTransactionRef::TransactionRef(TransactionRef {
-                        round: block.round(),
-                        author: block.author(),
-                        transactions_commitment: block.transactions_commitment(),
-                    })
-                } else {
-                    // When disabled, use BlockRef variant
-                    GenericTransactionRef::from(block.reference())
-                };
+                let generic_ref = GenericTransactionRef::TransactionRef(TransactionRef {
+                    round: block.round(),
+                    author: block.author(),
+                    transactions_commitment: block.transactions_commitment(),
+                });
                 let subscription =
                     transaction_consumer.subscribe_for_block_status_testing(generic_ref);
                 block_status_subscriptions.push(subscription);
@@ -3687,18 +3615,12 @@ mod test {
 
         // write headers in store
         store
-            .write(
-                WriteBatch::default().block_headers(dag_builder.block_headers(1..=8)),
-                context.clone(),
-            )
+            .write(WriteBatch::default().block_headers(dag_builder.block_headers(1..=8)))
             .expect("We should expect a successful storing of headers");
 
         // write transactions in store
         store
-            .write(
-                WriteBatch::default().transactions(dag_builder.transactions(1..=8)),
-                context.clone(),
-            )
+            .write(WriteBatch::default().transactions(dag_builder.transactions(1..=8)))
             .expect("We should expect a successful storing of transactions");
 
         // create dag state after all blocks have been written to store

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1213,11 +1213,7 @@ impl Core {
         drop(dag_state_guard);
         // Now acknowledge the transactions for their inclusion to block
         let block_ref = verified_block.reference();
-        let gen_transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
-            GenericTransactionRef::from(verified_block.transaction_ref())
-        } else {
-            GenericTransactionRef::from(block_ref)
-        };
+        let gen_transaction_ref = GenericTransactionRef::from(verified_block.transaction_ref());
         ack_transactions(gen_transaction_ref);
 
         info!("Created block {block_ref} for round {clock_round}");
@@ -1712,12 +1708,7 @@ impl Core {
     /// propose at `clock_round`. Ancestors strictly below this round are
     /// dropped — the linearizer would filter them out anyway, so keeping
     /// them only costs other validators header-synchronizer round-trips.
-    /// Returns `GENESIS_ROUND` when the `consensus_fast_commit_sync` protocol
-    /// flag is disabled, so the filter is a no-op on networks without it.
     fn min_ancestor_round(&self, clock_round: Round) -> Round {
-        if !self.context.protocol_config.consensus_fast_commit_sync() {
-            return GENESIS_ROUND;
-        }
         self.context.min_ref_round(clock_round)
     }
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -885,7 +885,6 @@ pub(crate) mod tests {
                 WriteBatch::default()
                     .block_headers(block_headers)
                     .transactions(block_transactions),
-                context.clone(),
             )
             .expect("Storage error");
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2807,7 +2807,6 @@ mod test {
     use std::vec;
 
     use parking_lot::RwLock;
-    use rstest::rstest;
 
     use super::*;
     use crate::{
@@ -3258,7 +3257,6 @@ mod test {
         assert_eq!(result, expected_headers);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_flush_and_recovery() {
         telemetry_subscribers::init_for_testing();
@@ -3895,7 +3893,6 @@ mod test {
         }
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_contains_transactions() {
         let (context, _) = Context::new_for_test(4);
@@ -3973,7 +3970,6 @@ mod test {
         assert_eq!(result, expected);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_are_transactions_available() {
         let (context, _) = Context::new_for_test(4);
@@ -4027,7 +4023,6 @@ mod test {
         assert_eq!(accepted_header, &block_header);
     }
 
-    #[rstest]
     #[tokio::test]
     async fn test_eviction() {
         telemetry_subscribers::init_for_testing();
@@ -4285,7 +4280,6 @@ mod test {
 
     /// Ensures `flush()` performs eviction even when there is nothing to write,
     /// so changes in `last_solid_subdag_base` take effect.
-    #[rstest]
     #[tokio::test]
     async fn test_flush_evicts_transactions_without_pending_writes() {
         telemetry_subscribers::init_for_testing();
@@ -4347,7 +4341,6 @@ mod test {
 
     /// Ensures transaction eviction during fast sync does not depend on cached
     /// headers (so `recent_headers_refs_by_authority` may be empty).
-    #[rstest]
     #[tokio::test]
     async fn test_fast_sync_transaction_eviction_without_headers() {
         telemetry_subscribers::init_for_testing();

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3108,7 +3108,7 @@ mod test {
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store.clone());
+        let mut dag_state = DagState::new(context, store.clone());
 
         // Create test block headers for round 1 ~ 10
         let num_rounds: u32 = 10;
@@ -3128,10 +3128,7 @@ mod test {
         block_headers.clone().into_iter().for_each(|block_header| {
             if block_header.round() <= 4 {
                 store
-                    .write(
-                        WriteBatch::default().block_headers(vec![block_header]),
-                        context.clone(),
-                    )
+                    .write(WriteBatch::default().block_headers(vec![block_header]))
                     .unwrap();
             } else {
                 dag_state.accept_block_headers(vec![block_header], DataSource::Test);
@@ -3172,7 +3169,7 @@ mod test {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store.clone());
+        let mut dag_state = DagState::new(context, store.clone());
 
         // Create test block headers for round 1 ~ 10
         let num_rounds: u32 = 10;
@@ -3192,10 +3189,7 @@ mod test {
         block_headers.clone().into_iter().for_each(|block_header| {
             if block_header.round() <= 4 {
                 store
-                    .write(
-                        WriteBatch::default().block_headers(vec![block_header]),
-                        context.clone(),
-                    )
+                    .write(WriteBatch::default().block_headers(vec![block_header]))
                     .unwrap();
             } else {
                 dag_state.accept_block_headers(vec![block_header], DataSource::Test);
@@ -3266,14 +3260,10 @@ mod test {
 
     #[rstest]
     #[tokio::test]
-    async fn test_flush_and_recovery(#[values(true, false)] consensus_fast_commit_sync: bool) {
+    async fn test_flush_and_recovery() {
         telemetry_subscribers::init_for_testing();
         let num_authorities: u32 = 4;
-        let (mut context, _) = Context::new_for_test(num_authorities as usize);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+        let (context, _) = Context::new_for_test(num_authorities as usize);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
@@ -3351,17 +3341,10 @@ mod test {
         all_transactions.extend(dag_builder.transactions(1..=num_rounds));
 
         // All transactions should be found in DagState.
-        let transactions_refs = if consensus_fast_commit_sync {
-            all_block_headers
-                .iter()
-                .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
-                .collect::<Vec<_>>()
-        } else {
-            block_refs
-                .iter()
-                .map(|&br| GenericTransactionRef::from(br))
-                .collect::<Vec<_>>()
-        };
+        let transactions_refs = all_block_headers
+            .iter()
+            .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
+            .collect::<Vec<_>>();
         let result = dag_state
             .get_verified_transactions(transactions_refs.as_slice())
             .into_iter()
@@ -3402,17 +3385,10 @@ mod test {
         assert_eq!(result, block_headers);
         // Transactions from the first 5 rounds should be found in DagState.
         let vec_transactions = dag_builder.transactions(1..=5);
-        let transactions_refs = if consensus_fast_commit_sync {
-            block_headers
-                .iter()
-                .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
-                .collect::<Vec<_>>()
-        } else {
-            block_refs
-                .iter()
-                .map(|&br| GenericTransactionRef::from(br))
-                .collect::<Vec<_>>()
-        };
+        let transactions_refs = block_headers
+            .iter()
+            .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
+            .collect::<Vec<_>>();
         let result = dag_state
             .get_verified_transactions(&transactions_refs)
             .into_iter()
@@ -3439,17 +3415,10 @@ mod test {
             .flatten()
             .collect::<Vec<_>>();
         assert!(retrieved_block_headers.is_empty());
-        let transactions_refs = if consensus_fast_commit_sync {
-            missing_block_headers
-                .iter()
-                .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
-                .collect::<Vec<_>>()
-        } else {
-            block_refs
-                .iter()
-                .map(|&br| GenericTransactionRef::from(br))
-                .collect::<Vec<_>>()
-        };
+        let transactions_refs = missing_block_headers
+            .iter()
+            .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
+            .collect::<Vec<_>>();
         let retrieved_transactions = dag_state
             .get_verified_transactions(&transactions_refs)
             .into_iter()
@@ -3928,12 +3897,8 @@ mod test {
 
     #[rstest]
     #[tokio::test]
-    async fn test_contains_transactions(#[values(true, false)] consensus_fast_commit_sync: bool) {
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+    async fn test_contains_transactions() {
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
@@ -3956,10 +3921,7 @@ mod test {
         blocks.clone().into_iter().for_each(|block| {
             if block.round() <= 4 {
                 store
-                    .write(
-                        WriteBatch::default().transactions(vec![block.verified_transactions]),
-                        context.clone(),
-                    )
+                    .write(WriteBatch::default().transactions(vec![block.verified_transactions]))
                     .unwrap();
             } else {
                 dag_state.add_transactions(block.verified_transactions, DataSource::Test);
@@ -3971,13 +3933,7 @@ mod test {
         // is from DagState.
         let mut transactions_refs = blocks
             .iter()
-            .map(|block| {
-                if consensus_fast_commit_sync {
-                    GenericTransactionRef::from(block.transaction_ref())
-                } else {
-                    GenericTransactionRef::from(block.reference())
-                }
-            })
+            .map(|block| GenericTransactionRef::from(block.transaction_ref()))
             .collect::<Vec<_>>();
         let result = dag_state.contains_transactions(transactions_refs.clone());
 
@@ -3986,19 +3942,11 @@ mod test {
         assert_eq!(result, expected);
 
         // Now try to ask also for one block ref that is neither in cache nor in store
-        let non_existent_ref = if consensus_fast_commit_sync {
-            GenericTransactionRef::from(TransactionRef {
-                round: 11,
-                author: AuthorityIndex::new_for_test(0),
-                transactions_commitment: TransactionsCommitment::default(),
-            })
-        } else {
-            GenericTransactionRef::from(BlockRef::new(
-                11,
-                AuthorityIndex::new_for_test(0),
-                BlockHeaderDigest::default(),
-            ))
-        };
+        let non_existent_ref = GenericTransactionRef::from(TransactionRef {
+            round: 11,
+            author: AuthorityIndex::new_for_test(0),
+            transactions_commitment: TransactionsCommitment::default(),
+        });
         transactions_refs.insert(3, non_existent_ref);
         let result = dag_state.contains_transactions(transactions_refs);
 
@@ -4014,13 +3962,7 @@ mod test {
 
         let transactions_refs = blocks
             .iter()
-            .map(|block| {
-                if consensus_fast_commit_sync {
-                    GenericTransactionRef::from(block.transaction_ref())
-                } else {
-                    GenericTransactionRef::from(block.reference())
-                }
-            })
+            .map(|block| GenericTransactionRef::from(block.transaction_ref()))
             .collect::<Vec<_>>();
         let result = dag_state.contains_transactions(transactions_refs);
 
@@ -4033,13 +3975,8 @@ mod test {
 
     #[rstest]
     #[tokio::test]
-    async fn test_are_transactions_available(
-        #[values(true, false)] consensus_fast_commit_sync: bool,
-    ) {
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+    async fn test_are_transactions_available() {
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context, store);
@@ -4058,15 +3995,11 @@ mod test {
         dag_state.add_transactions(block.verified_transactions, DataSource::Test);
         assert!(dag_state.are_transactions_available(&block_ref));
 
-        // Transactions without a header: flag-off ignores the header check;
-        // flag-on requires it.
+        // Transactions without a header: availability requires the header.
         let other = VerifiedBlock::new_for_test(TestBlockHeader::new(6, 2).build());
         let other_ref = other.reference();
         dag_state.add_transactions(other.verified_transactions, DataSource::Test);
-        assert_eq!(
-            dag_state.are_transactions_available(&other_ref),
-            !consensus_fast_commit_sync,
-        );
+        assert!(!dag_state.are_transactions_available(&other_ref));
     }
 
     #[tokio::test]
@@ -4096,16 +4029,12 @@ mod test {
 
     #[rstest]
     #[tokio::test]
-    async fn test_eviction(#[values(true, false)] consensus_fast_commit_sync: bool) {
+    async fn test_eviction() {
         telemetry_subscribers::init_for_testing();
         let num_authorities: u32 = 4;
         let (mut context, _) = Context::new_for_test(num_authorities as usize);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         const CACHED_ROUNDS: Round = 5;
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
@@ -4177,27 +4106,13 @@ mod test {
         all_transactions.extend(dag_builder.transactions(1..=num_rounds));
         let gc_round = dag_state.gc_round_for_last_commit();
 
-        let block_refs_with_transactions_in_dag: Vec<BlockRef> = block_refs
-            .iter()
-            .filter(|x| x.round > gc_round)
-            .cloned()
-            .collect();
-
         // Get block headers above GC round
         let block_headers_above_gc = dag_builder.block_headers(gc_round + 1..=num_rounds);
 
-        // Create appropriate transaction refs based on the flag
-        let transaction_refs = if consensus_fast_commit_sync {
-            block_headers_above_gc
-                .iter()
-                .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
-                .collect::<Vec<_>>()
-        } else {
-            block_refs_with_transactions_in_dag
-                .iter()
-                .map(|br| GenericTransactionRef::from(*br))
-                .collect::<Vec<_>>()
-        };
+        let transaction_refs = block_headers_above_gc
+            .iter()
+            .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
+            .collect::<Vec<_>>();
 
         let expected_transactions_in_dag = dag_builder.transactions(gc_round + 1..=num_rounds);
         // All transactions should be found in DagState or store.
@@ -4221,17 +4136,10 @@ mod test {
         );
 
         // All transactions should be found in DagState or store.
-        let transaction_refs = if consensus_fast_commit_sync {
-            all_block_headers
-                .iter()
-                .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
-                .collect::<Vec<_>>()
-        } else {
-            block_refs
-                .iter()
-                .map(|br| GenericTransactionRef::from(*br))
-                .collect::<Vec<_>>()
-        };
+        let transaction_refs = all_block_headers
+            .iter()
+            .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
+            .collect::<Vec<_>>();
 
         let result = dag_state
             .get_verified_transactions(&transaction_refs)
@@ -4379,18 +4287,12 @@ mod test {
     /// so changes in `last_solid_subdag_base` take effect.
     #[rstest]
     #[tokio::test]
-    async fn test_flush_evicts_transactions_without_pending_writes(
-        #[values(true, false)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_flush_evicts_transactions_without_pending_writes() {
         telemetry_subscribers::init_for_testing();
         let num_authorities: u32 = 4;
         let (mut context, _) = Context::new_for_test(num_authorities as usize);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         const CACHED_ROUNDS: Round = 5;
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
@@ -4447,18 +4349,12 @@ mod test {
     /// headers (so `recent_headers_refs_by_authority` may be empty).
     #[rstest]
     #[tokio::test]
-    async fn test_fast_sync_transaction_eviction_without_headers(
-        #[values(true, false)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn test_fast_sync_transaction_eviction_without_headers() {
         telemetry_subscribers::init_for_testing();
         let num_authorities: u32 = 4;
         let (mut context, _) = Context::new_for_test(num_authorities as usize);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
         const CACHED_ROUNDS: Round = 5;
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store);
@@ -4604,10 +4500,7 @@ mod test {
 
     #[tokio::test]
     async fn test_evict_pending_commit_votes() {
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let gc_depth = context.protocol_config.gc_depth();
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
@@ -4645,21 +4538,6 @@ mod test {
         unset.update_pending_commit_votes(votes);
         unset.evict_pending_commit_votes();
         assert_eq!(unset.pending_commit_votes.len(), 10);
-
-        // With the flag off the eviction is a no-op regardless of the field.
-        let (mut context_off, _) = Context::new_for_test(4);
-        context_off
-            .protocol_config
-            .set_consensus_block_restrictions_for_testing(false);
-        let context_off = Arc::new(context_off);
-        let mut dag_state_off = DagState::new(context_off, Arc::new(MemStore::new()));
-        dag_state_off.set_last_known_quorum_commit_index(1_000);
-        let votes: Vec<CommitRef> = (1..=10)
-            .map(|i| CommitRef::new(i, CommitDigest::MIN))
-            .collect();
-        dag_state_off.update_pending_commit_votes(votes);
-        dag_state_off.evict_pending_commit_votes();
-        assert_eq!(dag_state_off.pending_commit_votes.len(), 10);
     }
 
     /// Builds a 4-authority context with `consensus_starfish_speed` toggled

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2264,11 +2264,7 @@ impl DagState {
     /// Drops queued commit votes whose index is at or below the network's
     /// quorum commit index minus `gc_depth`. Those votes carry no new
     /// information for peers and only bloat the in-memory tracker.
-    /// No-op when `consensus_block_restrictions` is off.
     pub(crate) fn evict_pending_commit_votes(&mut self) {
-        if !self.context.protocol_config.consensus_block_restrictions() {
-            return;
-        }
         let gc_threshold = self
             .last_known_quorum_commit_index
             .saturating_sub(self.context.protocol_config.gc_depth());

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -539,7 +539,7 @@ impl DagState {
         // Reload transactions from storage
         let transactions = self
             .store
-            .scan_transactions_by_author(authority_index, eviction_round + 1, self.context.clone())
+            .scan_transactions_by_author(authority_index, eviction_round + 1)
             .expect("Database error");
         for txn in &transactions {
             self.update_transaction_metadata(txn, data_source);
@@ -738,15 +738,7 @@ impl DagState {
         source: DataSource,
     ) {
         let transaction_ref = transactions.transaction_ref();
-        let generic_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
-            GenericTransactionRef::from(transaction_ref)
-        } else {
-            let Some(block_ref) = transactions.block_ref() else {
-                error!("block_ref unavailable for transactions in non-transaction-ref path");
-                return;
-            };
-            GenericTransactionRef::from(block_ref)
-        };
+        let generic_ref = GenericTransactionRef::from(transaction_ref);
         if self.recent_transactions_by_authority[transaction_ref.author].contains_key(&generic_ref)
         {
             if transactions.has_transactions() {
@@ -903,11 +895,7 @@ impl DagState {
                 // Fetch transaction commitments for all acknowledged blocks in batch
                 let acknowledgments = block_header.acknowledgments();
                 let ack_transactions_commitments =
-                    if self.context.protocol_config.consensus_fast_commit_sync() {
-                        self.get_transactions_commitments_batch(acknowledgments)
-                    } else {
-                        vec![None; acknowledgments.len()]
-                    };
+                    self.get_transactions_commitments_batch(acknowledgments);
 
                 let cordial_message = CordialKnowledgeMessage::NewHeader {
                     header: block_header.clone(),
@@ -926,15 +914,7 @@ impl DagState {
         source: DataSource,
     ) {
         let transaction_ref = transactions.transaction_ref();
-        let generic_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
-            GenericTransactionRef::from(transaction_ref)
-        } else {
-            let Some(block_ref) = transactions.block_ref() else {
-                error!("block_ref unavailable for transactions in non-transaction-ref path");
-                return;
-            };
-            GenericTransactionRef::from(block_ref)
-        };
+        let generic_ref = GenericTransactionRef::from(transaction_ref);
         self.recent_transactions_by_authority[transaction_ref.author]
             .insert(generic_ref, transactions.clone());
         tracing::debug!("Adding transactions for {generic_ref}");
@@ -1577,16 +1557,11 @@ impl DagState {
             if last.round > GENESIS_ROUND {
                 let last_header_opt = self.recent_block_headers.get(last);
                 if let Some(last_header) = last_header_opt {
-                    let transaction_ref =
-                        if self.context.protocol_config.consensus_fast_commit_sync() {
-                            GenericTransactionRef::from(TransactionRef {
-                                round: last.round,
-                                author: last.author,
-                                transactions_commitment: last_header.transactions_commitment(),
-                            })
-                        } else {
-                            GenericTransactionRef::from(*last)
-                        };
+                    let transaction_ref = GenericTransactionRef::from(TransactionRef {
+                        round: last.round,
+                        author: last.author,
+                        transactions_commitment: last_header.transactions_commitment(),
+                    });
 
                     if let Some(last_transactions) =
                         self.recent_transactions_by_authority[last.author].get(&transaction_ref)
@@ -1647,15 +1622,11 @@ impl DagState {
             let header_opt = self.recent_block_headers.get(block_ref);
             let mut block_constructed = false;
             if let Some(header) = header_opt {
-                let transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
-                    GenericTransactionRef::from(TransactionRef {
-                        round: block_ref.round,
-                        author: block_ref.author,
-                        transactions_commitment: header.transactions_commitment(),
-                    })
-                } else {
-                    GenericTransactionRef::from(*block_ref)
-                };
+                let transaction_ref = GenericTransactionRef::from(TransactionRef {
+                    round: block_ref.round,
+                    author: block_ref.author,
+                    transactions_commitment: header.transactions_commitment(),
+                });
                 let transactions_opt =
                     self.recent_transactions_by_authority[block_ref.author].get(&transaction_ref);
                 if let Some(transactions) = transactions_opt {
@@ -2128,18 +2099,14 @@ impl DagState {
 
     /// Check if a block's transactions are locally available.
     pub(crate) fn are_transactions_available(&self, block_ref: &BlockRef) -> bool {
-        let transaction_ref = if self.context.protocol_config.consensus_fast_commit_sync() {
-            let Some(header) = self.recent_block_headers.get(block_ref) else {
-                return false;
-            };
-            GenericTransactionRef::from(TransactionRef {
-                round: block_ref.round,
-                author: block_ref.author,
-                transactions_commitment: header.transactions_commitment(),
-            })
-        } else {
-            GenericTransactionRef::from(*block_ref)
+        let Some(header) = self.recent_block_headers.get(block_ref) else {
+            return false;
         };
+        let transaction_ref = GenericTransactionRef::from(TransactionRef {
+            round: block_ref.round,
+            author: block_ref.author,
+            transactions_commitment: header.transactions_commitment(),
+        });
         self.recent_transactions_by_authority[block_ref.author].contains_key(&transaction_ref)
     }
 
@@ -2171,19 +2138,11 @@ impl DagState {
             let eviction_round = self.calculate_authority_eviction_round(authority_index);
 
             // Evict everything below split_key
-            let split_key = if self.context.protocol_config.consensus_fast_commit_sync() {
-                GenericTransactionRef::from(TransactionRef {
-                    round: eviction_round + 1,
-                    author: authority_index,
-                    transactions_commitment: TransactionsCommitment::MIN,
-                })
-            } else {
-                GenericTransactionRef::from(BlockRef::new(
-                    eviction_round + 1,
-                    authority_index,
-                    BlockHeaderDigest::MIN,
-                ))
-            };
+            let split_key = GenericTransactionRef::from(TransactionRef {
+                round: eviction_round + 1,
+                author: authority_index,
+                transactions_commitment: TransactionsCommitment::MIN,
+            });
             self.recent_shards_by_authority[authority_index] =
                 self.recent_shards_by_authority[authority_index].split_off(&split_key);
         }
@@ -2210,19 +2169,11 @@ impl DagState {
             };
 
             // Evict everything below split_key
-            let split_key = if self.context.protocol_config.consensus_fast_commit_sync() {
-                GenericTransactionRef::from(TransactionRef {
-                    round: transaction_eviction_round,
-                    author: authority_index,
-                    transactions_commitment: TransactionsCommitment::MIN,
-                })
-            } else {
-                GenericTransactionRef::from(BlockRef::new(
-                    transaction_eviction_round,
-                    authority_index,
-                    BlockHeaderDigest::MIN,
-                ))
-            };
+            let split_key = GenericTransactionRef::from(TransactionRef {
+                round: transaction_eviction_round,
+                author: authority_index,
+                transactions_commitment: TransactionsCommitment::MIN,
+            });
             self.recent_transactions_by_authority[authority_index] =
                 self.recent_transactions_by_authority[authority_index].split_off(&split_key);
         }
@@ -2520,18 +2471,15 @@ impl DagState {
 
             // Write all buffered data to storage
             self.store
-                .write(
-                    WriteBatch {
-                        transactions,
-                        block_headers,
-                        commits,
-                        commit_info,
-                        voting_block_headers,
-                        fast_commit_sync_flag,
-                        misbehavior_counts,
-                    },
-                    self.context.clone(),
-                )
+                .write(WriteBatch {
+                    transactions,
+                    block_headers,
+                    commits,
+                    commit_info,
+                    voting_block_headers,
+                    fast_commit_sync_flag,
+                    misbehavior_counts,
+                })
                 .unwrap_or_else(|e| panic!("Failed to write to storage: {e:?}"));
 
             self.context

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -177,9 +177,6 @@ pub(crate) enum ConsensusError {
     #[error("Merkle tree has no root (empty shard list)")]
     EmptyMerkleTree,
 
-    #[error("Missing block header for {block_ref}")]
-    MissingBlockHeader { block_ref: BlockRef },
-
     #[error(
         "Invalid overlap indices: overlap_start={overlap_start}, overlap_end={overlap_end}, references_len={references_len}"
     )]
@@ -371,12 +368,6 @@ pub(crate) enum ConsensusError {
 
     #[error("Voting block header {block_ref:?} for commit certification was not found in storage")]
     MissingVotingBlockHeaderInStorage { block_ref: BlockRef },
-
-    // TODO: This error can be removed once consensus_fast_commit_sync is enabled on all networks.
-    // It's currently used to gate fast commit sync endpoints and features during the gradual
-    // rollout phase.
-    #[error("Fast commit sync is not enabled in the current protocol version")]
-    FastCommitSyncNotEnabled,
 
     #[error(
         "ShardWithProof variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync})"

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -369,20 +369,14 @@ pub(crate) enum ConsensusError {
     #[error("Voting block header {block_ref:?} for commit certification was not found in storage")]
     MissingVotingBlockHeaderInStorage { block_ref: BlockRef },
 
-    #[error(
-        "ShardWithProof variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync})"
-    )]
-    WrongShardVersionForFlags {
-        actual: &'static str,
-        fast_commit_sync: bool,
-    },
+    #[error("ShardWithProof variant {actual} is not the expected V2")]
+    WrongShardVersionForFlags { actual: &'static str },
 
     #[error(
-        "Commit variant {actual} does not match protocol flags (consensus_fast_commit_sync={fast_commit_sync}, consensus_starfish_speed={starfish_speed})"
+        "Commit variant {actual} does not match protocol flags (consensus_starfish_speed={starfish_speed})"
     )]
     WrongCommitVersionForFlags {
         actual: &'static str,
-        fast_commit_sync: bool,
         starfish_speed: bool,
     },
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -177,6 +177,9 @@ pub(crate) enum ConsensusError {
     #[error("Merkle tree has no root (empty shard list)")]
     EmptyMerkleTree,
 
+    #[error("Missing block header for {block_ref}")]
+    MissingBlockHeader { block_ref: BlockRef },
+
     #[error(
         "Invalid overlap indices: overlap_start={overlap_start}, overlap_end={overlap_end}, references_len={references_len}"
     )]

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -354,14 +354,8 @@ pub(crate) enum ConsensusError {
     )]
     InconsistentTransactionRefVariants,
 
-    #[error(
-        "Transaction reference variant is inconsistent with protocol flag consensus_fast_commit_sync={protocol_flag_enabled}. Expected {expected_variant}, but received {received_variant}"
-    )]
-    TransactionRefVariantMismatch {
-        protocol_flag_enabled: bool,
-        expected_variant: &'static str,
-        received_variant: &'static str,
-    },
+    #[error("Expected TransactionRef, but received {received_variant}")]
+    TransactionRefVariantMismatch { received_variant: &'static str },
 
     #[error("Failed to fetch {num_requested} block headers from any peer")]
     FailedToFetchBlockHeaders { num_requested: usize },
@@ -370,7 +364,7 @@ pub(crate) enum ConsensusError {
     MissingVotingBlockHeaderInStorage { block_ref: BlockRef },
 
     #[error("ShardWithProof variant {actual} is not the expected V2")]
-    WrongShardVersionForFlags { actual: &'static str },
+    WrongShardVersion { actual: &'static str },
 
     #[error(
         "Commit variant {actual} does not match protocol flags (consensus_starfish_speed={starfish_speed})"

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -689,7 +689,6 @@ mod tests {
                     .commit_info(vec![(commit_ref, commit_info)])
                     .block_headers(block_headers_to_write)
                     .commits(expected_commits),
-                context.clone(),
             )
             .unwrap();
 
@@ -790,7 +789,6 @@ mod tests {
                 WriteBatch::default()
                     .block_headers(headers_to_write)
                     .commits(expected_commits),
-                context.clone(),
             )
             .unwrap();
 

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -169,34 +169,29 @@ impl Linearizer {
             "Duplicate BlockRef found"
         );
 
-        // Convert BlockRef to GenericTransactionRef based on protocol flag
-        let committed_transactions_refs: Vec<GenericTransactionRef> =
-            if self.context.protocol_config.consensus_fast_commit_sync() {
-                // Use batch function to get transaction commitments efficiently
-                let dag_state_guard = self.dag_state.read();
-                let transactions_commitments =
-                    dag_state_guard.get_transactions_commitments_batch(&committed_transactions);
+        // Convert each committed BlockRef to a TransactionRef, looking up its
+        // transactions commitment.
+        let committed_transactions_refs: Vec<GenericTransactionRef> = {
+            // Use batch function to get transaction commitments efficiently
+            let dag_state_guard = self.dag_state.read();
+            let transactions_commitments =
+                dag_state_guard.get_transactions_commitments_batch(&committed_transactions);
 
-                // Zip block_refs with their corresponding transaction commitments
-                committed_transactions
-                    .into_iter()
-                    .zip(transactions_commitments)
-                    .map(|(block_ref, transactions_commitment_opt)| {
-                        let transactions_commitment = transactions_commitment_opt
-                            .expect("Block header must exist for committed transaction");
-                        GenericTransactionRef::TransactionRef(TransactionRef {
-                            round: block_ref.round,
-                            author: block_ref.author,
-                            transactions_commitment,
-                        })
+            // Zip block_refs with their corresponding transaction commitments
+            committed_transactions
+                .into_iter()
+                .zip(transactions_commitments)
+                .map(|(block_ref, transactions_commitment_opt)| {
+                    let transactions_commitment = transactions_commitment_opt
+                        .expect("Block header must exist for committed transaction");
+                    GenericTransactionRef::TransactionRef(TransactionRef {
+                        round: block_ref.round,
+                        author: block_ref.author,
+                        transactions_commitment,
                     })
-                    .collect()
-            } else {
-                committed_transactions
-                    .into_iter()
-                    .map(GenericTransactionRef::BlockRef)
-                    .collect()
-            };
+                })
+                .collect()
+        };
 
         // Create the Commit.
         let commit = Commit::new(

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -412,12 +412,6 @@ impl TryFrom<BlockBundle> for SerializedBlockBundle {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct SerializedTransactionsV1 {
-    pub(crate) block_ref: BlockRef,
-    pub(crate) serialized_transactions: Bytes,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SerializedTransactionsV2 {
     pub(crate) transaction_ref: TransactionRef,
     pub(crate) serialized_transactions: Bytes,

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -1036,25 +1036,11 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         let committed_transactions_refs: Vec<GenericTransactionRef> = request
             .block_refs
             .iter()
-            .filter_map(|r| {
-                if self.context.protocol_config.consensus_fast_commit_sync() {
-                    match bcs::from_bytes::<TransactionRef>(r) {
-                        Ok(transaction_ref) => {
-                            Some(GenericTransactionRef::TransactionRef(transaction_ref))
-                        }
-                        Err(e) => {
-                            debug!("Failed to deserialize block ref: {e:?}");
-                            None
-                        }
-                    }
-                } else {
-                    match bcs::from_bytes::<BlockRef>(r) {
-                        Ok(block_ref) => Some(GenericTransactionRef::BlockRef(block_ref)),
-                        Err(e) => {
-                            debug!("Failed to deserialize block ref: {e:?}");
-                            None
-                        }
-                    }
+            .filter_map(|r| match bcs::from_bytes::<TransactionRef>(r) {
+                Ok(transaction_ref) => Some(GenericTransactionRef::TransactionRef(transaction_ref)),
+                Err(e) => {
+                    debug!("Failed to deserialize transaction ref: {e:?}");
+                    None
                 }
             })
             .collect();

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -1166,14 +1166,12 @@ mod tests {
             "Test pre-condition: carrier and shard-source blocks must differ"
         );
 
-        // GIVEN: a ShardWithProof whose block_ref points to shard_source (V1 variant,
-        // transaction_ref_enabled = false).
+        // GIVEN: a ShardWithProof whose block_ref points to shard_source.
         let shard_with_proof = ShardWithProof::new(
             vec![0u8; 32],
             vec![],
             shard_source_ref,
             shard_source.transactions_commitment(),
-            false,
         );
 
         // WHEN: build transaction messages using the carrier block together with a

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -73,7 +73,7 @@ impl MemStore {
 }
 
 impl Store for MemStore {
-    fn write(&self, write_batch: WriteBatch, context: Arc<Context>) -> ConsensusResult<()> {
+    fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()> {
         let mut inner = self.inner.write();
 
         // Store block headers
@@ -98,30 +98,20 @@ impl Store for MemStore {
         // Store transactions data separately
         for transaction in write_batch.transactions {
             let transaction_ref = transaction.transaction_ref();
-            if context.protocol_config.consensus_fast_commit_sync() {
-                inner.transactions_by_tx_refs.insert(
-                    (
-                        transaction_ref.round,
-                        transaction_ref.author,
-                        transaction_ref.transactions_commitment,
-                    ),
-                    transaction,
-                );
-
-                inner.transaction_commitments_by_authorities.insert((
-                    transaction_ref.author,
+            inner.transactions_by_tx_refs.insert(
+                (
                     transaction_ref.round,
+                    transaction_ref.author,
                     transaction_ref.transactions_commitment,
-                ));
-            } else {
-                let block_ref = transaction
-                    .block_ref()
-                    .expect("block_ref must be present in non-transaction-ref path");
-                inner.transactions.insert(
-                    (block_ref.round, block_ref.author, block_ref.digest),
-                    transaction,
-                );
-            }
+                ),
+                transaction,
+            );
+
+            inner.transaction_commitments_by_authorities.insert((
+                transaction_ref.author,
+                transaction_ref.round,
+                transaction_ref.transactions_commitment,
+            ));
         }
 
         for commit in write_batch.commits {
@@ -210,34 +200,22 @@ impl Store for MemStore {
 
     // TODO: Do we need this method or will DAGState always try to read both headers
     // and transactions separately?
-    fn read_blocks(
-        &self,
-        refs: &[BlockRef],
-        context: Arc<Context>,
-    ) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
+    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
         // Ensure we have a read lock on the inner state across reading both headers and
         // transactions reads
         let inner = self.inner.read();
         // Get both headers and transactions for the given references
         let headers = self.read_verified_block_headers(refs)?;
-        let tx_refs = if context.protocol_config.consensus_fast_commit_sync() {
-            headers
-                .iter()
-                .map(|vh| {
-                    if vh.is_none() {
-                        GenericTransactionRef::TransactionRef(TransactionRef::default())
-                    } else {
-                        GenericTransactionRef::TransactionRef(
-                            vh.as_ref().unwrap().transaction_ref(),
-                        )
-                    }
-                })
-                .collect::<Vec<GenericTransactionRef>>()
-        } else {
-            refs.iter()
-                .map(|r| GenericTransactionRef::BlockRef(*r))
-                .collect()
-        };
+        let tx_refs = headers
+            .iter()
+            .map(|vh| {
+                if vh.is_none() {
+                    GenericTransactionRef::TransactionRef(TransactionRef::default())
+                } else {
+                    GenericTransactionRef::TransactionRef(vh.as_ref().unwrap().transaction_ref())
+                }
+            })
+            .collect::<Vec<GenericTransactionRef>>();
         let transactions = self.read_verified_transactions(tx_refs.as_slice())?;
         drop(inner); // Explicitly drop the read lock before combining results
 
@@ -277,7 +255,6 @@ impl Store for MemStore {
         &self,
         author: AuthorityIndex,
         start_round: Round,
-        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let inner = self.inner.read();
         let mut refs = vec![];
@@ -287,7 +264,7 @@ impl Store for MemStore {
         )) {
             refs.push(BlockRef::new(round, author, digest));
         }
-        let results = self.read_blocks(refs.as_slice(), context)?;
+        let results = self.read_blocks(refs.as_slice())?;
         let mut blocks = Vec::with_capacity(refs.len());
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(
@@ -302,7 +279,6 @@ impl Store for MemStore {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
-        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let before_round = before_round.unwrap_or(Round::MAX);
         let mut refs = VecDeque::new();
@@ -327,7 +303,7 @@ impl Store for MemStore {
         // when the VecDeque ring buffer wraps; otherwise trailing entries would be
         // silently dropped.
         let refs_slice = refs.make_contiguous();
-        let results = self.read_blocks(refs_slice, context)?;
+        let results = self.read_blocks(refs_slice)?;
         let mut blocks = vec![];
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -5,7 +5,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     ops::Bound::Included,
-    sync::Arc,
 };
 
 use bytes::Bytes;
@@ -22,7 +21,6 @@ use crate::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRange, CommitRef,
         TrustedCommit,
     },
-    context::Context,
     error::{ConsensusError, ConsensusResult},
     misbehavior_store::MisbehaviorCounts,
     storage::rocksdb_store::check_ref_consistency,

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -33,7 +33,6 @@ pub(crate) struct MemStore {
 }
 
 struct Inner {
-    transactions: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedTransactions>,
     transactions_by_tx_refs:
         BTreeMap<(Round, AuthorityIndex, TransactionsCommitment), VerifiedTransactions>,
     block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
@@ -54,7 +53,6 @@ impl MemStore {
     pub(crate) fn new() -> Self {
         MemStore {
             inner: RwLock::new(Inner {
-                transactions: BTreeMap::new(),
                 transactions_by_tx_refs: BTreeMap::new(),
                 block_headers: BTreeMap::new(),
                 digests_by_authorities: BTreeSet::new(),
@@ -159,10 +157,8 @@ impl Store for MemStore {
         let transactions = refs
             .iter()
             .map(|r| match r {
-                GenericTransactionRef::BlockRef(b) => inner
-                    .transactions
-                    .get(&(b.round, b.author, b.digest))
-                    .cloned(),
+                // Legacy variant, never stored under v29.
+                GenericTransactionRef::BlockRef(_) => None,
                 GenericTransactionRef::TransactionRef(t) => inner
                     .transactions_by_tx_refs
                     .get(&(t.round, t.author, t.transactions_commitment))
@@ -183,10 +179,8 @@ impl Store for MemStore {
         let transactions = refs
             .iter()
             .map(|r| match r {
-                GenericTransactionRef::BlockRef(b) => inner
-                    .transactions
-                    .get(&(b.round, b.author, b.digest))
-                    .map(|tx| tx.serialized().clone()),
+                // Legacy variant, never stored under v29.
+                GenericTransactionRef::BlockRef(_) => None,
                 GenericTransactionRef::TransactionRef(t) => inner
                     .transactions_by_tx_refs
                     .get(&(t.round, t.author, t.transactions_commitment))
@@ -238,9 +232,8 @@ impl Store for MemStore {
         let exist = refs
             .iter()
             .map(|r| match r {
-                GenericTransactionRef::BlockRef(b) => inner
-                    .transactions
-                    .contains_key(&(b.round, b.author, b.digest)),
+                // Legacy variant, never stored under v29.
+                GenericTransactionRef::BlockRef(_) => false,
                 GenericTransactionRef::TransactionRef(t) => inner
                     .transactions_by_tx_refs
                     .contains_key(&(t.round, t.author, t.transactions_commitment)),

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod rocksdb_store;
 #[cfg(test)]
 mod store_tests;
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 
 use bytes::Bytes;
 use starfish_config::AuthorityIndex;
@@ -18,7 +18,6 @@ use crate::{
     CommitIndex,
     block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions},
     commit::{CommitDigest, CommitInfo, CommitRange, CommitRef, TrustedCommit},
-    context::Context,
     error::ConsensusResult,
     misbehavior_store::MisbehaviorCounts,
     transaction_ref::{GenericTransactionRef, TransactionRef},
@@ -27,15 +26,11 @@ use crate::{
 /// A common interface for consensus storage.
 pub(crate) trait Store: Send + Sync {
     /// Writes blocks, consensus commits and other data to store atomically.
-    fn write(&self, write_batch: WriteBatch, context: Arc<Context>) -> ConsensusResult<()>;
+    fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()>;
 
     /// Reads complete blocks by combining transactions and headers for the
     /// given refs.
-    fn read_blocks(
-        &self,
-        refs: &[BlockRef],
-        context: Arc<Context>,
-    ) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
+    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
 
     /// Read and get verified block headers for the given refs.
     fn read_verified_block_headers(
@@ -77,7 +72,6 @@ pub(crate) trait Store: Send + Sync {
         &self,
         authority: AuthorityIndex,
         start_round: Round,
-        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
     // The method returns the last `num_of_rounds` rounds blocks by author in round
@@ -90,7 +84,6 @@ pub(crate) trait Store: Send + Sync {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
-        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
     fn scan_block_references_by_author(
@@ -109,19 +102,12 @@ pub(crate) trait Store: Send + Sync {
         &self,
         author: AuthorityIndex,
         start_round: Round,
-        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedTransactions>> {
-        let refs = if context.protocol_config.consensus_fast_commit_sync() {
-            self.scan_transaction_references_by_author(author, start_round)?
-                .into_iter()
-                .map(GenericTransactionRef::from)
-                .collect::<Vec<_>>()
-        } else {
-            self.scan_block_references_by_author(author, start_round)?
-                .into_iter()
-                .map(GenericTransactionRef::from)
-                .collect::<Vec<_>>()
-        };
+        let refs = self
+            .scan_transaction_references_by_author(author, start_round)?
+            .into_iter()
+            .map(GenericTransactionRef::from)
+            .collect::<Vec<_>>();
         Ok(self
             .read_verified_transactions(&refs)?
             .into_iter()

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -32,7 +32,10 @@ use crate::{
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlockHeader by refs.
     block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-    /// Stores Transactions by block refs
+    /// Legacy column family for transactions keyed by block ref. No longer
+    /// written (transactions are stored in `transactions_by_tx_refs`); retained
+    /// so existing databases still open and pre-existing entries remain
+    /// readable via the `GenericTransactionRef::BlockRef` path.
     transactions: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// Stores Transactions by transaction refs
     transactions_by_tx_refs: DBMap<(Round, AuthorityIndex, TransactionsCommitment), Bytes>,

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -18,8 +18,8 @@ use super::{CommitInfo, Store, WriteBatch};
 use crate::{
     Transaction,
     block_header::{
-        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, SignedBlockHeader,
-        TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, TransactionsCommitment,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
@@ -32,11 +32,6 @@ use crate::{
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlockHeader by refs.
     block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-    /// Legacy column family for transactions keyed by block ref. No longer
-    /// written (transactions are stored in `transactions_by_tx_refs`); retained
-    /// so existing databases still open and pre-existing entries remain
-    /// readable via the `GenericTransactionRef::BlockRef` path.
-    transactions: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// Stores Transactions by transaction refs
     transactions_by_tx_refs: DBMap<(Round, AuthorityIndex, TransactionsCommitment), Bytes>,
     /// A secondary index that orders refs first by authors.
@@ -64,7 +59,6 @@ pub(crate) struct RocksDBStore {
 }
 
 impl RocksDBStore {
-    const TRANSACTIONS_CF: &'static str = "transactions";
     const TRANSACTIONS_BY_TX_REF_CF: &'static str = "transactions_by_tx_refs";
     const BLOCK_HEADERS_CF: &'static str = "block_headers";
     const DIGESTS_BY_AUTHORITIES_CF: &'static str = "digests";
@@ -86,13 +80,6 @@ impl RocksDBStore {
         metrics_conf.read_sample_interval = SamplingInterval::new(Duration::from_secs(60), 0);
         let cf_options = default_db_options().optimize_for_write_throughput();
         let column_family_options = DBMapTableConfigMap::new(BTreeMap::from([
-            (
-                Self::TRANSACTIONS_CF.to_string(),
-                default_db_options()
-                    .optimize_for_write_throughput_no_deletion()
-                    // Using larger block is ok since there is not much point reads on the cf.
-                    .set_block_options(512, 128 << 10),
-            ),
             (
                 Self::TRANSACTIONS_BY_TX_REF_CF.to_string(),
                 default_db_options()
@@ -350,77 +337,23 @@ impl Store for RocksDBStore {
         }
         let serialized_vec_transactions = self.read_serialized_transactions(refs)?;
 
-        let use_transaction_ref = match &refs[0] {
-            GenericTransactionRef::BlockRef { .. } => false,
-            GenericTransactionRef::TransactionRef { .. } => true,
-        };
         let mut result = Vec::with_capacity(refs.len());
-        if use_transaction_ref {
-            for (gen_tx_ref, serialized_transactions) in
-                refs.iter().zip(serialized_vec_transactions)
-            {
-                let GenericTransactionRef::TransactionRef(tx_ref) = gen_tx_ref else {
-                    return Err(ConsensusError::InconsistentTransactionRefVariants);
-                };
-                if let Some(serialized_transactions) = serialized_transactions {
-                    let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
-                        .map_err(ConsensusError::MalformedTransactions)?;
-                    // We don't check the transactions commitment from the header as it's loaded
-                    // from storage. Assemble verified transactions
-                    let verified_transactions = VerifiedTransactions::new(
-                        transactions,
-                        *tx_ref,
-                        None,
-                        serialized_transactions,
-                    );
-                    result.push(Some(verified_transactions));
-                } else {
-                    result.push(None);
-                }
-            }
-        } else {
-            let block_refs = refs
-                .iter()
-                .map(|gen_tx_ref| {
-                    let GenericTransactionRef::BlockRef(block_ref) = gen_tx_ref else {
-                        return Err(ConsensusError::InconsistentTransactionRefVariants);
-                    };
-                    Ok(*block_ref)
-                })
-                .collect::<Result<Vec<_>, ConsensusError>>()?;
-            let serialized_block_headers =
-                self.read_serialized_block_headers(block_refs.as_slice())?;
-
-            // TODO::optimize it later by storing commitment together with transactions
-
-            for ((block_ref, serialized_block_header), serialized_transactions) in block_refs
-                .iter()
-                .zip(serialized_block_headers)
-                .zip(serialized_vec_transactions)
-            {
-                if let (Some(serialized_block_header), Some(serialized_transactions)) =
-                    (serialized_block_header, serialized_transactions)
-                {
-                    let signed_block_header: SignedBlockHeader =
-                        bcs::from_bytes(&serialized_block_header)
-                            .map_err(ConsensusError::MalformedHeader)?;
-                    let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
-                        .map_err(ConsensusError::MalformedTransactions)?;
-                    // We don't check the transactions commitment from the header as it's loaded
-                    // from storage. Assemble verified transactions
-                    let verified_transactions = VerifiedTransactions::new(
-                        transactions,
-                        TransactionRef::new(
-                            *block_ref,
-                            signed_block_header.transactions_commitment(),
-                        ),
-                        Some(block_ref.digest),
-                        serialized_transactions,
-                    );
-                    result.push(Some(verified_transactions));
-                } else {
-                    result.push(None);
-                }
+        for (gen_tx_ref, serialized_transactions) in refs.iter().zip(serialized_vec_transactions) {
+            let GenericTransactionRef::TransactionRef(tx_ref) = gen_tx_ref else {
+                // Legacy variant, never stored under v29.
+                result.push(None);
+                continue;
+            };
+            if let Some(serialized_transactions) = serialized_transactions {
+                let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
+                    .map_err(ConsensusError::MalformedTransactions)?;
+                // We don't check the transactions commitment from the header as it's loaded
+                // from storage. Assemble verified transactions
+                let verified_transactions =
+                    VerifiedTransactions::new(transactions, *tx_ref, None, serialized_transactions);
+                result.push(Some(verified_transactions));
+            } else {
+                result.push(None);
             }
         }
         Ok(result)
@@ -438,34 +371,21 @@ impl Store for RocksDBStore {
         if refs.is_empty() {
             return Ok(vec![]);
         }
-        match &refs[0] {
-            GenericTransactionRef::BlockRef { .. } => {
-                let keys: Result<Vec<_>, ConsensusError> = refs
-                    .iter()
-                    .map(|r| {
-                        if let GenericTransactionRef::BlockRef(block_ref) = r {
-                            Ok((block_ref.round, block_ref.author, block_ref.digest))
-                        } else {
-                            Err(ConsensusError::InconsistentTransactionRefVariants)
-                        }
-                    })
-                    .collect();
-                Ok(self.transactions.multi_get(keys?)?)
-            }
-            GenericTransactionRef::TransactionRef { .. } => {
-                let keys: Result<Vec<_>, ConsensusError> = refs
-                    .iter()
-                    .map(|r| {
-                        if let GenericTransactionRef::TransactionRef(tx_ref) = r {
-                            Ok((tx_ref.round, tx_ref.author, tx_ref.transactions_commitment))
-                        } else {
-                            Err(ConsensusError::InconsistentTransactionRefVariants)
-                        }
-                    })
-                    .collect();
-                Ok(self.transactions_by_tx_refs.multi_get(keys?)?)
-            }
+        // Legacy variant, never stored under v29.
+        if matches!(refs[0], GenericTransactionRef::BlockRef(_)) {
+            return Ok(vec![None; refs.len()]);
         }
+        let keys: Result<Vec<_>, ConsensusError> = refs
+            .iter()
+            .map(|r| {
+                if let GenericTransactionRef::TransactionRef(tx_ref) = r {
+                    Ok((tx_ref.round, tx_ref.author, tx_ref.transactions_commitment))
+                } else {
+                    Err(ConsensusError::InconsistentTransactionRefVariants)
+                }
+            })
+            .collect();
+        Ok(self.transactions_by_tx_refs.multi_get(keys?)?)
     }
 
     fn contains_transactions(&self, refs: &[GenericTransactionRef]) -> ConsensusResult<Vec<bool>> {
@@ -475,34 +395,21 @@ impl Store for RocksDBStore {
         if refs.is_empty() {
             return Ok(vec![]);
         }
-        match &refs[0] {
-            GenericTransactionRef::BlockRef { .. } => {
-                let keys: Result<Vec<_>, ConsensusError> = refs
-                    .iter()
-                    .map(|r| {
-                        if let GenericTransactionRef::BlockRef(block_ref) = r {
-                            Ok((block_ref.round, block_ref.author, block_ref.digest))
-                        } else {
-                            Err(ConsensusError::InconsistentTransactionRefVariants)
-                        }
-                    })
-                    .collect();
-                Ok(self.transactions.multi_contains_keys(keys?)?)
-            }
-            GenericTransactionRef::TransactionRef { .. } => {
-                let keys: Result<Vec<_>, ConsensusError> = refs
-                    .iter()
-                    .map(|r| {
-                        if let GenericTransactionRef::TransactionRef(tx_ref) = r {
-                            Ok((tx_ref.round, tx_ref.author, tx_ref.transactions_commitment))
-                        } else {
-                            Err(ConsensusError::InconsistentTransactionRefVariants)
-                        }
-                    })
-                    .collect();
-                Ok(self.transactions_by_tx_refs.multi_contains_keys(keys?)?)
-            }
+        // Legacy variant, never stored under v29.
+        if matches!(refs[0], GenericTransactionRef::BlockRef(_)) {
+            return Ok(vec![false; refs.len()]);
         }
+        let keys: Result<Vec<_>, ConsensusError> = refs
+            .iter()
+            .map(|r| {
+                if let GenericTransactionRef::TransactionRef(tx_ref) = r {
+                    Ok((tx_ref.round, tx_ref.author, tx_ref.transactions_commitment))
+                } else {
+                    Err(ConsensusError::InconsistentTransactionRefVariants)
+                }
+            })
+            .collect();
+        Ok(self.transactions_by_tx_refs.multi_contains_keys(keys?)?)
     }
 
     fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
@@ -765,9 +672,6 @@ impl RocksDBStore {
     pub(crate) fn delete_all_transactions(&self) -> ConsensusResult<()> {
         use typed_store::Map as _;
 
-        self.transactions
-            .schedule_delete_all()
-            .map_err(ConsensusError::RocksDBFailure)?;
         self.transactions_by_tx_refs
             .schedule_delete_all()
             .map_err(ConsensusError::RocksDBFailure)?;

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, ops::Bound::Included, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, ops::Bound::Included, time::Duration};
 
 use bytes::Bytes;
 use iota_macros::fail_point;
@@ -22,7 +22,6 @@ use crate::{
         TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
-    context::Context,
     error::{ConsensusError, ConsensusResult},
     misbehavior_store::MisbehaviorCounts,
     transaction_ref::{GenericTransactionRef, TransactionRef},
@@ -138,7 +137,7 @@ impl RocksDBStore {
 }
 
 impl Store for RocksDBStore {
-    fn write(&self, write_batch: WriteBatch, context: Arc<Context>) -> ConsensusResult<()> {
+    fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()> {
         fail_point!("consensus-store-before-write");
         // TODO: does it matter which CF we use here?
         let mut batch = self.block_headers.batch();
@@ -178,51 +177,33 @@ impl Store for RocksDBStore {
         // Store transactions data
         for transaction in write_batch.transactions {
             let transaction_ref = transaction.transaction_ref();
-            if context.protocol_config.consensus_fast_commit_sync() {
-                batch
-                    .insert_batch(
-                        &self.transactions_by_tx_refs,
-                        [(
-                            (
-                                transaction_ref.round,
-                                transaction_ref.author,
-                                transaction_ref.transactions_commitment,
-                            ),
-                            transaction.serialized(),
-                        )],
-                    )
-                    .map_err(ConsensusError::RocksDBFailure)?;
-                // Store the authority digest
-                batch
-                    .insert_batch(
-                        &self.transaction_commitments_by_authorities,
-                        [(
-                            (
-                                transaction_ref.author,
-                                transaction_ref.round,
-                                transaction_ref.transactions_commitment,
-                            ),
-                            (),
-                        )],
-                    )
-                    .map_err(ConsensusError::RocksDBFailure)?;
-            } else {
-                batch
-                    .insert_batch(
-                        &self.transactions,
-                        [(
-                            (
-                                transaction_ref.round,
-                                transaction_ref.author,
-                                transaction.block_digest().expect(
-                                    "block digest should exist for consensus_fast_commit_sync=false",
-                                ),
-                            ),
-                            transaction.serialized(),
-                        )],
-                    )
-                    .map_err(ConsensusError::RocksDBFailure)?;
-            }
+            batch
+                .insert_batch(
+                    &self.transactions_by_tx_refs,
+                    [(
+                        (
+                            transaction_ref.round,
+                            transaction_ref.author,
+                            transaction_ref.transactions_commitment,
+                        ),
+                        transaction.serialized(),
+                    )],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
+            // Store the authority digest
+            batch
+                .insert_batch(
+                    &self.transaction_commitments_by_authorities,
+                    [(
+                        (
+                            transaction_ref.author,
+                            transaction_ref.round,
+                            transaction_ref.transactions_commitment,
+                        ),
+                        (),
+                    )],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
         }
 
         // Handle commits
@@ -289,31 +270,19 @@ impl Store for RocksDBStore {
         Ok(())
     }
 
-    fn read_blocks(
-        &self,
-        refs: &[BlockRef],
-        context: Arc<Context>,
-    ) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
+    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
         // Get both headers and transactions for the given references
         let headers = self.read_verified_block_headers(refs)?;
-        let tx_refs = if context.protocol_config.consensus_fast_commit_sync() {
-            headers
-                .iter()
-                .map(|vh| {
-                    if vh.is_none() {
-                        GenericTransactionRef::TransactionRef(TransactionRef::default())
-                    } else {
-                        GenericTransactionRef::TransactionRef(
-                            vh.as_ref().unwrap().transaction_ref(),
-                        )
-                    }
-                })
-                .collect::<Vec<GenericTransactionRef>>()
-        } else {
-            refs.iter()
-                .map(|r| GenericTransactionRef::BlockRef(*r))
-                .collect()
-        };
+        let tx_refs = headers
+            .iter()
+            .map(|vh| {
+                if vh.is_none() {
+                    GenericTransactionRef::TransactionRef(TransactionRef::default())
+                } else {
+                    GenericTransactionRef::TransactionRef(vh.as_ref().unwrap().transaction_ref())
+                }
+            })
+            .collect::<Vec<GenericTransactionRef>>();
         let transactions = self.read_verified_transactions(tx_refs.as_slice())?;
 
         // Combine them into blocks if both parts exist
@@ -595,7 +564,6 @@ impl Store for RocksDBStore {
         &self,
         author: AuthorityIndex,
         start_round: Round,
-        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let mut refs = vec![];
         for kv in self.digests_by_authorities.safe_range_iter((
@@ -605,7 +573,7 @@ impl Store for RocksDBStore {
             let ((author, round, digest), _) = kv?;
             refs.push(BlockRef::new(round, author, digest));
         }
-        let results = self.read_blocks(refs.as_slice(), context)?;
+        let results = self.read_blocks(refs.as_slice())?;
         let mut blocks = Vec::with_capacity(refs.len());
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(
@@ -624,7 +592,6 @@ impl Store for RocksDBStore {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
-        context: Arc<Context>,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let before_round = before_round.unwrap_or(Round::MAX);
         let mut refs = std::collections::VecDeque::new();
@@ -643,7 +610,7 @@ impl Store for RocksDBStore {
         // when the VecDeque ring buffer wraps; otherwise trailing entries would
         // be silently dropped.
         let refs_slice = refs.make_contiguous();
-        let results = self.read_blocks(refs_slice, context)?;
+        let results = self.read_blocks(refs_slice)?;
         let mut blocks = vec![];
         for (r, block) in refs.into_iter().zip(results) {
             blocks.push(

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -21,67 +21,37 @@ use crate::{
 /// Test fixture for store tests. Wraps around various store implementations.
 #[expect(clippy::large_enum_variant)]
 enum TestStore {
-    RocksDB((RocksDBStore, TempDir, bool)),
-    Mem(MemStore, bool),
+    RocksDB((RocksDBStore, TempDir)),
+    Mem(MemStore),
 }
 
 impl TestStore {
     fn store(&self) -> &dyn Store {
         match self {
-            TestStore::RocksDB((store, _, _)) => store,
-            TestStore::Mem(store, _) => store,
+            TestStore::RocksDB((store, _)) => store,
+            TestStore::Mem(store) => store,
         }
-    }
-
-    fn consensus_fast_commit_sync(&self) -> bool {
-        match self {
-            TestStore::RocksDB((_, _, enabled)) => *enabled,
-            TestStore::Mem(_, enabled) => *enabled,
-        }
-    }
-
-    /// Creates a context with the same configuration as the store.
-    fn context(&self) -> Arc<Context> {
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(self.consensus_fast_commit_sync());
-        context.parameters.enable_fast_commit_syncer = self.consensus_fast_commit_sync();
-        Arc::new(context)
     }
 }
 
-fn new_rocksdb_teststore(consensus_fast_commit_sync: bool) -> TestStore {
-    let (mut context, _) = Context::new_for_test(4);
-    context
-        .protocol_config
-        .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-    context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+fn new_rocksdb_teststore() -> TestStore {
     let temp_dir = TempDir::new().unwrap();
     TestStore::RocksDB((
         RocksDBStore::new(temp_dir.path().to_str().unwrap()),
         temp_dir,
-        consensus_fast_commit_sync,
     ))
 }
 
-fn new_mem_teststore(consensus_fast_commit_sync: bool) -> TestStore {
-    let (mut context, _) = Context::new_for_test(4);
-    context
-        .protocol_config
-        .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-    context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
-    TestStore::Mem(MemStore::new(), consensus_fast_commit_sync)
+fn new_mem_teststore() -> TestStore {
+    TestStore::Mem(MemStore::new())
 }
 
 #[rstest]
 #[tokio::test]
 async fn read_and_contain_block_headers(
-    #[values(new_rocksdb_teststore(false), new_mem_teststore(false))] test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
-
-    let (context, _) = Context::new_for_test(4);
 
     let written_blocks: Vec<VerifiedBlock> = vec![
         VerifiedBlock::new_for_test(TestBlockHeader::new(1, 1).build()),
@@ -99,7 +69,6 @@ async fn read_and_contain_block_headers(
                     .map(|b| b.verified_block_header.clone())
                     .collect(),
             ),
-            Arc::from(context),
         )
         .unwrap();
 
@@ -186,23 +155,9 @@ async fn read_and_contain_block_headers(
 #[rstest]
 #[tokio::test]
 async fn scan_block_headers(
-    #[values(
-        new_rocksdb_teststore(false),
-        new_mem_teststore(false),
-        new_rocksdb_teststore(true),
-        new_mem_teststore(true)
-    )]
-    test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
-    let (mut context, _) = crate::context::Context::new_for_test(4);
-    // Match the flag used to create the store
-    let consensus_fast_commit_sync = test_store.consensus_fast_commit_sync();
-    context
-        .protocol_config
-        .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-    context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
-    let context = Arc::new(context);
 
     let written_blocks = [
         VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
@@ -231,7 +186,6 @@ async fn scan_block_headers(
                         .map(|b| b.verified_transactions.clone())
                         .collect(),
                 ),
-            context.clone(),
         )
         .unwrap();
 
@@ -278,7 +232,6 @@ async fn scan_block_headers(
                         .map(|b| b.verified_transactions.clone())
                         .collect(),
                 ),
-            context.clone(),
         )
         .unwrap();
     {
@@ -300,7 +253,7 @@ async fn scan_block_headers(
 
     {
         let scanned_blocks = store
-            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 2, None, context.clone())
+            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 2, None)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 2, "{scanned_blocks:?}");
         assert_eq!(
@@ -309,7 +262,7 @@ async fn scan_block_headers(
         );
 
         let scanned_blocks = store
-            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 0, None, context)
+            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 0, None)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 0);
     }
@@ -318,13 +271,7 @@ async fn scan_block_headers(
 #[rstest]
 #[tokio::test]
 async fn read_and_contain_transactions(
-    #[values(
-        new_rocksdb_teststore(false),
-        new_mem_teststore(false),
-        new_rocksdb_teststore(true),
-        new_mem_teststore(true)
-    )]
-    test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
 
@@ -336,24 +283,13 @@ async fn read_and_contain_transactions(
         VerifiedBlock::new_for_test(TestBlockHeader::new(11, 3).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build()),
     ];
-    let (mut context, _) = Context::new_for_test(4);
-    // Match the flag used to create the store
-    let consensus_fast_commit_sync = test_store.consensus_fast_commit_sync();
-    context
-        .protocol_config
-        .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
-    context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
-    let context = Arc::new(context);
     // Write transactions to store
     let written_transactions: Vec<_> = written_blocks
         .iter()
         .map(|b| b.verified_transactions.clone())
         .collect();
     store
-        .write(
-            WriteBatch::default().transactions(written_transactions),
-            context.clone(),
-        )
+        .write(WriteBatch::default().transactions(written_transactions))
         .unwrap();
     // Also write headers since we read transaction commitment from headers now
     let written_headers = written_blocks
@@ -361,28 +297,14 @@ async fn read_and_contain_transactions(
         .map(|b| b.verified_block_header.clone())
         .collect();
     store
-        .write(
-            WriteBatch::default().block_headers(written_headers),
-            context,
-        )
+        .write(WriteBatch::default().block_headers(written_headers))
         .unwrap();
 
     // Test reading all transactions
-    let refs: Vec<_> = if consensus_fast_commit_sync {
-        // When flag is enabled, use TransactionRef
-        written_blocks
-            .iter()
-            .map(|b| {
-                GenericTransactionRef::TransactionRef(b.verified_block_header.transaction_ref())
-            })
-            .collect()
-    } else {
-        // When flag is disabled, use BlockRef
-        written_blocks
-            .iter()
-            .map(|b| GenericTransactionRef::from(b.reference()))
-            .collect()
-    };
+    let refs: Vec<_> = written_blocks
+        .iter()
+        .map(|b| GenericTransactionRef::TransactionRef(b.verified_block_header.transaction_ref()))
+        .collect();
     let read_txs = store
         .read_verified_transactions(&refs)
         .expect("Read txs should not fail");
@@ -393,17 +315,10 @@ async fn read_and_contain_transactions(
         let actual = tx_opt.as_ref().unwrap();
         assert_eq!(actual, expected);
 
-        if !consensus_fast_commit_sync {
-            assert_eq!(
-                tx_opt.as_ref().unwrap().block_ref().unwrap(),
-                written_blocks[i].reference()
-            );
-        } else {
-            assert_eq!(
-                tx_opt.as_ref().unwrap().transaction_ref(),
-                written_blocks[i].verified_block_header.transaction_ref()
-            );
-        }
+        assert_eq!(
+            tx_opt.as_ref().unwrap().transaction_ref(),
+            written_blocks[i].verified_block_header.transaction_ref()
+        );
     }
 
     // Test reading subset of transactions
@@ -452,7 +367,7 @@ async fn read_and_contain_transactions(
 #[rstest]
 #[tokio::test]
 async fn read_and_scan_commits(
-    #[values(new_rocksdb_teststore(false), new_mem_teststore(false))] test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
     let (context, _) = Context::new_for_test(4);
@@ -520,10 +435,7 @@ async fn read_and_scan_commits(
         ),
     ];
     store
-        .write(
-            WriteBatch::default().commits(written_commits.clone()),
-            context,
-        )
+        .write(WriteBatch::default().commits(written_commits.clone()))
         .unwrap();
 
     {
@@ -578,10 +490,9 @@ async fn read_and_scan_commits(
 #[rstest]
 #[tokio::test]
 async fn test_voting_block_headers_storage(
-    #[values(new_rocksdb_teststore(true), new_mem_teststore(true))] test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
-    let context = test_store.context();
 
     // Create blocks with commit votes
     let voting_blocks: Vec<VerifiedBlock> = vec![
@@ -610,7 +521,7 @@ async fn test_voting_block_headers_storage(
     // Write to voting storage using WriteBatch
     let write_batch = WriteBatch::default().voting_block_headers(voting_headers.clone());
     store
-        .write(write_batch, context)
+        .write(write_batch)
         .expect("Write voting block headers should not fail");
 
     // Read back
@@ -657,10 +568,9 @@ async fn test_voting_block_headers_storage(
 #[rstest]
 #[tokio::test]
 async fn test_read_highest_commit_index_with_votes(
-    #[values(new_rocksdb_teststore(true), new_mem_teststore(true))] test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
-    let context = test_store.context();
 
     // Create blocks voting on commits at indexes 1, 2, 5, 10 (with gaps at 3, 4,
     // 6-9)
@@ -696,7 +606,6 @@ async fn test_read_highest_commit_index_with_votes(
                     .map(|b| b.verified_block_header.clone())
                     .collect(),
             ),
-            context,
         )
         .expect("Write should not fail");
 
@@ -759,7 +668,7 @@ async fn test_read_highest_commit_index_with_votes(
 #[rstest]
 #[tokio::test]
 async fn scan_misbehavior_counts(
-    #[values(new_rocksdb_teststore(false), new_mem_teststore(false))] test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     use std::collections::BTreeMap;
 
@@ -790,10 +699,7 @@ async fn scan_misbehavior_counts(
     .into_iter()
     .collect();
     store
-        .write(
-            WriteBatch::default().misbehavior_counts(metrics_to_write.clone()),
-            test_store.context(),
-        )
+        .write(WriteBatch::default().misbehavior_counts(metrics_to_write.clone()))
         .unwrap();
 
     let scanned = store
@@ -806,10 +712,7 @@ async fn scan_misbehavior_counts(
         .into_iter()
         .collect();
     store
-        .write(
-            WriteBatch::default().misbehavior_counts(overwrite),
-            test_store.context(),
-        )
+        .write(WriteBatch::default().misbehavior_counts(overwrite))
         .unwrap();
 
     let scanned = store

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(test)]
-use std::sync::Arc;
 use std::{
     fmt,
     hash::{Hash, Hasher},
@@ -13,8 +11,6 @@ use fastcrypto::hash::Digest;
 use serde::{Deserialize, Serialize};
 use starfish_config::{AuthorityIndex, DIGEST_LENGTH};
 
-#[cfg(test)]
-use crate::context::Context;
 use crate::{
     block_header::{BlockRef, Round, TransactionsCommitment},
     error::{ConsensusError, ConsensusResult},
@@ -114,7 +110,6 @@ impl GenericTransactionRefAPI for TransactionRef {
 
 impl GenericTransactionRef {
     /// Extract TransactionRef, returning error if this is a BlockRef variant.
-    /// This should only be called when consensus_fast_commit_sync flag is true.
     pub(crate) fn expect_transaction_ref(self) -> ConsensusResult<TransactionRef> {
         match self {
             GenericTransactionRef::TransactionRef(tr) => Ok(tr),
@@ -122,23 +117,6 @@ impl GenericTransactionRef {
                 Err(ConsensusError::TransactionRefVariantMismatch {
                     protocol_flag_enabled: true,
                     expected_variant: "TransactionRef",
-                    received_variant: self.variant_name(),
-                })
-            }
-        }
-    }
-
-    /// Extract BlockRef, returning error if this is a TransactionRef variant.
-    /// This should only be called when consensus_fast_commit_sync flag is
-    /// false.
-    #[allow(dead_code)]
-    pub(crate) fn expect_block_ref(self) -> ConsensusResult<BlockRef> {
-        match self {
-            GenericTransactionRef::BlockRef(br) => Ok(br),
-            GenericTransactionRef::TransactionRef(_) => {
-                Err(ConsensusError::TransactionRefVariantMismatch {
-                    protocol_flag_enabled: false,
-                    expected_variant: "BlockRef",
                     received_variant: self.variant_name(),
                 })
             }
@@ -164,33 +142,24 @@ impl Hash for GenericTransactionRef {
     }
 }
 
-/// Helper function to convert BlockRefs to GenericTransactionRefs based on
-/// protocol flag.
+/// Helper function to convert BlockRefs to GenericTransactionRefs, fetching
+/// each block header for its transactions commitment.
 #[cfg(test)]
 pub(crate) fn convert_block_refs_to_generic_transaction_refs(
-    context: &Arc<Context>,
     store: &dyn crate::storage::Store,
     block_refs: &[BlockRef],
 ) -> Vec<GenericTransactionRef> {
-    if context.protocol_config.consensus_fast_commit_sync() {
-        // Fetch headers to get transactions_commitment for TransactionRef
-        let headers = store.read_verified_block_headers(block_refs).unwrap();
-        block_refs
-            .iter()
-            .enumerate()
-            .map(|(idx, block_ref)| {
-                let header = headers[idx].as_ref().unwrap();
-                GenericTransactionRef::TransactionRef(TransactionRef {
-                    round: block_ref.round,
-                    author: block_ref.author,
-                    transactions_commitment: header.transactions_commitment(),
-                })
+    let headers = store.read_verified_block_headers(block_refs).unwrap();
+    block_refs
+        .iter()
+        .enumerate()
+        .map(|(idx, block_ref)| {
+            let header = headers[idx].as_ref().unwrap();
+            GenericTransactionRef::TransactionRef(TransactionRef {
+                round: block_ref.round,
+                author: block_ref.author,
+                transactions_commitment: header.transactions_commitment(),
             })
-            .collect()
-    } else {
-        block_refs
-            .iter()
-            .map(|br| GenericTransactionRef::BlockRef(*br))
-            .collect()
-    }
+        })
+        .collect()
 }

--- a/crates/starfish/core/src/transaction_ref.rs
+++ b/crates/starfish/core/src/transaction_ref.rs
@@ -109,14 +109,13 @@ impl GenericTransactionRefAPI for TransactionRef {
 }
 
 impl GenericTransactionRef {
-    /// Extract TransactionRef, returning error if this is a BlockRef variant.
+    /// Returns the transaction reference or an error for a legacy block
+    /// reference.
     pub(crate) fn expect_transaction_ref(self) -> ConsensusResult<TransactionRef> {
         match self {
             GenericTransactionRef::TransactionRef(tr) => Ok(tr),
             GenericTransactionRef::BlockRef(_) => {
                 Err(ConsensusError::TransactionRefVariantMismatch {
-                    protocol_flag_enabled: true,
-                    expected_variant: "TransactionRef",
                     received_variant: self.variant_name(),
                 })
             }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1100,11 +1100,7 @@ mod tests {
     async fn successful_live_syncing() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = true;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1334,11 +1330,7 @@ mod tests {
     async fn live_syncing_with_timeout_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = true;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1465,11 +1457,7 @@ mod tests {
     async fn live_syncing_with_error_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = true;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1585,11 +1573,7 @@ mod tests {
     async fn live_syncing_with_empty_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = true;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1707,11 +1691,7 @@ mod tests {
     async fn live_syncing_with_corrupted_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = true;
-        context
-            .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -974,15 +974,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         // inside verify_transactions
         let transactions = match Handle::current()
             .spawn_blocking({
-                // Validate that all refs are TransactionRef as expected.
-                for tx_ref in requested_transactions_guard.transactions_refs.iter() {
-                    if let GenericTransactionRef::BlockRef(_) = tx_ref {
-                        return Err(ConsensusError::TransactionRefVariantMismatch {
-                            protocol_flag_enabled: true,
-                            expected_variant: "TransactionRef",
-                            received_variant: "BlockRef",
-                        });
-                    }
+                for tx_ref in &requested_transactions_guard.transactions_refs {
+                    tx_ref.expect_transaction_ref()?;
                 }
 
                 let mut serialized_transactions_map: BTreeMap<GenericTransactionRef, Bytes> =

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -32,13 +32,12 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::{
-    block_header::BlockRef,
-    commit_syncer::{verify_transactions_with_headers, verify_transactions_with_transactions_refs},
+    commit_syncer::verify_transactions_with_transactions_refs,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, DataSource},
     error::{ConsensusError, ConsensusResult},
-    network::{NetworkClient, SerializedTransactionsV1, SerializedTransactionsV2},
+    network::{NetworkClient, SerializedTransactionsV2},
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
 };
 
@@ -414,7 +413,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
-            dag_state.clone(),
             live_fetch_receiver,
             inflight_transactions_map.clone(),
             last_failure_by_peer.clone(),
@@ -525,7 +523,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         network_client: Arc<C>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
-        dag_state: Arc<RwLock<DagState>>,
         mut receiver: Receiver<BTreeMap<GenericTransactionRef, BTreeSet<AuthorityIndex>>>,
         inflight_transactions_map: Arc<InflightTransactionsMap>,
         last_failure_by_peer: Arc<LastFailureByPeer>,
@@ -547,7 +544,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                     let inflight_transactions_map = inflight_transactions_map.clone();
                     let network_client = network_client.clone();
                     let core_dispatcher = core_dispatcher.clone();
-                    let dag_state = dag_state.clone();
                     let last_failure_by_peer = last_failure_by_peer.clone();
                     tokio::spawn(async move {
                         Self::fetch_and_process_transactions_from_authorities(
@@ -557,7 +553,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                             network_client,
                             missing_transactions_block_refs,
                             core_dispatcher,
-                            dag_state,
                             last_failure_by_peer,
                             SyncMethod::Live,
                         )
@@ -636,7 +631,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         let network_client = self.network_client.clone();
         let core_dispatcher = self.core_dispatcher.clone();
         let commands_sender = self.commands_sender.clone();
-        let dag_state = self.dag_state.clone();
         let inflight_transactions_map = self.inflight_transactions_map.clone();
         let active_requests = self.active_requests.clone();
         let last_failure_by_round = self.last_failure_by_peer.clone();
@@ -658,7 +652,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                     network_client,
                     missing_transactions,
                     core_dispatcher,
-                    dag_state,
                     last_failure_by_round,
                     SyncMethod::Periodic,
                 )
@@ -684,7 +677,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         network_client: Arc<C>,
         missing_transactions: BTreeMap<GenericTransactionRef, BTreeSet<AuthorityIndex>>,
         core_dispatcher: Arc<D>,
-        dag_state: Arc<RwLock<DagState>>,
         last_failure_by_peer: Arc<LastFailureByPeer>,
         sync_method: SyncMethod,
     ) {
@@ -765,7 +757,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 let context = context.clone();
                 let network_client = network_client.clone();
                 let core_dispatcher = core_dispatcher.clone();
-                let dag_state = dag_state.clone();
                 request_futures.push(async move {
                     let result = Self::fetch_and_process_transactions_from_authority(
                         authority,
@@ -773,7 +764,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                         transactions_guard,
                         network_client,
                         core_dispatcher,
-                        dag_state,
                         sync_method,
                         active_request_guard,
                     )
@@ -813,7 +803,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         transactions_guard: TransactionsGuard,
         network_client: Arc<C>,
         core_dispatcher: Arc<D>,
-        dag_state: Arc<RwLock<DagState>>,
         sync_method: SyncMethod,
         _active_guard: ActiveRequestGuard,
     ) -> ConsensusResult<()> {
@@ -848,7 +837,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
             transactions_guard,
             core_dispatcher.clone(),
             context,
-            dag_state.clone(),
             sync_method,
         )
         .await?;
@@ -962,7 +950,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         requested_transactions_guard: TransactionsGuard,
         core_dispatcher: Arc<D>,
         context: Arc<Context>,
-        dag_state: Arc<RwLock<DagState>>,
         sync_method: SyncMethod,
     ) -> ConsensusResult<()> {
         let _s = context
@@ -985,130 +972,58 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
 
         // Deserialize and verify the transactions
         // inside verify_transactions
-        let transactions = if !context.protocol_config.consensus_fast_commit_sync() {
-            match Handle::current()
-                .spawn_blocking({
-                    // Use the block_refs from the requested_transactions_guard
-                    let block_refs: ConsensusResult<Vec<BlockRef>> = requested_transactions_guard
-                        .transactions_refs
-                        .iter()
-                        .map(|ctr| match ctr {
-                            GenericTransactionRef::TransactionRef(_) => {
-                                Err(ConsensusError::TransactionRefVariantMismatch {
-                                    protocol_flag_enabled: false,
-                                    expected_variant: "BlockRef",
-                                    received_variant: "TransactionRef",
-                                })
-                            }
-                            GenericTransactionRef::BlockRef(block_ref) => Ok(*block_ref),
-                        })
-                        .collect();
-                    let block_refs = block_refs?;
-                    let block_headers_vec =
-                        dag_state.read().get_verified_block_headers(&block_refs);
-                    let mut block_headers_map = BTreeMap::new();
-                    for block_header_opt in block_headers_vec.into_iter() {
-                        let block_header = block_header_opt
-                            .expect("block header for requested transactions must exist");
-                        block_headers_map.insert(block_header.reference(), block_header);
+        let transactions = match Handle::current()
+            .spawn_blocking({
+                // Validate that all refs are TransactionRef as expected.
+                for tx_ref in requested_transactions_guard.transactions_refs.iter() {
+                    if let GenericTransactionRef::BlockRef(_) = tx_ref {
+                        return Err(ConsensusError::TransactionRefVariantMismatch {
+                            protocol_flag_enabled: true,
+                            expected_variant: "TransactionRef",
+                            received_variant: "BlockRef",
+                        });
                     }
-
-                    let mut serialized_transactions_map: BTreeMap<GenericTransactionRef, Bytes> =
-                        BTreeMap::new();
-                    for serialized_transaction_bytes in &serialized_transactions_vec {
-                        let serialized_transactions: SerializedTransactionsV1 =
-                            bcs::from_bytes(serialized_transaction_bytes)
-                                .map_err(ConsensusError::MalformedTransactions)?;
-                        let committed_transaction_ref =
-                            GenericTransactionRef::BlockRef(serialized_transactions.block_ref);
-                        serialized_transactions_map.insert(
-                            committed_transaction_ref,
-                            serialized_transactions.serialized_transactions,
-                        );
-                    }
-                    let context_cloned = context.clone();
-
-                    move || {
-                        verify_transactions_with_headers(
-                            context_cloned,
-                            peer_index,
-                            serialized_transactions_map,
-                            block_headers_map,
-                        )
-                    }
-                })
-                .await
-                .expect("Spawn blocking should not fail")
-            {
-                Ok(transactions) => transactions,
-                Err(err) => {
-                    // Update metrics for invalid transactions.
-                    metrics
-                        .invalid_transactions
-                        .with_label_values(&[
-                            peer_hostname.as_str(),
-                            "transaction_synchronizer",
-                            err.name(),
-                        ])
-                        .inc();
-                    return Err(err);
                 }
-            }
-        } else {
-            match Handle::current()
-                .spawn_blocking({
-                    // Validate that all refs are TransactionRef as expected when
-                    // consensus_fast_commit_sync is true
-                    for tx_ref in requested_transactions_guard.transactions_refs.iter() {
-                        if let GenericTransactionRef::BlockRef(_) = tx_ref {
-                            return Err(ConsensusError::TransactionRefVariantMismatch {
-                                protocol_flag_enabled: true,
-                                expected_variant: "TransactionRef",
-                                received_variant: "BlockRef",
-                            });
-                        }
-                    }
 
-                    let mut serialized_transactions_map: BTreeMap<GenericTransactionRef, Bytes> =
-                        BTreeMap::new();
-                    for serialized_transaction_bytes in &serialized_transactions_vec {
-                        let serialized_transactions: SerializedTransactionsV2 =
-                            bcs::from_bytes(serialized_transaction_bytes)
-                                .map_err(ConsensusError::MalformedTransactions)?;
-                        let committed_transaction_ref = GenericTransactionRef::TransactionRef(
-                            serialized_transactions.transaction_ref,
-                        );
-                        serialized_transactions_map.insert(
-                            committed_transaction_ref,
-                            serialized_transactions.serialized_transactions,
-                        );
-                    }
-                    let context_cloned = context.clone();
-
-                    move || {
-                        verify_transactions_with_transactions_refs(
-                            &context_cloned,
-                            peer_index,
-                            serialized_transactions_map,
-                        )
-                    }
-                })
-                .await
-                .expect("Spawn blocking should not fail")
-            {
-                Ok(transactions) => transactions,
-                Err(err) => {
-                    // Update metrics for invalid transactions.
-                    metrics
-                        .invalid_transactions
-                        .with_label_values(&[
-                            peer_hostname.as_str(),
-                            "transaction_synchronizer",
-                            err.name(),
-                        ])
-                        .inc();
-                    return Err(err);
+                let mut serialized_transactions_map: BTreeMap<GenericTransactionRef, Bytes> =
+                    BTreeMap::new();
+                for serialized_transaction_bytes in &serialized_transactions_vec {
+                    let serialized_transactions: SerializedTransactionsV2 =
+                        bcs::from_bytes(serialized_transaction_bytes)
+                            .map_err(ConsensusError::MalformedTransactions)?;
+                    let committed_transaction_ref = GenericTransactionRef::TransactionRef(
+                        serialized_transactions.transaction_ref,
+                    );
+                    serialized_transactions_map.insert(
+                        committed_transaction_ref,
+                        serialized_transactions.serialized_transactions,
+                    );
                 }
+                let context_cloned = context.clone();
+
+                move || {
+                    verify_transactions_with_transactions_refs(
+                        &context_cloned,
+                        peer_index,
+                        serialized_transactions_map,
+                    )
+                }
+            })
+            .await
+            .expect("Spawn blocking should not fail")
+        {
+            Ok(transactions) => transactions,
+            Err(err) => {
+                // Update metrics for invalid transactions.
+                metrics
+                    .invalid_transactions
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        "transaction_synchronizer",
+                        err.name(),
+                    ])
+                    .inc();
+                return Err(err);
             }
         }
         .iter()

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1084,7 +1084,6 @@ mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
     use rand::{Rng, thread_rng};
-    use rstest::rstest;
     use tokio::{sync::Mutex, time::sleep};
 
     use super::*;
@@ -1100,20 +1099,19 @@ mod tests {
         core_thread::CoreError,
         dag_state::{DagState, DataSource},
         encoder::create_encoder,
-        network::{BlockBundleStream, NetworkClient, SerializedTransactionsV1},
+        network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
     };
 
-    #[rstest]
     #[tokio::test]
-    async fn successful_live_syncing(#[values(true, false)] consensus_fast_commit_sync: bool) {
+    async fn successful_live_syncing() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
         let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        context.parameters.enable_fast_commit_syncer = true;
         context
             .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+            .set_consensus_fast_commit_sync_for_testing(true);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1173,22 +1171,14 @@ mod tests {
             let mut authorities = BTreeSet::new();
             authorities.insert(AuthorityIndex::new_for_test(1));
             authorities.insert(AuthorityIndex::new_for_test(2));
-            let gen_ref = if consensus_fast_commit_sync {
-                GenericTransactionRef::from(header.transaction_ref())
-            } else {
-                GenericTransactionRef::from(header.reference())
-            };
+            let gen_ref = GenericTransactionRef::from(header.transaction_ref());
             missing_transactions.insert(gen_ref, authorities);
         }
 
         // Stub the transactions in the network client
         for transaction in &transactions {
             network_client
-                .stub_fetch_transactions(
-                    vec![transaction.clone()],
-                    AuthorityIndex::new_for_test(1),
-                    consensus_fast_commit_sync,
-                )
+                .stub_fetch_transactions(vec![transaction.clone()], AuthorityIndex::new_for_test(1))
                 .await;
         }
 
@@ -1347,18 +1337,15 @@ mod tests {
         handle.stop().await.unwrap();
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn live_syncing_with_timeout_peer(
-        #[values(true, false)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn live_syncing_with_timeout_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
         let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        context.parameters.enable_fast_commit_syncer = true;
         context
             .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+            .set_consensus_fast_commit_sync_for_testing(true);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1419,11 +1406,7 @@ mod tests {
             let mut authorities = BTreeSet::new();
             authorities.insert(AuthorityIndex::new_for_test(1)); // This peer will timeout
             authorities.insert(AuthorityIndex::new_for_test(2)); // This peer will succeed
-            let gen_ref = if consensus_fast_commit_sync {
-                GenericTransactionRef::from(header.transaction_ref())
-            } else {
-                GenericTransactionRef::from(header.reference())
-            };
+            let gen_ref = GenericTransactionRef::from(header.transaction_ref());
             missing_transactions.insert(gen_ref, authorities);
         }
 
@@ -1435,11 +1418,7 @@ mod tests {
         // Stub the transactions for peer 2
         for transaction in &transactions {
             network_client
-                .stub_fetch_transactions(
-                    vec![transaction.clone()],
-                    AuthorityIndex::new_for_test(2),
-                    consensus_fast_commit_sync,
-                )
+                .stub_fetch_transactions(vec![transaction.clone()], AuthorityIndex::new_for_test(2))
                 .await;
         }
 
@@ -1489,16 +1468,15 @@ mod tests {
         handle.stop().await.unwrap();
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn live_syncing_with_error_peer(#[values(true, false)] consensus_fast_commit_sync: bool) {
+    async fn live_syncing_with_error_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
         let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        context.parameters.enable_fast_commit_syncer = true;
         context
             .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+            .set_consensus_fast_commit_sync_for_testing(true);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1559,11 +1537,7 @@ mod tests {
             let mut authorities = BTreeSet::new();
             authorities.insert(AuthorityIndex::new_for_test(1)); // This peer will return an error
             authorities.insert(AuthorityIndex::new_for_test(2)); // This peer will succeed
-            let gen_ref = if consensus_fast_commit_sync {
-                GenericTransactionRef::from(header.transaction_ref())
-            } else {
-                GenericTransactionRef::from(header.reference())
-            };
+            let gen_ref = GenericTransactionRef::from(header.transaction_ref());
             missing_transactions.insert(gen_ref, authorities);
         }
 
@@ -1578,11 +1552,7 @@ mod tests {
         // Stub the transactions for peer 2
         for transaction in &transactions {
             network_client
-                .stub_fetch_transactions(
-                    vec![transaction.clone()],
-                    AuthorityIndex::new_for_test(2),
-                    consensus_fast_commit_sync,
-                )
+                .stub_fetch_transactions(vec![transaction.clone()], AuthorityIndex::new_for_test(2))
                 .await;
         }
 
@@ -1618,16 +1588,15 @@ mod tests {
         handle.stop().await.unwrap();
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn live_syncing_with_empty_peer(#[values(true, false)] consensus_fast_commit_sync: bool) {
+    async fn live_syncing_with_empty_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
         let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        context.parameters.enable_fast_commit_syncer = true;
         context
             .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+            .set_consensus_fast_commit_sync_for_testing(true);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1688,11 +1657,7 @@ mod tests {
             let mut authorities = BTreeSet::new();
             authorities.insert(AuthorityIndex::new_for_test(1)); // This peer will return empty results
             authorities.insert(AuthorityIndex::new_for_test(2)); // This peer will succeed
-            let gen_ref = if consensus_fast_commit_sync {
-                GenericTransactionRef::from(header.transaction_ref())
-            } else {
-                GenericTransactionRef::from(header.reference())
-            };
+            let gen_ref = GenericTransactionRef::from(header.transaction_ref());
             missing_transactions.insert(gen_ref, authorities);
         }
 
@@ -1704,11 +1669,7 @@ mod tests {
         // Stub the transactions for peer 2
         for transaction in &transactions {
             network_client
-                .stub_fetch_transactions(
-                    vec![transaction.clone()],
-                    AuthorityIndex::new_for_test(2),
-                    consensus_fast_commit_sync,
-                )
+                .stub_fetch_transactions(vec![transaction.clone()], AuthorityIndex::new_for_test(2))
                 .await;
         }
 
@@ -1749,18 +1710,15 @@ mod tests {
         handle.stop().await.unwrap();
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn live_syncing_with_corrupted_peer(
-        #[values(true, false)] consensus_fast_commit_sync: bool,
-    ) {
+    async fn live_syncing_with_corrupted_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
         let (mut context, _) = Context::new_for_test(4);
-        context.parameters.enable_fast_commit_syncer = consensus_fast_commit_sync;
+        context.parameters.enable_fast_commit_syncer = true;
         context
             .protocol_config
-            .set_consensus_fast_commit_sync_for_testing(consensus_fast_commit_sync);
+            .set_consensus_fast_commit_sync_for_testing(true);
         let context = Arc::new(context);
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
         let network_client = Arc::new(MockNetworkClient::new());
@@ -1821,15 +1779,10 @@ mod tests {
             let mut authorities = BTreeSet::new();
             authorities.insert(AuthorityIndex::new_for_test(1)); // This peer will return corrupted data
             authorities.insert(AuthorityIndex::new_for_test(2)); // This peer will succeed
-            if consensus_fast_commit_sync {
-                missing_transactions.insert(
-                    GenericTransactionRef::from(header.transaction_ref()),
-                    authorities,
-                );
-            } else {
-                missing_transactions
-                    .insert(GenericTransactionRef::from(header.reference()), authorities);
-            }
+            missing_transactions.insert(
+                GenericTransactionRef::from(header.transaction_ref()),
+                authorities,
+            );
         }
 
         // Set peer 1 to return corrupted data
@@ -1840,11 +1793,7 @@ mod tests {
         // Stub the transactions for peer 2
         for transaction in &transactions {
             network_client
-                .stub_fetch_transactions(
-                    vec![transaction.clone()],
-                    AuthorityIndex::new_for_test(2),
-                    consensus_fast_commit_sync,
-                )
+                .stub_fetch_transactions(vec![transaction.clone()], AuthorityIndex::new_for_test(2))
                 .await;
         }
 
@@ -2164,36 +2113,17 @@ mod tests {
             &self,
             transactions: Vec<VerifiedTransactions>,
             peer: AuthorityIndex,
-            consensus_fast_commit_sync: bool,
         ) {
             let mut transactions_map = self.transactions.lock().await;
             for transaction in transactions {
                 let transaction_ref = transaction.transaction_ref();
-
-                if consensus_fast_commit_sync {
-                    // Create a SerializedTransactionsV2 struct with TransactionRef
-                    let serialized_transactions = SerializedTransactionsV2 {
-                        transaction_ref,
-                        serialized_transactions: transaction.serialized().clone(),
-                    };
-                    let tx_ref = GenericTransactionRef::TransactionRef(transaction_ref);
-                    // Serialize the SerializedTransactions struct
-                    let serialized = bcs::to_bytes(&serialized_transactions).unwrap();
-                    transactions_map.insert((peer, tx_ref), serialized.into());
-                } else {
-                    // Create a SerializedTransactionsV1 struct with BlockRef
-                    let block_ref = transaction
-                        .block_ref()
-                        .expect("block_ref must be present in non-transaction-ref path");
-                    let serialized_transactions = SerializedTransactionsV1 {
-                        block_ref,
-                        serialized_transactions: transaction.serialized().clone(),
-                    };
-                    let tx_ref = GenericTransactionRef::BlockRef(block_ref);
-                    // Serialize the SerializedTransactions struct
-                    let serialized = bcs::to_bytes(&serialized_transactions).unwrap();
-                    transactions_map.insert((peer, tx_ref), serialized.into());
-                }
+                let serialized_transactions = SerializedTransactionsV2 {
+                    transaction_ref,
+                    serialized_transactions: transaction.serialized().clone(),
+                };
+                let tx_ref = GenericTransactionRef::TransactionRef(transaction_ref);
+                let serialized = bcs::to_bytes(&serialized_transactions).unwrap();
+                transactions_map.insert((peer, tx_ref), serialized.into());
             }
         }
 

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -415,7 +415,6 @@ pub async fn make_authority(config: Config, commit_consumer: CommitConsumer) -> 
         commit_sync_parallel_fetches: 2,
         commit_sync_batch_size: 3,
         sync_last_known_own_block_timeout: Duration::from_millis(2_000),
-        enable_fast_commit_syncer: protocol_config.consensus_fast_commit_sync(),
         ..Default::default()
     };
     let txn_verifier = NoopTransactionVerifier {};


### PR DESCRIPTION
# Description of change

The four consensus protocol flags first enabled for mainnet at protocol version 29 are now treated as permanently active. Their flag-off runtime branches are dead and have been removed. The flag definitions and historical per-version values remain in `iota-protocol-config`.

**`consensus_fast_commit_sync`**

Uses `TransactionRef` unconditionally across block proposal, commits, `DagState`, storage, cordial knowledge, authority RPCs, and the header, transaction, and commit synchronizers. This removes the legacy header-based commit-sync verification path, pre-versioned shard/transaction deserializers, and endpoint guards.

**`consensus_block_restrictions`**

Makes acknowledgment and commit-vote limits, round bounds, GC eviction, and the quorum-commit-round proposal skip unconditional.

**`consensus_median_timestamp_with_checkpoint_enforcement`**

Makes checkpoint timestamp monotonicity enforcement unconditional.

**`always_advance_dkg_to_resolution`**

Always advances pending random-beacon DKG state so persisted state can resolve without new inbound traffic.

The cleanup also removes obsolete test matrices and setup, `verify_transactions_with_headers`, `SerializedTransactionsV1`, the `FastCommitSyncNotEnabled` error, `GenericTransactionRef::expect_block_ref`, vestigial `Context` storage parameters, and the legacy BlockRef-keyed transaction maps and RocksDB column family.

## Compatibility

Commit digests include the BCS enum tag. The legacy `CommitV1` and `ShardWithProofV1` variant slots therefore remain as deserialize and format anchors, while their construction is removed. `GenericTransactionRef` also retains both variants. Legacy V1 commits and shards still deserialize, and peer-supplied V1 data is rejected by the existing version checks.

The consensus RocksDB path is epoch-scoped as `storage_base_path/{epoch}`. A v29 epoch creates a fresh TransactionRef-keyed store and never needs the pre-v29 BlockRef-keyed transaction column family, so removing it requires no migration of an existing epoch store.

No protocol-version change is required.

> [!IMPORTANT]
> **Deployment precondition.** The cleaned runtime unconditionally runs the flag-on behavior. It is safe to ship only after every network is permanently at a protocol version where all four flags are active.

## Links to any relevant issues

Fixes #11965

