### PR TITLE
fix(ci): authenticate release-notes-check GitHub API calls

### DIFF
--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -46,6 +46,8 @@ jobs:
       - run: |
           cd scripts/release_notes
           ./run.sh check-pr ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   dprint-format:
     runs-on: [self-hosted-x64]


### PR DESCRIPTION
## Description of change

The `release-notes-check` job runs `scripts/release_notes/release_notes.py` which makes GitHub API calls. Without a token these calls use the unauthenticated per-IP rate limit of **60 req/h**, which is easily exhausted on shared CI infrastructure and produces flaky `HTTP Error 403: rate limit exceeded` failures.

This passes `GH_TOKEN: ${{ github.token }}` to the step's env so the script's GitHub API calls are authenticated, raising the limit to **5000 req/h**. The script already supports this token.

## Links

Fixes #11959

🤖 Generated with [Claude Code](https://claude.com/claude-code)