### PR TITLE
chore(indexer): remove deprecated --optimistic-pruner-batch-size argument

### DIFF
--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -326,10 +326,6 @@ pub struct PruningOptions {
         value_parser = clap::value_parser!(u64).range(1..),
     )]
     pub pruning_batch_size: u64,
-    /// DEPRECATED: will be removed in v1.29.0. This parameter is no longer
-    /// used. Optimistic transactions are now pruned by the unified pruner.
-    #[arg(long, env = "OPTIMISTIC_PRUNER_BATCH_SIZE")]
-    pub optimistic_pruner_batch_size: Option<u64>,
 }
 
 impl Default for PruningOptions {
@@ -339,7 +335,6 @@ impl Default for PruningOptions {
             pruning_config_path: None,
             pruning_delay_ms: DEFAULT_PRUNING_DELAY_MS,
             pruning_batch_size: DEFAULT_PRUNING_BATCH_SIZE,
-            optimistic_pruner_batch_size: None,
         }
     }
 }

--- a/crates/iota-indexer/src/main.rs
+++ b/crates/iota-indexer/src/main.rs
@@ -75,14 +75,6 @@ async fn main() -> Result<(), IndexerError> {
                 }
             }
 
-            if pruning_options.optimistic_pruner_batch_size.is_some() {
-                warn!(
-                    "the --optimistic-pruner-batch-size argument is deprecated and no longer used. \
-                     This argument will be removed in v1.29.0. \
-                     Optimistic transactions are now pruned by the unified pruner."
-                );
-            }
-
             if snapshot_config.is_set() {
                 warn!(
                     "the --objects-snapshot-min-checkpoint-lag / --objects-snapshot-sleep-duration arguments \


### PR DESCRIPTION
Closes #11847.

`--optimistic-pruner-batch-size` / `OPTIMISTIC_PRUNER_BATCH_SIZE` has been deprecated since #10875 (watermarks-based pruning) — optimistic transactions are now pruned by the unified pruner with the same batching strategy as other tables. The removal release was set to v1.29.0 in #11846.

Removes the `optimistic_pruner_batch_size` field on `PruningOptions` and its `Default` entry, plus the deprecation `warn!` block from `iota-indexer`'s startup path.