### PR TITLE
feat(iota-core,iota-config,iota-node): add per-node config to toggle pre-consensus soft-locking

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -230,6 +230,14 @@ pub struct NodeConfig {
     #[serde(default = "bool_true")]
     pub enable_validator_tx_finalizer: bool,
 
+    /// Enables the pre-consensus soft-locking mechanism used by the
+    /// certificate-less (pcool) transaction flow (default: enabled).
+    ///
+    /// When disabled, post-consensus validation alone resolves owned-object
+    /// conflicts. Has no effect unless the pcool flow is enabled.
+    #[serde(default = "bool_true")]
+    pub enable_soft_locking: bool,
+
     #[serde(default)]
     pub verifier_signing_config: VerifierSigningConfig,
 
@@ -1550,6 +1558,16 @@ mod tests {
         const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
 
         let _template: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+    }
+
+    #[test]
+    fn enable_soft_locking_defaults_to_enabled() {
+        // The template omits `enable-soft-locking`, so this exercises the serde
+        // default and pins the documented "default: enabled" contract.
+        const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
+
+        let config: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+        assert!(config.enable_soft_locking);
     }
 
     #[test]

--- a/crates/iota-core/src/authority_server/soft_lock.rs
+++ b/crates/iota-core/src/authority_server/soft_lock.rs
@@ -85,6 +85,9 @@ pub struct PreConsensusSoftLocks {
     /// value is always consistent with the map at the moment the lock is
     /// released.
     lock_count: AtomicUsize,
+    /// When `false`, every operation is a no-op: `try_acquire` never reports a
+    /// conflict and nothing is ever stored.
+    enabled: bool,
 }
 
 impl Default for PreConsensusSoftLocks {
@@ -94,17 +97,29 @@ impl Default for PreConsensusSoftLocks {
 }
 
 impl PreConsensusSoftLocks {
-    /// Creates a new instance with the default TTL.
+    /// Creates a new enabled instance with the default TTL.
     pub fn new() -> Self {
         Self::with_ttl(DEFAULT_SOFT_LOCK_TTL)
     }
 
-    /// Creates a new instance with a custom TTL (useful for tests).
+    /// Creates a new enabled instance with a custom TTL (useful for tests).
     pub fn with_ttl(lock_ttl: Duration) -> Self {
+        Self::new_inner(lock_ttl, true)
+    }
+
+    /// Creates a disabled instance: every operation is a no-op and
+    /// `try_acquire` never reports a conflict, so post-consensus validation is
+    /// the sole conflict resolver.
+    pub fn disabled() -> Self {
+        Self::new_inner(DEFAULT_SOFT_LOCK_TTL, false)
+    }
+
+    fn new_inner(lock_ttl: Duration, enabled: bool) -> Self {
         Self {
             inner: Mutex::new(Inner::default()),
             lock_ttl,
             lock_count: AtomicUsize::new(0),
+            enabled,
         }
     }
 
@@ -124,7 +139,7 @@ impl PreConsensusSoftLocks {
         tx_digest: TransactionDigest,
         owned_objects: &[ObjectRef],
     ) -> Result<(), IotaError> {
-        if owned_objects.is_empty() {
+        if !self.enabled || owned_objects.is_empty() {
             return Ok(());
         }
 
@@ -186,6 +201,9 @@ impl PreConsensusSoftLocks {
     /// Called by active GC hooks (consensus processed / tx dropped) and on
     /// consensus submission failure.
     pub fn release(&self, tx_digest: &TransactionDigest) {
+        if !self.enabled {
+            return;
+        }
         let mut inner = self.inner.lock();
         Self::release_one(&mut inner, tx_digest);
         self.lock_count.store(inner.locks.len(), Ordering::Relaxed);
@@ -195,7 +213,7 @@ impl PreConsensusSoftLocks {
     /// single mutex acquisition. Equivalent to calling `release` for each
     /// digest, but avoids `N` lock/unlock cycles per consensus commit.
     pub fn release_for_batch(&self, tx_digests: &[TransactionDigest]) {
-        if tx_digests.is_empty() {
+        if !self.enabled || tx_digests.is_empty() {
             return;
         }
         let mut inner = self.inner.lock();
@@ -222,6 +240,9 @@ impl PreConsensusSoftLocks {
 
     /// Removes all entries whose timestamp is older than `lock_ttl`.
     pub fn sweep_expired(&self) {
+        if !self.enabled {
+            return;
+        }
         let now = Instant::now();
         let ttl = self.lock_ttl;
         let mut inner = self.inner.lock();
@@ -261,6 +282,9 @@ impl PreConsensusSoftLocks {
 
     /// Drops all entries.  Called at epoch boundary.
     pub fn clear(&self) {
+        if !self.enabled {
+            return;
+        }
         let mut inner = self.inner.lock();
         inner.locks.clear();
         inner.tx_to_objects.clear();
@@ -752,5 +776,37 @@ mod tests {
         let table = PreConsensusSoftLocks::with_ttl(Duration::from_secs(60));
         // Should not panic.
         table.release(&digest(42));
+    }
+
+    #[test]
+    fn test_disabled_never_conflicts() {
+        let table = PreConsensusSoftLocks::disabled();
+        let obj = obj_ref(1, 1);
+        let tx_a = digest(1);
+        let tx_b = digest(2);
+
+        // Two different transactions on the same object both succeed: a
+        // disabled table never reports a conflict and never stores a lock.
+        table.try_acquire(tx_a, &[obj]).unwrap();
+        table.try_acquire(tx_b, &[obj]).unwrap();
+        assert_eq!(table.lock_count(), 0);
+    }
+
+    #[test]
+    fn test_disabled_release_sweep_and_clear_are_noops() {
+        let table = PreConsensusSoftLocks::disabled();
+        let tx = digest(1);
+
+        table
+            .try_acquire(tx, &[obj_ref(1, 1), obj_ref(2, 1)])
+            .unwrap();
+        assert_eq!(table.lock_count(), 0);
+
+        // None of these touch any state, but they must not panic.
+        table.release(&tx);
+        table.release_for_batch(&[tx]);
+        table.sweep_expired();
+        table.clear();
+        assert_eq!(table.lock_count(), 0);
     }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1241,7 +1241,12 @@ impl IotaNode {
             &validator_registry,
         );
 
-        let soft_locks = Arc::new(PreConsensusSoftLocks::new());
+        let soft_locks = Arc::new(if config.enable_soft_locking {
+            PreConsensusSoftLocks::new()
+        } else {
+            info!("pre-consensus soft-locking disabled via node config");
+            PreConsensusSoftLocks::disabled()
+        });
 
         let checkpoint_metrics = CheckpointMetrics::new(&validator_registry);
         let iota_tx_validator_metrics = IotaTxValidatorMetrics::new(&validator_registry);

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -232,6 +232,7 @@ impl ValidatorConfigBuilder {
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
             enable_validator_tx_finalizer: true,
+            enable_soft_locking: true,
             verifier_signing_config: VerifierSigningConfig::default(),
             enable_db_write_stall: None,
             iota_names_config: None,
@@ -583,6 +584,9 @@ impl FullnodeConfigBuilder {
             execution_cache_config: ExecutionCacheConfig::default(),
             // This is a validator specific feature.
             enable_validator_tx_finalizer: false,
+            // No effect on a fullnode (soft-locking runs only in the validator
+            // submit path); kept at the default so the config mirrors production.
+            enable_soft_locking: true,
             verifier_signing_config: VerifierSigningConfig::default(),
             enable_db_write_stall: None,
             iota_names_config: self.iota_names_config,

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/iota-swarm-config/tests/snapshot_tests.rs
 expression: network_config
-snapshot_kind: text
 ---
 validator_configs:
   - authority-key-pair:
@@ -95,6 +94,7 @@ validator_configs:
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
+    enable-soft-locking: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
       max-per-mod-meter-units: ~
@@ -194,6 +194,7 @@ validator_configs:
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
+    enable-soft-locking: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
       max-per-mod-meter-units: ~
@@ -293,6 +294,7 @@ validator_configs:
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
+    enable-soft-locking: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
       max-per-mod-meter-units: ~
@@ -392,6 +394,7 @@ validator_configs:
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
+    enable-soft-locking: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
       max-per-mod-meter-units: ~
@@ -491,6 +494,7 @@ validator_configs:
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
+    enable-soft-locking: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
       max-per-mod-meter-units: ~
@@ -590,6 +594,7 @@ validator_configs:
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
+    enable-soft-locking: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
       max-per-mod-meter-units: ~
@@ -689,6 +694,7 @@ validator_configs:
     execution-cache-config:
       writeback-cache: {}
     enable-validator-tx-finalizer: true
+    enable-soft-locking: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
       max-per-mod-meter-units: ~


### PR DESCRIPTION
# Description of change

Adds a per-node config flag `enable_soft_locking` (default: enabled) that turns the pre-consensus soft-locking mechanism on or off on a single validator, without a protocol change.

Soft-locking (`PreConsensusSoftLocks`) is an in-memory, defense-in-depth optimization in the certificate-less (pcool) flow: a validator rejects transactions that obviously conflict on owned objects before they reach consensus, saving consensus bandwidth and giving submitters faster feedback. Post-consensus validation remains the authoritative conflict resolver, so disabling soft-locking only forgoes the early rejection. This is useful for exercising the post-consensus conflict-resolution flow end-to-end in tests, and as a local killswitch on a single validator should a soft-locking bug surface — neither of which requires a coordinated protocol upgrade.

The toggle is centralized inside `PreConsensusSoftLocks` via an `enabled` flag and a `disabled()` constructor: when disabled, `try_acquire` never reports a conflict and all mutating operations are no-ops. Gating it in one place keeps every call site (gRPC submit path, epoch-store release, background sweep) unchanged and impossible to miss. The flag is read once at the validator construction site in `iota-node`, and has no effect unless the pcool flow is enabled.

## Links to any relevant issues

fixes #11954

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Added unit tests covering the disabled path in `soft_lock.rs` (a disabled table never reports a conflict and never stores a lock; `release`/`release_for_batch`/`sweep_expired`/`clear` are no-ops) and a test in `node.rs` pinning the `default = enabled` contract on deserialization. Existing enabled-path `soft_lock` tests continue to pass, and the network-config snapshot was regenerated for the new serialized field. Scoped `cargo clippy` and `cargo +nightly fmt` are clean across the touched crates.
