### PR TITLE
chore(starfish): run sequential-restart simtests against all network protocol configs

### DIFF
--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -82,7 +82,7 @@ mod test {
     /// Verifies commit digest consistency across all running authorities.
     /// Checks that all authorities have identical commit digests for shared
     /// commit indices.
-    async fn verify_commit_consistency(authorities: &[AuthorityNode], network: &str, step: &str) {
+    async fn verify_commit_consistency(authorities: &[AuthorityNode], step: &str) {
         let commit_indices: Vec<u32> = authorities
             .iter()
             .filter(|a| a.is_running())
@@ -110,7 +110,7 @@ mod test {
                 for (auth_idx, digest) in digests.iter().skip(1) {
                     assert_eq!(
                         first_digest, digest,
-                        "[{network}] {step}: Commit {commit_idx} digest mismatch at authority {auth_idx}"
+                        "{step}: Commit {commit_idx} digest mismatch at authority {auth_idx}"
                     );
                 }
             }
@@ -130,14 +130,13 @@ mod test {
     }
 
     async fn run_network_config(
-        network: &str,
         chain: Chain,
         mode: RestartMode,
         long_run: bool,
         long_restart: bool,
     ) {
         let protocol_config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, chain);
-        run_sequential_restarts_test(network, protocol_config, mode, long_run, long_restart).await;
+        run_sequential_restarts_test(protocol_config, mode, long_run, long_restart).await;
     }
 
     /// Helper function for sequential authority restarts with commit sync
@@ -158,8 +157,6 @@ mod test {
     ///    (some may be lost during restarts when in RAM)
     ///
     /// Parameters:
-    /// - `network`: Label of the network(s) this configuration covers, prefixed
-    ///   onto assertion failures so a failure names the network it came from
     /// - `mode`: Restart mode controlling DB and state persistence
     ///   - `CleanAll`: Fresh empty DB (simulates node replacement)
     ///   - `PersistAll`: Keep DB and state (crash recovery)
@@ -168,7 +165,6 @@ mod test {
     /// - `long_run`: If true, use longer pre-stop and catch-up times
     /// - `long_restart`: If true, use longer stopped duration
     async fn run_sequential_restarts_test(
-        network: &str,
         protocol_config: ProtocolConfig,
         mode: RestartMode,
         long_run: bool,
@@ -311,11 +307,11 @@ mod test {
 
         assert!(
             baseline_commit > MIN_BASELINE_COMMIT,
-            "[{network}] Should have made initial progress: baseline_commit={baseline_commit}, min={MIN_BASELINE_COMMIT}"
+            "Should have made initial progress: baseline_commit={baseline_commit}, min={MIN_BASELINE_COMMIT}"
         );
 
         // Verify consistency after baseline progress
-        verify_commit_consistency(&authorities, network, "after initial progress").await;
+        verify_commit_consistency(&authorities, "after initial progress").await;
 
         // Sequential restart cycles for each authority.
         // CleanAll: restart <1/3 of authorities, keeping a supermajority alive as
@@ -340,7 +336,7 @@ mod test {
                 authorities[authority_idx].stop().await;
                 assert!(
                     !authorities[authority_idx].is_running(),
-                    "[{network}] authority {authority_idx} still running after stop"
+                    "authority {authority_idx} still running after stop"
                 );
 
                 // Wait while stopped (other authorities make progress)
@@ -349,7 +345,6 @@ mod test {
                 // Verify consistency while authority is stopped
                 verify_commit_consistency(
                     &authorities,
-                    network,
                     &format!("authority {authority_idx} cycle {cycle}: during stop"),
                 )
                 .await;
@@ -376,14 +371,13 @@ mod test {
                 if long_run {
                     assert!(
                         incremental_progress >= MIN_INCREMENTAL_COMMIT_PROGRESS,
-                        "[{network}] authority {authority_idx} cycle {cycle}: incremental commit progress too low: {incremental_progress} < {MIN_INCREMENTAL_COMMIT_PROGRESS}"
+                        "authority {authority_idx} cycle {cycle}: incremental commit progress too low: {incremental_progress} < {MIN_INCREMENTAL_COMMIT_PROGRESS}"
                     );
                 }
 
                 // Verify consistency after restart and catch-up
                 verify_commit_consistency(
                     &authorities,
-                    network,
                     &format!("authority {authority_idx} cycle {cycle}: after restart"),
                 )
                 .await;
@@ -407,11 +401,11 @@ mod test {
 
         assert!(
             max_commit - min_commit < MAX_COMMIT_GAP,
-            "[{network}] Gap too large: {max_commit} - {min_commit} >= {MAX_COMMIT_GAP}"
+            "Gap too large: {max_commit} - {min_commit} >= {MAX_COMMIT_GAP}"
         );
 
         // Final commit consistency verification
-        verify_commit_consistency(&authorities, network, "final").await;
+        verify_commit_consistency(&authorities, "final").await;
 
         // Verify catch-up via fast sync: all authorities should have caught up after
         // settlement
@@ -424,7 +418,7 @@ mod test {
 
         assert!(
             max_final - min_final <= CATCH_UP_SLACK,
-            "[{network}] After settlement, authorities not caught up: min={min_final}, max={max_final}, gap={} (slack: {CATCH_UP_SLACK})",
+            "After settlement, authorities not caught up: min={min_final}, max={max_final}, gap={} (slack: {CATCH_UP_SLACK})",
             max_final - min_final
         );
 
@@ -442,21 +436,21 @@ mod test {
 
         assert!(
             !committed_sets.is_empty(),
-            "[{network}] No running authorities to verify"
+            "No running authorities to verify"
         );
         // Verify all submitted transactions are in the committed set (submitted ⊆
         // committed)
         for txn in &submitted {
             assert!(
                 committed_sets.iter().any(|set| set.contains(txn)),
-                "[{network}] Submitted transaction not in committed set: {txn:?}"
+                "Submitted transaction not in committed set: {txn:?}"
             );
         }
 
         // Assert minimum submitted transactions
         assert!(
             submitted.len() >= MIN_SUBMITTED_TRANSACTIONS,
-            "[{network}] Too few submitted transactions: {} < {MIN_SUBMITTED_TRANSACTIONS}",
+            "Too few submitted transactions: {} < {MIN_SUBMITTED_TRANSACTIONS}",
             submitted.len()
         );
     }
@@ -474,40 +468,19 @@ mod test {
             $(#[$meta])*
             #[sim_test(config = "test_config()")]
             async fn $devnet_test() {
-                run_network_config(
-                    "devnet",
-                    Chain::Unknown,
-                    $mode,
-                    $long_run,
-                    $long_restart,
-                )
-                .await;
+                run_network_config(Chain::Unknown, $mode, $long_run, $long_restart).await;
             }
 
             $(#[$meta])*
             #[sim_test(config = "test_config()")]
             async fn $testnet_test() {
-                run_network_config(
-                    "testnet",
-                    Chain::Testnet,
-                    $mode,
-                    $long_run,
-                    $long_restart,
-                )
-                .await;
+                run_network_config(Chain::Testnet, $mode, $long_run, $long_restart).await;
             }
 
             $(#[$meta])*
             #[sim_test(config = "test_config()")]
             async fn $mainnet_test() {
-                run_network_config(
-                    "mainnet",
-                    Chain::Mainnet,
-                    $mode,
-                    $long_run,
-                    $long_restart,
-                )
-                .await;
+                run_network_config(Chain::Mainnet, $mode, $long_run, $long_restart).await;
             }
         };
     }

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -6,12 +6,16 @@
 
 #[cfg(msim)]
 mod test {
-    use std::{collections::HashSet, sync::Arc, time::Duration};
+    use std::{
+        collections::{BTreeMap, HashSet},
+        sync::Arc,
+        time::Duration,
+    };
 
     use iota_config::local_ip_utils;
     use iota_macros::sim_test;
     use iota_network_stack::Multiaddr;
-    use iota_protocol_config::ProtocolConfig;
+    use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use iota_simulator::{
         SimConfig,
         configs::{bimodal_latency_ms, env_config, uniform_latency_ms},
@@ -82,7 +86,7 @@ mod test {
     /// Verifies commit digest consistency across all running authorities.
     /// Checks that all authorities have identical commit digests for shared
     /// commit indices.
-    async fn verify_commit_consistency(authorities: &[AuthorityNode], step: &str) {
+    async fn verify_commit_consistency(authorities: &[AuthorityNode], network: &str, step: &str) {
         let commit_indices: Vec<u32> = authorities
             .iter()
             .filter(|a| a.is_running())
@@ -110,7 +114,7 @@ mod test {
                 for (auth_idx, digest) in digests.iter().skip(1) {
                     assert_eq!(
                         first_digest, digest,
-                        "{step}: Commit {commit_idx} digest mismatch at authority {auth_idx}"
+                        "[{network}] {step}: Commit {commit_idx} digest mismatch at authority {auth_idx}"
                     );
                 }
             }
@@ -127,6 +131,56 @@ mod test {
         post_restart_wait: Duration,
         /// Number of stop/restart cycles per authority
         cycles_per_authority: usize,
+    }
+
+    /// The protocol configuration each network runs at the latest protocol
+    /// version — devnet (which maps to [`Chain::Unknown`]), mainnet, and
+    /// testnet — paired with a label naming the network(s) it covers.
+    ///
+    /// Networks whose configurations are identical collapse into a single entry
+    /// whose label lists all of them (e.g. `devnet+testnet`), so identical
+    /// configs are not run twice while a failing assertion still names every
+    /// network the run stands for.
+    fn network_protocol_configs() -> Vec<(String, ProtocolConfig)> {
+        let mut keys: Vec<BTreeMap<String, String>> = Vec::new();
+        let mut configs: Vec<(String, ProtocolConfig)> = Vec::new();
+        for (network, chain) in [
+            ("devnet", Chain::Unknown),
+            ("mainnet", Chain::Mainnet),
+            ("testnet", Chain::Testnet),
+        ] {
+            let config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, chain);
+            // Key on the full parameter surface — every feature flag and every
+            // numeric/`Option` value — so only genuinely identical configs merge.
+            let key: BTreeMap<String, String> = config
+                .feature_map()
+                .into_iter()
+                .map(|(name, value)| (name, value.to_string()))
+                .chain(
+                    config
+                        .attr_map()
+                        .into_iter()
+                        .map(|(name, value)| (name, format!("{value:?}"))),
+                )
+                .collect();
+            match keys.iter().position(|seen| seen == &key) {
+                Some(idx) => configs[idx].0 = format!("{}+{network}", configs[idx].0),
+                None => {
+                    keys.push(key);
+                    configs.push((network.to_owned(), config));
+                }
+            }
+        }
+        configs
+    }
+
+    /// Runs [`run_sequential_restarts_test`] against every distinct network
+    /// configuration (see [`network_protocol_configs`]).
+    async fn run_for_all_network_configs(mode: RestartMode, long_run: bool, long_restart: bool) {
+        for (network, protocol_config) in network_protocol_configs() {
+            run_sequential_restarts_test(&network, protocol_config, mode, long_run, long_restart)
+                .await;
+        }
     }
 
     /// Helper function for sequential authority restarts with commit sync
@@ -147,6 +201,8 @@ mod test {
     ///    (some may be lost during restarts when in RAM)
     ///
     /// Parameters:
+    /// - `network`: Label of the network(s) this configuration covers, prefixed
+    ///   onto assertion failures so a failure names the network it came from
     /// - `mode`: Restart mode controlling DB and state persistence
     ///   - `CleanAll`: Fresh empty DB (simulates node replacement)
     ///   - `PersistAll`: Keep DB and state (crash recovery)
@@ -154,7 +210,13 @@ mod test {
     ///     recovery)
     /// - `long_run`: If true, use longer pre-stop and catch-up times
     /// - `long_restart`: If true, use longer stopped duration
-    async fn run_sequential_restarts_test(mode: RestartMode, long_run: bool, long_restart: bool) {
+    async fn run_sequential_restarts_test(
+        network: &str,
+        protocol_config: ProtocolConfig,
+        mode: RestartMode,
+        long_run: bool,
+        long_restart: bool,
+    ) {
         // ═══════════════════════════════════════════════════════════════
         // Constants
         // ═══════════════════════════════════════════════════════════════
@@ -184,10 +246,6 @@ mod test {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
-
-        // Enable fast commit sync (always enabled in this test)
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_fast_commit_sync_for_testing(true);
 
         // Calculate timing based on flags
         let run_time = if long_run {
@@ -296,11 +354,11 @@ mod test {
 
         assert!(
             baseline_commit > MIN_BASELINE_COMMIT,
-            "Should have made initial progress: baseline_commit={baseline_commit}, min={MIN_BASELINE_COMMIT}"
+            "[{network}] Should have made initial progress: baseline_commit={baseline_commit}, min={MIN_BASELINE_COMMIT}"
         );
 
         // Verify consistency after baseline progress
-        verify_commit_consistency(&authorities, "after initial progress").await;
+        verify_commit_consistency(&authorities, network, "after initial progress").await;
 
         // Sequential restart cycles for each authority.
         // CleanAll: restart <1/3 of authorities, keeping a supermajority alive as
@@ -323,7 +381,10 @@ mod test {
                     .max()
                     .unwrap_or(commit_at_stop);
                 authorities[authority_idx].stop().await;
-                assert!(!authorities[authority_idx].is_running());
+                assert!(
+                    !authorities[authority_idx].is_running(),
+                    "[{network}] authority {authority_idx} still running after stop"
+                );
 
                 // Wait while stopped (other authorities make progress)
                 sleep(restart_config.stop_duration).await;
@@ -331,6 +392,7 @@ mod test {
                 // Verify consistency while authority is stopped
                 verify_commit_consistency(
                     &authorities,
+                    network,
                     &format!("authority {authority_idx} cycle {cycle}: during stop"),
                 )
                 .await;
@@ -357,13 +419,14 @@ mod test {
                 if long_run {
                     assert!(
                         incremental_progress >= MIN_INCREMENTAL_COMMIT_PROGRESS,
-                        "Authority {authority_idx} cycle {cycle}: incremental commit progress too low: {incremental_progress} < {MIN_INCREMENTAL_COMMIT_PROGRESS}"
+                        "[{network}] authority {authority_idx} cycle {cycle}: incremental commit progress too low: {incremental_progress} < {MIN_INCREMENTAL_COMMIT_PROGRESS}"
                     );
                 }
 
                 // Verify consistency after restart and catch-up
                 verify_commit_consistency(
                     &authorities,
+                    network,
                     &format!("authority {authority_idx} cycle {cycle}: after restart"),
                 )
                 .await;
@@ -387,11 +450,11 @@ mod test {
 
         assert!(
             max_commit - min_commit < MAX_COMMIT_GAP,
-            "Gap too large: {max_commit} - {min_commit} >= {MAX_COMMIT_GAP}"
+            "[{network}] Gap too large: {max_commit} - {min_commit} >= {MAX_COMMIT_GAP}"
         );
 
         // Final commit consistency verification
-        verify_commit_consistency(&authorities, "final").await;
+        verify_commit_consistency(&authorities, network, "final").await;
 
         // Verify catch-up via fast sync: all authorities should have caught up after
         // settlement
@@ -404,7 +467,7 @@ mod test {
 
         assert!(
             max_final - min_final <= CATCH_UP_SLACK,
-            "After settlement, authorities not caught up: min={min_final}, max={max_final}, gap={} (slack: {CATCH_UP_SLACK})",
+            "[{network}] After settlement, authorities not caught up: min={min_final}, max={max_final}, gap={} (slack: {CATCH_UP_SLACK})",
             max_final - min_final
         );
 
@@ -422,21 +485,21 @@ mod test {
 
         assert!(
             !committed_sets.is_empty(),
-            "No running authorities to verify"
+            "[{network}] No running authorities to verify"
         );
         // Verify all submitted transactions are in the committed set (submitted ⊆
         // committed)
         for txn in &submitted {
             assert!(
                 committed_sets.iter().any(|set| set.contains(txn)),
-                "Submitted transaction not in committed set: {txn:?}"
+                "[{network}] Submitted transaction not in committed set: {txn:?}"
             );
         }
 
         // Assert minimum submitted transactions
         assert!(
             submitted.len() >= MIN_SUBMITTED_TRANSACTIONS,
-            "Too few submitted transactions: {} < {MIN_SUBMITTED_TRANSACTIONS}",
+            "[{network}] Too few submitted transactions: {} < {MIN_SUBMITTED_TRANSACTIONS}",
             submitted.len()
         );
     }
@@ -444,60 +507,60 @@ mod test {
     /// Fresh DB after each restart, long run before stop, long stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_clean_db_long_run_long_stop() {
-        run_sequential_restarts_test(RestartMode::CleanAll, true, true).await;
+        run_for_all_network_configs(RestartMode::CleanAll, true, true).await;
     }
 
     /// Fresh DB after each restart, short run before stop, short stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_clean_db_short_run_short_stop() {
-        run_sequential_restarts_test(RestartMode::CleanAll, false, false).await;
+        run_for_all_network_configs(RestartMode::CleanAll, false, false).await;
     }
 
     /// Fresh DB after each restart, long run before stop, short stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_clean_db_long_run_short_stop() {
-        run_sequential_restarts_test(RestartMode::CleanAll, true, false).await;
+        run_for_all_network_configs(RestartMode::CleanAll, true, false).await;
     }
 
     /// Fresh DB after each restart, short run before stop, long stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_clean_db_short_run_long_stop() {
-        run_sequential_restarts_test(RestartMode::CleanAll, false, true).await;
+        run_for_all_network_configs(RestartMode::CleanAll, false, true).await;
     }
 
     /// Persistent DB after each restart, long run before stop, long stop
     /// duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_persistent_db_long_run_long_stop() {
-        run_sequential_restarts_test(RestartMode::PersistAll, true, true).await;
+        run_for_all_network_configs(RestartMode::PersistAll, true, true).await;
     }
 
     /// Persistent DB after each restart, short run before stop, short stop
     /// duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_persistent_db_short_run_short_stop() {
-        run_sequential_restarts_test(RestartMode::PersistAll, false, false).await;
+        run_for_all_network_configs(RestartMode::PersistAll, false, false).await;
     }
 
     /// Persistent DB after each restart, long run before stop, short stop
     /// duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_persistent_db_long_run_short_stop() {
-        run_sequential_restarts_test(RestartMode::PersistAll, true, false).await;
+        run_for_all_network_configs(RestartMode::PersistAll, true, false).await;
     }
 
     /// Persistent DB after each restart, short run before stop, long stop
     /// duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_persistent_db_short_run_long_stop() {
-        run_sequential_restarts_test(RestartMode::PersistAll, false, true).await;
+        run_for_all_network_configs(RestartMode::PersistAll, false, true).await;
     }
 
     /// DB intact but last_processed_commit reset; long run before stop, long
     /// stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_reset_last_processed_long_run_long_stop() {
-        run_sequential_restarts_test(RestartMode::ResetLastProcessed, true, true).await;
+        run_for_all_network_configs(RestartMode::ResetLastProcessed, true, true).await;
     }
 
     /// Erase all transactions from DB, preserving commits and block headers.
@@ -505,6 +568,6 @@ mod test {
     /// Long run before stop, long stop duration.
     #[sim_test(config = "test_config()")]
     async fn test_sequential_restarts_erase_transactions_long_run_long_stop() {
-        run_sequential_restarts_test(RestartMode::EraseAllTransactions, true, true).await;
+        run_for_all_network_configs(RestartMode::EraseAllTransactions, true, true).await;
     }
 }

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -6,7 +6,11 @@
 
 #[cfg(msim)]
 mod test {
-    use std::{collections::HashSet, sync::Arc, time::Duration};
+    use std::{
+        collections::{BTreeMap, HashSet},
+        sync::Arc,
+        time::Duration,
+    };
 
     use iota_config::local_ip_utils;
     use iota_macros::sim_test;
@@ -129,13 +133,53 @@ mod test {
         cycles_per_authority: usize,
     }
 
+    // The first network with a given consensus config runs the test; later
+    // duplicates return immediately.
+    const NETWORK_CHAINS: [Chain; 3] = [Chain::Unknown, Chain::Testnet, Chain::Mainnet];
+
+    type ConsensusConfigKey = (BTreeMap<String, bool>, BTreeMap<String, Option<String>>);
+
+    fn consensus_config_key(config: &ProtocolConfig) -> ConsensusConfigKey {
+        let flags = config
+            .feature_map()
+            .into_iter()
+            .filter(|(name, _)| name.starts_with("consensus_"))
+            .collect();
+        let parameters = config
+            .attr_map()
+            .into_iter()
+            .filter(|(name, _)| name.starts_with("consensus_"))
+            .map(|(name, value)| (name, value.map(|value| value.to_string())))
+            .collect();
+
+        (flags, parameters)
+    }
+
+    fn distinct_network_protocol_config(chain: Chain) -> Option<ProtocolConfig> {
+        let config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, chain);
+        let key = consensus_config_key(&config);
+        let position = NETWORK_CHAINS
+            .iter()
+            .position(|candidate| *candidate == chain)
+            .expect("network chain must be configured");
+        let is_duplicate = NETWORK_CHAINS[..position].iter().any(|candidate| {
+            let candidate = ProtocolConfig::get_for_version(ProtocolVersion::MAX, *candidate);
+            consensus_config_key(&candidate) == key
+        });
+
+        (!is_duplicate).then_some(config)
+    }
+
     async fn run_network_config(
         chain: Chain,
         mode: RestartMode,
         long_run: bool,
         long_restart: bool,
     ) {
-        let protocol_config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, chain);
+        let Some(protocol_config) = distinct_network_protocol_config(chain) else {
+            tracing::info!(?chain, "skipping duplicate consensus protocol config");
+            return;
+        };
         run_sequential_restarts_test(protocol_config, mode, long_run, long_restart).await;
     }
 

--- a/crates/starfish/simtests/src/tests/simtests.rs
+++ b/crates/starfish/simtests/src/tests/simtests.rs
@@ -6,11 +6,7 @@
 
 #[cfg(msim)]
 mod test {
-    use std::{
-        collections::{BTreeMap, HashSet},
-        sync::Arc,
-        time::Duration,
-    };
+    use std::{collections::HashSet, sync::Arc, time::Duration};
 
     use iota_config::local_ip_utils;
     use iota_macros::sim_test;
@@ -133,54 +129,15 @@ mod test {
         cycles_per_authority: usize,
     }
 
-    /// The protocol configuration each network runs at the latest protocol
-    /// version — devnet (which maps to [`Chain::Unknown`]), mainnet, and
-    /// testnet — paired with a label naming the network(s) it covers.
-    ///
-    /// Networks whose configurations are identical collapse into a single entry
-    /// whose label lists all of them (e.g. `devnet+testnet`), so identical
-    /// configs are not run twice while a failing assertion still names every
-    /// network the run stands for.
-    fn network_protocol_configs() -> Vec<(String, ProtocolConfig)> {
-        let mut keys: Vec<BTreeMap<String, String>> = Vec::new();
-        let mut configs: Vec<(String, ProtocolConfig)> = Vec::new();
-        for (network, chain) in [
-            ("devnet", Chain::Unknown),
-            ("mainnet", Chain::Mainnet),
-            ("testnet", Chain::Testnet),
-        ] {
-            let config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, chain);
-            // Key on the full parameter surface — every feature flag and every
-            // numeric/`Option` value — so only genuinely identical configs merge.
-            let key: BTreeMap<String, String> = config
-                .feature_map()
-                .into_iter()
-                .map(|(name, value)| (name, value.to_string()))
-                .chain(
-                    config
-                        .attr_map()
-                        .into_iter()
-                        .map(|(name, value)| (name, format!("{value:?}"))),
-                )
-                .collect();
-            match keys.iter().position(|seen| seen == &key) {
-                Some(idx) => configs[idx].0 = format!("{}+{network}", configs[idx].0),
-                None => {
-                    keys.push(key);
-                    configs.push((network.to_owned(), config));
-                }
-            }
-        }
-        configs
-    }
-
-    /// Runs [`run_sequential_restarts_test`] against every distinct network
-    /// configuration (see [`network_protocol_configs`]).
-    async fn run_for_all_network_configs(mode: RestartMode, long_run: bool, long_restart: bool) {
-        for (network, protocol_config) in network_protocol_configs() {
-            run_sequential_restarts_test(&network, protocol_config, mode, long_run, long_restart)
-                .await;
-        }
+    async fn run_network_config(
+        network: &str,
+        chain: Chain,
+        mode: RestartMode,
+        long_run: bool,
+        long_restart: bool,
+    ) {
+        let protocol_config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, chain);
+        run_sequential_restarts_test(network, protocol_config, mode, long_run, long_restart).await;
     }
 
     /// Helper function for sequential authority restarts with commit sync
@@ -504,70 +461,156 @@ mod test {
         );
     }
 
-    /// Fresh DB after each restart, long run before stop, long stop duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_clean_db_long_run_long_stop() {
-        run_for_all_network_configs(RestartMode::CleanAll, true, true).await;
+    macro_rules! network_simtests {
+        (
+            $(#[$meta:meta])*
+            $devnet_test:ident,
+            $testnet_test:ident,
+            $mainnet_test:ident,
+            $mode:expr,
+            $long_run:expr,
+            $long_restart:expr $(,)?
+        ) => {
+            $(#[$meta])*
+            #[sim_test(config = "test_config()")]
+            async fn $devnet_test() {
+                run_network_config(
+                    "devnet",
+                    Chain::Unknown,
+                    $mode,
+                    $long_run,
+                    $long_restart,
+                )
+                .await;
+            }
+
+            $(#[$meta])*
+            #[sim_test(config = "test_config()")]
+            async fn $testnet_test() {
+                run_network_config(
+                    "testnet",
+                    Chain::Testnet,
+                    $mode,
+                    $long_run,
+                    $long_restart,
+                )
+                .await;
+            }
+
+            $(#[$meta])*
+            #[sim_test(config = "test_config()")]
+            async fn $mainnet_test() {
+                run_network_config(
+                    "mainnet",
+                    Chain::Mainnet,
+                    $mode,
+                    $long_run,
+                    $long_restart,
+                )
+                .await;
+            }
+        };
     }
 
-    /// Fresh DB after each restart, short run before stop, short stop duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_clean_db_short_run_short_stop() {
-        run_for_all_network_configs(RestartMode::CleanAll, false, false).await;
+    network_simtests! {
+        /// Fresh DB after each restart, long run before stop, long stop duration.
+        devnet_sequential_restarts_clean_db_long_run_long_stop,
+        testnet_sequential_restarts_clean_db_long_run_long_stop,
+        mainnet_sequential_restarts_clean_db_long_run_long_stop,
+        RestartMode::CleanAll,
+        true,
+        true,
     }
 
-    /// Fresh DB after each restart, long run before stop, short stop duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_clean_db_long_run_short_stop() {
-        run_for_all_network_configs(RestartMode::CleanAll, true, false).await;
+    network_simtests! {
+        /// Fresh DB after each restart, short run before stop, short stop duration.
+        devnet_sequential_restarts_clean_db_short_run_short_stop,
+        testnet_sequential_restarts_clean_db_short_run_short_stop,
+        mainnet_sequential_restarts_clean_db_short_run_short_stop,
+        RestartMode::CleanAll,
+        false,
+        false,
     }
 
-    /// Fresh DB after each restart, short run before stop, long stop duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_clean_db_short_run_long_stop() {
-        run_for_all_network_configs(RestartMode::CleanAll, false, true).await;
+    network_simtests! {
+        /// Fresh DB after each restart, long run before stop, short stop duration.
+        devnet_sequential_restarts_clean_db_long_run_short_stop,
+        testnet_sequential_restarts_clean_db_long_run_short_stop,
+        mainnet_sequential_restarts_clean_db_long_run_short_stop,
+        RestartMode::CleanAll,
+        true,
+        false,
     }
 
-    /// Persistent DB after each restart, long run before stop, long stop
-    /// duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_persistent_db_long_run_long_stop() {
-        run_for_all_network_configs(RestartMode::PersistAll, true, true).await;
+    network_simtests! {
+        /// Fresh DB after each restart, short run before stop, long stop duration.
+        devnet_sequential_restarts_clean_db_short_run_long_stop,
+        testnet_sequential_restarts_clean_db_short_run_long_stop,
+        mainnet_sequential_restarts_clean_db_short_run_long_stop,
+        RestartMode::CleanAll,
+        false,
+        true,
     }
 
-    /// Persistent DB after each restart, short run before stop, short stop
-    /// duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_persistent_db_short_run_short_stop() {
-        run_for_all_network_configs(RestartMode::PersistAll, false, false).await;
+    network_simtests! {
+        /// Persistent DB after each restart, long run before stop, long stop duration.
+        devnet_sequential_restarts_persistent_db_long_run_long_stop,
+        testnet_sequential_restarts_persistent_db_long_run_long_stop,
+        mainnet_sequential_restarts_persistent_db_long_run_long_stop,
+        RestartMode::PersistAll,
+        true,
+        true,
     }
 
-    /// Persistent DB after each restart, long run before stop, short stop
-    /// duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_persistent_db_long_run_short_stop() {
-        run_for_all_network_configs(RestartMode::PersistAll, true, false).await;
+    network_simtests! {
+        /// Persistent DB after each restart, short run before stop, short stop duration.
+        devnet_sequential_restarts_persistent_db_short_run_short_stop,
+        testnet_sequential_restarts_persistent_db_short_run_short_stop,
+        mainnet_sequential_restarts_persistent_db_short_run_short_stop,
+        RestartMode::PersistAll,
+        false,
+        false,
     }
 
-    /// Persistent DB after each restart, short run before stop, long stop
-    /// duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_persistent_db_short_run_long_stop() {
-        run_for_all_network_configs(RestartMode::PersistAll, false, true).await;
+    network_simtests! {
+        /// Persistent DB after each restart, long run before stop, short stop duration.
+        devnet_sequential_restarts_persistent_db_long_run_short_stop,
+        testnet_sequential_restarts_persistent_db_long_run_short_stop,
+        mainnet_sequential_restarts_persistent_db_long_run_short_stop,
+        RestartMode::PersistAll,
+        true,
+        false,
     }
 
-    /// DB intact but last_processed_commit reset; long run before stop, long
-    /// stop duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_reset_last_processed_long_run_long_stop() {
-        run_for_all_network_configs(RestartMode::ResetLastProcessed, true, true).await;
+    network_simtests! {
+        /// Persistent DB after each restart, short run before stop, long stop duration.
+        devnet_sequential_restarts_persistent_db_short_run_long_stop,
+        testnet_sequential_restarts_persistent_db_short_run_long_stop,
+        mainnet_sequential_restarts_persistent_db_short_run_long_stop,
+        RestartMode::PersistAll,
+        false,
+        true,
     }
 
-    /// Erase all transactions from DB, preserving commits and block headers.
-    /// Tests transaction recovery via sync from peers.
-    /// Long run before stop, long stop duration.
-    #[sim_test(config = "test_config()")]
-    async fn test_sequential_restarts_erase_transactions_long_run_long_stop() {
-        run_for_all_network_configs(RestartMode::EraseAllTransactions, true, true).await;
+    network_simtests! {
+        /// DB intact but last_processed_commit reset; long run before stop, long stop duration.
+        devnet_sequential_restarts_reset_last_processed_long_run_long_stop,
+        testnet_sequential_restarts_reset_last_processed_long_run_long_stop,
+        mainnet_sequential_restarts_reset_last_processed_long_run_long_stop,
+        RestartMode::ResetLastProcessed,
+        true,
+        true,
+    }
+
+    network_simtests! {
+        /// Erase all transactions from DB, preserving commits and block headers.
+        /// Tests transaction recovery via sync from peers.
+        /// Long run before stop, long stop duration.
+        devnet_sequential_restarts_erase_transactions_long_run_long_stop,
+        testnet_sequential_restarts_erase_transactions_long_run_long_stop,
+        mainnet_sequential_restarts_erase_transactions_long_run_long_stop,
+        RestartMode::EraseAllTransactions,
+        true,
+        true,
     }
 }


### PR DESCRIPTION
# Description of change

The starfish sequential-restart simtests previously ran against a single hardcoded configuration (`ProtocolConfig::get_for_max_version_UNSAFE()` with `consensus_fast_commit_sync` forced on). They now run against each network's latest protocol configuration — devnet (`Chain::Unknown`), testnet, and mainnet at `ProtocolVersion::MAX` — so consensus behavior is exercised under every network's feature-flag set.

Each scenario is expanded by the `network_simtests!` macro into three independent `#[sim_test]`s, one per network (`devnet_…`, `testnet_…`, `mainnet_…`), so the test runner schedules the per-network runs in parallel and a failing test names its network directly through the test-name prefix.

To avoid redundant work, `run_network_config` skips a network at runtime when its **consensus configuration** duplicates an earlier one (in `[Unknown, Testnet, Mainnet]` order): the first network with a given config runs the scenario, later identical ones return immediately. The dedup key is the set of `consensus_`-prefixed feature flags and parameters, which covers every protocol field starfish consensus actually reads — so merging on that subset is safe: networks that differ only outside consensus (crypto, gas, scoring, …) are correctly treated as equivalent for this test, while any divergence in consensus config makes them run independently.

`run_sequential_restarts_test` takes the `ProtocolConfig` as a parameter; the forced `set_consensus_fast_commit_sync_for_testing(true)` is removed because fast commit sync is enabled by default at the latest protocol version.

## Links to any relevant issues

Fixes #12003

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
