### PR TITLE
fix(move-disassembler): drop UTF8 comment suffix from inline constant preview

### DIFF
--- a/external-crates/move/crates/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/crates/move-disassembler/src/disassembler.rs
@@ -1558,15 +1558,26 @@ impl Disassembler<'_> {
         constant: &Constant,
         use_inline_formatting: bool,
     ) -> Result<()> {
-        let data_str = match try_render_constant(constant) {
-            RenderResult::NotRendered => hex::encode(&constant.data),
-            RenderResult::AsValue(v_str) => v_str,
-            RenderResult::AsString(s) => "\"".to_owned() + &s + "\" // interpreted as UTF8 string",
-        };
+        let rendered = try_render_constant(constant);
         if use_inline_formatting {
+            // The inline preview omits the `// interpreted as UTF8 string`
+            // suffix so that short rendered values (e.g. `"TA"`) are not
+            // falsely flagged as truncated by `preview_string`.
+            let inline_repr = match &rendered {
+                RenderResult::NotRendered => hex::encode(&constant.data),
+                RenderResult::AsValue(v_str) => v_str.clone(),
+                RenderResult::AsString(s) => format!("\"{s}\""),
+            };
             self.disassemble_sig_tok(buffer, &constant.type_, None, &[])?;
-            any_write!(buffer, ": {}", Self::preview_string(&data_str))
+            any_write!(buffer, ": {}", Self::preview_string(&inline_repr))
         } else {
+            let data_str = match rendered {
+                RenderResult::NotRendered => hex::encode(&constant.data),
+                RenderResult::AsValue(v_str) => v_str,
+                RenderResult::AsString(s) => {
+                    "\"".to_owned() + &s + "\" // interpreted as UTF8 string"
+                }
+            };
             any_write!(buffer, "\t{const_idx} => ")?;
             self.disassemble_sig_tok(buffer, &constant.type_, None, &[])?;
             any_writeln!(buffer, ": {data_str}")


### PR DESCRIPTION
Closes #9958.

`disassemble_constant`'s inline branch ran `preview_string` over a `data_str` that already had the ` // interpreted as UTF8 string` trailer appended for the `Constants` section. Short rendered values such as `vector<u8>: "TA"` were pushed past the 6-char truncation threshold by that trailer, so the disassembler emitted `LdConst[N](vector<u8>: "TA"..)` even though the value fit comfortably inline. The truncated form leaked back to clients of `iota_getObject` / `disassembled` and looked like malformed bytecode.

Built a separate inline representation that omits the trailer and previewed that instead. The trailer is still used in the `Constants` section produced by the non-inline branch, so the readable header is preserved. Long values still truncate with the existing `..` marker, and `cargo test -p move-cli --test build_testsuite disassemble` keeps passing without snapshot updates.