### PR TITLE
fix(core): Distinguish NotFound and other errors in object-store exists

### DIFF
--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -9,27 +9,19 @@ use std::{
     fs::File,
     io,
     io::{BufReader, Read, Write},
-    ops::Range,
     path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::Arc,
 };
 
 use anyhow::{Result, anyhow};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use bytes::{Buf, Bytes};
 use fastcrypto::hash::{HashFunction, Sha3_256};
-use futures::StreamExt;
 use iota_types::{
     committee::Committee,
-    messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointSequenceNumber, VerifiedCheckpoint,
-    },
+    messages_checkpoint::{CertifiedCheckpointSummary, VerifiedCheckpoint},
     storage::WriteStore,
 };
-use itertools::Itertools;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tracing::debug;
@@ -244,56 +236,4 @@ where
     });
 
     verify_checkpoint_with_committee(committee, current, checkpoint)
-}
-
-pub async fn verify_checkpoint_range<S>(
-    checkpoint_range: Range<CheckpointSequenceNumber>,
-    store: S,
-    checkpoint_counter: Arc<AtomicU64>,
-    max_concurrency: usize,
-) where
-    S: WriteStore + Clone,
-{
-    let range_clone = checkpoint_range.clone();
-    futures::stream::iter(range_clone.into_iter().tuple_windows())
-        .map(|(a, b)| {
-            let current = store
-                .get_checkpoint_by_sequence_number(a)
-                .unwrap_or_else(|| {
-                    panic!("Checkpoint {a} should exist in store after summary sync but does not");
-                });
-            let next = store
-                .get_checkpoint_by_sequence_number(b)
-                .unwrap_or_else(|| {
-                    panic!("Checkpoint {a} should exist in store after summary sync but does not");
-                });
-
-            let committee = store.get_committee(next.epoch()).unwrap_or_else(|| {
-                panic!(
-                    "BUG: should have committee for epoch {} before we try to verify checkpoint {}",
-                    next.epoch(),
-                    next.sequence_number()
-                )
-            });
-            tokio::spawn(async move {
-                verify_checkpoint_with_committee(committee, &current, next.clone().into())
-                    .expect("Checkpoint verification failed");
-            })
-        })
-        .buffer_unordered(max_concurrency)
-        .for_each(|result| {
-            result.expect("Checkpoint verification task failed");
-            checkpoint_counter.fetch_add(1, Ordering::Relaxed);
-            futures::future::ready(())
-        })
-        .await;
-    let last = checkpoint_range
-        .last()
-        .expect("Received empty checkpoint range");
-    let final_checkpoint = store
-        .get_checkpoint_by_sequence_number(last)
-        .expect("Expected end of checkpoint range to exist in store");
-    store
-        .try_update_highest_verified_checkpoint(&final_checkpoint)
-        .expect("Failed to update highest verified checkpoint");
 }

--- a/crates/iota-storage/src/object_store/http/gcs.rs
+++ b/crates/iota-storage/src/object_store/http/gcs.rs
@@ -13,7 +13,7 @@ use reqwest::{Client, ClientBuilder};
 
 use crate::object_store::{
     ObjectStoreGetExt,
-    http::{DEFAULT_USER_AGENT, get},
+    http::{DEFAULT_USER_AGENT, exists, get},
 };
 
 #[derive(Debug)]
@@ -38,6 +38,11 @@ impl GoogleCloudStorageClient {
     async fn get(&self, path: &Path) -> Result<GetResult> {
         let url = self.object_url(path);
         get(&url, "gcs", path, &self.client).await
+    }
+
+    async fn exists(&self, path: &Path) -> Result<bool> {
+        let url = self.object_url(path);
+        exists(&url, "gcs", path, &self.client).await
     }
 
     fn object_url(&self, path: &Path) -> String {
@@ -76,5 +81,9 @@ impl ObjectStoreGetExt for GoogleCloudStorage {
         let result = self.client.get(location).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)
+    }
+
+    async fn exists(&self, location: &Path) -> Result<bool> {
+        self.client.exists(location).await
     }
 }

--- a/crates/iota-storage/src/object_store/http/local.rs
+++ b/crates/iota-storage/src/object_store/http/local.rs
@@ -50,9 +50,12 @@ impl ObjectStoreGetExt for LocalStorage {
     async fn exists(&self, location: &Path) -> Result<bool> {
         let path_to_filesystem = path_to_filesystem(self.root.clone(), location)?;
         let exists = tokio::task::spawn_blocking(move || {
-            path_to_filesystem
-                .try_exists()
-                .map_err(|e| anyhow!("Failed to check if file exists with error: {e}"))
+            path_to_filesystem.try_exists().map_err(|e| {
+                anyhow!(
+                    "Failed to check if file {} exists with error: {e}",
+                    path_to_filesystem.display()
+                )
+            })
         })
         .await??;
         Ok(exists)

--- a/crates/iota-storage/src/object_store/http/local.rs
+++ b/crates/iota-storage/src/object_store/http/local.rs
@@ -46,4 +46,15 @@ impl ObjectStoreGetExt for LocalStorage {
         });
         handle.await?
     }
+
+    async fn exists(&self, location: &Path) -> Result<bool> {
+        let path_to_filesystem = path_to_filesystem(self.root.clone(), location)?;
+        let exists = tokio::task::spawn_blocking(move || {
+            path_to_filesystem
+                .try_exists()
+                .map_err(|e| anyhow!("Failed to check if file exists with error: {e}"))
+        })
+        .await??;
+        Ok(exists)
+    }
 }

--- a/crates/iota-storage/src/object_store/http/mod.rs
+++ b/crates/iota-storage/src/object_store/http/mod.rs
@@ -151,7 +151,7 @@ mod tests {
     use object_store::path::Path;
     use tempfile::TempDir;
 
-    use crate::object_store::http::HttpDownloaderBuilder;
+    use crate::object_store::{ObjectStoreGetExt, http::HttpDownloaderBuilder};
 
     #[tokio::test]
     pub async fn test_local_download() -> anyhow::Result<()> {
@@ -175,6 +175,24 @@ mod tests {
 
         let downloaded = input_store.get_bytes(&Path::from("child/file1")).await?;
         assert_eq!(downloaded.to_vec(), b"Lorem ipsum");
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_local_exists() -> anyhow::Result<()> {
+        let input = TempDir::new()?;
+        let input_path = input.path();
+        fs::write(input_path.join("file1"), b"Lorem ipsum")?;
+
+        let input_store = ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::File),
+            directory: Some(input_path.to_path_buf()),
+            ..Default::default()
+        }
+        .make_http()?;
+
+        assert!(input_store.exists(&Path::from("file1")).await?);
+        assert!(!input_store.exists(&Path::from("missing")).await?);
         Ok(())
     }
 }

--- a/crates/iota-storage/src/object_store/http/mod.rs
+++ b/crates/iota-storage/src/object_store/http/mod.rs
@@ -96,6 +96,24 @@ async fn get(
     })
 }
 
+async fn exists(url: &str, store: &'static str, location: &Path, client: &Client) -> Result<bool> {
+    let request = client.request(Method::HEAD, url);
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("failed to send HEAD request for {location} to {store}"))?;
+    let status = response.status();
+    if status.is_success() {
+        Ok(true)
+    } else if status == reqwest::StatusCode::NOT_FOUND {
+        Ok(false)
+    } else {
+        Err(anyhow!(
+            "{store} returned unexpected status {status} for {location}"
+        ))
+    }
+}
+
 fn header_meta(location: &Path, headers: &HeaderMap) -> Result<ObjectMeta> {
     let last_modified = headers
         .get(LAST_MODIFIED)

--- a/crates/iota-storage/src/object_store/http/s3.rs
+++ b/crates/iota-storage/src/object_store/http/s3.rs
@@ -13,7 +13,7 @@ use reqwest::{Client, ClientBuilder};
 
 use crate::object_store::{
     ObjectStoreGetExt,
-    http::{DEFAULT_USER_AGENT, STRICT_PATH_ENCODE_SET, get},
+    http::{DEFAULT_USER_AGENT, STRICT_PATH_ENCODE_SET, exists, get},
 };
 
 #[derive(Debug)]
@@ -38,6 +38,10 @@ impl S3Client {
     async fn get(&self, location: &Path) -> Result<GetResult> {
         let url = self.path_url(location);
         get(&url, "s3", location, &self.client).await
+    }
+    async fn exists(&self, location: &Path) -> Result<bool> {
+        let url = self.path_url(location);
+        exists(&url, "s3", location, &self.client).await
     }
     fn path_url(&self, path: &Path) -> String {
         format!("{}/{}", self.endpoint, Self::encode_path(path))
@@ -74,5 +78,9 @@ impl ObjectStoreGetExt for AmazonS3 {
         let result = self.client.get(location).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)
+    }
+
+    async fn exists(&self, location: &Path) -> Result<bool> {
+        self.client.exists(location).await
     }
 }

--- a/crates/iota-storage/src/object_store/mod.rs
+++ b/crates/iota-storage/src/object_store/mod.rs
@@ -16,6 +16,9 @@ pub mod util;
 pub trait ObjectStoreGetExt: std::fmt::Display + Send + Sync + 'static {
     /// Return the bytes at given path in object store
     async fn get_bytes(&self, src: &Path) -> Result<Bytes>;
+
+    /// Return whether an object exists at the given path.
+    async fn exists(&self, src: &Path) -> Result<bool>;
 }
 
 macro_rules! as_ref_get_ext_impl {
@@ -24,6 +27,10 @@ macro_rules! as_ref_get_ext_impl {
         impl ObjectStoreGetExt for $type {
             async fn get_bytes(&self, src: &Path) -> Result<Bytes> {
                 self.as_ref().get_bytes(src).await
+            }
+
+            async fn exists(&self, src: &Path) -> Result<bool> {
+                self.as_ref().exists(src).await
             }
         }
     };
@@ -46,6 +53,14 @@ macro_rules! as_ref_get_impl {
                         anyhow!(
                             "Failed to collect GET result for file {src} into bytes with error: {e:?}")
                     })
+            }
+
+            async fn exists(&self, src: &Path) -> Result<bool> {
+                match self.head(src).await {
+                    Ok(_) => Ok(true),
+                    Err(object_store::Error::NotFound { .. }) => Ok(false),
+                    Err(e) => Err(anyhow!("Failed to check if file {src} exists with error: {e:?}")),
+                }
             }
         }
     };

--- a/crates/iota-storage/src/object_store/mod.rs
+++ b/crates/iota-storage/src/object_store/mod.rs
@@ -161,3 +161,25 @@ impl ObjectStoreDeleteExt for Arc<DynObjectStore> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use object_store::{ObjectStore, memory::InMemory, path::Path};
+
+    use crate::object_store::{ObjectStoreGetExt, ObjectStorePutExt};
+
+    #[tokio::test]
+    async fn test_dyn_object_store_exists() -> anyhow::Result<()> {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("file1");
+        store
+            .put_bytes(&path, bytes::Bytes::from_static(b"Lorem ipsum"))
+            .await?;
+
+        assert!(store.exists(&path).await?);
+        assert!(!store.exists(&Path::from("missing")).await?);
+        Ok(())
+    }
+}

--- a/crates/iota-storage/src/object_store/util.rs
+++ b/crates/iota-storage/src/object_store/util.rs
@@ -108,10 +108,6 @@ pub async fn get<S: ObjectStoreGetExt>(store: &S, src: &Path) -> Result<Bytes> {
     Ok(bytes)
 }
 
-pub async fn exists<S: ObjectStoreGetExt>(store: &S, src: &Path) -> bool {
-    store.get_bytes(src).await.is_ok()
-}
-
 /// Writes bytes in the store with specified path.
 pub async fn put<S: ObjectStorePutExt>(store: &S, src: &Path, bytes: Bytes) -> Result<()> {
     retry(backoff::ExponentialBackoff::default(), || async {

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -57,6 +57,7 @@ use iota_storage::object_store::{
     ObjectStoreGetExt,
     http::HttpDownloaderBuilder,
     util::{MANIFEST_FILENAME, PerEpochManifest, RootManifest, copy_file, exists, get_path},
+    verify_checkpoint_range,
 };
 use iota_types::{
     base_types::*,
@@ -870,7 +871,10 @@ pub async fn check_completed_snapshot(
     } else {
         snapshot_store_config.make().map(Arc::new)?
     };
-    if exists(&remote_object_store, &get_path(success_marker.as_str())).await {
+    if remote_object_store
+        .exists(&get_path(success_marker.as_str()))
+        .await?
+    {
         Ok(())
     } else {
         bail!(

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -56,8 +56,7 @@ use iota_snapshot::{
 use iota_storage::object_store::{
     ObjectStoreGetExt,
     http::HttpDownloaderBuilder,
-    util::{MANIFEST_FILENAME, PerEpochManifest, RootManifest, copy_file, exists, get_path},
-    verify_checkpoint_range,
+    util::{MANIFEST_FILENAME, PerEpochManifest, RootManifest, copy_file, get_path},
 };
 use iota_types::{
     base_types::*,


### PR DESCRIPTION
# Description of change

Add `ObjectStoreGetExt::exists` returning `Result<bool>`: `Ok(false)` for a
genuine absence, `Err` for other failures. Each backend detects absence
natively using a metadata-only primitive rather than downloading the body:

- `Arc<dyn ObjectStore>` uses `head` and matches `Error::NotFound`
- S3/GCS issue an HTTP `HEAD` and classify by status (2xx / 404 / other)
- `LocalStorage` uses `Path::try_exists`


## Links to any relevant issues

Fixes #12108 
Fixes #11726

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
