### PR TITLE
upstream(core): Add labeled in-flight gauge guard to iota-metrics

### DIFF
--- a/crates/iota-metrics/src/guards.rs
+++ b/crates/iota-metrics/src/guards.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use prometheus::IntGauge;
+use prometheus::{IntGauge, IntGaugeVec};
 
 /// Increments gauge when acquired, decrements when guard drops
 pub struct GaugeGuard<'a>(&'a IntGauge);
@@ -30,9 +30,42 @@ impl Drop for GaugeGuard<'_> {
     }
 }
 
+/// Increments an `IntGaugeVec` for a set of label values when acquired,
+/// decrements the same labeled gauge when the guard drops.
+pub struct IntGaugeVecGuard<'a> {
+    gauge: &'a IntGaugeVec,
+    labels: Vec<String>,
+}
+
+impl<'a> IntGaugeVecGuard<'a> {
+    /// Acquires the labeled gauge by incrementing it and retaining the label
+    /// values so the matching gauge can be decremented on drop.
+    pub fn acquire(gauge: &'a IntGaugeVec, labels: &[&str]) -> Self {
+        gauge.with_label_values(labels).inc();
+        let labels: Vec<String> = labels.iter().map(|s| s.to_string()).collect();
+        Self { gauge, labels }
+    }
+}
+
+impl Drop for IntGaugeVecGuard<'_> {
+    /// Decrements the labeled gauge when the guard is dropped.
+    fn drop(&mut self) {
+        self.gauge
+            .with_label_values(&self.labels.iter().map(|s| s.as_str()).collect::<Vec<_>>())
+            .dec();
+    }
+}
+
 pub trait GaugeGuardFutureExt: Future + Sized {
     /// Count number of in flight futures running
     fn count_in_flight(self, g: &IntGauge) -> GaugeGuardFuture<'_, Self>;
+
+    /// Count number of in flight futures running, tracked on a labeled gauge.
+    fn count_in_flight_with_labels<'a>(
+        self,
+        g: &'a IntGaugeVec,
+        labels: &[&str],
+    ) -> IntGaugeVecGuardFuture<'a, Self>;
 }
 
 impl<F: Future> GaugeGuardFutureExt for F {
@@ -41,6 +74,18 @@ impl<F: Future> GaugeGuardFutureExt for F {
         GaugeGuardFuture {
             f: Box::pin(self),
             _guard: GaugeGuard::acquire(g),
+        }
+    }
+
+    /// Count number of in flight futures running, tracked on a labeled gauge.
+    fn count_in_flight_with_labels<'a>(
+        self,
+        g: &'a IntGaugeVec,
+        labels: &[&str],
+    ) -> IntGaugeVecGuardFuture<'a, Self> {
+        IntGaugeVecGuardFuture {
+            f: Box::pin(self),
+            _guard: IntGaugeVecGuard::acquire(g, labels),
         }
     }
 }
@@ -64,6 +109,24 @@ impl<F: Future> Future for GaugeGuardFuture<'_, F> {
     /// `GaugeGuardFuture` to manage the polling lifecycle.
     /// Returns `Poll::Pending` if the future is not ready or `Poll::Ready` with
     /// the future's result if complete.
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.f.as_mut().poll(cx)
+    }
+}
+
+/// A struct that wraps a future (`f`) with an `IntGaugeVecGuard`. The labeled
+/// gauge is incremented when the future starts and decremented when the
+/// `IntGaugeVecGuardFuture` is dropped.
+pub struct IntGaugeVecGuardFuture<'a, F: Sized> {
+    f: Pin<Box<F>>,
+    _guard: IntGaugeVecGuard<'a>,
+}
+
+impl<F: Future> Future for IntGaugeVecGuardFuture<'_, F> {
+    type Output = F::Output;
+
+    /// Polls the wrapped future (`f`) to determine its readiness, forwarding
+    /// the poll to the inner future.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.f.as_mut().poll(cx)
     }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.51.5, v1.52.3)
- Port commit:
  - [MystenLabs/sui@b6a2a2a](https://github.com/MystenLabs/sui/commit/b6a2a2a2758e23eac19a24dcb3e74b16a56c4f4e)
- Description:

Only the `iota-metrics` changes are applicable. The rest of the changes we do not have (e.g., no fastpath, no per-transaction certifier)

Ported `IntGaugeVecGuard` and `GaugeGuardFutureExt::count_in_flight_with_labels`, which generalize the existing unlabeled gauge guard to labeled `IntGaugeVec` metrics.
A future is wrapped so the labeled gauge is incremented on construction and
decremented exactly once when the future completes or is dropped.


## Links to any relevant issues

Part of #11885

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes