### PR TITLE
upstream(starfish-core): reduce consensus log verbosity and avoid hot-path block clone

### DIFF
--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -376,7 +376,7 @@ impl BaseCommitter {
             .map(|b| self.context.committee.stake(b.author()))
             .sum();
         if !self.context.committee.reached_quorum(total_stake) {
-            tracing::debug!(
+            tracing::trace!(
                 "Not enough support for {leader_block}. Stake not enough: {total_stake} < {}",
                 self.context.committee.quorum_threshold()
             );

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -665,6 +665,12 @@ impl fmt::Debug for BlockRef {
     }
 }
 
+/// Formats a slice of block references as a comma-separated list of their
+/// short `Display` form, for debug/log output.
+pub(crate) fn format_block_digests(blocks: &[BlockRef]) -> String {
+    blocks.iter().map(|b| b.to_string()).join(", ")
+}
+
 impl Hash for BlockRef {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(&self.digest.0[..8]);
@@ -1293,14 +1299,11 @@ impl fmt::Debug for VerifiedBlockHeader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{:?}([{}];{}ms;[{}]a;{}c)",
+            "{:?}({}ms;[{}]r;[{}]a;{}c)",
             self.reference(),
-            self.ancestors().iter().map(|a| a.to_string()).join(", "),
             self.timestamp_ms(),
-            self.acknowledgments()
-                .iter()
-                .map(|a| a.to_string())
-                .join(", "),
+            format_block_digests(self.ancestors()),
+            format_block_digests(self.acknowledgments()),
             self.commit_votes().len(),
         )
     }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -13,6 +13,7 @@ use bytes::Bytes;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction};
 use iota_sdk_types::crypto::{Intent, IntentMessage, IntentScope};
+use itertools::Itertools as _;
 use rs_merkle::{MerkleProof, MerkleTree};
 use serde::{Deserialize, Serialize};
 use starfish_config::{
@@ -1292,11 +1293,14 @@ impl fmt::Debug for VerifiedBlockHeader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{:?}({}ms;{:?}r;{:?}a;{}c)",
+            "{:?}([{}];{}ms;[{}]a;{}c)",
             self.reference(),
+            self.ancestors().iter().map(|a| a.to_string()).join(", "),
             self.timestamp_ms(),
-            self.ancestors(),
-            self.acknowledgments(),
+            self.acknowledgments()
+                .iter()
+                .map(|a| a.to_string())
+                .join(", "),
             self.commit_votes().len(),
         )
     }

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -13,8 +13,7 @@ use itertools::Itertools as _;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 #[cfg(test)]
-use tracing::debug;
-use tracing::warn;
+use tracing::trace;
 
 /// Block Suspender is a private module unless under test.
 #[cfg(not(test))]
@@ -407,7 +406,7 @@ impl BlockManager {
 
         block_refs.sort_by_key(|b| b.round);
 
-        debug!(
+        trace!(
             "Trying to find blocks: {}",
             block_refs.iter().map(|b| b.to_string()).join(",")
         );

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -14,6 +14,7 @@ use std::{
 use bytes::Bytes;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction as _};
+use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 use starfish_config::{AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction};
 use tracing::debug;
@@ -941,16 +942,7 @@ fn format_transaction_ref_digests(transaction_refs: &[GenericTransactionRef]) ->
 }
 
 fn format_block_digests(blocks: &[BlockRef]) -> String {
-    let mut result = String::new();
-    for (idx, block) in blocks.iter().enumerate() {
-        if idx > 0 {
-            result.push_str(", ");
-        }
-        result.push_str(&block.digest.to_string());
-        result.push('@');
-        result.push_str(&block.round.to_string());
-    }
-    result
+    blocks.iter().map(|b| b.to_string()).join(", ")
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -14,7 +14,6 @@ use std::{
 use bytes::Bytes;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction as _};
-use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 use starfish_config::{AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction};
 use tracing::debug;
@@ -22,7 +21,7 @@ use tracing::debug;
 use crate::{
     block_header::{
         BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, SERIALIZED_BLOCK_REF_BYTES, Slot,
-        VerifiedBlockHeader, VerifiedTransactions, uleb128_len,
+        VerifiedBlockHeader, VerifiedTransactions, format_block_digests, uleb128_len,
     },
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -939,10 +938,6 @@ fn format_transaction_ref_digests(transaction_refs: &[GenericTransactionRef]) ->
         result.push_str(&block.round().to_string());
     }
     result
-}
-
-fn format_block_digests(blocks: &[BlockRef]) -> String {
-    blocks.iter().map(|b| b.to_string()).join(", ")
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -387,7 +387,7 @@ impl Core {
             self.block_manager.try_accept_blocks(blocks, source);
 
         let missing_committed_txns = if !accepted_blocks_headers.is_empty() {
-            debug!(
+            trace!(
                 "Accepted block headers: {}",
                 accepted_blocks_headers
                     .iter()
@@ -461,7 +461,7 @@ impl Core {
         }
 
         let missing_committed_txns = if !accepted_block_headers.is_empty() {
-            debug!(
+            trace!(
                 "Accepted block headers: {}",
                 accepted_block_headers
                     .iter()

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -228,7 +228,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             .with_label_values(&[peer_hostname])
                             .inc();
                         let result = authority_service
-                            .handle_subscribed_block_bundle(peer, block.clone(), &mut encoder)
+                            .handle_subscribed_block_bundle(peer, block, &mut encoder)
                             .await;
                         if let Err(e) = result {
                             match e {

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -69,11 +69,11 @@ impl UniversalCommitter {
                     break 'outer;
                 }
 
-                tracing::debug!("Trying to decide {slot} with {committer}",);
+                tracing::trace!("Trying to decide {slot} with {committer}",);
 
                 let mut status = committer.try_direct_decide(slot);
                 let mut decision = Decision::Direct;
-                tracing::debug!("Outcome of direct rule: {status}");
+                tracing::debug!("Outcome of direct rule: {status} with {committer}");
 
                 // If the direct result is not final (Commit(Pending) or
                 // Undecided), run the indirect rule. For Pending, a
@@ -83,7 +83,7 @@ impl UniversalCommitter {
                     let indirect = committer
                         .try_indirect_decide(status.clone(), leaders.iter().map(|(x, _)| x));
                     if indirect != status {
-                        tracing::debug!("Outcome of indirect rule: {indirect}");
+                        tracing::debug!("Outcome of indirect rule: {indirect} with {committer}");
                         decision = match (&status, &indirect) {
                             (
                                 LeaderStatus::Commit(_, Some(CommitMetastate::Pending), _),
@@ -115,7 +115,9 @@ impl UniversalCommitter {
             Self::update_metrics(&self.context, &decided_leader, decision);
             decided_leaders.push(decided_leader);
         }
-        tracing::debug!("Decided {decided_leaders:?}");
+        if !decided_leaders.is_empty() {
+            tracing::debug!("Decided {decided_leaders:?}");
+        }
         decided_leaders
     }
 


### PR DESCRIPTION
# Description of change

This bundles three small, low-risk upstream consensus polish changes.

- Port of upstream PRs:
  - [MystenLabs/sui#24746](https://github.com/MystenLabs/sui/pull/24746) — avoid cloning the subscribed block before handling
  - [MystenLabs/sui#22487](https://github.com/MystenLabs/sui/pull/22487) — reduce logging level on hot paths
  - [MystenLabs/sui#22837](https://github.com/MystenLabs/sui/pull/22837) — minor logging updates (compact block-ref display)
- Description:

Three independent changes to the starfish consensus core. First, the subscribed block bundle is owned and unused after being handed to `handle_subscribed_block_bundle`, so it is moved directly instead of cloned, removing one allocation per received block. Second, the chattiest steady-state log lines (block acceptance, leader-decision loop, stake-quorum checks) are downgraded from DEBUG to TRACE, committer context is added to the remaining direct/indirect-rule DEBUG lines, and a couple of list-printing messages are guarded behind `is_empty()` checks. Third, raw `Debug` formatting of ancestor/acknowledgment slices and digest loops is replaced with the compact `BlockRef` `Display` string.

Adapted to the fork:
- starfish's `block_manager.rs` is a directory, so the log changes were applied in `block_manager/mod.rs`.
- the `block.rs` logging hunks from upstream were mapped onto starfish's `block_header.rs`.
- the starfish block-acceptance path is structured differently from upstream, so the per-call-site log levels diverge slightly (see PR discussion).

## Links to any relevant issues

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
