### PR TITLE
upstream(core): Replace IntGaugeVecGuard with InflightGuard

### DIFF
--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -21,7 +21,7 @@ use futures::{
     pin_mut,
     stream::FuturesUnordered,
 };
-use iota_metrics::{GaugeGuard, GaugeGuardFutureExt, LATENCY_SEC_BUCKETS, spawn_monitored_task};
+use iota_metrics::{GaugeGuard, InflightGuardFutureExt, LATENCY_SEC_BUCKETS, spawn_monitored_task};
 use iota_simulator::anemo::PeerId;
 use iota_types::{
     base_types::{AuthorityName, TransactionDigest},
@@ -769,7 +769,7 @@ impl ConsensusAdapter {
             let _permit: SemaphorePermit = self
                 .submit_semaphore
                 .acquire()
-                .count_in_flight(&self.metrics.sequencing_in_flight_semaphore_wait)
+                .count_in_flight(self.metrics.sequencing_in_flight_semaphore_wait.clone())
                 .await
                 .expect("Consensus adapter does not close semaphore");
             let _in_flight_submission_guard =

--- a/crates/iota-metrics/src/guards.rs
+++ b/crates/iota-metrics/src/guards.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use prometheus::{IntGauge, IntGaugeVec};
+use prometheus::IntGauge;
 
 /// Increments gauge when acquired, decrements when guard drops
 pub struct GaugeGuard<'a>(&'a IntGauge);
@@ -30,103 +30,60 @@ impl Drop for GaugeGuard<'_> {
     }
 }
 
-/// Increments an `IntGaugeVec` for a set of label values when acquired,
-/// decrements the same labeled gauge when the guard drops.
-pub struct IntGaugeVecGuard<'a> {
-    gauge: &'a IntGaugeVec,
-    labels: Vec<String>,
-}
+/// Difference vs `GaugeGuard`: stores the gauge by value to avoid borrowing
+/// issues. Increments the gauge when acquired, decrements when the guard drops.
+pub struct InflightGuard(IntGauge);
 
-impl<'a> IntGaugeVecGuard<'a> {
-    /// Acquires the labeled gauge by incrementing it and retaining the label
-    /// values so the matching gauge can be decremented on drop.
-    pub fn acquire(gauge: &'a IntGaugeVec, labels: &[&str]) -> Self {
-        gauge.with_label_values(labels).inc();
-        let labels: Vec<String> = labels.iter().map(|s| s.to_string()).collect();
-        Self { gauge, labels }
+impl InflightGuard {
+    /// Acquires an `IntGauge` by incrementing its value and taking ownership of
+    /// the gauge so it can be decremented on drop.
+    pub fn acquire(g: IntGauge) -> Self {
+        g.inc();
+        Self(g)
     }
 }
 
-impl Drop for IntGaugeVecGuard<'_> {
-    /// Decrements the labeled gauge when the guard is dropped.
+impl Drop for InflightGuard {
+    /// Decrements the value of the `IntGauge` when the guard is dropped.
     fn drop(&mut self) {
-        self.gauge
-            .with_label_values(&self.labels.iter().map(|s| s.as_str()).collect::<Vec<_>>())
-            .dec();
+        self.0.dec();
     }
 }
 
-pub trait GaugeGuardFutureExt: Future + Sized {
+pub trait InflightGuardFutureExt: Future + Sized {
     /// Count number of in flight futures running
-    fn count_in_flight(self, g: &IntGauge) -> GaugeGuardFuture<'_, Self>;
-
-    /// Count number of in flight futures running, tracked on a labeled gauge.
-    fn count_in_flight_with_labels<'a>(
-        self,
-        g: &'a IntGaugeVec,
-        labels: &[&str],
-    ) -> IntGaugeVecGuardFuture<'a, Self>;
+    fn count_in_flight(self, g: IntGauge) -> InflightGuardFuture<Self>;
 }
 
-impl<F: Future> GaugeGuardFutureExt for F {
+impl<F: Future> InflightGuardFutureExt for F {
     /// Count number of in flight futures running.
-    fn count_in_flight(self, g: &IntGauge) -> GaugeGuardFuture<'_, Self> {
-        GaugeGuardFuture {
+    fn count_in_flight(self, g: IntGauge) -> InflightGuardFuture<Self> {
+        InflightGuardFuture {
             f: Box::pin(self),
-            _guard: GaugeGuard::acquire(g),
-        }
-    }
-
-    /// Count number of in flight futures running, tracked on a labeled gauge.
-    fn count_in_flight_with_labels<'a>(
-        self,
-        g: &'a IntGaugeVec,
-        labels: &[&str],
-    ) -> IntGaugeVecGuardFuture<'a, Self> {
-        IntGaugeVecGuardFuture {
-            f: Box::pin(self),
-            _guard: IntGaugeVecGuard::acquire(g, labels),
+            _guard: InflightGuard::acquire(g),
         }
     }
 }
 
-/// A struct that wraps a future (`f`) with a `GaugeGuard`. The
-/// `GaugeGuardFuture` is used to manage the lifecycle of a future while
-/// ensuring the associated `GaugeGuard` properly tracks the resource usage
+/// A struct that wraps a future (`f`) with an `InflightGuard`. The
+/// `InflightGuardFuture` is used to manage the lifecycle of a future while
+/// ensuring the associated `InflightGuard` properly tracks the resource usage
 /// during the future's execution. The guard increments the gauge
-/// when the future starts and decrements it when the `GaugeGuardFuture` is
+/// when the future starts and decrements it when the `InflightGuardFuture` is
 /// dropped.
-pub struct GaugeGuardFuture<'a, F: Sized> {
+pub struct InflightGuardFuture<F: Sized> {
     f: Pin<Box<F>>,
-    _guard: GaugeGuard<'a>,
+    _guard: InflightGuard,
 }
 
-impl<F: Future> Future for GaugeGuardFuture<'_, F> {
+impl<F: Future> Future for InflightGuardFuture<F> {
     type Output = F::Output;
 
     /// Polls the wrapped future (`f`) to determine its readiness. This function
     /// forwards the poll operation to the inner future, allowing the
-    /// `GaugeGuardFuture` to manage the polling lifecycle.
+    /// `InflightGuardFuture` to manage the polling lifecycle.
     /// Returns `Poll::Pending` if the future is not ready or `Poll::Ready` with
     /// the future's result if complete.
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.f.as_mut().poll(cx)
-    }
-}
-
-/// A struct that wraps a future (`f`) with an `IntGaugeVecGuard`. The labeled
-/// gauge is incremented when the future starts and decremented when the
-/// `IntGaugeVecGuardFuture` is dropped.
-pub struct IntGaugeVecGuardFuture<'a, F: Sized> {
-    f: Pin<Box<F>>,
-    _guard: IntGaugeVecGuard<'a>,
-}
-
-impl<F: Future> Future for IntGaugeVecGuardFuture<'_, F> {
-    type Output = F::Output;
-
-    /// Polls the wrapped future (`f`) to determine its readiness, forwarding
-    /// the poll to the inner future.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.f.as_mut().poll(cx)
     }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.51.5, v1.52.3)
- Port commit:
  - [MystenLabs/sui@4275c1a](https://github.com/MystenLabs/sui/commit/4275c1a55988d28b638be8720aebdf1e7da3b06b)
- Description:

Replaces the borrow-based `IntGaugeVecGuard`/`GaugeGuardFuture` machinery in
`iota-metrics` with a single `InflightGuard` that owns its `IntGauge` by value
(avoiding borrow lifetimes), and renames the extension trait
`GaugeGuardFutureExt` → `InflightGuardFutureExt`. `count_in_flight` now takes an
`IntGauge` by value; the labeled `count_in_flight_with_labels` variant is
removed. `consensus_adapter` is updated to pass the gauge by value (`.clone()`).

## Links to any relevant issues

Part of #11885

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes