### PR TITLE
fix(core): Return input/output objects for already-executed transactions

### DIFF
--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -217,12 +217,40 @@ impl ValidatorService {
                     None
                 };
 
+                let effects = signed_effects.data();
+
+                let input_objects = include_input_objects
+                    .then(|| self.state.get_transaction_input_objects(effects))
+                    .and_then(|res| {
+                        res.map_err(|e| {
+                            warn!(
+                                tx_digest = ?effects.transaction_digest(),
+                                error = ?e,
+                                "Failed to load transaction input objects requested by client",
+                            )
+                        })
+                        .ok()
+                    });
+
+                let output_objects = include_output_objects
+                    .then(|| self.state.get_transaction_output_objects(effects))
+                    .and_then(|res| {
+                        res.map_err(|e| {
+                            warn!(
+                                tx_digest = ?effects.transaction_digest(),
+                                error = ?e,
+                                "Failed to load transaction output objects requested by client",
+                            )
+                        })
+                        .ok()
+                    });
+
                 return Ok((
                     Some(vec![HandleCertificateResponseV1 {
                         signed_effects: signed_effects.into_inner(),
                         events,
-                        input_objects: None,
-                        output_objects: None,
+                        input_objects,
+                        output_objects,
                         auxiliary_data: None,
                     }]),
                     Weight::one(),


### PR DESCRIPTION
# Description of change

The already-executed fast path in `ValidatorService::handle_certificates`
returned the cached effects (and events) but hardcoded `input_objects: None`
and `output_objects: None`, ignoring the client's `include_input_objects` /
`include_output_objects` flags. Only the normal first-execution path fetched
them.

As a result, a re-execution returns empty input/output objects, which made the indexer skip optimistic indexing (logged as `cannot optimistically index because of missing in/out objs`).

This PR fetches the input/output objects in the already-executed path when requested.

## Links to any relevant issues

fixes #11979

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

