### PR TITLE
refactor(iota-core,iota-config,iota-node,iota-e2e-tests): finish white-flag → PCOOL rename on pcool-feature

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -805,7 +805,7 @@ pub struct ConsensusConfig {
     /// consensus, including those in submission wait. Used as the upper
     /// bound for graduated pre-consensus load shedding
     /// (`graduated_load_shedding_soft_limit_pct`) in the certificate-less
-    /// (pcool / white-flag) mode, and as the threshold for the binary
+    /// (P-COOL) mode, and as the threshold for the binary
     /// cutoff in `ConsensusAdapter::check_consensus_overload()` in both
     /// certificate-less and certificate-based flows.
     ///
@@ -835,8 +835,7 @@ pub struct ConsensusConfig {
     /// limit at which graduated pre-consensus load shedding begins. When
     /// in-flight transactions are at or below the soft limit, no shedding
     /// occurs; above it, the shedding rate scales linearly from 0% to 100% at
-    /// `max_pending_transactions`. Used in the certificate-less (pcool /
-    /// white-flag) mode.
+    /// `max_pending_transactions`. Used in the certificate-less (P-COOL) mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub graduated_load_shedding_soft_limit_pct: Option<u32>,
 }
@@ -856,7 +855,7 @@ impl ConsensusConfig {
     /// Returns the percentage of `max_pending_transactions` (hard limit)
     /// defining the soft limit at which graduated pre-consensus load
     /// shedding begins. Defaults to 50%. Used in the certificate-less
-    /// (pcool / white-flag) mode.
+    /// (P-COOL) mode.
     pub fn graduated_load_shedding_soft_limit_pct(&self) -> u32 {
         self.graduated_load_shedding_soft_limit_pct
             .unwrap_or(50)
@@ -1238,7 +1237,7 @@ pub struct AuthorityOverloadConfig {
     pub max_transaction_manager_per_object_queue_length: usize,
 
     /// Percentage of `max_transaction_manager_queue_length` at which graduated
-    /// load shedding begins in the certificate-less (white-flag) mode. Read
+    /// load shedding begins in the certificate-less (P-COOL) mode. Read
     /// via the same-named accessor, which clamps the value to <=100.
     #[serde(default = "default_max_transaction_manager_queue_length_soft_limit_pct")]
     pub max_transaction_manager_queue_length_soft_limit_pct: u32,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -329,7 +329,7 @@ pub struct AuthorityMetrics {
     /// Stake-weighted quorum (2f+1) load shedding percentage enforced on user
     /// transactions in the most recent consensus commit. This is the cluster
     /// value actually applied post-consensus, as opposed to this authority's
-    /// own `authority_load_shedding_percentage`. 0 when the white-flag flow is
+    /// own `authority_load_shedding_percentage`. 0 when the P-COOL flow is
     /// disabled.
     pub consensus_handler_load_shedding_percentage: IntGauge,
     pub consensus_handler_max_object_costs: IntGaugeVec,
@@ -571,7 +571,7 @@ impl AuthorityMetrics {
                 .unwrap(),
             local_post_consensus_load_shedding_percentage: register_int_gauge_with_registry!(
                 "authority_load_shedding_percentage",
-                "This authority's locally computed load shedding percentage. In the white-flag flow this is the value broadcast to peers, not necessarily the rate enforced (see consensus_handler_load_shedding_percentage).",
+                "This authority's locally computed load shedding percentage. In the P-COOL flow this is the value broadcast to peers, not necessarily the rate enforced (see consensus_handler_load_shedding_percentage).",
                 registry)
                 .unwrap(),
             consensus_queue_load_shedding_percentage: register_int_gauge_with_registry!(
@@ -760,7 +760,7 @@ impl AuthorityMetrics {
             ).unwrap(),
             consensus_handler_load_shedding_percentage: register_int_gauge_with_registry!(
                 "consensus_handler_load_shedding_percentage",
-                "Stake-weighted quorum (2f+1) load shedding percentage enforced on user transactions in the most recent consensus commit. 0 when the white-flag flow is disabled.",
+                "Stake-weighted quorum (2f+1) load shedding percentage enforced on user transactions in the most recent consensus commit. 0 when the P-COOL flow is disabled.",
                 registry,
             ).unwrap(),
             consensus_handler_max_object_costs: register_int_gauge_vec_with_registry!(
@@ -1216,7 +1216,7 @@ impl AuthorityState {
 
     /// Checks system overload conditions before accepting a transaction.
     ///
-    /// In certificate-less (white-flag) mode: only checks consensus
+    /// In certificate-less (P-COOL) mode: only checks consensus
     /// queue overload, since execution-based overload will be handled
     /// post-consensus.
     ///
@@ -1228,9 +1228,9 @@ impl AuthorityState {
         consensus_adapter: &Arc<ConsensusAdapter>,
         tx_data: &SenderSignedData,
         do_authority_overload_check: bool,
-        white_flag_flow_enabled: bool,
+        pcool_flow_enabled: bool,
     ) -> IotaResult {
-        if white_flag_flow_enabled {
+        if pcool_flow_enabled {
             // Graduated shedding: 0% to 100% as consensus queue fills from soft
             // to hard limit.
             self.check_consensus_queue_graduated_limits(consensus_adapter, tx_data)

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -692,7 +692,7 @@ pub struct AuthorityPerEpochStore {
     /// `Rejected` response instead of waiting for the gRPC deadline.
     dropped_tx_status_cache: super::dropped_tx_status_cache::DroppedTxStatusCache,
 
-    /// Pre-consensus soft locks for owned objects (pcool / white-flag flow).
+    /// Pre-consensus soft locks for owned objects (P-COOL flow).
     ///
     /// Set via `OnceCell` rather than passed through the constructor because
     /// the same `Arc` instance must be shared with the gRPC `ValidatorService`
@@ -1812,7 +1812,7 @@ impl AuthorityPerEpochStore {
     }
 
     /// Sets the pre-consensus soft lock table. Called once during validator
-    /// setup. Gating on `enable_white_flag_flow` is the caller's
+    /// setup. Gating on `enable_pcool_flow` is the caller's
     /// responsibility — when the flow is disabled, releases simply produce no
     /// digests so the `OnceCell` may stay empty harmlessly.
     ///
@@ -3379,7 +3379,7 @@ impl AuthorityPerEpochStore {
                 end_of_publish_transactions.push(tx);
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
-            // In the white-flag flow, randomness transactions are separated
+            // In the P-COOL flow, randomness transactions are separated
             // later in the flow to preserve ordering in conflict resolution, so
             // should be included with the regular transactions here.
             } else if !enable_pcool && tx.0.is_user_tx_with_randomness() {
@@ -3797,10 +3797,10 @@ impl AuthorityPerEpochStore {
         // released: accepted ones now hold permanent locks, rejected ones need
         // their non-conflicting owned objects freed for new transactions.
         //
-        // If the white-flag flow produced digests to release but the OnceCell
+        // If the P-COOL flow produced digests to release but the OnceCell
         // was never wired, that's a startup bug — locks would leak until TTL
         // expiry. Log at `error!` so alerts fire; tests that exercise the
-        // white-flag path without a validator service take this branch
+        // P-COOL path without a validator service take this branch
         // harmlessly.
         if !soft_lock_release_tx_digests.is_empty() {
             if let Some(soft_locks) = self.soft_locks.get() {
@@ -3808,7 +3808,7 @@ impl AuthorityPerEpochStore {
             } else {
                 error!(
                     count = soft_lock_release_tx_digests.len(),
-                    "white-flag flow produced soft-lock release digests but \
+                    "P-COOL flow produced soft-lock release digests but \
                          soft_locks OnceCell was never set — wiring bug in \
                          start_epoch_specific_validator_components"
                 );

--- a/crates/iota-core/src/authority_server/soft_lock.rs
+++ b/crates/iota-core/src/authority_server/soft_lock.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Pre-consensus soft locking for the pcool (white-flag) transaction flow.
+//! Pre-consensus soft locking for the P-COOL transaction flow.
 //!
 //! This module provides an in-memory, defense-in-depth mechanism that prevents
 //! a validator from accepting two transactions that conflict on the same owned

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -105,7 +105,7 @@ impl ValidatorService {
             &consensus_adapter,
             transaction.data(),
             state.check_system_overload_at_signing(),
-            // `false` means white-flag flow is disabled - ensured by `fp_ensure!` above
+            // `false` means P-COOL flow is disabled - ensured by `fp_ensure!` above
             false,
         );
         if let Err(error) = overload_check_res {
@@ -272,7 +272,7 @@ impl ValidatorService {
                 &self.consensus_adapter,
                 certificate.data(),
                 self.state.check_system_overload_at_execution(),
-                // `false` means white-flag flow is disabled - ensured by `fp_ensure!` in callers
+                // `false` means P-COOL flow is disabled - ensured by `fp_ensure!` in callers
                 false,
             );
             if let Err(error) = overload_check_res {

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -167,7 +167,7 @@ impl ValidatorService {
             consensus_adapter,
             transaction.data(),
             state.check_system_overload_at_signing(),
-            // `true` means white-flag flow is enabled - ensured by `fp_ensure!` in the caller
+            // `true` means P-COOL flow is enabled - ensured by `fp_ensure!` in the caller
             true,
         ) {
             metrics

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -249,7 +249,7 @@ pub struct ConsensusAdapter {
     /// The hard limit on the number of inflight transactions at this node.
     /// Used as the upper bound for graduated pre-consensus load shedding
     /// (`graduated_load_shedding_soft_limit_pct`) in the certificate-less
-    /// (pcool / white-flag) mode, and as the threshold for the binary
+    /// (P-COOL) mode, and as the threshold for the binary
     /// cutoff in `ConsensusAdapter::check_consensus_overload()` in both
     /// certificate-less and certificate-based flows.
     max_pending_transactions: usize,
@@ -286,8 +286,7 @@ pub struct ConsensusAdapter {
     /// limit at which graduated pre-consensus load shedding begins. When
     /// in-flight transactions are at or below the soft limit, no shedding
     /// occurs; above it, the shedding rate scales linearly from 0% to 100% at
-    /// `max_pending_transactions`. Used in the certificate-less (pcool /
-    /// white-flag) mode.
+    /// `max_pending_transactions`. Used in the certificate-less (P-COOL) mode.
     graduated_load_shedding_soft_limit_pct: u32,
 }
 
@@ -651,7 +650,7 @@ impl ConsensusAdapter {
     /// Returns the percentage of `max_pending_transactions` (hard limit)
     /// defining the soft limit at which graduated pre-consensus load
     /// shedding begins. Defaults to 50%. Used in the certificate-less
-    /// (pcool / white-flag) mode.
+    /// (P-COOL) mode.
     pub(super) fn graduated_load_shedding_soft_limit_pct(&self) -> u32 {
         self.graduated_load_shedding_soft_limit_pct
     }
@@ -675,7 +674,7 @@ impl ConsensusAdapter {
     /// Uses relaxed atomic reads: the two limits are not observed atomically.
     fn check_consensus_hard_limits(&self) -> bool {
         // First check total in-flight transactions (waiting and in submission).
-        // TODO: this check is redundant in the white-flag flow - graduated
+        // TODO: this check is redundant in the P-COOL flow - graduated
         // shedding already rejects at 100% once `num_inflight_transactions`
         // reaches `max_pending_transactions`. Remove when the certificate-based
         // flow is removed from the codebase. The semaphore check below stays in

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -430,7 +430,7 @@ mod tests {
                 // compatibility.
                 ConsensusTransactionKind::NewJWKFetchedDeprecated => Some(false),
 
-                // Gated behind `enable_white_flag_flow`.
+                // Gated behind `enable_pcool_flow`.
                 ConsensusTransactionKind::OverloadNotificationV1(_, _, _) => {
                     Some(config.enable_pcool_flow())
                 }

--- a/crates/iota-core/src/overload_monitor.rs
+++ b/crates/iota-core/src/overload_monitor.rs
@@ -90,7 +90,7 @@ pub async fn overload_monitor(
 /// metric so it tracks the current consensus queue depth even when no
 /// gRPC traffic is arriving (which would otherwise be the only path that
 /// updates the metric, via `check_consensus_queue_graduated_limits` on
-/// `AuthorityState`). Used only in the certificate-less (pcool / white-flag)
+/// `AuthorityState`). Used only in the certificate-less (P-COOL)
 /// mode.
 pub async fn consensus_queue_overload_monitor(
     authority_state: Weak<AuthorityState>,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -7255,7 +7255,7 @@ async fn test_pcool_deferred_tx_not_dropped_next_round_but_executed() {
 }
 
 /// Tests graduated load shedding based on the consensus queue length
-/// in the white-flag (certificate-less) path of
+/// in the P-COOL (certificate-less) path of
 /// [`AuthorityState::check_system_overload`]. Verifies that:
 /// - below soft limit: all transactions are accepted
 /// - between soft and hard limit: some transactions are rejected
@@ -7302,8 +7302,8 @@ async fn test_consensus_queue_graduated_load_shedding() {
         rgp,
     );
 
-    let white_flag_flow_enabled = true;
-    // Does not matter in the white-flag flow.
+    let pcool_flow_enabled = true;
+    // Does not matter in the P-COOL flow.
     let do_authority_overload_check = false;
 
     // Below and at soft limit, all transactions should be accepted.
@@ -7313,7 +7313,7 @@ async fn test_consensus_queue_graduated_load_shedding() {
             &consensus_adapter,
             tx.data(),
             do_authority_overload_check,
-            white_flag_flow_enabled,
+            pcool_flow_enabled,
         );
 
         assert!(
@@ -7338,7 +7338,7 @@ async fn test_consensus_queue_graduated_load_shedding() {
             &consensus_adapter,
             tx.data(),
             do_authority_overload_check,
-            white_flag_flow_enabled,
+            pcool_flow_enabled,
         );
 
         assert_eq!(
@@ -7360,7 +7360,7 @@ async fn test_consensus_queue_graduated_load_shedding() {
         }
     }
 
-    // Verify that with `white_flag_flow_enabled = false` (certificate flow),
+    // Verify that with `pcool_flow_enabled = false` (certificate flow),
     // the consensus graduated shedding does NOT apply - only the binary
     // hard cutoff runs.
     consensus_adapter.set_num_inflight_transactions_for_testing(hard_limit as u64);

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
@@ -562,39 +562,37 @@ async fn execute_transaction_batch_with_checkpoint_inclusion() {
     }
 }
 
-/// Drop-guard that restores the white-flag env vars on scope exit so the
+/// Drop-guard that restores the P-COOL env vars on scope exit so the
 /// process-wide flag does not leak into sibling tests sharing this process.
 #[must_use = "bind the guard for the lifetime of the test"]
-struct WhiteFlagEnvGuard;
+struct PcoolEnvGuard;
 
-impl Drop for WhiteFlagEnvGuard {
+impl Drop for PcoolEnvGuard {
     fn drop(&mut self) {
-        // SAFETY: paired with `enable_white_flag_env`; both run on the test
+        // SAFETY: paired with `enable_pcool_env`; both run on the test
         // thread before/after the cluster is alive.
         unsafe {
             std::env::remove_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE");
-            std::env::remove_var(
-                "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_WHITE_FLAG_FLOW",
-            );
+            std::env::remove_var("IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW");
         }
     }
 }
 
-fn enable_white_flag_env() -> WhiteFlagEnvGuard {
+fn enable_pcool_env() -> PcoolEnvGuard {
     // SAFETY: must be set before the test cluster starts spawning validator
     // tasks; thread-local protocol-config overrides do not propagate across
     // spawned tasks outside msim.
     unsafe {
         std::env::set_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE", "1");
         std::env::set_var(
-            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_WHITE_FLAG_FLOW",
+            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW",
             "true",
         );
     }
-    WhiteFlagEnvGuard
+    PcoolEnvGuard
 }
 
-/// Skip-effect-certification path through the gRPC handler. With the white-flag
+/// Skip-effect-certification path through the gRPC handler. With the P-COOL
 /// flow enabled and `checkpoint_inclusion_timeout_ms` set, the handler must
 /// (1) drive the TD without a 2f+1 broadcast, (2) wait for local checkpoint
 /// inclusion, and (3) rebuild the response from the local cache so the client
@@ -607,7 +605,7 @@ fn enable_white_flag_env() -> WhiteFlagEnvGuard {
 /// the handler rather than a successful response.
 #[sim_test]
 async fn execute_transaction_v1_skip_cert_rebuilds_from_cache() {
-    let _env_guard = enable_white_flag_env();
+    let _env_guard = enable_pcool_env();
     let _proto_guard =
         iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_enable_pcool_flow_for_testing(true);
@@ -670,7 +668,7 @@ async fn execute_transaction_v1_skip_cert_rebuilds_from_cache() {
 /// "no successful response with uncertified data and no whole-RPC failure."
 #[sim_test]
 async fn execute_transaction_v1_skip_cert_no_quorum_yields_per_item_error() {
-    let _env_guard = enable_white_flag_env();
+    let _env_guard = enable_pcool_env();
     let _proto_guard =
         iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_enable_pcool_flow_for_testing(true);

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -371,50 +371,48 @@ async fn execute_transaction_v1() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// With the white-flag flow enabled, `WaitForLocalExecution` takes the
+/// With the P-COOL flow enabled, `WaitForLocalExecution` takes the
 /// skip-effect-certification path inside the orchestrator. The single-
 /// validator response tagged `UncertifiedSingleValidator` must be upgraded
 /// to `Checkpointed(epoch, seq)` by the local-cache reconciliation before
 /// being returned to the caller — otherwise the safety guard at the end of
 /// `execute_transaction_block` would reject the response as
 /// `QuorumDriverInternal`.
-/// Drop-guard that clears the white-flag env vars on scope exit, so a test
+/// Drop-guard that clears the P-COOL env vars on scope exit, so a test
 /// that enables the flow does not contaminate sibling tests sharing the same
 /// process (e.g. when run via `cargo nextest` with `--test-threads`).
 #[must_use = "drop the guard at the end of the test to restore env vars"]
-struct WhiteFlagEnvGuard;
+struct PcoolEnvGuard;
 
-impl Drop for WhiteFlagEnvGuard {
+impl Drop for PcoolEnvGuard {
     fn drop(&mut self) {
-        // SAFETY: paired with `enable_white_flag_env`; both calls run on the
+        // SAFETY: paired with `enable_pcool_env`; both calls run on the
         // test thread before/after the cluster is alive.
         unsafe {
             std::env::remove_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE");
-            std::env::remove_var(
-                "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_WHITE_FLAG_FLOW",
-            );
+            std::env::remove_var("IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW");
         }
     }
 }
 
-fn enable_white_flag_env() -> WhiteFlagEnvGuard {
+fn enable_pcool_env() -> PcoolEnvGuard {
     // SAFETY: set before spawning the test cluster; env vars are the only
-    // reliable way to flip the white-flag protocol flag inside validator
+    // reliable way to flip the P-COOL protocol flag inside validator
     // tasks spawned by the cluster (thread-local `apply_overrides_for_testing`
     // does not propagate to spawned tasks outside msim).
     unsafe {
         std::env::set_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE", "1");
         std::env::set_var(
-            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_WHITE_FLAG_FLOW",
+            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW",
             "true",
         );
     }
-    WhiteFlagEnvGuard
+    PcoolEnvGuard
 }
 
 #[sim_test]
 async fn test_skip_effect_cert_reconciles_to_checkpointed() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_white_flag_env();
+    let _env_guard = enable_pcool_env();
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -472,11 +470,11 @@ async fn test_skip_effect_cert_reconciles_to_checkpointed() -> Result<(), anyhow
     Ok(())
 }
 
-/// With the white-flag flow enabled, a caller that did *not* ask for events
+/// With the P-COOL flow enabled, a caller that did *not* ask for events
 /// or input/output objects must not receive them.
 #[sim_test]
 async fn test_skip_effect_cert_respects_request_flags() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_white_flag_env();
+    let _env_guard = enable_pcool_env();
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -536,7 +534,7 @@ async fn test_skip_effect_cert_respects_request_flags() -> Result<(), anyhow::Er
 /// page on-call for a routine availability dip.
 #[sim_test]
 async fn test_skip_effect_cert_timeout_without_quorum() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_white_flag_env();
+    let _env_guard = enable_pcool_env();
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -163,7 +163,7 @@ pub struct ValidatorComponents {
     validator_server_handle: SpawnOnce,
     validator_overload_monitor_handle: Option<JoinHandle<()>>,
     /// Handle for the consensus queue overload monitor task, present only
-    /// when the certificate-less (pcool / white-flag) flow is enabled. The
+    /// when the certificate-less (P-COOL) flow is enabled. The
     /// task self-terminates via `Weak` references; this handle exists purely
     /// for ownership clarity.
     consensus_queue_overload_monitor_handle: Option<JoinHandle<()>>,
@@ -1299,7 +1299,7 @@ impl IotaNode {
         // `consensus_queue_load_shedding_percentage` metric. Without this, the
         // metric goes stale once gRPC traffic stops (the only other update
         // path is `AuthorityState::check_consensus_queue_graduated_limits`, called on
-        // each inbound tx). Used in the certificate-less (pcool / white-flag)
+        // each inbound tx). Used in the certificate-less (P-COOL)
         // mode.
         let consensus_queue_overload_monitor_handle =
             if epoch_store.protocol_config().enable_pcool_flow() {


### PR DESCRIPTION
# Description of change

PR #11839 renamed the certificate-less transaction flow from "white flag flow" to "P-COOL flow" on `develop`, but the rename was never propagated to `consensus/feat/pcool-feature`, which carries the bulk of the P-COOL implementation. This applies the equivalent rename to the leftover flow-level references on this branch.

Following the same boundary as #11839, "white flag" is kept only where it names the owned-object **conflict-resolution algorithm** (`post_consensus_validation`, the dropped-tx cache, `validator_v2.proto`, and the `test_post_consensus_white_flag_*` conflict tests). Everything that describes the overall *flow* is renamed to P-COOL: the `check_system_overload` parameter, doc/inline comments, metric help strings, and the e2e test env-guard helpers.

One change is functional rather than cosmetic. The feature-flag override env var is name-derived — `ProtocolConfig` parses overrides via `serde_env::from_env_with_prefix("IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE")`, so the suffix must match the field name. The field is `enable_pcool_flow`, but the two e2e env guards still set `..._ENABLE_WHITE_FLAG_FLOW`, which no longer maps to any flag. The override was silently dropped and the flow left at its default (disabled), so those skip-cert tests were exercising the certificate flow rather than the P-COOL flow they intend to cover. Both guards now set `..._ENABLE_PCOOL_FLOW`.

Targets `consensus/feat/pcool-feature` since that is where the P-COOL feature integrates.

## Links to any relevant issues

fixes #12042

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes