### PR TITLE
fix(consensus): deflake test_fast_sync_voting_blocks_served_to_peer

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1477,6 +1477,7 @@
                 "consensus_bad_nodes_stake_threshold": {
                   "u64": "20"
                 },
+                "consensus_commits_per_schedule": null,
                 "consensus_gc_depth": null,
                 "consensus_max_acknowledgments_per_block": null,
                 "consensus_max_num_transactions_in_block": {

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1798,12 +1798,12 @@ impl ProtocolConfig {
         self.feature_flags.enable_pcool_flow
     }
 
-    pub fn commits_per_schedule(&self) -> u64 {
+    pub fn commits_per_schedule(&self) -> u32 {
         if cfg!(msim) {
             // Exercise faster leader-schedule rotation in simtests.
-            min(10, self.consensus_commits_per_schedule.unwrap_or(300)) as u64
+            min(10, self.consensus_commits_per_schedule.unwrap_or(300))
         } else {
-            self.consensus_commits_per_schedule.unwrap_or(300) as u64
+            self.consensus_commits_per_schedule.unwrap_or(300)
         }
     }
 }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1403,6 +1403,10 @@ pub struct ProtocolConfig {
     // `fun native_sender_authenticator_function_info_v1<F>(): &Option<F>`
     // `fun native_sponsor_authenticator_function_info_v1<F>(): &Option<F>`
     auth_context_authenticator_function_info_v1_cost_base: Option<u64>,
+
+    /// Number of committed subdags between leader-schedule recomputations.
+    /// When unset, defaults to 300.
+    consensus_commits_per_schedule: Option<u32>,
 }
 
 // feature flags
@@ -1792,6 +1796,15 @@ impl ProtocolConfig {
 
     pub fn enable_pcool_flow(&self) -> bool {
         self.feature_flags.enable_pcool_flow
+    }
+
+    pub fn commits_per_schedule(&self) -> u64 {
+        if cfg!(msim) {
+            // Exercise faster leader-schedule rotation in simtests.
+            min(10, self.consensus_commits_per_schedule.unwrap_or(300)) as u64
+        } else {
+            self.consensus_commits_per_schedule.unwrap_or(300) as u64
+        }
     }
 }
 
@@ -2393,6 +2406,7 @@ impl ProtocolConfig {
             auth_context_replace_cost_base: None,
             auth_context_replace_cost_per_byte: None,
             auth_context_authenticator_function_info_v1_cost_base: None,
+            consensus_commits_per_schedule: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -3200,6 +3214,10 @@ impl ProtocolConfig {
 
     pub fn set_enable_pcool_flow_for_testing(&mut self, val: bool) {
         self.feature_flags.enable_pcool_flow = val;
+    }
+
+    pub fn set_commits_per_schedule_for_testing(&mut self, val: u32) {
+        self.consensus_commits_per_schedule = Some(val);
     }
 }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -880,8 +880,12 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
 
+    use iota_metrics::monitored_mpsc::UnboundedReceiver;
     use iota_protocol_config::ProtocolConfig;
     use prometheus::Registry;
     use starfish_config::{Parameters, local_committee_and_keys};
@@ -890,7 +894,81 @@ mod tests {
     use tracing::info;
     use typed_store::DBMetrics;
 
-    use crate::authority_node::tests::make_authority_with_params;
+    use crate::{
+        authority_node::tests::make_authority_with_params, commit::CommittedSubDag,
+        commit_consumer::CommitConsumerMonitor,
+    };
+
+    /// Drains all ready committed subdags from the running validators (those
+    /// whose index is not in `stopped`), asserting commit indices advance
+    /// monotonically and updating both the per-validator high-water marks and
+    /// the consumer monitors.
+    fn drain_running(
+        output_receivers: &mut [UnboundedReceiver<CommittedSubDag>],
+        committed_index: &mut [u32],
+        consumer_monitors: &[Arc<CommitConsumerMonitor>],
+        stopped: &[usize],
+    ) {
+        for (index, receiver) in output_receivers.iter_mut().enumerate() {
+            if stopped.contains(&index) {
+                continue;
+            }
+            while let Ok(committed_subdag) = receiver.try_recv() {
+                let commit_index = committed_subdag.commit_ref.index;
+                assert!(
+                    commit_index > committed_index[index],
+                    "Commit index {} should be greater than previous {}",
+                    commit_index,
+                    committed_index[index]
+                );
+                committed_index[index] = commit_index;
+                consumer_monitors[index].set_highest_handled_commit(commit_index);
+            }
+        }
+    }
+
+    /// Runs the running validators (those not in `stopped`) until the highest
+    /// commit index among them reaches `target`, draining their output
+    /// meanwhile. Panics if `target` is not reached within `timeout`.
+    ///
+    /// Phases drive a target commit count rather than a fixed wall-clock
+    /// duration so the gap a restarted validator must close is deterministic
+    /// regardless of how fast the host commits: a too-small gap would fall
+    /// under the fast-sync threshold and silently downgrade to regular
+    /// sync.
+    async fn run_until_commit_index(
+        output_receivers: &mut [UnboundedReceiver<CommittedSubDag>],
+        committed_index: &mut [u32],
+        consumer_monitors: &[Arc<CommitConsumerMonitor>],
+        stopped: &[usize],
+        target: u32,
+        timeout: Duration,
+    ) {
+        let start_time = Instant::now();
+        loop {
+            drain_running(
+                output_receivers,
+                committed_index,
+                consumer_monitors,
+                stopped,
+            );
+            let highest = committed_index
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| !stopped.contains(i))
+                .map(|(_, v)| *v)
+                .max()
+                .unwrap_or(0);
+            if highest >= target {
+                return;
+            }
+            assert!(
+                start_time.elapsed() < timeout,
+                "running validators only reached commit {highest}, expected {target}, within {timeout:?}"
+            );
+            sleep(Duration::from_millis(50)).await;
+        }
+    }
 
     /// Test that voting blocks stored during fast sync can be served to peers.
     /// This test verifies:
@@ -920,15 +998,23 @@ mod tests {
         // stopped.
         const NUM_AUTHORITIES: usize = 7;
         const COMMIT_GAP_THRESHOLD: u32 = 30;
-
-        // Work phases need to be long enough to create a gap larger than
-        // COMMIT_GAP_THRESHOLD (30) for fast sync to trigger.
-        let stable_work_duration = Duration::from_secs(10);
+        // Gap a restarted validator must close, in commits. Set comfortably above
+        // COMMIT_GAP_THRESHOLD so fast sync (not regular sync) is selected even with
+        // some slack between the consumer high-water mark and the quorum index.
+        const TARGET_GAP: u32 = COMMIT_GAP_THRESHOLD * 2;
+        // Safety bound on how long a work phase waits to reach its target commit
+        // count; generous so a slow host still completes rather than hangs.
+        let work_phase_timeout = Duration::from_secs(60);
 
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; NUM_AUTHORITIES]);
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_fast_commit_sync_for_testing(true);
         protocol_config.set_gc_depth_for_testing(5);
+        // Shrink the leader-schedule rotation window — which also bounds the
+        // fast-sync reinitialization fetch window — well below TARGET_GAP. With the
+        // default window a recovering node refetches the whole synced gap into its
+        // regular block storage, so the fallback always answers and the voting-block
+        // store this test exercises is never actually consulted.
         protocol_config.set_commits_per_schedule_for_testing(10);
 
         let temp_dirs: Vec<TempDir> = (0..NUM_AUTHORITIES)
@@ -976,78 +1062,52 @@ mod tests {
             consumer_monitors.push(monitor);
         }
 
-        // Phase 1: Let all authorities run and commit transactions
-        let start_time = Instant::now();
+        // Phase 1: Let all authorities run and build a shared committed prefix.
         let mut committed_index = [0u32; NUM_AUTHORITIES];
-        while start_time.elapsed() < stable_work_duration {
-            for (index, receiver) in output_receivers.iter_mut().enumerate() {
-                while let Ok(committed_subdag) = receiver.try_recv() {
-                    let commit_index = committed_subdag.commit_ref.index;
-                    assert!(
-                        commit_index > committed_index[index],
-                        "Commit index {} should be greater than previous {}",
-                        commit_index,
-                        committed_index[index]
-                    );
-                    committed_index[index] = commit_index;
-                    consumer_monitors[index].set_highest_handled_commit(commit_index);
-                }
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
+        run_until_commit_index(
+            &mut output_receivers,
+            &mut committed_index,
+            &consumer_monitors,
+            &[],
+            TARGET_GAP,
+            work_phase_timeout,
+        )
+        .await;
 
         // Phase 2: Stop validator B first (so B misses commits created while it's down)
         let last_processed_b = consumer_monitors[validator_b_index].highest_handled_commit();
         authorities.remove(validator_b_index).stop().await;
 
-        // Phase 3: Let A and others continue committing (B misses these)
-        let start_time = Instant::now();
-        while start_time.elapsed() < stable_work_duration {
-            for (index, receiver) in output_receivers.iter_mut().enumerate() {
-                if index == validator_b_index {
-                    continue;
-                }
-                while let Ok(committed_subdag) = receiver.try_recv() {
-                    let commit_index = committed_subdag.commit_ref.index;
-                    assert!(
-                        commit_index > committed_index[index],
-                        "Commit index {} should be greater than previous {}",
-                        commit_index,
-                        committed_index[index]
-                    );
-                    committed_index[index] = commit_index;
-                    consumer_monitors[index].set_highest_handled_commit(commit_index);
-                }
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
+        // Phase 3: Let A and others continue committing (B misses these), advancing
+        // far enough beyond B's stop point that B's gap clears the fast-sync
+        // threshold on restart.
+        run_until_commit_index(
+            &mut output_receivers,
+            &mut committed_index,
+            &consumer_monitors,
+            &[validator_b_index],
+            last_processed_b + TARGET_GAP,
+            work_phase_timeout,
+        )
+        .await;
 
         // Phase 4: Stop validator A
         let last_processed_a = consumer_monitors[validator_a_index].highest_handled_commit();
         authorities.remove(validator_a_index).stop().await;
 
         // Phase 5: Let the remaining validators (all except A and B) continue
-        // committing (both A and B miss these commits)
-        let start_time = Instant::now();
-        while start_time.elapsed() < stable_work_duration {
-            for (index, receiver) in output_receivers.iter_mut().enumerate() {
-                if index == validator_a_index || index == validator_b_index {
-                    continue;
-                }
-                while let Ok(committed_subdag) = receiver.try_recv() {
-                    let commit_index = committed_subdag.commit_ref.index;
-                    assert!(
-                        commit_index > committed_index[index],
-                        "Commit index {} should be greater than previous {}",
-                        commit_index,
-                        committed_index[index]
-                    );
-                    committed_index[index] = commit_index;
-                    consumer_monitors[index].set_highest_handled_commit(commit_index);
-                }
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
+        // committing (both A and B miss these). This is the gap A must close on
+        // restart, so it must clear the fast-sync threshold for A to fast sync and
+        // store voting block headers.
+        run_until_commit_index(
+            &mut output_receivers,
+            &mut committed_index,
+            &consumer_monitors,
+            &[validator_a_index, validator_b_index],
+            last_processed_a + TARGET_GAP,
+            work_phase_timeout,
+        )
+        .await;
 
         // Phase 6: Restart validator A - it will fast sync and store voting blocks
         let parameters = Parameters {
@@ -1080,23 +1140,13 @@ mod tests {
         // Wait for validator A to catch up via fast sync
         let start_time = Instant::now();
         let mut a_caught_up = false;
-        while start_time.elapsed() < Duration::from_secs(60) {
-            for (index, receiver) in output_receivers.iter_mut().enumerate() {
-                if index == validator_b_index {
-                    continue;
-                }
-                while let Ok(committed_subdag) = receiver.try_recv() {
-                    let commit_index = committed_subdag.commit_ref.index;
-                    assert!(
-                        commit_index > committed_index[index],
-                        "Commit index {} should be greater than previous {}",
-                        commit_index,
-                        committed_index[index]
-                    );
-                    committed_index[index] = commit_index;
-                    consumer_monitors[index].set_highest_handled_commit(commit_index);
-                }
-            }
+        while start_time.elapsed() < Duration::from_secs(90) {
+            drain_running(
+                &mut output_receivers,
+                &mut committed_index,
+                &consumer_monitors,
+                &[validator_b_index],
+            );
 
             let a_index = consumer_monitors[validator_a_index].highest_handled_commit();
             let max_other = consumer_monitors
@@ -1151,20 +1201,13 @@ mod tests {
         // Wait for validator B to catch up
         let start_time = Instant::now();
         let mut b_caught_up = false;
-        while start_time.elapsed() < Duration::from_secs(60) {
-            for (index, receiver) in output_receivers.iter_mut().enumerate() {
-                while let Ok(committed_subdag) = receiver.try_recv() {
-                    let commit_index = committed_subdag.commit_ref.index;
-                    assert!(
-                        commit_index > committed_index[index],
-                        "Commit index {} should be greater than previous {}",
-                        commit_index,
-                        committed_index[index]
-                    );
-                    committed_index[index] = commit_index;
-                    consumer_monitors[index].set_highest_handled_commit(commit_index);
-                }
-            }
+        while start_time.elapsed() < Duration::from_secs(90) {
+            drain_running(
+                &mut output_receivers,
+                &mut committed_index,
+                &consumer_monitors,
+                &[],
+            );
 
             let b_index = consumer_monitors[validator_b_index].highest_handled_commit();
             let max_other = consumer_monitors

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -718,7 +718,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // Fetch the maximum to satisfy all requirements
         let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
         let gc_depth = inner.context.protocol_config.gc_depth();
-        let leader_schedule_window = inner.context.protocol_config.commits_per_schedule() as u32;
+        let leader_schedule_window = inner.context.protocol_config.commits_per_schedule();
         // Get block refs from recent commits stored during fast sync
         // TODO: The commits might not yet stored, but only fetched and pending
         // processing.

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -718,7 +718,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // Fetch the maximum to satisfy all requirements
         let cached_rounds = inner.context.parameters.dag_state_cached_rounds;
         let gc_depth = inner.context.protocol_config.gc_depth();
-        let leader_schedule_window = crate::leader_schedule::CONSENSUS_COMMITS_PER_SCHEDULE as u32;
+        let leader_schedule_window = inner.context.protocol_config.commits_per_schedule() as u32;
         // Get block refs from recent commits stored during fast sync
         // TODO: The commits might not yet stored, but only fetched and pending
         // processing.
@@ -929,6 +929,7 @@ mod tests {
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_fast_commit_sync_for_testing(true);
         protocol_config.set_gc_depth_for_testing(5);
+        protocol_config.set_commits_per_schedule_for_testing(10);
 
         let temp_dirs: Vec<TempDir> = (0..NUM_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -52,14 +52,6 @@ fn recover_leader_swap_table(
     )
 }
 
-/// The window where the schedule change takes place in consensus. It
-/// represents number of committed sub dags.
-/// TODO: move this to protocol config
-#[cfg(not(msim))]
-pub(crate) const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 300;
-#[cfg(msim)]
-pub(crate) const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 10;
-
 /// The `LeaderSchedule` is responsible for producing the leader schedule across
 /// an epoch. The leader schedule is subject to change periodically based on
 /// calculated `ReputationScores` of the authorities.
@@ -72,9 +64,10 @@ pub(crate) struct LeaderSchedule {
 
 impl LeaderSchedule {
     pub(crate) fn new(context: Arc<Context>, leader_swap_table: LeaderSwapTable) -> Self {
+        let num_commits_per_schedule = context.protocol_config.commits_per_schedule();
         Self {
             context,
-            num_commits_per_schedule: CONSENSUS_COMMITS_PER_SCHEDULE,
+            num_commits_per_schedule,
             leader_swap_table: Arc::new(RwLock::new(leader_swap_table)),
         }
     }

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -59,7 +59,7 @@ fn recover_leader_swap_table(
 pub(crate) struct LeaderSchedule {
     pub leader_swap_table: Arc<RwLock<LeaderSwapTable>>,
     context: Arc<Context>,
-    num_commits_per_schedule: u64,
+    num_commits_per_schedule: u32,
 }
 
 impl LeaderSchedule {
@@ -73,7 +73,7 @@ impl LeaderSchedule {
     }
 
     #[cfg(test)]
-    pub(crate) fn with_num_commits_per_schedule(mut self, num_commits_per_schedule: u64) -> Self {
+    pub(crate) fn with_num_commits_per_schedule(mut self, num_commits_per_schedule: u32) -> Self {
         self.num_commits_per_schedule = num_commits_per_schedule;
         self
     }
@@ -112,7 +112,7 @@ impl LeaderSchedule {
         &self,
         dag_state: Arc<RwLock<DagState>>,
     ) -> usize {
-        let subdag_count = dag_state.read().scoring_subdags_count() as u64;
+        let subdag_count = dag_state.read().scoring_subdags_count() as u32;
 
         // In the normal online flow, `scoring_subdag` is cleared every time we
         // update the schedule, so its size stays within `num_commits_per_schedule`.
@@ -312,7 +312,7 @@ impl LeaderSchedule {
             return Ok(());
         }
 
-        let range_start = range_end.saturating_sub(self.num_commits_per_schedule as u32 - 1);
+        let range_start = range_end.saturating_sub(self.num_commits_per_schedule - 1);
         let commit_range = CommitRange::new(range_start..=range_end);
 
         let reputation_scores = ReputationScores::from_scores_desc(

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -644,7 +644,7 @@ mod tests {
             context.clone(),
             Arc::new(MemStore::new()),
         )));
-        const NUM_OF_COMMITS_PER_SCHEDULE: u64 = 10;
+        const NUM_OF_COMMITS_PER_SCHEDULE: u32 = 10;
         let leader_schedule = Arc::new(
             LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
                 .with_num_commits_per_schedule(NUM_OF_COMMITS_PER_SCHEDULE),


### PR DESCRIPTION
# Description of change

`test_fast_sync_voting_blocks_served_to_peer` was non-deterministic and failed intermittently in CI. There were two independent causes:

- **Gap built from wall-clock time.** The work phases created the commit gap with fixed 10s sleeps. On a slow or loaded host they produce fewer commits, so the gap can fall below the fast-sync threshold; the restarted validator then catches up via regular sync, never stores voting block headers, and the metric assertions fail. Phases now drive a target commit count (twice the threshold) with a generous timeout, so the gap clears the threshold regardless of host speed.

- **Recovery window dwarfed the gap.** The leader-schedule rotation window — which also bounds the fast-sync reinitialization fetch — was a hardcoded constant (300), far larger than the synced gap. The recovering node therefore repopulated its regular block store across the whole gap, and the voting-block store under test was never consulted, leaving `commit_sync_voting_block_headers_hits` at the mercy of incidental alignment. It is now a `consensus_commits_per_schedule` protocol-config parameter (default unchanged — 300, 10 under msim — so no version bump and no snapshot changes), and the test shrinks it below the gap so the voting-serve path is actually exercised.

## Links to any relevant issues

fixes #11877

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
