### PR TITLE
fix(core): amortize checkpoint interval over a sliding window

### DIFF
--- a/crates/iota-core/src/checkpoints/metrics.rs
+++ b/crates/iota-core/src/checkpoints/metrics.rs
@@ -24,6 +24,7 @@ pub struct CheckpointMetrics {
     pub last_ignored_checkpoint_signature_received: IntGauge,
     pub highest_accumulated_epoch: IntGauge,
     pub checkpoint_creation_latency: Histogram,
+    pub commits_per_checkpoint: Histogram,
     pub remote_checkpoint_forks: IntCounter,
     pub split_brain_checkpoint_forks: IntCounter,
     pub last_created_checkpoint_age: Histogram,
@@ -117,6 +118,12 @@ impl CheckpointMetrics {
                 "checkpoint_creation_latency",
                 "Latency from consensus commit timestamp to local checkpoint creation in milliseconds",
                 iota_metrics::LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            commits_per_checkpoint: register_histogram_with_registry!(
+                "commits_per_checkpoint",
+                "Number of consensus commits coalesced into a single checkpoint",
+                vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
                 registry,
             ).unwrap(),
             remote_checkpoint_forks: register_int_counter_with_registry!(

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1193,6 +1193,7 @@ impl CheckpointBuilder {
             // Min interval has elapsed, we can now coalesce and build a checkpoint.
             last_height = Some(height);
             last_timestamp = Some(current_timestamp);
+            let commits_in_checkpoint = grouped_pending_checkpoints.len();
             debug!(
                 checkpoint_commit_height_from = grouped_pending_checkpoints
                     .first()
@@ -1208,6 +1209,11 @@ impl CheckpointBuilder {
                 .await
             {
                 Ok(seq) => {
+                    // Count only on success; a failed build retries the same
+                    // group and would otherwise double-count it.
+                    self.metrics
+                        .commits_per_checkpoint
+                        .observe(commits_in_checkpoint as f64);
                     // Advance the window anchor to the highest checkpoint just
                     // built (a single call may emit several when chunked).
                     last_seq = Some(seq);

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1114,14 +1114,21 @@ impl CheckpointBuilder {
             .epoch_store
             .last_built_checkpoint_builder_summary()
             .expect("epoch should not have ended");
-        let mut last_height = summary.clone().and_then(|s| s.checkpoint_height);
-        let mut last_timestamp = summary.map(|s| s.summary.timestamp_ms);
+        let mut last_height = summary.as_ref().and_then(|s| s.checkpoint_height);
+        let mut last_timestamp = summary.as_ref().map(|s| s.summary.timestamp_ms);
+        let mut last_seq = summary.map(|s| s.summary.sequence_number);
 
         let min_checkpoint_interval_ms = self
             .epoch_store
             .protocol_config()
             .min_checkpoint_interval_ms_as_option()
             .unwrap_or_default();
+        // When set, the interval may additionally be amortized over this many
+        // recent checkpoints of the current epoch.
+        let checkpoint_rate_window_size = self
+            .epoch_store
+            .protocol_config()
+            .checkpoint_rate_window_size_as_option();
         let mut grouped_pending_checkpoints = Vec::new();
         let mut checkpoints_iter = self
             .epoch_store
@@ -1130,17 +1137,44 @@ impl CheckpointBuilder {
             .into_iter()
             .peekable();
         while let Some((height, pending)) = checkpoints_iter.next() {
-            // Group PendingCheckpoints until:
-            // - minimum interval has elapsed ...
             let current_timestamp = pending.details().timestamp_ms;
-            let can_build = match last_timestamp {
+            // Strict interval against the immediately preceding checkpoint.
+            let adjacent_interval_elapsed = match last_timestamp {
                 Some(last_timestamp) => {
                     current_timestamp >= last_timestamp + min_checkpoint_interval_ms
                 }
                 None => true,
+            };
+            // Windowed arm: also allow building once the checkpoint `window`
+            // back is at least `window * interval` older. This recycles the
+            // slack the strict arm loses to discrete commit timestamps,
+            // holding the sustained rate at the ceiling, while the strict arm
+            // keeps every quiet gap — and thus checkpoint sizes — within one
+            // interval. Only checkpoints built in the current epoch are
+            // consulted: every validator builds all of them, so the look-back
+            // resolves identically everywhere and the gate stays
+            // deterministic. Until the window fills (epoch start, chain
+            // genesis) the arm is inert.
+            let interval_elapsed = adjacent_interval_elapsed
+                || checkpoint_rate_window_size.is_some_and(|window| {
+                    last_seq
+                        .and_then(|seq| (seq + 1).checked_sub(window))
+                        .and_then(|window_start_seq| {
+                            self.epoch_store
+                                .get_built_checkpoint_summary(window_start_seq)
+                                .expect("epoch store should not error reading a built checkpoint summary")
+                        })
+                        .is_some_and(|window_start| {
+                            current_timestamp
+                                >= window_start.timestamp_ms + window * min_checkpoint_interval_ms
+                        })
+                });
+            // Group PendingCheckpoints until:
+            // - the minimum interval has elapsed ...
+            let can_build = interval_elapsed
                 // - or, next PendingCheckpoint is last-of-epoch (since the last-of-epoch checkpoint
                 //   should be written separately) ...
-            } || checkpoints_iter
+                || checkpoints_iter
                 .peek()
                 .is_some_and(|(_, next_pending)| next_pending.details().last_of_epoch)
                 // - or, we have reached end of epoch.
@@ -1174,6 +1208,9 @@ impl CheckpointBuilder {
                 .await
             {
                 Ok(seq) => {
+                    // Advance the window anchor to the highest checkpoint just
+                    // built (a single call may emit several when chunked).
+                    last_seq = Some(seq);
                     self.last_built.send_if_modified(|cur| {
                         // when rebuilding checkpoints at startup, seq can be for an old checkpoint
                         if seq > *cur {
@@ -3038,6 +3075,8 @@ mod tests {
         let mut protocol_config =
             ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
         protocol_config.set_min_checkpoint_interval_ms_for_testing(100);
+        // This test exercises the strict adjacent-checkpoint interval.
+        protocol_config.disable_checkpoint_rate_window_size_for_testing();
         let state = TestAuthorityBuilder::new()
             .with_protocol_config(protocol_config)
             .build()
@@ -3296,6 +3335,170 @@ mod tests {
         let c2sc = certified_result.recv().await.unwrap();
         assert_eq!(c1sc.sequence_number, 0);
         assert_eq!(c2sc.sequence_number, 1);
+    }
+
+    #[sim_test]
+    pub async fn checkpoint_builder_windowed_interval_test() {
+        telemetry_subscribers::init_for_testing();
+
+        // 100ms interval with a window of 3 checkpoints: a checkpoint is built
+        // when either 100ms passed since the previous one or the checkpoint 3
+        // back is >= 300ms older. The windowed arm permits sub-interval bursts
+        // while banked budget lasts; the adjacent arm caps every quiet gap at
+        // one interval regardless of window state.
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+        protocol_config.set_min_checkpoint_interval_ms_for_testing(100);
+        protocol_config.set_checkpoint_rate_window_size_for_testing(3);
+        let state = TestAuthorityBuilder::new()
+            .with_protocol_config(protocol_config)
+            .build()
+            .await;
+
+        // Distinct real transactions: only build timing is under test, but the
+        // builder pairs each stored transaction with its effects by digest, so
+        // effects must reference the digests of actually stored transactions.
+        let make_tx = |seed: u8| {
+            let mut id = [0u8; 32];
+            id[0] = seed;
+            VerifiedTransaction::new_genesis_transaction(
+                vec![GenesisObject::new(
+                    ObjectData::Package(
+                        MovePackage::new(
+                            ObjectId::new(id),
+                            Version::default(),
+                            BTreeMap::from([(Identifier::new_unchecked("m"), vec![0u8; 1])]),
+                            100_000,
+                            // no modules so empty type_origin_table as no types are defined in
+                            // this package
+                            Vec::new(),
+                            // no modules so empty linkage_table as no dependencies of this package
+                            // exist
+                            BTreeMap::new(),
+                        )
+                        .unwrap(),
+                    ),
+                    Owner::Immutable,
+                )],
+                vec![],
+            )
+        };
+        let txns: Vec<_> = (1..=8).map(make_tx).collect();
+        let digests: Vec<TransactionDigest> = txns.iter().map(|tx| *tx.digest()).collect();
+        // Digest for test index `i` (1-based).
+        let d = |i: u8| digests[(i - 1) as usize];
+
+        for tx in &txns {
+            state
+                .database_for_testing()
+                .perpetual_tables
+                .transactions
+                .insert(tx.digest(), tx.serializable_ref())
+                .unwrap();
+        }
+
+        let mut store = HashMap::<TransactionDigest, TransactionEffects>::new();
+        for i in 1..=8 {
+            commit_cert_for_test(
+                &mut store,
+                state.clone(),
+                d(i),
+                vec![],
+                GasCostSummary::new(11, 11, 12, 11, 1),
+            );
+        }
+        let all_digests: Vec<_> = store.keys().copied().collect();
+        for digest in all_digests {
+            let signature = Signature::Ed25519IotaSignature(Default::default()).into();
+            state
+                .epoch_store_for_testing()
+                .test_insert_user_signature(digest, vec![signature]);
+        }
+
+        let (output, mut result) = mpsc::channel::<(CheckpointContents, CheckpointSummary)>(10);
+        let (certified_output, _certified_result) = mpsc::channel::<CertifiedCheckpointSummary>(10);
+        let store = Arc::new(store);
+
+        let tmp_dir = iota_common::tempdir();
+        let checkpoint_store = CheckpointStore::new(tmp_dir.path());
+        let epoch_store = state.epoch_store_for_testing();
+
+        let global_state_hasher = Arc::new(GlobalStateHasher::new_for_tests(
+            state.get_global_state_hash_store().clone(),
+        ));
+
+        let checkpoint_service = CheckpointService::build(
+            state.clone(),
+            checkpoint_store,
+            epoch_store.clone(),
+            store,
+            Arc::downgrade(&global_state_hasher),
+            Box::new(output),
+            Box::new(certified_output),
+            CheckpointMetrics::new_for_tests(),
+            3,
+            100_000,
+        );
+        let _tasks = checkpoint_service.spawn(None).await;
+
+        // The windowed arm is inert until 3 checkpoints exist; the first three
+        // build via the adjacent arm, which their spread-out timestamps
+        // (0, 1000, 2000) satisfy while accruing burst budget.
+        // window_ms = 3 * 100 = 300.
+        for (height, root, timestamp_ms) in [(0, 1u8, 0), (1, 2, 1000), (2, 3, 2000)] {
+            checkpoint_service
+                .write_and_notify_checkpoint_for_testing(
+                    &epoch_store,
+                    p(height, vec![d(root)], timestamp_ms),
+                )
+                .unwrap();
+        }
+        // p3 @ 2010: adjacent red (< C2 + 100 = 2100) but windowed green
+        // (>= C0(0) + 300) -> builds, only 10ms after C2. A strict adjacent
+        // rule would instead coalesce it.
+        checkpoint_service
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(3, vec![d(4)], 2010))
+            .unwrap();
+        // p4 @ 2020: windowed green (>= C1(1000) + 300) -> builds, another
+        // sub-interval burst.
+        checkpoint_service
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(4, vec![d(5)], 2020))
+            .unwrap();
+        // Budget now spent: the window covers the tight 2000-2020 cluster.
+        // p5 @ 2030: adjacent red (< C4 + 100 = 2120), windowed red
+        // (< C2(2000) + 300 = 2300) -> coalesced.
+        checkpoint_service
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(5, vec![d(6)], 2030))
+            .unwrap();
+        // p6 @ 2130: windowed still red (< 2300), but adjacent green
+        // (>= 2120) -> builds, coalescing p5 and p6. A window-only gate would
+        // keep coalescing until 2300; the adjacent arm caps the gap.
+        checkpoint_service
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(6, vec![d(7)], 2130))
+            .unwrap();
+        // p7 @ 2300: windowed red (< C3(2010) + 300 = 2310), adjacent green
+        // (>= C5 + 100 = 2230) -> builds.
+        checkpoint_service
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(7, vec![d(8)], 2300))
+            .unwrap();
+
+        let mut built = Vec::new();
+        for _ in 0..7 {
+            let (contents, summary) = result.recv().await.unwrap();
+            built.push((summary.sequence_number, contents.iter().count()));
+        }
+
+        // Seven checkpoints, contiguous sequence numbers.
+        let sequence_numbers: Vec<_> = built.iter().map(|(seq, _)| *seq).collect();
+        assert_eq!(sequence_numbers, vec![0, 1, 2, 3, 4, 5, 6]);
+        // Bursts (seq 3, 4) stand alone despite sub-interval spacing; once the
+        // budget is spent, pendings coalesce only until the adjacent interval
+        // elapses (seq 5), never longer. A strict adjacent rule would build
+        // [0,1,2] and then coalesce the whole 2010-2130 cluster into one
+        // checkpoint; a window-only rule would coalesce p5-p7 into one
+        // checkpoint at 2300.
+        let sizes: Vec<_> = built.iter().map(|(_, size)| *size).collect();
+        assert_eq!(sizes, vec![1, 1, 1, 1, 1, 2, 1]);
     }
 
     impl TransactionCacheRead for HashMap<TransactionDigest, TransactionEffects> {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1480,6 +1480,9 @@
                 },
                 "check_zklogin_id_cost_base": null,
                 "check_zklogin_issuer_cost_base": null,
+                "checkpoint_rate_window_size": {
+                  "u64": "20"
+                },
                 "checkpoint_summary_version_specific_data": {
                   "u64": "1"
                 },

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -176,6 +176,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 // Version 31: Rebuild the framework binaries for the latest iota_system
 //             validator set changes.
 //             Enable validator metadata verification v2.
+//             Amortize the minimum checkpoint interval over a sliding window
+//             on non-Mainnet/Testnet chains.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -1342,6 +1344,17 @@ pub struct ProtocolConfig {
     /// Minimum interval of commit timestamps between consecutive checkpoints.
     min_checkpoint_interval_ms: Option<u64>,
 
+    /// Number of recent checkpoints over which `min_checkpoint_interval_ms`
+    /// may be amortized. When set, a checkpoint is built once the full
+    /// interval elapsed since the previous checkpoint, or once the checkpoint
+    /// this many back in the current epoch is at least that many intervals
+    /// older. The windowed arm recycles the slack that discrete commit
+    /// timestamps add to the strict arm, holding the sustained rate at the
+    /// ceiling, while the strict arm keeps quiet gaps within one interval.
+    /// The window does not cross epoch boundaries; before it fills — and
+    /// always when unset — only the strict adjacent check applies.
+    checkpoint_rate_window_size: Option<u64>,
+
     /// Version number to use for version_specific_data in `CheckpointSummary`.
     checkpoint_summary_version_specific_data: Option<u64>,
 
@@ -2384,6 +2397,8 @@ impl ProtocolConfig {
 
             min_checkpoint_interval_ms: Some(200),
 
+            checkpoint_rate_window_size: None,
+
             checkpoint_summary_version_specific_data: Some(1),
 
             max_soft_bundle_size: Some(5),
@@ -2977,6 +2992,13 @@ impl ProtocolConfig {
                 }
                 31 => {
                     cfg.feature_flags.validator_metadata_verify_v2 = true;
+
+                    // Amortize the minimum checkpoint interval over a sliding
+                    // window so the checkpoint rate holds at the ceiling.
+                    // Enabled on non-Mainnet/Testnet chains only for now.
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        cfg.checkpoint_rate_window_size = Some(20);
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_31.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_31.snap
@@ -330,6 +330,7 @@ consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
 max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
+checkpoint_rate_window_size: 20
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -662,7 +662,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 6
       },
@@ -1189,9 +1189,9 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
+        "x": 12,
         "w": 12,
-        "y": 30,
+        "y": 6,
         "h": 8
       },
       "id": 318,
@@ -1632,7 +1632,7 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
+        "x": 0,
         "y": 30
       },
       "id": 325,
@@ -1676,6 +1676,92 @@
       ],
       "title": "Checkpoint TPS",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Distribution of the number of consensus commits coalesced into each checkpoint (`commits_per_checkpoint`). Each cell shows the rate of checkpoints whose commit count fell in the bucket on the Y axis. Buckets are 1..10 with a +Inf overflow (10+). At ~20 commits/s against the ~5 checkpoints/s cap, most checkpoints coalesce 3-5 commits (average ~4); a bimodal spread \u2014 many single-commit checkpoints plus a tail toward 10+ \u2014 indicates clustering.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 418,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "11.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(le) (rate(commits_per_checkpoint_bucket[5m]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Commits per checkpoint",
+      "type": "heatmap"
     },
     {
       "datasource": {


### PR DESCRIPTION
# Description of change

Checkpoint creation rate regressed after sliding-window block creation (#11790) raised the block/commit rate: block rate rose to the 20 b/s ceiling but checkpoint rate fell (~4.85 → ~4.25 c/s, worst on large committees).

`min_checkpoint_interval_ms = 200` caps the checkpoint rate to bound the storage and bandwidth cost of creating, certifying, and syncing checkpoints; the rate also drives end-to-end latency for consumers that wait on verified checkpoints. This PR keeps the same ~5 c/s asymptotic cap while restoring the rate to it under the relaxed block-creation rules.

## Root cause

`maybe_build_checkpoints` gated each checkpoint on the previous one, then advanced the anchor to the *actual* triggering commit timestamp:

```
build when  current_commit_ts >= last_checkpoint_ts + min_checkpoint_interval_ms
then        last_checkpoint_ts = current_commit_ts
```

Commit timestamps are discrete, so the trigger overshoots the deadline every time. Anchoring on the actual timestamp makes every checkpoint pay that overshoot, pushing sustained spacing above `interval` — worse as higher block rates coarsen the timestamp grid.

## Fix

Keep the strict adjacent check and add a windowed one; checkpoint `k` builds when **either** holds:

```
adjacent:  current_commit_ts >= timestamp(checkpoint k−1) + interval
windowed:  current_commit_ts >= timestamp(checkpoint k−N) + N * interval
```

The windowed arm amortizes the overshoot over `N` checkpoints (paid once per window, not per checkpoint), restoring the rate to the ceiling; the adjacent arm keeps every gap — hence every coalesced checkpoint — within one interval, avoiding the burst-then-jumbo clustering a window-only rule drifts into. Both arms consume ≥ one interval of commit time per checkpoint, so the sustained ~5 c/s cap is preserved. `N` is the new protocol parameter `checkpoint_rate_window_size`.

## Determinism

Checkpoint boundaries must be identical on every validator or checkpoints cannot be certified. The gate reads only deterministic data: commit timestamps and this epoch's already-built checkpoint timestamps, from the per-epoch builder summaries (`get_built_checkpoint_summary`). Every validator builds every checkpoint of its epoch, so the look-back resolves to the same summary everywhere — or to none, exactly when it would cross the epoch start (windowed arm inert). No wall-clock, no per-node or cross-epoch state.

## Rollout

`checkpoint_rate_window_size` is set to `20` at **protocol version 31, devnet only** (non-Mainnet/Testnet); unset at versions ≤ 30 and on Mainnet/Testnet, preserving the strict adjacent behavior. It takes effect at the next epoch boundary that upgrades a network to v31.

## Observability

New `commits_per_checkpoint` histogram (commits coalesced per checkpoint, buckets 1–10 plus 10+) surfaced as a "Commits per checkpoint" heatmap on the Starfish dashboard; under load a checkpoint typically holds 3–5 commits (average ~4).

## Validation

Tested on local multi-validator deployments under varying network conditions: the sustained checkpoint rate rose from ~4.2 to ~4.95 c/s, matching the predicted ceiling.
<img width="920" height="613" alt="image" src="https://github.com/user-attachments/assets/6015b813-6885-450d-8e39-317a146dc540" />



## Links to any relevant issues

Fixes #12106

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Adds a new protocol parameter `checkpoint_rate_window_size`, enabled on devnet, which amortizes the minimum checkpoint interval over a sliding window of checkpoints so the sustained checkpoint rate holds at its ceiling instead of sagging.
