### PR TITLE
refactor(iota-adapter): simplify object_change_for_id

### DIFF
--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -213,28 +213,25 @@ impl<'backing> TemporaryStore<'backing> {
     /// Returns the [`EffectsObjectChange`] for `id`, gathered from the
     /// execution results.
     fn object_change_for_id(&self, id: &ObjectId) -> EffectsObjectChange {
-        let modified_at = self
-            .get_object_modified_at(id)
-            .map(|metadata| ((metadata.version, metadata.digest), metadata.owner));
         let results = &self.execution_results;
-        let written = results.written_objects.get(id);
         let id_created = results.created_object_ids.contains(id);
         let id_deleted = results.deleted_object_ids.contains(id);
-
         debug_assert!(
             !id_created || !id_deleted,
             "Object ID can't be created and deleted at the same time."
         );
-        EffectsObjectChange {
-            object_id: *id,
-            input_state: modified_at.map_or(ObjectIn::Missing, |((version, digest), owner)| {
-                ObjectIn::Data {
-                    version,
-                    digest,
-                    owner,
-                }
-            }),
-            output_state: written.map_or(ObjectOut::Missing, |o| {
+
+        let input_state = self
+            .get_object_modified_at(id)
+            .map_or(ObjectIn::Missing, |m| ObjectIn::Data {
+                version: m.version,
+                digest: m.digest,
+                owner: m.owner,
+            });
+        let output_state = results
+            .written_objects
+            .get(id)
+            .map_or(ObjectOut::Missing, |o| {
                 if o.is_package() {
                     ObjectOut::PackageWrite {
                         version: o.version(),
@@ -246,14 +243,20 @@ impl<'backing> TemporaryStore<'backing> {
                         owner: o.owner,
                     }
                 }
-            }),
-            id_operation: if id_created {
-                IDOperation::Created
-            } else if id_deleted {
-                IDOperation::Deleted
-            } else {
-                IDOperation::None
-            },
+            });
+        let id_operation = if id_created {
+            IDOperation::Created
+        } else if id_deleted {
+            IDOperation::Deleted
+        } else {
+            IDOperation::None
+        };
+
+        EffectsObjectChange {
+            object_id: *id,
+            input_state,
+            output_state,
+            id_operation,
         }
     }
 


### PR DESCRIPTION
# Description of change

Small, behavior-preserving readability cleanup of
`TemporaryStore::object_change_for_id` in `iota-adapter` — the helper that builds
the `EffectsObjectChange` for a single object from the execution results.
Resolves the follow-up raised in #11597 (from the #10336 review).

**The main win:** the old code packed the modified-at metadata into a nested tuple
*only to immediately destructure it* in the caller:

```rust
// before
let modified_at = self
    .get_object_modified_at(id)
    .map(|metadata| ((metadata.version, metadata.digest), metadata.owner));
// ...then, inside the struct literal:
input_state: modified_at.map_or(ObjectIn::Missing, |((version, digest), owner)| {
    ObjectIn::Data { version, digest, owner }
}),
```
```rust
// after — build ObjectIn::Data straight from the metadata, no tuple round-trip
let input_state = self
    .get_object_modified_at(id)
    .map_or(ObjectIn::Missing, |m| ObjectIn::Data {
        version: m.version,
        digest: m.digest,
        owner: m.owner,
    });
```

Secondary tidy-ups (same idea, no logic change):
- `input_state` / `output_state` / `id_operation` are now computed as named locals
  top-to-bottom, so the returned `EffectsObjectChange { .. }` reads as the flat shape
  of the struct instead of three multi-line expressions nested inside the literal.
- `debug_assert!(!id_created || !id_deleted, ...)` now sits directly under the two
  flags it validates.

**No behavior change:** the exact same `EffectsObjectChange` is produced for every
input — same values, single call site (`get_object_changes`). The `output_state`
closure is intentionally left inline: the `is_package()` → `PackageWrite`/`ObjectWrite`
mapping is used only here, so there's nothing to extract.

## Links to any relevant issues

fixes #11597

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage) — N/A, behavior-preserving refactor
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, no behavior change
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo +nightly fmt`, `cargo check -p iota-adapter-latest --all-targets` (clean), and
`iota-adapter-latest` + `iota-types` unit tests pass locally.
