### PR TITLE
refactor(consensus): skip V2 vote scoring on sliding-window path

### DIFF
--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -142,6 +142,16 @@ impl ScoringSubdag {
             .scope_processing_time
             .with_label_values(&["ScoringSubdag::add_unscored_committed_subdags"])
             .start_timer();
+
+        // The vote traversal below feeds only the V2 boundary score computation;
+        // the sliding-window path scores from its running window aggregate
+        // instead. There only `commit_range` is needed (it drives rotation
+        // timing), so skip the per-commit traversal.
+        let sliding_window_enabled = self
+            .context
+            .protocol_config
+            .consensus_enable_sliding_window_leader_schedule();
+
         for subdag in committed_subdags {
             if let Some(commit_range) = self.commit_range.as_mut() {
                 commit_range.extend_to(subdag.commit_ref.index);
@@ -152,6 +162,11 @@ impl ScoringSubdag {
                     subdag.commit_ref.index..=subdag.commit_ref.index,
                 ));
             }
+
+            if sliding_window_enabled {
+                continue;
+            }
+
             // Add the committed leader to the list of leaders we will be scoring.
             tracing::trace!("Adding new committed leader {} for scoring", subdag.leader);
             self.leaders.insert(subdag.leader);
@@ -544,5 +559,34 @@ mod tests {
             scores, expected,
             "equivocating certifier's stake must be counted once, not per block"
         );
+    }
+
+    #[tokio::test]
+    async fn test_add_subdags_skips_vote_scoring_when_sliding_window_enabled() {
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+
+        // A fully-connected DAG that would produce non-zero votes on the V2 path.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=4).build();
+
+        let mut scoring_subdag = ScoringSubdag::new(context);
+        for (sub_dag, _commit) in dag_builder.get_sub_dag_and_commits(1..=4) {
+            scoring_subdag.add_subdags(vec![sub_dag.base]);
+        }
+
+        // The commit range is still maintained — it is what drives rotation
+        // timing (`scored_subdags_count` / `is_empty`) on the sliding-window path.
+        assert_eq!(scoring_subdag.scored_subdags_count(), 4);
+        assert_eq!(scoring_subdag.commit_range, Some(CommitRange::new(1..=4)));
+        assert!(!scoring_subdag.is_empty());
+
+        // But the per-commit vote traversal was skipped: no leaders or votes
+        // accumulated, so the V2 boundary score computation is never fed.
+        assert!(scoring_subdag.leaders.is_empty());
+        assert!(scoring_subdag.votes.is_empty());
     }
 }


### PR DESCRIPTION
# Description of change

When the sliding-window leader schedule is enabled, reputation scores are sourced from the running window aggregate, so `ScoringSubdag`'s per-commit vote traversal is never read — yet it still runs on every commit alongside the sliding-window scorer.

This gates that traversal behind the flag, inside `add_subdags`, keeping only the `commit_range` update that drives rotation timing (`scored_subdags_count` / `is_empty`). The gate lives in the function rather than at a call site, so it covers the commit path, recovery rebuild, and construction uniformly. The V2 path is unchanged.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
