### PR TITLE
fix(node): full nodes rebuild epoch_info locally if snapshot fetch fails

### DIFF
--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -920,10 +920,9 @@ impl IotaNode {
             );
             if recognized_source.is_some() {
                 anyhow::bail!(
-                    "{detail}: the formal snapshot couldn't complete the chain (older than this \
-                     node's history, or its source unreachable) and the missing epochs' \
-                     checkpoint data is already pruned locally; retry once the snapshot source \
-                     is reachable and current"
+                    "{detail}: the latest published snapshot is older than this node's history \
+                     and the missing epochs' checkpoint data is already pruned locally; retry \
+                     once a newer snapshot is available"
                 );
             }
             warn!(

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -880,14 +880,20 @@ impl IotaNode {
         {
             // snapshot pull (recognized chains only)
             if let Some(remote_store_config) = &recognized_source {
-                Self::backfill_epoch_info_from_snapshot(
+                if let Err(e) = Self::backfill_epoch_info_from_snapshot(
                     checkpoint_store,
                     remote_store_config,
                     genesis.committee()?,
                     genesis.iota_system_object(),
                     expected_chain_id,
                 )
-                .await?;
+                .await
+                {
+                    warn!(
+                        "epoch_info snapshot backfill failed ({e:#}); falling back to \
+                         rebuilding from local checkpoint history"
+                    );
+                }
             }
 
             // local replay
@@ -914,9 +920,10 @@ impl IotaNode {
             );
             if recognized_source.is_some() {
                 anyhow::bail!(
-                    "{detail}: the latest published snapshot is older than this node's history \
-                     and the missing epochs' checkpoint data is already pruned locally; retry \
-                     once a newer snapshot is published"
+                    "{detail}: the formal snapshot couldn't complete the chain (older than this \
+                     node's history, or its source unreachable) and the missing epochs' \
+                     checkpoint data is already pruned locally; retry once the snapshot source \
+                     is reachable and current"
                 );
             }
             warn!(


### PR DESCRIPTION
# Description of change

If the snapshot download fails, a node that still has its full local history now rebuilds `epoch_info` from that local data instead of refusing to start. It only fails if neither the snapshot nor local data can complete the chain (e.g. a pruned node that also can't reach the snapshot).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes