### PR TITLE
fix(typed-store): make lazy DBMetrics init race-safe

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -1013,7 +1013,9 @@ impl DBMetrics {
             .dec();
     }
     pub fn get() -> &'static Arc<DBMetrics> {
-        ONCE.get()
-            .unwrap_or_else(|| DBMetrics::init(prometheus::default_registry()))
+        // Lazily initialize against the global default registry when no explicit
+        // `init` has run. `get_or_init` ensures the rocksdb metrics are
+        // registered at most once even when first reached concurrently.
+        ONCE.get_or_init(|| Arc::new(DBMetrics::new(prometheus::default_registry())))
     }
 }


### PR DESCRIPTION
# Description of change

`test_consensus_handler*` and `test_consensus_commit_prologue_generation` failed intermittently under parallel (in-process) execution and passed single-threaded. The root cause is a process-global Prometheus double-registration race in `DBMetrics`: `DBMetrics::get()` lazily initialized the global metrics via a non-atomic `OnceCell::get().unwrap_or_else(|| DBMetrics::init(default_registry()))`. When two tests in the same process build RocksDB-backed `DBMap`s before the cell is set, both run the fallback, both register the same rocksdb metric names into the global default registry, and the loser panics with `Result::unwrap()` on `Err(AlreadyReg)` in `crates/typed-store/src/metrics.rs`.

The fix makes only the lazy `get()` path atomic by switching to `OnceCell::get_or_init`, so the build-and-register closure runs at most once across threads. `init(registry)` is left unchanged, so explicit callers still register into whatever registry they pass. There is no metrics behavior change otherwise: `get()` still registers into the default registry on first use and returns the cached instance thereafter — concurrent first-time initialization simply can no longer double-register.

This is an in-process (`cargo test` / libtest) hazard. Under nextest (process-per-test) each test runs in its own process and is isolated, so CI was unaffected, which is why the flake only reproduced locally.

## Links to any relevant issues

fixes #11705

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Reproduced the panic reliably (failed on the first run) by running the two `test_consensus_handler*` tests in a single process under `--test-threads 2` with CPU oversubscription. After the fix the same loop is green over 80+ runs, the named-flaky set under `--test-threads 8` is green over 30 runs, single-threaded and nextest (`-j16`) runs remain green, and the `typed-store` suite (51 tests) passes. A deterministic concurrency regression test is non-trivial for this race; happy to add a best-effort multi-threaded `get()` stress test if reviewers want one.