### PR TITLE
feat(core+node): add separate tokio runtime for serving API requests

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -683,14 +683,6 @@ pub fn default_grpc_api_config() -> Option<GrpcApiConfig> {
     Some(GrpcApiConfig::default())
 }
 
-/// Number of CPU cores available to the process, falling back to 8 when it
-/// cannot be determined.
-pub fn available_cpu_cores() -> usize {
-    std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(8)
-}
-
 pub fn default_concurrency_limit() -> Option<usize> {
     Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
 }
@@ -1522,11 +1514,6 @@ mod tests {
 
     use super::Genesis;
     use crate::NodeConfig;
-
-    #[test]
-    fn available_cpu_cores_is_never_zero() {
-        assert!(super::available_cpu_cores() >= 1);
-    }
 
     #[test]
     fn serialize_genesis_from_file() {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -37,8 +37,16 @@ use crate::{
     transaction_deny_config::TransactionDenyConfig, verifier_signing_config::VerifierSigningConfig,
 };
 
-// Default max number of concurrent requests served
+// Effectively-unlimited concurrency, used by tests that must not be throttled.
 pub const DEFAULT_GRPC_CONCURRENCY_LIMIT: usize = 20000000000;
+
+// Per-core ceiling on concurrent in-flight validator gRPC requests. Most
+// request time is spent awaiting locks, I/O or consensus rather than on-CPU, so
+// the ceiling is generous; its purpose is to bound total in-flight work so a
+// request flood cannot grow queues and memory without limit, not to throttle
+// normal load. Operators wanting hard load-shedding can lower
+// `grpc_concurrency_limit` and set `grpc_load_shed`.
+const GRPC_CONCURRENCY_LIMIT_PER_CORE: usize = 1000;
 
 /// Default gas price of 1000 Nanos
 pub const DEFAULT_VALIDATOR_GAS_PRICE: u64 = iota_types::transaction::DEFAULT_VALIDATOR_GAS_PRICE;
@@ -684,7 +692,10 @@ pub fn default_grpc_api_config() -> Option<GrpcApiConfig> {
 }
 
 pub fn default_concurrency_limit() -> Option<usize> {
-    Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8);
+    Some(cores.saturating_mul(GRPC_CONCURRENCY_LIMIT_PER_CORE))
 }
 
 pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -37,16 +37,8 @@ use crate::{
     transaction_deny_config::TransactionDenyConfig, verifier_signing_config::VerifierSigningConfig,
 };
 
-// Effectively-unlimited concurrency, used by tests that must not be throttled.
+// Default max number of concurrent requests served
 pub const DEFAULT_GRPC_CONCURRENCY_LIMIT: usize = 20000000000;
-
-// Per-core ceiling on concurrent in-flight validator gRPC requests. Most
-// request time is spent awaiting locks, I/O or consensus rather than on-CPU, so
-// the ceiling is generous; its purpose is to bound total in-flight work so a
-// request flood cannot grow queues and memory without limit, not to throttle
-// normal load. Operators wanting hard load-shedding can lower
-// `grpc_concurrency_limit` and set `grpc_load_shed`.
-const GRPC_CONCURRENCY_LIMIT_PER_CORE: usize = 1000;
 
 /// Default gas price of 1000 Nanos
 pub const DEFAULT_VALIDATOR_GAS_PRICE: u64 = iota_types::transaction::DEFAULT_VALIDATOR_GAS_PRICE;
@@ -700,7 +692,7 @@ pub fn available_cpu_cores() -> usize {
 }
 
 pub fn default_concurrency_limit() -> Option<usize> {
-    Some(available_cpu_cores().saturating_mul(GRPC_CONCURRENCY_LIMIT_PER_CORE))
+    Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
 }
 
 pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -691,11 +691,16 @@ pub fn default_grpc_api_config() -> Option<GrpcApiConfig> {
     Some(GrpcApiConfig::default())
 }
 
-pub fn default_concurrency_limit() -> Option<usize> {
-    let cores = std::thread::available_parallelism()
+/// Number of CPU cores available to the process, falling back to 8 when it
+/// cannot be determined.
+pub fn available_cpu_cores() -> usize {
+    std::thread::available_parallelism()
         .map(|n| n.get())
-        .unwrap_or(8);
-    Some(cores.saturating_mul(GRPC_CONCURRENCY_LIMIT_PER_CORE))
+        .unwrap_or(8)
+}
+
+pub fn default_concurrency_limit() -> Option<usize> {
+    Some(available_cpu_cores().saturating_mul(GRPC_CONCURRENCY_LIMIT_PER_CORE))
 }
 
 pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {
@@ -1525,6 +1530,11 @@ mod tests {
 
     use super::Genesis;
     use crate::NodeConfig;
+
+    #[test]
+    fn available_cpu_cores_is_never_zero() {
+        assert!(super::available_cpu_cores() >= 1);
+    }
 
     #[test]
     fn serialize_genesis_from_file() {

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -2,8 +2,41 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_config::NodeConfig;
+use iota_config::{NodeConfig, node::available_cpu_cores};
 use tokio::runtime::Runtime;
+
+/// Minimum number of worker threads for the serving runtime.
+const MIN_SERVING_THREADS: usize = 2;
+/// Minimum number of worker threads for the node-core runtime.
+const MIN_NODE_THREADS: usize = 4;
+
+/// Splits the available cores between the node-core and serving runtimes,
+/// returning `(node_threads, serving_threads)`.
+///
+/// A validator runs consensus and execution on the core and must protect it
+/// from client load, so it reserves most threads for the core. A fullnode has
+/// no consensus and exists primarily to serve reads, so it splits threads
+/// evenly. The two runtimes together never exceed `available`, except on
+/// machines with fewer than `MIN_NODE_THREADS + MIN_SERVING_THREADS` cores,
+/// where the minimum floors win.
+fn split_worker_threads(available: usize, is_validator: bool) -> (usize, usize) {
+    let serving_share = if is_validator {
+        available / 4
+    } else {
+        available / 2
+    }
+    .max(MIN_SERVING_THREADS);
+    // The core has priority: it gets everything the serving share does not use,
+    // but never fewer than its minimum. Serving then gets whatever is actually
+    // left, so the floors are the only way the split can exceed `available`.
+    let node_threads = available
+        .saturating_sub(serving_share)
+        .max(MIN_NODE_THREADS);
+    let serving_threads = available
+        .saturating_sub(node_threads)
+        .max(MIN_SERVING_THREADS);
+    (node_threads, serving_threads)
+}
 
 pub struct IotaRuntimes {
     // Order in this struct is the order in which runtimes are stopped.
@@ -21,22 +54,9 @@ pub struct IotaRuntimes {
 
 impl IotaRuntimes {
     pub fn new(config: &NodeConfig) -> Self {
-        let available = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(8);
-        // Split worker threads between the node core and the serving runtime
-        // according to the node's role. A validator runs consensus and execution
-        // on the core and must protect it from client load, so it reserves most
-        // threads for the core. A fullnode has no consensus and exists primarily
-        // to serve reads, so it favors the serving runtime. The split is sized so
-        // the two runtimes together do not oversubscribe the available cores.
         let is_validator = config.consensus_config().is_some();
-        let serving_threads = if is_validator {
-            (available / 4).max(2)
-        } else {
-            (available / 2).max(2)
-        };
-        let node_threads = available.saturating_sub(serving_threads).max(4);
+        let (node_threads, serving_threads) =
+            split_worker_threads(available_cpu_cores(), is_validator);
 
         let iota_node = tokio::runtime::Builder::new_multi_thread()
             .thread_name("iota-node-runtime")
@@ -61,6 +81,61 @@ impl IotaRuntimes {
             serving,
             iota_node,
             metrics,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validator_reserves_most_threads_for_the_core() {
+        assert_eq!(split_worker_threads(16, true), (12, 4));
+        assert_eq!(split_worker_threads(8, true), (6, 2));
+    }
+
+    #[test]
+    fn fullnode_splits_threads_evenly() {
+        assert_eq!(split_worker_threads(16, false), (8, 8));
+        assert_eq!(split_worker_threads(12, false), (6, 6));
+    }
+
+    #[test]
+    fn split_never_oversubscribes_above_the_minimum_floors() {
+        for available in (MIN_NODE_THREADS + MIN_SERVING_THREADS)..=256 {
+            for is_validator in [true, false] {
+                let (node, serving) = split_worker_threads(available, is_validator);
+                assert_eq!(
+                    node + serving,
+                    available,
+                    "oversubscribed with {available} cores (is_validator: {is_validator}): \
+                     node {node} + serving {serving}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn small_machines_fall_back_to_the_minimum_floors() {
+        for available in 1..(MIN_NODE_THREADS + MIN_SERVING_THREADS) {
+            for is_validator in [true, false] {
+                assert_eq!(
+                    split_worker_threads(available, is_validator),
+                    (MIN_NODE_THREADS, MIN_SERVING_THREADS),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn both_runtimes_always_get_their_minimum_threads() {
+        for available in 1..=256 {
+            for is_validator in [true, false] {
+                let (node, serving) = split_worker_threads(available, is_validator);
+                assert!(node >= MIN_NODE_THREADS);
+                assert!(serving >= MIN_SERVING_THREADS);
+            }
         }
     }
 }

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -6,15 +6,36 @@ use iota_config::NodeConfig;
 use tokio::runtime::Runtime;
 
 pub struct IotaRuntimes {
-    // Order in this struct is the order in which runtimes are stopped
+    // Order in this struct is the order in which runtimes are stopped.
+    /// Node core: consensus, execution, state sync, checkpoints and p2p
+    /// networking.
     pub iota_node: Runtime,
+    /// Client-facing servers (validator gRPC, JSON-RPC, gRPC read API) and the
+    /// per-request handlers they spawn. Isolated from `iota_node` so that a
+    /// flood of external requests cannot starve the node core.
+    pub serving: Runtime,
     pub metrics: Runtime,
 }
 
 impl IotaRuntimes {
     pub fn new(_config: &NodeConfig) -> Self {
+        let available = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8);
+        // Reserve half the cores for serving and keep the rest for the node core,
+        // so the two runtimes do not oversubscribe physical cores.
+        let serving_threads = (available / 2).max(2);
+        let node_threads = available.saturating_sub(serving_threads).max(4);
+
         let iota_node = tokio::runtime::Builder::new_multi_thread()
             .thread_name("iota-node-runtime")
+            .worker_threads(node_threads)
+            .enable_all()
+            .build()
+            .unwrap();
+        let serving = tokio::runtime::Builder::new_multi_thread()
+            .thread_name("serving-runtime")
+            .worker_threads(serving_threads)
             .enable_all()
             .build()
             .unwrap();
@@ -25,6 +46,10 @@ impl IotaRuntimes {
             .build()
             .unwrap();
 
-        Self { iota_node, metrics }
+        Self {
+            iota_node,
+            serving,
+            metrics,
+        }
     }
 }

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -18,13 +18,22 @@ pub struct IotaRuntimes {
 }
 
 impl IotaRuntimes {
-    pub fn new(_config: &NodeConfig) -> Self {
+    pub fn new(config: &NodeConfig) -> Self {
         let available = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(8);
-        // Reserve half the cores for serving and keep the rest for the node core,
-        // so the two runtimes do not oversubscribe physical cores.
-        let serving_threads = (available / 2).max(2);
+        // Split worker threads between the node core and the serving runtime
+        // according to the node's role. A validator runs consensus and execution
+        // on the core and must protect it from client load, so it reserves most
+        // threads for the core. A fullnode has no consensus and exists primarily
+        // to serve reads, so it favors the serving runtime. The split is sized so
+        // the two runtimes together do not oversubscribe the available cores.
+        let is_validator = config.consensus_config().is_some();
+        let serving_threads = if is_validator {
+            (available / 4).max(2)
+        } else {
+            (available / 2).max(2)
+        };
         let node_threads = available.saturating_sub(serving_threads).max(4);
 
         let iota_node = tokio::runtime::Builder::new_multi_thread()

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -7,13 +7,15 @@ use tokio::runtime::Runtime;
 
 pub struct IotaRuntimes {
     // Order in this struct is the order in which runtimes are stopped.
+    /// Client-facing servers (validator gRPC, JSON-RPC, gRPC read API) and the
+    /// per-request handlers they spawn. Isolated from `iota_node` so that a
+    /// flood of external requests cannot starve the node core. Stopped first so
+    /// that client requests are cut off before the node core they call into is
+    /// torn down.
+    pub serving: Runtime,
     /// Node core: consensus, execution, state sync, checkpoints and p2p
     /// networking.
     pub iota_node: Runtime,
-    /// Client-facing servers (validator gRPC, JSON-RPC, gRPC read API) and the
-    /// per-request handlers they spawn. Isolated from `iota_node` so that a
-    /// flood of external requests cannot starve the node core.
-    pub serving: Runtime,
     pub metrics: Runtime,
 }
 
@@ -56,8 +58,8 @@ impl IotaRuntimes {
             .unwrap();
 
         Self {
-            iota_node,
             serving,
+            iota_node,
             metrics,
         }
     }

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -9,9 +9,8 @@ use tokio::runtime::Runtime;
 const MIN_SERVING_THREADS: usize = 2;
 /// Minimum number of worker threads for the node-core runtime.
 const MIN_NODE_THREADS: usize = 4;
-/// Number of worker threads for the metrics runtime. Deliberately not part of
-/// the node/serving split: it is small and mostly idle, so oversubscribing by
-/// this amount is cheaper than taking the threads away from the core.
+/// Number of worker threads for the metrics runtime. Small and mostly idle;
+/// sits outside [`size_worker_threads`].
 const METRICS_THREADS: usize = 2;
 
 /// Number of CPU cores available to the process, falling back to 8 when it
@@ -22,33 +21,26 @@ pub fn available_cpu_cores() -> usize {
         .unwrap_or(8)
 }
 
-/// Splits the available cores between the node-core and serving runtimes,
-/// returning `(node_threads, serving_threads)`.
+/// Sizes the node-core and serving runtimes, returning `(node_threads,
+/// serving_threads)`.
 ///
-/// A validator runs consensus and execution on the core and must protect it
-/// from client load, so it reserves most threads for the core. A fullnode has
-/// no consensus and exists primarily to serve reads, so it splits threads
-/// evenly. The two runtimes together never exceed `available`, except on
-/// machines with fewer than `MIN_NODE_THREADS + MIN_SERVING_THREADS` cores,
-/// where the minimum floors win. The metrics runtime sits outside this split
-/// (see [`METRICS_THREADS`]), so the process as a whole runs `METRICS_THREADS`
-/// more workers than `available`.
-fn split_worker_threads(available: usize, is_validator: bool) -> (usize, usize) {
-    let serving_share = if is_validator {
+/// The core always gets one worker per available core, so it can use the
+/// whole machine while serving is idle. The serving workers are added on top,
+/// deliberately oversubscribing the machine: a worker blocked in RocksDB
+/// frees its core for the other runtime, and when both runtimes are saturated
+/// the OS schedules fairly per thread, so the serving pool's size relative to
+/// the core pool bounds the CPU share serving can take. A validator caps
+/// serving at a quarter of the cores (at most ~20% of the machine under
+/// saturation) to protect consensus and execution; a fullnode, whose primary
+/// job is serving reads, allows half (~33%).
+fn size_worker_threads(available: usize, is_validator: bool) -> (usize, usize) {
+    let node_threads = available.max(MIN_NODE_THREADS);
+    let serving_threads = if is_validator {
         available / 4
     } else {
         available / 2
     }
     .max(MIN_SERVING_THREADS);
-    // The core has priority: it gets everything the serving share does not use,
-    // but never fewer than its minimum. Serving then gets whatever is actually
-    // left, so the floors are the only way the split can exceed `available`.
-    let node_threads = available
-        .saturating_sub(serving_share)
-        .max(MIN_NODE_THREADS);
-    let serving_threads = available
-        .saturating_sub(node_threads)
-        .max(MIN_SERVING_THREADS);
     (node_threads, serving_threads)
 }
 
@@ -70,7 +62,7 @@ impl IotaRuntimes {
     pub fn new(config: &NodeConfig) -> Self {
         let is_validator = config.consensus_config().is_some();
         let (node_threads, serving_threads) =
-            split_worker_threads(available_cpu_cores(), is_validator);
+            size_worker_threads(available_cpu_cores(), is_validator);
 
         let iota_node = tokio::runtime::Builder::new_multi_thread()
             .thread_name("iota-node-runtime")
@@ -109,39 +101,26 @@ mod tests {
     }
 
     #[test]
-    fn validator_reserves_most_threads_for_the_core() {
-        assert_eq!(split_worker_threads(16, true), (12, 4));
-        assert_eq!(split_worker_threads(8, true), (6, 2));
+    fn validator_serving_gets_a_quarter_of_the_cores() {
+        assert_eq!(size_worker_threads(16, true), (16, 4));
+        assert_eq!(size_worker_threads(8, true), (8, 2));
     }
 
     #[test]
-    fn fullnode_splits_threads_evenly() {
-        assert_eq!(split_worker_threads(16, false), (8, 8));
-        assert_eq!(split_worker_threads(12, false), (6, 6));
+    fn fullnode_serving_gets_half_of_the_cores() {
+        assert_eq!(size_worker_threads(16, false), (16, 8));
+        assert_eq!(size_worker_threads(12, false), (12, 6));
     }
 
     #[test]
-    fn split_never_oversubscribes_above_the_minimum_floors() {
-        for available in (MIN_NODE_THREADS + MIN_SERVING_THREADS)..=256 {
+    fn the_core_always_gets_one_thread_per_core() {
+        for available in MIN_NODE_THREADS..=256 {
             for is_validator in [true, false] {
-                let (node, serving) = split_worker_threads(available, is_validator);
+                let (node, _) = size_worker_threads(available, is_validator);
                 assert_eq!(
-                    node + serving,
-                    available,
-                    "oversubscribed with {available} cores (is_validator: {is_validator}): \
-                     node {node} + serving {serving}",
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn small_machines_fall_back_to_the_minimum_floors() {
-        for available in 1..(MIN_NODE_THREADS + MIN_SERVING_THREADS) {
-            for is_validator in [true, false] {
-                assert_eq!(
-                    split_worker_threads(available, is_validator),
-                    (MIN_NODE_THREADS, MIN_SERVING_THREADS),
+                    node, available,
+                    "core throttled below the machine size with {available} cores \
+                     (is_validator: {is_validator})",
                 );
             }
         }
@@ -151,7 +130,7 @@ mod tests {
     fn both_runtimes_always_get_their_minimum_threads() {
         for available in 1..=256 {
             for is_validator in [true, false] {
-                let (node, serving) = split_worker_threads(available, is_validator);
+                let (node, serving) = size_worker_threads(available, is_validator);
                 assert!(node >= MIN_NODE_THREADS);
                 assert!(serving >= MIN_SERVING_THREADS);
             }

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_config::{NodeConfig, node::available_cpu_cores};
+use iota_config::NodeConfig;
 use tokio::runtime::Runtime;
 
 /// Minimum number of worker threads for the serving runtime.
@@ -13,6 +13,14 @@ const MIN_NODE_THREADS: usize = 4;
 /// the node/serving split: it is small and mostly idle, so oversubscribing by
 /// this amount is cheaper than taking the threads away from the core.
 const METRICS_THREADS: usize = 2;
+
+/// Number of CPU cores available to the process, falling back to 8 when it
+/// cannot be determined.
+pub fn available_cpu_cores() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8)
+}
 
 /// Splits the available cores between the node-core and serving runtimes,
 /// returning `(node_threads, serving_threads)`.
@@ -94,6 +102,11 @@ impl IotaRuntimes {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn available_cpu_cores_is_never_zero() {
+        assert!(super::available_cpu_cores() >= 1);
+    }
 
     #[test]
     fn validator_reserves_most_threads_for_the_core() {

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -9,6 +9,10 @@ use tokio::runtime::Runtime;
 const MIN_SERVING_THREADS: usize = 2;
 /// Minimum number of worker threads for the node-core runtime.
 const MIN_NODE_THREADS: usize = 4;
+/// Number of worker threads for the metrics runtime. Deliberately not part of
+/// the node/serving split: it is small and mostly idle, so oversubscribing by
+/// this amount is cheaper than taking the threads away from the core.
+const METRICS_THREADS: usize = 2;
 
 /// Splits the available cores between the node-core and serving runtimes,
 /// returning `(node_threads, serving_threads)`.
@@ -18,7 +22,9 @@ const MIN_NODE_THREADS: usize = 4;
 /// no consensus and exists primarily to serve reads, so it splits threads
 /// evenly. The two runtimes together never exceed `available`, except on
 /// machines with fewer than `MIN_NODE_THREADS + MIN_SERVING_THREADS` cores,
-/// where the minimum floors win.
+/// where the minimum floors win. The metrics runtime sits outside this split
+/// (see [`METRICS_THREADS`]), so the process as a whole runs `METRICS_THREADS`
+/// more workers than `available`.
 fn split_worker_threads(available: usize, is_validator: bool) -> (usize, usize) {
     let serving_share = if is_validator {
         available / 4
@@ -72,7 +78,7 @@ impl IotaRuntimes {
             .unwrap();
         let metrics = tokio::runtime::Builder::new_multi_thread()
             .thread_name("metrics-runtime")
-            .worker_threads(2)
+            .worker_threads(METRICS_THREADS)
             .enable_all()
             .build()
             .unwrap();

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -42,6 +42,10 @@ pub mod metered_channel;
 pub mod metric_groups;
 pub mod metrics_network;
 pub mod monitored_mpsc;
+// Relies on tokio's `RuntimeMetrics`, which the deterministic simulator's tokio
+// fork does not provide; the node only starts these monitors outside simtests.
+#[cfg(not(msim))]
+pub mod runtime_metrics;
 pub mod thread_stall_monitor;
 pub use guards::*;
 pub use metric_groups::{MetricGroups, MetricLevel};

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -124,8 +124,8 @@ pub struct MetricGroups {
     /// `authority` group's gRPC transport metrics.
     pub epoch: MetricLevel,
     /// Async-runtime and process health: monitored tokio tasks, channels, and
-    /// scopes, thread stalls, invariant violations, and tracing span
-    /// latencies.
+    /// scopes, per-runtime tokio scheduler metrics (`tokio_runtime_*`), thread
+    /// stalls, invariant violations, and tracing span latencies.
     ///
     /// Modules: `iota_metrics` (except the `hardware` and `p2p` group
     /// submodules), `telemetry_subscribers`.

--- a/crates/iota-metrics/src/runtime_metrics.rs
+++ b/crates/iota-metrics/src/runtime_metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! Per-runtime observability for the tokio runtimes the node runs on.
@@ -15,7 +15,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use prometheus::{
+use prometheus_filtered::{
     HistogramVec, IntGaugeVec, Registry, register_histogram_vec_with_registry,
     register_int_gauge_vec_with_registry,
 };

--- a/crates/iota-metrics/src/runtime_metrics.rs
+++ b/crates/iota-metrics/src/runtime_metrics.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-runtime observability for the tokio runtimes the node runs on.
+//!
+//! The node splits work across separate tokio runtimes (notably a node-core
+//! runtime and a client-facing serving runtime). These metrics make it possible
+//! to tell whether one runtime is starving another for worker threads: the
+//! `scheduler_lag_seconds` heartbeat and a non-zero `global_queue_depth` are
+//! the direct signals of a runtime whose workers cannot keep up with ready
+//! tasks.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use prometheus::{
+    HistogramVec, IntGaugeVec, Registry, register_histogram_vec_with_registry,
+    register_int_gauge_vec_with_registry,
+};
+use tokio::runtime::Handle;
+
+/// How often the tokio runtime counters are sampled.
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
+/// How often the scheduler-lag heartbeat fires.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(100);
+
+pub struct RuntimeMonitorMetrics {
+    workers: IntGaugeVec,
+    alive_tasks: IntGaugeVec,
+    global_queue_depth: IntGaugeVec,
+    scheduler_lag_seconds: HistogramVec,
+}
+
+impl RuntimeMonitorMetrics {
+    pub fn new(registry: &Registry) -> Arc<Self> {
+        Arc::new(Self {
+            workers: register_int_gauge_vec_with_registry!(
+                "tokio_runtime_workers",
+                "Number of worker threads in the tokio runtime.",
+                &["runtime"],
+                registry,
+            )
+            .unwrap(),
+            alive_tasks: register_int_gauge_vec_with_registry!(
+                "tokio_runtime_alive_tasks",
+                "Number of alive (spawned, not yet completed) tasks in the tokio runtime.",
+                &["runtime"],
+                registry,
+            )
+            .unwrap(),
+            global_queue_depth: register_int_gauge_vec_with_registry!(
+                "tokio_runtime_global_queue_depth",
+                "Tasks waiting in the runtime's global injection queue. A persistently \
+                 non-zero value means the workers cannot keep up with ready tasks.",
+                &["runtime"],
+                registry,
+            )
+            .unwrap(),
+            scheduler_lag_seconds: register_histogram_vec_with_registry!(
+                "tokio_runtime_scheduler_lag_seconds",
+                "Delay between when a fixed-interval heartbeat task was scheduled to wake \
+                 and when it actually ran. High values indicate worker-thread starvation.",
+                &["runtime"],
+                vec![
+                    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0
+                ],
+                registry,
+            )
+            .unwrap(),
+        })
+    }
+}
+
+/// Starts background monitoring of the tokio runtime identified by `handle`,
+/// labelling all metrics with `runtime`.
+///
+/// Both the counter sampler and the scheduler-lag heartbeat run *on the
+/// monitored runtime* so that the heartbeat observes that runtime's scheduling
+/// latency directly.
+pub fn start_runtime_monitor(
+    runtime: &'static str,
+    handle: &Handle,
+    metrics: Arc<RuntimeMonitorMetrics>,
+) {
+    // Sampler: periodically read the stable RuntimeMetrics counters.
+    {
+        let runtime_metrics = handle.metrics();
+        let workers = metrics.workers.with_label_values(&[runtime]);
+        let alive_tasks = metrics.alive_tasks.with_label_values(&[runtime]);
+        let global_queue_depth = metrics.global_queue_depth.with_label_values(&[runtime]);
+        handle.spawn(async move {
+            loop {
+                workers.set(runtime_metrics.num_workers() as i64);
+                alive_tasks.set(runtime_metrics.num_alive_tasks() as i64);
+                global_queue_depth.set(runtime_metrics.global_queue_depth() as i64);
+                tokio::time::sleep(SAMPLE_INTERVAL).await;
+            }
+        });
+    }
+
+    // Heartbeat: the excess of the actual sleep duration over the intended
+    // interval is the time the task spent waiting for a free worker thread.
+    {
+        let lag = metrics.scheduler_lag_seconds.with_label_values(&[runtime]);
+        handle.spawn(async move {
+            loop {
+                let start = Instant::now();
+                tokio::time::sleep(HEARTBEAT_INTERVAL).await;
+                let lag_secs = start
+                    .elapsed()
+                    .saturating_sub(HEARTBEAT_INTERVAL)
+                    .as_secs_f64();
+                lag.observe(lag_secs);
+            }
+        });
+    }
+}

--- a/crates/iota-metrics/src/runtime_metrics.rs
+++ b/crates/iota-metrics/src/runtime_metrics.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use prometheus_filtered::{
-    HistogramVec, IntGaugeVec, Registry, register_histogram_vec_with_registry,
+    HistogramVec, IntGaugeVec, MetricLevel, Registry, register_histogram_vec_with_registry,
     register_int_gauge_vec_with_registry,
 };
 use tokio::runtime::Handle;
@@ -40,14 +40,16 @@ impl RuntimeMonitorMetrics {
                 "tokio_runtime_workers",
                 "Number of worker threads in the tokio runtime.",
                 &["runtime"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             alive_tasks: register_int_gauge_vec_with_registry!(
                 "tokio_runtime_alive_tasks",
                 "Number of alive (spawned, not yet completed) tasks in the tokio runtime.",
                 &["runtime"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             global_queue_depth: register_int_gauge_vec_with_registry!(
@@ -55,7 +57,8 @@ impl RuntimeMonitorMetrics {
                 "Tasks waiting in the runtime's global injection queue. A persistently \
                  non-zero value means the workers cannot keep up with ready tasks.",
                 &["runtime"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             scheduler_lag_seconds: register_histogram_vec_with_registry!(
@@ -66,7 +69,8 @@ impl RuntimeMonitorMetrics {
                 vec![
                     0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0
                 ],
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
         })

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2433,19 +2433,25 @@ impl SpawnOnce {
     pub async fn start(self) -> Self {
         match self {
             Self::Unstarted(future, serving_rt_handle) => {
-                let server = future
-                    .into_inner()
-                    .await
-                    .unwrap_or_else(|err| panic!("Failed to start validator gRPC server: {err}"));
-                let handle = server.handle().clone();
-                // Serve client requests on the dedicated serving runtime so that
-                // request load never shares worker threads with the node core.
+                // bind() and serve() must execute on the serving runtime:
+                // iota_http::Builder::serve captures Handle::current() there for
+                // the accept loop and every request handler.
+                let (handle_tx, handle_rx) = tokio::sync::oneshot::channel();
                 serving_rt_handle.spawn(async move {
+                    let server = future.into_inner().await.unwrap_or_else(|err| {
+                        panic!("Failed to start validator gRPC server: {err}")
+                    });
+                    if handle_tx.send(server.handle().clone()).is_err() {
+                        return;
+                    }
                     if let Err(err) = server.serve().await {
                         info!("Server stopped: {err}");
                     }
                     info!("Server stopped");
                 });
+                let handle = handle_rx
+                    .await
+                    .expect("validator gRPC server exited before returning its handle");
                 Self::Started(handle)
             }
             Self::Started(_) => self,
@@ -2742,4 +2748,104 @@ fn max_tx_per_checkpoint(protocol_config: &ProtocolConfig) -> usize {
 #[cfg(test)]
 fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
     2
+}
+
+// Not msim: this test asserts routing across real OS worker-thread pools by
+// name, which the deterministic simulator collapses onto a single thread.
+#[cfg(all(test, not(msim)))]
+mod runtime_split_tests {
+    use std::{
+        sync::mpsc,
+        time::{Duration, Instant},
+    };
+
+    use anyhow::anyhow;
+
+    use super::SpawnOnce;
+
+    /// A single-worker-thread runtime whose worker thread carries `name`, so a
+    /// task can tell which runtime it is running on via `current_pool()`.
+    fn runtime(name: &'static str) -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name(name)
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    /// Name of the runtime whose worker thread is executing this code.
+    fn current_pool() -> String {
+        std::thread::current()
+            .name()
+            .unwrap_or("<unnamed>")
+            .to_string()
+    }
+
+    /// Regression guard for the runtime split. `SpawnOnce::start()` is invoked
+    /// on the node-core runtime (as `IotaNode::start_async` does), but it
+    /// must run the server *bind* on the serving runtime:
+    /// `iota_http::Builder::serve` captures `Handle::current()` there for
+    /// the accept loop and every request handler.
+    ///
+    /// The test records the runtime `start()` runs on and the runtime the bind
+    /// runs on, and asserts the former is node-core and the latter is
+    /// serving (so they differ). With the pre-fix inline bind the bind ran
+    /// on the caller (node-core) runtime, and this test fails.
+    #[test]
+    fn spawn_once_binds_on_serving_not_the_core_runtime() {
+        let node = runtime("node-core");
+        let serving = runtime("serving");
+        let (tx, rx) = mpsc::channel::<(&'static str, String)>();
+
+        // The "bind" future records where it runs, then binds a minimal real
+        // server (health service only) on an ephemeral port.
+        let bind_tx = tx.clone();
+        let bind_future = async move {
+            let _ = bind_tx.send(("bind", current_pool()));
+            let addr = "/ip4/127.0.0.1/tcp/0/http".parse().unwrap();
+            let server = iota_network_stack::config::Config::new()
+                .server_builder()
+                .bind(&addr, None)
+                .await
+                .map_err(|e| anyhow!("bind failed: {e}"))?;
+            Ok(server)
+        };
+        let once = SpawnOnce::new(bind_future, serving.handle().clone());
+
+        // Drive start() ON the node-core runtime and record the runtime it runs on.
+        let caller_tx = tx.clone();
+        node.spawn(async move {
+            let _ = caller_tx.send(("caller", current_pool()));
+            let _ = once.start().await;
+        });
+
+        // Collect both readings.
+        let (mut caller_pool, mut bind_pool) = (None, None);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while (caller_pool.is_none() || bind_pool.is_none()) && Instant::now() < deadline {
+            if let Ok((which, pool)) = rx.recv_timeout(Duration::from_millis(200)) {
+                match which {
+                    "caller" => caller_pool = Some(pool),
+                    "bind" => bind_pool = Some(pool),
+                    _ => {}
+                }
+            }
+        }
+        let caller_pool = caller_pool.expect("start() never ran");
+        let bind_pool = bind_pool.expect("bind future never ran");
+
+        assert!(
+            caller_pool.starts_with("node-core"),
+            "start() should run on the node-core runtime, ran on: {caller_pool}"
+        );
+        assert!(
+            bind_pool.starts_with("serving"),
+            "server bind must run on the serving runtime, ran on: {bind_pool}"
+        );
+        assert_ne!(
+            caller_pool, bind_pool,
+            "the fix must move the bind off the caller (node-core) runtime onto serving"
+        );
+    }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -386,6 +386,25 @@ impl IotaNode {
         #[cfg(not(msim))]
         iota_metrics::thread_stall_monitor::start_thread_stall_monitor();
 
+        // Monitor the node-core and serving runtimes so that worker-thread
+        // starvation between them is observable. Gated out of simtests, where
+        // tokio runs under the deterministic simulator.
+        #[cfg(not(msim))]
+        {
+            let runtime_monitor_metrics =
+                iota_metrics::runtime_metrics::RuntimeMonitorMetrics::new(&prometheus_registry);
+            iota_metrics::runtime_metrics::start_runtime_monitor(
+                "iota_node",
+                &tokio::runtime::Handle::current(),
+                runtime_monitor_metrics.clone(),
+            );
+            iota_metrics::runtime_metrics::start_runtime_monitor(
+                "serving",
+                &serving_rt_handle,
+                runtime_monitor_metrics,
+            );
+        }
+
         // Register uptime metric
         prometheus_registry
             .register(iota_metrics::uptime_metric(

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -267,6 +267,10 @@ pub struct IotaNode {
     // TODO: Eventually we can make this auth aggregator a shared reference so that this
     // update will automatically propagate to other uses.
     auth_agg: Arc<ArcSwap<AuthorityAggregator<NetworkAuthorityClient>>>,
+
+    /// Runtime that hosts the client-facing servers and their per-request
+    /// handlers, isolating external request load from the node core.
+    serving_rt_handle: tokio::runtime::Handle,
 }
 
 impl fmt::Debug for IotaNode {
@@ -286,6 +290,7 @@ impl IotaNode {
             config,
             registry_service,
             ServerVersion::new("iota-node", "unknown"),
+            tokio::runtime::Handle::current(),
         )
         .await
     }
@@ -339,6 +344,7 @@ impl IotaNode {
         config: NodeConfig,
         registry_service: RegistryService,
         server_version: ServerVersion,
+        serving_rt_handle: tokio::runtime::Handle,
     ) -> Result<Arc<IotaNode>> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
         let mut config = config.clone();
@@ -746,13 +752,27 @@ impl IotaNode {
             None
         };
 
-        let http_server = build_http_server(
-            state.clone(),
-            &transaction_orchestrator.clone(),
-            &config,
-            &prometheus_registry,
-        )
-        .await?;
+        // Run the JSON-RPC server (and its per-request handlers) on the serving
+        // runtime. `iota_http::Builder::serve` spawns the accept loop via
+        // `Handle::current()`, so the builder must execute on the serving runtime.
+        let http_server = serving_rt_handle
+            .spawn({
+                let state = state.clone();
+                let transaction_orchestrator = transaction_orchestrator.clone();
+                let config = config.clone();
+                let prometheus_registry = prometheus_registry.clone();
+                async move {
+                    build_http_server(
+                        state,
+                        &transaction_orchestrator,
+                        &config,
+                        &prometheus_registry,
+                    )
+                    .await
+                }
+            })
+            .await
+            .expect("Failed to join JSON-RPC server startup task")?;
 
         let global_state_hasher = Arc::new(GlobalStateHasher::new(
             cache_traits.global_state_hash_store.clone(),
@@ -799,15 +819,28 @@ impl IotaNode {
                 .clone()
                 .map(|o| o as Arc<dyn iota_types::transaction_executor::TransactionExecutor>);
 
-        let grpc_server_handle = build_grpc_server(
-            &config,
-            state.clone(),
-            state_sync_store.clone(),
-            executor,
-            &prometheus_registry,
-            server_version,
-        )
-        .await?;
+        // Run the gRPC read API server (and its per-request handlers) on the
+        // serving runtime, for the same reason as the JSON-RPC server above.
+        let grpc_server_handle = serving_rt_handle
+            .spawn({
+                let config = config.clone();
+                let state = state.clone();
+                let state_sync_store = state_sync_store.clone();
+                let prometheus_registry = prometheus_registry.clone();
+                async move {
+                    build_grpc_server(
+                        &config,
+                        state,
+                        state_sync_store,
+                        executor,
+                        &prometheus_registry,
+                        server_version,
+                    )
+                    .await
+                }
+            })
+            .await
+            .expect("Failed to join gRPC server startup task")?;
 
         let validator_components = if state.is_committee_validator(&epoch_store) {
             let (components, _) = futures::join!(
@@ -823,6 +856,7 @@ impl IotaNode {
                     backpressure_manager.clone(),
                     connection_monitor_status.clone(),
                     &registry_service,
+                    serving_rt_handle.clone(),
                 ),
                 Self::reexecute_pending_consensus_certs(&epoch_store, &state,)
             );
@@ -872,6 +906,8 @@ impl IotaNode {
             grpc_server_handle: Mutex::new(grpc_server_handle),
 
             auth_agg,
+
+            serving_rt_handle,
         };
 
         info!("IotaNode started!");
@@ -1186,6 +1222,7 @@ impl IotaNode {
         backpressure_manager: Arc<BackpressureManager>,
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
         registry_service: &RegistryService,
+        serving_rt_handle: tokio::runtime::Handle,
     ) -> Result<ValidatorComponents> {
         let mut config_clone = config.clone();
         let consensus_config = config_clone
@@ -1255,6 +1292,7 @@ impl IotaNode {
             &validator_registry,
             soft_locks.clone(),
             validator_service_metrics.clone(),
+            serving_rt_handle,
         )
         .await?;
 
@@ -1548,6 +1586,7 @@ impl IotaNode {
         prometheus_registry: &Registry,
         soft_locks: Arc<PreConsensusSoftLocks>,
         validator_service_metrics: Arc<ValidatorServiceMetrics>,
+        serving_rt_handle: tokio::runtime::Handle,
     ) -> Result<SpawnOnce> {
         let validator_service = ValidatorService::new(
             state,
@@ -1585,7 +1624,7 @@ impl IotaNode {
             Ok(server)
         };
 
-        Ok(SpawnOnce::new(bind_future))
+        Ok(SpawnOnce::new(bind_future, serving_rt_handle))
     }
 
     /// Re-executes pending consensus certificates, which may not have been
@@ -2093,6 +2132,7 @@ impl IotaNode {
                         self.backpressure_manager.clone(),
                         self.connection_monitor_status.clone(),
                         &self.registry_service,
+                        self.serving_rt_handle.clone(),
                     )
                     .await?;
 
@@ -2355,7 +2395,10 @@ impl IotaNode {
 
 enum SpawnOnce {
     // Mutex is only needed to make SpawnOnce Sync
-    Unstarted(Mutex<BoxFuture<'static, Result<iota_network_stack::server::Server>>>),
+    Unstarted(
+        Mutex<BoxFuture<'static, Result<iota_network_stack::server::Server>>>,
+        tokio::runtime::Handle,
+    ),
     #[allow(unused)]
     Started(iota_http::ServerHandle),
 }
@@ -2363,19 +2406,22 @@ enum SpawnOnce {
 impl SpawnOnce {
     pub fn new(
         future: impl Future<Output = Result<iota_network_stack::server::Server>> + Send + 'static,
+        serving_rt_handle: tokio::runtime::Handle,
     ) -> Self {
-        Self::Unstarted(Mutex::new(Box::pin(future)))
+        Self::Unstarted(Mutex::new(Box::pin(future)), serving_rt_handle)
     }
 
     pub async fn start(self) -> Self {
         match self {
-            Self::Unstarted(future) => {
+            Self::Unstarted(future, serving_rt_handle) => {
                 let server = future
                     .into_inner()
                     .await
                     .unwrap_or_else(|err| panic!("Failed to start validator gRPC server: {err}"));
                 let handle = server.handle().clone();
-                tokio::spawn(async move {
+                // Serve client requests on the dedicated serving runtime so that
+                // request load never shares worker threads with the node core.
+                serving_rt_handle.spawn(async move {
                     if let Err(err) = server.serve().await {
                         info!("Server stopped: {err}");
                     }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -282,6 +282,16 @@ impl fmt::Debug for IotaNode {
 }
 
 impl IotaNode {
+    /// Starts a node that hosts the client-facing servers on the caller's
+    /// runtime, alongside everything else.
+    ///
+    /// This is intentional: this entry point serves the in-process nodes of
+    /// iota-swarm, where a separate serving runtime is either impossible
+    /// (simtests must keep every task on the simulator's deterministic
+    /// scheduler) or not worth the threads (thread-mode swarm runs many nodes
+    /// per process). Only the `iota-node` binary isolates client-facing
+    /// request handling on the dedicated serving runtime of `IotaRuntimes`,
+    /// via [`IotaNode::start_async`].
     pub async fn start(
         config: NodeConfig,
         registry_service: RegistryService,

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -146,9 +146,15 @@ fn main() {
     // let iota-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
+    // Client-facing servers run on a dedicated runtime so that external request
+    // load never shares worker threads with the node core on `iota_node`.
+    let serving_rt_handle = runtimes.serving.handle().clone();
+
     runtimes.iota_node.spawn(async move {
         let server_version = ServerVersion::new(env!("CARGO_BIN_NAME"), VERSION);
-        match IotaNode::start_async(config, registry_service, server_version).await {
+        match IotaNode::start_async(config, registry_service, server_version, serving_rt_handle)
+            .await
+        {
             Ok(iota_node) => node_once_cell_clone
                 .set(iota_node)
                 .expect("Failed to set node in AsyncOnceCell"),


### PR DESCRIPTION
# Description of change

## Problem

A validator runs everything on a single shared multi-threaded tokio runtime (iota_node). When the node signs/votes on a flood of incoming user transactions (creating certificates), those request-handler tasks saturate the shared worker threads, starving latency-critical node-core work — consensus commit processing and checkpoint signature creation — because all tasks compete for the same threads (tokio::spawn inherits Handle::current(), so request handlers and core tasks land on the same runtime).

## Approach

Carve all externally-triggered, client-facing server work onto a dedicated serving runtime, leaving the node core — consensus, execution, state sync, checkpoints, reconfiguration, and all peer-to-peer networking — alone on iota_node. Each client-facing server in the process has a single entry task (one tokio::spawn); routing that entry task onto the serving runtime moves the whole accept loop and every per-request handler with it, via runtime inheritance.

## The three commits:

1. add separate tokio runtime for serving API requests — Adds a serving runtime to IotaRuntimes, plumbs its Handle from main.rs through IotaNode, and re-homes the three client-facing servers onto it:
  - Validator client gRPC (transaction / handle_certificate) via SpawnOnce.
  - JSON-RPC HTTP server (fullnode).
  - gRPC read API server (fullnode).

The node core and p2p networking are untouched. The validator-to-validator consensus hot path runs on the separate Starfish/anemo network and is unaffected; the validator-peer gRPC carried on the moved listener is only a read-only GetCheckpoint plus rare control-plane RPCs.

2. add tokio runtime metrics — Adds per-runtime observability (iota-metrics/src/runtime_metrics.rs), exporting, labelled per runtime:
  - tokio_runtime_workers, tokio_runtime_alive_tasks, tokio_runtime_global_queue_depth (stable tokio RuntimeMetrics)
  - tokio_runtime_scheduler_lag_seconds — a heartbeat histogram measuring wake-up delay, the direct signal of worker-thread starvation.

Started for both iota_node and serving. Gated #[cfg(not(msim))] because the simulator's tokio fork lacks Handle::metrics() (mirrors thread_stall_monitor).

3. optimize runtime worker threads per node role — The core runtime always gets one worker per available core, so it can use the whole machine while serving is idle. The serving workers are added on top (validators: N/4, fullnodes: N/2), deliberately oversubscribing the machine: workers blocked in RocksDB free their core for the other runtime instead of leaving it idle, and when both runtimes are saturated the OS schedules fairly per runnable thread, so the serving pool's size relative to the core pool bounds the CPU share serving can take — at most ~20% of the machine on a validator (N vs N/4 threads), ~33% on a fullnode. This both protects the core under request floods and avoids throttling it when there is no request load at all.

Behavioral / config notes

- Thread counts change. The core runtime keeps one worker per core (as before the split); the serving runtime's workers come on top of that, so the process runs more threads than cores. Both counts are derived from available_parallelism.
- Request-triggered follow-ups (consensus submission, tx finalizer, owned-object cert execution) now run on the serving runtime — intentional backpressure: a flooded node serves/submits slightly slower while the core engine stays unaffected. Consensus-ordered and checkpoint execution run on the core and are protected.
- Thread isolation guarantees the core always has a worker ready to poll; it does not partition raw CPU. Under simultaneous saturation of both runtimes the core is no longer starved and holds ~80% of the CPU (validators), at the cost of some timeslicing between threads.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Client-facing request handling (validator gRPC, JSON-RPC, gRPC read API) now runs on a dedicated tokio runtime, isolated from node-core work (consensus, execution, checkpoints) so a flood of incoming transactions can no longer starve consensus commits or checkpoint signing. The core runtime keeps one worker per CPU core; serving threads are sized per node role and added on top. New tokio_runtime_* metrics expose per-runtime saturation.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC: