### PR TITLE
feat(dev-tools): private-network experiment tooling

### DIFF
--- a/dev-tools/iota-private-network/bootstrap.sh
+++ b/dev-tools/iota-private-network/bootstrap.sh
@@ -250,12 +250,10 @@ main() {
       exit 1
     fi
 
-  # Refuse to regenerate genesis / wipe data while another experiment runner
-  # holds the shared lock. Same env-var / flag bypass shape as cleanup.sh
-  # and run.sh; orchestrators pass IOTA_EXPERIMENT_LOCK_HELD=1 through sudo
-  # so the runner-internal `sudo ./bootstrap.sh` path skips this check.
-  # Read-only FD + shared flock: see cleanup.sh for the rationale (avoids
-  # false positives under fs.protected_regular).
+  # Refuse to regenerate genesis / wipe data while another runner holds the
+  # lock. Bypass via IOTA_EXPERIMENT_LOCK_HELD (orchestrators pass it through
+  # sudo) or an explicit -f. Read-only FD + shared flock avoid a false
+  # "locked" under fs.protected_regular.
   LOCK_PATH="/tmp/iota-experiments.lock"
   if [ "$FORCE" != "true" ] \
      && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
@@ -269,9 +267,7 @@ main() {
 
   [ -d "$TEMP_EXPORT_DIR" ] && rm -rf "$TEMP_EXPORT_DIR"
 
-  # bootstrap.sh has already gated the lock above; pass -f so the inner
-  # cleanup.sh skips its (now-redundant) check rather than fighting the
-  # same lock we already saw is free.
+  # Lock already checked above; -f skips cleanup.sh's redundant re-check.
   [ -d "$PRIVATE_DATA_DIR" ] && ./cleanup.sh -f
 
   # Generate genesis template if missing

--- a/dev-tools/iota-private-network/bootstrap.sh
+++ b/dev-tools/iota-private-network/bootstrap.sh
@@ -18,12 +18,14 @@ NUM_VALIDATORS=4
 EPOCH_DURATION_MS=1200000
 FLAG_SPECIFIED=false
 BENCHMARK_MODE=false
-while getopts "n:e:b" opt; do
+FORCE=false
+while getopts "n:e:bf" opt; do
   case "$opt" in
     n) NUM_VALIDATORS="$OPTARG"; FLAG_SPECIFIED=true ;;
     e) EPOCH_DURATION_MS="$OPTARG"; FLAG_SPECIFIED=true ;;
     b) BENCHMARK_MODE=true; FLAG_SPECIFIED=true ;;
-    *) echo "Usage: $0 [-n num_validators] [-e epoch_duration_ms] [-b]"; exit 1 ;;
+    f) FORCE=true ;;
+    *) echo "Usage: $0 [-n num_validators] [-e epoch_duration_ms] [-b] [-f]"; exit 1 ;;
   esac
 done
 
@@ -247,10 +249,30 @@ main() {
       echo "Please run as root or with sudo"
       exit 1
     fi
-  
+
+  # Refuse to regenerate genesis / wipe data while another experiment runner
+  # holds the shared lock. Same env-var / flag bypass shape as cleanup.sh
+  # and run.sh; orchestrators pass IOTA_EXPERIMENT_LOCK_HELD=1 through sudo
+  # so the runner-internal `sudo ./bootstrap.sh` path skips this check.
+  # Read-only FD + shared flock: see cleanup.sh for the rationale (avoids
+  # false positives under fs.protected_regular).
+  LOCK_PATH="/tmp/iota-experiments.lock"
+  if [ "$FORCE" != "true" ] \
+     && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
+     && [ -f "$LOCK_PATH" ] \
+     && ! (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null; then
+    holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
+    echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
+    echo "       Wait for it to finish, or pass -f to override." >&2
+    exit 1
+  fi
+
   [ -d "$TEMP_EXPORT_DIR" ] && rm -rf "$TEMP_EXPORT_DIR"
 
-  [ -d "$PRIVATE_DATA_DIR" ] && ./cleanup.sh
+  # bootstrap.sh has already gated the lock above; pass -f so the inner
+  # cleanup.sh skips its (now-redundant) check rather than fighting the
+  # same lock we already saw is free.
+  [ -d "$PRIVATE_DATA_DIR" ] && ./cleanup.sh -f
 
   # Generate genesis template if missing
   generate_genesis_template_if_missing

--- a/dev-tools/iota-private-network/bootstrap.sh
+++ b/dev-tools/iota-private-network/bootstrap.sh
@@ -244,6 +244,28 @@ create_folder_for_postgres() {
   chmod 0755 "$PRIVATE_DATA_DIR/primary" "$PRIVATE_DATA_DIR/replica"
 }
 
+# Lock state of $LOCK_PATH: 0 = free, 3 = held, 4 = cannot tell. Shared flock
+# on a read-only FD avoids a false "locked" under fs.protected_regular; the
+# python3 fcntl probe covers macOS, which lacks flock(1).
+experiment_lock_state() {
+  if command -v flock >/dev/null 2>&1; then
+    (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null && return 0
+    return 3
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import fcntl, sys
+try:
+    fcntl.flock(open(sys.argv[1]), fcntl.LOCK_SH | fcntl.LOCK_NB)
+except OSError:
+    sys.exit(3)' "$LOCK_PATH" 2>/dev/null
+    case "$?" in
+      0) return 0 ;;
+      3) return 3 ;;
+    esac
+  fi
+  return 4
+}
+
 main() {
   if [[ "$OSTYPE" != "darwin"* && "$EUID" -ne 0 ]]; then
       echo "Please run as root or with sudo"
@@ -252,17 +274,23 @@ main() {
 
   # Refuse to regenerate genesis / wipe data while another runner holds the
   # lock. Bypass via IOTA_EXPERIMENT_LOCK_HELD (orchestrators pass it through
-  # sudo) or an explicit -f. Read-only FD + shared flock avoid a false
-  # "locked" under fs.protected_regular.
+  # sudo) or an explicit -f.
   LOCK_PATH="/tmp/iota-experiments.lock"
   if [ "$FORCE" != "true" ] \
      && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
-     && [ -f "$LOCK_PATH" ] \
-     && ! (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null; then
-    holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
-    echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
-    echo "       Wait for it to finish, or pass -f to override." >&2
-    exit 1
+     && [ -f "$LOCK_PATH" ]; then
+    lock_state=0
+    experiment_lock_state || lock_state=$?
+    if [ "$lock_state" -eq 3 ]; then
+      holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
+      echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
+      echo "       Wait for it to finish, or pass -f to override." >&2
+      exit 1
+    elif [ "$lock_state" -ne 0 ]; then
+      echo "ERROR: $LOCK_PATH exists but cannot be verified (need flock or a working python3)." >&2
+      echo "       Install one, or pass -f if no experiment run is active." >&2
+      exit 1
+    fi
   fi
 
   [ -d "$TEMP_EXPORT_DIR" ] && rm -rf "$TEMP_EXPORT_DIR"

--- a/dev-tools/iota-private-network/build.sh
+++ b/dev-tools/iota-private-network/build.sh
@@ -9,32 +9,26 @@ build_one() {
   local subdir="$1"
   pushd "$REPO_ROOT/docker/$subdir" >/dev/null
   ./build.sh
-  # Capture rc explicitly: when build_all is called from a conditional (`if`,
-  # `||`), bash suspends `set -e` inside the function body, so a failed
-  # ./build.sh would otherwise be masked by a successful popd.
+  # Capture rc across popd: set -e is suspended inside a function called from
+  # a conditional, so a failed ./build.sh must be propagated explicitly.
   local rc=$?
   popd >/dev/null
   return $rc
 }
 
 build_all() {
-  # `&&` chain (not just sequential calls): when build_all is called from a
-  # conditional, bash suspends `set -e` inside the function, so without the
-  # short-circuit a failed iota-node build would still let iota-indexer and
-  # iota-tools run, and build_all would return the last call's exit code —
-  # masking the earlier failure from build_all_with_retry.
+  # &&-chain so a failed build short-circuits instead of running the rest and
+  # returning only the last build's status.
   build_one iota-node \
     && build_one iota-indexer \
     && build_one iota-tools
 }
 
-# Symmetric to the post-build HEAD-vs-label check below: when BuildKit's cargo
-# cache mount has stale .rlib files (e.g., after a develop rebase removed a
-# symbol the working tree still references), the inner `cargo build` fails
-# before any image is produced — so the post-build verifier can't catch it.
-# Try the build once against the existing cache; on failure prune just the
-# cache mounts and retry once. A second failure means staleness was not the
-# issue, so propagate that exit code and let the user see the real error.
+# BuildKit's cargo cache mount can serve stale .rlib files (e.g. after a
+# develop rebase removed a symbol the working tree still references), failing
+# the inner `cargo build` before any image is produced. Try once against the
+# existing cache; on failure prune just the cache mounts and retry once. A
+# second failure is a real error — propagate it.
 build_all_with_retry() {
   if build_all; then
     return 0
@@ -46,13 +40,9 @@ build_all_with_retry() {
   build_all
 }
 
-# Verify each image's git-revision label matches HEAD. BuildKit's cargo-cache
-# mount can silently serve a stale binary across rebuilds even when crates/
-# source changed. The official
-# Docker Hub `iotaledger/iota-{node,tools,indexer}:latest` tags can also clobber
-# the local tag via an implicit `docker pull` from external tooling. In both
-# cases the resulting binary's git-revision won't match HEAD, so we detect and
-# self-heal here rather than silently running stale code.
+# Verify each image's git-revision label matches HEAD: a stale cargo cache
+# mount, or an implicit `docker pull` retagging :latest, can leave an image
+# whose binary predates HEAD. Detect and self-heal rather than run stale code.
 HEAD_REV="$(git -C "$REPO_ROOT" rev-parse --short=12 HEAD)"
 
 verify_image() {
@@ -82,12 +72,8 @@ echo "=== Verifying built images match HEAD ($HEAD_REV) ==="
 if ! verify_all; then
   echo
   echo "=== Stale image(s) detected — pruning cache mounts and rebuilding once ==="
-  # Only prune `--mount=type=cache` data (cargo target, cargo registry, cargo git).
-  # The plain layer cache (Debian base, apt steps, etc.) is preserved so other
-  # users on this shared Docker daemon don't pay a from-scratch rebuild cost when
-  # our verifier fires on a tag revert. This narrow prune is sufficient because
-  # the staleness path is always BuildKit's cargo cache mount serving outdated
-  # compilation output — not stale Dockerfile layers.
+  # Prune only the cargo cache mounts (target/registry/git); keep the layer
+  # cache so other users on this shared daemon don't pay a full rebuild.
   docker builder prune -f --filter type=exec.cachemount
   build_all
   echo

--- a/dev-tools/iota-private-network/build.sh
+++ b/dev-tools/iota-private-network/build.sh
@@ -3,18 +3,69 @@ set -e
 
 # Determine script's location to resolve the relative path correctly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." >/dev/null && pwd -P)"
 
-# Go to ../../docker/iota-node with pushd and build the image
-pushd "$SCRIPT_DIR/../../docker/iota-node"
-./build.sh
-popd
+build_one() {
+  local subdir="$1"
+  pushd "$REPO_ROOT/docker/$subdir" >/dev/null
+  ./build.sh
+  popd >/dev/null
+}
 
-# Go to ../../docker/iota-indexer with pushd and build the image
-pushd "$SCRIPT_DIR/../../docker/iota-indexer"
-./build.sh
-popd
+build_all() {
+  build_one iota-node
+  build_one iota-indexer
+  build_one iota-tools
+}
 
-# Go to ../../docker/iota-tools with pushd and build the image
-pushd "$SCRIPT_DIR/../../docker/iota-tools"
-./build.sh
-popd
+# Verify each image's git-revision label matches HEAD. BuildKit's cargo-cache
+# mount can silently serve a stale binary across rebuilds even when crates/
+# source changed. The official
+# Docker Hub `iotaledger/iota-{node,tools,indexer}:latest` tags can also clobber
+# the local tag via an implicit `docker pull` from external tooling. In both
+# cases the resulting binary's git-revision won't match HEAD, so we detect and
+# self-heal here rather than silently running stale code.
+HEAD_REV="$(git -C "$REPO_ROOT" rev-parse --short=12 HEAD)"
+
+verify_image() {
+  local image="$1"
+  local image_rev
+  image_rev="$(docker image inspect "$image:latest" --format '{{ index .Config.Labels "git-revision" }}' 2>/dev/null || true)"
+  # "-dirty" suffix means uncommitted local edits — accept it.
+  local image_rev_clean="${image_rev%-dirty}"
+  echo "  $image:latest -> git-revision=${image_rev:-(missing)}  (HEAD=$HEAD_REV)"
+  [ "$image_rev_clean" = "$HEAD_REV" ]
+}
+
+verify_all() {
+  local all_ok=true
+  for image in iotaledger/iota-node iotaledger/iota-tools iotaledger/iota-indexer; do
+    if ! verify_image "$image"; then
+      all_ok=false
+    fi
+  done
+  $all_ok
+}
+
+build_all
+
+echo
+echo "=== Verifying built images match HEAD ($HEAD_REV) ==="
+if ! verify_all; then
+  echo
+  echo "=== Stale image(s) detected — pruning BuildKit cache and rebuilding once ==="
+  docker builder prune -f
+  build_all
+  echo
+  echo "=== Re-verifying after prune+rebuild ==="
+  if ! verify_all; then
+    echo
+    echo "ERROR: at least one image is STILL stale after prune+rebuild." >&2
+    echo "       This indicates a deeper problem (e.g., :latest tag is being" >&2
+    echo "       repointed by an implicit docker pull from external tooling)." >&2
+    echo "       Manually retag the dangling images, or use a non-:latest tag." >&2
+    exit 1
+  fi
+fi
+
+echo "=== All images current at HEAD ($HEAD_REV) ==="

--- a/dev-tools/iota-private-network/build.sh
+++ b/dev-tools/iota-private-network/build.sh
@@ -53,8 +53,14 @@ echo
 echo "=== Verifying built images match HEAD ($HEAD_REV) ==="
 if ! verify_all; then
   echo
-  echo "=== Stale image(s) detected — pruning BuildKit cache and rebuilding once ==="
-  docker builder prune -f
+  echo "=== Stale image(s) detected — pruning cache mounts and rebuilding once ==="
+  # Only prune `--mount=type=cache` data (cargo target, cargo registry, cargo git).
+  # The plain layer cache (Debian base, apt steps, etc.) is preserved so other
+  # users on this shared Docker daemon don't pay a from-scratch rebuild cost when
+  # our verifier fires on a tag revert. This narrow prune is sufficient because
+  # the staleness path is always BuildKit's cargo cache mount serving outdated
+  # compilation output — not stale Dockerfile layers.
+  docker builder prune -f --filter type=exec.cachemount
   build_all
   echo
   echo "=== Re-verifying after prune+rebuild ==="

--- a/dev-tools/iota-private-network/build.sh
+++ b/dev-tools/iota-private-network/build.sh
@@ -9,13 +9,41 @@ build_one() {
   local subdir="$1"
   pushd "$REPO_ROOT/docker/$subdir" >/dev/null
   ./build.sh
+  # Capture rc explicitly: when build_all is called from a conditional (`if`,
+  # `||`), bash suspends `set -e` inside the function body, so a failed
+  # ./build.sh would otherwise be masked by a successful popd.
+  local rc=$?
   popd >/dev/null
+  return $rc
 }
 
 build_all() {
-  build_one iota-node
-  build_one iota-indexer
-  build_one iota-tools
+  # `&&` chain (not just sequential calls): when build_all is called from a
+  # conditional, bash suspends `set -e` inside the function, so without the
+  # short-circuit a failed iota-node build would still let iota-indexer and
+  # iota-tools run, and build_all would return the last call's exit code —
+  # masking the earlier failure from build_all_with_retry.
+  build_one iota-node \
+    && build_one iota-indexer \
+    && build_one iota-tools
+}
+
+# Symmetric to the post-build HEAD-vs-label check below: when BuildKit's cargo
+# cache mount has stale .rlib files (e.g., after a develop rebase removed a
+# symbol the working tree still references), the inner `cargo build` fails
+# before any image is produced — so the post-build verifier can't catch it.
+# Try the build once against the existing cache; on failure prune just the
+# cache mounts and retry once. A second failure means staleness was not the
+# issue, so propagate that exit code and let the user see the real error.
+build_all_with_retry() {
+  if build_all; then
+    return 0
+  fi
+  echo
+  echo "=== Build failed — pruning cargo cache mounts and retrying once ==="
+  echo "    (likely cause: BuildKit cargo cache has stale .rlib metadata)"
+  docker builder prune -f --filter type=exec.cachemount
+  build_all
 }
 
 # Verify each image's git-revision label matches HEAD. BuildKit's cargo-cache
@@ -47,7 +75,7 @@ verify_all() {
   $all_ok
 }
 
-build_all
+build_all_with_retry
 
 echo
 echo "=== Verifying built images match HEAD ($HEAD_REV) ==="

--- a/dev-tools/iota-private-network/cleanup.sh
+++ b/dev-tools/iota-private-network/cleanup.sh
@@ -3,9 +3,47 @@
 # Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
+usage() {
+  echo "Usage: $0 [-f]" >&2
+  echo "  -f   force: skip the /tmp/iota-experiments.lock check" >&2
+  exit 2
+}
+
+FORCE=false
+while getopts ":fh" opt; do
+  case "$opt" in
+    f) FORCE=true ;;
+    h|*) usage ;;
+  esac
+done
+
 if [[ "$OSTYPE" != "darwin"* && "$EUID" -ne 0 ]]; then
   echo "Please run as root or with sudo"
   exit
+fi
+
+# Refuse to tear down state if another experiment runner holds the shared
+# lock — `docker compose down --remove-orphans` here would silently nuke its
+# validators. Bypass when the caller is itself a lock-holding orchestrator
+# (it sets IOTA_EXPERIMENT_LOCK_HELD=1 in the child env before invoking us,
+# so its own bootstrap.sh -> cleanup.sh chain still works) or when the user
+# explicitly passes -f.
+LOCK_PATH="/tmp/iota-experiments.lock"
+# Read-only FD + shared (`-s`) non-blocking flock. Read-only opens are always
+# allowed for mode-666 files, unlike write opens which fs.protected_regular=2
+# blocks on files owned by other users in sticky /tmp — a plain
+# `flock -n FILE ...` would then report the lock as held even after a dead
+# holder's flock had been released, because it can't get past the open().
+# A shared flock succeeds iff no process holds an EXCLUSIVE flock, which is
+# exactly what the orchestrator's fcntl.LOCK_EX contends for.
+if [ "$FORCE" != "true" ] \
+   && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
+   && [ -f "$LOCK_PATH" ] \
+   && ! (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null; then
+  holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
+  echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
+  echo "       Wait for it to finish, or pass -f to override." >&2
+  exit 1
 fi
 
 docker compose down --remove-orphans

--- a/dev-tools/iota-private-network/cleanup.sh
+++ b/dev-tools/iota-private-network/cleanup.sh
@@ -26,19 +26,44 @@ fi
 # `docker compose down --remove-orphans` would nuke its validators. Bypass via
 # IOTA_EXPERIMENT_LOCK_HELD (set by a parent orchestrator) or an explicit -f.
 LOCK_PATH="/tmp/iota-experiments.lock"
-# Read-only FD + shared (-s) non-blocking flock. A write open (plain
-# `flock -n FILE`) can be blocked by fs.protected_regular on a /tmp file owned
-# by another (possibly dead) user, giving a false "locked"; a read open always
-# succeeds. The shared flock then succeeds iff no one holds the orchestrator's
-# exclusive lock.
+
+# Lock state of $LOCK_PATH: 0 = free, 3 = held, 4 = cannot tell. Shared flock
+# on a read-only FD avoids a false "locked" under fs.protected_regular; the
+# python3 fcntl probe covers macOS, which lacks flock(1).
+experiment_lock_state() {
+  if command -v flock >/dev/null 2>&1; then
+    (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null && return 0
+    return 3
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import fcntl, sys
+try:
+    fcntl.flock(open(sys.argv[1]), fcntl.LOCK_SH | fcntl.LOCK_NB)
+except OSError:
+    sys.exit(3)' "$LOCK_PATH" 2>/dev/null
+    case "$?" in
+      0) return 0 ;;
+      3) return 3 ;;
+    esac
+  fi
+  return 4
+}
+
 if [ "$FORCE" != "true" ] \
    && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
-   && [ -f "$LOCK_PATH" ] \
-   && ! (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null; then
-  holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
-  echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
-  echo "       Wait for it to finish, or pass -f to override." >&2
-  exit 1
+   && [ -f "$LOCK_PATH" ]; then
+  lock_state=0
+  experiment_lock_state || lock_state=$?
+  if [ "$lock_state" -eq 3 ]; then
+    holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
+    echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
+    echo "       Wait for it to finish, or pass -f to override." >&2
+    exit 1
+  elif [ "$lock_state" -ne 0 ]; then
+    echo "ERROR: $LOCK_PATH exists but cannot be verified (need flock or a working python3)." >&2
+    echo "       Install one, or pass -f if no experiment run is active." >&2
+    exit 1
+  fi
 fi
 
 docker compose down --remove-orphans

--- a/dev-tools/iota-private-network/cleanup.sh
+++ b/dev-tools/iota-private-network/cleanup.sh
@@ -22,20 +22,15 @@ if [[ "$OSTYPE" != "darwin"* && "$EUID" -ne 0 ]]; then
   exit
 fi
 
-# Refuse to tear down state if another experiment runner holds the shared
-# lock — `docker compose down --remove-orphans` here would silently nuke its
-# validators. Bypass when the caller is itself a lock-holding orchestrator
-# (it sets IOTA_EXPERIMENT_LOCK_HELD=1 in the child env before invoking us,
-# so its own bootstrap.sh -> cleanup.sh chain still works) or when the user
-# explicitly passes -f.
+# Refuse to tear down state while another runner holds the lock —
+# `docker compose down --remove-orphans` would nuke its validators. Bypass via
+# IOTA_EXPERIMENT_LOCK_HELD (set by a parent orchestrator) or an explicit -f.
 LOCK_PATH="/tmp/iota-experiments.lock"
-# Read-only FD + shared (`-s`) non-blocking flock. Read-only opens are always
-# allowed for mode-666 files, unlike write opens which fs.protected_regular=2
-# blocks on files owned by other users in sticky /tmp — a plain
-# `flock -n FILE ...` would then report the lock as held even after a dead
-# holder's flock had been released, because it can't get past the open().
-# A shared flock succeeds iff no process holds an EXCLUSIVE flock, which is
-# exactly what the orchestrator's fcntl.LOCK_EX contends for.
+# Read-only FD + shared (-s) non-blocking flock. A write open (plain
+# `flock -n FILE`) can be blocked by fs.protected_regular on a /tmp file owned
+# by another (possibly dead) user, giving a false "locked"; a read open always
+# succeeds. The shared flock then succeeds iff no one holds the orchestrator's
+# exclusive lock.
 if [ "$FORCE" != "true" ] \
    && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
    && [ -f "$LOCK_PATH" ] \

--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -797,6 +797,7 @@ def start_grafana(grafana_dir: Path, override_file: str | None = None) -> None:
     run_timed(cmd, "Starting monitoring stack", cwd=grafana_dir)
     print()
     log(f"  Grafana: {_C.CYAN}http://localhost:3000/dashboards{_C.RESET}")
+    log(f"  StarfishOverview: {_C.CYAN}http://localhost:3000/d/StarfishOverview{_C.RESET}")
     log(f"  Prometheus: {_C.CYAN}http://localhost:9090/targets{_C.RESET}")
 
 
@@ -941,6 +942,23 @@ def _update_or_clone_benchmark_repo() -> None:
     run_timed(
         ["git", "clone", NETWORK_BENCHMARK_REPO, str(NETWORK_BENCHMARK_DIR)],
         "Cloning network-benchmark", check=False,
+    )
+
+
+def ensure_iota_spammer_script() -> None:
+    """Verify the iota-spammer fuzz script is reachable BEFORE the network
+    comes up. Mirrors `ensure_stress_image` for the iota-spammer backend:
+    skipping the check leaves the run to fail in `start_spammer` ~5 minutes
+    in, after bootstrap + validator startup. The script lives in a separate
+    private repo, so a missing checkout is a likely-enough misconfiguration
+    to be worth surfacing up front."""
+    script = Path.home() / "iota-spammer" / "scripts" / "spamming_fuzz_test.sh"
+    if script.is_file():
+        return
+    raise RuntimeError(
+        f"iota-spammer spammer requested but script not found at {script}; "
+        "clone github.com/iotaledger/iota-spammer to ~/iota-spammer "
+        "or select the stress backend (-C stress)"
     )
 
 

--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -338,6 +338,12 @@ def acquire_single_run_lock(runner: str) -> None:
     )
     fh.flush()
     _run_lock_fh = fh  # keep the fd open: the flock dies with the process
+    # Signal child processes (bootstrap.sh -> cleanup.sh chain, plus any
+    # direct invocations of cleanup.sh / run.sh from within an orchestrator)
+    # that the shared lock is already held by their parent, so their own
+    # lock-checks should not fire. Default subprocess.run inherits env, so
+    # setting this in os.environ propagates cleanly.
+    os.environ["IOTA_EXPERIMENT_LOCK_HELD"] = "1"
 
 
 def _lock_holder_pid(holder: str) -> int | None:
@@ -739,9 +745,19 @@ def generate_compose_file(
 
 
 def bootstrap_genesis(network_dir: Path, num_validators: int, epoch_ms: int) -> None:
-    """Run bootstrap.sh under sudo (writes the root-owned data dir)."""
+    """Run bootstrap.sh under sudo (writes the root-owned data dir).
+
+    `IOTA_EXPERIMENT_LOCK_HELD=1` is passed as a sudo command-line env
+    assignment so bootstrap.sh's (and its inner cleanup.sh's) lock check
+    bypasses — the orchestrator already holds the shared lock. sudo's
+    default env_reset strips inherited variables, so the explicit cmdline
+    assignment is required (relying on os.environ alone would not survive
+    sudo)."""
     run_timed(
-        ["sudo", "./bootstrap.sh", "-n", str(num_validators), "-e", str(epoch_ms)],
+        [
+            "sudo", "IOTA_EXPERIMENT_LOCK_HELD=1",
+            "./bootstrap.sh", "-n", str(num_validators), "-e", str(epoch_ms),
+        ],
         "Bootstrapping genesis",
         cwd=network_dir,
     )

--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -1324,7 +1324,7 @@ def post_run_canary(
                 ts = _parse_iso_utc(ts_match.group(1))
             except ValueError:
                 unknown.append(
-                    f"{archive.name}:{lineno} (unparseable timestamp): {snippet}"
+                    f"{archive.name}:{lineno} (unparsable timestamp): {snippet}"
                 )
                 continue
             if _in_shutdown_window(idx, ts):

--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -35,7 +35,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -1193,9 +1193,13 @@ def stop_spammer(cfg, proc: subprocess.Popen[str] | None) -> None:
         proc.wait(timeout=5)
 
 
-def run_loop(cfg, prefix: str, final_prefix: str) -> None:
+def run_loop(cfg, prefix: str, final_prefix: str) -> str:
     """Sleep for cfg.run_duration with a progress bar, saving validator logs
-    every cfg.log_interval seconds and once more at the end."""
+    every cfg.log_interval seconds and once more at the end.
+
+    Returns the timestamp string used for the final per-validator archives
+    (`{final_prefix}-<ts>-validator-<i>.log`) so callers can pass it on to
+    `post_run_canary`."""
     log(_phase_banner(
         f"Running for {cfg.run_duration}s (logs every {cfg.log_interval}s)", "RUN",
     ))
@@ -1218,6 +1222,125 @@ def run_loop(cfg, prefix: str, final_prefix: str) -> None:
         prefix=f"{final_prefix}-{ts}",
         latest=False,
     )
+    return ts
+
+
+# Correctness-failure markers grepped from per-validator archives.
+_CANARY_MARKER_RE = re.compile(
+    r"Split brain detected|"
+    r"Local checkpoint fork detected|"
+    r"WrongBlockHeaderVersionForFlag|"
+    r"panicked at"
+)
+# Leading UTC timestamp on every iota-node log line.
+_VAL_LINE_TS_RE = re.compile(
+    r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\b"
+)
+# `network-fuzz.sh` emits one of these per validator at each mid-run restart.
+_FUZZ_STOP_RE = re.compile(
+    r"^(\S+)\s+Stopping validator-(\d+)\b"
+)
+
+
+def post_run_canary(
+    log_dir: Path,
+    archive_prefix: str,
+    archive_ts: str,
+    fuzz_log_path: Path | None,
+    num_validators: int,
+    *,
+    grace_seconds: int = 30,
+) -> None:
+    """Post-run analysis that classifies panic/fork/split-brain markers in
+    per-validator archives, filtering shutdown-race noise by time-window
+    correlation.
+
+    A panic in validator-N's archive is treated as expected shutdown noise
+    iff its timestamp falls within `grace_seconds` of a
+    `Stopping validator-N for ...` event in the fuzz log. The grace window
+    covers the tokio runtime-drop duration, during which receivers may be
+    cancelled before senders and the `.expect(...)` assertions on closed
+    channels fire.
+
+    Any marker that does not fall in such a window is logged as an
+    "unknown" hit and counts toward a `Canary FAILURE` verdict.
+
+    If `fuzz_log_path` is None, no shutdown windows are derived; every
+    marker is treated as unknown. Use this for orchestrators that never
+    restart validators mid-run (e.g. benchmark).
+    """
+    # Locate per-validator archives written by `run_loop`.
+    archives = [
+        log_dir / f"{archive_prefix}-{archive_ts}-validator-{i}.log"
+        for i in range(1, num_validators + 1)
+    ]
+    archives = [p for p in archives if p.exists()]
+    if not archives:
+        log(f"  Canary: no validator archives found at "
+            f"{log_dir}/{archive_prefix}-{archive_ts}-validator-*.log; "
+            "skipping.")
+        return
+
+    # Parse fuzz log for per-validator stop timestamps.
+    stop_windows: dict[int, list[tuple[datetime, datetime]]] = {}
+    if fuzz_log_path is not None and fuzz_log_path.exists():
+        grace = timedelta(seconds=grace_seconds)
+        for line in fuzz_log_path.read_text().splitlines():
+            m = _FUZZ_STOP_RE.match(line)
+            if not m:
+                continue
+            try:
+                ts = datetime.fromisoformat(m.group(1))
+            except ValueError:
+                continue
+            ts_utc = ts.astimezone(timezone.utc)
+            idx = int(m.group(2))
+            stop_windows.setdefault(idx, []).append((ts_utc, ts_utc + grace))
+
+    def _in_shutdown_window(idx: int, ts: datetime) -> bool:
+        for lo, hi in stop_windows.get(idx, ()):
+            if lo <= ts <= hi:
+                return True
+        return False
+
+    filtered = 0
+    unknown: list[str] = []
+    for archive in archives:
+        idx = int(archive.stem.rsplit("-validator-", 1)[1])
+        for lineno, line in enumerate(archive.read_text().splitlines(), 1):
+            if not _CANARY_MARKER_RE.search(line):
+                continue
+            ts_match = _VAL_LINE_TS_RE.match(line)
+            if not ts_match:
+                # Marker on a line without a timestamp (continuation of a
+                # multi-line panic message). Skip; the first line of the
+                # panic carries the timestamp and is what we classify on.
+                continue
+            try:
+                ts = datetime.fromisoformat(ts_match.group(1))
+            except ValueError:
+                continue
+            # All iota-node timestamps are UTC ("Z" suffix), so the resulting
+            # datetime is already tz-aware in UTC.
+            if _in_shutdown_window(idx, ts):
+                filtered += 1
+            else:
+                # Trim long stack-trace lines for the summary log.
+                snippet = line[:240] + ("..." if len(line) > 240 else "")
+                unknown.append(f"{archive.name}:{lineno}: {snippet}")
+
+    if not unknown and filtered == 0:
+        log(f"  Canary CLEAN: no panic/fork/split-brain markers in "
+            f"{len(archives)} validator archive(s).")
+    elif not unknown:
+        log(f"  Canary CLEAN: {filtered} marker(s) filtered as expected "
+            "shutdown-race noise (in fuzz-stop windows); no unknown.")
+    else:
+        log(f"  {_C.RED}Canary FAILURE{_C.RESET}: {len(unknown)} "
+            "unknown marker(s) outside expected shutdown windows "
+            f"({filtered} other marker(s) filtered as shutdown noise):")
+        for entry in unknown:
+            log(f"    {entry}")
 
 
 def network_stats(num_validators: int) -> None:

--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -338,11 +338,8 @@ def acquire_single_run_lock(runner: str) -> None:
     )
     fh.flush()
     _run_lock_fh = fh  # keep the fd open: the flock dies with the process
-    # Signal child processes (bootstrap.sh -> cleanup.sh chain, plus any
-    # direct invocations of cleanup.sh / run.sh from within an orchestrator)
-    # that the shared lock is already held by their parent, so their own
-    # lock-checks should not fire. Default subprocess.run inherits env, so
-    # setting this in os.environ propagates cleanly.
+    # Child scripts (bootstrap.sh -> cleanup.sh, direct cleanup.sh/run.sh)
+    # inherit this and skip their own lock check, since we already hold it.
     os.environ["IOTA_EXPERIMENT_LOCK_HELD"] = "1"
 
 
@@ -747,12 +744,8 @@ def generate_compose_file(
 def bootstrap_genesis(network_dir: Path, num_validators: int, epoch_ms: int) -> None:
     """Run bootstrap.sh under sudo (writes the root-owned data dir).
 
-    `IOTA_EXPERIMENT_LOCK_HELD=1` is passed as a sudo command-line env
-    assignment so bootstrap.sh's (and its inner cleanup.sh's) lock check
-    bypasses — the orchestrator already holds the shared lock. sudo's
-    default env_reset strips inherited variables, so the explicit cmdline
-    assignment is required (relying on os.environ alone would not survive
-    sudo)."""
+    Passes the lock-held flag as a sudo cmdline assignment (sudo's env_reset
+    strips inherited env) so the child's lock check is bypassed."""
     run_timed(
         [
             "sudo", "IOTA_EXPERIMENT_LOCK_HELD=1",
@@ -962,12 +955,8 @@ def _update_or_clone_benchmark_repo() -> None:
 
 
 def ensure_iota_spammer_script() -> None:
-    """Verify the iota-spammer fuzz script is reachable BEFORE the network
-    comes up. Mirrors `ensure_stress_image` for the iota-spammer backend:
-    skipping the check leaves the run to fail in `start_spammer` ~5 minutes
-    in, after bootstrap + validator startup. The script lives in a separate
-    private repo, so a missing checkout is a likely-enough misconfiguration
-    to be worth surfacing up front."""
+    """Fail fast if the iota-spammer fuzz script is missing, before the
+    network comes up (otherwise the run fails in start_spammer ~5 min in)."""
     script = Path.home() / "iota-spammer" / "scripts" / "spamming_fuzz_test.sh"
     if script.is_file():
         return
@@ -1211,11 +1200,8 @@ def stop_spammer(cfg, proc: subprocess.Popen[str] | None) -> None:
 
 def run_loop(cfg, prefix: str, final_prefix: str) -> str:
     """Sleep for cfg.run_duration with a progress bar, saving validator logs
-    every cfg.log_interval seconds and once more at the end.
-
-    Returns the timestamp string used for the final per-validator archives
-    (`{final_prefix}-<ts>-validator-<i>.log`) so callers can pass it on to
-    `post_run_canary`."""
+    every cfg.log_interval seconds and once more at the end. Returns the
+    timestamp used in the final archive filenames."""
     log(_phase_banner(
         f"Running for {cfg.run_duration}s (logs every {cfg.log_interval}s)", "RUN",
     ))
@@ -1279,23 +1265,13 @@ def post_run_canary(
     *,
     grace_seconds: int = 30,
 ) -> None:
-    """Post-run analysis that classifies panic/fork/split-brain markers in
-    per-validator archives, filtering shutdown-race noise by time-window
-    correlation.
+    """Classify panic/fork/split-brain markers in per-validator archives.
 
-    A panic in validator-N's archive is treated as expected shutdown noise
-    iff its timestamp falls within `grace_seconds` of a
-    `Stopping validator-N for ...` event in the fuzz log. The grace window
-    covers the tokio runtime-drop duration, during which receivers may be
-    cancelled before senders and the `.expect(...)` assertions on closed
-    channels fire.
-
-    Any marker that does not fall in such a window is logged as an
-    "unknown" hit and counts toward a `Canary FAILURE` verdict.
-
-    If `fuzz_log_path` is None, no shutdown windows are derived; every
-    marker is treated as unknown. Use this for orchestrators that never
-    restart validators mid-run (e.g. benchmark).
+    A marker within `grace_seconds` of a `Stopping validator-N` fuzz-log
+    event is treated as expected shutdown-race noise; anything else counts
+    toward a `Canary FAILURE` verdict. With `fuzz_log_path=None` there are no
+    shutdown windows, so every marker is unknown (for runners that never
+    restart validators mid-run, e.g. benchmark).
     """
     # Locate per-validator archives written by `run_loop`.
     archives = [
@@ -1339,9 +1315,8 @@ def post_run_canary(
                 continue
             ts_match = _VAL_LINE_TS_RE.match(line)
             if not ts_match:
-                # Marker on a line without a timestamp (continuation of a
-                # multi-line panic message). Skip; the first line of the
-                # panic carries the timestamp and is what we classify on.
+                # Continuation line of a multi-line panic; the first line
+                # carries the timestamp we classify on. Skip.
                 continue
             try:
                 ts = _parse_iso_utc(ts_match.group(1))

--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -1318,15 +1318,18 @@ def post_run_canary(
                 # Continuation line of a multi-line panic; the first line
                 # carries the timestamp we classify on. Skip.
                 continue
+            # Trim long stack-trace lines for the summary log.
+            snippet = line[:240] + ("..." if len(line) > 240 else "")
             try:
                 ts = _parse_iso_utc(ts_match.group(1))
             except ValueError:
+                unknown.append(
+                    f"{archive.name}:{lineno} (unparseable timestamp): {snippet}"
+                )
                 continue
             if _in_shutdown_window(idx, ts):
                 filtered += 1
             else:
-                # Trim long stack-trace lines for the summary log.
-                snippet = line[:240] + ("..." if len(line) > 240 else "")
                 unknown.append(f"{archive.name}:{lineno}: {snippet}")
 
     if not unknown and filtered == 0:

--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -1258,6 +1258,18 @@ _FUZZ_STOP_RE = re.compile(
 )
 
 
+def _parse_iso_utc(ts_str: str) -> datetime:
+    """Parse an ISO-8601 timestamp to a tz-aware UTC datetime, accepting a
+    trailing `Z` UTC marker (normalized to `+00:00` before parsing). A
+    timestamp without an offset is assumed to be UTC."""
+    if ts_str.endswith("Z"):
+        ts_str = ts_str[:-1] + "+00:00"
+    ts = datetime.fromisoformat(ts_str)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc)
+
+
 def post_run_canary(
     log_dir: Path,
     archive_prefix: str,
@@ -1306,10 +1318,9 @@ def post_run_canary(
             if not m:
                 continue
             try:
-                ts = datetime.fromisoformat(m.group(1))
+                ts_utc = _parse_iso_utc(m.group(1))
             except ValueError:
                 continue
-            ts_utc = ts.astimezone(timezone.utc)
             idx = int(m.group(2))
             stop_windows.setdefault(idx, []).append((ts_utc, ts_utc + grace))
 
@@ -1333,11 +1344,9 @@ def post_run_canary(
                 # panic carries the timestamp and is what we classify on.
                 continue
             try:
-                ts = datetime.fromisoformat(ts_match.group(1))
+                ts = _parse_iso_utc(ts_match.group(1))
             except ValueError:
                 continue
-            # All iota-node timestamps are UTC ("Z" suffix), so the resulting
-            # datetime is already tz-aware in UTC.
             if _in_shutdown_window(idx, ts):
                 filtered += 1
             else:

--- a/dev-tools/iota-private-network/experiments/run-benchmark.py
+++ b/dev-tools/iota-private-network/experiments/run-benchmark.py
@@ -264,6 +264,10 @@ def main() -> None:
             # Resolve the load image up front (pull, else build from the
             # network-benchmark clone) instead of surprising the run mid-way.
             ec.ensure_stress_image(cfg.spammer_image)
+        if cfg.spammer_enable and cfg.spammer_type == "iota-spammer":
+            # Check the script exists before bringing up the network; surfaces
+            # a misconfigured spammer in seconds instead of ~5 min in.
+            ec.ensure_iota_spammer_script()
         if not cfg.build:
             ec.require_local_image(
                 cfg.image,

--- a/dev-tools/iota-private-network/experiments/run-fuzz.py
+++ b/dev-tools/iota-private-network/experiments/run-fuzz.py
@@ -109,10 +109,12 @@ _spammer_proc: subprocess.Popen[str] | None = None
 # ========================= Fuzz-specific phases =========================
 
 
-def apply_fuzz(cfg: Config) -> subprocess.Popen[str]:
+def apply_fuzz(cfg: Config) -> tuple[subprocess.Popen[str], Path]:
     """Launch network-fuzz.sh (it self-sudos for tc/iptables). Returns the
-    running process. A separate timestamped fuzz log keeps its per-round
-    output out of the main script log."""
+    running process and the per-run fuzz log path (consumed later by the
+    post-run canary to derive validator-stop timestamps). A separate
+    timestamped fuzz log keeps its per-round output out of the main script
+    log."""
     ts = datetime.now().strftime("%Y%m%d-%H%M%S")
     fuzz_log = cfg.log_dir / f"fuzz_{ts}.log"
     # Clear any leftover stop/lock files from a previous fuzz run.
@@ -148,7 +150,7 @@ def apply_fuzz(cfg: Config) -> subprocess.Popen[str]:
         time.sleep(1)
     print()
     log(f"  Fuzz ({cfg.topology}) applied; log: {fuzz_log}")
-    return proc
+    return proc, fuzz_log
 
 
 def _clear_fuzzdrop_rules() -> None:
@@ -362,7 +364,7 @@ def main() -> None:
         log(ec._phase_banner("Starting Grafana/Prometheus", "MONITOR"))
         ec.start_grafana(cfg.grafana_dir)
         log(ec._phase_banner(f"Applying fuzz ({cfg.topology})", "FUZZ"))
-        _fuzz_proc = apply_fuzz(cfg)
+        _fuzz_proc, fuzz_log_path = apply_fuzz(cfg)
         # Start load as soon as the network is up (validators running, fuzz
         # applied) so the block-production measurement runs under load — matching
         # the migration runner. Previously the spammer started only after the
@@ -372,7 +374,14 @@ def main() -> None:
             ec.measure_block_production(
                 cfg.num_validators, cfg.block_measurement_seconds,
             )
-        ec.run_loop(cfg, "fuzz", "fuzz")
+        archive_ts = ec.run_loop(cfg, "fuzz", "fuzz")
+        ec.post_run_canary(
+            cfg.log_dir,
+            archive_prefix="fuzz",
+            archive_ts=archive_ts,
+            fuzz_log_path=fuzz_log_path,
+            num_validators=cfg.num_validators,
+        )
     finally:
         cleanup(cfg)
 

--- a/dev-tools/iota-private-network/experiments/run-fuzz.py
+++ b/dev-tools/iota-private-network/experiments/run-fuzz.py
@@ -322,6 +322,10 @@ def main() -> None:
             # Resolve the load image up front (pull, else build from the
             # network-benchmark clone) instead of surprising the run mid-way.
             ec.ensure_stress_image(cfg.spammer_image)
+        if cfg.spammer_enable and cfg.spammer_type == "iota-spammer":
+            # Check the script exists before bringing up the network; surfaces
+            # a misconfigured spammer in seconds instead of ~5 min in.
+            ec.ensure_iota_spammer_script()
         if not cfg.build:
             ec.require_local_image(
                 cfg.image,

--- a/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
+++ b/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
@@ -8,10 +8,11 @@
 Brings up all validators on a released image, then mid-epoch-0 rolls the
 locally-built upgrade image out to a deterministic random half of the
 network. The mixed-binary network holds the lower of the two halves'
-MAX_PROTOCOL_VERSION values (the new-binary half is below 2f+1). Mid-epoch-1,
-upgrades the rest; after the next boundary the whole network supports (and,
-if HEAD's version is higher, advances to) the new protocol. Observes one
-final epoch.
+MAX_PROTOCOL_VERSION values (the new-binary half is below 2f+1) for
+`--mid-observation-epochs` full epochs (epoch 1 by default). At the start of
+the following epoch (epoch 2 by default), upgrades the rest; after the next
+boundary the whole network supports (and, if HEAD's version is higher,
+advances to) the new protocol. Observes one final epoch.
 
 Run from: iota/dev-tools/iota-private-network/experiments/
 """
@@ -341,16 +342,16 @@ def phase9_observe_mixed(cfg: Config, epoch_0_start: float, epoch_0: int) -> tup
     return current_epoch, current_start
 
 
-def phase12_observe_upgraded(cfg: Config, epoch_1: int) -> int:
+def phase12_observe_upgraded(cfg: Config, second_half_upgrade_epoch: int) -> int:
     """Cross the post-upgrade epoch boundary (protocol advances here if HEAD's
     version is higher), then hold `cfg.post_observation_epochs` extra epochs.
     Returns the final epoch."""
     phase_start = time.time()
     log(_phase_banner("Waiting for post-second-half-upgrade epoch boundary", "PHASE 12"))
 
-    current_epoch = _wait_for_epoch_with_log_save(cfg, epoch_1)
-    if current_epoch <= epoch_1:
-        raise RuntimeError(f"Epoch did not advance past {epoch_1}")
+    current_epoch = _wait_for_epoch_with_log_save(cfg, second_half_upgrade_epoch)
+    if current_epoch <= second_half_upgrade_epoch:
+        raise RuntimeError(f"Epoch did not advance past {second_half_upgrade_epoch}")
 
     log(f"  Reading validator-1 protocol info...")
     time.sleep(cfg.protocol_probe_wait)
@@ -389,7 +390,8 @@ def parse_args() -> argparse.Namespace:
         epilog=(
             "Defaults: 19 validators, 15-min epoch, geodistributed latency, "
             "two rolling-upgrade phases (first half mid-epoch-0, second half "
-            "mid-epoch-1) with one full mixed-binary epoch between them."
+            "at the start of epoch 2) with one full mixed-binary epoch "
+            "between them."
         ),
     )
     parser.add_argument(
@@ -525,11 +527,11 @@ def main() -> None:
     log(f"  {_C.BOLD}Build local image{_C.RESET}    : {cfg.build}")
     log(f"  {_C.BOLD}Geodistributed{_C.RESET}      : {cfg.geodistributed}")
     log(f"  {_C.BOLD}Split seed{_C.RESET}          : {cfg.seed}")
-    log(f"  {_C.BOLD}First half (mid-ep-0){_C.RESET} : {first_half}  ({len(first_half)} vals)")
-    log(f"  {_C.BOLD}Second half (mid-ep-1){_C.RESET}: {second_half}  ({len(second_half)} vals)")
+    log(f"  {_C.BOLD}First half (mid-epoch 0){_C.RESET} : {first_half}  ({len(first_half)} vals)")
+    log(f"  {_C.BOLD}Second half (start of epoch {1 + cfg.mid_observation_epochs}){_C.RESET}: {second_half}  ({len(second_half)} vals)")
     log(f"  {_C.BOLD}Mid-epoch wait{_C.RESET}      : {cfg.mid_epoch_wait}s")
     log(f"  {_C.BOLD}Rolling offline pause{_C.RESET}: {cfg.rolling_restart_pause_min}-{cfg.rolling_restart_pause_max}s per validator")
-    log(f"  {_C.BOLD}Mid-binary observation{_C.RESET}: {cfg.mid_observation_epochs} extra epoch(s) of mixed-binary state between halves")
+    log(f"  {_C.BOLD}Mixed-binary observation{_C.RESET}: {cfg.mid_observation_epochs} extra epoch(s) of mixed-binary state between halves")
     log(f"  {_C.BOLD}Post-upgrade observation{_C.RESET} : {cfg.post_observation_epochs} extra epoch(s) after all validators on HEAD")
     if cfg.head_only:
         log(f"  {_C.BOLD}Head-only mode{_C.RESET}      : ON — all validators start on HEAD "
@@ -569,20 +571,20 @@ def main() -> None:
 
     # --- Mixed-binary observation in epoch 1 ---
     epoch_0 = get_current_epoch()
-    epoch_1, epoch_1_start = phase9_observe_mixed(cfg, epoch_0_start, epoch_0)
+    second_half_upgrade_epoch, _ = phase9_observe_mixed(cfg, epoch_0_start, epoch_0)
 
-    # --- Second half upgrade — skip the mid-epoch wait so it rolls at the
-    # start of the mixed-binary epoch, leaving most of the epoch as all-on-HEAD
-    # steady state before the boundary fires the protocol advance.
+    # --- Second half upgrade — rolls at the start of the epoch, so most of
+    # it runs as all-on-HEAD steady state before the next boundary fires the
+    # protocol advance.
     phase11_second_half(cfg, second_half)
 
     # --- Cross the post-upgrade epoch boundary (protocol advance if applicable) ---
-    final_epoch = phase12_observe_upgraded(cfg, epoch_1)
+    final_epoch = phase12_observe_upgraded(cfg, second_half_upgrade_epoch)
 
     log(_phase_banner("Half-Network Upgrade Test Complete"))
     log(f"  Final epoch: {final_epoch}")
-    log(f"  First-half (upgraded mid-ep-0): {first_half}")
-    log(f"  Second-half (upgraded mid-ep-1): {second_half}")
+    log(f"  First-half (upgraded mid-epoch 0): {first_half}")
+    log(f"  Second-half (upgraded at start of epoch {second_half_upgrade_epoch}): {second_half}")
     log("  Validator log archives are under experiments/logs/")
 
     # Best-effort latency teardown (cleanup() also does this on exit)

--- a/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
+++ b/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
@@ -5,24 +5,13 @@
 
 """Half-network upgrade test.
 
-Brings up all validators on a released image, then mid-epoch-0 rolls out the
-locally-built upgrade image to a deterministic random half of the network.
-Observes the resulting mixed-binary network for one full epoch (protocol
-stays at the lower-of-the-two MAX_PROTOCOL_VERSION values because the
-new-binary half doesn't reach 2f+1 supermajority). Mid-epoch-1, upgrades the
-remaining half. After the next epoch boundary the network has unanimous
-support for the higher protocol version (if HEAD's MAX_PROTOCOL_VERSION is
-higher than the release image's), advances, and any new feature flags
-become active. Observes one final epoch under the new protocol.
-
-When HEAD's MAX_PROTOCOL_VERSION equals the release image's, no protocol
-advance occurs at any boundary — the test still exercises the heterogeneous
-binary path but only verifies stability, not feature-flag activation.
-
-Reuses the setup / latency / monitoring / phase plumbing from
-run-migration-test.py via importlib because hyphenated module names cannot
-be imported the normal way. The only orchestration-specific helpers we
-define locally are `split_halves` and `rolling_upgrade(indices)`.
+Brings up all validators on a released image, then mid-epoch-0 rolls the
+locally-built upgrade image out to a deterministic random half of the
+network. The mixed-binary network holds the lower of the two halves'
+MAX_PROTOCOL_VERSION values (the new-binary half is below 2f+1). Mid-epoch-1,
+upgrades the rest; after the next boundary the whole network supports (and,
+if HEAD's version is higher, advances to) the new protocol. Observes one
+final epoch.
 
 Run from: iota/dev-tools/iota-private-network/experiments/
 """
@@ -42,11 +31,9 @@ from pathlib import Path
 
 # ========================= Load migration_test as a module =========================
 #
-# `run-migration-test.py` contains all the heavy lifting (Config, docker_compose,
-# get_current_epoch / wait_for_epoch_change, phase1..phase7, phase10, log helpers,
-# cleanup, _read_validator_protocol_info, etc.). Hyphens block normal `import`,
-# so we load it via importlib. A future cleanup is to refactor those helpers
-# into a hyphen-free `migration_lib.py`; until then this is the pragmatic path.
+# run-migration-test.py holds the shared machinery (Config, phases, log
+# helpers, cleanup). Its hyphenated filename blocks a normal import, so load
+# it via importlib.
 
 _HERE = Path(__file__).resolve().parent
 _MIGRATION_PATH = _HERE / "run-migration-test.py"
@@ -78,8 +65,6 @@ phase3_bootstrap_genesis = mt.phase3_bootstrap_genesis
 phase4_start_validators = mt.phase4_start_validators
 phase5_start_monitoring = mt.phase5_start_monitoring
 phase6_apply_latency = mt.phase6_apply_latency
-phase7_wait_mid_epoch = mt.phase7_wait_mid_epoch
-phase10_observation = mt.phase10_observation
 cleanup = mt.cleanup
 _signal_handler = mt._signal_handler
 _C = mt._C
@@ -87,20 +72,13 @@ _C = mt._C
 
 # ========================= Patch Config for half-upgrade timing =========================
 #
-# Migration test's Config.__post_init__ reserves an epoch budget for both phase
-# 8 (rolling upgrade) AND phase 9 (restart-stress with/without DB wipe). The
-# half-upgrade test doesn't run phase 9 at all, so we override __post_init__
-# to zero the phase-9 budget and recompute mid_epoch_wait without it.
-#
-# Mode is forced to "advanced" because we use phase 7's mid-epoch wait and do
-# NOT use simple-mode block-production measurement. The new dataclass has a
-# few simple-mode-only fields (phase8_simple_estimate, pre_rolling_wait,
-# stable_window_seconds) that we set to safe placeholders for dataclass
-# completeness even though the half-upgrade test's flow does not consult them.
+# Override migration_test's __post_init__ to drop the phase-9 (restart-stress)
+# epoch budget this test never uses, and force advanced mode. Simple-mode-only
+# fields get placeholder values so the dataclass stays complete.
 
 
 def _half_upgrade_post_init(self: Config) -> None:
-    # Validation mirrored from migration_test.Config.__post_init__
+    # Input validation.
     mt.ec.validate_num_validators(self.num_validators)
     if self.load_qps < 0:
         raise ValueError("load qps must be >= 0")
@@ -108,8 +86,7 @@ def _half_upgrade_post_init(self: Config) -> None:
         raise ValueError("load in-flight ratio must be > 0")
     if self.load_transfer_objects <= 0:
         raise ValueError("load transfer objects must be > 0")
-    # Force advanced-mode semantics: we use phase 7 and skip simple-mode's
-    # block-production measurement.
+    # Force advanced mode: phase 7 wait, no simple-mode measurement.
     self.mode = "advanced"
 
     epoch_s = self.epoch_duration_ms // 1000
@@ -123,7 +100,7 @@ def _half_upgrade_post_init(self: Config) -> None:
     )
     self.fresh_db_restart_pause_min = self.rolling_restart_pause_min
     self.fresh_db_restart_pause_max = self.rolling_restart_pause_max
-    # Migration test pins this to 15s. Match that.
+    # 15s, matching the base config.
     self.protocol_probe_wait = 15
     self.restart_settle_wait = min(10, max(1, self.rolling_restart_pause_max // 3))
     self.restart_pause_keep_db = max(
@@ -135,9 +112,9 @@ def _half_upgrade_post_init(self: Config) -> None:
         n * (self.rolling_restart_pause_max + self.upgrade_delay)
         + self.protocol_probe_wait
     )
-    # *** Half-upgrade-specific: no restart-stress phase ***
+    # Half-upgrade-specific: no restart-stress phase.
     self.phase9_epoch0_worst_case = 0
-    # Simple-mode-only fields. Set safe placeholders for dataclass completeness.
+    # Simple-mode-only placeholders (unused in this test).
     self.phase8_simple_estimate = n * 10 + self.protocol_probe_wait + 5
     self.pre_rolling_wait = 0
     self.stable_window_seconds = 0
@@ -179,13 +156,8 @@ Config.__post_init__ = _half_upgrade_post_init
 
 
 def split_halves(num_validators: int, seed: int) -> tuple[list[int], list[int]]:
-    """Deterministic random partition of [1..num_validators] into two halves.
-
-    First returned list has floor(N/2) entries (upgraded first, mid-epoch 0).
-    Second list has the remaining ceil(N/2) (upgraded mid-epoch 1).
-    Both lists are sorted for readability; the seeded shuffle determines
-    which validators go in which half, not the iteration order within.
-    """
+    """Deterministic random partition of [1..num_validators] into two sorted
+    halves: floor(N/2) upgraded first (mid-epoch 0), the rest second."""
     indices = list(range(1, num_validators + 1))
     random.Random(seed).shuffle(indices)
     half = num_validators // 2
@@ -193,12 +165,8 @@ def split_halves(num_validators: int, seed: int) -> tuple[list[int], list[int]]:
 
 
 def rolling_upgrade(cfg: Config, indices: list[int], label: str) -> None:
-    """Roll the given subset of validators forward to cfg.image_upgrade.
-
-    Mirrors the per-validator mechanism of run-migration-test.py's
-    phase8_rolling_upgrade but takes an explicit list of validator indices
-    so it can be called twice (once per half) instead of iterating all.
-    """
+    """Roll the given validator subset forward to cfg.image_upgrade, one at a
+    time with a randomized offline pause. Called once per half."""
     env_path = cfg.network_dir / cfg.env_migration_file
     rng = random.Random(cfg.seed + sum(indices))  # tied to the subset for determinism
 
@@ -255,12 +223,9 @@ def rolling_upgrade(cfg: Config, indices: list[int], label: str) -> None:
 
 
 def _wait_for_epoch_with_log_save(cfg: Config, epoch_before: int) -> int:
-    """Like migration_test.wait_for_epoch_change but also saves validator logs
-    every cfg.log_interval seconds during the wait. The migration test's wait
-    polls every 30 s without saving logs, so for long waits (e.g. a full epoch)
-    we lose the live-log snapshot of that whole window. This version preserves
-    it.
-    """
+    """Wait for the epoch to advance past `epoch_before`, saving validator
+    logs every cfg.log_interval seconds during the wait. Returns the new
+    epoch (or the current one if the timeout elapses)."""
     timeout = cfg.epoch_duration_ms // 1000 * 3 // 2  # 1.5x epoch duration
     start = time.time()
     last_log_save = start
@@ -291,10 +256,8 @@ def _wait_for_epoch_with_log_save(cfg: Config, epoch_before: int) -> int:
 
 
 def _wait_mid_epoch(cfg: Config, epoch_start: float, phase_label: str) -> None:
-    """Local copy of migration test's phase7_wait_mid_epoch with a customizable
-    banner label so the half-upgrade test's two mid-epoch waits get monotonic
-    phase numbers (7a, 7b) instead of both reading "PHASE 7".
-    """
+    """Wait until mid-epoch before the rolling upgrade, with a caller-supplied
+    phase-banner label."""
     phase_start = time.time()
     epoch_s = cfg.epoch_duration_ms // 1000
     elapsed = int(time.time() - epoch_start)
@@ -341,13 +304,8 @@ def phase11_second_half(cfg: Config, second_half: list[int]) -> None:
 
 
 def phase9_observe_mixed(cfg: Config, epoch_0_start: float, epoch_0: int) -> tuple[int, float]:
-    """Wait through the 0->1 boundary, then hold the mixed-binary network
-    through `cfg.mid_observation_epochs` extra full epochs. Protocol version
-    is expected to stay at the lower of the two halves' MAX_PROTOCOL_VERSION
-    values because the new-binary half is below 2f+1. Returns
-    (current_epoch, current_epoch_start_time) — the most recent epoch and
-    when it started, used to anchor the next mid-epoch wait.
-    """
+    """Hold the mixed-binary network from the 0→1 boundary through
+    `cfg.mid_observation_epochs` extra epochs. Returns (epoch, epoch_start)."""
     phase_start = time.time()
     log(_phase_banner("Waiting for epoch 0→1 transition (mixed binaries)", "PHASE 9"))
 
@@ -384,13 +342,9 @@ def phase9_observe_mixed(cfg: Config, epoch_0_start: float, epoch_0: int) -> tup
 
 
 def phase12_observe_upgraded(cfg: Config, epoch_1: int) -> int:
-    """Wait through the next epoch boundary. If HEAD's MAX_PROTOCOL_VERSION
-    is higher than the release image's, the protocol advances here (whole
-    network now supports the new version) and any new feature flags become
-    active; otherwise the protocol stays put and this is just steady-state
-    observation. Holds the resulting state for `cfg.post_observation_epochs`
-    additional full epochs. Periodically saves validator logs throughout.
-    """
+    """Cross the post-upgrade epoch boundary (protocol advances here if HEAD's
+    version is higher), then hold `cfg.post_observation_epochs` extra epochs.
+    Returns the final epoch."""
     phase_start = time.time()
     log(_phase_banner("Waiting for post-second-half-upgrade epoch boundary", "PHASE 12"))
 
@@ -509,14 +463,9 @@ def parse_args() -> argparse.Namespace:
         "--head-only",
         action="store_true",
         help=(
-            "Start every validator on the locally-built HEAD image from the "
-            "very beginning (image_old := image_upgrade) instead of on the "
-            "release image. All phases still run; the rolling 'upgrades' "
-            "in phases 8 and 11 become same-binary restarts. Used to isolate "
-            "orchestrator overhead (compose file, network-benchmark.sh) from "
-            "binary-version effects: compare the pre-phase-8 window of a "
-            "--head-only run against the same window of a normal run, where "
-            "the only difference is release vs HEAD binary."
+            "Start every validator on the locally-built HEAD image from "
+            "genesis (rolling upgrades become same-binary restarts). Isolates "
+            "orchestrator overhead from binary-version effects."
         ),
     )
     return parser.parse_args()
@@ -528,12 +477,9 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    # The other orchestrators (run-fuzz, run-benchmark, run-migration-test)
-    # all acquire /tmp/iota-experiments.lock at startup. They share container
-    # names, the docker network, and the tc/iptables state on validators —
-    # concurrent runs silently corrupt each other (one run's cleanup tears
-    # down the other run's network mid-flight). Acquire it here too so the
-    # half-upgrade test plays nicely alongside them.
+    # Shared with the other orchestrators via /tmp/iota-experiments.lock: they
+    # share container names, the docker network, and validator tc/iptables
+    # state, so concurrent runs corrupt each other. Acquire it here too.
     mt.ec.acquire_single_run_lock("run-half-upgrade-test.py")
 
     try:
@@ -552,8 +498,7 @@ def main() -> None:
 
     # Distinct log file from the migration test so transcripts don't get clobbered
     cfg.log_file = cfg.log_dir / "half_upgrade_script_latest.log"
-    # Attach half-upgrade-specific observation knobs (extra attrs on the Config
-    # instance — Config is a non-frozen dataclass so this is allowed).
+    # Extra observation knobs (Config is a non-frozen dataclass).
     cfg.mid_observation_epochs = max(0, args.mid_observation_epochs)
     cfg.post_observation_epochs = max(0, args.post_observation_epochs)
     cfg.head_only = bool(args.head_only)
@@ -563,9 +508,7 @@ def main() -> None:
         print("Error: run from experiments/", file=sys.stderr)
         sys.exit(1)
 
-    # Routes future log() calls to the half-upgrade-specific log file. The
-    # function also mkdir -p's log_dir; migration test's cleanup() will close
-    # the handle via ec.close_logging().
+    # Route log() to the half-upgrade log file.
     mt.ec.setup_logging(cfg.log_file)
 
     atexit.register(cleanup)
@@ -595,12 +538,8 @@ def main() -> None:
     # --- Setup phases (reused from migration test) ---
     local_branch, local_commit = phase1_docker_images(cfg)
 
-    # In head-only mode, every validator starts directly on the HEAD-built
-    # image. Overriding image_old here means phase2's compose template, phase4's
-    # boot, and the env-file substitution all see the upgrade image as the
-    # default. We deliberately do this AFTER phase1 so phase1's release-image
-    # pull/tag still runs (it's cached anyway, and keeping the unconditional
-    # pull avoids forking the phase1 logic just for this mode).
+    # head-only: every validator starts on the HEAD image. Do this after
+    # phase1 so its (cached) release-image pull still runs unchanged.
     if cfg.head_only:
         log(
             f"  {_C.BOLD}--head-only{_C.RESET}: overriding image_old "
@@ -632,12 +571,9 @@ def main() -> None:
     epoch_0 = get_current_epoch()
     epoch_1, epoch_1_start = phase9_observe_mixed(cfg, epoch_0_start, epoch_0)
 
-    # --- Second half upgrade — skip the mid-epoch wait so Phase 11 starts at
-    # the beginning of the current (mixed-binary) epoch. That leaves most of
-    # the epoch for an "all-on-HEAD on the still-old protocol" steady-state
-    # window before the next epoch boundary fires the protocol advance (if
-    # any). With -e 15 this is ~9 min of steady state instead of just the
-    # tail of the rolling-upgrade recovery.
+    # --- Second half upgrade — skip the mid-epoch wait so it rolls at the
+    # start of the mixed-binary epoch, leaving most of the epoch as all-on-HEAD
+    # steady state before the boundary fires the protocol advance.
     phase11_second_half(cfg, second_half)
 
     # --- Cross the post-upgrade epoch boundary (protocol advance if applicable) ---

--- a/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
+++ b/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
@@ -475,9 +475,9 @@ def parse_args() -> argparse.Namespace:
         "-n", "--num-validators",
         default=19,
         type=int,
-        choices=range(2, 101),
+        choices=range(mt.ec.MIN_VALIDATORS, mt.ec.MAX_VALIDATORS + 1),
         metavar="N",
-        help="Number of validators to run (2-100, default: 19)",
+        help="Number of validators to run (2-30, default: 19)",
     )
     parser.add_argument(
         "-c", "--chain-override",

--- a/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
+++ b/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
@@ -220,6 +220,31 @@ def rolling_upgrade(cfg: Config, indices: list[int], label: str) -> None:
     )
 
 
+def _prometheus_int(expr: str) -> int | None:
+    value = mt.ec.prometheus_scalar(expr)
+    return int(float(value)) if value is not None else None
+
+
+def read_onchain_protocol_version(attempts: int = 6, delay: float = 5.0) -> int:
+    """Network-wide on-chain protocol version from Prometheus. Raises if the
+    metric stays missing or validators keep disagreeing."""
+    last = "no data"
+    for attempt in range(attempts):
+        lo = _prometheus_int("min(iota_current_protocol_version)")
+        hi = _prometheus_int("max(iota_current_protocol_version)")
+        if lo is not None and hi is not None:
+            if lo == hi:
+                return lo
+            last = f"validators disagree: min={lo}, max={hi}"
+        if attempt < attempts - 1:
+            time.sleep(delay)
+    raise RuntimeError(
+        "could not read a consistent iota_current_protocol_version from "
+        f"Prometheus after {attempts} attempts ({last}); old release images "
+        "may not export this metric"
+    )
+
+
 # ========================= Phase wrappers tailored to half-upgrade =========================
 
 
@@ -304,16 +329,35 @@ def phase11_second_half(cfg: Config, second_half: list[int]) -> None:
     log(_phase_complete("Phase 11", time.time() - phase_start))
 
 
-def phase9_observe_mixed(cfg: Config, epoch_0_start: float, epoch_0: int) -> tuple[int, float]:
+def phase9_observe_mixed(
+    cfg: Config, epoch_0: int, initial_proto_version: int
+) -> int:
     """Hold the mixed-binary network from the 0→1 boundary through
-    `cfg.mid_observation_epochs` extra epochs. Returns (epoch, epoch_start)."""
+    `cfg.mid_observation_epochs` extra epochs. Returns the epoch it ended on.
+
+    Raises if the on-chain protocol version moves while the binaries are
+    mixed (the upgraded half is below 2f+1, so it must not)."""
     phase_start = time.time()
     log(_phase_banner("Waiting for epoch 0→1 transition (mixed binaries)", "PHASE 9"))
+
+    def check_protocol_unchanged() -> None:
+        onchain = read_onchain_protocol_version()
+        if cfg.head_only:
+            log(f"  On-chain protocol version {onchain} (head-only mode: an "
+                "advance at any boundary is legitimate; not asserted)")
+        elif onchain != initial_proto_version:
+            raise RuntimeError(
+                f"on-chain protocol version moved from {initial_proto_version} "
+                f"to {onchain} in the mixed-binary state; the upgraded half is "
+                "below 2f+1 and must not carry a version change"
+            )
+        else:
+            log(f"  On-chain protocol version {onchain} — unchanged, as expected "
+                "(upgraded half below 2f+1).")
 
     current_epoch = _wait_for_epoch_with_log_save(cfg, epoch_0)
     if current_epoch <= epoch_0:
         raise RuntimeError(f"Epoch did not advance past {epoch_0}")
-    current_start = time.time()
 
     log(f"  Reading validator-1 protocol info...")
     time.sleep(cfg.protocol_probe_wait)
@@ -322,10 +366,7 @@ def phase9_observe_mixed(cfg: Config, epoch_0_start: float, epoch_0: int) -> tup
         f"  {_C.CYAN}Epoch {current_epoch}{_C.RESET} (mixed binaries) — "
         f"max_protocol={proto or 'unknown'}, consensus={consensus or 'unknown'}"
     )
-    log(
-        "  Expectation: protocol version unchanged (supermajority of upgrade-side "
-        "not reached; old binary still in the committee)."
-    )
+    check_protocol_unchanged()
 
     extra = getattr(cfg, "mid_observation_epochs", 0)
     for i in range(extra):
@@ -335,17 +376,22 @@ def phase9_observe_mixed(cfg: Config, epoch_0_start: float, epoch_0: int) -> tup
             log(f"  {_C.YELLOW}WARN: epoch did not advance further; stopping mixed-state observation{_C.RESET}")
             break
         current_epoch = new_epoch
-        current_start = time.time()
         log(f"  Mixed-binary epoch advanced to {current_epoch} (extra observation)")
+        check_protocol_unchanged()
 
     log(_phase_complete("Phase 9", time.time() - phase_start))
-    return current_epoch, current_start
+    return current_epoch
 
 
-def phase12_observe_upgraded(cfg: Config, second_half_upgrade_epoch: int) -> int:
+def phase12_observe_upgraded(
+    cfg: Config, second_half_upgrade_epoch: int, initial_proto_version: int
+) -> int:
     """Cross the post-upgrade epoch boundary (protocol advances here if HEAD's
     version is higher), then hold `cfg.post_observation_epochs` extra epochs.
-    Returns the final epoch."""
+    Returns the final epoch.
+
+    Raises if the on-chain protocol version does not land on the version the
+    whole (now all-upgraded) committee supports, or moves off it later."""
     phase_start = time.time()
     log(_phase_banner("Waiting for post-second-half-upgrade epoch boundary", "PHASE 12"))
 
@@ -360,11 +406,29 @@ def phase12_observe_upgraded(cfg: Config, second_half_upgrade_epoch: int) -> int
         f"  {_C.GREEN}Epoch {current_epoch}{_C.RESET} (all upgraded) — "
         f"max_protocol={proto or 'unknown'}, consensus={consensus or 'unknown'}"
     )
-    log(
-        "  Note: protocol advances here only if HEAD's MAX_PROTOCOL_VERSION "
-        "exceeds the release image's. Otherwise this is steady-state "
-        "observation on the same protocol the whole run used."
-    )
+
+    # Every validator now runs HEAD, so the committee-wide supported maximum
+    # is the lowest configured max across the network; the chain must sit on
+    # it (== the initial version when HEAD brings no protocol bump).
+    supported = _prometheus_int("min(iota_configured_max_protocol_version)")
+    if supported is None:
+        raise RuntimeError(
+            "could not read iota_configured_max_protocol_version from Prometheus"
+        )
+    expected = max(initial_proto_version, supported)
+
+    def check_protocol_settled() -> None:
+        onchain = read_onchain_protocol_version()
+        if onchain != expected:
+            raise RuntimeError(
+                f"on-chain protocol version is {onchain} after the all-upgraded "
+                f"boundary; expected {expected} (started at {initial_proto_version}, "
+                f"every validator supports up to {supported})"
+            )
+        log(f"  On-chain protocol version {onchain} — as expected (started at "
+            f"{initial_proto_version}, supported max {supported}).")
+
+    check_protocol_settled()
 
     extra = getattr(cfg, "post_observation_epochs", 0)
     for i in range(extra):
@@ -375,6 +439,7 @@ def phase12_observe_upgraded(cfg: Config, second_half_upgrade_epoch: int) -> int
             break
         current_epoch = new_epoch
         log(f"  Post-upgrade epoch advanced to {current_epoch}")
+        check_protocol_settled()
 
     log(_phase_complete("Phase 12", time.time() - phase_start))
     return current_epoch
@@ -564,6 +629,8 @@ def main() -> None:
         f"  {_C.BOLD}Local build{_C.RESET}  ({local_branch}@{local_commit}) : "
         "(version will be confirmed after first-half upgrade)"
     )
+    initial_proto_version = read_onchain_protocol_version()
+    log(f"  {_C.BOLD}On-chain protocol{_C.RESET}     : version {initial_proto_version} at start")
 
     # --- First half upgrade in epoch 0 ---
     _wait_mid_epoch(cfg, epoch_0_start, "PHASE 7")
@@ -571,7 +638,9 @@ def main() -> None:
 
     # --- Mixed-binary observation in epoch 1 ---
     epoch_0 = get_current_epoch()
-    second_half_upgrade_epoch, _ = phase9_observe_mixed(cfg, epoch_0_start, epoch_0)
+    second_half_upgrade_epoch = phase9_observe_mixed(
+        cfg, epoch_0, initial_proto_version
+    )
 
     # --- Second half upgrade — rolls at the start of the epoch, so most of
     # it runs as all-on-HEAD steady state before the next boundary fires the
@@ -579,7 +648,9 @@ def main() -> None:
     phase11_second_half(cfg, second_half)
 
     # --- Cross the post-upgrade epoch boundary (protocol advance if applicable) ---
-    final_epoch = phase12_observe_upgraded(cfg, second_half_upgrade_epoch)
+    final_epoch = phase12_observe_upgraded(
+        cfg, second_half_upgrade_epoch, initial_proto_version
+    )
 
     log(_phase_banner("Half-Network Upgrade Test Complete"))
     log(f"  Final epoch: {final_epoch}")

--- a/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
+++ b/dev-tools/iota-private-network/experiments/run-half-upgrade-test.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+"""Half-network upgrade test.
+
+Brings up all validators on a released image, then mid-epoch-0 rolls out the
+locally-built upgrade image to a deterministic random half of the network.
+Observes the resulting mixed-binary network for one full epoch (protocol
+stays at the lower-of-the-two MAX_PROTOCOL_VERSION values because the
+new-binary half doesn't reach 2f+1 supermajority). Mid-epoch-1, upgrades the
+remaining half. After the next epoch boundary the network has unanimous
+support for the higher protocol version (if HEAD's MAX_PROTOCOL_VERSION is
+higher than the release image's), advances, and any new feature flags
+become active. Observes one final epoch under the new protocol.
+
+When HEAD's MAX_PROTOCOL_VERSION equals the release image's, no protocol
+advance occurs at any boundary — the test still exercises the heterogeneous
+binary path but only verifies stability, not feature-flag activation.
+
+Reuses the setup / latency / monitoring / phase plumbing from
+run-migration-test.py via importlib because hyphenated module names cannot
+be imported the normal way. The only orchestration-specific helpers we
+define locally are `split_halves` and `rolling_upgrade(indices)`.
+
+Run from: iota/dev-tools/iota-private-network/experiments/
+"""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import importlib.util
+import random
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+# ========================= Load migration_test as a module =========================
+#
+# `run-migration-test.py` contains all the heavy lifting (Config, docker_compose,
+# get_current_epoch / wait_for_epoch_change, phase1..phase7, phase10, log helpers,
+# cleanup, _read_validator_protocol_info, etc.). Hyphens block normal `import`,
+# so we load it via importlib. A future cleanup is to refactor those helpers
+# into a hyphen-free `migration_lib.py`; until then this is the pragmatic path.
+
+_HERE = Path(__file__).resolve().parent
+_MIGRATION_PATH = _HERE / "run-migration-test.py"
+if not _MIGRATION_PATH.exists():
+    print(f"FATAL: cannot find {_MIGRATION_PATH}", file=sys.stderr)
+    sys.exit(1)
+
+_spec = importlib.util.spec_from_file_location("migration_test", _MIGRATION_PATH)
+mt = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+sys.modules["migration_test"] = mt
+_spec.loader.exec_module(mt)  # type: ignore[union-attr]
+
+# Re-bind frequently used names so the rest of this file reads cleanly.
+Config = mt.Config
+log = mt.log
+log_status = mt.log_status
+run = mt.run
+docker_compose = mt.docker_compose
+save_validator_logs = mt.save_validator_logs
+get_current_epoch = mt.get_current_epoch
+wait_for_epoch_change = mt.wait_for_epoch_change
+_phase_banner = mt._phase_banner
+_phase_complete = mt._phase_complete
+_progress_bar = mt._progress_bar
+_read_validator_protocol_info = mt._read_validator_protocol_info
+phase1_docker_images = mt.phase1_docker_images
+phase2_generate_compose = mt.phase2_generate_compose
+phase3_bootstrap_genesis = mt.phase3_bootstrap_genesis
+phase4_start_validators = mt.phase4_start_validators
+phase5_start_monitoring = mt.phase5_start_monitoring
+phase6_apply_latency = mt.phase6_apply_latency
+phase7_wait_mid_epoch = mt.phase7_wait_mid_epoch
+phase10_observation = mt.phase10_observation
+cleanup = mt.cleanup
+_signal_handler = mt._signal_handler
+_C = mt._C
+
+
+# ========================= Patch Config for half-upgrade timing =========================
+#
+# Migration test's Config.__post_init__ reserves an epoch budget for both phase
+# 8 (rolling upgrade) AND phase 9 (restart-stress with/without DB wipe). The
+# half-upgrade test doesn't run phase 9 at all, so we override __post_init__
+# to zero the phase-9 budget and recompute mid_epoch_wait without it.
+#
+# Mode is forced to "advanced" because we use phase 7's mid-epoch wait and do
+# NOT use simple-mode block-production measurement. The new dataclass has a
+# few simple-mode-only fields (phase8_simple_estimate, pre_rolling_wait,
+# stable_window_seconds) that we set to safe placeholders for dataclass
+# completeness even though the half-upgrade test's flow does not consult them.
+
+
+def _half_upgrade_post_init(self: Config) -> None:
+    # Validation mirrored from migration_test.Config.__post_init__
+    mt.ec.validate_num_validators(self.num_validators)
+    if self.load_qps < 0:
+        raise ValueError("load qps must be >= 0")
+    if self.load_in_flight_ratio <= 0:
+        raise ValueError("load in-flight ratio must be > 0")
+    if self.load_transfer_objects <= 0:
+        raise ValueError("load transfer objects must be > 0")
+    # Force advanced-mode semantics: we use phase 7 and skip simple-mode's
+    # block-production measurement.
+    self.mode = "advanced"
+
+    epoch_s = self.epoch_duration_ms // 1000
+    n = max(self.num_validators, 1)
+    self.rolling_restart_pause_max = max(1, (2 * epoch_s) // (3 * n))
+    self.rolling_restart_pause_min = max(1, (self.rolling_restart_pause_max * 3 + 3) // 4)
+    self.upgrade_delay = (
+        0
+        if self.rolling_restart_pause_max <= 1
+        else min(5, max(1, self.rolling_restart_pause_max // 120))
+    )
+    self.fresh_db_restart_pause_min = self.rolling_restart_pause_min
+    self.fresh_db_restart_pause_max = self.rolling_restart_pause_max
+    # Migration test pins this to 15s. Match that.
+    self.protocol_probe_wait = 15
+    self.restart_settle_wait = min(10, max(1, self.rolling_restart_pause_max // 3))
+    self.restart_pause_keep_db = max(
+        1, min(epoch_s // 30, self.rolling_restart_pause_max // 2)
+    )
+    self.restart_pause_wipe_db = max(1, min(epoch_s // 20, self.rolling_restart_pause_max))
+
+    self.phase8_worst_case = (
+        n * (self.rolling_restart_pause_max + self.upgrade_delay)
+        + self.protocol_probe_wait
+    )
+    # *** Half-upgrade-specific: no restart-stress phase ***
+    self.phase9_epoch0_worst_case = 0
+    # Simple-mode-only fields. Set safe placeholders for dataclass completeness.
+    self.phase8_simple_estimate = n * 10 + self.protocol_probe_wait + 5
+    self.pre_rolling_wait = 0
+    self.stable_window_seconds = 0
+
+    self.timeline_safety_margin = min(max(10, epoch_s // 60), max(0, epoch_s // 10))
+    self.mid_epoch_wait = (
+        epoch_s
+        - self.phase8_worst_case
+        - self.timeline_safety_margin
+        - self.epoch_start_slop_seconds
+    )
+    if self.mid_epoch_wait < 0:
+        required = (
+            self.phase8_worst_case
+            + self.timeline_safety_margin
+            + self.epoch_start_slop_seconds
+        )
+        raise ValueError(
+            "epoch duration is too short for the half-upgrade schedule: "
+            f"need at least {required}s for {self.num_validators} validators, "
+            f"got {epoch_s}s"
+        )
+
+    self.network_dir = self.script_dir.parent
+    self.repo_root = mt._find_repo_root(self.script_dir)
+    self.grafana_dir = self.network_dir / ".." / "grafana-local"
+    self.log_dir = self.script_dir / "logs"
+    self.log_file = self.log_dir / "migration_script_latest.log"
+
+    if not self.chain_override:
+        if self.release_network in ("testnet", "mainnet"):
+            self.chain_override = self.release_network
+
+
+Config.__post_init__ = _half_upgrade_post_init
+
+
+# ========================= Local helpers =========================
+
+
+def split_halves(num_validators: int, seed: int) -> tuple[list[int], list[int]]:
+    """Deterministic random partition of [1..num_validators] into two halves.
+
+    First returned list has floor(N/2) entries (upgraded first, mid-epoch 0).
+    Second list has the remaining ceil(N/2) (upgraded mid-epoch 1).
+    Both lists are sorted for readability; the seeded shuffle determines
+    which validators go in which half, not the iteration order within.
+    """
+    indices = list(range(1, num_validators + 1))
+    random.Random(seed).shuffle(indices)
+    half = num_validators // 2
+    return sorted(indices[:half]), sorted(indices[half:])
+
+
+def rolling_upgrade(cfg: Config, indices: list[int], label: str) -> None:
+    """Roll the given subset of validators forward to cfg.image_upgrade.
+
+    Mirrors the per-validator mechanism of run-migration-test.py's
+    phase8_rolling_upgrade but takes an explicit list of validator indices
+    so it can be called twice (once per half) instead of iterating all.
+    """
+    env_path = cfg.network_dir / cfg.env_migration_file
+    rng = random.Random(cfg.seed + sum(indices))  # tied to the subset for determinism
+
+    total = len(indices)
+    upgrade_start = time.time()
+    for i_pos, i in enumerate(indices):
+        v = f"validator-{i}"
+        bar = _progress_bar(i_pos, total)
+        log_status(f"  {bar} {label}: upgrading {_C.BOLD}{v}{_C.RESET}...")
+
+        # Snapshot pre-upgrade logs so the old-image side of the comparison survives
+        with (cfg.log_dir / f"pre-upgrade-{v}.log").open("w") as fh:
+            subprocess.run(
+                ["docker", "logs", v],
+                stdout=fh,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+
+        with env_path.open("a") as f:
+            f.write(f"VALIDATOR_{i}_IMAGE={cfg.image_upgrade}\n")
+
+        docker_compose(cfg, ["stop", v], quiet=True)
+        restart_pause = rng.randint(
+            cfg.rolling_restart_pause_min,
+            cfg.rolling_restart_pause_max,
+        )
+        log_status(f"  {bar} {label}: {v} stopped — restarting in {restart_pause}s...")
+        time.sleep(restart_pause)
+        docker_compose(cfg, ["up", "-d", "--no-deps", v], quiet=True)
+        time.sleep(cfg.upgrade_delay)
+
+        result = run(
+            ["docker", "ps", "--format", "{{.Names}}"],
+            capture=True,
+            quiet=True,
+        )
+        running = set(result.stdout.strip().splitlines())
+        if v in running:
+            bar = _progress_bar(i_pos + 1, total)
+            log_status(f"  {bar} {_C.GREEN}✔{_C.RESET} {label}: {v} upgraded")
+        else:
+            print()  # newline before error
+            raise RuntimeError(f"{v} failed to start after upgrade!")
+
+    print()  # finish status line
+    log(
+        f"  {label}: rolled {total} validator(s) "
+        f"({indices[0]}..{indices[-1]} subset) in {time.time() - upgrade_start:.1f}s"
+    )
+
+
+# ========================= Phase wrappers tailored to half-upgrade =========================
+
+
+def _wait_for_epoch_with_log_save(cfg: Config, epoch_before: int) -> int:
+    """Like migration_test.wait_for_epoch_change but also saves validator logs
+    every cfg.log_interval seconds during the wait. The migration test's wait
+    polls every 30 s without saving logs, so for long waits (e.g. a full epoch)
+    we lose the live-log snapshot of that whole window. This version preserves
+    it.
+    """
+    timeout = cfg.epoch_duration_ms // 1000 * 3 // 2  # 1.5x epoch duration
+    start = time.time()
+    last_log_save = start
+    log(f"  Waiting for epoch > {epoch_before}...")
+    while True:
+        epoch_now = get_current_epoch()
+        if epoch_now > epoch_before:
+            print()  # finish status line
+            log(f"  {_C.GREEN}Epoch advanced to {epoch_now}{_C.RESET} (was {epoch_before})")
+            return epoch_now
+
+        elapsed = int(time.time() - start)
+        if elapsed >= timeout:
+            print()
+            log(
+                f"  {_C.YELLOW}WARNING: Epoch did not advance within {timeout}s "
+                f"— proceeding anyway{_C.RESET}"
+            )
+            return epoch_now
+
+        if time.time() - last_log_save >= cfg.log_interval:
+            save_validator_logs(cfg, cfg.num_validators)
+            last_log_save = time.time()
+
+        bar = _progress_bar(elapsed, timeout)
+        log_status(f"  Epoch wait: {bar} epoch={epoch_now}, {elapsed}s / {timeout}s")
+        time.sleep(10)
+
+
+def _wait_mid_epoch(cfg: Config, epoch_start: float, phase_label: str) -> None:
+    """Local copy of migration test's phase7_wait_mid_epoch with a customizable
+    banner label so the half-upgrade test's two mid-epoch waits get monotonic
+    phase numbers (7a, 7b) instead of both reading "PHASE 7".
+    """
+    phase_start = time.time()
+    epoch_s = cfg.epoch_duration_ms // 1000
+    elapsed = int(time.time() - epoch_start)
+    required_after = cfg.phase8_worst_case
+    remaining = epoch_s - elapsed
+    if remaining < required_after:
+        raise RuntimeError(
+            "not enough epoch time left for half-upgrade schedule: "
+            f"remaining={remaining}s, required={required_after}s (Phase 8 worst-case)"
+        )
+
+    wait_s = max(0, cfg.mid_epoch_wait - elapsed)
+    log(_phase_banner(f"Waiting {wait_s}s before rolling upgrade", phase_label))
+    log(
+        f"  Epoch elapsed={elapsed}s, reserved after wait={required_after}s, "
+        f"safety={max(0, remaining - wait_s - required_after)}s"
+    )
+
+    start = time.time()
+    last_log_save = start
+    while time.time() < start + wait_s:
+        if time.time() - last_log_save >= cfg.log_interval:
+            save_validator_logs(cfg, cfg.num_validators)
+            last_log_save = time.time()
+        time.sleep(1)
+
+    log(_phase_complete(phase_label, time.time() - phase_start))
+
+
+def phase8_first_half(cfg: Config, first_half: list[int]) -> None:
+    phase_start = time.time()
+    log(_phase_banner(f"Rolling upgrade — first half ({len(first_half)} validators)", "PHASE 8"))
+    log(f"  Upgrading: {first_half}")
+    rolling_upgrade(cfg, first_half, label="first half")
+    log(_phase_complete("Phase 8", time.time() - phase_start))
+
+
+def phase11_second_half(cfg: Config, second_half: list[int]) -> None:
+    phase_start = time.time()
+    log(_phase_banner(f"Rolling upgrade — second half ({len(second_half)} validators)", "PHASE 11"))
+    log(f"  Upgrading: {second_half}")
+    rolling_upgrade(cfg, second_half, label="second half")
+    log(_phase_complete("Phase 11", time.time() - phase_start))
+
+
+def phase9_observe_mixed(cfg: Config, epoch_0_start: float, epoch_0: int) -> tuple[int, float]:
+    """Wait through the 0->1 boundary, then hold the mixed-binary network
+    through `cfg.mid_observation_epochs` extra full epochs. Protocol version
+    is expected to stay at the lower of the two halves' MAX_PROTOCOL_VERSION
+    values because the new-binary half is below 2f+1. Returns
+    (current_epoch, current_epoch_start_time) — the most recent epoch and
+    when it started, used to anchor the next mid-epoch wait.
+    """
+    phase_start = time.time()
+    log(_phase_banner("Waiting for epoch 0→1 transition (mixed binaries)", "PHASE 9"))
+
+    current_epoch = _wait_for_epoch_with_log_save(cfg, epoch_0)
+    if current_epoch <= epoch_0:
+        raise RuntimeError(f"Epoch did not advance past {epoch_0}")
+    current_start = time.time()
+
+    log(f"  Reading validator-1 protocol info...")
+    time.sleep(cfg.protocol_probe_wait)
+    proto, consensus = _read_validator_protocol_info("validator-1", last=True)
+    log(
+        f"  {_C.CYAN}Epoch {current_epoch}{_C.RESET} (mixed binaries) — "
+        f"max_protocol={proto or 'unknown'}, consensus={consensus or 'unknown'}"
+    )
+    log(
+        "  Expectation: protocol version unchanged (supermajority of upgrade-side "
+        "not reached; old binary still in the committee)."
+    )
+
+    extra = getattr(cfg, "mid_observation_epochs", 0)
+    for i in range(extra):
+        log(f"  [{i + 1}/{extra}] Holding mixed-binary state for one more epoch...")
+        new_epoch = _wait_for_epoch_with_log_save(cfg, current_epoch)
+        if new_epoch <= current_epoch:
+            log(f"  {_C.YELLOW}WARN: epoch did not advance further; stopping mixed-state observation{_C.RESET}")
+            break
+        current_epoch = new_epoch
+        current_start = time.time()
+        log(f"  Mixed-binary epoch advanced to {current_epoch} (extra observation)")
+
+    log(_phase_complete("Phase 9", time.time() - phase_start))
+    return current_epoch, current_start
+
+
+def phase12_observe_upgraded(cfg: Config, epoch_1: int) -> int:
+    """Wait through the next epoch boundary. If HEAD's MAX_PROTOCOL_VERSION
+    is higher than the release image's, the protocol advances here (whole
+    network now supports the new version) and any new feature flags become
+    active; otherwise the protocol stays put and this is just steady-state
+    observation. Holds the resulting state for `cfg.post_observation_epochs`
+    additional full epochs. Periodically saves validator logs throughout.
+    """
+    phase_start = time.time()
+    log(_phase_banner("Waiting for post-second-half-upgrade epoch boundary", "PHASE 12"))
+
+    current_epoch = _wait_for_epoch_with_log_save(cfg, epoch_1)
+    if current_epoch <= epoch_1:
+        raise RuntimeError(f"Epoch did not advance past {epoch_1}")
+
+    log(f"  Reading validator-1 protocol info...")
+    time.sleep(cfg.protocol_probe_wait)
+    proto, consensus = _read_validator_protocol_info("validator-1", last=True)
+    log(
+        f"  {_C.GREEN}Epoch {current_epoch}{_C.RESET} (all upgraded) — "
+        f"max_protocol={proto or 'unknown'}, consensus={consensus or 'unknown'}"
+    )
+    log(
+        "  Note: protocol advances here only if HEAD's MAX_PROTOCOL_VERSION "
+        "exceeds the release image's. Otherwise this is steady-state "
+        "observation on the same protocol the whole run used."
+    )
+
+    extra = getattr(cfg, "post_observation_epochs", 0)
+    for i in range(extra):
+        log(f"  [{i + 1}/{extra}] Observing post-upgrade steady-state for one more epoch...")
+        new_epoch = _wait_for_epoch_with_log_save(cfg, current_epoch)
+        if new_epoch <= current_epoch:
+            log(f"  {_C.YELLOW}WARN: epoch did not advance further; stopping post-upgrade observation{_C.RESET}")
+            break
+        current_epoch = new_epoch
+        log(f"  Post-upgrade epoch advanced to {current_epoch}")
+
+    log(_phase_complete("Phase 12", time.time() - phase_start))
+    return current_epoch
+
+
+# ========================= CLI =========================
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Half-network upgrade test for IOTA validators.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Defaults: 19 validators, 15-min epoch, geodistributed latency, "
+            "two rolling-upgrade phases (first half mid-epoch-0, second half "
+            "mid-epoch-1) with one full mixed-binary epoch between them."
+        ),
+    )
+    parser.add_argument(
+        "-r", "--release-network",
+        default="devnet",
+        choices=("devnet", "testnet", "mainnet", "alphanet"),
+        help="Release network to pull the old image from (default: devnet)",
+    )
+    parser.add_argument(
+        "-b", "--build",
+        default=True,
+        type=lambda v: v.lower() in ("true", "1", "yes"),
+        help="Whether to build the local upgrade image (default: true)",
+    )
+    parser.add_argument(
+        "-n", "--num-validators",
+        default=19,
+        type=int,
+        choices=range(2, 101),
+        metavar="N",
+        help="Number of validators to run (2-100, default: 19)",
+    )
+    parser.add_argument(
+        "-c", "--chain-override",
+        default="",
+        choices=("", "testnet", "mainnet"),
+        help="Chain override for protocol feature flags (default: none = devnet-like)",
+    )
+    parser.add_argument(
+        "-e", "--epoch-duration",
+        default=15,
+        type=int,
+        metavar="MINUTES",
+        help="Epoch duration in minutes (default: 15)",
+    )
+    parser.add_argument(
+        "--geodistributed",
+        default=True,
+        type=lambda v: v.lower() in ("true", "1", "yes"),
+        help="Use large geodistributed latencies (default: true)",
+    )
+    parser.add_argument(
+        "--seed",
+        default=42,
+        type=int,
+        help="Seed for the deterministic split into halves (default: 42)",
+    )
+    parser.add_argument(
+        "--mid-observation-epochs",
+        default=1,
+        type=int,
+        metavar="N",
+        help=(
+            "Additional full epochs to hold the mixed-binary state between "
+            "first-half and second-half upgrades (default: 1). 0 = behaviour "
+            "of the original test (move on as soon as the 0->1 boundary fires)."
+        ),
+    )
+    parser.add_argument(
+        "--post-observation-epochs",
+        default=1,
+        type=int,
+        metavar="N",
+        help=(
+            "Full epochs of post-upgrade steady-state observation after the "
+            "all-upgraded epoch boundary (default: 1). 0 = no extra "
+            "observation past the boundary itself."
+        ),
+    )
+    parser.add_argument(
+        "--head-only",
+        action="store_true",
+        help=(
+            "Start every validator on the locally-built HEAD image from the "
+            "very beginning (image_old := image_upgrade) instead of on the "
+            "release image. All phases still run; the rolling 'upgrades' "
+            "in phases 8 and 11 become same-binary restarts. Used to isolate "
+            "orchestrator overhead (compose file, network-benchmark.sh) from "
+            "binary-version effects: compare the pre-phase-8 window of a "
+            "--head-only run against the same window of a normal run, where "
+            "the only difference is release vs HEAD binary."
+        ),
+    )
+    return parser.parse_args()
+
+
+# ========================= Main =========================
+
+
+def main() -> None:
+    args = parse_args()
+
+    # The other orchestrators (run-fuzz, run-benchmark, run-migration-test)
+    # all acquire /tmp/iota-experiments.lock at startup. They share container
+    # names, the docker network, and the tc/iptables state on validators —
+    # concurrent runs silently corrupt each other (one run's cleanup tears
+    # down the other run's network mid-flight). Acquire it here too so the
+    # half-upgrade test plays nicely alongside them.
+    mt.ec.acquire_single_run_lock("run-half-upgrade-test.py")
+
+    try:
+        cfg = Config(
+            release_network=args.release_network,
+            build=args.build,
+            chain_override=args.chain_override,
+            num_validators=args.num_validators,
+            geodistributed=args.geodistributed,
+            seed=args.seed,
+            epoch_duration_ms=args.epoch_duration * 60_000,
+        )
+    except ValueError as err:
+        print(f"Configuration error: {err}", file=sys.stderr)
+        sys.exit(2)
+
+    # Distinct log file from the migration test so transcripts don't get clobbered
+    cfg.log_file = cfg.log_dir / "half_upgrade_script_latest.log"
+    # Attach half-upgrade-specific observation knobs (extra attrs on the Config
+    # instance — Config is a non-frozen dataclass so this is allowed).
+    cfg.mid_observation_epochs = max(0, args.mid_observation_epochs)
+    cfg.post_observation_epochs = max(0, args.post_observation_epochs)
+    cfg.head_only = bool(args.head_only)
+    mt._cfg = cfg
+
+    if cfg.script_dir.name != "experiments":
+        print("Error: run from experiments/", file=sys.stderr)
+        sys.exit(1)
+
+    # Routes future log() calls to the half-upgrade-specific log file. The
+    # function also mkdir -p's log_dir; migration test's cleanup() will close
+    # the handle via ec.close_logging().
+    mt.ec.setup_logging(cfg.log_file)
+
+    atexit.register(cleanup)
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+    first_half, second_half = split_halves(cfg.num_validators, cfg.seed)
+
+    log(_phase_banner("Half-Network Upgrade Test Configuration"))
+    log(f"  {_C.BOLD}Validators{_C.RESET}           : {cfg.num_validators}")
+    log(f"  {_C.BOLD}Epoch duration{_C.RESET}       : {cfg.epoch_duration_ms // 60_000} min")
+    log(f"  {_C.BOLD}Release network{_C.RESET}      : {cfg.release_network}")
+    log(f"  {_C.BOLD}Chain override{_C.RESET}       : {cfg.chain_override or 'none (devnet-like)'}")
+    log(f"  {_C.BOLD}Build local image{_C.RESET}    : {cfg.build}")
+    log(f"  {_C.BOLD}Geodistributed{_C.RESET}      : {cfg.geodistributed}")
+    log(f"  {_C.BOLD}Split seed{_C.RESET}          : {cfg.seed}")
+    log(f"  {_C.BOLD}First half (mid-ep-0){_C.RESET} : {first_half}  ({len(first_half)} vals)")
+    log(f"  {_C.BOLD}Second half (mid-ep-1){_C.RESET}: {second_half}  ({len(second_half)} vals)")
+    log(f"  {_C.BOLD}Mid-epoch wait{_C.RESET}      : {cfg.mid_epoch_wait}s")
+    log(f"  {_C.BOLD}Rolling offline pause{_C.RESET}: {cfg.rolling_restart_pause_min}-{cfg.rolling_restart_pause_max}s per validator")
+    log(f"  {_C.BOLD}Mid-binary observation{_C.RESET}: {cfg.mid_observation_epochs} extra epoch(s) of mixed-binary state between halves")
+    log(f"  {_C.BOLD}Post-upgrade observation{_C.RESET} : {cfg.post_observation_epochs} extra epoch(s) after all validators on HEAD")
+    if cfg.head_only:
+        log(f"  {_C.BOLD}Head-only mode{_C.RESET}      : ON — all validators start on HEAD "
+            "(rolling 'upgrades' will be same-binary restarts)")
+
+    # --- Setup phases (reused from migration test) ---
+    local_branch, local_commit = phase1_docker_images(cfg)
+
+    # In head-only mode, every validator starts directly on the HEAD-built
+    # image. Overriding image_old here means phase2's compose template, phase4's
+    # boot, and the env-file substitution all see the upgrade image as the
+    # default. We deliberately do this AFTER phase1 so phase1's release-image
+    # pull/tag still runs (it's cached anyway, and keeping the unconditional
+    # pull avoids forking the phase1 logic just for this mode).
+    if cfg.head_only:
+        log(
+            f"  {_C.BOLD}--head-only{_C.RESET}: overriding image_old "
+            f"({cfg.image_old}) := image_upgrade ({cfg.image_upgrade})"
+        )
+        cfg.image_old = cfg.image_upgrade
+
+    phase2_generate_compose(cfg)
+    phase3_bootstrap_genesis(cfg)
+    old_max_proto, old_consensus, epoch_0_start = phase4_start_validators(cfg)
+    phase5_start_monitoring(cfg)
+    latency_proc = phase6_apply_latency(cfg)
+
+    log(
+        f"  {_C.BOLD}Old release{_C.RESET}  ({cfg.release_network:>8s}) : "
+        f"max_protocol={old_max_proto or 'unknown'}, "
+        f"consensus={old_consensus or 'unknown'}"
+    )
+    log(
+        f"  {_C.BOLD}Local build{_C.RESET}  ({local_branch}@{local_commit}) : "
+        "(version will be confirmed after first-half upgrade)"
+    )
+
+    # --- First half upgrade in epoch 0 ---
+    _wait_mid_epoch(cfg, epoch_0_start, "PHASE 7")
+    phase8_first_half(cfg, first_half)
+
+    # --- Mixed-binary observation in epoch 1 ---
+    epoch_0 = get_current_epoch()
+    epoch_1, epoch_1_start = phase9_observe_mixed(cfg, epoch_0_start, epoch_0)
+
+    # --- Second half upgrade — skip the mid-epoch wait so Phase 11 starts at
+    # the beginning of the current (mixed-binary) epoch. That leaves most of
+    # the epoch for an "all-on-HEAD on the still-old protocol" steady-state
+    # window before the next epoch boundary fires the protocol advance (if
+    # any). With -e 15 this is ~9 min of steady state instead of just the
+    # tail of the rolling-upgrade recovery.
+    phase11_second_half(cfg, second_half)
+
+    # --- Cross the post-upgrade epoch boundary (protocol advance if applicable) ---
+    final_epoch = phase12_observe_upgraded(cfg, epoch_1)
+
+    log(_phase_banner("Half-Network Upgrade Test Complete"))
+    log(f"  Final epoch: {final_epoch}")
+    log(f"  First-half (upgraded mid-ep-0): {first_half}")
+    log(f"  Second-half (upgraded mid-ep-1): {second_half}")
+    log("  Validator log archives are under experiments/logs/")
+
+    # Best-effort latency teardown (cleanup() also does this on exit)
+    run(["sudo", "pkill", "-f", r"network-benchmark\.sh"], check=False, quiet=True)
+    if latency_proc.poll() is None:
+        latency_proc.terminate()
+
+
+if __name__ == "__main__":
+    main()

--- a/dev-tools/iota-private-network/run.sh
+++ b/dev-tools/iota-private-network/run.sh
@@ -16,14 +16,12 @@ while getopts "n:fh" opt; do
 done
 shift $((OPTIND -1))
 
-# Refuse to bring up validators on top of another active experiment's
-# network — different docker compose project, same `iota-network` and
-# container names; recreates / port conflicts ensue. Same env-var /
-# explicit-flag bypass shape as cleanup.sh.
+# Refuse to bring up validators over another active run's network — same
+# `iota-network` and container names, so recreates / port conflicts ensue.
+# Bypass via IOTA_EXPERIMENT_LOCK_HELD or an explicit -f.
 LOCK_PATH="/tmp/iota-experiments.lock"
-# Read-only FD + shared flock: see cleanup.sh for the rationale (avoids
-# false positives under fs.protected_regular when the lock file was left
-# behind by a dead orchestrator from another user).
+# Read-only FD + shared flock avoid a false "locked" under fs.protected_regular
+# when a dead orchestrator left the lock file behind.
 if [ "$FORCE" != "true" ] \
    && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
    && [ -f "$LOCK_PATH" ] \

--- a/dev-tools/iota-private-network/run.sh
+++ b/dev-tools/iota-private-network/run.sh
@@ -20,16 +20,44 @@ shift $((OPTIND -1))
 # `iota-network` and container names, so recreates / port conflicts ensue.
 # Bypass via IOTA_EXPERIMENT_LOCK_HELD or an explicit -f.
 LOCK_PATH="/tmp/iota-experiments.lock"
-# Read-only FD + shared flock avoid a false "locked" under fs.protected_regular
-# when a dead orchestrator left the lock file behind.
+
+# Lock state of $LOCK_PATH: 0 = free, 3 = held, 4 = cannot tell. Shared flock
+# on a read-only FD avoids a false "locked" under fs.protected_regular; the
+# python3 fcntl probe covers macOS, which lacks flock(1).
+function experiment_lock_state() {
+  if command -v flock >/dev/null 2>&1; then
+    (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null && return 0
+    return 3
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import fcntl, sys
+try:
+    fcntl.flock(open(sys.argv[1]), fcntl.LOCK_SH | fcntl.LOCK_NB)
+except OSError:
+    sys.exit(3)' "$LOCK_PATH" 2>/dev/null
+    case "$?" in
+      0) return 0 ;;
+      3) return 3 ;;
+    esac
+  fi
+  return 4
+}
+
 if [ "$FORCE" != "true" ] \
    && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
-   && [ -f "$LOCK_PATH" ] \
-   && ! (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null; then
-  holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
-  echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
-  echo "       Wait for it to finish, or pass -f to override." >&2
-  exit 1
+   && [ -f "$LOCK_PATH" ]; then
+  lock_state=0
+  experiment_lock_state || lock_state=$?
+  if [ "$lock_state" -eq 3 ]; then
+    holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
+    echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
+    echo "       Wait for it to finish, or pass -f to override." >&2
+    exit 1
+  elif [ "$lock_state" -ne 0 ]; then
+    echo "ERROR: $LOCK_PATH exists but cannot be verified (need flock or a working python3)." >&2
+    echo "       Install one, or pass -f if no experiment run is active." >&2
+    exit 1
+  fi
 fi
 
 function start_services() {

--- a/dev-tools/iota-private-network/run.sh
+++ b/dev-tools/iota-private-network/run.sh
@@ -6,13 +6,33 @@
 
 # Default validator count
 NUM_VALIDATORS=4
-while getopts "n:" opt; do
+FORCE=false
+while getopts "n:fh" opt; do
   case "$opt" in
     n) NUM_VALIDATORS="$OPTARG" ;;
-    *) echo "Usage: $0 [-n num_validators]"; exit 1 ;;
+    f) FORCE=true ;;
+    h|*) echo "Usage: $0 [-n num_validators] [-f] <modes...>"; exit 1 ;;
   esac
 done
 shift $((OPTIND -1))
+
+# Refuse to bring up validators on top of another active experiment's
+# network — different docker compose project, same `iota-network` and
+# container names; recreates / port conflicts ensue. Same env-var /
+# explicit-flag bypass shape as cleanup.sh.
+LOCK_PATH="/tmp/iota-experiments.lock"
+# Read-only FD + shared flock: see cleanup.sh for the rationale (avoids
+# false positives under fs.protected_regular when the lock file was left
+# behind by a dead orchestrator from another user).
+if [ "$FORCE" != "true" ] \
+   && [ "${IOTA_EXPERIMENT_LOCK_HELD:-0}" != "1" ] \
+   && [ -f "$LOCK_PATH" ] \
+   && ! (flock -n -s 9) 9<"$LOCK_PATH" 2>/dev/null; then
+  holder=$(cat "$LOCK_PATH" 2>/dev/null || true)
+  echo "ERROR: another experiment run is active: ${holder:-(holder unknown)}" >&2
+  echo "       Wait for it to finish, or pass -f to override." >&2
+  exit 1
+fi
 
 function start_services() {
   services="$1"


### PR DESCRIPTION
# Description of change

Tooling for running Starfish/consensus experiments on the local private network. All changes live under `dev-tools/iota-private-network/`:

- **Experiment scripts**: a half-network rolling-upgrade test, a post-run canary that filters shutdown-window noise, plus a StarfishOverview dashboard link and an `iota-spammer` precheck wired into the benchmark/fuzz runners.
- **Build self-healing**: verify built images match `HEAD` and rebuild if stale, and recover from a stale cargo cache on build failure (staleness auto-prune narrowed to cache mounts only).
- **Experiment lock**: `cleanup`/`bootstrap`/`run` refuse to start while another experiment holds the lock, avoiding concurrent runs stepping on each other.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
