### PR TITLE
chore(rust): bump rust nightly

### DIFF
--- a/.github/workflows/_rust_examples.yml
+++ b/.github/workflows/_rust_examples.yml
@@ -46,13 +46,13 @@ jobs:
           shopt -s globstar
           for manifest in ./**/examples/**/Cargo.toml; do
               echo "Checking format for $manifest"
-              cargo +nightly-2026-01-07 ci-fmt --manifest-path $manifest
+              cargo +nightly-2026-06-29 ci-fmt --manifest-path $manifest
 
               echo "Clippy linting for $manifest"
               cargo clippy --manifest-path $manifest --all-features
 
               echo "Checking unused dependencies of $manifest"
-              cargo +nightly-2026-01-07 ci-udeps --manifest-path $manifest
+              cargo +nightly-2026-06-29 ci-udeps --manifest-path $manifest
           done
 
   lint-examples-cancel:

--- a/.github/workflows/_rust_lints.yml
+++ b/.github/workflows/_rust_lints.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check Rust formatting
-        run: cargo +nightly-2026-01-07 ci-fmt
+        run: cargo +nightly-2026-06-29 ci-fmt
 
   rustfmt-cancel:
     needs: [rustfmt]

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -238,10 +238,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Cargo Udeps
-        run: cargo +nightly-2026-01-07 ci-udeps ${{ matrix.flags }}
+        run: cargo +nightly-2026-06-29 ci-udeps ${{ matrix.flags }}
 
       - name: Run Cargo Udeps (external crates)
-        run: cargo +nightly-2026-01-07 ci-udeps-external ${{ matrix.flags }}
+        run: cargo +nightly-2026-06-29 ci-udeps-external ${{ matrix.flags }}
 
   check-unused-deps-cancel:
     needs: [check-unused-deps]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expect-test"

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expect-test"

--- a/scripts/ci_tests/rust_tests.py
+++ b/scripts/ci_tests/rust_tests.py
@@ -819,8 +819,8 @@ class RustTestOrchestrator:
     # check for unused dependencies with cargo-udeps.
     def run_unused_deps(self) -> int:
         commands = [
-            "cargo +nightly-2026-01-07 ci-udeps --all-features",
-            "cargo +nightly-2026-01-07 ci-udeps --no-default-features"
+            "cargo +nightly-2026-06-29 ci-udeps --all-features",
+            "cargo +nightly-2026-06-29 ci-udeps --no-default-features"
         ]
         
         for cmd in commands:

--- a/scripts/indexer-schema/generate.sh
+++ b/scripts/indexer-schema/generate.sh
@@ -76,4 +76,4 @@ docker exec ${CONTAINER_NAME} diesel print-schema \
 $PYTHON_CMD ${REPO}/scripts/indexer-schema/generate_for_all_tables_macro.py "${REPO}/crates/iota-indexer/src/schema.rs"
 
 # Applying the patch may destroy the formatting, fix it
-rustfmt +nightly-2026-01-07 "${REPO}/crates/iota-indexer/src/schema.rs"
+rustfmt +nightly-2026-06-29 "${REPO}/crates/iota-indexer/src/schema.rs"


### PR DESCRIPTION
# Description of change

A dependency I want to update in another PR complains that it is incompatible with our rust nightly version. Also the rust nightly version is older than our current stable toolchain, so I bumped it to todays nightly version.

```
  error: rustc 1.94.0-nightly is not supported by the following package:
  sysinfo@0.39.5 requires rustc 1.95
```

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes