### PR TITLE
upstream(iota-types): symmetric byte-blob serde for Signature

### DIFF
--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -52,7 +52,7 @@ use rand::{
 };
 use roaring::RoaringBitmap;
 use serde::{Deserialize, Deserializer, Serialize, ser::Serializer};
-use serde_with::{Bytes, serde_as};
+use serde_with::{Bytes, DeserializeAs, serde_as};
 use strum::EnumString;
 use tracing::{instrument, warn};
 
@@ -702,8 +702,7 @@ impl<'de> Deserialize<'de> for Signature {
             let s = String::deserialize(deserializer)?;
             Base64::decode(&s).map_err(|e| Error::custom(e.to_string()))?
         } else {
-            let data: Vec<u8> = Vec::deserialize(deserializer)?;
-            data
+            Bytes::deserialize_as(deserializer)?
         };
 
         Self::from_bytes(&bytes).map_err(|e| Error::custom(e.to_string()))


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#26753](https://github.com/MystenLabs/sui/pull/26753)
- Description:

`Signature`'s `Serialize` impl writes the binary form as a single byte blob via `serialize_bytes`, but its `Deserialize` impl previously read it back through `Vec::<u8>::deserialize`, which routes through `deserialize_seq`. For non-self-describing formats the encoder and decoder therefore took two different views of the same bytes, so the type was not guaranteed to round-trip in general. Switch the binary deserialize branch to `serde_with::Bytes::deserialize_as` so both directions use the byte-blob path.

The on-wire bytes are unchanged for BCS, bincode, and JSON, so this is compatible with already-serialized data.

## Links to any relevant issues

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
