### PR TITLE
fix(release-notes): stop parsing note values at a blank line

### DIFF
--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -27,14 +27,17 @@ RE_HEADING = re.compile(
     re.DOTALL | re.IGNORECASE,
 )
 
-RE_CHECK = re.compile(
-    r"^\s*-\s*\[.\]",
-    re.MULTILINE,
-)
-
 RE_NOTE = re.compile(
     r"^\s*-\s*\[( |x)?\]\s*([^:]+):",
     re.MULTILINE | re.IGNORECASE,
+)
+
+# A note's value ends at the next checkbox, a heading, or a blank line. The
+# blank-line boundary keeps content appended after the release notes block
+# (e.g. tooling attribution footers) from being absorbed into the last note.
+RE_NOTE_END = re.compile(
+    r"^[ \t]*$|^\s*#|^\s*-\s*\[.\]",
+    re.MULTILINE,
 )
 
 RE_BREAKING = re.compile(
@@ -444,8 +447,9 @@ def extract_notes(commit_or_pr, seen, is_pr, crate_names, is_dry_run):
         impacted = match.group(2)
         begin = match.end()
 
-        # Find the end of the note, or the end of the commit
-        match = RE_CHECK.search(notes, begin)
+        # Find the end of the note: the next checkbox, heading, or blank line,
+        # whichever comes first, or the end of the commit.
+        match = RE_NOTE_END.search(notes, begin)
         end = match.start() if match else len(notes)
 
         result[impacted] = Note(


### PR DESCRIPTION
# Description of change

The `release_notes.py check-pr` parser read a release note's value from the category marker (`- [ ] <Category>:`) up to the *next* checkbox. The final entry therefore had no closing checkbox to bound it and absorbed everything after it in the release-notes block.

When external tooling appends a footer after the release notes (e.g. the `🤖 Generated with [Claude Code](https://claude.com/claude-code)` attribution line), that text became the value of the last category. Because the category was unchecked but now "had a note", the check failed with a false positive (observed on #11851, where the trailing content was attributed to an unchecked `gRPC:` entry).

## Changes

- Bound each note at the next checkbox, a heading, or a **blank line**, whichever comes first (`RE_NOTE_END`), instead of only at the next checkbox. Content appended below the template — always separated by a blank line — is no longer consumed.
- Removed the now-unused `RE_CHECK` regex (subsumed by `RE_NOTE_END`).

Inline notes (`- [x] CLI: added foo`) and notes written on the line immediately following the marker (no blank line) both still parse as before.

## Links to any relevant issues

Fixes #11874

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Reproduced the original failure, then confirmed the fix against several bodies: the bug case (attribution after unchecked `gRPC:`), inline notes, next-line notes, and a checked note followed by an attribution footer. Also ran `python3 release_notes.py check-pr 11851`, which now exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)