### PR TITLE
upstream(starfish-simtests): drop dead network_type and use integration-test layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13415,8 +13415,6 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "tokio",
- "tokio-stream",
- "tokio-util 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "typed-store",
 ]

--- a/crates/starfish/simtests/Cargo.toml
+++ b/crates/starfish/simtests/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 [lints]
 workspace = true
 
+# The crate's code is entirely `#[cfg(msim)]`-gated, so all dependencies are
+# only used under the simulator. Keeping them target-scoped means the non-msim
+# `cargo udeps` build sees no active deps and doesn't flag them as unused.
 [target.'cfg(msim)'.dependencies]
 # external dependencies
 arc-swap.workspace = true
@@ -17,8 +20,6 @@ parking_lot.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
-tokio-stream.workspace = true
-tokio-util.workspace = true
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/starfish/simtests/src/lib.rs
+++ b/crates/starfish/simtests/src/lib.rs
@@ -2,9 +2,5 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(all(msim, test))]
-mod node;
-
-#[cfg(all(msim, test))]
-#[path = "tests/simtests.rs"]
-mod simtests;
+#[cfg(msim)]
+pub mod node;

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -15,7 +15,7 @@ use std::{
 use arc_swap::ArcSwapOption;
 use eyre::Result;
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
-use iota_protocol_config::{ConsensusNetwork, ProtocolConfig};
+use iota_protocol_config::ProtocolConfig;
 use parking_lot::Mutex;
 use prometheus_filtered::Registry;
 use starfish_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
@@ -30,7 +30,7 @@ use tracing::{info, trace};
 
 /// Restart mode for authority nodes during testing
 #[derive(Clone, Copy, Debug)]
-pub(crate) enum RestartMode {
+pub enum RestartMode {
     /// Erase both consensus DB and node tracking state (fresh start)
     CleanAll,
     /// Keep both consensus DB and node tracking state (crash recovery)
@@ -44,13 +44,11 @@ pub(crate) enum RestartMode {
 }
 
 #[derive(Clone)]
-pub(crate) struct Config {
+pub struct Config {
     pub authority_index: AuthorityIndex,
     pub db_dir: Arc<TempDir>,
     pub committee: Committee,
     pub keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
-    #[expect(dead_code)]
-    pub network_type: ConsensusNetwork,
     pub boot_counter: u64,
     pub clock_drift: BlockTimestampMs,
     pub protocol_config: ProtocolConfig,
@@ -58,7 +56,7 @@ pub(crate) struct Config {
     pub last_processed_commit: CommitIndex,
 }
 
-pub(crate) struct AuthorityNode {
+pub struct AuthorityNode {
     inner: Mutex<Option<AuthorityNodeInner>>,
     config: Config,
     db_dir: Mutex<Arc<TempDir>>,
@@ -396,16 +394,12 @@ impl AuthorityNodeInner {
     }
 }
 
-pub(crate) async fn make_authority(
-    config: Config,
-    commit_consumer: CommitConsumer,
-) -> ConsensusAuthority {
+pub async fn make_authority(config: Config, commit_consumer: CommitConsumer) -> ConsensusAuthority {
     let Config {
         authority_index,
         db_dir,
         committee,
         keypairs,
-        network_type: _,
         boot_counter,
         clock_drift,
         protocol_config,

--- a/crates/starfish/simtests/tests/simtests.rs
+++ b/crates/starfish/simtests/tests/simtests.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg_attr(not(test), expect(unused))]
-
 #[cfg(msim)]
 mod test {
     use std::{
@@ -26,11 +24,10 @@ mod test {
         Authority, AuthorityKeyPair, Committee, Epoch, NetworkKeyPair, ProtocolKeyPair, Stake,
     };
     use starfish_core::transaction::BlockStatus;
+    use starfish_simtests::node::{AuthorityNode, Config, RestartMode};
     use tempfile::TempDir;
     use tokio::{sync::RwLock, time::sleep};
     use typed_store::DBMetrics;
-
-    use crate::node::{AuthorityNode, Config, RestartMode};
 
     fn test_config() -> SimConfig {
         env_config(
@@ -286,7 +283,6 @@ mod test {
                 db_dir: Arc::new(TempDir::new().unwrap()),
                 committee: committee.clone(),
                 keypairs: keypairs.clone(),
-                network_type: iota_protocol_config::ConsensusNetwork::Tonic,
                 boot_counter: 0,
                 protocol_config: protocol_config.clone(),
                 clock_drift: clock_drifts[authority_index.value()],


### PR DESCRIPTION
# Description of change

- Port of upstream PRs:
  - [MystenLabs/sui#24760](https://github.com/MystenLabs/sui/pull/24760) — remove the dead `network_type` from the simtest config
  - [MystenLabs/sui#22601](https://github.com/MystenLabs/sui/pull/22601) — move the starfish simtests into the standard integration-test layout
- Description:

Two small cleanups to the `starfish-simtests` crate:
- Remove the unused `network_type` field (and its `ConsensusNetwork` import / destructure / construction site) from the simtest `Config`. It was already marked `#[expect(dead_code)]`.
- Move `src/tests/simtests.rs` to `tests/simtests.rs` so it runs as a Cargo integration test against the crate's public API. `node.rs`'s `Config`, `AuthorityNode`, `RestartMode`, and `make_authority` are made `pub`, `node` becomes a public module, and `rand` moves to `[dev-dependencies]`. The simtests can now be run from the repo root via the `simtests` test target.

Adapted to the fork: applied to develop's current simtest files (which have since been refactored downstream) rather than cherry-picked, so only the above changes are included.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Verified under the simulator from the repo root: the crate builds as the `simtests` integration-test target and `devnet_sequential_restarts_clean_db_short_run_short_stop` passes.
