### PR TITLE
upstream(iota-network): don't panic when randomness receiver channel is closed during shutdown

### DIFF
--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -791,9 +791,18 @@ impl RandomnessEventLoop {
         }
 
         let sig_bytes = bcs::to_bytes(&sig).expect("signature serialization should not fail");
-        self.randomness_tx
-            .try_send((epoch, round, sig_bytes))
-            .expect("RandomnessRoundReceiver mailbox should not overflow or be closed");
+        if let Err(e) = self.randomness_tx.try_send((epoch, round, sig_bytes)) {
+            match e {
+                // Receiver is torn down during node shutdown; dropping the round is harmless.
+                mpsc::error::TrySendError::Closed(_) => {
+                    info!("dropping completed randomness round {round}: receiver channel closed");
+                }
+                // Mailbox capacity is huge (default 1M); a full mailbox means a real bug.
+                mpsc::error::TrySendError::Full(_) => {
+                    panic!("RandomnessRoundReceiver mailbox should not overflow");
+                }
+            }
+        }
     }
 
     fn maybe_ignore_byzantine_peer(&mut self, epoch: EpochId, peer_id: PeerId) {


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#26989](https://github.com/MystenLabs/sui/pull/26989)
- Description:

Completed randomness rounds are forwarded to the node-lifetime `RandomnessRoundReceiver`, which runs in a separate task with no shutdown ordering relative to the randomness network event loop, so it can be torn down first and close the channel. The previous unconditional `.expect()` on `try_send` panicked on this benign shutdown race. Treat a closed channel as benign shutdown — log and drop the completed round — and only panic on a full mailbox, which still indicates a real bug.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Fixes a spurious panic that could occur during a normal node shutdown/restart. No action required.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
