### PR TITLE
fix(typed-store): open db corruption-check in a separate thread under simulator

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -73,7 +73,12 @@ pub(crate) fn rocks_cf<'a>(
 // Check if the database is corrupted, and if so, panic.
 // If the corrupted key is not set, we set it to [1].
 pub fn check_and_mark_db_corruption(path: &Path) -> Result<(), String> {
-    let db = rocksdb::DB::open_default(path).map_err(|e| e.to_string())?;
+    // rocksdb spawns its background threads when the DB is opened; under the
+    // simulator that open must run off the test thread, or the threads are
+    // scheduled against the simulated clock and then run against the real one,
+    // aborting periodic-task registration. Only the open needs the guard — the
+    // get/put below spawn no threads. See `open_cf_opts`. No-op outside msim.
+    let db = nondeterministic!(rocksdb::DB::open_default(path)).map_err(|e| e.to_string())?;
 
     db.get(DB_CORRUPTED_KEY)
         .map_err(|e| format!("Failed to open database: {e}"))
@@ -92,7 +97,8 @@ pub fn check_and_mark_db_corruption(path: &Path) -> Result<(), String> {
 }
 
 pub fn unmark_db_corruption(path: &Path) -> Result<(), Error> {
-    rocksdb::DB::open_default(path)?.put(DB_CORRUPTED_KEY, [0])
+    // See `check_and_mark_db_corruption` for why the open runs off the test thread.
+    nondeterministic!(rocksdb::DB::open_default(path))?.put(DB_CORRUPTED_KEY, [0])
 }
 
 /// Opens a database with options, and a number of column families with


### PR DESCRIPTION
# Description of change

`check_and_mark_db_corruption` and `unmark_db_corruption` opened RocksDB via a raw `rocksdb::DB::open_default(path)`, outside the `nondeterministic!` guard that every other RocksDB open in this module already uses. Under the simulator, RocksDB schedules its background periodic-task threads against the test thread's simulated clock, but those threads then run against the real wall clock, so periodic-task registration aborts (`Operation aborted: Failed to register periodic task`) and the node panics at startup. This surfaced as a deterministic, seed-dependent flake (~16% of seeds) in `reconfiguration_tests`, failing in under 1.5s before the test body could run.

Wrap both opens in `nondeterministic!` so RocksDB creates its background threads off the test thread, matching the existing pattern (and rationale comment) on `open_cf_opts` / `open_cf_opts_secondary`. The macro is a no-op in non-simulator builds, so production behavior is unchanged.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Reproduced on a simulator build of `reconfiguration_tests`: 5 seeds that panicked with `Failed to register periodic task` on `develop` (538007/013/015/018/020) all pass after the fix, and a 60-seed run of `test_reconfig_with_committee_change_basic` plus a 24-seed run of `test_reconfig_with_failing_validator` show zero occurrences of the startup race.
