### PR TITLE
fix(move-package): fetch git dependencies as sparse, blobless clones

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
@@ -466,6 +466,11 @@ mod tests {
         run_git(root, &["config", "user.email", "test@example.com"]);
         run_git(root, &["config", "user.name", "test"]);
         run_git(root, &["config", "commit.gpgsign", "false"]);
+        // Let this repo serve partial (`--filter`) clones and fetches of arbitrary
+        // object ids over `file://`. Without these a blobless clone is silently
+        // downgraded to a full one, so the tests could not observe blob deferral.
+        run_git(root, &["config", "uploadpack.allowFilter", "true"]);
+        run_git(root, &["config", "uploadpack.allowAnySHA1InWant", "true"]);
         for sub in subdirs {
             let dir = root.join(sub);
             fs::create_dir_all(&dir).unwrap();
@@ -493,13 +498,38 @@ mod tests {
         (repo, sha)
     }
 
+    /// A `file://` URL for the fixture repo. The scheme matters: git treats a
+    /// bare local path as a "local clone" and silently ignores `--filter`, but
+    /// over `file://` it goes through the real fetch protocol that honours it.
     fn repo_url(repo: &TempDir) -> String {
-        repo.path().to_str().unwrap().to_string()
+        format!("file://{}", repo.path().display())
     }
 
     /// Whether the package at `subdir` has been checked out in `dest`.
     fn has_pkg(dest: &Path, subdir: &str) -> bool {
         dest.join(subdir).join("Move.toml").exists()
+    }
+
+    /// Number of objects the clone left un-downloaded (fetched lazily on
+    /// demand) -- direct proof that `--filter=blob:none` actually took
+    /// effect. A full clone, or one whose filter was silently ignored,
+    /// reports 0.
+    fn deferred_object_count(dest: &Path) -> usize {
+        let output = Command::new("git")
+            .args([
+                OsStr::new("-C"),
+                dest.as_os_str(),
+                OsStr::new("rev-list"),
+                OsStr::new("--objects"),
+                OsStr::new("--all"),
+                OsStr::new("--missing=print"),
+            ])
+            .output()
+            .expect("failed to spawn git");
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|line| line.starts_with('?'))
+            .count()
     }
 
     #[test]
@@ -523,6 +553,13 @@ mod tests {
         assert!(
             !has_pkg(&dest, "c"),
             "unrequested subdir is not checked out"
+        );
+        // The point of the whole change: blobs outside the checked-out subdir are
+        // deferred, not downloaded. This fails if `--filter=blob:none` is dropped or
+        // silently ignored (e.g. a bare-path clone source).
+        assert!(
+            deferred_object_count(&dest) > 0,
+            "blobless clone should defer blob downloads",
         );
     }
 
@@ -577,6 +614,11 @@ mod tests {
         .unwrap();
 
         assert!(!is_sparse_repo(&dest), "a full clone is not a sparse repo");
+        assert_eq!(
+            deferred_object_count(&dest),
+            0,
+            "a full clone downloads every object, it defers nothing",
+        );
         assert!(
             has_pkg(&dest, "a") && has_pkg(&dest, "b") && has_pkg(&dest, "c"),
             "a full clone contains every subdir",

--- a/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     ffi::OsStr,
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
@@ -23,8 +23,12 @@ use crate::{
 /// fetched when building a given package.
 #[derive(Debug, Clone)]
 pub struct DependencyCache {
-    /// A set of paths for remote dependencies that have already been fetched
-    fetched_deps: BTreeSet<PathBuf>,
+    /// Subdirs already materialized for each fetched git repository, keyed by
+    /// the repository's local cache path. A single clone is shared by every
+    /// subdir of the same `url + rev`, so we track the subdirs individually:
+    /// the first one triggers the clone and later ones are added to the
+    /// repository's sparse-checkout set.
+    fetched_deps: BTreeMap<PathBuf, BTreeSet<PathBuf>>,
 
     /// Should a dependency fetched when building a different package be
     /// refreshed to the newest version when building a new package
@@ -33,7 +37,7 @@ pub struct DependencyCache {
 
 impl DependencyCache {
     pub fn new(skip_fetch_latest_git_deps: bool) -> DependencyCache {
-        let fetched_deps = BTreeSet::new();
+        let fetched_deps = BTreeMap::new();
         DependencyCache {
             fetched_deps,
             skip_fetch_latest_git_deps,
@@ -50,8 +54,12 @@ impl DependencyCache {
             DependencyKind::Local(_) => Ok(()),
 
             DependencyKind::OnChain(info) => {
-                // check if a give dependency type has already been fetched
-                if !self.fetched_deps.insert(repository_path(kind)) {
+                // check if a given dependency type has already been fetched
+                if self
+                    .fetched_deps
+                    .insert(repository_path(kind), BTreeSet::new())
+                    .is_some()
+                {
                     return Ok(());
                 }
                 package_hooks::resolve_on_chain_dependency(dep_name, info)
@@ -60,27 +68,22 @@ impl DependencyCache {
             DependencyKind::Git(GitInfo {
                 git_url,
                 git_rev,
-                subdir: _,
+                subdir,
             }) => {
                 let repository_path = repository_path(kind);
-                // check if a give dependency type has already been fetched
-                if !self.fetched_deps.insert(repository_path.clone()) {
-                    return Ok(());
-                }
 
-                if Command::new("git")
-                    .arg("--version")
-                    .stdin(Stdio::null())
-                    .output()
-                    .is_err()
-                {
-                    writeln!(progress_output, "Git is not installed or not in the PATH.")?;
-                    return Err(anyhow::anyhow!("Git is not installed or not in the PATH."));
-                }
+                // A single clone serves every subdir of the same `url + rev`. Skip if this
+                // exact subdir is already materialized this run; otherwise note whether this
+                // is the first subdir of the repository we touch (only then is it refreshed).
+                let first_touch = match self.fetched_deps.get(&repository_path) {
+                    Some(subdirs) if subdirs.contains(subdir) => return Ok(()),
+                    Some(_) => false,
+                    None => true,
+                };
 
-                let git_path = repository_path;
-                let os_git_url = OsStr::new(git_url.as_str());
-                let os_git_rev = OsStr::new(git_rev.as_str());
+                ensure_git_available(progress_output)?;
+
+                let git_path = repository_path.as_path();
 
                 if !git_path.exists() {
                     writeln!(
@@ -89,165 +92,519 @@ impl DependencyCache {
                         "FETCHING GIT DEPENDENCY".bold().green(),
                         git_url,
                     )?;
-                    // If the cached folder does not exist, download and clone accordingly
-                    if let Ok(mut output) = Command::new("git")
-                        .args([OsStr::new("clone"), os_git_url, git_path.as_os_str()])
-                        .stdin(Stdio::null())
-                        .spawn()
-                    {
-                        output.wait().map_err(|_| {
-                            anyhow::anyhow!(
-                                "Failed to clone Git repository for package '{}'",
-                                dep_name
-                            )
-                        })?;
-                        if output.stdout.is_some() {
-                            writeln!(progress_output, "{:?}", output)?;
-                        }
-                    } else {
-                        return Err(anyhow::anyhow!(
-                            "Failed to clone Git repository for package '{}'",
-                            dep_name
-                        ));
-                    }
-
-                    Command::new("git")
-                        .args([
-                            OsStr::new("-C"),
-                            git_path.as_os_str(),
-                            OsStr::new("checkout"),
-                            os_git_rev,
-                        ])
-                        .stdin(Stdio::null())
-                        .output()
-                        .map_err(|_| {
-                            anyhow::anyhow!(
-                                "Failed to checkout Git reference '{}' for package '{}'",
-                                git_rev,
-                                dep_name
-                            )
-                        })?;
-                } else if !self.skip_fetch_latest_git_deps {
-                    // Update the git dependency
-                    // Check first that it isn't a git rev (if it doesn't work, just continue with
-                    // the fetch)
-                    if let Ok(rev) = Command::new("git")
-                        .args([
-                            OsStr::new("-C"),
-                            git_path.as_os_str(),
-                            OsStr::new("rev-parse"),
-                            OsStr::new("--verify"),
-                            os_git_rev,
-                        ])
-                        .stdin(Stdio::null())
-                        .output()
-                    {
-                        if let Ok(parsable_version) = String::from_utf8(rev.stdout) {
-                            // If it's exactly the same, then it's a git rev
-                            if parsable_version.trim().starts_with(git_rev.as_str()) {
-                                return Ok(());
-                            }
-                        }
-                    }
-
-                    let tag = Command::new("git")
-                        .args([
-                            OsStr::new("-C"),
-                            git_path.as_os_str(),
-                            OsStr::new("tag"),
-                            OsStr::new("--list"),
-                            os_git_rev,
-                        ])
-                        .stdin(Stdio::null())
-                        .output();
-
-                    if let Ok(tag) = tag {
-                        if let Ok(parsable_version) = String::from_utf8(tag.stdout) {
-                            // If it's exactly the same, then it's a git tag, for now tags won't be
-                            // updated Tags don't easily update locally
-                            // and you can't use reset --hard to cleanup
-                            // any extra files
-                            if parsable_version.trim().starts_with(git_rev.as_str()) {
-                                return Ok(());
-                            }
-                        }
-                    }
-
-                    writeln!(
+                    clone_dependency(
+                        git_path,
+                        git_url.as_str(),
+                        git_rev.as_str(),
+                        subdir,
+                        dep_name,
                         progress_output,
-                        "{} {}",
-                        "UPDATING GIT DEPENDENCY".bold().green(),
-                        git_url,
                     )?;
+                } else {
+                    // The repository is already cached. Make sure this subdir is checked
+                    // out (a no-op for full clones and for subdirs already present) before
+                    // optionally refreshing the repository. The refresh is per-repository,
+                    // so only the first subdir we touch this run performs it.
+                    ensure_subdir_present(git_path, subdir);
 
-                    // If the current folder exists, do a fetch and reset to ensure that the branch
-                    // is up to date.
-                    //
-                    // NOTE: this means that you must run the package system with a working network
-                    // connection.
-
-                    if let Ok(mut output) = Command::new("git")
-                        .args([
-                            OsStr::new("-C"),
-                            git_path.as_os_str(),
-                            OsStr::new("fetch"),
-                            OsStr::new("origin"),
-                        ])
-                        .stdin(Stdio::null())
-                        .spawn()
-                    {
-                        output.wait().map_err(|_| {
-                            anyhow::anyhow!(
-                                "Failed to fetch latest Git state for package '{}', to skip set \
-                             --skip-fetch-latest-git-deps",
-                                dep_name
-                            )
-                        })?;
-                        if output.stdout.is_some() {
-                            writeln!(progress_output, "{:?}", output)?;
-                        }
-                    } else {
-                        return Err(anyhow::anyhow!(
-                            "Failed to fetch latest Git state for package '{}', to skip set \
-                             --skip-fetch-latest-git-deps",
-                            dep_name
-                        ));
-                    }
-
-                    let status = Command::new("git")
-                        .args([
-                            OsStr::new("-C"),
-                            git_path.as_os_str(),
-                            OsStr::new("reset"),
-                            OsStr::new("--hard"),
-                            OsStr::new(&format!("origin/{}", git_rev)),
-                        ])
-                        .stdin(Stdio::null())
-                        .stdout(Stdio::null())
-                        .stderr(Stdio::null())
-                        .status()
-                        .map_err(|_| {
-                            anyhow::anyhow!(
-                            "Failed to reset to latest Git state '{}' for package '{}', to skip \
-                             set --skip-fetch-latest-git-deps",
-                            git_rev,
-                            dep_name
-                        )
-                        })?;
-
-                    if !status.success() {
-                        return Err(anyhow::anyhow!(
-                            "Failed to reset to latest Git state '{}' for package '{}', to skip set \
-                         --skip-fetch-latest-git-deps | Exit status: {}",
-                            git_rev,
+                    if first_touch && !self.skip_fetch_latest_git_deps {
+                        update_dependency(
+                            git_path,
+                            git_url.as_str(),
+                            git_rev.as_str(),
                             dep_name,
-                            status
-                        ));
+                            progress_output,
+                        )?;
                     }
                 }
+
+                self.fetched_deps
+                    .entry(repository_path)
+                    .or_default()
+                    .insert(subdir.clone());
 
                 Ok(())
             }
         }
+    }
+}
+
+/// Errors out if `git` is not callable.
+fn ensure_git_available<Progress: Write>(progress_output: &mut Progress) -> Result<()> {
+    if Command::new("git")
+        .arg("--version")
+        .stdin(Stdio::null())
+        .output()
+        .is_err()
+    {
+        writeln!(progress_output, "Git is not installed or not in the PATH.")?;
+        return Err(anyhow::anyhow!("Git is not installed or not in the PATH."));
+    }
+    Ok(())
+}
+
+/// Clones a git dependency into `git_path` and checks out `git_rev`.
+///
+/// Prefers a blobless, sparse clone restricted to `subdir`: this downloads only
+/// the commit graph plus the blobs reachable from `subdir`, rather than the
+/// whole repository and its history. Falls back to a full clone when sparse
+/// cloning is unavailable (e.g. an old `git`) or when the package lives at the
+/// repository root (`subdir` is empty), where there is nothing to narrow to.
+fn clone_dependency<Progress: Write>(
+    git_path: &Path,
+    git_url: &str,
+    git_rev: &str,
+    subdir: &Path,
+    dep_name: PackageName,
+    progress_output: &mut Progress,
+) -> Result<()> {
+    if !subdir.as_os_str().is_empty() && try_sparse_clone(git_path, git_url, git_rev, subdir) {
+        return Ok(());
+    }
+
+    full_clone(git_path, git_url, git_rev, dep_name, progress_output)
+}
+
+/// Attempts a blobless sparse clone of `subdir` at `git_rev`. Returns `true` on
+/// success. On any failure it removes the (possibly partial) clone and returns
+/// `false` so the caller can fall back to a full clone.
+fn try_sparse_clone(git_path: &Path, git_url: &str, git_rev: &str, subdir: &Path) -> bool {
+    // `--filter=blob:none` keeps the full commit graph so any revision -- tag,
+    // branch, or commit SHA -- still resolves, while deferring blob downloads;
+    // `--sparse --no-checkout` leaves the working tree empty until we narrow it.
+    let ok = git_status(&[
+        OsStr::new("clone"),
+        OsStr::new("--filter=blob:none"),
+        OsStr::new("--sparse"),
+        OsStr::new("--no-checkout"),
+        OsStr::new(git_url),
+        git_path.as_os_str(),
+    ]) && git_status(&[
+        OsStr::new("-C"),
+        git_path.as_os_str(),
+        OsStr::new("sparse-checkout"),
+        OsStr::new("set"),
+        OsStr::new("--cone"),
+        subdir.as_os_str(),
+    ]) && git_status(&[
+        OsStr::new("-C"),
+        git_path.as_os_str(),
+        OsStr::new("checkout"),
+        OsStr::new(git_rev),
+    ]);
+
+    if ok {
+        return true;
+    }
+
+    // Leave no partial clone behind for the full-clone fallback.
+    if git_path.exists() {
+        let _ = std::fs::remove_dir_all(git_path);
+    }
+    false
+}
+
+/// Performs a full clone (history and all files) followed by a checkout of
+/// `git_rev`. This is the original fetch behaviour, kept as a fallback.
+fn full_clone<Progress: Write>(
+    git_path: &Path,
+    git_url: &str,
+    git_rev: &str,
+    dep_name: PackageName,
+    progress_output: &mut Progress,
+) -> Result<()> {
+    if let Ok(mut output) = Command::new("git")
+        .args([
+            OsStr::new("clone"),
+            OsStr::new(git_url),
+            git_path.as_os_str(),
+        ])
+        .stdin(Stdio::null())
+        .spawn()
+    {
+        output.wait().map_err(|_| {
+            anyhow::anyhow!("Failed to clone Git repository for package '{}'", dep_name)
+        })?;
+        if output.stdout.is_some() {
+            writeln!(progress_output, "{:?}", output)?;
+        }
+    } else {
+        return Err(anyhow::anyhow!(
+            "Failed to clone Git repository for package '{}'",
+            dep_name
+        ));
+    }
+
+    Command::new("git")
+        .args([
+            OsStr::new("-C"),
+            git_path.as_os_str(),
+            OsStr::new("checkout"),
+            OsStr::new(git_rev),
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "Failed to checkout Git reference '{}' for package '{}'",
+                git_rev,
+                dep_name
+            )
+        })?;
+
+    Ok(())
+}
+
+/// Ensures `subdir` is checked out in an already-cached repository.
+///
+/// Only repositories we cloned sparsely are touched: a `sparse-checkout add` is
+/// idempotent for subdirs already present, and pulls in new ones. Full clones
+/// from older tool versions already contain every subdir, so they are left
+/// alone, and root packages (empty `subdir`) need no narrowing.
+fn ensure_subdir_present(git_path: &Path, subdir: &Path) {
+    if subdir.as_os_str().is_empty() || !is_sparse_repo(git_path) {
+        return;
+    }
+
+    git_status(&[
+        OsStr::new("-C"),
+        git_path.as_os_str(),
+        OsStr::new("sparse-checkout"),
+        OsStr::new("add"),
+        subdir.as_os_str(),
+    ]);
+}
+
+/// Whether `git_path` is a sparse-checkout repository (i.e. one we created with
+/// [`try_sparse_clone`]). Full clones report `false` and are left untouched.
+fn is_sparse_repo(git_path: &Path) -> bool {
+    Command::new("git")
+        .args([
+            OsStr::new("-C"),
+            git_path.as_os_str(),
+            OsStr::new("config"),
+            OsStr::new("--get"),
+            OsStr::new("core.sparseCheckout"),
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim() == "true")
+        .unwrap_or(false)
+}
+
+/// Refreshes a cached repository to the latest state of `git_rev`.
+///
+/// Revisions pinned to a tag or a commit SHA are already immutable and return
+/// early; only branch-pinned dependencies are fetched and hard-reset.
+fn update_dependency<Progress: Write>(
+    git_path: &Path,
+    git_url: &str,
+    git_rev: &str,
+    dep_name: PackageName,
+    progress_output: &mut Progress,
+) -> Result<()> {
+    let os_git_rev = OsStr::new(git_rev);
+
+    // Check first that it isn't a git rev (if it doesn't work, just continue with
+    // the fetch)
+    if let Ok(rev) = Command::new("git")
+        .args([
+            OsStr::new("-C"),
+            git_path.as_os_str(),
+            OsStr::new("rev-parse"),
+            OsStr::new("--verify"),
+            os_git_rev,
+        ])
+        .stdin(Stdio::null())
+        .output()
+    {
+        if let Ok(parsable_version) = String::from_utf8(rev.stdout) {
+            // If it's exactly the same, then it's a git rev
+            if parsable_version.trim().starts_with(git_rev) {
+                return Ok(());
+            }
+        }
+    }
+
+    let tag = Command::new("git")
+        .args([
+            OsStr::new("-C"),
+            git_path.as_os_str(),
+            OsStr::new("tag"),
+            OsStr::new("--list"),
+            os_git_rev,
+        ])
+        .stdin(Stdio::null())
+        .output();
+
+    if let Ok(tag) = tag {
+        if let Ok(parsable_version) = String::from_utf8(tag.stdout) {
+            // If it's exactly the same, then it's a git tag, for now tags won't be
+            // updated Tags don't easily update locally
+            // and you can't use reset --hard to cleanup
+            // any extra files
+            if parsable_version.trim().starts_with(git_rev) {
+                return Ok(());
+            }
+        }
+    }
+
+    writeln!(
+        progress_output,
+        "{} {}",
+        "UPDATING GIT DEPENDENCY".bold().green(),
+        git_url,
+    )?;
+
+    // If the current folder exists, do a fetch and reset to ensure that the branch
+    // is up to date.
+    //
+    // NOTE: this means that you must run the package system with a working network
+    // connection.
+
+    if let Ok(mut output) = Command::new("git")
+        .args([
+            OsStr::new("-C"),
+            git_path.as_os_str(),
+            OsStr::new("fetch"),
+            OsStr::new("origin"),
+        ])
+        .stdin(Stdio::null())
+        .spawn()
+    {
+        output.wait().map_err(|_| {
+            anyhow::anyhow!(
+                "Failed to fetch latest Git state for package '{}', to skip set \
+                 --skip-fetch-latest-git-deps",
+                dep_name
+            )
+        })?;
+        if output.stdout.is_some() {
+            writeln!(progress_output, "{:?}", output)?;
+        }
+    } else {
+        return Err(anyhow::anyhow!(
+            "Failed to fetch latest Git state for package '{}', to skip set \
+             --skip-fetch-latest-git-deps",
+            dep_name
+        ));
+    }
+
+    let status = Command::new("git")
+        .args([
+            OsStr::new("-C"),
+            git_path.as_os_str(),
+            OsStr::new("reset"),
+            OsStr::new("--hard"),
+            OsStr::new(&format!("origin/{}", git_rev)),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "Failed to reset to latest Git state '{}' for package '{}', to skip \
+                 set --skip-fetch-latest-git-deps",
+                git_rev,
+                dep_name
+            )
+        })?;
+
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "Failed to reset to latest Git state '{}' for package '{}', to skip set \
+             --skip-fetch-latest-git-deps | Exit status: {}",
+            git_rev,
+            dep_name,
+            status
+        ));
+    }
+
+    Ok(())
+}
+
+/// Runs `git` with `args`, inheriting stdio so progress is shown, and reports
+/// whether it exited successfully. A spawn failure (e.g. `git` missing) is
+/// treated as a non-successful run.
+fn git_status(args: &[&OsStr]) -> bool {
+    Command::new("git")
+        .args(args)
+        .stdin(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Runs `git -C <dir> <args>`, asserting success.
+    fn run_git(dir: &Path, args: &[&str]) {
+        let success = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .status()
+            .expect("failed to spawn git")
+            .success();
+        assert!(success, "git {args:?} failed in {}", dir.display());
+    }
+
+    /// Builds a throwaway git repository containing one package per entry in
+    /// `subdirs` (each with a minimal `Move.toml`), committed and tagged `v1`.
+    /// Returns the repository and its `HEAD` commit SHA.
+    fn make_repo(subdirs: &[&str]) -> (TempDir, String) {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path();
+        run_git(root, &["init", "--quiet"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "test"]);
+        run_git(root, &["config", "commit.gpgsign", "false"]);
+        for sub in subdirs {
+            let dir = root.join(sub);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(
+                dir.join("Move.toml"),
+                format!("[package]\nname = \"{sub}\"\n"),
+            )
+            .unwrap();
+        }
+        run_git(root, &["add", "-A"]);
+        run_git(root, &["commit", "--quiet", "-m", "init"]);
+        run_git(root, &["tag", "v1"]);
+        let sha = String::from_utf8(
+            Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        (repo, sha)
+    }
+
+    fn repo_url(repo: &TempDir) -> String {
+        repo.path().to_str().unwrap().to_string()
+    }
+
+    /// Whether the package at `subdir` has been checked out in `dest`.
+    fn has_pkg(dest: &Path, subdir: &str) -> bool {
+        dest.join(subdir).join("Move.toml").exists()
+    }
+
+    #[test]
+    fn sparse_clone_narrows_to_requested_subdir() {
+        let (repo, _) = make_repo(&["a", "b", "c"]);
+        let dest_dir = tempfile::tempdir().unwrap();
+        let dest = dest_dir.path().join("clone");
+
+        assert!(try_sparse_clone(
+            &dest,
+            &repo_url(&repo),
+            "v1",
+            Path::new("a")
+        ));
+        assert!(is_sparse_repo(&dest));
+        assert!(has_pkg(&dest, "a"), "requested subdir is checked out");
+        assert!(
+            !has_pkg(&dest, "b"),
+            "unrequested subdir is not checked out"
+        );
+        assert!(
+            !has_pkg(&dest, "c"),
+            "unrequested subdir is not checked out"
+        );
+    }
+
+    #[test]
+    fn ensure_subdir_present_adds_sibling_to_sparse_clone() {
+        let (repo, _) = make_repo(&["a", "b", "c"]);
+        let dest_dir = tempfile::tempdir().unwrap();
+        let dest = dest_dir.path().join("clone");
+        assert!(try_sparse_clone(
+            &dest,
+            &repo_url(&repo),
+            "v1",
+            Path::new("a")
+        ));
+
+        ensure_subdir_present(&dest, Path::new("b"));
+
+        assert!(has_pkg(&dest, "b"), "sibling subdir is added");
+        assert!(has_pkg(&dest, "a"), "original subdir remains");
+        assert!(!has_pkg(&dest, "c"), "untouched subdir stays absent");
+    }
+
+    #[test]
+    fn sparse_clone_resolves_a_raw_commit_sha() {
+        // A commit SHA must resolve -- a shallow clone (`--depth 1`) could not do this.
+        let (repo, sha) = make_repo(&["a", "b"]);
+        let dest_dir = tempfile::tempdir().unwrap();
+        let dest = dest_dir.path().join("clone");
+
+        assert!(try_sparse_clone(
+            &dest,
+            &repo_url(&repo),
+            &sha,
+            Path::new("a")
+        ));
+        assert!(has_pkg(&dest, "a"));
+    }
+
+    #[test]
+    fn full_clone_checks_out_everything_and_is_not_sparse() {
+        let (repo, _) = make_repo(&["a", "b", "c"]);
+        let dest_dir = tempfile::tempdir().unwrap();
+        let dest = dest_dir.path().join("clone");
+
+        full_clone(
+            &dest,
+            &repo_url(&repo),
+            "v1",
+            PackageName::from("pkg"),
+            &mut std::io::sink(),
+        )
+        .unwrap();
+
+        assert!(!is_sparse_repo(&dest), "a full clone is not a sparse repo");
+        assert!(
+            has_pkg(&dest, "a") && has_pkg(&dest, "b") && has_pkg(&dest, "c"),
+            "a full clone contains every subdir",
+        );
+    }
+
+    #[test]
+    fn ensure_subdir_present_leaves_full_clone_untouched() {
+        // Backward compatibility: a full clone created by an older tool version must
+        // not be narrowed -- doing so would hide files an existing build relies on.
+        let (repo, _) = make_repo(&["a", "b", "c"]);
+        let dest_dir = tempfile::tempdir().unwrap();
+        let dest = dest_dir.path().join("clone");
+        full_clone(
+            &dest,
+            &repo_url(&repo),
+            "v1",
+            PackageName::from("pkg"),
+            &mut std::io::sink(),
+        )
+        .unwrap();
+
+        ensure_subdir_present(&dest, Path::new("a"));
+
+        assert!(!is_sparse_repo(&dest), "still a full clone");
+        assert!(
+            has_pkg(&dest, "a") && has_pkg(&dest, "b") && has_pkg(&dest, "c"),
+            "every subdir is still present",
+        );
     }
 }

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -524,8 +524,19 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
     ) -> Result<Vec<(DependencyGraph, bool, bool, Symbol, Option<Symbol>)>> {
         match dep {
             PM::Dependency::Internal(d) => {
+                // Resolve the dependency against its parent before fetching, so a local
+                // dependency of a git package (e.g. `{ local = "../move-stdlib" }`) becomes
+                // a git dependency into the same repository. The fetch can then materialize
+                // that subdir, which matters for sparse checkouts where the sibling is not on
+                // disk until it is explicitly added.
+                let mut fetch_kind = d.kind.clone();
+                fetch_kind.reroot(parent)?;
                 self.dependency_cache
-                    .download_and_update_if_remote(dep_pkg_name, &d.kind, &mut self.progress_output)
+                    .download_and_update_if_remote(
+                        dep_pkg_name,
+                        &fetch_kind,
+                        &mut self.progress_output,
+                    )
                     .with_context(|| format!("Fetching '{}'", dep_pkg_name))?;
                 let pkg_path = dep_pkg_path.join(local_path(&d.kind));
                 let manifest_string =
@@ -551,8 +562,17 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
                 // save dependency for cycle detection
                 self.visited_dependencies
                     .push_front((resolved_pkg_id, d.clone()));
+                // Parent kind for resolving this dependency's own dependencies. When the
+                // dependency resolved into a git repository, use that git kind so nested
+                // local siblings resolve into -- and are fetched from -- the same repository.
+                // Purely local chains keep the original kind, since rerooting a local parent
+                // accumulates the path and would corrupt nested local paths.
+                let nested_parent = match fetch_kind {
+                    PM::DependencyKind::Git(_) => &fetch_kind,
+                    _ => &d.kind,
+                };
                 let (mut pkg_graph, modified) =
-                    self.get_graph(&d.kind, pkg_path, manifest_string, lock_string)?;
+                    self.get_graph(nested_parent, pkg_path, manifest_string, lock_string)?;
                 self.visited_dependencies.pop_front();
                 // reroot all packages to normalize local paths across all graphs
                 for (_, p) in pkg_graph.package_table.iter_mut() {

--- a/external-crates/move/crates/move-package/src/source_package/parsed_manifest.rs
+++ b/external-crates/move/crates/move-package/src/source_package/parsed_manifest.rs
@@ -195,3 +195,134 @@ pub fn normalize_path(path: impl AsRef<Path>, allow_cwd_parent: bool) -> Result<
 
     Ok(normalized)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git(url: &str, rev: &str, subdir: &str) -> DependencyKind {
+        DependencyKind::Git(GitInfo {
+            git_url: Symbol::from(url),
+            git_rev: Symbol::from(rev),
+            subdir: PathBuf::from(subdir),
+        })
+    }
+
+    fn local(path: &str) -> DependencyKind {
+        DependencyKind::Local(PathBuf::from(path))
+    }
+
+    fn onchain(id: &str) -> DependencyKind {
+        DependencyKind::OnChain(OnChainInfo {
+            id: Symbol::from(id),
+        })
+    }
+
+    /// Reroot `child` against `parent`, asserting success, and return the
+    /// result.
+    fn rerooted(mut child: DependencyKind, parent: &DependencyKind) -> DependencyKind {
+        child.reroot(parent).expect("reroot should succeed");
+        child
+    }
+
+    const URL: &str = "https://github.com/iotaledger/iota.git";
+    const REV: &str = "v1.23.2-rc";
+    const FW: &str = "crates/iota-framework/packages/iota-framework";
+    const SYS: &str = "crates/iota-framework/packages/iota-system";
+    const STD: &str = "crates/iota-framework/packages/move-stdlib";
+
+    #[test]
+    fn git_child_is_absolute_and_unchanged() {
+        // A git dependency's location is absolute; the parent must not affect it.
+        let child = git(URL, REV, FW);
+        assert_eq!(rerooted(child.clone(), &local("some/dir")), child);
+        assert_eq!(
+            rerooted(child.clone(), &git("other.git", "main", "x")),
+            child
+        );
+        assert_eq!(rerooted(child.clone(), &DependencyKind::default()), child);
+    }
+
+    #[test]
+    fn onchain_child_is_unchanged() {
+        let child = onchain("0x2");
+        assert_eq!(rerooted(child.clone(), &git(URL, REV, FW)), child);
+        assert_eq!(rerooted(child.clone(), &local("a/b")), child);
+    }
+
+    #[test]
+    fn onchain_parent_leaves_child_unchanged() {
+        let child = local("../move-stdlib");
+        assert_eq!(rerooted(child.clone(), &onchain("0x2")), child);
+    }
+
+    #[test]
+    fn local_under_local_joins_and_normalizes() {
+        assert_eq!(rerooted(local("../C"), &local("deps/B")), local("deps/C"));
+        assert_eq!(rerooted(local("./sub"), &local("root")), local("root/sub"));
+        // A top-level local dependency: parent is the default (empty) root.
+        assert_eq!(
+            rerooted(local("packages/foo"), &DependencyKind::default()),
+            local("packages/foo"),
+        );
+    }
+
+    #[test]
+    fn local_under_git_becomes_a_sibling_git_subdir() {
+        // The core of the fix: `{ local = "../move-stdlib" }` declared inside
+        // iota-framework resolves into the same repo at the sibling subdir.
+        assert_eq!(
+            rerooted(local("../move-stdlib"), &git(URL, REV, FW)),
+            git(URL, REV, STD),
+        );
+    }
+
+    #[test]
+    fn multiple_local_siblings_under_one_git_parent() {
+        // iota-system depends on both move-stdlib and iota-framework via `../`.
+        let parent = git(URL, REV, SYS);
+        assert_eq!(
+            rerooted(local("../move-stdlib"), &parent),
+            git(URL, REV, STD)
+        );
+        assert_eq!(
+            rerooted(local("../iota-framework"), &parent),
+            git(URL, REV, FW)
+        );
+    }
+
+    #[test]
+    fn deep_chain_git_local_local_stays_in_repo() {
+        // iota-system -> iota-framework -> move-stdlib, every hop a `../` local.
+        // Rerooting against the resolved git kind at each level keeps the chain
+        // inside the repository (this is what the recursion threads through).
+        let sys = git(URL, REV, SYS);
+        let fw = rerooted(local("../iota-framework"), &sys);
+        assert_eq!(fw, git(URL, REV, FW));
+        let std = rerooted(local("../move-stdlib"), &fw);
+        assert_eq!(std, git(URL, REV, STD));
+    }
+
+    #[test]
+    fn git_child_under_git_parent_keeps_its_own_repo() {
+        // git -> git into a different repository: the git child is absolute and
+        // does not inherit the parent's url/rev/subdir.
+        let parent = git(URL, REV, FW);
+        let other = git("https://example.com/other.git", "main", "pkgs/x");
+        assert_eq!(rerooted(other.clone(), &parent), other);
+    }
+
+    #[test]
+    fn git_subdir_normalizes_dotdot_components() {
+        let parent = git(URL, REV, "a/b/c");
+        assert_eq!(rerooted(local("../../x"), &parent), git(URL, REV, "a/x"));
+    }
+
+    #[test]
+    fn local_escaping_git_repo_root_is_rejected() {
+        // A subdir that climbs above the repository root is invalid.
+        let parent = git(URL, REV, "a");
+        let mut child = local("../../x");
+        assert!(child.reroot(&parent).is_err());
+    }
+}


### PR DESCRIPTION
# Description of change

Move git dependencies were fetched with a plain git clone - full history and every file of the repository. When a package depends on a large monorepo (e.g. iota.git), each url + rev cost ~625 MB on disk under $MOVE_HOME, even though a build only needs a few package subdirectories.

This PR fetches git dependencies as blobless, sparse clones instead:

`git clone --filter=blob:none --sparse --no-checkout` downloads the full commit graph (so any tag, branch, or commit-SHA rev still resolves) but defers file blobs, then narrows the working tree to the required subdir via git sparse-checkout set --cone and checks out the rev.
A single clone is shared by every subdir of the same url + rev. Additional subdirs are added incrementally with git sparse-checkout add instead of re-cloning (the fetch cache is now keyed per (repository, subdir) rather than per repository).
Local dependencies of a git package (e.g. MoveStdlib = { local = "../move-stdlib" }) are rerooted into the same repository before fetching, so their subdirs are materialized as well. This is threaded through nested resolution so deeply nested local siblings (e.g. iota-system → iota-framework → move-stdlib) resolve correctly too.

### Compatibility:

Pre-existing full clones created by older tool versions are detected (core.sparseCheckout) and left untouched - never narrowed.
If sparse/partial clone is unavailable (old git, server without partial-clone support, or a root-level dependency with empty subdir), the fetch falls back to the original full clone, so behaviour never regresses.

### Result 
The iota.git dependency cache shrinks from ~625 MB to ~55 MB per url + rev. (Not the theoretical ~7 MB - the remaining size is the commit/tree graph that blob:none deliberately keeps so every revision stays resolvable; **see open questions**.)

### Open questions
- Opt-in --filter=tree:0? We chose blob:none (keeps the commit/tree graph → ~55 MB, but every rev resolves offline). tree:0 would reach ~7 MB but fetches trees on demand - more network round-trips and more fragile. Worth exposing as an opt-in flag / env var for space-constrained users, likely in a follow-up PR? - **Resolved**(will be implemented in separate upstream pulls) 
- Additional e2e tests. If the approach is agreed, we can add end-to-end tests through the public DependencyGraphBuilder API (local git fixture) that assert sibling materialization "from the outside" - kept out of this PR because they require overriding the process-global MOVE_HOME.
_A fully automated e2e test through DependencyGraphBuilder would have to redirect the git cache, which is hardcoded to the process-global MOVE_HOME. Isolating it requires either mutating MOVE_HOME in-process (racy, and read only once per process) or a production change to make the cache dir injectable._

### Comparison with upstream move-package

**Same as upstream**
Aspect | This PR (v1) | Upstream (v2)
-- | -- | --
Blobless partial clone | --filter=blob:none | --filter=blob:none
Sparse working tree | --sparse | --sparse
Deferred checkout | --no-checkout, then narrow, then checkout | same
Incremental subdir add | sparse-checkout add for extra subdirs | sparse-checkout add
Detect "is this our sparse repo" | git config --get core.sparseCheckout == "true" | same check
One clone shared per repository | keyed by url+rev | keyed by url+sha

**Differences** 
Aspect | This PR (v1) | Upstream (v2) | Why we differ
-- | -- | -- | --
Rev pinning | none — the manifest rev (tag/branch/SHA) is used as-is | pins rev → full commit SHA before fetch (#22878) | Pinning is a whole subsystem (lockfile v2, resolve/sha layers). Out of scope for a v1 backport.
Shallow clone | not used | --depth 1 | Shallow is only safe once every rev is pinned to a concrete SHA. Without pinning, a raw SHA/tag rev may not resolve. We keep the full commit graph (via blob:none) so any rev still resolves.
Offline rebuilds | build still consults git for branch revs (unless --skip-fetch-latest-git-deps) | no git access after first fetch | Follows from pinning; v1 has no pin state.
Root package (empty subdir) | falls back to a full clone (history + all files) | blobless clone + sparse-checkout disable | v2's variant keeps the blobless win even for root deps; ours does not.
Cache dedup granularity | per url + rev string (a tag and a branch pointing at the same commit → two folders) | per resolved SHA (shared folder) | Follows from pinning.


Relationship to upstream: Sui optimized this same v1 move-package clone path in [#22350](https://github.com/MystenLabs/sui/pull/22350) (--filter=tree:0 --no-checkout), which is tracked in IOTA's port backlog ([#10852](https://github.com/iotaledger/iota/issues/10852)). This PR takes a more aggressive approach - --filter=blob:none --sparse --no-checkout plus narrowing the working tree to the required subdir - reducing the cache from ~625 MB to ~55 MB (vs. tree:0, which only defers trees without sparse narrowing). It should be reconciled with the #22350 port rather than layered on top. The fuller upstream design (rev pinning, --depth 1, offline rebuilds) lives in move-package-alt (v2) and is out of scope here.

## Links to any relevant issues

Fixes #11542 .

## How the change has been tested

move-package suite: 242 tests pass - `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p move-package`

Covered test cases:

**parsed_manifest.rs**
1. git_child_is_absolute_and_unchanged:
Rerooting a git dep (e.g. `{git: iota.git, rev: v1, subdir: iota-framework}`) against a local parent, a different git parent, and the default root - all return it unchanged. A git URL is absolute, so who references it must not alter it. Guards against accidentally re-pointing top-level/nested git deps.
2. onchain_child_is_unchanged:
Same idea for an on-chain dep (`{OnChain: 0x2}`): rerooting against git or local parents leaves it as-is. On-chain addresses are absolute too.
3. onchain_parent_leaves_child_unchanged:
The reverse direction: a local child under an on-chain parent stays unchanged. Covers the (OnChain, _) match arm so the whole reroot match is exercised (an edge case, but keeps behavior defined).
4. local_under_local_joins_and_normalizes:
Pure local chains: `../C` under `deps/B` → `deps/C`; `./sub` under `root` → `root/sub`; and a top-level local under the empty default root stays `packages/foo`. Confirms path joining + `./..` normalization with allow_cwd_parent=true. This is the case that must not be re-rerooted (double-processing corrupts it - the regression we hit).
5. local_under_git_becomes_a_sibling_git_subdir:
`{local: ../move-stdlib}` declared inside iota-framework (a git dep) becomes {git: iota.git, rev: v1, subdir: .../move-stdlib} - same url+rev, sibling subdir. This is the transformation that lets sparse checkout fetch the sibling; without it the build failed with No such file.
6. multiple_local_siblings_under_one_git_parent:
`iota-system` (git) has two local siblings: `../move-stdlib` → move-stdlib subdir, `../iota-framework `→ iota-framework subdir. Verifies each independently resolves to the correct git subdir when a package depends on several siblings.
7. deep_chain_git_local_local_stays_in_repo:
Simulates `iota-system → iota-framework → move-stdlib`: reroot `../iota-framework` against the git parent → git subdir; then reroot `../move-stdlib` against that result → still a git subdir in the same repo. Proves the git context propagates down nested local hops (what the recursion's `nested_parent` threads through) — the deep-nesting bug we fixed.
8. git_child_under_git_parent_keeps_its_own_repo:
A git child pointing at `example.com/other.git` under an `iota.git` git parent stays on `other.`git (own url/rev/subdir). This is `git → local → git` into a different repo: the inner git dep is absolute and doesn't inherit the outer repo (it gets its own cache folder).
9. git_subdir_normalizes_dotdot_components:
`../../x` under a git parent with subdir `a/b/c` → subdir `a/x`. Confirms `..` components collapse correctly inside the git subdir (so the fetched path is clean).
10. local_escaping_git_repo_root_is_rejected:
`../../x` under a git parent with subdir `a` would climb above the repository root → `reroot` returns an `Err`. Ensures an invalid subdir fails loudly (`allow_cwd_parent=false`) instead of silently pointing outside the repo.

**dependency_cache.rs**
1. sparse_clone_narrows_to_requested_subdir - sparse clone checks out only the requested subdir; siblings absent; repo marked sparse.
2. ensure_subdir_present_adds_sibling_to_sparse_clone - sparse-checkout add materializes a sibling subdir into the same clone.
3. sparse_clone_resolves_a_raw_commit_sha - checkout by a raw commit SHA works (guards against the --depth 1 pitfall).
4. full_clone_checks_out_everything_and_is_not_sparse - the full-clone fallback checks out every subdir and is not sparse.
5. ensure_subdir_present_leaves_full_clone_untouched - a pre-existing full clone is not narrowed (backward compatibility).

### Manual end-to-end:

- build the CLI with the change
```bash
cargo build -p iota
```
- build a Move package that depends on iota.git, into an isolated cache
```bash
export MOVE_HOME=$(mktemp -d)/move-cache
./target/debug/iota move build -p <path/to/package>
```
- verify the result
```bash
du -sh "$MOVE_HOME"/*                    # ~55 MB instead of ~625 MB
````
Verified across configurations: direct multi-subdir deps (Iota, IotaSystem, MoveStdlib, Stardust), deeply nested local siblings (IotaSystem-only, Stardust-only), warm cache-hit (no re-clone), and backward-compat against a pre-existing full clone.