### PR TITLE
upstream(starfish-core): return error on invalid URI and fix IPv6 host formatting

### DIFF
--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -641,7 +641,7 @@ impl ChannelPool {
             Some(network_keypair.private_key().into_inner()),
         );
         let endpoint = tonic_rustls::Channel::from_shared(address.clone())
-            .unwrap()
+            .map_err(|e| ConsensusError::NetworkConfig(format!("invalid URI '{address}': {e}")))?
             .connect_timeout(timeout)
             .initial_connection_window_size(Some(buffer_size as u32))
             .initial_stream_window_size(Some(buffer_size as u32 / 2))
@@ -1350,7 +1350,9 @@ fn to_host_port_str(addr: &Multiaddr) -> Result<String, String> {
 
     match (iter.next(), iter.next()) {
         (Some(Protocol::Ip4(ipaddr)), Some(Protocol::Udp(port))) => Ok(format!("{ipaddr}:{port}")),
-        (Some(Protocol::Ip6(ipaddr)), Some(Protocol::Udp(port))) => Ok(format!("{ipaddr}:{port}")),
+        (Some(Protocol::Ip6(ipaddr)), Some(Protocol::Udp(port))) => {
+            Ok(format!("{}", SocketAddrV6::new(ipaddr, port, 0, 0)))
+        }
         (Some(Protocol::Dns(hostname)), Some(Protocol::Udp(port))) => {
             Ok(format!("{hostname}:{port}"))
         }


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#25020](https://github.com/MystenLabs/sui/pull/25020)
- Description:

Small networking robustness fixes in the consensus gRPC channel setup, ported from upstream:
- Return a `ConsensusError::NetworkConfig` instead of unwrapping when a peer address cannot be parsed into a channel URI.
- Format the IPv6 `host:port` via `SocketAddrV6` so it uses the standard bracketed form.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
