### PR TITLE
feat(prometheus-filtered): Add missing macro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,6 +87,7 @@
 /crates/iota-upgrade-compatibility-transactional-tests/ @iotaledger/vm-language
 /crates/iota-verifier-transactional-tests/ @iotaledger/vm-language
 /crates/prometheus-closure-metric/ @iotaledger/node
+/crates/prometheus-filtered/ @iotaledger/node
 /crates/simulacrum/ @iotaledger/node @iotaledger/vm-language
 /crates/simulacrum-server/ @iotaledger/node
 /crates/starfish/ @iotaledger/consensus

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -855,6 +855,27 @@ macro_rules! register_counter {
     }};
 }
 
+/// register_counter_vec_with_registry!(name, help, labels, registry)
+#[macro_export]
+macro_rules! register_counter_vec_with_registry {
+    ($name:expr, $help:expr, $labels:expr, $registry:expr $(,)?) => {{
+        let _n = $name;
+        let name: &str = &*_n;
+        let module: &str = module_path!();
+        if ($registry).is_enabled(name, module) {
+            $crate::prometheus::register_counter_vec_with_registry!(
+                name,
+                $help,
+                $labels,
+                ($registry).inner()
+            )
+            .map($crate::core::GenericCounterVec::new_some)
+        } else {
+            ::std::result::Result::Ok($crate::core::GenericCounterVec::new_none())
+        }
+    }};
+}
+
 /// register_counter_vec!(name, help, labels) - global registry, filtered.
 #[macro_export]
 macro_rules! register_counter_vec {


### PR DESCRIPTION
# Description of change

This PR adds `register_counter_vec_with_registry` macro.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
