### PR TITLE
feat(graphql): Fallback for fetching transactions by digest

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.move
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transaction-by-digest queries under pruning, with no
+// historical fallback configured. Covers:
+// - `Query.transactionBlock(digest)` for pruned and unpruned digests
+// - `Query.transactionBlocksByDigests` for pruned and unpruned digests
+// - `Event.transactionBlock` on an event from an unpruned tx
+// - `MoveObject.previousTransactionBlock` where the prior-tx digest is pruned
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    use iota::event;
+
+    public struct Foo has key, store { id: UID, v: u64 }
+    public struct Bumped has copy, drop { v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+
+    public entry fun bump(foo: &mut Foo) {
+        foo.v = foo.v + 1;
+        event::emit(Bumped { v: foo.v })
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M::bump --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: pruned digest resolves to null (no fallback).
+{
+  pruned: transactionBlock(digest: "@{digest_2}") { digest }
+}
+
+//# run-graphql
+# B: unpruned digest resolves correctly
+{
+  unpruned: transactionBlock(digest: "@{digest_10}") { digest }
+}
+
+//# run-graphql
+# C: mixed case - one pruned and one unpruned
+{
+  transactionBlocksByDigests(digests: ["@{digest_2}", "@{digest_10}"]) {
+    digest
+  }
+}
+
+//# run-graphql
+# D: Event.transactionBlock on an event from an unpruned tx
+{
+  events(filter: { sender: "@{A}" }, last: 1) {
+    nodes {
+      transactionBlock { digest }
+    }
+  }
+}
+
+//# run-graphql
+# E: MoveObject.previousTransactionBlock where the tx is pruned.
+{
+  object(address: "@{obj_5_0}") {
+    asMoveObject {
+      previousTransactionBlock { digest }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
@@ -1,0 +1,126 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 19 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 13-28:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6285200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 30:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 32:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 34:
+//# advance-epoch
+Epoch advanced: 0
+
+task 5, line 36:
+//# run Test::M::create --sender A
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 6, line 38:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 40:
+//# advance-epoch
+Epoch advanced: 1
+
+task 8, line 42:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 9, line 44:
+//# advance-epoch
+Epoch advanced: 2
+
+task 10, line 46:
+//# run Test::M::bump --sender A --args object(2,0)
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 11, line 48:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 12, line 50:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 13, line 52:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 14, lines 54-58:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "pruned": null
+  }
+}
+
+task 15, lines 60-64:
+//# run-graphql
+Response: {
+  "data": {
+    "unpruned": {
+      "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+    }
+  }
+}
+
+task 16, lines 66-72:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocksByDigests": [
+      null,
+      {
+        "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+      }
+    ]
+  }
+}
+
+task 17, lines 74-82:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "transactionBlock": {
+            "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 18, lines 84-92:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "previousTransactionBlock": null
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/src/types/digest.rs
+++ b/crates/iota-graphql-rpc/src/types/digest.rs
@@ -25,10 +25,6 @@ pub(crate) enum Error {
 }
 
 impl Digest {
-    pub(crate) fn to_vec(self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
     pub(crate) fn as_slice(&self) -> &[u8] {
         &self.0
     }

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -29,9 +29,10 @@ use crate::{
         base64::Base64,
         cursor::{Page, Target},
         date_time::DateTime,
+        digest::Digest,
         move_module::MoveModule,
         move_value::MoveValue,
-        transaction_block::{SeqKey, TransactionBlock},
+        transaction_block::{DigestKey, TransactionBlock},
     },
 };
 
@@ -44,18 +45,22 @@ pub(crate) use filter::EventFilter;
 /// An event emitted in a transaction that has been checkpointed.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct CheckpointedEventInfo {
-    /// The sequence number of the parent transaction.
-    tx_sequence_number: u64,
+    /// The digest of the parent transaction.
+    tx_digest: Digest,
     /// The timestamp of the parent transaction.
     timestamp_ms: i64,
 }
 
-impl From<&StoredEvent> for CheckpointedEventInfo {
-    fn from(value: &StoredEvent) -> Self {
-        Self {
-            tx_sequence_number: value.tx_sequence_number as u64,
+impl TryFrom<&StoredEvent> for CheckpointedEventInfo {
+    type Error = Error;
+
+    fn try_from(value: &StoredEvent) -> Result<Self, Self::Error> {
+        let tx_digest = Digest::try_from(value.transaction_digest.as_slice())
+            .map_err(|e| Error::Internal(format!("Bad transaction digest on event: {e}")))?;
+        Ok(Self {
+            tx_digest,
             timestamp_ms: value.timestamp_ms,
-        }
+        })
     }
 }
 
@@ -89,9 +94,9 @@ impl Event {
         let Some(checkpointed) = &self.checkpointed_info else {
             return Ok(None);
         };
-        let key = SeqKey::new(checkpointed.tx_sequence_number, self.checkpoint_viewed_at);
+        let key = DigestKey::new(checkpointed.tx_digest, self.checkpoint_viewed_at);
 
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     /// The Move module containing some function that when called by
@@ -279,8 +284,10 @@ impl Event {
             ))
         })?;
 
+        let tx_digest = Digest::try_from(stored_tx.transaction_digest.as_slice())
+            .map_err(|e| Error::Internal(format!("Bad transaction digest on transaction: {e}")))?;
         let checkpointed = CheckpointedEventInfo {
-            tx_sequence_number: stored_tx.tx_sequence_number as u64,
+            tx_digest,
             timestamp_ms: stored_tx.timestamp_ms,
         };
         Ok(Self {
@@ -297,7 +304,7 @@ impl Event {
         let Some(Some(sender_bytes)) = stored.senders.first() else {
             return Err(Error::Internal("No senders found for event".to_string()));
         };
-        let checkpointed = CheckpointedEventInfo::from(&stored);
+        let checkpointed = CheckpointedEventInfo::try_from(&stored)?;
         let sender = NativeIotaAddress::from_bytes(sender_bytes)
             .map_err(|e| Error::Internal(e.to_string()))?;
         let package_id =

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -665,7 +665,7 @@ impl ObjectImpl<'_> {
         let digest = native.previous_transaction;
         let key = transaction_block::DigestKey::new(digest.into(), self.0.checkpoint_viewed_at);
 
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     pub(crate) async fn storage_rebate(&self) -> Option<BigInt> {

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -388,7 +388,7 @@ impl Query {
     ) -> Result<Option<TransactionBlock>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
         let key = transaction_block::DigestKey::new(digest, checkpoint);
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     /// Fetch multiple transaction blocks by their digests.

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -7,17 +7,19 @@ use std::collections::{BTreeMap, HashMap};
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
 use cursor::TxLookup;
-use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
+use diesel::{ExpressionMethods, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{
     apis::ReadApi,
     models::transactions::{OptimisticTransaction, StoredTransaction},
-    schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
+    read::TransactionRead,
+    schema::transactions,
 };
 use iota_json_rpc_api::ReadApiServer;
 use iota_sdk_types::{Event as NativeEvent, TransactionExpiration};
 use iota_types::{
     base_types::IotaAddress as NativeIotaAddress,
+    digests::TransactionDigest,
     effects::TransactionEffects as NativeTransactionEffects,
     message_envelope::Message,
     transaction::{
@@ -151,41 +153,6 @@ impl DigestKey {
             digest,
             checkpoint_viewed_at,
         }
-    }
-}
-
-/// `DataLoader` key for fetching a `TransactionBlock` by its sequence number,
-/// constrained by a consistency cursor.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub(crate) struct SeqKey {
-    pub tx_sequence_number: u64,
-    pub checkpoint_viewed_at: u64,
-}
-
-impl SeqKey {
-    pub fn new(tx_sequence_number: u64, checkpoint_viewed_at: u64) -> Self {
-        Self {
-            tx_sequence_number,
-            checkpoint_viewed_at,
-        }
-    }
-}
-
-/// Filter for a point query of a TransactionBlock.
-pub(crate) enum TransactionBlockLookup {
-    ByDigest(DigestKey),
-    BySeq(SeqKey),
-}
-
-impl From<DigestKey> for TransactionBlockLookup {
-    fn from(key: DigestKey) -> Self {
-        TransactionBlockLookup::ByDigest(key)
-    }
-}
-
-impl From<SeqKey> for TransactionBlockLookup {
-    fn from(key: SeqKey) -> Self {
-        TransactionBlockLookup::BySeq(key)
     }
 }
 
@@ -350,15 +317,9 @@ impl TransactionBlock {
     /// or sequence number. Treats it as if it is being viewed at the
     /// `checkpoint_viewed_at` (e.g. the state of all relevant addresses
     /// will be at that checkpoint).
-    pub(crate) async fn query(
-        ctx: &Context<'_>,
-        key: TransactionBlockLookup,
-    ) -> Result<Option<Self>, Error> {
+    pub(crate) async fn query(ctx: &Context<'_>, key: DigestKey) -> Result<Option<Self>, Error> {
         let DataLoader(loader) = ctx.data_unchecked();
-        match key {
-            TransactionBlockLookup::ByDigest(digest_key) => loader.load_one(digest_key).await,
-            TransactionBlockLookup::BySeq(seq_key) => loader.load_one(seq_key).await,
-        }
+        loader.load_one(key).await
     }
 
     /// Look up multiple `TransactionBlock`s by their digests. Returns a map
@@ -548,145 +509,41 @@ impl Loader<DigestKey> for Db {
         &self,
         keys: &[DigestKey],
     ) -> Result<HashMap<DigestKey, TransactionBlock>, Error> {
-        use optimistic_transactions::dsl as opt_tx;
-        use transactions::dsl as tx;
-        use tx_digests::dsl as ds;
-        use tx_global_order::dsl as tx_global;
+        let digests: Vec<TransactionDigest> = keys.iter().map(|k| k.digest.into()).collect();
 
-        let digests: Vec<_> = keys.iter().map(|k| k.digest.to_vec()).collect();
-
-        // First, fetch from the main transactions table
-        let transactions: Vec<StoredTransaction> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    let join = ds::tx_sequence_number.eq(tx::tx_sequence_number);
-
-                    tx::transactions
-                        .inner_join(ds::tx_digests.on(join))
-                        .select(StoredTransaction::as_select())
-                        .filter(ds::tx_digest.eq_any(digests.clone()))
-                })
-            })
+        let by_digest: BTreeMap<Vec<u8>, TransactionRead> = self
+            .inner
+            .multi_get_transactions_with_fallback(&digests)
             .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
-
-        let transaction_digest_to_stored: BTreeMap<Vec<u8>, StoredTransaction> = transactions
+            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?
             .into_iter()
-            .map(|tx| (tx.transaction_digest.clone(), tx))
+            .map(|tx| (tx.transaction_digest().to_vec(), tx))
             .collect();
 
-        // Process stored transactions and collect missing digests
         let mut results = HashMap::new();
-        let mut missing_digests = Vec::new();
-
         for key in keys {
-            let digest_bytes = key.digest.as_slice();
-
-            if let Some(stored) = transaction_digest_to_stored.get(digest_bytes) {
-                let mut checkpoint_viewed_at = key.checkpoint_viewed_at;
-                if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                    checkpoint_viewed_at = UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER;
-                }
-                let tx_block = TransactionBlock {
-                    inner: TransactionBlockInner::try_from(stored.clone())?,
-                    checkpoint_viewed_at,
-                };
-                results.insert(*key, tx_block);
-            } else {
-                missing_digests.push(key.digest.to_vec());
-            }
-        }
-
-        if !missing_digests.is_empty() {
-            let optimistic_transactions: Vec<OptimisticTransaction> = self
-                .execute(move |conn| {
-                    conn.results(move || {
-                        opt_tx::optimistic_transactions
-                            .inner_join(
-                                tx_global::tx_global_order.on(opt_tx::global_sequence_number
-                                    .eq(tx_global::global_sequence_number)
-                                    .and(
-                                        opt_tx::optimistic_sequence_number
-                                            .eq(tx_global::optimistic_sequence_number),
-                                    )),
-                            )
-                            // Filter by digest on tx_global_order table because it is indexed by
-                            // digest, optimistic_transactions table is not
-                            .filter(tx_global::tx_digest.eq_any(missing_digests.clone()))
-                            .select(OptimisticTransaction::as_select())
-                    })
-                })
-                .await
-                .map_err(|e| {
-                    Error::Internal(format!("Failed to fetch optimistic transactions: {e}"))
-                })?;
-
-            let transaction_digest_to_optimistic: BTreeMap<Vec<u8>, OptimisticTransaction> =
-                optimistic_transactions
-                    .into_iter()
-                    .map(|opt_tx| (opt_tx.transaction_digest.clone(), opt_tx))
-                    .collect();
-
-            for key in keys {
-                let digest_bytes = key.digest.as_slice();
-                if let Some(optimistic) = transaction_digest_to_optimistic.get(digest_bytes) {
-                    let tx_block = TransactionBlock {
-                        inner: TransactionBlockInner::try_from(optimistic.clone())?,
-                        checkpoint_viewed_at: UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER,
-                    };
-                    results.insert(*key, tx_block);
-                }
-            }
-        }
-
-        Ok(results)
-    }
-}
-
-impl Loader<SeqKey> for Db {
-    type Value = TransactionBlock;
-    type Error = Error;
-
-    async fn load(&self, keys: &[SeqKey]) -> Result<HashMap<SeqKey, TransactionBlock>, Error> {
-        use transactions::dsl as tx;
-
-        let tx_seqs = keys
-            .iter()
-            .map(|k| k.tx_sequence_number as i64)
-            .collect::<Vec<_>>();
-        let transactions: Vec<StoredTransaction> = self
-            .execute(move |conn| {
-                conn.results(|| {
-                    tx::transactions
-                        .select(StoredTransaction::as_select())
-                        .filter(tx::tx_sequence_number.eq_any(tx_seqs.clone()))
-                })
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
-
-        let seq_num_to_tx: HashMap<i64, StoredTransaction> = transactions
-            .into_iter()
-            .map(|tx| (tx.tx_sequence_number, tx))
-            .collect();
-
-        let mut results = HashMap::with_capacity(keys.len());
-        for key in keys {
-            let Some(stored) = seq_num_to_tx.get(&(key.tx_sequence_number as i64)) else {
+            let Some(tx) = by_digest.get(key.digest.as_slice()) else {
                 continue;
             };
-
-            let mut checkpoint_viewed_at = key.checkpoint_viewed_at;
-            if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                checkpoint_viewed_at = UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER;
-            }
-            results.insert(
-                *key,
-                TransactionBlock {
-                    inner: TransactionBlockInner::try_from(stored.clone())?,
-                    checkpoint_viewed_at,
+            let block = match tx {
+                TransactionRead::Checkpointed(stored) => {
+                    let checkpoint_viewed_at =
+                        if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                            UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
+                        } else {
+                            key.checkpoint_viewed_at
+                        };
+                    TransactionBlock {
+                        inner: TransactionBlockInner::try_from(stored.clone())?,
+                        checkpoint_viewed_at,
+                    }
+                }
+                TransactionRead::Optimistic(opt) => TransactionBlock {
+                    inner: TransactionBlockInner::try_from(opt.clone())?,
+                    checkpoint_viewed_at: UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER,
                 },
-            );
+            };
+            results.insert(*key, block);
         }
 
         Ok(results)

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -33,7 +33,7 @@ use crate::{
         display::StoredDisplay,
         transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
     },
-    read::{IndexerReader, InputObjectsStatus, TransactionRead},
+    read::{IndexerReader, InputObjectsStatus},
     store::{IndexerStore, PgIndexerStore},
     transactional_blocking_with_retry_with_conditional_abort,
     types::{IndexedDeletedObject, IndexedObject, IndexerResult, grpc_conversion},
@@ -297,15 +297,17 @@ impl OptimisticTransactionExecutor {
         // may be persisted before objects and other related tables. We wait until all
         // such updates are completed.
         self.wait_for_local_indexing(tx_digest).await?;
-        let stored_transaction = match self.read.multi_get_transactions(&[tx_digest]).await?.pop() {
-            Some(TransactionRead::Checkpointed(s)) => s,
-            Some(TransactionRead::Optimistic(o)) => o.into(),
-            None => {
-                return Err(IndexerError::PersistentStorageDataCorruption(format!(
+        let stored_transaction = self
+            .read
+            .multi_get_transactions(&[tx_digest])
+            .await?
+            .pop()
+            .map(StoredTransaction::from)
+            .ok_or_else(|| {
+                IndexerError::PersistentStorageDataCorruption(format!(
                     "transaction {tx_digest} not found in the DB after being marked as indexed."
-                )));
-            }
-        };
+                ))
+            })?;
         db_read_timer.stop_and_record();
         Ok(stored_transaction)
     }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -33,7 +33,7 @@ use crate::{
         display::StoredDisplay,
         transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
     },
-    read::{IndexerReader, InputObjectsStatus},
+    read::{IndexerReader, InputObjectsStatus, TransactionRead},
     store::{IndexerStore, PgIndexerStore},
     transactional_blocking_with_retry_with_conditional_abort,
     types::{IndexedDeletedObject, IndexedObject, IndexerResult, grpc_conversion},
@@ -297,16 +297,15 @@ impl OptimisticTransactionExecutor {
         // may be persisted before objects and other related tables. We wait until all
         // such updates are completed.
         self.wait_for_local_indexing(tx_digest).await?;
-        let stored_transaction = self
-            .read
-            .multi_get_transactions(&[tx_digest])
-            .await?
-            .pop()
-            .ok_or_else(|| {
-                IndexerError::PersistentStorageDataCorruption(format!(
+        let stored_transaction = match self.read.multi_get_transactions(&[tx_digest]).await?.pop() {
+            Some(TransactionRead::Checkpointed(s)) => s,
+            Some(TransactionRead::Optimistic(o)) => o.into(),
+            None => {
+                return Err(IndexerError::PersistentStorageDataCorruption(format!(
                     "transaction {tx_digest} not found in the DB after being marked as indexed."
-                ))
-            })?;
+                )));
+            }
+        };
         db_read_timer.stop_and_record();
         Ok(stored_transaction)
     }

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -295,6 +295,25 @@ impl IndexerReader {
     }
 }
 
+/// A transaction returned by [`IndexerReader::multi_get_transactions`] or
+/// [`IndexerReader::multi_get_transactions_with_fallback`]. Each row is
+/// either checkpointed (from Postgres or the historical fallback) or
+/// optimistic (from Postgres).
+pub enum TransactionRead {
+    Checkpointed(StoredTransaction),
+    Optimistic(OptimisticTransaction),
+}
+
+impl TransactionRead {
+    /// Raw transaction digest bytes, common to both variants.
+    pub fn transaction_digest(&self) -> &[u8] {
+        match self {
+            Self::Checkpointed(s) => &s.transaction_digest,
+            Self::Optimistic(o) => &o.transaction_digest,
+        }
+    }
+}
+
 // Impl for reading data from the DB
 impl IndexerReader {
     fn get_object_from_db(
@@ -888,101 +907,71 @@ impl IndexerReader {
             .collect())
     }
 
-    /// Fetches multiple transactions from the database.
+    /// Fetches multiple transactions from the database. Each row is returned
+    /// as [`TransactionRead::Checkpointed`] or [`TransactionRead::Optimistic`]
+    /// depending on which table it came from.
     ///
-    ///  Retrieval order:
+    /// Retrieval order per digest:
     /// 1. Checkpointed data (finalized transactions)
     /// 2. Optimistic data (pending transactions not yet checkpointed)
     pub(crate) async fn multi_get_transactions(
         &self,
         digests: &[TransactionDigest],
-    ) -> IndexerResult<Vec<StoredTransaction>> {
-        let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
-        let checkpointed_txs = self
+    ) -> IndexerResult<Vec<TransactionRead>> {
+        let digest_bytes: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
+        let mut found: Vec<TransactionRead> = self
             .db()
-            .get_checkpointed_transactions(digests.clone())
-            .await?;
-
-        if checkpointed_txs.len() == digests.len() {
-            return Ok(checkpointed_txs);
-        }
-
-        let missing_digests = Self::check_for_missing_tx_digests(&digests, &checkpointed_txs);
-        let optimistic_txs = self
-            .db()
-            .get_optimistic_transactions(missing_digests)
-            .await?;
-
-        Ok(checkpointed_txs
-            .into_iter()
-            .chain(optimistic_txs.into_iter().map(Into::into))
-            .collect::<Vec<StoredTransaction>>())
-    }
-
-    /// Fetches multiple transactions from the indexer storage.
-    ///
-    /// Retrieval order:
-    /// 1. Checkpointed data (finalized transactions)
-    /// 2. Optimistic data (pending transactions not yet checkpointed)
-    /// 3. Historical fallback storage (if enabled)
-    async fn multi_get_transactions_with_fallback(
-        &self,
-        digests: &[TransactionDigest],
-    ) -> IndexerResult<Vec<StoredTransaction>> {
-        let fetched_transactions = self.multi_get_transactions(digests).await?;
-
-        // fallback to historical storage
-        let Some(fallback) = self
-            .fallback_reader()
-            // As for now we don't have a way to identify if the user requested pruned or invalid
-            // transaction digests. As a measure, we check if the number of requested transactions
-            // matches the number of fetched transactions. In case of missing transactions,
-            // if fallback is enabled, we use it to fetch the missing ones.
-            .filter(|_| fetched_transactions.len() != digests.len())
-        else {
-            // return data from database.
-            return Ok(fetched_transactions);
-        };
-
-        let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
-        let missing_digests = Self::check_for_missing_tx_digests(&digests, &fetched_transactions)
-            .iter()
-            .map(|digest| {
-                TransactionDigest::from_bytes(digest.as_slice()).map_err(|e| {
-                    IndexerError::PersistentStorageDataCorruption(format!(
-                        "can't convert {digest:?} as tx_digest. Error: {e}",
-                    ))
-                })
-            })
-            .collect::<IndexerResult<Vec<TransactionDigest>>>()?;
-
-        let historical_transactions = fallback
-            .transactions(&missing_digests)
+            .get_checkpointed_transactions(digest_bytes)
             .await?
             .into_iter()
-            .flatten()
-            .collect::<Vec<StoredTransaction>>();
+            .map(TransactionRead::Checkpointed)
+            .collect();
 
-        Ok(fetched_transactions
-            .into_iter()
-            .chain(historical_transactions)
-            .collect())
+        let missing = Self::check_for_missing_tx_digests(digests, &found);
+        if !missing.is_empty() {
+            let missing_bytes: Vec<Vec<u8>> = missing.iter().map(|d| d.inner().to_vec()).collect();
+            for opt in self.db().get_optimistic_transactions(missing_bytes).await? {
+                found.push(TransactionRead::Optimistic(opt));
+            }
+        }
+        Ok(found)
     }
 
-    /// Checks for missing transaction digests in the fetched transactions.
+    /// Same as [`Self::multi_get_transactions`], but also reads from the
+    /// historical fallback (when configured) for digests not found in
+    /// Postgres. Fallback rows are returned as
+    /// [`TransactionRead::Checkpointed`].
+    pub async fn multi_get_transactions_with_fallback(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> IndexerResult<Vec<TransactionRead>> {
+        let mut found = self.multi_get_transactions(digests).await?;
+
+        if found.len() == digests.len() {
+            return Ok(found);
+        }
+        let Some(fallback) = self.fallback_reader() else {
+            return Ok(found);
+        };
+
+        let missing = Self::check_for_missing_tx_digests(digests, &found);
+        for stored in fallback.transactions(&missing).await?.into_iter().flatten() {
+            found.push(TransactionRead::Checkpointed(stored));
+        }
+        Ok(found)
+    }
+
+    /// Returns the `requested` digests that are not in `found`.
     fn check_for_missing_tx_digests(
-        requested_digests: &[Vec<u8>],
-        fetched_txs: &[StoredTransaction],
-    ) -> Vec<Vec<u8>> {
-        let fetched_txs_digests_set = fetched_txs
+        requested: &[TransactionDigest],
+        found: &[TransactionRead],
+    ) -> Vec<TransactionDigest> {
+        let found_set: HashSet<&[u8]> = found.iter().map(|t| t.transaction_digest()).collect();
+        requested
             .iter()
-            .map(|tx| &tx.transaction_digest)
-            .collect::<HashSet<&Vec<u8>>>();
-        requested_digests
-            .iter()
-            .filter(|digest| !fetched_txs_digests_set.contains(digest))
-            .cloned()
-            .collect::<Vec<Vec<u8>>>()
+            .filter(|d| !found_set.contains(d.inner().as_slice()))
+            .copied()
+            .collect()
     }
 
     /// This method tries to transform [`StoredTransaction`] values
@@ -1666,7 +1655,15 @@ impl IndexerReader {
         digests: &[TransactionDigest],
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
     ) -> Result<Vec<iota_json_rpc_types::IotaTransactionBlockResponse>, IndexerError> {
-        let stored_txes = self.multi_get_transactions_with_fallback(digests).await?;
+        let stored_txes: Vec<StoredTransaction> = self
+            .multi_get_transactions_with_fallback(digests)
+            .await?
+            .into_iter()
+            .map(|tx| match tx {
+                TransactionRead::Checkpointed(s) => s,
+                TransactionRead::Optimistic(o) => o.into(),
+            })
+            .collect();
         self.stored_transaction_to_transaction_block(stored_txes, options)
             .await
     }

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -314,6 +314,15 @@ impl TransactionRead {
     }
 }
 
+impl From<TransactionRead> for StoredTransaction {
+    fn from(tx: TransactionRead) -> Self {
+        match tx {
+            TransactionRead::Checkpointed(s) => s,
+            TransactionRead::Optimistic(o) => o.into(),
+        }
+    }
+}
+
 // Impl for reading data from the DB
 impl IndexerReader {
     fn get_object_from_db(
@@ -1659,10 +1668,7 @@ impl IndexerReader {
             .multi_get_transactions_with_fallback(digests)
             .await?
             .into_iter()
-            .map(|tx| match tx {
-                TransactionRead::Checkpointed(s) => s,
-                TransactionRead::Optimistic(o) => o.into(),
-            })
+            .map(StoredTransaction::from)
             .collect();
         self.stored_transaction_to_transaction_block(stored_txes, options)
             .await

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -295,7 +295,7 @@ impl IndexerReader {
     }
 }
 
-/// A transaction returned by [`IndexerReader::multi_get_transactions`] or
+/// A transaction returned by `IndexerReader::multi_get_transactions` or
 /// [`IndexerReader::multi_get_transactions_with_fallback`]. Each row is
 /// either checkpointed (from Postgres or the historical fallback) or
 /// optimistic (from Postgres).
@@ -946,7 +946,7 @@ impl IndexerReader {
         Ok(found)
     }
 
-    /// Same as [`Self::multi_get_transactions`], but also reads from the
+    /// Same as `Self::multi_get_transactions`, but also reads from the
     /// historical fallback (when configured) for digests not found in
     /// Postgres. Fallback rows are returned as
     /// [`TransactionRead::Checkpointed`].


### PR DESCRIPTION
# Description of change

Adds historical fallback support for GraphQL transaction-by-digest lookups. The four covered paths:

- `Query.transactionBlock(digest)`
- `Query.transactionBlocksByDigests(digests)`
- `Event.transactionBlock`
- `MoveObject.previousTransactionBlock`

All four go through `IndexerReader::multi_get_transactions_with_fallback`, the same method JSON-RPC already uses for transactions by digest.

`multi_get_transactions` and `multi_get_transactions_with_fallback` now return `Vec<TransactionRead>` - a new enum that tags each row as `Checkpointed` or `Optimistic`, so the GraphQL loader can build the right `TransactionBlockInner` variant.

`Event.transactionBlock` switched from a sequence-number lookup to a digest lookup. A seq-based lookup would not work for events extracted from fallback as we would not be able to do the seq_num->digest conversion for already pruned transactions.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11935

## How the change has been tested

New e2e test: `crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.move` covers the four affected paths.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.



### Release Notes

- [x] GraphQL: `Query.transactionBlock(digest)` and `Query.transactionBlocksByDigests` can now read pruned transactions from the fallback KV store when it is configured.
