### PR TITLE
upstream(iota-network-stack): apply connect_timeout to lazy gRPC channels

### DIFF
--- a/crates/iota-network-stack/src/client.rs
+++ b/crates/iota-network-stack/src/client.rs
@@ -124,12 +124,20 @@ impl MyEndpoint {
             disable_caching_resolver
         });
 
+        // Propagate the endpoint's configured connect timeout (Config::connect_timeout
+        // applied in apply_config_to_endpoint) down to the HTTP connector. tonic's
+        // Channel::new path does not forward Endpoint::connect_timeout to a provided
+        // connector, so without this the lazy channel can sit in State::Connecting
+        // forever when a peer is unreachable (msim with dropped SYNs, real network
+        // partitions, etc), blocking every gRPC call on that channel.
+        let connect_timeout = self.endpoint.get_connect_timeout();
+
         if disable_caching_resolver {
             let mut http = HttpConnector::new();
             http.enforce_http(false);
             http.set_nodelay(true);
             http.set_keepalive(None);
-            http.set_connect_timeout(None);
+            http.set_connect_timeout(connect_timeout);
 
             Channel::new(
                 hyper_rustls::HttpsConnectorBuilder::new()
@@ -144,7 +152,7 @@ impl MyEndpoint {
             http.enforce_http(false);
             http.set_nodelay(true);
             http.set_keepalive(None);
-            http.set_connect_timeout(None);
+            http.set_connect_timeout(connect_timeout);
 
             let https = hyper_rustls::HttpsConnectorBuilder::new()
                 .with_tls_config(self.tls_config)


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#26911](https://github.com/MystenLabs/sui/pull/26911)
- Description:

`connect_lazy()` built its `HttpConnector` with `set_connect_timeout(None)`, discarding the `connect_timeout` already applied to the `Endpoint`. tonic's `Channel::new` does not forward `Endpoint::connect_timeout` to a user-provided connector, so the timeout was silently ignored for every lazy channel. When SYNs to an unreachable host are dropped without an RST (network partition, reassigned IP, firewalled peer), the channel then sits in `State::Connecting` forever, blocking every gRPC call on it.

The fix reads `self.endpoint.get_connect_timeout()` and passes it to `http.set_connect_timeout(...)` in both the caching and non-caching connector paths.

## Priority for IOTA: low

- The affected path is the validator gRPC client (`AuthorityAggregator`), which dials on-chain committee addresses. A 10s `connect_timeout` is already configured there — this only restores it on the lazy path, where it was silently dropped.
- In Sui the hang surfaced via the discovery tests from [#25950](https://github.com/MystenLabs/sui/pull/25950) (a discovery feature IOTA has not ported), which can gossip bad peer addresses. Without that feature, IOTA's exposure is limited to genuine network blackholes (partitions, an IP reassigned behind a stale committee/DNS entry) on otherwise-known committee addresses — uncommon, but real.
- Not reproducible under `simtest`: the simulator errors on unreachable sends rather than blackholing them, so this is a real-network hardening.

## Links to any relevant issues

## How the change has been tested

Verified with a targeted test that dials a non-routable blackhole (`192.0.2.1`) through `connect_lazy`: with the bug the call is still stuck connecting after 10s; with the fix it returns at the configured 2s `connect_timeout`. Confirmed against the real `iota-network-stack` code on Linux.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
