### PR TITLE
feat(release-notes): report earliest epoch a new protocol version can be enabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,17 @@ jobs:
           trl=$(echo "$iota_tag" | sed -n 's/^[^-]*\(-.*\)/\1/p')
           echo "trl = $trl"
 
+          # Map the tag suffix to the network this release targets, so the notes
+          # can report the earliest epoch at which the new protocol version can
+          # be enabled on that network.
+          case "$iota_tag" in
+            *-alpha*) network=alphanet ;;
+            *-beta*)  network=devnet ;;
+            *-rc*)    network=testnet ;;
+            *)        network=mainnet ;;
+          esac
+          echo "network = $network"
+
           current_minor=$(echo "$iota_tag" | sed -E 's/^v[0-9]+\.([0-9]+)\..*/\1/')
           current_major=$(echo "$iota_tag" | sed -E 's/^v([0-9]+)\..*/\1/')
           previous_minor=$((current_minor - 1))
@@ -242,7 +253,7 @@ jobs:
           echo "Previous commit hash: $previous_commit_hash"
 
           pushd "scripts/release_notes" > /dev/null
-          ./run.sh generate $previous_commit_hash $new_commit_hash | tee -a "../../${{ env.RELEASE_NOTES_FILE }}" > /dev/null
+          ./run.sh generate $previous_commit_hash $new_commit_hash --network "$network" | tee -a "../../${{ env.RELEASE_NOTES_FILE }}" > /dev/null
           popd > /dev/null
           echo "---" >> ${{ env.RELEASE_NOTES_FILE }}
           echo "#### Full Log: https://github.com/iotaledger/iota/compare/$previous_tag...${{ needs.generate-tag.outputs.iota_ref }}" >> ${{ env.RELEASE_NOTES_FILE }}

--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import datetime
 from collections import defaultdict
 import json
 import os
@@ -11,6 +12,7 @@ import re
 import subprocess
 import sys
 from typing import NamedTuple
+import urllib.error
 import urllib.request
 
 GH_TOKEN = os.environ.get("GH_TOKEN")
@@ -80,6 +82,14 @@ RE_ROLLOUT_ACTION_LINE = re.compile(
 )
 
 ROLLOUT_NETWORKS = ("devnet", "testnet", "mainnet")
+
+# Networks a release can target, keyed off the release tag suffix in
+# release.yml (alpha/beta/rc/none). Used to look up the network's current epoch.
+UPGRADE_NETWORKS = ("alphanet", "devnet", "testnet", "mainnet")
+
+# Public JSON-RPC endpoint of a network's fullnode, used to look up the current
+# epoch when reporting the earliest time a new protocol version can be enabled.
+IOTA_RPC_URL_TEMPLATE = "https://api.{network}.iota.cafe"
 
 # Only commits that affect changes in these directories will be
 # considered when generating release notes.
@@ -187,6 +197,17 @@ def parse_args():
         help="The commit to end at (inclusive), defaults to HEAD.",
     )
 
+    generate_p.add_argument(
+        "--network",
+        choices=UPGRADE_NETWORKS,
+        default=None,
+        help=(
+            "Target network of this release. When a new protocol version is "
+            "introduced, the network's fullnode is queried to report the "
+            "earliest epoch at which the version can be enabled."
+        ),
+    )
+
     test_p = sub_parser.add_parser(
         "dry-run",
         description="Generate release notes from local git commits without PR lookup.",
@@ -202,6 +223,17 @@ def parse_args():
         nargs="?",
         default="HEAD",
         help="The commit to end at (inclusive), defaults to HEAD.",
+    )
+
+    test_p.add_argument(
+        "--network",
+        choices=UPGRADE_NETWORKS,
+        default=None,
+        help=(
+            "Target network of this release. When a new protocol version is "
+            "introduced, the network's fullnode is queried to report the "
+            "earliest epoch at which the version can be enabled."
+        ),
     )
 
     check_p = sub_parser.add_parser(
@@ -482,6 +514,59 @@ def extract_protocol_version(commit):
         return match[0]
 
 
+def earliest_protocol_upgrade(network):
+    """Earliest epoch and time at which `network` can enable a new protocol version.
+
+    A protocol version can be enabled no earlier than the next epoch boundary,
+    i.e. the end of the current epoch (`epoch_start_timestamp_ms +
+    epoch_duration_ms`). The current epoch is read from the network's public
+    fullnode.
+
+    Returns a `(next_epoch, "YYYY-MM-DD HH:MM UTC")` tuple, or `None` if the
+    network could not be reached or returned unexpected data, in which case the
+    caller omits the date rather than failing the whole run.
+    """
+    url = IOTA_RPC_URL_TEMPLATE.format(network=network)
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "iotax_getLatestIotaSystemStateV2",
+            "params": [],
+        }
+    ).encode()
+    req = urllib.request.Request(
+        url, data=payload, headers={"Content-Type": "application/json"}
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            result = json.load(response)["result"]
+
+        # `getLatestIotaSystemStateV2` returns an externally-tagged enum, e.g.
+        # `{"V2": {...}}`; unwrap the single variant to reach the summary fields.
+        summary = (
+            next(iter(result.values())) if set(result) <= {"V1", "V2"} else result
+        )
+
+        next_epoch = int(summary["epoch"]) + 1
+        boundary_ms = int(summary["epochStartTimestampMs"]) + int(
+            summary["epochDurationMs"]
+        )
+    except (urllib.error.URLError, TimeoutError, ValueError, KeyError, TypeError) as exc:
+        print(
+            f"Warning: could not determine the earliest protocol upgrade time "
+            f"for '{network}': {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+    when = datetime.datetime.fromtimestamp(
+        boundary_ms / 1000, tz=datetime.timezone.utc
+    ).strftime("%Y-%m-%d %H:%M UTC")
+    return next_epoch, when
+
+
 def print_changelog(pr, log, commit=None, is_dry_run=False):
     if pr:
         print(f"[#{pr}](https://github.com/iotaledger/iota/pull/{pr}): ", end="")
@@ -558,7 +643,7 @@ def do_check(commit_or_pr, is_pr):
     sys.exit(1)
 
 
-def do_generate(from_, to, is_dry_run):
+def do_generate(from_, to, is_dry_run, network=None):
     """Generate release notes from git commits.
 
     This will extract the release notes from all commits between
@@ -569,7 +654,9 @@ def do_generate(from_, to, is_dry_run):
     Only looks for commits affecting INTERESTING_DIRECTORIES.
 
     Additionally injects the current protocol version into the
-    "Protocol" changelog.
+    "Protocol" changelog. When `network` is given and the release
+    introduces a new protocol version, also reports the earliest epoch
+    at which that network can enable it, read from its fullnode.
 
     """
     results = defaultdict(list)
@@ -623,6 +710,13 @@ def do_generate(from_, to, is_dry_run):
                 print(f"\n#### This release does not introduce a new protocol version (current version: `{protocol_version_to}`)")
             else:
                 print(f"\n#### This release introduces protocol version `{protocol_version_to}`")
+                upgrade = earliest_protocol_upgrade(network) if network else None
+                if upgrade:
+                    next_epoch, when = upgrade
+                    print(
+                        f"\nOn `{network}`, this protocol version can be enabled no "
+                        f"earlier than `{when}` (start of epoch {next_epoch})."
+                    )
         print()
 
         if notes:
@@ -655,9 +749,9 @@ def do_generate(from_, to, is_dry_run):
 
 args = parse_args()
 if args["command"] == "generate":
-    do_generate(args["from"], args["to"], False)
+    do_generate(args["from"], args["to"], False, args["network"])
 if args["command"] == "dry-run":
-    do_generate(args["from"], args["to"], True)
+    do_generate(args["from"], args["to"], True, args["network"])
 elif args["command"] == "check":
     do_check(args["commit"], False)
 elif args["command"] == "check-pr":


### PR DESCRIPTION
# Description of change

When a release introduces a new protocol version, the release notes now report the earliest epoch — and its UTC time — at which that version can actually be enabled on the target network. Previously the notes only stated that a new protocol version was introduced, leaving readers to guess *when* it could take effect.

The generator learns the target network from a new `--network` argument. `release.yml` derives it from the release tag suffix (`-alpha` → `alphanet`, `-beta` → `devnet`, `-rc` → `testnet`, otherwise `mainnet`) and passes it to `run.sh generate`. When a new protocol version is present, `release_notes.py` queries that network's public fullnode (`iotax_getLatestIotaSystemStateV2`) for the current epoch and computes the next epoch boundary from `epochStartTimestampMs + epochDurationMs`. If the fullnode is unreachable or returns unexpected data, it logs a warning and omits the line rather than failing the release run.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Verified that the script parses cleanly and that `--network` accepts exactly `{alphanet, devnet, testnet, mainnet}` via `generate --help` / `dry-run --help`. The network lookup and date formatting have not yet been exercised against a live fullnode as part of a full release run.

Regenerating the exact same release notes of https://github.com/iotaledger/iota/releases/tag/v1.26.1 produced the following:
```
## Protocol

#### This release introduces protocol version `29`

On `mainnet`, this protocol version can be enabled no earlier than `2026-07-03 07:41 UTC` (start of epoch 424).
```