### PR TITLE
feat(graphql): expose checkpoint summary BCS on the Checkpoint type

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -359,6 +359,11 @@ type Checkpoint {
 	"""
 	digest: String!
 	"""
+	The Base64-encoded BCS serialization of this checkpoint's
+	`CheckpointSummary`.
+	"""
+	bcs: Base64!
+	"""
 	This checkpoint's position in the total order of finalized checkpoints,
 	agreed upon by consensus.
 	"""

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -98,6 +98,25 @@ impl Checkpoint {
         Ok(self.digest_impl().extend()?.to_base58())
     }
 
+    /// The Base64-encoded BCS serialization of this checkpoint's
+    /// `CheckpointSummary`.
+    #[graphql(complexity = 0)]
+    async fn bcs(&self) -> Result<Base64> {
+        let bytes = self
+            .stored
+            .checkpoint_summary_bcs
+            .as_ref()
+            .ok_or_else(|| {
+                Error::Internal(
+                    "Checkpoint summary BCS is not available; the indexer must be re-run to \
+                     populate it"
+                        .to_string(),
+                )
+            })
+            .extend()?;
+        Ok(Base64::from(bytes))
+    }
+
     /// This checkpoint's position in the total order of finalized checkpoints,
     /// agreed upon by consensus.
     #[graphql(complexity = 0)]

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -363,6 +363,11 @@ type Checkpoint {
 	"""
 	digest: String!
 	"""
+	The Base64-encoded BCS serialization of this checkpoint's
+	`CheckpointSummary`.
+	"""
+	bcs: Base64!
+	"""
 	This checkpoint's position in the total order of finalized checkpoints,
 	agreed upon by consensus.
 	"""

--- a/crates/iota-indexer/migrations/pg/2026-06-23-100000_checkpoints_add_summary_bcs/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-06-23-100000_checkpoints_add_summary_bcs/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE checkpoints DROP COLUMN checkpoint_summary_bcs;

--- a/crates/iota-indexer/migrations/pg/2026-06-23-100000_checkpoints_add_summary_bcs/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-06-23-100000_checkpoints_add_summary_bcs/up.sql
@@ -1,0 +1,3 @@
+-- Full BCS-serialized `CheckpointSummary`. The individual columns omit
+-- `content_digest` and `version_specific_data`, so they cannot reconstruct it.
+ALTER TABLE checkpoints ADD COLUMN checkpoint_summary_bcs BYTEA;

--- a/crates/iota-indexer/src/models/checkpoints.rs
+++ b/crates/iota-indexer/src/models/checkpoints.rs
@@ -41,6 +41,7 @@ pub struct StoredCheckpoint {
     pub min_tx_sequence_number: Option<i64>,
     pub max_tx_sequence_number: Option<i64>,
     pub computation_cost_burned: Option<i64>,
+    pub checkpoint_summary_bcs: Option<Vec<u8>>,
 }
 
 impl StoredCheckpoint {
@@ -83,6 +84,7 @@ impl From<&IndexedCheckpoint> for StoredCheckpoint {
             end_of_epoch: c.end_of_epoch_data.is_some(),
             min_tx_sequence_number: Some(c.min_tx_sequence_number as i64),
             max_tx_sequence_number: Some(c.max_tx_sequence_number as i64),
+            checkpoint_summary_bcs: Some(c.checkpoint_summary_bcs.clone()),
         }
     }
 }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -81,6 +81,7 @@ diesel::table! {
         min_tx_sequence_number -> Nullable<Int8>,
         max_tx_sequence_number -> Nullable<Int8>,
         computation_cost_burned -> Nullable<Int8>,
+        checkpoint_summary_bcs -> Nullable<Bytea>,
     }
 }
 

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -47,6 +47,7 @@ pub struct IndexedCheckpoint {
     pub non_refundable_storage_fee: u64,
     pub checkpoint_commitments: Vec<CheckpointCommitment>,
     pub validator_signature: AggregateAuthoritySignature,
+    pub checkpoint_summary_bcs: Vec<u8>,
     // Note: not used in StoredCheckpoint conversion and in code overall.
     pub successful_tx_num: usize,
     pub end_of_epoch_data: Option<EndOfEpochData>,
@@ -69,6 +70,8 @@ impl IndexedCheckpoint {
         // NOTE: + 1u64 first to avoid subtraction with overflow
         let min_tx_sequence_number = max_tx_sequence_number + 1u64 - tx_digests.len() as u64;
         let auth_sig = &checkpoint.auth_sig().signature;
+        let checkpoint_summary_bcs = bcs::to_bytes(checkpoint.data())
+            .expect("checkpoint summary serialization should not fail");
         Self {
             sequence_number: checkpoint.sequence_number,
             checkpoint_digest: *checkpoint.digest(),
@@ -92,6 +95,7 @@ impl IndexedCheckpoint {
             timestamp_ms: checkpoint.timestamp_ms,
             validator_signature: auth_sig.clone(),
             checkpoint_commitments: checkpoint.checkpoint_commitments.clone(),
+            checkpoint_summary_bcs,
             min_tx_sequence_number,
             max_tx_sequence_number,
         }


### PR DESCRIPTION
Related to #12002.

`Checkpoint` exposed only the summary `digest` plus a subset of summary fields — no content digest, commitments, or `version_specific_data` — so clients had to hand-roll a lossy `CheckpointSummary` and recomputed the wrong digest (downstream: iotaledger/iota-rust-sdk#1211).

Adds `Checkpoint.bcs: Base64!`, the BCS of the `CheckpointSummary`, matching how `Object` / `TransactionBlock` / effects already expose `bcs`.

- **Indexer**: new nullable `checkpoints.checkpoint_summary_bcs` column (migration + `schema.rs`), populated from `bcs(checkpoint.data())` for both live and historical ingestion.
- **GraphQL**: `bcs` resolver returning the stored bytes; SDL + snapshot regenerated.

The column is additive and nullable, so the migration is safe on existing DBs; they need a re-index to backfill it (the resolver returns a clear error for rows that predate the column).

## Test plan
Localnet with the indexer feature: across 68 checkpoints the column is populated, and via the SDK `checkpoint(seq) → digest() → checkpoint(digest)` round-trips with matching summary/content digests.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FumoL7FkC7B8QL9qfVFXJo

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] Indexer: Added a `checkpoint_summary_bcs` column to the `checkpoints` table storing the BCS-serialized `CheckpointSummary`. Existing databases must be re-indexed to backfill it.
- [ ] JSON-RPC:
- [x] GraphQL: Added `Checkpoint.bcs: Base64!`, the Base64-encoded BCS of the checkpoint's `CheckpointSummary`.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
