### PR TITLE
feat(json-rpc): shutdown JSON-RPC gracefully

### DIFF
--- a/crates/iota-json-rpc/src/lib.rs
+++ b/crates/iota-json-rpc/src/lib.rs
@@ -232,23 +232,31 @@ impl JsonRpcServerBuilder {
             Error::Unexpected(format!("invalid listen address {listen_address}: {e}"))
         })?;
 
-        let fut = async move {
-            axum::serve(
-                listener,
-                app.into_make_service_with_connect_info::<SocketAddr>(),
-            )
-            .await
-            .unwrap();
-            if let Some(cancel) = cancel {
-                // Signal that the server is shutting down, so other tasks can clean-up.
-                cancel.cancel();
+        let serve = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        );
+        let shutdown = cancel.clone().map(|token| token.cancelled_owned());
+        let run_server = async move {
+            if let Some(shutdown) = shutdown {
+                serve
+                    .with_graceful_shutdown(shutdown)
+                    .await
+                    .inspect(|_| info!("Shutting down IOTA JSON-RPC server"))
+                    .unwrap()
+            } else {
+                serve.await.unwrap()
+            };
+            if let Some(token) = cancel {
+                token.cancel();
             }
         };
+
         let handle = if let Some(custom_runtime) = custom_runtime {
             debug!("Spawning server with custom runtime");
-            custom_runtime.spawn(fut)
+            custom_runtime.spawn(run_server)
         } else {
-            tokio::spawn(fut)
+            tokio::spawn(run_server)
         };
 
         let handle = ServerHandle {


### PR DESCRIPTION
# Description of change

This patch adds allows shutting down the JSON-RPC server when a cancellation token is cancelled.

## Links to any relevant issues

Fixes #12072

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

Manual tests, starting the Indexer JSON-RPC service, and interrupting with Ctrl-C.
