### PR TITLE
feat(snapshot): add epoch end timestamp to formal snapshot metadata

### DIFF
--- a/crates/iota-snapshot/src/uploader.rs
+++ b/crates/iota-snapshot/src/uploader.rs
@@ -196,7 +196,7 @@ impl StateSnapshotUploader {
                     .await?;
                 } else {
                     error!(
-                        "Could not determine epoch start timestamp for epoch {epoch}; skipping metadata write"
+                        "Could not determine epoch end timestamp for epoch {epoch}; skipping metadata write"
                     );
                 }
                 // Drops marker in the output directory that upload completed successfully

--- a/crates/iota-snapshot/src/uploader.rs
+++ b/crates/iota-snapshot/src/uploader.rs
@@ -179,13 +179,12 @@ impl StateSnapshotUploader {
                     .write(*epoch, db, ECMHLiveObjectSetDigest { digest })
                     .await?;
                 info!("State snapshot creation successful for epoch: {}", *epoch);
-                // Records the on-chain start timestamp of this epoch (= timestamp of the
-                // last checkpoint of the previous epoch, which is when advance_epoch ran;
-                // for epoch 0, the genesis checkpoint at sequence 0) in each epoch bucket,
+                // Records the on-chain end timestamp of this epoch (= timestamp of the
+                // last checkpoint of the epoch) in each epoch bucket,
                 // which will be read when updating the MANIFEST file.
-                let epoch_start_checkpoint =
+                let epoch_end_checkpoint =
                     self.checkpoint_store.get_epoch_last_checkpoint(*epoch)?;
-                if let Some(checkpoint) = epoch_start_checkpoint {
+                if let Some(checkpoint) = epoch_end_checkpoint {
                     let metadata = EpochMetadata {
                         epoch_end_timestamp_ms: checkpoint.timestamp_ms,
                     };

--- a/crates/iota-snapshot/src/uploader.rs
+++ b/crates/iota-snapshot/src/uploader.rs
@@ -186,12 +186,11 @@ impl StateSnapshotUploader {
                 let epoch_start_checkpoint = if *epoch == 0 {
                     self.checkpoint_store.get_checkpoint_by_sequence_number(0)?
                 } else {
-                    self.checkpoint_store
-                        .get_epoch_last_checkpoint(*epoch - 1)?
+                    self.checkpoint_store.get_epoch_last_checkpoint(*epoch)?
                 };
                 if let Some(checkpoint) = epoch_start_checkpoint {
                     let metadata = EpochMetadata {
-                        epoch_start_timestamp_ms: checkpoint.timestamp_ms,
+                        epoch_end_timestamp_ms: checkpoint.timestamp_ms,
                     };
                     put(
                         &self.snapshot_store,

--- a/crates/iota-snapshot/src/uploader.rs
+++ b/crates/iota-snapshot/src/uploader.rs
@@ -183,11 +183,8 @@ impl StateSnapshotUploader {
                 // last checkpoint of the previous epoch, which is when advance_epoch ran;
                 // for epoch 0, the genesis checkpoint at sequence 0) in each epoch bucket,
                 // which will be read when updating the MANIFEST file.
-                let epoch_start_checkpoint = if *epoch == 0 {
-                    self.checkpoint_store.get_checkpoint_by_sequence_number(0)?
-                } else {
-                    self.checkpoint_store.get_epoch_last_checkpoint(*epoch)?
-                };
+                let epoch_start_checkpoint =
+                    self.checkpoint_store.get_epoch_last_checkpoint(*epoch)?;
                 if let Some(checkpoint) = epoch_start_checkpoint {
                     let metadata = EpochMetadata {
                         epoch_end_timestamp_ms: checkpoint.timestamp_ms,

--- a/crates/iota-storage/src/object_store/util.rs
+++ b/crates/iota-storage/src/object_store/util.rs
@@ -283,7 +283,8 @@ pub async fn find_all_dirs_with_epoch_prefix(
 }
 
 /// Finds all epochs in the store and returns them as a sorted list, paired
-/// with each epoch's start timestamp in ms when its metadata file is present.
+/// with each epoch's end timestamp in ms when its metadata file is present, or
+/// 0 otherwise.
 pub async fn list_all_epochs(object_store: Arc<DynObjectStore>) -> Result<Vec<(u64, u64)>> {
     let remote_epoch_dirs = find_all_dirs_with_epoch_prefix(&object_store, None).await?;
     let mut out = vec![];

--- a/crates/iota-storage/src/object_store/util.rs
+++ b/crates/iota-storage/src/object_store/util.rs
@@ -27,12 +27,12 @@ pub const EPOCH_METADATA_FILENAME: &str = "_epoch_metadata.json";
 
 #[derive(Serialize, Deserialize)]
 pub struct RootManifest {
-    /// Epoch number paired with its start timestamp in ms (when known).
-    pub available_epochs: Vec<(u64, Option<u64>)>,
+    /// Epoch number paired with its end timestamp in ms (or 0 when unknown).
+    pub available_epochs: Vec<(u64, u64)>,
 }
 
 impl RootManifest {
-    pub fn new(available_epochs: Vec<(u64, Option<u64>)>) -> Self {
+    pub fn new(available_epochs: Vec<(u64, u64)>) -> Self {
         RootManifest { available_epochs }
     }
 
@@ -53,7 +53,7 @@ impl RootManifest {
 
 #[derive(Serialize, Deserialize)]
 pub struct EpochMetadata {
-    pub epoch_start_timestamp_ms: u64,
+    pub epoch_end_timestamp_ms: u64,
 }
 
 impl EpochMetadata {
@@ -284,7 +284,7 @@ pub async fn find_all_dirs_with_epoch_prefix(
 
 /// Finds all epochs in the store and returns them as a sorted list, paired
 /// with each epoch's start timestamp in ms when its metadata file is present.
-pub async fn list_all_epochs(object_store: Arc<DynObjectStore>) -> Result<Vec<(u64, Option<u64>)>> {
+pub async fn list_all_epochs(object_store: Arc<DynObjectStore>) -> Result<Vec<(u64, u64)>> {
     let remote_epoch_dirs = find_all_dirs_with_epoch_prefix(&object_store, None).await?;
     let mut out = vec![];
     let mut success_marker_found = false;
@@ -301,13 +301,13 @@ pub async fn list_all_epochs(object_store: Arc<DynObjectStore>) -> Result<Vec<(u
                 let metadata_path = path.child(EPOCH_METADATA_FILENAME);
                 let epoch_start_timestamp_ms = match object_store.get_bytes(&metadata_path).await {
                     Ok(bytes) => match serde_json::from_slice::<EpochMetadata>(&bytes) {
-                        Ok(metadata) => Some(metadata.epoch_start_timestamp_ms),
+                        Ok(metadata) => metadata.epoch_end_timestamp_ms,
                         Err(err) => {
                             warn!("Failed to parse epoch metadata for epoch {epoch}: {err}");
-                            None
+                            0
                         }
                     },
-                    Err(_) => None,
+                    Err(_) => 0,
                 };
                 out.push((*epoch, epoch_start_timestamp_ms));
                 success_marker_found = true;

--- a/docs/site/src/components/FormalSnapshotPicker/index.tsx
+++ b/docs/site/src/components/FormalSnapshotPicker/index.tsx
@@ -25,6 +25,7 @@ function normalizeEpochs(
 }
 
 function formatTimestamp(ms: number): string {
+    if (ms == 0) return '';
     const d = new Date(ms);
     if (Number.isNaN(d.getTime())) return '';
     return `${d.toISOString().slice(0, 16).replace('T', ' ')} UTC`;
@@ -185,9 +186,11 @@ function Picker() {
                         <option value="latest">
                             {loading ? 'Loading…' : 'Latest'}
                         </option>
-                        {epochs.map(([ep, ts]) => {
+                        {epochs.map(([ep, ts], i) => {
                             const label = ts
-                                ? `${ep} — started ${formatTimestamp(ts)}`
+                                ? `${ep} — ended at ${formatTimestamp(ts)}${
+                                    i === 0 ? ' [latest]' : ''
+                                }`
                                 : String(ep);
                             return (
                                 <option key={ep} value={ep}>


### PR DESCRIPTION
# Description of change

This PR adds epoch end timestamp to formal snapshot metadata. Snapshots are now listed by the end date time in the docs page.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
