### PR TITLE
fix(protocol-config): do not force `TotalComputationUnits` mode in attestation flow

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1466,12 +1466,6 @@ impl ProtocolConfig {
     }
 
     pub fn per_object_congestion_control_mode(&self) -> PerObjectCongestionControlMode {
-        // TODO(attestation): Once `enable_validator_attestation` is set in a version
-        // arm, set `per_object_congestion_control_mode = TotalComputationUnits`
-        // there too and revert this to a plain getter.
-        if self.enable_validator_attestation() {
-            return PerObjectCongestionControlMode::TotalComputationUnits;
-        }
         self.feature_flags.per_object_congestion_control_mode
     }
 


### PR DESCRIPTION
# Description of change

This PR removes the silent forced override of `PerObjectCongestionControlMode` in the `ProtocolConfig::per_object_congestion_control_mode()` getter in the validator-attestation path: the `TotalComputationUnits` mode was forcibly returned if `enable_validator_attestation=true`. Rationale:

- other modes could not be tested in the validator-attestation path due to the silent forced override;
- we cannot simply set the `TotalComputationUnits` mode without properly tuning the per-object congestion control limit per commit; the sequencer exercised the new `TotalComputationUnits` mode but with the `TotalTxCount` mode's limit of 10, effectively cancelling every shared-object transaction;
- there is a dedicated parameter (`per_object_congestion_control_mode`) to set per-object congestion control mode; it should not be controlled or forced by the `enable_validator_attestation` flag.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes