### PR TITLE
feat(indexer): populate displays during formal-snapshot restore

### DIFF
--- a/crates/iota-graphql-rpc/src/types/display.rs
+++ b/crates/iota-graphql-rpc/src/types/display.rs
@@ -66,13 +66,13 @@ impl Display {
     /// Render the fields defined by this `Display` from the contents of
     /// `struct_`.
     pub(crate) fn render(&self, struct_: &MoveStruct) -> Result<Vec<DisplayEntry>, Error> {
-        let event = self
+        let display_fields = self
             .stored
-            .to_display_update_event()
+            .to_display_fields()
             .map_err(|e| Error::Internal(e.to_string()))?;
 
         let mut rendered = vec![];
-        for entry in event.fields.contents {
+        for entry in display_fields.contents {
             rendered.push(match parse_template(&entry.value, struct_) {
                 Ok(v) => DisplayEntry::create_value(entry.key, v),
                 Err(e) => DisplayEntry::create_error(entry.key, e.to_string()),

--- a/crates/iota-indexer/migrations/pg/2026-06-26-161223_display_bcs_kind/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-06-26-161223_display_bcs_kind/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE display DROP COLUMN bcs_kind;

--- a/crates/iota-indexer/migrations/pg/2026-06-26-161223_display_bcs_kind/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-06-26-161223_display_bcs_kind/up.sql
@@ -1,0 +1,10 @@
+-- Discriminates what the `bcs` column encodes:
+--   0 = full DisplayVersionUpdatedEvent (legacy default)
+--   1 = VecMap<String, String> display fields only
+--       (this is what is used for rendering views)
+--
+-- We set initially to 0 to match the legacy encoding of existing databases.
+ALTER TABLE display ADD COLUMN bcs_kind SMALLINT NOT NULL DEFAULT 0;
+
+-- Restarting ingestion after this migration will encode the fields.
+ALTER TABLE display ALTER COLUMN bcs_kind SET DEFAULT 1;

--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -172,7 +172,7 @@ async fn construct_object_response(
         )),
         ObjectRead::Exists(object_ref, o, layout) => {
             if options.show_display {
-                match reader.get_display_fields(&o, &layout).await {
+                match reader.get_rendered_display_fields(&o, &layout).await {
                     Ok(rendered_fields) => Ok(IotaObjectResponse::new_with_data(
                         IotaObjectData::new(object_ref, o, layout, &options, rendered_fields)?,
                     )),

--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -79,7 +79,7 @@ impl ReadApi {
             ObjectRead::Exists(object_ref, o, layout) => {
                 let mut display_fields = None;
                 if options.show_display {
-                    match self.inner.get_display_fields(&o, &layout).await {
+                    match self.inner.get_rendered_display_fields(&o, &layout).await {
                         Ok(rendered_fields) => display_fields = Some(rendered_fields),
                         Err(e) => {
                             return Ok(IotaObjectResponse::new(
@@ -127,7 +127,7 @@ impl ReadApi {
                 let display_fields = if options.show_display {
                     let rendered_fields = self
                         .inner
-                        .get_display_fields(&object, &layout)
+                        .get_rendered_display_fields(&object, &layout)
                         .await
                         .map_err(internal_error)?;
 

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -32,7 +32,7 @@ pub(crate) struct CheckpointDataToCommit {
     pub(crate) events: Vec<IndexedEvent>,
     pub(crate) event_indices: Vec<EventIndex>,
     pub(crate) tx_indices: Vec<TxIndex>,
-    pub(crate) display_updates: BTreeMap<String, StoredDisplay>,
+    pub(crate) displays: BTreeMap<String, StoredDisplay>,
     pub(crate) object_changes: CheckpointObjectChanges,
     pub(crate) backward_history_changes: Vec<StoredBackwardHistoryObject>,
     pub(crate) object_versions: Vec<StoredObjectVersion>,
@@ -104,7 +104,7 @@ impl PrimaryWriter {
         let mut events_batch = Vec::with_capacity(batch_len);
         let mut tx_indices_batch = Vec::with_capacity(batch_len);
         let mut event_indices_batch = Vec::with_capacity(batch_len);
-        let mut display_updates_batch = BTreeMap::new();
+        let mut displays_batch = Vec::with_capacity(batch_len);
         let mut object_changes_batch = Vec::with_capacity(batch_len);
         let mut backward_history_batch = Vec::new();
         let mut object_versions_batch = Vec::with_capacity(batch_len);
@@ -117,7 +117,7 @@ impl PrimaryWriter {
                 events,
                 event_indices,
                 tx_indices,
-                display_updates,
+                displays,
                 object_changes,
                 backward_history_changes,
                 object_versions,
@@ -129,7 +129,7 @@ impl PrimaryWriter {
             events_batch.push(events);
             tx_indices_batch.push(tx_indices);
             event_indices_batch.push(event_indices);
-            display_updates_batch.extend(display_updates.into_iter());
+            displays_batch.extend(displays.into_values());
             object_changes_batch.push(object_changes);
             backward_history_batch.extend(backward_history_changes);
             object_versions_batch.push(object_versions);
@@ -167,7 +167,7 @@ impl PrimaryWriter {
                 self.state.persist_tx_indices(tx_indices_batch),
                 self.state.persist_events(events_batch),
                 self.state.persist_event_indices(event_indices_batch),
-                self.state.persist_displays(display_updates_batch),
+                self.state.persist_displays(displays_batch),
                 self.state.persist_packages(packages_batch),
                 self.state
                     .persist_object_versions(object_versions_batch.clone()),

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -279,7 +279,7 @@ impl PrimaryWorker {
             events: db_events,
             tx_indices: db_tx_indices,
             event_indices: db_event_indices,
-            display_updates: db_displays,
+            displays: db_displays,
             object_changes,
             backward_history_changes,
             object_versions,

--- a/crates/iota-indexer/src/models/display.rs
+++ b/crates/iota-indexer/src/models/display.rs
@@ -3,11 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::prelude::*;
-use iota_sdk_types::{Event, TypeTag};
-use iota_types::display::DisplayVersionUpdatedEvent;
+use iota_sdk_types::{Address, Event, Identifier, StructTag, TypeTag};
+use iota_types::{
+    collection_types::VecMap,
+    display::{DisplayObject, DisplayVersionUpdatedEvent},
+    object::Object,
+};
 
-use crate::schema::display;
 use crate::{errors::IndexerError, schema::display};
+
+const DISPLAY_STRUCT_NAME: Identifier = Identifier::from_static("Display");
 
 /// Identifies what type is encoded in [`StoredDisplay`]'s `bcs` column.
 #[derive(Debug, Copy, Clone)]
@@ -65,6 +70,29 @@ impl StoredDisplay {
         })
     }
 
+    /// Builds a display row from a live `0x2::display::Display<T>` object.
+    ///
+    /// Returns `None` when the object is not a `Display<T>`.
+    pub fn try_from_object(object: &Object) -> Option<Self> {
+        let move_object = object.data.as_opt_struct()?;
+        let struct_tag = move_object.struct_tag();
+        if !is_display(struct_tag) {
+            return None;
+        }
+        let [TypeTag::Struct(object_type)] = struct_tag.type_params() else {
+            return None;
+        };
+        let display: DisplayObject = bcs::from_bytes(move_object.contents()).ok()?;
+
+        Some(Self {
+            object_type: object_type.to_canonical_string(/* with_prefix */ true),
+            id: display.id.object_id().as_bytes().to_vec(),
+            version: display.version as i16,
+            bcs: bcs::to_bytes(&display.fields)
+                .expect("serializing a deserialized value should succeed"),
+            bcs_kind: DisplayBcsKind::Fields as i16,
+        })
+    }
 
     pub fn to_display_fields(&self) -> Result<VecMap<String, String>, IndexerError> {
         match DisplayBcsKind::try_from(self.bcs_kind)? {
@@ -79,4 +107,11 @@ impl StoredDisplay {
             ))
         })
     }
+}
+
+/// Returns whether `struct_tag` is of `0x2::display::Display` type.
+fn is_display(struct_tag: &StructTag) -> bool {
+    struct_tag.address() == Address::FRAMEWORK
+        && struct_tag.module() == &Identifier::DISPLAY_MODULE
+        && struct_tag.name() == &DISPLAY_STRUCT_NAME
 }

--- a/crates/iota-indexer/src/models/display.rs
+++ b/crates/iota-indexer/src/models/display.rs
@@ -7,6 +7,32 @@ use iota_sdk_types::{Event, TypeTag};
 use iota_types::display::DisplayVersionUpdatedEvent;
 
 use crate::schema::display;
+use crate::{errors::IndexerError, schema::display};
+
+/// Identifies what type is encoded in [`StoredDisplay`]'s `bcs` column.
+#[derive(Debug, Copy, Clone)]
+pub enum DisplayBcsKind {
+    /// Full [`DisplayVersionUpdatedEvent`] BCS, written from on-chain events.
+    Event = 0,
+    /// Only the [`DisplayVersionUpdatedEvent::fields`].
+    Fields = 1,
+}
+
+impl TryFrom<i16> for DisplayBcsKind {
+    type Error = IndexerError;
+
+    fn try_from(value: i16) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Self::Event,
+            1 => Self::Fields,
+            value => {
+                return Err(IndexerError::PersistentStorageDataCorruption(format!(
+                    "{value} as DisplayBcsKind"
+                )));
+            }
+        })
+    }
+}
 
 #[derive(Queryable, Insertable, Selectable, Debug, Clone)]
 #[diesel(table_name = display)]
@@ -15,6 +41,7 @@ pub struct StoredDisplay {
     pub id: Vec<u8>,
     pub version: i16,
     pub bcs: Vec<u8>,
+    pub bcs_kind: i16,
 }
 
 impl StoredDisplay {
@@ -32,11 +59,24 @@ impl StoredDisplay {
             object_type: ty.to_canonical_string(/* with_prefix */ true),
             id: display_event.id.bytes.as_bytes().to_vec(),
             version: display_event.version as i16,
-            bcs: event.contents.clone(),
+            bcs: bcs::to_bytes(&display_event.fields)
+                .expect("serializing a deserialized value should succeed"),
+            bcs_kind: DisplayBcsKind::Fields as i16,
         })
     }
 
-    pub fn to_display_update_event(&self) -> Result<DisplayVersionUpdatedEvent, bcs::Error> {
-        bcs::from_bytes(&self.bcs)
+
+    pub fn to_display_fields(&self) -> Result<VecMap<String, String>, IndexerError> {
+        match DisplayBcsKind::try_from(self.bcs_kind)? {
+            DisplayBcsKind::Event => {
+                bcs::from_bytes::<DisplayVersionUpdatedEvent>(&self.bcs).map(|event| event.fields)
+            }
+            DisplayBcsKind::Fields => bcs::from_bytes(&self.bcs),
+        }
+        .map_err(|e| {
+            IndexerError::PersistentStorageDataCorruption(format!(
+                "failed to decode stored display: {e}"
+            ))
+        })
     }
 }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -460,7 +460,7 @@ impl OptimisticTransactionExecutor {
             .persist_objects_in_existing_transaction(conn, vec![object_changes])?;
         self.store.persist_displays_chunk_in_existing_transaction(
             conn,
-            indexed_displays.into_values().collect(),
+            &indexed_displays.into_values().collect::<Vec<_>>(),
         )?;
 
         self.store

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -458,7 +458,7 @@ impl OptimisticTransactionExecutor {
 
         self.store
             .persist_objects_in_existing_transaction(conn, vec![object_changes])?;
-        self.store.persist_displays_in_existing_transaction(
+        self.store.persist_displays_chunk_in_existing_transaction(
             conn,
             indexed_displays.into_values().collect(),
         )?;

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -460,7 +460,7 @@ impl OptimisticTransactionExecutor {
             .persist_objects_in_existing_transaction(conn, vec![object_changes])?;
         self.store.persist_displays_in_existing_transaction(
             conn,
-            indexed_displays.values().collect::<Vec<_>>(),
+            indexed_displays.into_values().collect(),
         )?;
 
         self.store

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -39,6 +39,7 @@ use iota_types::{
     base_types::{SequenceNumber, VersionNumber},
     coin::TreasuryCap,
     coin_manager::CoinManager,
+    collection_types::VecMap,
     committee::EpochId,
     digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, visitor as DFV},
@@ -2266,19 +2267,19 @@ impl IndexerReader {
         Ok(name_bcs_value)
     }
 
-    pub async fn get_display_object_by_type(
+    pub async fn get_display_fields_by_type(
         &self,
         object_type: &StructTag,
-    ) -> Result<Option<iota_types::display::DisplayVersionUpdatedEvent>, IndexerError> {
+    ) -> Result<Option<VecMap<String, String>>, IndexerError> {
         let object_type = object_type.to_canonical_string(/* with_prefix */ true);
-        self.spawn_blocking(move |this| this.get_display_update_event(object_type))
+        self.spawn_blocking(move |this| this.get_display_fields(object_type))
             .await
     }
 
-    fn get_display_update_event(
+    fn get_display_fields(
         &self,
         object_type: String,
-    ) -> Result<Option<iota_types::display::DisplayVersionUpdatedEvent>, IndexerError> {
+    ) -> Result<Option<VecMap<String, String>>, IndexerError> {
         let stored_display = run_query!(&self.pool, |conn| {
             display::table
                 .filter(display::object_type.eq(object_type))
@@ -2291,9 +2292,7 @@ impl IndexerReader {
             None => return Ok(None),
         };
 
-        let display_update = stored_display.to_display_update_event()?;
-
-        Ok(Some(display_update))
+        Ok(Some(stored_display.to_display_fields()?))
     }
 
     pub async fn get_owned_coins_in_blocking_task(
@@ -2513,7 +2512,7 @@ impl IndexerReader {
             .collect())
     }
 
-    pub(crate) async fn get_display_fields(
+    pub(crate) async fn get_rendered_display_fields(
         &self,
         original_object: &iota_types::object::Object,
         original_layout: &Option<MoveStructLayout>,
@@ -2530,8 +2529,8 @@ impl IndexerReader {
             });
         };
 
-        if let Some(display_object) = self.get_display_object_by_type(&object_type).await? {
-            return iota_json_rpc::read_api::get_rendered_fields(display_object.fields, &layout)
+        if let Some(display_fields) = self.get_display_fields_by_type(&object_type).await? {
+            return iota_json_rpc::read_api::get_rendered_fields(display_fields, &layout)
                 .map_err(|e| IndexerError::Generic(e.to_string()));
         }
         Ok(DisplayFieldsResponse {

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -82,7 +82,6 @@ impl Restore for PgIndexerStore {
                     "failed to persist all formal snapshot object chunks: {e:?}",
                 ))
             })?;
-        // TODO: enable chunking
         self.persist_displays(displays.into_values().collect())
             .await?;
         Ok(())

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use bytes::Bytes;
 use fastcrypto::hash::{HashFunction, Sha3_256};
 use iota_core::authority::authority_store_tables::LiveObject as SnapshotObject;
@@ -16,6 +18,7 @@ use crate::{
     ingestion::{common::prepare::LiveObject, primary::persist::EpochToCommit},
     models::{
         checkpoints::StoredChainIdentifier,
+        display::StoredDisplay,
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate, extract_epoch_info_event},
     },
     pruning::pruner::PrunableTable,
@@ -31,6 +34,7 @@ impl Restore for PgIndexerStore {
         expected_checksum: &[u8; SHA3_BYTES],
     ) -> anyhow::Result<()> {
         let mut hasher = Sha3_256::default();
+        let mut display_updates = BTreeMap::new();
         let partition = LiveObjectIter::new(&file_metadata, bytes)?.scan(
             &mut hasher,
             |hasher,
@@ -39,6 +43,9 @@ impl Restore for PgIndexerStore {
                  previous_transaction_checkpoint,
              }| {
                 hasher.update(object.object_ref().digest.inner());
+                if let Some(display) = StoredDisplay::try_from_object(&object) {
+                    display_updates.insert(display.object_type.clone(), display);
+                }
                 let checkpoint_sequence_number =
                     previous_transaction_checkpoint.unwrap_or_default();
                 Some(LiveObject::new(checkpoint_sequence_number, object))
@@ -75,6 +82,8 @@ impl Restore for PgIndexerStore {
                     "failed to persist all formal snapshot object chunks: {e:?}",
                 ))
             })?;
+        // TODO: enable chunking
+        self.persist_displays(display_updates).await?;
         Ok(())
     }
 }

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -34,7 +34,7 @@ impl Restore for PgIndexerStore {
         expected_checksum: &[u8; SHA3_BYTES],
     ) -> anyhow::Result<()> {
         let mut hasher = Sha3_256::default();
-        let mut display_updates = BTreeMap::new();
+        let mut displays = BTreeMap::new();
         let partition = LiveObjectIter::new(&file_metadata, bytes)?.scan(
             &mut hasher,
             |hasher,
@@ -44,7 +44,7 @@ impl Restore for PgIndexerStore {
              }| {
                 hasher.update(object.object_ref().digest.inner());
                 if let Some(display) = StoredDisplay::try_from_object(&object) {
-                    display_updates.insert(display.object_type.clone(), display);
+                    displays.insert(display.object_type.clone(), display);
                 }
                 let checkpoint_sequence_number =
                     previous_transaction_checkpoint.unwrap_or_default();
@@ -83,7 +83,8 @@ impl Restore for PgIndexerStore {
                 ))
             })?;
         // TODO: enable chunking
-        self.persist_displays(display_updates).await?;
+        self.persist_displays(displays.into_values().collect())
+            .await?;
         Ok(())
     }
 }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -90,6 +90,7 @@ diesel::table! {
         id -> Bytea,
         version -> Int2,
         bcs -> Bytea,
+        bcs_kind -> Int2,
     }
 }
 

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{any::Any, collections::BTreeMap};
+use std::any::Any;
 
 use async_trait::async_trait;
 use diesel::PgConnection;
@@ -70,10 +70,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         event_indices: Vec<EventIndex>,
     ) -> Result<(), IndexerError>;
 
-    async fn persist_displays(
-        &self,
-        display_updates: BTreeMap<String, StoredDisplay>,
-    ) -> Result<(), IndexerError>;
+    async fn persist_displays(&self, displays: Vec<StoredDisplay>) -> Result<(), IndexerError>;
 
     async fn persist_packages(&self, packages: Vec<IndexedPackage>) -> Result<(), IndexerError>;
 
@@ -93,7 +90,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     fn persist_displays_in_existing_transaction(
         &self,
         conn: &mut PgConnection,
-        display_updates: Vec<&StoredDisplay>,
+        displays: Vec<StoredDisplay>,
     ) -> Result<(), IndexerError>;
 
     fn persist_objects_in_existing_transaction(

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -87,7 +87,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 
     fn as_any(&self) -> &dyn Any;
 
-    fn persist_displays_in_existing_transaction(
+    fn persist_displays_chunk_in_existing_transaction(
         &self,
         conn: &mut PgConnection,
         displays: Vec<StoredDisplay>,

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -90,7 +90,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     fn persist_displays_chunk_in_existing_transaction(
         &self,
         conn: &mut PgConnection,
-        displays: Vec<StoredDisplay>,
+        displays: &[StoredDisplay],
     ) -> Result<(), IndexerError>;
 
     fn persist_objects_in_existing_transaction(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -249,15 +249,10 @@ impl PgIndexerStore {
         .context("Failed reading min and max epoch numbers from PostgresDB")
     }
 
-    fn persist_displays_chunk(&self, mut displays: Vec<StoredDisplay>) -> Result<(), IndexerError> {
+    fn persist_displays_chunk(&self, displays: Vec<StoredDisplay>) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
-            {
-                // The parent uses an FnMut closure that mutably borrows the `displays`
-                // So we can't move the value. To avoid cloning we use `std::mem::take`.
-                let displays = std::mem::take(&mut displays);
-                |conn| self.persist_displays_chunk_in_existing_transaction(conn, displays)
-            },
+            |conn| self.persist_displays_chunk_in_existing_transaction(conn, &displays),
             PG_DB_COMMIT_SLEEP_DURATION
         )?;
 
@@ -1979,7 +1974,7 @@ impl IndexerStore for PgIndexerStore {
     fn persist_displays_chunk_in_existing_transaction(
         &self,
         conn: &mut PgConnection,
-        displays: Vec<StoredDisplay>,
+        displays: &[StoredDisplay],
     ) -> Result<(), IndexerError> {
         if displays.is_empty() {
             return Ok(());

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1980,6 +1980,7 @@ impl IndexerStore for PgIndexerStore {
                 display::id.eq(excluded(display::id)),
                 display::version.eq(excluded(display::version)),
                 display::bcs.eq(excluded(display::bcs)),
+                display::bcs_kind.eq(excluded(display::bcs_kind)),
             ),
             excluded(display::version).gt(display::version),
             conn

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -249,14 +249,14 @@ impl PgIndexerStore {
         .context("Failed reading min and max epoch numbers from PostgresDB")
     }
 
-    fn persist_displays(&self, mut displays: Vec<StoredDisplay>) -> Result<(), IndexerError> {
+    fn persist_displays_chunk(&self, mut displays: Vec<StoredDisplay>) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             {
                 // The parent uses an FnMut closure that mutably borrows the `displays`
                 // So we can't move the value. To avoid cloning we use `std::mem::take`.
                 let displays = std::mem::take(&mut displays);
-                |conn| self.persist_displays_in_existing_transaction(conn, displays)
+                |conn| self.persist_displays_chunk_in_existing_transaction(conn, displays)
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )?;
@@ -1951,11 +1951,32 @@ impl IndexerStore for PgIndexerStore {
             return Ok(());
         }
 
-        self.spawn_blocking_task(move |this| this.persist_displays(displays))
-            .await?
+        if displays.len() < self.config.parallel_objects_chunk_size {
+            self.spawn_blocking_task(move |this| this.persist_displays_chunk(displays))
+                .await??;
+            return Ok(());
+        }
+        let chunks = chunk!(displays, self.config.parallel_objects_chunk_size);
+        let persist_tasks = chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_displays_chunk(c)));
+        futures::future::try_join_all(persist_tasks)
+            .await
+            .map_err(|e| {
+                tracing::error!("failed to join futures for persisting displays: {e}");
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(
+                    format!("Failed to persist all displays chunks: {e:?}",),
+                )
+            })?;
+        Ok(())
     }
 
-    fn persist_displays_in_existing_transaction(
+    fn persist_displays_chunk_in_existing_transaction(
         &self,
         conn: &mut PgConnection,
         displays: Vec<StoredDisplay>,

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -3,11 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::result::Result::Ok;
-use std::{
-    any::Any as StdAny,
-    collections::{BTreeMap, HashMap},
-    time::Duration,
-};
+use std::{any::Any as StdAny, collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use diesel::{
@@ -253,15 +249,14 @@ impl PgIndexerStore {
         .context("Failed reading min and max epoch numbers from PostgresDB")
     }
 
-    fn persist_display_updates(
-        &self,
-        display_updates: BTreeMap<String, StoredDisplay>,
-    ) -> Result<(), IndexerError> {
+    fn persist_displays(&self, mut displays: Vec<StoredDisplay>) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             {
-                let value = display_updates.values().collect::<Vec<_>>();
-                |conn| self.persist_displays_in_existing_transaction(conn, value)
+                // The parent uses an FnMut closure that mutably borrows the `displays`
+                // So we can't move the value. To avoid cloning we use `std::mem::take`.
+                let displays = std::mem::take(&mut displays);
+                |conn| self.persist_displays_in_existing_transaction(conn, displays)
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )?;
@@ -1951,30 +1946,27 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_displays(
-        &self,
-        display_updates: BTreeMap<String, StoredDisplay>,
-    ) -> Result<(), IndexerError> {
-        if display_updates.is_empty() {
+    async fn persist_displays(&self, displays: Vec<StoredDisplay>) -> Result<(), IndexerError> {
+        if displays.is_empty() {
             return Ok(());
         }
 
-        self.spawn_blocking_task(move |this| this.persist_display_updates(display_updates))
+        self.spawn_blocking_task(move |this| this.persist_displays(displays))
             .await?
     }
 
     fn persist_displays_in_existing_transaction(
         &self,
         conn: &mut PgConnection,
-        display_updates: Vec<&StoredDisplay>,
+        displays: Vec<StoredDisplay>,
     ) -> Result<(), IndexerError> {
-        if display_updates.is_empty() {
+        if displays.is_empty() {
             return Ok(());
         }
 
         on_conflict_do_update_with_condition!(
             display::table,
-            display_updates,
+            displays,
             display::object_type,
             (
                 display::id.eq(excluded(display::id)),


### PR DESCRIPTION
# Description of change

This patch enables the population of the `displays` table while restoring from a formal snapshot. 

During restore the indexer only has access to live `0x2::display::Display<T>`  objects, as opposed to the on-chain `DisplayVersionUpdatedEvent` that live ingestion encodes as `bcs` into the `displays` table. Rendering however only ever needs the display fields stored in both the object and the event.

With these changes we generalize the table schema to allow encoding the fields directly as well, which becomes the default from this version and on. The kind of bcs encoding is distinguished by a new discriminator, that keeps existing databases valid with no backfill.

The changes can be summarized as follows:

  - Added a new `bcs_kind` column in `displays` to distinguish between the two types of bcs encoding stored in `display::bcs`: These are the legacy event, and the new display-fields type.
  - Added conversion methods for `StoredDisplay`  from a live `Display<T>` object, used by the restore path to populate displays as it streams objects.
  - Both live ingestion and restore now persist the fields-only encoding.
  - Generalized display persistence to chunk large batches and write them in parallel, matching how objects are persisted.

> [!NOTE]
> Since the display fields are stored in the display object as well, the idea of redirecting reads to the `objects` table and dropping `displays` was also investigated. This essentially put into question the necessary for a dedicated index for display fields. The `object` table does have an index that supports queries of objects by full-qualified type. However the sizes of the two tables differ by orders of magnitude. In `testnet` for example, `displays` count to hundreds whereas `objects` count to hundreds of millions. This implies that even index lookups on the `objects` table would be less efficient than on the dedicated index.

## Links to any relevant issues

Resolves #12059

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)


### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

QA is planned as part of #12061 

### Release Notes

- [x] Indexer: Introduces a new migration to add a `bcs_kind` column in `displays` to allow encoding different values in the `bcs` column. :warning: Operators should take all necessary measures to manage any downtime that the migration might incur. Nevertheless, minimal downtime is expected in this case. 