### PR TITLE
fix(starfish): process commit observer recovery in bounded batches

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -106,6 +106,12 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_commit_sync_batches_ahead")]
     pub commit_sync_batches_ahead: usize,
 
+    /// Maximum number of commits scanned and replayed per batch during
+    /// recovery, bounding peak memory when a large unprocessed range is
+    /// replayed at startup.
+    #[serde(default = "Parameters::default_commit_recovery_batch_size")]
+    pub commit_recovery_batch_size: u32,
+
     /// Maximum number of headers to be included in a bundle. Headers exceeding
     /// the max allowed limit will be truncated.
     #[serde(default = "Parameters::default_max_headers_per_bundle")]
@@ -257,6 +263,10 @@ impl Parameters {
                 self.commit_sync_batch_size as u128,
             ),
             (
+                "commit_recovery_batch_size",
+                self.commit_recovery_batch_size as u128,
+            ),
+            (
                 "commit_sync_batches_ahead",
                 self.commit_sync_batches_ahead as u128,
             ),
@@ -368,6 +378,10 @@ impl Parameters {
         }
     }
 
+    pub(crate) fn default_commit_recovery_batch_size() -> u32 {
+        if cfg!(msim) { 3 } else { 250 }
+    }
+
     pub(crate) fn default_commit_sync_batches_ahead() -> usize {
         // This is set to be a multiple of default commit_sync_parallel_fetches to allow
         // fetching ahead, while keeping the total number of inflight fetches
@@ -439,6 +453,7 @@ impl Default for Parameters {
             commit_sync_parallel_fetches: Parameters::default_commit_sync_parallel_fetches(),
             commit_sync_batch_size: Parameters::default_commit_sync_batch_size(),
             commit_sync_batches_ahead: Parameters::default_commit_sync_batches_ahead(),
+            commit_recovery_batch_size: Parameters::default_commit_recovery_batch_size(),
             max_headers_per_bundle: Parameters::default_max_headers_per_bundle(),
             max_shards_per_bundle: Parameters::default_max_shards_per_bundle(),
             tonic: TonicParameters::default(),

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -26,6 +26,7 @@ peer_round_ahead_margin: 1000
 commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100
 commit_sync_batches_ahead: 32
+commit_recovery_batch_size: 250
 max_headers_per_bundle: 150
 max_shards_per_bundle: 150
 tonic:

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -48,10 +48,6 @@ impl CommittedSubDagSource {
     }
 }
 
-/// Maximum number of commits scanned and processed per batch during recovery,
-/// to bound peak memory when a large unprocessed range must be replayed.
-const COMMIT_RECOVERY_BATCH_SIZE: u32 = if cfg!(test) { 3 } else { 250 };
-
 /// Role of CommitObserver
 /// - Called by core when try_commit() returns newly committed leaders.
 /// - The newly committed leaders are sent to commit observer and then commit
@@ -347,11 +343,10 @@ impl CommitObserver {
         // data lagged behind commits for a long period) is never materialized at
         // once. Disjoint, ascending, contiguous batches feed the solidifier
         // exactly as a single pass would.
-        for start_index in
-            (recovery_start..=last_commit_index).step_by(COMMIT_RECOVERY_BATCH_SIZE as usize)
-        {
+        let batch_size = self.context.parameters.commit_recovery_batch_size;
+        for start_index in (recovery_start..=last_commit_index).step_by(batch_size as usize) {
             let end_index = start_index
-                .saturating_add(COMMIT_RECOVERY_BATCH_SIZE - 1)
+                .saturating_add(batch_size - 1)
                 .min(last_commit_index);
 
             let batch_commits = self.store.scan_commits((start_index..=end_index).into())?;
@@ -534,10 +529,11 @@ impl CommitObserver {
         // (e.g. when an authority quarantines commits for a long period), process
         // in bounded batches.
         let unhandled_commits_threshold = self.context.parameters.unhandled_commits_threshold();
+        let batch_size = self.context.parameters.commit_recovery_batch_size;
         let mut any_sent = false;
         let mut expected_commit_index = last_processed_commit_index;
-        for start_index in (last_processed_commit_index + 1..=last_commit_index)
-            .step_by(COMMIT_RECOVERY_BATCH_SIZE as usize)
+        for start_index in
+            (last_processed_commit_index + 1..=last_commit_index).step_by(batch_size as usize)
         {
             // Pace on consumer progress like the commit syncers do: don't run
             // more than unhandled_commits_threshold commits ahead of the
@@ -548,7 +544,7 @@ impl CommitObserver {
                 .await;
 
             let end_index = start_index
-                .saturating_add(COMMIT_RECOVERY_BATCH_SIZE - 1)
+                .saturating_add(batch_size - 1)
                 .min(last_commit_index);
 
             let batch_commits = self.store.scan_commits((start_index..=end_index).into())?;
@@ -1336,6 +1332,7 @@ mod tests {
                 db_path: temp_dir.keep(),
                 commit_sync_batch_size: 3,
                 commit_sync_batches_ahead: 1,
+                commit_recovery_batch_size: 3,
                 ..Default::default()
             },
             iota_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE(),
@@ -1479,6 +1476,7 @@ mod tests {
             committee,
             starfish_config::Parameters {
                 db_path: temp_dir.keep(),
+                commit_recovery_batch_size: 3,
                 ..Default::default()
             },
             protocol_config,
@@ -1614,6 +1612,7 @@ mod tests {
             committee,
             starfish_config::Parameters {
                 db_path: temp_dir.keep(),
+                commit_recovery_batch_size: 3,
                 ..Default::default()
             },
             protocol_config,

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -48,6 +48,10 @@ impl CommittedSubDagSource {
     }
 }
 
+/// Maximum number of commits scanned and processed per batch during recovery,
+/// to bound peak memory when a large unprocessed range must be replayed.
+const COMMIT_RECOVERY_BATCH_SIZE: u32 = if cfg!(test) { 3 } else { 250 };
+
 /// Role of CommitObserver
 /// - Called by core when try_commit() returns newly committed leaders.
 /// - The newly committed leaders are sent to commit observer and then commit
@@ -329,80 +333,101 @@ impl CommitObserver {
         let solidifier_recovery_start = self.last_sent_commit_index.saturating_add(1);
         let recovery_start = linearizer_recovery_start.min(solidifier_recovery_start);
 
-        let recovery_commits = self
-            .store
-            .scan_commits((recovery_start..=last_commit_index).into())?;
-
         info!(
-            "Recovering linearizer/solidifier state from {} commits (indices {}..={})",
-            recovery_commits.len(),
-            recovery_start,
-            last_commit_index
+            "Recovering linearizer/solidifier state from commits {recovery_start}..={last_commit_index}"
         );
 
+        // Set the solidifier cursor exactly once. The solidifier advances
+        // last_solid_committed_index itself in try_get_solid_sub_dags, so it must
+        // not be reset per batch.
         self.commit_solidifier
             .set_last_solid_committed_index(self.last_sent_commit_index);
 
-        let mut pending_for_solidifier = Vec::new();
-        for commit in recovery_commits {
-            // Recovery only needs headers/acks, so reputation scores are irrelevant here.
-            let commit_index = commit.index();
-            let is_optimistic = commit.is_optimistic();
-            let pending_sub_dag =
-                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![])?;
+        // Process in bounded batches so a large unprocessed range (e.g. when tx
+        // data lagged behind commits for a long period) is never materialized at
+        // once. Disjoint, ascending, contiguous batches feed the solidifier
+        // exactly as a single pass would.
+        for start_index in
+            (recovery_start..=last_commit_index).step_by(COMMIT_RECOVERY_BATCH_SIZE as usize)
+        {
+            let end_index = start_index
+                .saturating_add(COMMIT_RECOVERY_BATCH_SIZE - 1)
+                .min(last_commit_index);
 
-            if commit_index >= linearizer_recovery_start {
-                // Rebuild traversed headers tracker
-                self.linearizer
-                    .record_traversed_headers(pending_sub_dag.headers.iter());
+            let batch_commits = self.store.scan_commits((start_index..=end_index).into())?;
+            if batch_commits.is_empty() {
+                break;
+            }
 
-                // Recover transaction acknowledgments tracker state
-                for ((round, authority_idx), transaction_acknowledgments) in
-                    pending_sub_dag.transaction_acknowledgments().into_iter()
-                {
-                    self.linearizer.add_committed_transaction_acks(
-                        round,
-                        authority_idx,
-                        transaction_acknowledgments,
-                    );
-                }
+            // Re-declared per batch so it stays bounded to the batch.
+            let mut pending_for_solidifier = Vec::new();
+            for commit in batch_commits {
+                // Recovery only needs headers/acks, so reputation scores are irrelevant here.
+                let commit_index = commit.index();
+                let is_optimistic = commit.is_optimistic();
+                let pending_sub_dag =
+                    load_pending_subdag_from_store(self.store.as_ref(), commit, vec![])?;
 
-                // Repopulate the ack tracker for transactions optimistically committed
-                // pre-restart so post-restart acks don't cross 2f+1 and re-commit them.
-                // The full committee is used as a conservative over-approximation of
-                // the actual acknowledging set.
-                if is_optimistic {
-                    let leader_ref = pending_sub_dag.leader;
-                    let leader_header = pending_sub_dag
-                        .headers
-                        .iter()
-                        .find(|h| h.reference() == leader_ref)
-                        .expect("leader header must be present in pending sub-dag");
-                    let refs: Vec<BlockRef> = std::iter::once(leader_ref)
-                        .chain(leader_header.acknowledgments().iter().copied())
-                        .collect();
-                    for (authority_idx, _) in self.context.committee.authorities() {
-                        let _ = self.linearizer.add_committed_transaction_acks(
-                            leader_header.round() + 1,
+                if commit_index >= linearizer_recovery_start {
+                    // Rebuild traversed headers tracker
+                    self.linearizer
+                        .record_traversed_headers(pending_sub_dag.headers.iter());
+
+                    // Recover transaction acknowledgments tracker state
+                    for ((round, authority_idx), transaction_acknowledgments) in
+                        pending_sub_dag.transaction_acknowledgments().into_iter()
+                    {
+                        self.linearizer.add_committed_transaction_acks(
+                            round,
                             authority_idx,
-                            refs.clone(),
+                            transaction_acknowledgments,
                         );
                     }
+
+                    // Repopulate the ack tracker for transactions optimistically committed
+                    // pre-restart so post-restart acks don't cross 2f+1 and re-commit them.
+                    // The full committee is used as a conservative over-approximation of
+                    // the actual acknowledging set.
+                    if is_optimistic {
+                        let leader_ref = pending_sub_dag.leader;
+                        let leader_header = pending_sub_dag
+                            .headers
+                            .iter()
+                            .find(|h| h.reference() == leader_ref)
+                            .expect("leader header must be present in pending sub-dag");
+                        let refs: Vec<BlockRef> = std::iter::once(leader_ref)
+                            .chain(leader_header.acknowledgments().iter().copied())
+                            .collect();
+                        for (authority_idx, _) in self.context.committee.authorities() {
+                            let _ = self.linearizer.add_committed_transaction_acks(
+                                leader_header.round() + 1,
+                                authority_idx,
+                                refs.clone(),
+                            );
+                        }
+                    }
                 }
+
+                if commit_index >= solidifier_recovery_start {
+                    pending_for_solidifier.push(pending_sub_dag);
+                }
+
+                tokio::task::yield_now().await;
             }
 
-            if commit_index >= solidifier_recovery_start {
-                pending_for_solidifier.push(pending_sub_dag);
+            if !pending_for_solidifier.is_empty() {
+                let (solid_sub_dags, _missing) = self
+                    .commit_solidifier
+                    .try_get_solid_sub_dags(&pending_for_solidifier);
+                self.finalize_and_send_solid_subdags(&[], &solid_sub_dags, source)?;
             }
 
+            if end_index == last_commit_index {
+                break;
+            }
+
+            // Yield between batches during a potentially long recovery.
             tokio::task::yield_now().await;
-        }
-
-        if !pending_for_solidifier.is_empty() {
-            let (solid_sub_dags, _missing) = self
-                .commit_solidifier
-                .try_get_solid_sub_dags(&pending_for_solidifier);
-            self.finalize_and_send_solid_subdags(&[], &solid_sub_dags, source)?;
         }
         Ok(())
     }
@@ -508,8 +533,6 @@ impl CommitObserver {
         // To avoid loading too many commits at once and causing OOM under stress
         // (e.g. when an authority quarantines commits for a long period), process
         // in bounded batches.
-        const COMMIT_RECOVERY_BATCH_SIZE: u32 = if cfg!(test) { 3 } else { 250 };
-
         let unhandled_commits_threshold = self.context.parameters.unhandled_commits_threshold();
         let mut any_sent = false;
         let mut expected_commit_index = last_processed_commit_index;

--- a/crates/starfish/core/src/context.rs
+++ b/crates/starfish/core/src/context.rs
@@ -87,6 +87,7 @@ impl Context {
             committee,
             Parameters {
                 db_path: temp_dir.keep(),
+                commit_recovery_batch_size: 3,
                 ..Default::default()
             },
             ProtocolConfig::get_for_max_version_UNSAFE(),


### PR DESCRIPTION
# Description of change

During recovery, the commit observer's `recover_linearizer_and_solidifier_state` scanned the entire `recovery_start..=last_commit_index` range into a single `Vec<TrustedCommit>` and accumulated one `PendingSubDag` per commit before seeding the commit solidifier. When the unprocessed range is large (e.g. transaction data lagged behind commits for a long period so commits stay unprocessed), the whole range was materialized in memory at once at startup.

This processes the range in bounded batches, mirroring `resend_unprocessed_solid_commits`: each batch scans one chunk, rebuilds linearizer state for commits in the `gc_depth * 2` window, seeds the solidifier, and finalizes solid sub-dags. The solidifier cursor is set once before the loop; disjoint, ascending, contiguous batches feed the solidifier exactly as a single pass would, so the recovered linearizer/solidifier state and the set and order of sub-dags sent to the consumer are unchanged — only peak memory during recovery is reduced (the transient scan and the per-batch pending buffer become `O(batch)` instead of `O(range)`).

The batch size is a `commit_recovery_batch_size` local parameter (default 250; 3 under the simulator), shared by both recovery phases. `Parameters::validate` rejects a zero value, which would otherwise panic `step_by(0)`.

The commit solidifier's internal pending-sub-dag buffer still holds the unprocessed range while the front of that range is missing transactions; that is inherent to seeding (identical to the previous single-pass behaviour) and is a separate, tail-side concern.

## Links to any relevant issues

Fixes #12036

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
