### PR TITLE
chore(starfish): drop obsolete consensus_block_commit_latency references

### DIFF
--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -487,21 +487,18 @@ def prometheus_vector(expr: str) -> list[tuple[dict[str, str], float]]:
 def _commit_latency_queries(range_s: int) -> dict[str, str]:
     """PromQL for block/transaction commit latency over a *range_s* window.
 
-    Block queries carry `or` fallbacks across the two block-latency metric
-    naming conventions. Transaction queries intentionally have no block
-    fallback: unavailable transaction latency must be reported as n/a rather
-    than mislabeled block latency."""
+    Transaction queries intentionally have no block fallback: unavailable
+    transaction latency must be reported as n/a rather than mislabeled block
+    latency."""
     r = f"{range_s}s"
     return {
         "blk_p50": (
             "histogram_quantile(0.5,"
-            f" sum(rate(consensus_block_commit_latency_bucket[{r}])) by (le)"
-            f" or sum(rate(consensus_block_header_commit_latency_bucket[{r}])) by (le))"
+            f" sum(rate(consensus_block_header_commit_latency_bucket[{r}])) by (le))"
         ),
         "blk_p95": (
             "histogram_quantile(0.95,"
-            f" sum(rate(consensus_block_commit_latency_bucket[{r}])) by (le)"
-            f" or sum(rate(consensus_block_header_commit_latency_bucket[{r}])) by (le))"
+            f" sum(rate(consensus_block_header_commit_latency_bucket[{r}])) by (le))"
         ),
         "txn_p50": (
             "histogram_quantile(0.5,"

--- a/dev-tools/iota-private-network/experiments/run-migration-test.py
+++ b/dev-tools/iota-private-network/experiments/run-migration-test.py
@@ -559,8 +559,8 @@ class CheckpointMonitor:
             ("Tx commit p50", "histogram_quantile(0.5, sum by (le) (rate(consensus_transaction_commit_latency_bucket[{w}s] @ {t})))", "ms", 1000.0),
             ("Tx commit p95", "histogram_quantile(0.95, sum by (le) (rate(consensus_transaction_commit_latency_bucket[{w}s] @ {t})))", "ms", 1000.0),
             ("Tx commit p99", "histogram_quantile(0.99, sum by (le) (rate(consensus_transaction_commit_latency_bucket[{w}s] @ {t})))", "ms", 1000.0),
-            ("Block commit p50", "histogram_quantile(0.5, sum by (le) (rate(consensus_block_commit_latency_bucket[{w}s] @ {t})) or sum by (le) (rate(consensus_block_header_commit_latency_bucket[{w}s] @ {t})))", "ms", 1000.0),
-            ("Block commit p95", "histogram_quantile(0.95, sum by (le) (rate(consensus_block_commit_latency_bucket[{w}s] @ {t})) or sum by (le) (rate(consensus_block_header_commit_latency_bucket[{w}s] @ {t})))", "ms", 1000.0),
+            ("Block commit p50", "histogram_quantile(0.5, sum by (le) (rate(consensus_block_header_commit_latency_bucket[{w}s] @ {t})))", "ms", 1000.0),
+            ("Block commit p95", "histogram_quantile(0.95, sum by (le) (rate(consensus_block_header_commit_latency_bucket[{w}s] @ {t})))", "ms", 1000.0),
             ("Proposed blocks/s", "sum(rate(consensus_proposed_blocks[{w}s] @ {t}))", "blk/s", 1.0),
             ("Commits/s", "sum(rate(consensus_transaction_commit_latency_count[{w}s] @ {t}))", "/s", 1.0),
         ]

--- a/dev-tools/iota-private-network/fuzzer/src/net_fuzz/metrics.py
+++ b/dev-tools/iota-private-network/fuzzer/src/net_fuzz/metrics.py
@@ -77,16 +77,12 @@ def get_consensus_metrics(container_name: str) -> dict[str, float]:
     if val is not None:
         metrics["proposal_interval_sum"] = val
 
-    # Latency (support both legacy and header-level metrics)
-    val = get_metric_value(text, "consensus_block_commit_latency_sum")
-    if val is None:
-        val = get_metric_value(text, "consensus_block_header_commit_latency_sum")
+    # Latency
+    val = get_metric_value(text, "consensus_block_header_commit_latency_sum")
     if val is not None:
         metrics["block_commit_latency_sum"] = val
 
-    val = get_metric_value(text, "consensus_block_commit_latency_count")
-    if val is None:
-        val = get_metric_value(text, "consensus_block_header_commit_latency_count")
+    val = get_metric_value(text, "consensus_block_header_commit_latency_count")
     if val is not None:
         metrics["block_commit_latency_count"] = val
 


### PR DESCRIPTION
# Description of change

The consensus block-commit latency histogram was renamed `consensus_block_commit_latency` → `consensus_block_header_commit_latency` in #9120 and the old name no longer exists. This removes the now-dead legacy-name references from the private-network tooling, keeping only the current metric:

- `experiments/run-migration-test.py` — drop the `block_commit_latency or …` fallback from the Block commit p50/p95 queries.
- `experiments/experiment_common.py` — same for `blk_p50`/`blk_p95`; update the docstring (transaction queries still intentionally carry no block fallback).
- `fuzzer/src/net_fuzz/metrics.py` — read `consensus_block_header_commit_latency_sum/count` directly instead of trying the legacy name first.

No behavior change against current nodes (queries already fell back to the live name); this just removes dead references.

## Links to any relevant issues

Relates to #12052

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
