### PR TITLE
refactor(consensus): rename metric to last_finalized_leader_round

### DIFF
--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1282,7 +1282,7 @@ impl Core {
             self.context
                 .metrics
                 .node_metrics
-                .last_decided_leader_round
+                .last_finalized_leader_round
                 .set(self.last_finalized_leader.round as i64);
 
             // It's possible to reach this point as the decided leaders might all of them be

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -203,7 +203,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) last_known_own_block_header_round: IntGauge,
     pub(crate) sync_last_known_own_block_header_retries: IntCounter,
     pub(crate) commit_round_advancement_interval: Histogram,
-    pub(crate) last_decided_leader_round: IntGauge,
+    pub(crate) last_finalized_leader_round: IntGauge,
     pub(crate) missing_block_headers_total: IntCounter,
     pub(crate) missing_block_headers_after_fetch_total: IntCounter,
     pub(crate) num_of_bad_nodes: IntGauge,
@@ -831,9 +831,9 @@ impl NodeMetrics {
                 FINE_GRAINED_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
-            last_decided_leader_round: register_int_gauge_with_registry!(
-                "last_decided_leader_round",
-                "The last round where a commit decision was made.",
+            last_finalized_leader_round: register_int_gauge_with_registry!(
+                "last_finalized_leader_round",
+                "The round of the last finalized leader.",
                 registry,
             ).unwrap(),
             missing_block_headers_total: register_int_counter_with_registry!(


### PR DESCRIPTION
# Description of change

Renames the consensus leader-round gauge from `last_decided_leader_round` to
`last_finalized_leader_round`. The gauge is set from the last finalized leader,
so the old name disagreed with the value it reports — "decided", "committed",
and "finalized" are distinct leader states, and the other leader-round metrics
already match the state they track.

The emitted Prometheus metric changes from `consensus_last_decided_leader_round`
to `consensus_last_finalized_leader_round`; the corresponding Grafana dashboard
panel needs the same rename.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
