### PR TITLE
upstream(iota-core): remove unnecessary async from AuthorityState methods

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3039,8 +3039,7 @@ impl AuthorityState {
 
         let requested_object_seq = match request.request_kind {
             ObjectInfoRequestKind::LatestObjectInfo => {
-                self.try_get_object_or_tombstone(request.object_id)
-                    .await?
+                self.try_get_object_or_tombstone(request.object_id)?
                     .ok_or_else(|| {
                         IotaError::from(UserInputError::ObjectNotFound {
                             object_id: request.object_id,
@@ -3079,8 +3078,7 @@ impl AuthorityState {
             // Only address owned objects have locks.
             None
         } else {
-            self.get_transaction_lock(&object.object_ref(), &epoch_store)
-                .await?
+            self.get_transaction_lock(&object.object_ref(), &epoch_store)?
                 .map(|s| s.into_inner())
         };
 
@@ -3781,23 +3779,21 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn try_get_object(&self, object_id: &ObjectId) -> IotaResult<Option<Object>> {
+    pub fn try_get_object(&self, object_id: &ObjectId) -> IotaResult<Option<Object>> {
         self.get_object_store()
             .try_get_object(object_id)
             .map_err(Into::into)
     }
 
     /// Non-fallible version of `try_get_object`.
-    pub async fn get_object(&self, object_id: &ObjectId) -> Option<Object> {
+    pub fn get_object(&self, object_id: &ObjectId) -> Option<Object> {
         self.try_get_object(object_id)
-            .await
             .expect("storage access failed")
     }
 
-    pub async fn get_iota_system_package_object_ref(&self) -> IotaResult<ObjectRef> {
+    pub fn get_iota_system_package_object_ref(&self) -> IotaResult<ObjectRef> {
         Ok(self
-            .try_get_object(&ObjectId::SYSTEM)
-            .await?
+            .try_get_object(&ObjectId::SYSTEM)?
             .expect("system package should always exist")
             .object_ref())
     }
@@ -4070,7 +4066,7 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub async fn get_move_objects<T>(&self, owner: Address, tag: StructTag) -> IotaResult<Vec<T>>
+    pub fn get_move_objects<T>(&self, owner: Address, tag: StructTag) -> IotaResult<Vec<T>>
     where
         T: DeserializeOwned,
     {
@@ -4556,19 +4552,16 @@ impl AuthorityState {
         Ok(events)
     }
 
-    pub async fn insert_genesis_object(&self, object: Object) {
+    pub fn insert_genesis_object(&self, object: Object) {
         self.get_reconfig_api()
             .try_insert_genesis_object(object)
             .expect("Cannot insert genesis object")
     }
 
-    pub async fn insert_genesis_objects(&self, objects: &[Object]) {
-        futures::future::join_all(
-            objects
-                .iter()
-                .map(|o| self.insert_genesis_object(o.clone())),
-        )
-        .await;
+    pub fn insert_genesis_objects(&self, objects: &[Object]) {
+        for o in objects {
+            self.insert_genesis_object(o.clone());
+        }
     }
 
     /// Make a status response for a transaction
@@ -4770,7 +4763,7 @@ impl AuthorityState {
     /// transaction,     or cannot find the transaction in transaction
     /// table, because of data race etc.
     #[instrument(level = "trace", skip_all)]
-    pub async fn get_transaction_lock(
+    pub fn get_transaction_lock(
         &self,
         object_ref: &ObjectRef,
         epoch_store: &AuthorityPerEpochStore,
@@ -4795,18 +4788,17 @@ impl AuthorityState {
         epoch_store.get_signed_transaction(&lock_info)
     }
 
-    pub async fn try_get_objects(&self, objects: &[ObjectId]) -> IotaResult<Vec<Option<Object>>> {
+    pub fn try_get_objects(&self, objects: &[ObjectId]) -> IotaResult<Vec<Option<Object>>> {
         self.get_object_cache_reader().try_get_objects(objects)
     }
 
     /// Non-fallible version of `try_get_objects`.
-    pub async fn get_objects(&self, objects: &[ObjectId]) -> Vec<Option<Object>> {
+    pub fn get_objects(&self, objects: &[ObjectId]) -> Vec<Option<Object>> {
         self.try_get_objects(objects)
-            .await
             .expect("storage access failed")
     }
 
-    pub async fn try_get_object_or_tombstone(
+    pub fn try_get_object_or_tombstone(
         &self,
         object_id: ObjectId,
     ) -> IotaResult<Option<ObjectRef>> {
@@ -4815,9 +4807,8 @@ impl AuthorityState {
     }
 
     /// Non-fallible version of `try_get_object_or_tombstone`.
-    pub async fn get_object_or_tombstone(&self, object_id: ObjectId) -> Option<ObjectRef> {
+    pub fn get_object_or_tombstone(&self, object_id: ObjectId) -> Option<ObjectRef> {
         self.try_get_object_or_tombstone(object_id)
-            .await
             .expect("storage access failed")
     }
 
@@ -4933,7 +4924,7 @@ impl AuthorityState {
             .iter()
             .map(|object_ref| object_ref.object_id)
             .collect();
-        let objects = self.get_objects(&ids).await;
+        let objects = self.get_objects(&ids);
 
         let mut res = Vec::with_capacity(system_packages.len());
         for (system_package_ref, object) in system_packages.into_iter().zip(objects.iter()) {

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -205,7 +205,7 @@ pub async fn init_state_with_ids<I: IntoIterator<Item = (Address, ObjectId)>>(
     for (address, object_id) in objects {
         let obj = Object::with_id_owner_for_testing(object_id, address);
         // TODO: Make this part of genesis initialization instead of explicit insert.
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     state
 }
@@ -219,7 +219,7 @@ pub async fn init_state_with_ids_and_versions<
     for (address, object_id, version) in objects {
         let obj =
             Object::with_id_owner_version_for_testing(object_id, version, Owner::Address(address));
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     state
 }
@@ -244,7 +244,7 @@ pub async fn init_state_with_objects_and_committee<I: IntoIterator<Item = Object
 ) -> Arc<AuthorityState> {
     let state = init_state_with_committee(genesis, authority_key).await;
     for o in objects {
-        state.insert_genesis_object(o).await;
+        state.insert_genesis_object(o);
     }
     state
 }
@@ -266,7 +266,7 @@ pub async fn init_state_with_ids_and_expensive_checks<
     for (address, object_id) in objects {
         let obj = Object::with_id_owner_for_testing(object_id, address);
         // TODO: Make this part of genesis initialization instead of explicit insert.
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     state
 }

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -1068,12 +1068,8 @@ mod tests {
         let mut subdag_transactions = Vec::new();
 
         for (i, (owned_obj, gas_obj)) in owned_objects.iter().zip(gas_objects.iter()).enumerate() {
-            let owned_ref = state
-                .get_object(&owned_obj.id())
-                .await
-                .unwrap()
-                .object_ref();
-            let gas_ref = state.get_object(&gas_obj.id()).await.unwrap().object_ref();
+            let owned_ref = state.get_object(&owned_obj.id()).unwrap().object_ref();
+            let gas_ref = state.get_object(&gas_obj.id()).unwrap().object_ref();
 
             let tx_data = TransactionData::new_transfer(
                 recipient,

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -365,7 +365,7 @@ mod tests {
             .await;
 
         let rgp = state.epoch_store_for_testing().reference_gas_price();
-        let gas_ref = state.get_object(&gas_object_id).await.unwrap().object_ref();
+        let gas_ref = state.get_object(&gas_object_id).unwrap().object_ref();
         let recipient = iota_types::crypto::get_key_pair::<AccountKeyPair>().0;
         let signed_tx =
             make_transfer_iota_transaction(gas_ref, recipient, None, sender, &sender_key, rgp);

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -119,7 +119,7 @@ impl TestCallArg {
     }
 
     async fn call_arg_from_id(object_id: ObjectId, state: &AuthorityState) -> CallArg {
-        let object = state.get_object(&object_id).await.unwrap();
+        let object = state.get_object(&object_id).unwrap();
         match &object.owner {
             Owner::Address(_) | Owner::Object(_) | Owner::Immutable => {
                 CallArg::ImmutableOrOwned(object.object_ref())
@@ -169,7 +169,7 @@ async fn construct_shared_object_transaction_with_sequence_number(
         .unwrap();
         effects.status().unwrap();
         let shared_object_id = effects.created()[0].0.object_id;
-        let mut shared_object = authority.get_object(&shared_object_id).await.unwrap();
+        let mut shared_object = authority.get_object(&shared_object_id).unwrap();
         if let Some(initial_shared_version) = initial_shared_version_override {
             shared_object
                 .data
@@ -186,10 +186,10 @@ async fn construct_shared_object_transaction_with_sequence_number(
     // Make a sample transaction.
     let (validator, fullnode, package) =
         init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
-    validator.insert_genesis_object(shared_object.clone()).await;
-    fullnode.insert_genesis_object(shared_object.clone()).await;
+    validator.insert_genesis_object(shared_object.clone());
+    fullnode.insert_genesis_object(shared_object.clone());
     let rgp = validator.reference_gas_price_for_testing().unwrap();
-    let gas_object = validator.get_object(&gas_object_id).await;
+    let gas_object = validator.get_object(&gas_object_id);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let data = TransactionData::new_move_call(
         sender,
@@ -225,11 +225,7 @@ async fn construct_shared_object_transaction_with_sequence_number(
 async fn test_dry_run_transaction_block() {
     let (validator, fullnode, transaction, gas_object_id, shared_object_id) =
         construct_shared_object_transaction_with_sequence_number(None).await;
-    let initial_shared_object_version = validator
-        .get_object(&shared_object_id)
-        .await
-        .unwrap()
-        .version();
+    let initial_shared_object_version = validator.get_object(&shared_object_id).unwrap().version();
 
     let transaction_digest = *transaction.digest();
 
@@ -243,13 +239,9 @@ async fn test_dry_run_transaction_block() {
     let gas_usage = response.effects.gas_cost_summary();
 
     // Make sure that objects are not mutated after dry run.
-    let gas_object_version = fullnode.get_object(&gas_object_id).await.unwrap().version();
+    let gas_object_version = fullnode.get_object(&gas_object_id).unwrap().version();
     assert_eq!(gas_object_version, OBJECT_START_VERSION);
-    let shared_object_version = fullnode
-        .get_object(&shared_object_id)
-        .await
-        .unwrap()
-        .version();
+    let shared_object_version = fullnode.get_object(&shared_object_id).unwrap().version();
     assert_eq!(shared_object_version, initial_shared_object_version);
 
     let txn_data = &transaction.data().intent_message().value;
@@ -361,7 +353,7 @@ async fn test_dev_inspect_object_by_bytes() {
     .await
     .unwrap();
     let created_object_id = effects.created()[0].0.object_id;
-    let created_object = validator.get_object(&created_object_id).await.unwrap();
+    let created_object = validator.get_object(&created_object_id).unwrap();
     let created_object_bytes = created_object
         .data
         .as_opt_struct()
@@ -432,7 +424,7 @@ async fn test_dev_inspect_object_by_bytes() {
     assert!(effects.unwrapped_then_deleted().is_empty());
 
     // compare the bytes
-    let updated_object = validator.get_object(&created_object_id).await.unwrap();
+    let updated_object = validator.get_object(&created_object_id).unwrap();
     let updated_object_bytes = updated_object.data.as_opt_struct().unwrap().contents();
     assert_eq!(updated_object_bytes, updated_reference_bytes)
 }
@@ -465,7 +457,7 @@ async fn test_dev_inspect_unowned_object() {
     .await
     .unwrap();
     let created_object_id = effects.created()[0].0.object_id;
-    let created_object = validator.get_object(&created_object_id).await.unwrap();
+    let created_object = validator.get_object(&created_object_id).unwrap();
     assert!(alice != bob);
     assert_eq!(created_object.owner, Owner::Address(bob));
 
@@ -534,7 +526,7 @@ async fn test_dev_inspect_dynamic_field() {
                 .unwrap();
                 assert!(effects.status().is_success(), "{:#?}", effects.status());
                 let created_object_id = effects.created()[0].0.object_id;
-                let created_object = validator.get_object(&created_object_id).await.unwrap();
+                let created_object = validator.get_object(&created_object_id).unwrap();
                 created_object
                     .data
                     .as_opt_struct()
@@ -641,7 +633,7 @@ async fn test_dev_inspect_return_values() {
     .await
     .unwrap();
     let created_object_id = effects.created()[0].0.object_id;
-    let created_object = validator.get_object(&created_object_id).await.unwrap();
+    let created_object = validator.get_object(&created_object_id).unwrap();
     let created_object_bytes = created_object
         .data
         .as_opt_struct()
@@ -991,8 +983,8 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     let (fullnode, _object_basics) = publish_object_basics(fullnode).await;
     let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
     let gas_object_ref = gas_object.object_ref();
-    validator.insert_genesis_object(gas_object.clone()).await;
-    fullnode.insert_genesis_object(gas_object).await;
+    validator.insert_genesis_object(gas_object.clone());
+    fullnode.insert_genesis_object(gas_object);
     // create the parent
     let effects = call_move_(
         &validator,
@@ -1062,7 +1054,7 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     assert_eq!(effects.created().len(), 1);
 
     // make sure the parent was updated
-    let new_parent = fullnode.get_object(&parent.object_id).await.unwrap();
+    let new_parent = fullnode.get_object(&parent.object_id).unwrap();
     assert!(parent.version < new_parent.version());
 
     // no child to delete since we are using the old version of the parent
@@ -1118,8 +1110,8 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
         Owner::Address(sender),
     );
     let gas_object_ref = gas_object.object_ref();
-    validator.insert_genesis_object(gas_object.clone()).await;
-    fullnode.insert_genesis_object(gas_object).await;
+    validator.insert_genesis_object(gas_object.clone());
+    fullnode.insert_genesis_object(gas_object);
     let rgp = fullnode.reference_gas_price_for_testing().unwrap();
     let pt = ProgrammableTransaction {
         inputs: vec![CallArg::pure(&(32_u64)), CallArg::pure(&sender)],
@@ -1163,8 +1155,8 @@ async fn test_handle_transfer_transaction_bad_signature() {
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
         sender,
@@ -1211,14 +1203,13 @@ async fn test_handle_transfer_transaction_bad_signature() {
     // address in verify_user_input (transaction.rs)
     // assert_eq!(metrics.signature_errors.get(), 1);
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
     assert!(
         authority_state
             .get_transaction_lock(
                 &object.object_ref(),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1229,7 +1220,6 @@ async fn test_handle_transfer_transaction_bad_signature() {
                 &object.object_ref(),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1248,8 +1238,8 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
     .await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
         sender,
@@ -1298,8 +1288,8 @@ async fn test_handle_transfer_transaction_unknown_sender() {
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let unknown_sender_transfer_transaction = init_transfer_transaction(
         &authority_state,
@@ -1319,14 +1309,13 @@ async fn test_handle_transfer_transaction_unknown_sender() {
             .is_err()
     );
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
     assert!(
         authority_state
             .get_transaction_lock(
                 &object.object_ref(),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1337,7 +1326,6 @@ async fn test_handle_transfer_transaction_unknown_sender() {
                 &object.object_ref(),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1355,8 +1343,8 @@ async fn test_handle_transfer_transaction_ok() {
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let before_object_version = object.version();
     let after_object_version =
@@ -1382,7 +1370,6 @@ async fn test_handle_transfer_transaction_ok() {
                 &ObjectReference::new(object_id, before_object_version, object.digest()),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .unwrap()
             .is_none()
     );
@@ -1392,7 +1379,6 @@ async fn test_handle_transfer_transaction_ok() {
                 &ObjectReference::new(object_id, after_object_version, object.digest()),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .is_err()
     );
 
@@ -1406,7 +1392,6 @@ async fn test_handle_transfer_transaction_ok() {
             &object.object_ref(),
             &authority_state.epoch_store_for_testing(),
         )
-        .await
         .unwrap()
         .unwrap();
 
@@ -1421,7 +1406,6 @@ async fn test_handle_transfer_transaction_ok() {
             &ObjectReference::new(object_id, before_object_version, object.digest()),
             &authority_state.epoch_store_for_testing(),
         )
-        .await
         .unwrap()
     else {
         panic!("No verified envelope for transaction");
@@ -1445,8 +1429,8 @@ async fn test_handle_sponsored_transaction() {
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
@@ -1571,10 +1555,9 @@ async fn test_transfer_package() {
     let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
-    let gas_object = authority_state.get_object(&object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&object_id).unwrap();
     let package_object_ref = authority_state
         .get_iota_system_package_object_ref()
-        .await
         .unwrap();
     // We are trying to transfer the genesis package object, which is immutable.
     let transfer_transaction = init_transfer_transaction(
@@ -1606,10 +1589,8 @@ async fn test_immutable_gas() {
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let imm_object_id = ObjectId::random();
     let imm_object = Object::immutable_with_id_for_testing(imm_object_id);
-    authority_state
-        .insert_genesis_object(imm_object.clone())
-        .await;
-    let mut_object = authority_state.get_object(&mut_object_id).await.unwrap();
+    authority_state.insert_genesis_object(imm_object.clone());
+    let mut_object = authority_state.get_object(&mut_object_id).unwrap();
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
         sender,
@@ -1640,9 +1621,7 @@ async fn test_objected_owned_gas() {
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let child_object_id = ObjectId::random();
     let child_object = Object::with_object_owner_for_testing(child_object_id, parent_object_id);
-    authority_state
-        .insert_genesis_object(child_object.clone())
-        .await;
+    authority_state.insert_genesis_object(child_object.clone());
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let data = TransactionData::new_transfer_iota(
         recipient,
@@ -1739,7 +1718,7 @@ async fn test_publish_dependent_module_ok() {
     .fresh_id();
 
     // Object does not exist
-    assert!(authority.get_object(&dependent_module_id).await.is_none());
+    assert!(authority.get_object(&dependent_module_id).is_none());
     let signed_effects = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap()
@@ -1747,7 +1726,7 @@ async fn test_publish_dependent_module_ok() {
     signed_effects.into_data().status().unwrap();
 
     // check that the dependent module got published
-    assert!(authority.get_object(&dependent_module_id).await.is_some());
+    assert!(authority.get_object(&dependent_module_id).is_some());
 }
 
 // Test that publishing a module with no dependencies works
@@ -1764,7 +1743,7 @@ async fn test_publish_module_no_dependencies_ok() {
     let gas_payment_object =
         Object::with_id_owner_gas_for_testing(gas_payment_object_id, sender, gas_balance);
     let gas_payment_object_ref = gas_payment_object.object_ref();
-    authority.insert_genesis_object(gas_payment_object).await;
+    authority.insert_genesis_object(gas_payment_object);
 
     let module = file_format::empty_module();
     let mut module_bytes = Vec::new();
@@ -1870,7 +1849,6 @@ async fn test_publish_non_existing_dependent_module() {
     assert_eq!(
         authority
             .get_object(&gas_payment_object_id)
-            .await
             .unwrap()
             .version(),
         gas_payment_object_ref.version
@@ -1954,10 +1932,7 @@ async fn test_handle_move_transaction() {
 
     let created_object_id = effects.created()[0].0.object_id;
     // check that transaction actually created an object with the expected ID, owner
-    let created_obj = authority_state
-        .get_object(&created_object_id)
-        .await
-        .unwrap();
+    let created_obj = authority_state.get_object(&created_object_id).unwrap();
     assert_eq!(created_obj.owner, sender);
     assert_eq!(created_obj.id(), created_object_id);
 }
@@ -1974,8 +1949,8 @@ async fn test_conflicting_transactions() {
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let tx1 = init_transfer_transaction(
         &authority_state,
@@ -2077,8 +2052,8 @@ async fn test_handle_transfer_transaction_double_spend() {
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let transfer_transaction = init_transfer_transaction(
         &authority_state,
         sender,
@@ -2111,7 +2086,7 @@ async fn test_handle_transfer_iota_with_amount_insufficient_gas() {
     let object_id = ObjectId::random();
     let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
     let data = TransactionData::new_transfer_iota(
         recipient,
         sender,
@@ -2142,7 +2117,7 @@ async fn test_missing_package() {
         init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let non_existent_package = ObjectId::MAX;
     let gas_object_ref = gas_object.object_ref();
     let data = TransactionData::new_move_call(
@@ -2181,15 +2156,15 @@ async fn test_type_argument_dependencies() {
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let gas1 = {
-        let o = authority_state.get_object(&gas1).await.unwrap();
+        let o = authority_state.get_object(&gas1).unwrap();
         o.object_ref()
     };
     let gas2 = {
-        let o = authority_state.get_object(&gas2).await.unwrap();
+        let o = authority_state.get_object(&gas2).unwrap();
         o.object_ref()
     };
     let gas3 = {
-        let o = authority_state.get_object(&gas3).await.unwrap();
+        let o = authority_state.get_object(&gas3).unwrap();
         o.object_ref()
     };
     // primitive type tag succeeds
@@ -2276,8 +2251,8 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
     let gas_object_id = ObjectId::random();
     let authority_state =
         init_state_with_ids(vec![(address, object_id), (address, gas_object_id)]).await;
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let certified_transfer_transaction = init_certified_transfer_transaction(
         address,
@@ -2305,8 +2280,8 @@ async fn test_handle_confirmation_transaction_ok() {
     let gas_object_id = ObjectId::random();
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let next_sequence_number =
         Version::lamport_increment([object.version(), gas_object.version()]).unwrap();
@@ -2320,7 +2295,7 @@ async fn test_handle_confirmation_transaction_ok() {
         &authority_state,
     );
 
-    let old_account = authority_state.get_object(&object_id).await.unwrap();
+    let old_account = authority_state.get_object(&object_id).unwrap();
 
     let signed_effects = authority_state
         .wait_for_certificate_execution(
@@ -2332,7 +2307,7 @@ async fn test_handle_confirmation_transaction_ok() {
     signed_effects.status().unwrap();
     // Key check: the ownership has changed
 
-    let new_account = authority_state.get_object(&object_id).await.unwrap();
+    let new_account = authority_state.get_object(&object_id).unwrap();
     assert_eq!(new_account.owner, recipient);
     assert_eq!(next_sequence_number, new_account.version());
 
@@ -2343,7 +2318,6 @@ async fn test_handle_confirmation_transaction_ok() {
                 &ObjectReference::new(object_id, 1.into(), old_account.digest()),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .is_err()
     );
     assert!(
@@ -2352,7 +2326,6 @@ async fn test_handle_confirmation_transaction_ok() {
                 &ObjectReference::new(object_id, 2.into(), new_account.digest()),
                 &authority_state.epoch_store_for_testing()
             )
-            .await
             .expect("failed to retrieve transaction lock")
             .is_none()
     );
@@ -2366,8 +2339,8 @@ async fn test_handle_confirmation_transaction_idempotent() {
     let gas_object_id = ObjectId::random();
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let certified_transfer_transaction = init_certified_transfer_transaction(
         sender,
@@ -2454,7 +2427,6 @@ async fn test_move_call_mutable_object_not_mutated() {
 
     let gas_version = authority_state
         .get_object(&gas_object_id)
-        .await
         .unwrap()
         .version();
 
@@ -2483,7 +2455,6 @@ async fn test_move_call_mutable_object_not_mutated() {
     assert_eq!(
         authority_state
             .get_object(&new_object_id1)
-            .await
             .unwrap()
             .version(),
         next_object_version
@@ -2491,7 +2462,6 @@ async fn test_move_call_mutable_object_not_mutated() {
     assert_eq!(
         authority_state
             .get_object(&new_object_id2)
-            .await
             .unwrap()
             .version(),
         next_object_version
@@ -2523,14 +2493,9 @@ async fn test_move_call_insufficient_gas() {
         sender,
         &sender_key,
         recipient,
-        authority_state
-            .get_object(&object_id)
-            .await
-            .unwrap()
-            .object_ref(),
+        authority_state.get_object(&object_id).unwrap().object_ref(),
         authority_state
             .get_object(&gas_object_id1)
-            .await
             .unwrap()
             .object_ref(),
         &authority_state,
@@ -2545,15 +2510,10 @@ async fn test_move_call_insufficient_gas() {
     let gas_used = effects.gas_cost_summary().net_gas_usage() as u64;
     let kind_of_rebate_to_remove = effects.gas_cost_summary().storage_cost / 2;
 
-    let obj_ref = authority_state
-        .get_object(&object_id)
-        .await
-        .unwrap()
-        .object_ref();
+    let obj_ref = authority_state.get_object(&object_id).unwrap().object_ref();
 
     let gas_ref = authority_state
         .get_object(&gas_object_id2)
-        .await
         .unwrap()
         .object_ref();
 
@@ -2582,7 +2542,7 @@ async fn test_move_call_insufficient_gas() {
         .1;
     let effects = signed_effects.into_data();
     assert!(effects.status().is_failure());
-    let obj = authority_state.get_object(&object_id).await.unwrap();
+    let obj = authority_state.get_object(&object_id).unwrap();
     assert_eq!(obj.previous_transaction, tx_digest);
     assert_eq!(obj.version(), next_object_version);
     assert_eq!(obj.owner, recipient);
@@ -2672,7 +2632,6 @@ async fn test_get_latest_parent_entry_genesis() {
     assert!(
         authority_state
             .get_object_or_tombstone(ObjectId::ZERO)
-            .await
             .is_none()
     );
 }
@@ -2737,7 +2696,6 @@ async fn test_get_latest_parent_entry() {
     // Check entry for object to be deleted is returned
     let obj_ref = authority_state
         .get_object_or_tombstone(new_object_id1)
-        .await
         .unwrap();
     assert_eq!(obj_ref.object_id, new_object_id1);
     assert_eq!(obj_ref.version, update_version);
@@ -2770,14 +2728,12 @@ async fn test_get_latest_parent_entry() {
     assert!(
         authority_state
             .get_object_or_tombstone(unknown_object_id)
-            .await
             .is_none()
     );
 
     // Check gas object is returned.
     let obj_ref = authority_state
         .get_object_or_tombstone(gas_object_id)
-        .await
         .unwrap();
     assert_eq!(obj_ref.object_id, gas_object_id);
     assert_eq!(obj_ref.version, delete_version);
@@ -2785,7 +2741,6 @@ async fn test_get_latest_parent_entry() {
     // Check entry for deleted object is returned
     let obj_ref = authority_state
         .get_object_or_tombstone(new_object_id1)
-        .await
         .unwrap();
     assert_eq!(obj_ref.object_id, new_object_id1);
     assert_eq!(obj_ref.version, delete_version);
@@ -2798,7 +2753,7 @@ async fn test_account_state_ok() {
     let object_id = dbg_object_id(1);
 
     let authority_state = init_state_with_object_id(sender, object_id).await;
-    authority_state.get_object(&object_id).await.unwrap();
+    authority_state.get_object(&object_id).unwrap();
 }
 
 #[tokio::test]
@@ -2806,7 +2761,7 @@ async fn test_account_state_unknown_account() {
     let sender = dbg_addr(1);
     let unknown_address = dbg_object_id(99);
     let authority_state = init_state_with_object_id(sender, ObjectId::random()).await;
-    assert!(authority_state.get_object(&unknown_address).await.is_none());
+    assert!(authority_state.get_object(&unknown_address).is_none());
 }
 
 #[tokio::test]
@@ -2845,7 +2800,7 @@ async fn test_authority_persist() {
     let obj = Object::with_id_owner_for_testing(object_id, recipient);
 
     // Store an object
-    authority.insert_genesis_object(obj).await;
+    authority.insert_genesis_object(obj);
 
     // Close the authority
     drop(authority);
@@ -2865,7 +2820,7 @@ async fn test_authority_persist() {
             .await
             .unwrap();
     let authority2 = init_state(&genesis, authority_key, store).await;
-    let obj2 = authority2.get_object(&object_id).await.unwrap();
+    let obj2 = authority2.get_object(&object_id).unwrap();
 
     // Check the object is present
     assert_eq!(obj2.id(), object_id);
@@ -3105,10 +3060,7 @@ async fn test_genesis_iota_system_state_object() {
     // And its Move layout matches the definition in Rust (so that we can
     // deserialize it).
     let authority_state = TestAuthorityBuilder::new().build().await;
-    let wrapper = authority_state
-        .get_object(&ObjectId::SYSTEM_STATE)
-        .await
-        .unwrap();
+    let wrapper = authority_state.get_object(&ObjectId::SYSTEM_STATE).unwrap();
     assert_eq!(wrapper.version(), Version::from(1));
     let move_object = wrapper.data.as_opt_struct().unwrap();
     let _iota_system_state =
@@ -3171,10 +3123,9 @@ async fn test_transfer_iota_no_amount() {
     assert!(effects.mutated_excluding_gas().is_empty());
     assert!(gas_ref.version < effects.gas_object().0.version);
     assert_eq!(effects.gas_object().1, Owner::Address(recipient));
-    let new_balance = iota_types::gas::get_gas_balance(
-        &authority_state.get_object(&gas_object_id).await.unwrap(),
-    )
-    .unwrap();
+    let new_balance =
+        iota_types::gas::get_gas_balance(&authority_state.get_object(&gas_object_id).unwrap())
+            .unwrap();
     assert_eq!(
         new_balance as i64 + effects.gas_cost_summary().net_gas_usage(),
         init_balance as i64
@@ -3214,15 +3165,13 @@ async fn test_transfer_iota_with_amount() {
     assert_eq!(effects.created()[0].1, Owner::Address(recipient));
     let new_gas = authority_state
         .get_object(&effects.created()[0].0.object_id)
-        .await
         .unwrap();
     assert_eq!(iota_types::gas::get_gas_balance(&new_gas).unwrap(), 500);
     assert!(gas_ref.version < effects.gas_object().0.version);
     assert_eq!(effects.gas_object().1, Owner::Address(sender));
-    let new_balance = iota_types::gas::get_gas_balance(
-        &authority_state.get_object(&gas_object_id).await.unwrap(),
-    )
-    .unwrap();
+    let new_balance =
+        iota_types::gas::get_gas_balance(&authority_state.get_object(&gas_object_id).unwrap())
+            .unwrap();
     assert_eq!(
         new_balance as i64 + effects.gas_cost_summary().net_gas_usage() + 500,
         init_balance as i64
@@ -3893,8 +3842,8 @@ async fn test_iter_live_object_set() {
         })
         .collect();
 
-    let gas_obj = authority.get_object(&gas).await.unwrap();
-    let obj = authority.get_object(&obj_id).await.unwrap();
+    let gas_obj = authority.get_object(&gas).unwrap();
+    let obj = authority.get_object(&obj_id).unwrap();
 
     let certified_transfer_transaction = init_certified_transfer_transaction(
         sender,
@@ -4092,7 +4041,7 @@ pub async fn init_state_with_objects_and_object_basics<I: IntoIterator<Item = Ob
 ) -> (Arc<AuthorityState>, ObjectReference) {
     let state = TestAuthorityBuilder::new().build().await;
     for obj in objects {
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     publish_object_basics(state).await
 }
@@ -4104,7 +4053,7 @@ pub async fn init_state_with_ids_and_object_basics<I: IntoIterator<Item = (Addre
     let state = TestAuthorityBuilder::new().build().await;
     for (address, object_id) in objects {
         let obj = Object::with_id_owner_for_testing(object_id, address);
-        state.insert_genesis_object(obj).await;
+        state.insert_genesis_object(obj);
     }
     publish_object_basics(state).await
 }
@@ -4131,7 +4080,7 @@ pub async fn publish_object_basics(
     )
     .unwrap();
     let pkg_ref = pkg.object_ref();
-    state.insert_genesis_object(pkg).await;
+    state.insert_genesis_object(pkg);
     (state, pkg_ref)
 }
 
@@ -4148,8 +4097,8 @@ pub async fn init_state_with_ids_and_object_basics_with_fullnode<
     let (validator, fullnode) = init_state_validator_with_fullnode().await;
     for (address, object_id) in objects {
         let obj = Object::with_id_owner_for_testing(object_id, address);
-        validator.insert_genesis_object(obj.clone()).await;
-        fullnode.insert_genesis_object(obj).await;
+        validator.insert_genesis_object(obj.clone());
+        fullnode.insert_genesis_object(obj);
     }
 
     // add object_basics package object to genesis, since lots of test use it
@@ -4169,8 +4118,8 @@ pub async fn init_state_with_ids_and_object_basics_with_fullnode<
     )
     .unwrap();
     let pkg_ref = pkg.object_ref();
-    validator.insert_genesis_object(pkg.clone()).await;
-    fullnode.insert_genesis_object(pkg).await;
+    validator.insert_genesis_object(pkg.clone());
+    fullnode.insert_genesis_object(pkg);
     (validator, fullnode, pkg_ref)
 }
 
@@ -4214,7 +4163,7 @@ pub async fn call_move_(
     test_args: Vec<TestCallArg>,
     with_shared: bool, // Move call includes shared objects
 ) -> IotaResult<TransactionEffects> {
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let mut builder = ProgrammableTransactionBuilder::new();
     let mut args = vec![];
@@ -4298,7 +4247,7 @@ pub async fn build_programmable_transaction(
     gas_unit: u64,
 ) -> IotaResult<Transaction> {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let data =
         TransactionData::new_programmable(*sender, vec![gas_object_ref], pt, rgp * gas_unit, rgp);
@@ -4317,7 +4266,7 @@ async fn execute_programmable_transaction_(
     gas_unit: u64,
 ) -> IotaResult<TransactionEffects> {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let data =
         TransactionData::new_programmable(*sender, vec![gas_object_ref], pt, rgp * gas_unit, rgp);
@@ -4346,7 +4295,7 @@ async fn call_move_with_gas_coins(
 ) -> IotaResult<TransactionEffects> {
     let mut gas_object_refs = vec![];
     for obj_id in gas_object_ids {
-        let gas_object = authority.get_object(obj_id).await;
+        let gas_object = authority.get_object(obj_id);
         let gas_ref = gas_object.unwrap().object_ref();
         gas_object_refs.push(gas_ref);
     }
@@ -4669,11 +4618,7 @@ async fn test_shared_object_transaction_ok() {
     authority.notify_read_effects(&certificate).await.unwrap();
 
     // Ensure shared object sequence number increased.
-    let shared_object_version = authority
-        .get_object(&shared_object_id)
-        .await
-        .unwrap()
-        .version();
+    let shared_object_version = authority.get_object(&shared_object_id).unwrap().version();
     assert_eq!(shared_object_version, Version::from(2));
 }
 
@@ -5647,8 +5592,7 @@ async fn test_gas_smashing() {
         }
         // balance on first coin is correct
         let balance =
-            iota_types::gas::get_gas_balance(&state.get_object(&gas_coin_ids[0]).await.unwrap())
-                .unwrap();
+            iota_types::gas::get_gas_balance(&state.get_object(&gas_coin_ids[0]).unwrap()).unwrap();
         let gas_used = effects.gas_cost_summary().gas_used();
         assert!(reference_gas_used > balance);
         assert_eq!(reference_gas_used, balance + gas_used);
@@ -5895,7 +5839,7 @@ async fn test_publish_transitive_dependencies_ok() {
     let rgp = state.reference_gas_price_for_testing().unwrap();
 
     // Get gas object
-    let gas_object = state.get_object(&gas_id).await.unwrap();
+    let gas_object = state.get_object(&gas_id).unwrap();
     let gas_ref = gas_object.object_ref();
 
     // Publish `package C`
@@ -6092,7 +6036,7 @@ async fn test_publish_missing_dependency() {
     let state = init_state_with_ids(vec![(sender, gas_id)]).await;
 
     // Get gas object
-    let gas_object = state.get_object(&gas_id).await.unwrap();
+    let gas_object = state.get_object(&gas_id).unwrap();
     let gas_ref = gas_object.object_ref();
 
     // Module bytes
@@ -6138,7 +6082,7 @@ async fn test_publish_missing_transitive_dependency() {
     let state = init_state_with_ids(vec![(sender, gas_id)]).await;
 
     // Get gas object
-    let gas_object = state.get_object(&gas_id).await.unwrap();
+    let gas_object = state.get_object(&gas_id).unwrap();
     let gas_ref = gas_object.object_ref();
 
     // Module bytes
@@ -6184,7 +6128,7 @@ async fn test_publish_not_a_package_dependency() {
     let state = init_state_with_ids(vec![(sender, gas_id)]).await;
 
     // Get gas object
-    let gas_object = state.get_object(&gas_id).await.unwrap();
+    let gas_object = state.get_object(&gas_id).unwrap();
     let gas_ref = gas_object.object_ref();
 
     // Module bytes
@@ -6304,7 +6248,7 @@ async fn test_consensus_handler_per_object_congestion_control(
     let mut genesis_objects = gas_objects_commit_1.clone();
     genesis_objects.extend(gas_objects_commit_2.clone());
     genesis_objects.extend(shared_objects.clone());
-    authority.insert_genesis_objects(&genesis_objects).await;
+    authority.insert_genesis_objects(&genesis_objects);
 
     // Create first batch of commits. Here, we create 5 transactions that operate on
     // the first shared object with very high gas budget. And
@@ -6526,7 +6470,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     genesis_objects.extend(gas_objects_cancelled_txn.clone());
     genesis_objects.extend(shared_objects.clone());
     genesis_objects.extend(owned_objects_cancelled_txn.clone());
-    authority.insert_genesis_objects(&genesis_objects).await;
+    authority.insert_genesis_objects(&genesis_objects);
 
     let mut certificates: Vec<VerifiedCertificate> = vec![];
     let gas_price_of_non_cancelled_txs = 2_000;
@@ -6760,9 +6704,9 @@ async fn test_post_consensus_white_flag_simple_conflict() {
 
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let object = authority.get_object(&object_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let gas2 = authority.get_object(&gas2_id).await.unwrap();
+    let object = authority.get_object(&object_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let gas2 = authority.get_object(&gas2_id).unwrap();
 
     // Create two conflicting transactions
     let verified_tx1 = init_transfer_transaction(
@@ -6872,10 +6816,10 @@ async fn test_post_consensus_white_flag_no_conflict() {
 
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let object1 = authority.get_object(&object1_id).await.unwrap();
-    let object2 = authority.get_object(&object2_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let gas2 = authority.get_object(&gas2_id).await.unwrap();
+    let object1 = authority.get_object(&object1_id).unwrap();
+    let object2 = authority.get_object(&object2_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let gas2 = authority.get_object(&gas2_id).unwrap();
 
     // Create two non-conflicting transactions
     let verified_tx1 = init_transfer_transaction(
@@ -6985,9 +6929,9 @@ async fn test_post_consensus_white_flag_conflict_different_commits() {
 
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let object = authority.get_object(&object_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let gas2 = authority.get_object(&gas2_id).await.unwrap();
+    let object = authority.get_object(&object_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let gas2 = authority.get_object(&gas2_id).unwrap();
 
     // First commit: tx1 locks the object
     let verified_tx1 = init_transfer_transaction(
@@ -7141,7 +7085,7 @@ async fn test_pcool_deferred_tx_not_dropped_next_round_but_executed() {
         .await;
     let mut genesis_objects = gas_objects.clone();
     genesis_objects.extend(shared_objects.clone());
-    authority.insert_genesis_objects(&genesis_objects).await;
+    authority.insert_genesis_objects(&genesis_objects);
 
     // Build two `UserTransactionV1` transactions touching the same shared object,
     // each paid by a distinct gas coin. The move call is never executed (the

--- a/crates/iota-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/batch_transaction_tests.rs
@@ -34,11 +34,7 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
         builder
             .transfer_object(
                 recipient,
-                authority_state
-                    .get_object(obj_id)
-                    .await
-                    .unwrap()
-                    .object_ref(),
+                authority_state.get_object(obj_id).unwrap().object_ref(),
             )
             .unwrap()
     }
@@ -63,7 +59,6 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
         vec![
             authority_state
                 .get_object(&all_ids[N])
-                .await
                 .unwrap()
                 .object_ref(),
         ],
@@ -119,11 +114,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
         builder
             .transfer_object(
                 recipient,
-                authority_state
-                    .get_object(obj_id)
-                    .await
-                    .unwrap()
-                    .object_ref(),
+                authority_state.get_object(obj_id).unwrap().object_ref(),
             )
             .unwrap()
     }
@@ -141,7 +132,6 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
         vec![
             authority_state
                 .get_object(&all_ids[N])
-                .await
                 .unwrap()
                 .object_ref(),
         ],
@@ -176,9 +166,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
         sender,
         49999, // We need 50000
     );
-    authority_state
-        .insert_genesis_object(gas_object.clone())
-        .await;
+    authority_state.insert_genesis_object(gas_object.clone());
 
     const N: usize = 10;
     let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -37,7 +37,7 @@ async fn test_regulated_coin_v1_types() {
     let mut regulated_metadata_object = None;
     let mut package_id = None;
     for (oref, _owner) in env.publish_effects.created() {
-        let object = env.authority.get_object(&oref.object_id).await.unwrap();
+        let object = env.authority.get_object(&oref.object_id).unwrap();
         if object.is_package() {
             package_id = Some(object.id());
             continue;
@@ -219,7 +219,7 @@ struct TestEnv {
 
 impl TestEnv {
     async fn get_latest_object_ref(&self, id: &ObjectId) -> ObjectRef {
-        self.authority.get_object(id).await.unwrap().object_ref()
+        self.authority.get_object(id).unwrap().object_ref()
     }
 }
 

--- a/crates/iota-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/iota-core/src/unit_tests/congestion_control_tests.rs
@@ -86,9 +86,7 @@ impl TestSetup {
 
         let gas_object_id = ObjectId::random();
         let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-        setup_authority_state
-            .insert_genesis_object(gas_object.clone())
-            .await;
+        setup_authority_state.insert_genesis_object(gas_object.clone());
 
         let package = build_and_publish_test_package(
             &setup_authority_state,
@@ -187,19 +185,17 @@ impl TestSetup {
         genesis_objects.push(TestSetup::convert_to_genesis_obj(
             self.setup_authority_state
                 .get_object(&self.package.object_id)
-                .await
                 .unwrap(),
         ));
         genesis_objects.push(TestSetup::convert_to_genesis_obj(
             self.setup_authority_state
                 .get_object(&self.gas_object_id)
-                .await
                 .unwrap(),
         ));
 
         for obj in objects {
             genesis_objects.push(TestSetup::convert_to_genesis_obj(
-                self.setup_authority_state.get_object(obj).await.unwrap(),
+                self.setup_authority_state.get_object(obj).unwrap(),
             ));
         }
         genesis_objects
@@ -316,17 +312,13 @@ async fn test_congestion_control_execution_cancellation() {
         .with_protocol_config(test_setup.protocol_config.clone())
         .build()
         .await;
-    authority_state
-        .insert_genesis_objects(&genesis_objects)
-        .await;
+    authority_state.insert_genesis_objects(&genesis_objects);
     let authority_state_2 = TestAuthorityBuilder::new()
         .with_reference_gas_price(TEST_ONLY_GAS_PRICE)
         .with_protocol_config(test_setup.protocol_config.clone())
         .build()
         .await;
-    authority_state_2
-        .insert_genesis_objects(&genesis_objects)
-        .await;
+    authority_state_2.insert_genesis_objects(&genesis_objects);
 
     // The congestion limit, taking overshoot into account is
     // 2 * TEST_ONLY_GAS_PRICE * TEST_ONLY_GAS_UNIT. We set the initial debt to be
@@ -389,7 +381,6 @@ async fn test_congestion_control_execution_cancellation() {
         ],
         &authority_state
             .get_object(&owned_object.object_id)
-            .await
             .unwrap()
             .object_ref(),
         TEST_ONLY_GAS_UNIT,
@@ -487,9 +478,7 @@ async fn test_congestion_control_debt_tracking() {
         .with_protocol_config(test_setup.protocol_config.clone())
         .build()
         .await;
-    authority_state
-        .insert_genesis_objects(&genesis_objects)
-        .await;
+    authority_state.insert_genesis_objects(&genesis_objects);
 
     // Commit 1: a transaction with gas budget 3*default_tx_gas_budget that touches
     // shared_object_1 and an owned object.
@@ -504,7 +493,6 @@ async fn test_congestion_control_debt_tracking() {
         &[(shared_object_1.object_id, shared_object_1.version)],
         &authority_state
             .get_object(&owned_object.object_id)
-            .await
             .unwrap()
             .object_ref(),
         3 * TEST_ONLY_GAS_UNIT,
@@ -556,7 +544,6 @@ async fn test_congestion_control_debt_tracking() {
         ],
         &authority_state
             .get_object(&owned_object.object_id)
-            .await
             .unwrap()
             .object_ref(),
         TEST_ONLY_GAS_UNIT / 2,
@@ -610,7 +597,6 @@ async fn test_congestion_control_debt_tracking() {
         &[(shared_object_2.object_id, shared_object_2.version)],
         &authority_state
             .get_object(&owned_object.object_id)
-            .await
             .unwrap()
             .object_ref(),
         2 * TEST_ONLY_GAS_UNIT,
@@ -695,7 +681,6 @@ async fn test_congestion_control_debt_tracking() {
         &[(shared_object_1.object_id, shared_object_1.version)],
         &authority_state
             .get_object(&owned_object.object_id)
-            .await
             .unwrap()
             .object_ref(),
         5 * TEST_ONLY_GAS_UNIT / 2,
@@ -753,7 +738,6 @@ async fn test_congestion_control_debt_tracking() {
         ],
         &authority_state
             .get_object(&owned_object.object_id)
-            .await
             .unwrap()
             .object_ref(),
         3 * TEST_ONLY_GAS_UNIT / 2,
@@ -843,7 +827,6 @@ async fn test_congestion_control_debt_tracking() {
         &[],
         &authority_state
             .get_object(&owned_object.object_id)
-            .await
             .unwrap()
             .object_ref(),
         3 * TEST_ONLY_GAS_UNIT,
@@ -897,7 +880,6 @@ async fn test_congestion_control_debt_tracking() {
         ],
         &authority_state
             .get_object(&owned_object.object_id)
-            .await
             .unwrap()
             .object_ref(),
         3 * TEST_ONLY_GAS_UNIT,

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -68,7 +68,7 @@ pub async fn test_certificates(
     ));
     for gas_object in test_gas_objects() {
         // Object digest may be different in genesis than originally generated.
-        let gas_object = authority.get_object(&gas_object.id()).await.unwrap();
+        let gas_object = authority.get_object(&gas_object.id()).unwrap();
         // Make a sample transaction.
         let module = "object_basics";
         let function = "create";

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -740,9 +740,7 @@ async fn test_authority_txn_signing_pushback() {
         .with_authority_overload_config(overload_config)
         .build()
         .await;
-    authority_state
-        .insert_genesis_objects(&[gas_object1.clone(), gas_object2.clone()])
-        .await;
+    authority_state.insert_genesis_objects(&[gas_object1.clone(), gas_object2.clone()]);
 
     // Create a validator service around the `authority_state`.
     let epoch_store = authority_state.epoch_store_for_testing();
@@ -789,7 +787,6 @@ async fn test_authority_txn_signing_pushback() {
     // Check that the input object should be locked by the above transaction.
     let lock_tx = authority_state
         .get_transaction_lock(&gas_object1.object_ref(), &epoch_store)
-        .await
         .unwrap()
         .unwrap();
     assert_eq!(tx.digest(), lock_tx.digest());
@@ -872,9 +869,7 @@ async fn test_authority_txn_execution_pushback() {
         .with_authority_overload_config(overload_config)
         .build()
         .await;
-    authority_state
-        .insert_genesis_objects(&[gas_object1.clone(), gas_object2.clone()])
-        .await;
+    authority_state.insert_genesis_objects(&[gas_object1.clone(), gas_object2.clone()]);
 
     // Create a validator service around the `authority_state`.
     let consensus_adapter = Arc::new(ConsensusAdapter::new(

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -128,7 +128,7 @@ impl GasPriceFeedbackTester {
             .iter()
             .map(|gas_object_id| Object::with_id_owner_for_testing(*gas_object_id, sender))
             .collect::<Vec<_>>();
-        authority_state.insert_genesis_objects(&gas_objects).await;
+        authority_state.insert_genesis_objects(&gas_objects);
 
         let gas_object_id = gas_object_ids.first().unwrap();
 
@@ -191,7 +191,6 @@ impl GasPriceFeedbackTester {
 
         let gas_object_ref = authority_state
             .get_object(gas_object_id)
-            .await
             .unwrap()
             .object_ref();
 
@@ -230,7 +229,6 @@ impl GasPriceFeedbackTester {
         let gas_object_ref = self
             .authority_state
             .get_object(&gas_data.gas_object_id)
-            .await
             .unwrap()
             .object_ref();
 

--- a/crates/iota-core/src/unit_tests/gas_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_tests.rs
@@ -161,12 +161,12 @@ where
     let gas_coin_ids: Vec<_> = gas_coins.iter().map(|obj| obj.id()).collect();
     let authority_state = TestAuthorityBuilder::new().build().await;
     for obj in gas_coins {
-        authority_state.insert_genesis_object(obj).await;
+        authority_state.insert_genesis_object(obj);
     }
 
     let gas_object_id = ObjectId::random();
     let gas_coin = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_amount);
-    authority_state.insert_genesis_object(gas_coin).await;
+    authority_state.insert_genesis_object(gas_coin);
     // touch gas coins so that `storage_rebate` is set (not 0 as in genesis)
     touch_gas_coins(
         &authority_state,
@@ -184,11 +184,7 @@ where
     // call move entry function
     let mut gas_coin_refs = vec![];
     for coin_id in &gas_coin_ids {
-        let coin_ref = authority_state
-            .get_object(coin_id)
-            .await
-            .unwrap()
-            .object_ref();
+        let coin_ref = authority_state.get_object(coin_id).unwrap().object_ref();
         gas_coin_refs.push(coin_ref);
     }
     let module = Identifier::from_static("move_random");
@@ -234,10 +230,7 @@ where
         );
     }
     let gas_ref = effects.gas_object().0;
-    let gas_object = authority_state
-        .get_object(&gas_ref.object_id)
-        .await
-        .unwrap();
+    let gas_object = authority_state.get_object(&gas_ref.object_id).unwrap();
     let final_value = GasCoin::try_from(&gas_object)?.value();
     let summary = effects.gas_cost_summary();
 
@@ -279,18 +272,13 @@ async fn touch_gas_coins(
 ) {
     let mut builder = ProgrammableTransactionBuilder::new();
     for coin_id in coin_ids {
-        let coin_ref = authority_state
-            .get_object(coin_id)
-            .await
-            .unwrap()
-            .object_ref();
+        let coin_ref = authority_state.get_object(coin_id).unwrap().object_ref();
         builder.transfer_object(recipient, coin_ref).unwrap();
     }
     let pt = builder.finish();
     let kind = TransactionKind::Programmable(pt);
     let gas_object_ref = authority_state
         .get_object(&gas_object_id)
-        .await
         .unwrap()
         .object_ref();
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
@@ -512,7 +500,6 @@ async fn test_native_transfer_sufficient_gas() -> IotaResult {
     let gas_object = result
         .authority_state
         .get_object(&result.gas_object_id)
-        .await
         .unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
@@ -564,7 +551,7 @@ async fn test_transfer_iota_insufficient_gas() {
     let gas_object_id = ObjectId::random();
     let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, *MAX_GAS_BUDGET);
     let gas_object_ref = gas_object.object_ref();
-    authority_state.insert_genesis_object(gas_object).await;
+    authority_state.insert_genesis_object(gas_object);
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
     let pt = {
@@ -605,7 +592,7 @@ async fn test_invalid_gas_owners() {
 
     let init_object = |o: Object| async {
         let obj_ref = o.object_ref();
-        authority_state.insert_genesis_object(o).await;
+        authority_state.insert_genesis_object(o);
         obj_ref
     };
 
@@ -749,7 +736,6 @@ async fn test_native_transfer_insufficient_gas_execution() {
     let gas_object = result
         .authority_state
         .get_object(&result.gas_object_id)
-        .await
         .unwrap();
     let gas_coin = GasCoin::try_from(&gas_object).unwrap();
     assert_eq!(gas_coin.value(), 0);
@@ -789,7 +775,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
     let gas_cost = effects.gas_cost_summary();
     assert!(gas_cost.storage_cost > 0);
 
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let gas_size = gas_object.object_size_for_gas_metering();
     let expected_gas_balance = GAS_VALUE_FOR_TESTING - gas_cost.net_gas_usage() as u64;
     assert_eq!(
@@ -828,7 +814,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
 
     assert!(gas_cost.gas_used() > 0);
 
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let expected_gas_balance = expected_gas_balance - gas_cost.net_gas_usage() as u64;
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
@@ -845,7 +831,7 @@ async fn test_move_call_gas() -> IotaResult {
     let (authority_state, package_object_ref) =
         init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let module = Identifier::from_static("object_basics");
     let function = Identifier::from_static("create");
@@ -874,7 +860,7 @@ async fn test_move_call_gas() -> IotaResult {
     let gas_cost = effects.gas_cost_summary();
     assert!(gas_cost.storage_cost > 0);
     assert_eq!(gas_cost.storage_rebate, 0);
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
     let expected_gas_balance = GAS_VALUE_FOR_TESTING - gas_cost.net_gas_usage() as u64;
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
@@ -941,15 +927,15 @@ async fn test_tx_gas_coins_input_coins() {
         .iter()
         .map(|obj| obj.object_ref())
         .collect::<Vec<_>>();
-    authority_state.insert_genesis_objects(&gas_coins).await;
+    authority_state.insert_genesis_objects(&gas_coins);
     let coins = (0..260)
         .map(|_| Object::with_owner_for_testing(sender))
         .collect::<Vec<_>>();
     let coin_refs = coins.iter().map(|obj| obj.object_ref()).collect::<Vec<_>>();
-    authority_state.insert_genesis_objects(&coins).await;
+    authority_state.insert_genesis_objects(&coins);
     let coin = Object::with_owner_for_testing(sender);
     let coin_ref = coin.object_ref();
-    authority_state.insert_genesis_object(coin).await;
+    authority_state.insert_genesis_object(coin);
 
     async fn run_merge(
         authority_state: &AuthorityState,
@@ -1038,8 +1024,8 @@ async fn execute_transfer_with_price(
     let gas_object_id = ObjectId::random();
     let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_balance);
     let gas_object_ref = gas_object.object_ref();
-    authority_state.insert_genesis_object(gas_object).await;
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    authority_state.insert_genesis_object(gas_object);
+    let object = authority_state.get_object(&object_id).unwrap();
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/iota-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_integration_tests.rs
@@ -45,7 +45,7 @@ async fn test_object_wrapping_unwrapping() {
     )
     .await;
 
-    let gas_version = authority.get_object(&gas).await.unwrap().version();
+    let gas_version = authority.get_object(&gas).unwrap().version();
     let create_child_version = SequenceNumber::lamport_increment([gas_version]).unwrap();
 
     // Create a Child object.
@@ -356,7 +356,7 @@ async fn test_object_owning_another_object() {
         .unwrap();
     // Check that the child is now owned by the parent.
     let field_id = child_effect.1.as_object();
-    let field_object = authority.get_object(field_id).await.unwrap();
+    let field_object = authority.get_object(field_id).unwrap();
     assert_eq!(field_object.owner, parent_id);
 
     // Mutate the child directly will now fail because we need the parent to
@@ -2936,7 +2936,7 @@ pub async fn build_and_try_publish_test_package(
     let all_module_bytes = compiled_package.get_package_bytes(with_unpublished_deps);
     let dependencies = compiled_package.get_dependency_storage_package_ids();
 
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().object_ref();
 
     let data = TransactionData::new_module(
@@ -3036,7 +3036,7 @@ pub async fn collect_packages_and_upgrade_caps(
         if !matches!(owner, Owner::Address(_)) {
             continue;
         }
-        let cap = authority.get_object(&obj_ref.object_id).await.unwrap();
+        let cap = authority.get_object(&obj_ref.object_id).unwrap();
         let bcs = cap.data.as_opt_struct().unwrap().contents();
         let obj: UpgradeCap = bcs::from_bytes(bcs).unwrap();
         let pkg = packages.get(&obj.package.bytes).unwrap();
@@ -3054,7 +3054,7 @@ pub async fn run_multi_txns(
 ) -> Result<(CertifiedTransaction, SignedTransactionEffects), IotaError> {
     // build the transaction data
     let pt = builder.finish();
-    let gas_object = authority.get_object(gas_object_id).await;
+    let gas_object = authority.get_object(gas_object_id);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let gas_price = authority.reference_gas_price_for_testing().unwrap();
     let gas_budget = pt.non_system_packages_to_be_published().count() as u64

--- a/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
@@ -100,7 +100,7 @@ async fn test_publish_empty_package() {
     let gas = ObjectId::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().object_ref();
 
     // empty package
@@ -152,7 +152,7 @@ async fn test_publish_duplicate_modules() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectId::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
@@ -317,7 +317,7 @@ async fn test_publish_extraneous_bytes_modules() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectId::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
@@ -341,7 +341,7 @@ async fn test_publish_extraneous_bytes_modules() {
     assert_eq!(result.status(), &ExecutionStatus::Success);
 
     // make the bytes invalid
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let mut modules = correct_modules.clone();
     modules[0].push(0);
@@ -368,7 +368,7 @@ async fn test_publish_extraneous_bytes_modules() {
     );
 
     // make the bytes invalid, in a different way
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let mut modules = correct_modules.clone();
     let first_module = modules[0].clone();
@@ -396,7 +396,7 @@ async fn test_publish_extraneous_bytes_modules() {
     );
 
     // make the bytes invalid by adding metadata
-    let gas_object = authority.get_object(&gas).await;
+    let gas_object = authority.get_object(&gas);
     let gas_object_ref = gas_object.unwrap().object_ref();
     let mut modules = correct_modules.clone();
     let new_bytes = {

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -179,7 +179,7 @@ impl UpgradeStateRunner {
         let gas_object_id = ObjectId::random();
         let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
         let authority_state = TestAuthorityBuilder::new().build().await;
-        authority_state.insert_genesis_object(gas_object).await;
+        authority_state.insert_genesis_object(gas_object);
         let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
         let (package, upgrade_cap) = build_and_publish_test_package_with_upgrade_cap(

--- a/crates/iota-core/src/unit_tests/pay_iota_tests.rs
+++ b/crates/iota-core/src/unit_tests/pay_iota_tests.rs
@@ -4,7 +4,6 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use futures::future::join_all;
 use iota_sdk_types::{Address, ExecutionError, ExecutionStatus, ObjectId};
 use iota_types::{
     base_types::{ObjectRef, dbg_addr},
@@ -174,21 +173,9 @@ async fn test_pay_iota_success_one_input_coin() -> anyhow::Result<()> {
     let created_obj_id1 = effects.created()[0].0.object_id;
     let created_obj_id2 = effects.created()[1].0.object_id;
     let created_obj_id3 = effects.created()[2].0.object_id;
-    let created_obj1 = res
-        .authority_state
-        .get_object(&created_obj_id1)
-        .await
-        .unwrap();
-    let created_obj2 = res
-        .authority_state
-        .get_object(&created_obj_id2)
-        .await
-        .unwrap();
-    let created_obj3 = res
-        .authority_state
-        .get_object(&created_obj_id3)
-        .await
-        .unwrap();
+    let created_obj1 = res.authority_state.get_object(&created_obj_id1).unwrap();
+    let created_obj2 = res.authority_state.get_object(&created_obj_id2).unwrap();
+    let created_obj3 = res.authority_state.get_object(&created_obj_id3).unwrap();
 
     let addr1 = *effects.created()[0]
         .1
@@ -221,7 +208,7 @@ async fn test_pay_iota_success_one_input_coin() -> anyhow::Result<()> {
     assert_eq!(effects.mutated()[0].0.object_id, object_id);
     assert_eq!(effects.mutated()[0].1, sender);
     let gas_used = effects.gas_cost_summary().net_gas_usage() as u64;
-    let gas_object = res.authority_state.get_object(&object_id).await.unwrap();
+    let gas_object = res.authority_state.get_object(&object_id).unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
         coin_amount - 100 - 200 - 300 - gas_used,
@@ -260,16 +247,8 @@ async fn test_pay_iota_success_multiple_input_coins() -> anyhow::Result<()> {
     assert_eq!(effects.created().len(), 2);
     let created_obj_id1 = effects.created()[0].0.object_id;
     let created_obj_id2 = effects.created()[1].0.object_id;
-    let created_obj1 = res
-        .authority_state
-        .get_object(&created_obj_id1)
-        .await
-        .unwrap();
-    let created_obj2 = res
-        .authority_state
-        .get_object(&created_obj_id2)
-        .await
-        .unwrap();
+    let created_obj1 = res.authority_state.get_object(&created_obj_id1).unwrap();
+    let created_obj2 = res.authority_state.get_object(&created_obj_id2).unwrap();
     let addr1 = *effects.created()[0]
         .1
         .address_or_object()
@@ -292,7 +271,7 @@ async fn test_pay_iota_success_multiple_input_coins() -> anyhow::Result<()> {
     assert_eq!(effects.mutated()[0].0.object_id, object_id1);
     assert_eq!(effects.mutated()[0].1, sender);
     let gas_used = effects.gas_cost_summary().net_gas_usage() as u64;
-    let gas_object = res.authority_state.get_object(&object_id1).await.unwrap();
+    let gas_object = res.authority_state.get_object(&object_id1).unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
         5002000 - 500 - 1500 - gas_used,
@@ -358,7 +337,7 @@ async fn test_pay_all_iota_success_one_input_coin() -> anyhow::Result<()> {
     assert_eq!(effects.mutated()[0].1, recipient);
 
     let gas_used = effects.gas_cost_summary().gas_used();
-    let gas_object = res.authority_state.get_object(&object_id).await.unwrap();
+    let gas_object = res.authority_state.get_object(&object_id).unwrap();
     assert_eq!(GasCoin::try_from(&gas_object)?.value(), 3000000 - gas_used,);
     Ok(())
 }
@@ -390,7 +369,7 @@ async fn test_pay_all_iota_success_multiple_input_coins() -> anyhow::Result<()> 
     assert_eq!(effects.mutated()[0].1, recipient);
 
     let gas_used = effects.gas_cost_summary().gas_used();
-    let gas_object = res.authority_state.get_object(&object_id1).await.unwrap();
+    let gas_object = res.authority_state.get_object(&object_id1).unwrap();
     assert_eq!(GasCoin::try_from(&gas_object)?.value(), 3002000 - gas_used,);
     Ok(())
 }
@@ -414,11 +393,9 @@ async fn execute_pay_iota(
         .iter()
         .map(|coin_obj| coin_obj.object_ref())
         .collect();
-    let handles: Vec<_> = input_coin_objects
-        .into_iter()
-        .map(|obj| authority_state.insert_genesis_object(obj))
-        .collect();
-    join_all(handles).await;
+    for obj in input_coin_objects {
+        authority_state.insert_genesis_object(obj);
+    }
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
     let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -93,8 +93,8 @@ async fn test_valid_user_transaction_passes() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_ref = authority.get_object(&object_id).await.unwrap().object_ref();
-    let gas_ref = authority.get_object(&gas_id).await.unwrap().object_ref();
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
 
     let tx =
         make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
@@ -171,8 +171,8 @@ async fn test_duplicate_transaction_deduplicated() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_ref = authority.get_object(&object_id).await.unwrap().object_ref();
-    let gas_ref = authority.get_object(&gas_id).await.unwrap().object_ref();
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
 
     let tx =
         make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
@@ -229,10 +229,10 @@ async fn test_mixed_batch_filtering() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let obj1_ref = authority.get_object(&obj1_id).await.unwrap().object_ref();
-    let gas1_ref = authority.get_object(&gas1_id).await.unwrap().object_ref();
-    let obj2_ref = authority.get_object(&obj2_id).await.unwrap().object_ref();
-    let gas2_ref = authority.get_object(&gas2_id).await.unwrap().object_ref();
+    let obj1_ref = authority.get_object(&obj1_id).unwrap().object_ref();
+    let gas1_ref = authority.get_object(&gas1_id).unwrap().object_ref();
+    let obj2_ref = authority.get_object(&obj2_id).unwrap().object_ref();
+    let gas2_ref = authority.get_object(&gas2_id).unwrap().object_ref();
 
     let tx1 =
         make_transfer_object_transaction(obj1_ref, gas1_ref, sender, &sender_key, recipient, rgp);
@@ -300,9 +300,9 @@ async fn test_simple_conflict() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object = authority.get_object(&object_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let gas2 = authority.get_object(&gas2_id).await.unwrap();
+    let object = authority.get_object(&object_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let gas2 = authority.get_object(&gas2_id).unwrap();
 
     let tx1 = make_transfer_object_transaction(
         object.object_ref(),
@@ -391,8 +391,8 @@ async fn test_stale_version_dropped_fresh_kept() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let gas_stale = authority.get_object(&gas_stale_id).await.unwrap();
-    let gas_fresh = authority.get_object(&gas_fresh_id).await.unwrap();
+    let gas_stale = authority.get_object(&gas_stale_id).unwrap();
+    let gas_fresh = authority.get_object(&gas_fresh_id).unwrap();
 
     let fresh_ref = object.object_ref();
     // Stale reference: same object id and digest, but the previous version.
@@ -491,10 +491,10 @@ async fn test_no_conflict() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object1 = authority.get_object(&object1_id).await.unwrap();
-    let object2 = authority.get_object(&object2_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let gas2 = authority.get_object(&gas2_id).await.unwrap();
+    let object1 = authority.get_object(&object1_id).unwrap();
+    let object2 = authority.get_object(&object2_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let gas2 = authority.get_object(&gas2_id).unwrap();
 
     let tx1 = make_transfer_object_transaction(
         object1.object_ref(),
@@ -576,11 +576,11 @@ async fn test_chain_conflict() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_a = authority.get_object(&object_a_id).await.unwrap();
-    let object_b = authority.get_object(&object_b_id).await.unwrap();
-    let object_c = authority.get_object(&object_c_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let shared_gas = authority.get_object(&shared_gas_id).await.unwrap();
+    let object_a = authority.get_object(&object_a_id).unwrap();
+    let object_b = authority.get_object(&object_b_id).unwrap();
+    let object_c = authority.get_object(&object_c_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let shared_gas = authority.get_object(&shared_gas_id).unwrap();
 
     let tx1 = make_transfer_object_transaction(
         object_a.object_ref(),
@@ -681,12 +681,12 @@ async fn test_multiple_conflicts_in_batch() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_a = authority.get_object(&object_a_id).await.unwrap();
-    let object_b = authority.get_object(&object_b_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let gas2 = authority.get_object(&gas2_id).await.unwrap();
-    let gas3 = authority.get_object(&gas3_id).await.unwrap();
-    let gas4 = authority.get_object(&gas4_id).await.unwrap();
+    let object_a = authority.get_object(&object_a_id).unwrap();
+    let object_b = authority.get_object(&object_b_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let gas2 = authority.get_object(&gas2_id).unwrap();
+    let gas3 = authority.get_object(&gas3_id).unwrap();
+    let gas4 = authority.get_object(&gas4_id).unwrap();
 
     let tx1 = make_transfer_object_transaction(
         object_a.object_ref(),
@@ -787,9 +787,9 @@ async fn test_gas_object_conflict() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object1 = authority.get_object(&object1_id).await.unwrap();
-    let object2 = authority.get_object(&object2_id).await.unwrap();
-    let shared_gas = authority.get_object(&shared_gas_id).await.unwrap();
+    let object1 = authority.get_object(&object1_id).unwrap();
+    let object2 = authority.get_object(&object2_id).unwrap();
+    let shared_gas = authority.get_object(&shared_gas_id).unwrap();
 
     let tx1 = make_transfer_object_transaction(
         object1.object_ref(),
@@ -872,11 +872,11 @@ async fn test_winner_blocks_multiple_losers() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_a = authority.get_object(&object_a_id).await.unwrap();
-    let object_b = authority.get_object(&object_b_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let gas2 = authority.get_object(&gas2_id).await.unwrap();
-    let gas3 = authority.get_object(&gas3_id).await.unwrap();
+    let object_a = authority.get_object(&object_a_id).unwrap();
+    let object_b = authority.get_object(&object_b_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let gas2 = authority.get_object(&gas2_id).unwrap();
+    let gas3 = authority.get_object(&gas3_id).unwrap();
 
     use iota_sdk_types::Identifier;
     use iota_types::transaction::{CallArg, TransactionData, TransactionDataAPI};
@@ -988,11 +988,11 @@ async fn test_dropped_tx_does_not_acquire_locks() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_a = authority.get_object(&object_a_id).await.unwrap();
-    let object_b = authority.get_object(&object_b_id).await.unwrap();
-    let gas1 = authority.get_object(&gas1_id).await.unwrap();
-    let gas2 = authority.get_object(&gas2_id).await.unwrap();
-    let shared_gas = authority.get_object(&shared_gas_id).await.unwrap();
+    let object_a = authority.get_object(&object_a_id).unwrap();
+    let object_b = authority.get_object(&object_b_id).unwrap();
+    let gas1 = authority.get_object(&gas1_id).unwrap();
+    let gas2 = authority.get_object(&gas2_id).unwrap();
+    let shared_gas = authority.get_object(&shared_gas_id).unwrap();
 
     let tx1 = make_transfer_object_transaction(
         object_a.object_ref(),
@@ -1128,8 +1128,8 @@ async fn already_executed_tx_must_remain_in_checkpoint_roots() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_ref = authority.get_object(&object_id).await.unwrap().object_ref();
-    let gas_ref = authority.get_object(&gas_id).await.unwrap().object_ref();
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
 
     let tx =
         make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
@@ -1228,9 +1228,9 @@ async fn double_spend_loser_excluded_from_checkpoint_roots() {
     let epoch_store = authority.epoch_store_for_testing();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
-    let object_ref = authority.get_object(&object_id).await.unwrap().object_ref();
-    let gas_a_ref = authority.get_object(&gas_a).await.unwrap().object_ref();
-    let gas_b_ref = authority.get_object(&gas_b).await.unwrap().object_ref();
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_a_ref = authority.get_object(&gas_a).unwrap().object_ref();
+    let gas_b_ref = authority.get_object(&gas_b).unwrap().object_ref();
 
     // Two transactions spending the same owned object — a double spend.
     let tx_winner = make_transfer_object_transaction(
@@ -1359,8 +1359,8 @@ async fn setup_lock_tier() -> LockTierSetup {
 
     let epoch_store = (*authority.epoch_store_for_testing()).clone();
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    let object_ref = authority.get_object(&object_id).await.unwrap().object_ref();
-    let gas_ref = authority.get_object(&gas_id).await.unwrap().object_ref();
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
 
     LockTierSetup {
         authority,

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -326,7 +326,7 @@ async fn build_shared_object_transaction(
     pkg_ref: iota_types::base_types::ObjectRef,
 ) -> Transaction {
     let rgp = state.reference_gas_price_for_testing().unwrap();
-    let gas = state.get_object(&gas_object_id).await.unwrap();
+    let gas = state.get_object(&gas_object_id).unwrap();
     let tx_data = TransactionData::new_move_call(
         sender,
         pkg_ref.object_id,
@@ -457,8 +457,8 @@ async fn test_v2_submit_tx_success() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
     let recipient = dbg_addr(2);
 
     let tx_data = TransactionData::new_transfer(
@@ -528,8 +528,8 @@ async fn test_v2_submit_tx_invalid_signature() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
     let recipient = dbg_addr(2);
 
     let tx_data = TransactionData::new_transfer(
@@ -596,8 +596,8 @@ async fn test_v2_submit_tx_feature_flag_disabled() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
     let recipient = dbg_addr(2);
 
     let tx_data = TransactionData::new_transfer(
@@ -663,8 +663,8 @@ async fn test_v2_submit_tx_already_executed() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
 
     let tx_data = TransactionData::new_transfer(
         dbg_addr(2),
@@ -791,7 +791,7 @@ async fn test_v2_submit_tx_invalid_transaction() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
 
     let pt = ProgrammableTransaction {
         inputs: vec![],
@@ -863,7 +863,7 @@ async fn test_v2_submit_tx_gas_object_validation() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
 
     let tx_data = TransactionData::new_transfer(
         dbg_addr(2),
@@ -928,8 +928,8 @@ async fn test_v2_submit_tx_different_gas_prices_accepted() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let gas1 = authority_state.get_object(&gas_id1).await.unwrap();
-    let gas2 = authority_state.get_object(&gas_id2).await.unwrap();
+    let gas1 = authority_state.get_object(&gas_id1).unwrap();
+    let gas2 = authority_state.get_object(&gas_id2).unwrap();
 
     let tx_data1 = TransactionData::new_move_call(
         sender,
@@ -1012,7 +1012,7 @@ async fn test_v2_submit_tx_oversized_transaction() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
 
     // Build a PTB whose inputs alone total ~140 KiB > max_tx_size_bytes (128 KiB).
     let inputs: Vec<_> = (0u8..10)
@@ -1147,8 +1147,8 @@ async fn test_v2_get_tx_status_already_executed() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
 
     let tx_data = TransactionData::new_transfer(
         dbg_addr(2),
@@ -1230,8 +1230,8 @@ async fn test_v2_get_tx_status_already_executed_with_details() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas = authority_state.get_object(&gas_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
 
     let tx_data = TransactionData::new_transfer(
         dbg_addr(2),
@@ -1311,10 +1311,10 @@ async fn test_v2_get_tx_status_multiple_queries() {
     ));
 
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let obj1 = authority_state.get_object(&object_id1).await.unwrap();
-    let gas1 = authority_state.get_object(&gas_id1).await.unwrap();
-    let obj2 = authority_state.get_object(&object_id2).await.unwrap();
-    let gas2 = authority_state.get_object(&gas_id2).await.unwrap();
+    let obj1 = authority_state.get_object(&object_id1).unwrap();
+    let gas1 = authority_state.get_object(&gas_id1).unwrap();
+    let obj2 = authority_state.get_object(&object_id2).unwrap();
+    let gas2 = authority_state.get_object(&gas_id2).unwrap();
 
     // Build and execute two transactions.
     let tx1 = to_sender_signed_transaction(

--- a/crates/iota-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/iota-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -62,7 +62,7 @@ impl TestRunner {
         for _ in 0..20 {
             let gas_object_id = ObjectId::random();
             let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-            authority_state.insert_genesis_object(gas_object).await;
+            authority_state.insert_genesis_object(gas_object);
             gas_object_ids.push(gas_object_id);
         }
 

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -357,9 +357,9 @@ async fn do_transaction_test_impl(
     ])
     .await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object1 = authority_state.get_object(&gas_object_id1).await.unwrap();
-    let gas_object2 = authority_state.get_object(&gas_object_id2).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object1 = authority_state.get_object(&gas_object_id1).unwrap();
+    let gas_object2 = authority_state.get_object(&gas_object_id2).unwrap();
 
     // Execute the test with two transactions, one transfer and one move call.
     // The move call contains access to a shared object.
@@ -481,14 +481,13 @@ async fn do_transaction_test_impl(
 
 async fn check_locks(authority_state: Arc<AuthorityState>, object_ids: Vec<ObjectId>) {
     for object_id in object_ids {
-        let object = authority_state.get_object(&object_id).await.unwrap();
+        let object = authority_state.get_object(&object_id).unwrap();
         assert!(
             authority_state
                 .get_transaction_lock(
                     &object.object_ref(),
                     &authority_state.epoch_store_for_testing()
                 )
-                .await
                 .unwrap()
                 .is_none()
         );
@@ -510,7 +509,7 @@ async fn test_oversized_txn() {
         .epoch_store_for_testing()
         .protocol_config()
         .max_tx_size_bytes() as usize;
-    let object = authority_state.get_object(&object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
     let obj_ref = object.object_ref();
 
     // Construct an oversized txn.
@@ -568,8 +567,8 @@ async fn test_very_large_certificate() {
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let transfer_transaction = init_transfer_transaction(
         |_| {},
@@ -657,8 +656,8 @@ async fn test_handle_certificate_errors() {
     let authority_state =
         init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object = authority_state.get_object(&gas_object_id).await.unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
 
     let transfer_transaction = init_transfer_transaction(
         |_| {},
@@ -829,7 +828,7 @@ async fn test_handle_soft_bundle_certificates() {
         let gas_object_id = ObjectId::random();
 
         let obj = Object::with_id_owner_for_testing(gas_object_id, address);
-        authority.insert_genesis_object(obj).await;
+        authority.insert_genesis_object(obj);
 
         senders.push((address, keypair));
         gas_object_ids.push(gas_object_id);
@@ -855,7 +854,7 @@ async fn test_handle_soft_bundle_certificates() {
         .unwrap();
         effects.status().unwrap();
         let shared_object_id = effects.created()[0].0.object_id;
-        authority.get_object(&shared_object_id).await.unwrap()
+        authority.get_object(&shared_object_id).unwrap()
     };
     let initial_shared_version = shared_object.version();
 
@@ -907,7 +906,6 @@ async fn test_handle_soft_bundle_certificates() {
         let cert = {
             let gas_object_ref = authority
                 .get_object(&gas_object_ids[i])
-                .await
                 .unwrap()
                 .object_ref();
             let data = TransactionData::new_move_call(
@@ -998,8 +996,8 @@ async fn test_handle_soft_bundle_certificates_errors() {
         .build()
         .await;
 
-    authority.insert_genesis_objects(&gas_objects).await;
-    authority.insert_genesis_objects(&owned_objects).await;
+    authority.insert_genesis_objects(&gas_objects);
+    authority.insert_genesis_objects(&owned_objects);
 
     let (authority, package) = publish_object_basics(authority).await;
 
@@ -1021,7 +1019,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
         .unwrap();
         effects.status().unwrap();
         let shared_object_id = effects.created()[0].0.object_id;
-        authority.get_object(&shared_object_id).await.unwrap()
+        authority.get_object(&shared_object_id).unwrap()
     };
     let initial_shared_version = shared_object.version();
 
@@ -1089,12 +1087,10 @@ async fn test_handle_soft_bundle_certificates_errors() {
         for i in 0..5 {
             let owned_object_ref = authority
                 .get_object(&owned_objects[i].id())
-                .await
                 .unwrap()
                 .object_ref();
             let gas_object_ref = authority
                 .get_object(&gas_objects[i].id())
-                .await
                 .unwrap()
                 .object_ref();
             let data = TransactionData::new_transfer(
@@ -1136,12 +1132,10 @@ async fn test_handle_soft_bundle_certificates_errors() {
     {
         let owned_object_ref = authority
             .get_object(&owned_objects[5].id())
-            .await
             .unwrap()
             .object_ref();
         let gas_object_ref = authority
             .get_object(&gas_objects[5].id())
-            .await
             .unwrap()
             .object_ref();
         let data = TransactionData::new_transfer(
@@ -1182,7 +1176,6 @@ async fn test_handle_soft_bundle_certificates_errors() {
         let cert0 = {
             let gas_object_ref = authority
                 .get_object(&gas_objects[6].id())
-                .await
                 .unwrap()
                 .object_ref();
             let data = TransactionData::new_move_call(
@@ -1212,7 +1205,6 @@ async fn test_handle_soft_bundle_certificates_errors() {
         let cert1 = {
             let gas_object_ref = authority
                 .get_object(&gas_objects[7].id())
-                .await
                 .unwrap()
                 .object_ref();
             let data = TransactionData::new_move_call(
@@ -1268,7 +1260,6 @@ async fn test_handle_soft_bundle_certificates_errors() {
         let cert0 = {
             let gas_object_ref = authority
                 .get_object(&gas_objects[8].id())
-                .await
                 .unwrap()
                 .object_ref();
             let data = TransactionData::new_move_call(
@@ -1298,7 +1289,6 @@ async fn test_handle_soft_bundle_certificates_errors() {
         let cert1 = {
             let gas_object_ref = authority
                 .get_object(&gas_objects[9].id())
-                .await
                 .unwrap()
                 .object_ref();
             let data = TransactionData::new_move_call(
@@ -1357,12 +1347,10 @@ async fn test_handle_soft_bundle_certificates_errors() {
         for i in 11..14 {
             let owned_object_ref = authority
                 .get_object(&owned_objects[i].id())
-                .await
                 .unwrap()
                 .object_ref();
             let gas_object_ref = authority
                 .get_object(&gas_objects[i].id())
-                .await
                 .unwrap()
                 .object_ref();
             let sender = &senders[i];

--- a/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
@@ -86,7 +86,7 @@ impl TestRunner {
         for _ in 0..num {
             let gas_object_id = ObjectId::random();
             let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-            authority_state.insert_genesis_object(gas_object).await;
+            authority_state.insert_genesis_object(gas_object);
             gas_object_ids.push(gas_object_id);
         }
 

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -720,7 +720,7 @@ mod tests {
         keypair: &AccountKeyPair,
         gas_object_id: ObjectId,
     ) -> VerifiedSignedTransaction {
-        let gas_object_ref = state.get_object(&gas_object_id).await.unwrap().object_ref();
+        let gas_object_ref = state.get_object(&gas_object_id).unwrap().object_ref();
         let tx_data = TestTransactionBuilder::new(
             sender,
             gas_object_ref,

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -638,29 +638,25 @@ mod sim_only_tests {
     ) -> TransactionEffects {
         let node_handle = &cluster.fullnode_handle.iota_node;
 
-        node_handle
-            .with_async(|node| async {
-                let store = node.state().get_object_cache_reader().clone();
-                let framework = store.get_object(package);
-                let digest = framework.unwrap().previous_transaction;
-                let tx_store = node.state().get_transaction_cache_reader().clone();
-                let effects = tx_store.get_executed_effects(&digest);
-                effects.unwrap()
-            })
-            .await
+        node_handle.with(|node| {
+            let store = node.state().get_object_cache_reader().clone();
+            let framework = store.get_object(package);
+            let digest = framework.unwrap().previous_transaction;
+            let tx_store = node.state().get_transaction_cache_reader().clone();
+            let effects = tx_store.get_executed_effects(&digest);
+            effects.unwrap()
+        })
     }
 
     async fn get_object(cluster: &TestCluster, object_id: &ObjectId) -> Object {
         let node_handle = &cluster.fullnode_handle.iota_node;
 
-        node_handle
-            .with_async(|node| async {
-                node.state()
-                    .get_object_cache_reader()
-                    .get_object(object_id)
-                    .unwrap()
-            })
-            .await
+        node_handle.with(|node| {
+            node.state()
+                .get_object_cache_reader()
+                .get_object(object_id)
+                .unwrap()
+        })
     }
 
     #[sim_test]

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -205,19 +205,17 @@ async fn reconfig_with_revert_end_to_end_test() {
         .await
         .unwrap();
 
-    authorities[reverting_authority_idx]
-        .with_async(|node| async {
-            let object = node
-                .state()
-                .get_objects(&[gas2.object_id])
-                .into_iter()
-                .next()
-                .unwrap()
-                .unwrap();
-            // verify that authority 0 advanced object version
-            assert_eq!(2, object.version());
-        })
-        .await;
+    authorities[reverting_authority_idx].with(|node| {
+        let object = node
+            .state()
+            .get_objects(&[gas2.object_id])
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        // verify that authority 0 advanced object version
+        assert_eq!(2, object.version());
+    });
 
     // Wait for all nodes to reach the next epoch.
     let handles: Vec<_> = authorities
@@ -237,38 +235,36 @@ async fn reconfig_with_revert_end_to_end_test() {
 
     let mut epoch = None;
     for handle in authorities.iter() {
-        handle
-            .with_async(|node| async {
-                let object = node
-                    .state()
-                    .get_objects(&[gas1.object_id])
-                    .into_iter()
-                    .next()
-                    .unwrap()
-                    .unwrap();
-                assert_eq!(2, object.version());
-                // Due to race conditions, it's possible that tx2 went in
-                // before 2f+1 validators sent EndOfPublish messages and close
-                // the curtain of epoch 0. So, we are asserting that
-                // the object version is either 1 or 2, but needs to be
-                // consistent in all validators.
-                // Note that previously test checked that object version == 2 on authority 0
-                let object = node
-                    .state()
-                    .get_objects(&[gas2.object_id])
-                    .into_iter()
-                    .next()
-                    .unwrap()
-                    .unwrap();
-                let object_version = object.version();
-                if epoch.is_none() {
-                    assert!(object_version == 1 || object_version == 2);
-                    epoch.replace(object_version);
-                } else {
-                    assert_eq!(epoch, Some(object_version));
-                }
-            })
-            .await;
+        handle.with(|node| {
+            let object = node
+                .state()
+                .get_objects(&[gas1.object_id])
+                .into_iter()
+                .next()
+                .unwrap()
+                .unwrap();
+            assert_eq!(2, object.version());
+            // Due to race conditions, it's possible that tx2 went in
+            // before 2f+1 validators sent EndOfPublish messages and close
+            // the curtain of epoch 0. So, we are asserting that
+            // the object version is either 1 or 2, but needs to be
+            // consistent in all validators.
+            // Note that previously test checked that object version == 2 on authority 0
+            let object = node
+                .state()
+                .get_objects(&[gas2.object_id])
+                .into_iter()
+                .next()
+                .unwrap()
+                .unwrap();
+            let object_version = object.version();
+            if epoch.is_none() {
+                assert!(object_version == 1 || object_version == 2);
+                epoch.replace(object_version);
+            } else {
+                assert_eq!(epoch, Some(object_version));
+            }
+        });
     }
 }
 

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -210,7 +210,6 @@ async fn reconfig_with_revert_end_to_end_test() {
             let object = node
                 .state()
                 .get_objects(&[gas2.object_id])
-                .await
                 .into_iter()
                 .next()
                 .unwrap()
@@ -243,7 +242,6 @@ async fn reconfig_with_revert_end_to_end_test() {
                 let object = node
                     .state()
                     .get_objects(&[gas1.object_id])
-                    .await
                     .into_iter()
                     .next()
                     .unwrap()
@@ -258,7 +256,6 @@ async fn reconfig_with_revert_end_to_end_test() {
                 let object = node
                     .state()
                     .get_objects(&[gas2.object_id])
-                    .await
                     .into_iter()
                     .next()
                     .unwrap()

--- a/crates/iota-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/iota-e2e-tests/tests/shared_objects_tests.rs
@@ -523,18 +523,14 @@ async fn access_clock_object_test() {
 
     let mut attempt = 0;
     loop {
-        let checkpoint = test_cluster
-            .fullnode_handle
-            .iota_node
-            .with_async(|node| async {
-                node.state()
-                    .get_transaction_checkpoint_for_tests(
-                        &digest,
-                        &node.state().epoch_store_for_testing(),
-                    )
-                    .unwrap()
-            })
-            .await;
+        let checkpoint = test_cluster.fullnode_handle.iota_node.with(|node| {
+            node.state()
+                .get_transaction_checkpoint_for_tests(
+                    &digest,
+                    &node.state().epoch_store_for_testing(),
+                )
+                .unwrap()
+        });
         let Some(checkpoint) = checkpoint else {
             attempt += 1;
             if attempt > 30 {

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -894,18 +894,14 @@ async fn get_checkpoint_by_seq_number() {
 
     cluster.wait_for_checkpoint(6, None).await;
 
-    let fullnode_checkpoints = cluster
-        .fullnode_handle
-        .iota_node
-        .with_async(|node| async {
-            node.state()
-                .get_checkpoint_store()
-                .multi_get_checkpoint_by_sequence_number(
-                    &(0..=5).collect::<Vec<CheckpointSequenceNumber>>(),
-                )
-                .unwrap()
-        })
-        .await;
+    let fullnode_checkpoints = cluster.fullnode_handle.iota_node.with(|node| {
+        node.state()
+            .get_checkpoint_store()
+            .multi_get_checkpoint_by_sequence_number(
+                &(0..=5).collect::<Vec<CheckpointSequenceNumber>>(),
+            )
+            .unwrap()
+    });
 
     let envelope = fullnode_checkpoints[0].clone().unwrap();
     let digest = *envelope.digest();
@@ -962,18 +958,14 @@ async fn get_checkpoint_by_digest() {
 
     cluster.wait_for_checkpoint(6, None).await;
 
-    let fullnode_checkpoints = cluster
-        .fullnode_handle
-        .iota_node
-        .with_async(|node| async {
-            node.state()
-                .get_checkpoint_store()
-                .multi_get_checkpoint_by_sequence_number(
-                    &(0..=5).collect::<Vec<CheckpointSequenceNumber>>(),
-                )
-                .unwrap()
-        })
-        .await;
+    let fullnode_checkpoints = cluster.fullnode_handle.iota_node.with(|node| {
+        node.state()
+            .get_checkpoint_store()
+            .multi_get_checkpoint_by_sequence_number(
+                &(0..=5).collect::<Vec<CheckpointSequenceNumber>>(),
+            )
+            .unwrap()
+    });
 
     let envelope = fullnode_checkpoints[0].clone().unwrap();
     let digest = *envelope.digest();

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -256,7 +256,7 @@ impl StateRead for AuthorityState {
     }
 
     async fn get_object(&self, object_id: &ObjectId) -> StateReadResult<Option<Object>> {
-        Ok(self.try_get_object(object_id).await?)
+        Ok(self.try_get_object(object_id)?)
     }
 
     fn get_past_object_read(
@@ -393,18 +393,14 @@ impl StateRead for AuthorityState {
     }
 
     async fn get_staked_iota(&self, owner: Address) -> StateReadResult<Vec<StakedIota>> {
-        Ok(self
-            .get_move_objects(owner, StructTag::new_staked_iota())
-            .await?)
+        Ok(self.get_move_objects(owner, StructTag::new_staked_iota())?)
     }
 
     async fn get_timelocked_staked_iota(
         &self,
         owner: Address,
     ) -> StateReadResult<Vec<TimelockedStakedIota>> {
-        Ok(self
-            .get_move_objects(owner, StructTag::new_timelocked_staked_iota())
-            .await?)
+        Ok(self.get_move_objects(owner, StructTag::new_timelocked_staked_iota())?)
     }
 
     fn get_system_state(&self) -> StateReadResult<IotaSystemState> {

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -478,7 +478,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         self.shard_accumulators = self.shard_accumulators.split_off(&lower_bound);
     }
 
-    async fn get_transactions_with_headers_in_dag_state(&mut self) -> Vec<VerifiedTransactions> {
+    fn get_transactions_with_headers_in_dag_state(&mut self) -> Vec<VerifiedTransactions> {
         let transactions_map = std::mem::take(&mut self.reconstructed_transactions);
         // In most cases, all reconstructed transactions will go to the core
         let mut ready_to_be_sent_transactions = Vec::new();
@@ -525,7 +525,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
 
     /// Send reconstructed transactions to the core
     async fn send_to_core(&mut self) -> ConsensusResult<()> {
-        let transactions = self.get_transactions_with_headers_in_dag_state().await;
+        let transactions = self.get_transactions_with_headers_in_dag_state();
         if !transactions.is_empty() {
             let highest_accepted_round = self.dag_state.read().highest_accepted_round();
             for transaction in &transactions {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -267,8 +267,7 @@ impl TestCluster {
     pub async fn get_object_from_fullnode_store(&self, object_id: &ObjectId) -> Option<Object> {
         self.fullnode_handle
             .iota_node
-            .with_async(|node| async { node.state().get_object(object_id) })
-            .await
+            .with(|node| node.state().get_object(object_id))
     }
 
     pub async fn get_latest_object_ref(&self, object_id: &ObjectId) -> ObjectRef {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -267,7 +267,7 @@ impl TestCluster {
     pub async fn get_object_from_fullnode_store(&self, object_id: &ObjectId) -> Option<Object> {
         self.fullnode_handle
             .iota_node
-            .with_async(|node| async { node.state().get_object(object_id).await })
+            .with_async(|node| async { node.state().get_object(object_id) })
             .await
     }
 

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -96,11 +96,11 @@ impl Executor {
     }
 
     pub fn add_object(&mut self, object: Object) {
-        self.rt.block_on(self.state.insert_genesis_object(object));
+        self.state.insert_genesis_object(object);
     }
 
     pub fn add_objects(&mut self, objects: &[Object]) {
-        self.rt.block_on(self.state.insert_genesis_objects(objects));
+        self.state.insert_genesis_objects(objects);
     }
 
     pub fn execute_transaction(&mut self, txn: Transaction) -> ExecutionResult {

--- a/crates/transaction-fuzzer/tests/pt_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/pt_fuzz.rs
@@ -46,8 +46,8 @@ fn publish_coin_factory(
         .into_iter()
         .find(|(obj_ref, _)| {
             if let Some(stag) = exec
-                .rt
-                .block_on(exec.state.get_object(&obj_ref.object_id))
+                .state
+                .get_object(&obj_ref.object_id)
                 .unwrap()
                 .data
                 .opt_struct_tag()
@@ -103,8 +103,8 @@ pub fn run_pt_success(
         .into_iter()
         .find(|(obj_ref, _)| {
             if let Some(stag) = exec
-                .rt
-                .block_on(exec.state.get_object(&obj_ref.object_id))
+                .state
+                .get_object(&obj_ref.object_id)
                 .unwrap()
                 .data
                 .opt_struct_tag()


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#26889](https://github.com/MystenLabs/sui/pull/26889)
- Description:

Several `AuthorityState` object-access methods were declared `async` but never awaited anything — they just call synchronously into the object store/cache. This makes them synchronous and drops the now-unnecessary `.await` at every call site. The de-async'd methods: `try_get_object`, `get_object`, `get_iota_system_package_object_ref`, `get_move_objects`, `insert_genesis_object`, `insert_genesis_objects`, `get_transaction_lock`, `try_get_objects`, `get_objects`, `try_get_object_or_tombstone`, `get_object_or_tombstone`. `insert_genesis_objects` also drops a pointless `join_all` over now-synchronous calls in favour of a plain loop.

No behavioural change — the methods did no real async work; this only removes the async/await overhead and noise.

Adapted to the fork:
- Applied to develop's current code rather than cherry-picked: develop had diverged (e.g. `get_move_objects` takes `Address`, not `IotaAddress`) and added call sites the upstream diff didn't touch. The de-async was re-derived against develop and every call site was found with the compiler, so this covers a few more files than the upstream PR (e.g. `post_consensus_validation_tests`, `server_tests`).

### Follow-up commit (starfish-core, not part of upstream #26889)

A second commit de-async'es `ShardReconstructor::get_transactions_with_headers_in_dag_state` (starfish-core), which never awaited anything in either cfg branch (found via `clippy::unused_async`). Its single call site in `send_to_core` drops the `.await`; `send_to_core` itself stays async (it still awaits `add_transactions`). This is fork-only code with no upstream counterpart.

(Note: `AuthorityState::get_system_package_bytes` also becomes awaitless after this change, but is intentionally left `async` to stay aligned with upstream, which keeps it async too.)

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`iota-core`, `iota-json-rpc`, `test-cluster`, `transaction-fuzzer`, and `iota-e2e-tests` all build (lib + tests); `iota-core` also builds under the simulator; clippy clean on `iota-core`, `starfish-core`, and the dependent crates; fmt clean. The change is mechanically behaviour-preserving (sync vs async on methods that never awaited).
