### PR TITLE
fix(genesis-builder): enable skip_fetch_latest_git_deps for genesis package builds

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/native_token/package_builder.rs
+++ b/crates/iota-genesis-builder/src/stardust/native_token/package_builder.rs
@@ -209,7 +209,7 @@ fn genesis_build_configuration() -> BuildConfig {
         force_recompilation: false,
         lock_file: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: true,
         default_edition: None,
         deps_as_root: false,
         silence_warnings: false,


### PR DESCRIPTION
# Description of change

Fixes #12084

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
