### PR TITLE
fix(scripts): poll for cluster state in split-cluster CI checks

### DIFF
--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -142,11 +142,9 @@ dump_diagnostics() {
   done
 }
 
-# Poll for the fullnode to finish reconfiguration rather than waiting a fixed
-# 60s: with a 20s epoch the marker normally appears within a minute, but
-# boot + DKG + end-of-epoch checkpoint + fullnode sync can take longer under CI
-# load, which is the source of the historical flake. Polling keeps the
-# slow-but-correct case green while still bounding the wait.
+# Upper bound on the poll for the fullnode to finish reconfiguration. With a 20s
+# epoch the marker normally appears within a minute, but boot + DKG +
+# end-of-epoch checkpoint + fullnode sync can take longer under CI load.
 MAX_WAIT=${MAX_WAIT:-180}
 POLL_INTERVAL=${POLL_INTERVAL:-5}
 RECONFIG_MARKER="Node State has been reconfigured"
@@ -160,7 +158,7 @@ while true; do
     reconfigured=1
     break
   fi
-  # Fail fast if any node died rather than burning the whole timeout.
+  # Fail fast if any node died.
   for i in "${!NODE_NAMES[@]}"; do
     if ! kill -0 "${NODE_PIDS[$i]}" 2>/dev/null; then
       echo "ERROR: ${NODE_NAMES[$i]} exited early after ${SECONDS}s"
@@ -180,10 +178,9 @@ if [ "$reconfigured" -ne 1 ]; then
   exit 1
 fi
 
-# Ensure the random beacon's DKG completes on both versions. node-0 (release)
-# and node-2 (candidate) are each checked for both markers (2 nodes x 2 markers
-# = 4 checks, same coverage as before). Report every missing marker before
-# failing so one run shows the full picture.
+# Ensure the random beacon's DKG completes on both versions: node-0 (release)
+# and node-2 (candidate) are each checked for both markers. Report every missing
+# marker before failing so one run shows the full picture.
 dkg_ok=1
 for node in node-0 node-2; do
   for marker in "random beacon: created" "random beacon: DKG complete"; do

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -78,52 +78,128 @@ done < <(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print0)
 
 export RUST_LOG=iota=debug,info
 
-# 2 release nodes
-"$WORKING_DIR/iota-node-release" --config-path "${CONFIGS[0]}" > "$LOG_DIR/node-0.log" 2>&1 &
-"$WORKING_DIR/iota-node-release" --config-path "${CONFIGS[1]}" > "$LOG_DIR/node-1.log" 2>&1 &
+# Track child PIDs (and which binary version each runs) so we can report
+# liveness and tear the cluster down cleanly.
+NODE_PIDS=()
+NODE_NAMES=()
+NODE_VERSIONS=()
 
-# 2 candidate nodes
-"$WORKING_DIR/iota-node-candidate" --config-path "${CONFIGS[2]}" > "$LOG_DIR/node-2.log" 2>&1 &
-"$WORKING_DIR/iota-node-candidate" --config-path "${CONFIGS[3]}" > "$LOG_DIR/node-3.log" 2>&1 &
+start_node() {
+  local name=$1 version=$2 binary=$3 config=$4
+  "$binary" --config-path "$config" > "$LOG_DIR/$name.log" 2>&1 &
+  local pid=$!
+  NODE_PIDS+=("$pid")
+  NODE_NAMES+=("$name")
+  NODE_VERSIONS+=("$version")
+  echo "Started $name ($version) with PID $pid"
+}
 
-# and a fullnode
-"$WORKING_DIR/iota-node-release" --config-path "$IOTA_CONFIG_DIR/fullnode.yaml" > "$LOG_DIR/fullnode.log" 2>&1 &
+# Tear the cluster down on any exit (success, timeout, or early node death).
+cleanup() {
+  echo "shutting down nodes"
+  pkill -P $$ 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT
 
-echo "sleeping for 60 seconds"
-sleep 60
+# 2 release nodes, 2 candidate nodes, and a release fullnode.
+start_node node-0 release "$WORKING_DIR/iota-node-release" "${CONFIGS[0]}"
+start_node node-1 release "$WORKING_DIR/iota-node-release" "${CONFIGS[1]}"
+start_node node-2 candidate "$WORKING_DIR/iota-node-candidate" "${CONFIGS[2]}"
+start_node node-3 candidate "$WORKING_DIR/iota-node-candidate" "${CONFIGS[3]}"
+start_node fullnode release "$WORKING_DIR/iota-node-release" "$IOTA_CONFIG_DIR/fullnode.yaml"
 
-# kill all child processes
-echo "shutting down nodes"
-pkill -P $$
+# Progress markers checked on failure to show how far each node got through
+# epoch-0 reconfiguration (crates/iota-node/src/lib.rs,
+# crates/iota-core/src/epoch/randomness.rs).
+DIAG_MARKERS=(
+  "Creating checkpoint executor for epoch 1"
+  "Finished executing all checkpoints in epoch"
+  "Node State has been reconfigured"
+  "random beacon: created"
+  "random beacon: DKG complete"
+)
 
-# ensure that "Node State has been reconfigured" is in "$LOG_DIR/fullnode.log"
-if ! grep -q "Node State has been reconfigured" "$LOG_DIR/fullnode.log"; then
-  echo "Could not find 'Node State has been reconfigured' in fullnode log"
+dump_diagnostics() {
+  local i label marker status
+  echo "===== DIAGNOSTICS (elapsed ${SECONDS}s) ====="
+  for i in "${!NODE_NAMES[@]}"; do
+    if kill -0 "${NODE_PIDS[$i]}" 2>/dev/null; then status="ALIVE"; else status="DEAD"; fi
+    echo "  ${NODE_NAMES[$i]} (${NODE_VERSIONS[$i]}, pid ${NODE_PIDS[$i]}): $status"
+  done
+  echo "===== MARKER MATRIX ====="
+  for i in "${!NODE_NAMES[@]}"; do
+    label="${NODE_NAMES[$i]} (${NODE_VERSIONS[$i]})"
+    for marker in "${DIAG_MARKERS[@]}"; do
+      if grep -q "$marker" "$LOG_DIR/${NODE_NAMES[$i]}.log" 2>/dev/null; then status="present"; else status="ABSENT "; fi
+      printf '  %-20s | %-45s | %s\n' "$label" "$marker" "$status"
+    done
+  done
+  echo "===== LOG TAILS (last 50 lines) ====="
+  for i in "${!NODE_NAMES[@]}"; do
+    echo "----- ${NODE_NAMES[$i]}.log (${NODE_VERSIONS[$i]}) -----"
+    tail -n 50 "$LOG_DIR/${NODE_NAMES[$i]}.log" 2>/dev/null
+  done
+}
+
+# Poll for the fullnode to finish reconfiguration rather than waiting a fixed
+# 60s: with a 20s epoch the marker normally appears within a minute, but
+# boot + DKG + end-of-epoch checkpoint + fullnode sync can take longer under CI
+# load, which is the source of the historical flake. Polling keeps the
+# slow-but-correct case green while still bounding the wait.
+MAX_WAIT=${MAX_WAIT:-180}
+POLL_INTERVAL=${POLL_INTERVAL:-5}
+RECONFIG_MARKER="Node State has been reconfigured"
+
+echo "Waiting up to ${MAX_WAIT}s for fullnode reconfiguration (polling every ${POLL_INTERVAL}s)"
+SECONDS=0
+reconfigured=0
+while true; do
+  if grep -q "$RECONFIG_MARKER" "$LOG_DIR/fullnode.log" 2>/dev/null; then
+    echo "Fullnode reconfigured after ${SECONDS}s"
+    reconfigured=1
+    break
+  fi
+  # Fail fast if any node died rather than burning the whole timeout.
+  for i in "${!NODE_NAMES[@]}"; do
+    if ! kill -0 "${NODE_PIDS[$i]}" 2>/dev/null; then
+      echo "ERROR: ${NODE_NAMES[$i]} exited early after ${SECONDS}s"
+      dump_diagnostics
+      exit 1
+    fi
+  done
+  # Stop once the deadline passes, but only after the check above so a marker
+  # that first appears during the final poll interval is not missed.
+  if [ "$SECONDS" -ge "$MAX_WAIT" ]; then break; fi
+  sleep "$POLL_INTERVAL"
+done
+
+if [ "$reconfigured" -ne 1 ]; then
+  echo "ERROR: timed out after ${SECONDS}s waiting for '$RECONFIG_MARKER' in fullnode log"
+  dump_diagnostics
   exit 1
 fi
 
-# ensure that the random beacon's DKG completes on both versions.
-# Both "random beacon: created" and "random beacon: DKG complete" must be present.
-if ! grep -q "random beacon: created" "$LOG_DIR/node-0.log"; then
-  echo "Could not find 'random beacon: created' in node-0"
-  exit 1
-fi
+# Ensure the random beacon's DKG completes on both versions. node-0 (release)
+# and node-2 (candidate) are each checked for both markers (2 nodes x 2 markers
+# = 4 checks, same coverage as before). Report every missing marker before
+# failing so one run shows the full picture.
+dkg_ok=1
+for node in node-0 node-2; do
+  for marker in "random beacon: created" "random beacon: DKG complete"; do
+    if ! grep -q "$marker" "$LOG_DIR/$node.log"; then
+      echo "ERROR: could not find '$marker' in $node log"
+      dkg_ok=0
+    fi
+  done
+done
 
-if ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-0.log"; then
-  echo "Could not find 'random beacon: DKG complete' in node-0"
-  exit 1
-fi
-
-if ! grep -q "random beacon: created" "$LOG_DIR/node-2.log"; then
-  echo "Could not find 'random beacon: created' in node-2"
-  exit 1
-fi
-
-if ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-2.log"; then
-  echo "Could not find 'random beacon: DKG complete' in node-2"
+if [ "$dkg_ok" -ne 1 ]; then
+  dump_diagnostics
   exit 1
 fi
 
 echo "Cluster reconfigured successfully"
 
+# The EXIT trap shuts the cluster down.
 exit 0

--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -85,8 +85,23 @@ done < <(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print0)
 
 export RUST_LOG=iota=debug,info
 
-# Track PIDs for process management
+# Track child PIDs (and which binary version each runs) so we can report
+# liveness and tear the cluster down cleanly. node-3 is appended only once it
+# starts (late), so the warmup liveness check naturally covers just the initial
+# quorum.
 NODE_PIDS=()
+NODE_NAMES=()
+NODE_VERSIONS=()
+
+start_node() {
+  local name=$1 version=$2 binary=$3 config=$4
+  "$binary" --config-path "$config" > "$LOG_DIR/$name.log" 2>&1 &
+  local pid=$!
+  NODE_PIDS+=("$pid")
+  NODE_NAMES+=("$name")
+  NODE_VERSIONS+=("$version")
+  echo "Started $name ($version) with PID $pid"
+}
 
 # Cleanup function to kill child processes on exit
 cleanup() {
@@ -156,57 +171,41 @@ WARMUP_SECS=${WARMUP_SECS:-180}
 # simultaneously wasteful on a fast runner and too short on a loaded one.
 CATCHUP_MAX_WAIT=${CATCHUP_MAX_WAIT:-180}
 
-# Echo "<name> (pid <pid>)" of the first dead node among the given name/pid
-# pairs and return 0; return 1 if all are alive.
+# Echo "<name> (<version>, pid <pid>)" of the first dead node among those
+# started so far and return 0; return 1 if all are alive.
 first_dead_node() {
-  while [ "$#" -ge 2 ]; do
-    if ! kill -0 "$2" 2>/dev/null; then
-      echo "$1 (pid $2)"
+  local i
+  for i in "${!NODE_NAMES[@]}"; do
+    if ! kill -0 "${NODE_PIDS[$i]}" 2>/dev/null; then
+      echo "${NODE_NAMES[$i]} (${NODE_VERSIONS[$i]}, pid ${NODE_PIDS[$i]})"
       return 0
     fi
-    shift 2
   done
   return 1
 }
 
-# Dump the tail of every node log for triage on failure. node-0..2 and the
-# fullnode run the release binary; node-3 is the candidate.
+# Dump the tail of every started node's log for triage on failure.
 dump_log_tails() {
-  local entry name version
+  local i
   echo "===== LOG TAILS (last 50 lines) ====="
-  for entry in node-0:release node-1:release node-2:release node-3:candidate fullnode:release; do
-    name="${entry%%:*}"
-    version="${entry##*:}"
-    echo "----- $name.log ($version) -----"
-    tail -n 50 "$LOG_DIR/$name.log" 2>/dev/null
+  for i in "${!NODE_NAMES[@]}"; do
+    echo "----- ${NODE_NAMES[$i]}.log (${NODE_VERSIONS[$i]}) -----"
+    tail -n 50 "$LOG_DIR/${NODE_NAMES[$i]}.log" 2>/dev/null
   done
 }
 
 echo "=== Phase 1: Initial Quorum Startup (3 release nodes) ==="
 echo "Starting nodes 0-2 with release binary to establish quorum..."
 
-# Start first 3 nodes with release binary
-"$WORKING_DIR/iota-node-release" --config-path "${CONFIGS[0]}" > "$LOG_DIR/node-0.log" 2>&1 &
-NODE_PIDS[0]=$!
-echo "Started node-0 (release) with PID ${NODE_PIDS[0]}"
-
-"$WORKING_DIR/iota-node-release" --config-path "${CONFIGS[1]}" > "$LOG_DIR/node-1.log" 2>&1 &
-NODE_PIDS[1]=$!
-echo "Started node-1 (release) with PID ${NODE_PIDS[1]}"
-
-"$WORKING_DIR/iota-node-release" --config-path "${CONFIGS[2]}" > "$LOG_DIR/node-2.log" 2>&1 &
-NODE_PIDS[2]=$!
-echo "Started node-2 (release) with PID ${NODE_PIDS[2]}"
-
-# Start fullnode
-"$WORKING_DIR/iota-node-release" --config-path "$IOTA_CONFIG_DIR/fullnode.yaml" > "$LOG_DIR/fullnode.log" 2>&1 &
-FULLNODE_PID=$!
-echo "Started fullnode with PID $FULLNODE_PID"
+start_node node-0 release "$WORKING_DIR/iota-node-release" "${CONFIGS[0]}"
+start_node node-1 release "$WORKING_DIR/iota-node-release" "${CONFIGS[1]}"
+start_node node-2 release "$WORKING_DIR/iota-node-release" "${CONFIGS[2]}"
+start_node fullnode release "$WORKING_DIR/iota-node-release" "$IOTA_CONFIG_DIR/fullnode.yaml"
 
 echo "Building a commit backlog for ${WARMUP_SECS}s before starting node-3..."
 SECONDS=0
 while [ "$SECONDS" -lt "$WARMUP_SECS" ]; do
-  if dead=$(first_dead_node "node-0 (release)" "${NODE_PIDS[0]}" "node-1 (release)" "${NODE_PIDS[1]}" "node-2 (release)" "${NODE_PIDS[2]}" "fullnode (release)" "$FULLNODE_PID"); then
+  if dead=$(first_dead_node); then
     echo "ERROR: $dead exited early during warmup after ${SECONDS}s"
     dump_log_tails
     exit 1
@@ -227,24 +226,20 @@ echo "Consensus protocol: Starfish"
 echo -e "\n=== Phase 2: Late Start of Candidate Node ==="
 echo "Starting node-3 (candidate) - should trigger synchronization to catch up..."
 
-# Start the 4th node with candidate binary (late joiner)
-"$WORKING_DIR/iota-node-candidate" --config-path "${CONFIGS[3]}" > "$LOG_DIR/node-3.log" 2>&1 &
-NODE_PIDS[3]=$!
-echo "Started node-3 (candidate) with PID ${NODE_PIDS[3]}"
+# Start the 4th node with candidate binary (late joiner).
+start_node node-3 candidate "$WORKING_DIR/iota-node-candidate" "${CONFIGS[3]}"
 
 echo -e "\n=== Checking Node-3 After Initial Sync ==="
 echo "Waiting for node-3 to catch up past commit index $INITIAL_COMMIT_INDEX (up to ${CATCHUP_MAX_WAIT}s)..."
 SECONDS=0
 NODE3_COMMIT_AFTER_JOIN=0
-caught_up=0
 while true; do
   get_metrics "${CONFIGS[3]}" "$METRICS_DIR/node-3-after-join.txt"
   NODE3_COMMIT_AFTER_JOIN=$(get_metric_value "$METRICS_DIR/node-3-after-join.txt" "consensus_last_commit_index")
   if [ "$NODE3_COMMIT_AFTER_JOIN" -gt "$INITIAL_COMMIT_INDEX" ]; then
-    caught_up=1
     break
   fi
-  if dead=$(first_dead_node "node-0 (release)" "${NODE_PIDS[0]}" "node-1 (release)" "${NODE_PIDS[1]}" "node-2 (release)" "${NODE_PIDS[2]}" "node-3 (candidate)" "${NODE_PIDS[3]}" "fullnode (release)" "$FULLNODE_PID"); then
+  if dead=$(first_dead_node); then
     echo "ERROR: $dead exited early during catch-up after ${SECONDS}s"
     dump_log_tails
     exit 1
@@ -263,8 +258,6 @@ if [ ! -s "$METRICS_DIR/node-3-after-join.txt" ]; then
   head -20 "$METRICS_DIR/node-3-after-join.txt" 2>/dev/null || echo "  File does not exist or is empty"
 fi
 
-NODE3_COMMIT_AFTER_JOIN=$(get_metric_value "$METRICS_DIR/node-3-after-join.txt" "consensus_last_commit_index")
-
 # Starfish: commit_sync_fetched_commits is labeled by source (commit_sync, fast_commit_sync), so sum across labels
 NODE3_COMMIT_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_fetched_commits")
 NODE3_HEADER_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_synchronizer_fetched_block_headers_by_peer")
@@ -279,7 +272,7 @@ echo "  commit_sync_total_fetched_transactions_size: $NODE3_COMMIT_SYNC_TXN_SIZE
 echo "  transaction_synchronizer_fetched_transactions_by_peer (sum): $NODE3_TXN_SYNC"
 
 # Check 1: Node-3 caught up past initial commit index
-if [ "$caught_up" -ne 1 ]; then
+if [ "$NODE3_COMMIT_AFTER_JOIN" -le "$INITIAL_COMMIT_INDEX" ]; then
   FAILURES+=("FAIL: Node-3 did not catch up after late start within ${CATCHUP_MAX_WAIT}s (node-3: $NODE3_COMMIT_AFTER_JOIN, initial node-0: $INITIAL_COMMIT_INDEX)")
 else
   echo "✓ Node-3 caught up past initial commit index"
@@ -323,10 +316,7 @@ echo "  Node-1 (release): $FINAL_NODE1_COMMIT"
 echo "  Node-2 (release): $FINAL_NODE2_COMMIT"
 echo "  Node-3 (candidate): $FINAL_NODE3_COMMIT"
 
-echo -e "\n=== Shutting Down Cluster ==="
-kill ${NODE_PIDS[0]} ${NODE_PIDS[1]} ${NODE_PIDS[2]} ${NODE_PIDS[3]} $FULLNODE_PID 2>/dev/null
-pkill -P $$
-wait 2>/dev/null
+# The cluster is torn down by the EXIT trap.
 
 # Print summary
 echo -e "\n=== Test Summary ==="

--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -5,8 +5,8 @@
 # Enhanced split-cluster test that specifically triggers and tests Synchronizer and CommitSyncer
 #
 # This script runs a cluster with 3 validators built at the release commit and 1 validator
-# built at the candidate commit. The candidate validator is started late (after 3 minutes)
-# to trigger synchronization components.
+# built at the candidate commit. The candidate validator is started late (once the
+# initial quorum has built up a commit backlog) to trigger synchronization components.
 #
 # Usage:
 #
@@ -16,7 +16,7 @@
 # every time. If you omit WORKING_DIR, a temp dir will be created and used.
 #
 # Test scenario:
-# - Staggered node startup: candidate node started 3 minutes late to accumulate enough rounds for synchronization
+# - Staggered node startup: candidate node started late, once the initial quorum has accumulated enough rounds for synchronization
 
 # first arg is the released commit, defaults to `origin/mainnet`
 RELEASE_COMMIT=${1:-origin/mainnet}
@@ -143,6 +143,45 @@ sum_metric_values() {
 # Track failures
 FAILURES=()
 
+POLL_INTERVAL=${POLL_INTERVAL:-5}
+# Fixed warmup so node-0..2 build a large enough commit backlog that the
+# late-joining node-3 must use the Synchronizer/CommitSyncer to catch up. A
+# small backlog is caught up through live consensus and exercises neither, which
+# is exactly what this test verifies — so this stays a fixed duration rather
+# than an "until N commits" poll. Liveness is still polled to fail fast on an
+# early crash.
+WARMUP_SECS=${WARMUP_SECS:-180}
+# Poll (rather than a fixed sleep) for the late joiner to catch up past the
+# baseline: that wait is an observable condition, and a fixed sleep there was
+# simultaneously wasteful on a fast runner and too short on a loaded one.
+CATCHUP_MAX_WAIT=${CATCHUP_MAX_WAIT:-180}
+
+# Echo "<name> (pid <pid>)" of the first dead node among the given name/pid
+# pairs and return 0; return 1 if all are alive.
+first_dead_node() {
+  while [ "$#" -ge 2 ]; do
+    if ! kill -0 "$2" 2>/dev/null; then
+      echo "$1 (pid $2)"
+      return 0
+    fi
+    shift 2
+  done
+  return 1
+}
+
+# Dump the tail of every node log for triage on failure. node-0..2 and the
+# fullnode run the release binary; node-3 is the candidate.
+dump_log_tails() {
+  local entry name version
+  echo "===== LOG TAILS (last 50 lines) ====="
+  for entry in node-0:release node-1:release node-2:release node-3:candidate fullnode:release; do
+    name="${entry%%:*}"
+    version="${entry##*:}"
+    echo "----- $name.log ($version) -----"
+    tail -n 50 "$LOG_DIR/$name.log" 2>/dev/null
+  done
+}
+
 echo "=== Phase 1: Initial Quorum Startup (3 release nodes) ==="
 echo "Starting nodes 0-2 with release binary to establish quorum..."
 
@@ -164,13 +203,24 @@ echo "Started node-2 (release) with PID ${NODE_PIDS[2]}"
 FULLNODE_PID=$!
 echo "Started fullnode with PID $FULLNODE_PID"
 
-echo "Waiting 3 minutes (180 seconds) for initial quorum to accumulate rounds..."
-sleep 180
+echo "Building a commit backlog for ${WARMUP_SECS}s before starting node-3..."
+SECONDS=0
+while [ "$SECONDS" -lt "$WARMUP_SECS" ]; do
+  if dead=$(first_dead_node "node-0 (release)" "${NODE_PIDS[0]}" "node-1 (release)" "${NODE_PIDS[1]}" "node-2 (release)" "${NODE_PIDS[2]}" "fullnode (release)" "$FULLNODE_PID"); then
+    echo "ERROR: $dead exited early during warmup after ${SECONDS}s"
+    dump_log_tails
+    exit 1
+  fi
+  sleep "$POLL_INTERVAL"
+done
 
-# Capture initial metrics from node-0
+# Capture the baseline commit index that node-3 will have to catch up past.
 get_metrics "${CONFIGS[0]}" "$METRICS_DIR/node-0-before-node3.txt"
 INITIAL_COMMIT_INDEX=$(get_metric_value "$METRICS_DIR/node-0-before-node3.txt" "consensus_last_commit_index")
-echo "Initial commit index on node-0: $INITIAL_COMMIT_INDEX"
+echo "Initial commit index on node-0: $INITIAL_COMMIT_INDEX (after ${WARMUP_SECS}s)"
+if [ "$INITIAL_COMMIT_INDEX" -le 0 ]; then
+  FAILURES+=("FAIL: initial quorum produced no commits in ${WARMUP_SECS}s")
+fi
 
 echo "Consensus protocol: Starfish"
 
@@ -182,12 +232,29 @@ echo "Starting node-3 (candidate) - should trigger synchronization to catch up..
 NODE_PIDS[3]=$!
 echo "Started node-3 (candidate) with PID ${NODE_PIDS[3]}"
 
-echo "Waiting 60 seconds for node-3 to catch up..."
-sleep 60
-
-# Capture metrics after node-3 joined and perform checks
 echo -e "\n=== Checking Node-3 After Initial Sync ==="
-get_metrics "${CONFIGS[3]}" "$METRICS_DIR/node-3-after-join.txt"
+echo "Waiting for node-3 to catch up past commit index $INITIAL_COMMIT_INDEX (up to ${CATCHUP_MAX_WAIT}s)..."
+SECONDS=0
+NODE3_COMMIT_AFTER_JOIN=0
+caught_up=0
+while true; do
+  get_metrics "${CONFIGS[3]}" "$METRICS_DIR/node-3-after-join.txt"
+  NODE3_COMMIT_AFTER_JOIN=$(get_metric_value "$METRICS_DIR/node-3-after-join.txt" "consensus_last_commit_index")
+  if [ "$NODE3_COMMIT_AFTER_JOIN" -gt "$INITIAL_COMMIT_INDEX" ]; then
+    caught_up=1
+    break
+  fi
+  if dead=$(first_dead_node "node-0 (release)" "${NODE_PIDS[0]}" "node-1 (release)" "${NODE_PIDS[1]}" "node-2 (release)" "${NODE_PIDS[2]}" "node-3 (candidate)" "${NODE_PIDS[3]}" "fullnode (release)" "$FULLNODE_PID"); then
+    echo "ERROR: $dead exited early during catch-up after ${SECONDS}s"
+    dump_log_tails
+    exit 1
+  fi
+  # Stop once the deadline passes, but only after the check above so a catch-up
+  # that first happens during the final poll interval is not missed.
+  if [ "$SECONDS" -ge "$CATCHUP_MAX_WAIT" ]; then break; fi
+  sleep "$POLL_INTERVAL"
+done
+echo "node-3 commit index after ${SECONDS}s: $NODE3_COMMIT_AFTER_JOIN"
 
 # Debug: Check if metrics file exists and has content
 if [ ! -s "$METRICS_DIR/node-3-after-join.txt" ]; then
@@ -212,8 +279,8 @@ echo "  commit_sync_total_fetched_transactions_size: $NODE3_COMMIT_SYNC_TXN_SIZE
 echo "  transaction_synchronizer_fetched_transactions_by_peer (sum): $NODE3_TXN_SYNC"
 
 # Check 1: Node-3 caught up past initial commit index
-if [ "$NODE3_COMMIT_AFTER_JOIN" -le "$INITIAL_COMMIT_INDEX" ]; then
-  FAILURES+=("FAIL: Node-3 did not catch up after late start (node-3: $NODE3_COMMIT_AFTER_JOIN, initial node-0: $INITIAL_COMMIT_INDEX)")
+if [ "$caught_up" -ne 1 ]; then
+  FAILURES+=("FAIL: Node-3 did not catch up after late start within ${CATCHUP_MAX_WAIT}s (node-3: $NODE3_COMMIT_AFTER_JOIN, initial node-0: $INITIAL_COMMIT_INDEX)")
 else
   echo "✓ Node-3 caught up past initial commit index"
 fi
@@ -269,7 +336,7 @@ if [ ${#FAILURES[@]} -eq 0 ]; then
   echo ""
   echo "Successfully verified:"
   echo "  - Split-cluster with 3 release + 1 candidate node (consensus: Starfish)"
-  echo "  - Candidate node synchronized after late start (3 minute delay):"
+  echo "  - Candidate node synchronized after late start (joined once a commit backlog had built up):"
   echo "    • Header Synchronizer: fetched $NODE3_HEADER_SYNC block headers"
   echo "    • Commit Syncer: fetched $NODE3_COMMIT_SYNC commits ($NODE3_COMMIT_SYNC_TXN_SIZE bytes txn, txn_sync: $NODE3_TXN_SYNC transactions)"
   echo "    • Caught up from commit $INITIAL_COMMIT_INDEX to $NODE3_COMMIT_AFTER_JOIN"

--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -159,16 +159,11 @@ sum_metric_values() {
 FAILURES=()
 
 POLL_INTERVAL=${POLL_INTERVAL:-5}
-# Fixed warmup so node-0..2 build a large enough commit backlog that the
-# late-joining node-3 must use the Synchronizer/CommitSyncer to catch up. A
-# small backlog is caught up through live consensus and exercises neither, which
-# is exactly what this test verifies — so this stays a fixed duration rather
-# than an "until N commits" poll. Liveness is still polled to fail fast on an
-# early crash.
+# node-0..2 warm up for this long to build a commit backlog large enough that
+# node-3 must use the Synchronizer/CommitSyncer to catch up; with a small backlog
+# node-3 catches up through live consensus and exercises neither.
 WARMUP_SECS=${WARMUP_SECS:-180}
-# Poll (rather than a fixed sleep) for the late joiner to catch up past the
-# baseline: that wait is an observable condition, and a fixed sleep there was
-# simultaneously wasteful on a fast runner and too short on a loaded one.
+# Upper bound on the poll for node-3 to catch up past the baseline commit index.
 CATCHUP_MAX_WAIT=${CATCHUP_MAX_WAIT:-180}
 
 # Echo "<name> (<version>, pid <pid>)" of the first dead node among those

--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -213,7 +213,9 @@ get_metrics "${CONFIGS[0]}" "$METRICS_DIR/node-0-before-node3.txt"
 INITIAL_COMMIT_INDEX=$(get_metric_value "$METRICS_DIR/node-0-before-node3.txt" "consensus_last_commit_index")
 echo "Initial commit index on node-0: $INITIAL_COMMIT_INDEX (after ${WARMUP_SECS}s)"
 if [ "$INITIAL_COMMIT_INDEX" -le 0 ]; then
-  FAILURES+=("FAIL: initial quorum produced no commits in ${WARMUP_SECS}s")
+  echo "ERROR: initial quorum produced no commits in ${WARMUP_SECS}s; cannot validate catch-up against a zero baseline"
+  dump_log_tails
+  exit 1
 fi
 
 echo "Consensus protocol: Starfish"


### PR DESCRIPTION
# Description of change

The split-cluster compatibility checks (`scripts/compatibility/split-cluster-check.sh` and `split-cluster-sync-check.sh`) waited a fixed `sleep` and then grepped/asserted once. Under CI runner load that fixed window is simultaneously wasteful on a fast runner and too short on a slow one, so the checks fail non-deterministically — and on failure they printed a single generic line with no diagnostics, so triage requires downloading log artifacts.

`split-cluster-check.sh`:
- Replace the fixed `sleep 60` + one-shot grep with a poll loop that waits up to `MAX_WAIT` (default 180s) for the fullnode `Node State has been reconfigured` marker, checking every `POLL_INTERVAL` (5s).
- Capture each node PID and fail fast (with diagnostics) if any node exits early, instead of burning the whole timeout.
- On timeout or early death, dump per-node liveness, a node x marker matrix (reconfiguration + random-beacon DKG markers), and the last 50 lines of every node log. Each node is labelled with the binary version it runs (release vs candidate).
- Add a `trap`-based cleanup so the cluster is always torn down. The DKG checks still verify all four markers (node-0 and node-2, each for `random beacon: created` and `random beacon: DKG complete`).

`split-cluster-sync-check.sh`:
- Replace the fixed `sleep 60` catch-up wait with a poll (up to `CATCHUP_MAX_WAIT`, default 180s) until the late-joining node-3 passes the baseline commit index.
- Keep the Phase-1 warmup a fixed duration (`WARMUP_SECS`, default 180s) on purpose: it builds a large commit backlog so node-3 is far enough behind to actually exercise the Synchronizer/CommitSyncer (a small backlog is caught up through live consensus and exercises neither). It now polls node liveness during warmup to fail fast on an early crash.
- Fail fast on node death and dump version-labelled log tails on failure.

## Links to any relevant issues

fixes #11706

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

`bash -n` passes on both scripts. Verified locally against a real 5-node cluster:
- `split-cluster-check.sh`: reconfigures (the poll reported 25s on an idle machine — well within the window, vs the >60s seen on loaded CI runners), and a forced short timeout exercises the diagnostics path (version-labelled liveness table, node x marker matrix, and log tails).
- `split-cluster-sync-check.sh`: the 180s warmup built a 1864-commit backlog, node-3 caught up via the Synchronizer (300 block headers) and CommitSyncer (1533 commits, ~843 KB of transactions), and all four sync checks passed.

Run locally before marking ready to avoid spending CI worker time on the (heavy) split-cluster jobs.