### PR TITLE
feat(snapshot): extend VerifiedEpochInfo API

### DIFF
--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -321,10 +321,6 @@ impl EpochInfo {
 pub struct VerifiedEpochInfo {
     epoch_info: EpochInfo,
     committees: Vec<Committee>,
-    /// Digest-verified start state per epoch: `[i]` is epoch `i`'s start state
-    /// — the genesis root for `i == 0`, else derived from epoch `i - 1`'s
-    /// boundary. Length `snapshot_epoch + 2`; the trailing entry has no epoch
-    /// info row.
     start_system_states: Vec<IotaSystemState>,
 }
 
@@ -340,13 +336,19 @@ impl VerifiedEpochInfo {
         &self.committees
     }
 
-    /// Consumes the verified info into its components: the epoch info, the
-    /// per-epoch committees, and the per-epoch start system states.
+    /// Digest-verified start system state per epochs `[0, snapshot_epoch + 1].
     ///
-    /// `start_system_states[i]` is epoch `i`'s digest-verified start state — the
-    /// genesis root for `i == 0`, else derived from epoch `i - 1`'s boundary.
-    /// Its length is `snapshot_epoch + 2`; the trailing entry has no epoch info
-    /// row.
+    /// Contains the genesis start system state, plus the ones derived by the
+    /// epoch boundaries represented by [`Self::entries`].
+    pub fn start_system_states(&self) -> &[IotaSystemState] {
+        &self.start_system_states
+    }
+
+    /// Consumes the verified info into its components: the epoch info entries,
+    /// the per-epoch committees, and the per-epoch start system states.
+    ///
+    /// See [`Self::entries`], [`Self::committees`], and
+    /// [`Self::start_system_states`].
     pub fn into_parts(self) -> (EpochInfo, Vec<Committee>, Vec<IotaSystemState>) {
         (self.epoch_info, self.committees, self.start_system_states)
     }

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -305,7 +305,7 @@ impl EpochInfo {
         }
     }
 
-    fn into_entries(self) -> Vec<EpochInfoV1Entry> {
+    pub fn into_entries(self) -> Vec<EpochInfoV1Entry> {
         match self {
             Self::V1(info) => info.entries,
         }
@@ -338,6 +338,17 @@ impl VerifiedEpochInfo {
     /// plus one handed forward by each entry's `end_of_epoch_data`.
     pub fn committees(&self) -> &[Committee] {
         &self.committees
+    }
+
+    /// Consumes the verified info into its components: the epoch info, the
+    /// per-epoch committees, and the per-epoch start system states.
+    ///
+    /// `start_system_states[i]` is epoch `i`'s digest-verified start state — the
+    /// genesis root for `i == 0`, else derived from epoch `i - 1`'s boundary.
+    /// Its length is `snapshot_epoch + 2`; the trailing entry has no epoch info
+    /// row.
+    pub fn into_parts(self) -> (EpochInfo, Vec<Committee>, Vec<IotaSystemState>) {
+        (self.epoch_info, self.committees, self.start_system_states)
     }
 
     /// Convert the verified entries `[0, snapshot_epoch]` into `EpochInfoV2`

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -326,6 +326,14 @@ pub struct VerifiedEpochInfo {
 
 impl VerifiedEpochInfo {
     /// Entries for epochs `[0, snapshot_epoch]`, in epoch order.
+    ///
+    /// These values represent data at the boundary of each epoch, including the
+    /// committee and start system state of the next epoch.
+    ///
+    /// The last entry represents the snapshot epoch boundary, which carries
+    /// information about the next epoch. Thus [`Self::committees`], and
+    /// [`Self::start_system_states`] have one more item for the committee and
+    /// the start system state of the epoch following the snapshot epoch.
     pub fn entries(&self) -> &[EpochInfoV1Entry] {
         self.epoch_info.entries()
     }

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -193,6 +193,9 @@ impl StateSnapshotReaderV1 {
                 .unwrap(),
             ),
         );
+        // Render the bar on a timer so it stays visible while the first files are
+        // still in flight, rather than only repainting on completion.
+        progress_bar.enable_steady_tick(Duration::from_millis(100));
         // Downloads all reference files from remote store to local store in parallel
         // and updates the progress bar accordingly
         copy_files(


### PR DESCRIPTION
# Description of change

This patch introduces three changes motivated by the parallel work on using the V2 api in the indexer.

1. It updates the progress bar on regular ticks, so it doesn't made for download completion to appear while restoring
2. Exposes a consuming `VerifiedEpochInfo::into_parts` method that extracts all inner values, so that custom indexing logic on epoch can be implemented efficiently.
3. Expose a getter to the `start_system_states` as a slice, to complement the existing API and make documentation more concise.

## Links to any relevant issues

Part of #11023 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
