### PR TITLE
fix(iota-kvstore): use latest version of iota-bigtable crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,8 +5594,9 @@ dependencies = [
 [[package]]
 name = "iota-bigtable"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?tag=v0.1.0#da30081e1b3fbd162cc00fa723a03837d89c4a58"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=4321c99c12ceb473abea5fffbb42482ab4f25495#4321c99c12ceb473abea5fffbb42482ab4f25495"
 dependencies = [
+ "backoff",
  "gcp_auth",
  "http 1.4.0",
  "prometheus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "iota-bigtable"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=2331a4689b9214b32fb73b8a0064bcf9a9052330#2331a4689b9214b32fb73b8a0064bcf9a9052330"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?tag=v0.1.1#7fee772a2b124fe97b94826ca108d22d40b3de0a"
 dependencies = [
  "backoff",
  "gcp_auth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "iota-bigtable"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=4321c99c12ceb473abea5fffbb42482ab4f25495#4321c99c12ceb473abea5fffbb42482ab4f25495"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=2331a4689b9214b32fb73b8a0064bcf9a9052330#2331a4689b9214b32fb73b8a0064bcf9a9052330"
 dependencies = [
  "backoff",
  "gcp_auth",

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -252,6 +252,7 @@ async fn main() -> Result<()> {
                         None,
                     )
                     .await?
+                    .with_backoff(BigTableClient::default_backoff())
                 };
 
                 let kv_worker = match kv_config.tables.filter(|s| !s.is_empty()) {

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
-iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "4321c99c12ceb473abea5fffbb42482ab4f25495" }
+iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "2331a4689b9214b32fb73b8a0064bcf9a9052330" }
 serde.workspace = true
 strum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
-iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", tag = "v0.1.0" }
+iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "4321c99c12ceb473abea5fffbb42482ab4f25495" }
 serde.workspace = true
 strum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
-iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "2331a4689b9214b32fb73b8a0064bcf9a9052330" }
+iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", tag = "v0.1.1" }
 serde.workspace = true
 strum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/iota-kvstore/src/main.rs
+++ b/crates/iota-kvstore/src/main.rs
@@ -73,7 +73,8 @@ async fn run_fetch(instance_id: String, column_family: String, entry: Entry) -> 
         column_family,
         None,
     )
-    .await?;
+    .await?
+    .with_backoff(BigTableClient::default_backoff());
 
     let result = match entry {
         Entry::Object { id, version } => {

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -83,6 +83,7 @@ impl KvStoreClient {
                 None,
             )
             .await?
+            .with_backoff(BigTableClient::default_backoff())
         };
 
         Ok(Self {


### PR DESCRIPTION
# Description of change

This PR bumps the `iota-bigtable` dependency to the latest revision, which adds handling for the transient connection errors that arise when Google BigTable recycles long-lived gRPC connections.

Previously the client had no retry, so requests in flight on a recycled connection failed and were surfaced as dropped queries to callers. The updated `iota-bigtable` retries these transient errors with exponential backoff and adds a small connection pool to reduce the blast radius of a single reset.
  
More information is available in the corresponding PR: https://github.com/iotaledger/iota-bigtable/pull/13

> [!NOTE]
> For now we pin the commit hash, once the `iota-bigtable` PR is merged, a new tag will be created and used in place of the commit hash.

## Links to any relevant issues

fixes #11978 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran locally on mainnet the iota-rest-kv with updated bigtable, ensuring the added connection pool didn't cause any unwanted behavior.
- Checked that backoff was triggered correctly.
- Was not able to receive the errors which in first place started this issue since BigTable connection reset can happen randomly, this isn't conclusive proof.


### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.