### PR TITLE
fix(iota-core, iota-node): make transaction orchestrator driver accessors P-COOL-safe

### DIFF
--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -75,16 +75,22 @@ const LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 const WAIT_FOR_FINALITY_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// The submission flow used to drive transactions to finality. Exactly one
+/// flow is active, selected by the P-COOL protocol flag at construction
+/// time.
+enum Driver<A: Clone> {
+    /// Certificate-based flow (P-COOL disabled).
+    Quorum(Arc<QuorumDriverHandler<A>>),
+    /// Direct-to-consensus P-COOL flow.
+    Transaction(Arc<TransactionDriver<A>>),
+}
+
 /// Transaction Orchestrator is a Node component that supports both QuorumDriver
 /// and TransactionDriver for submitting transactions to validators for
 /// finality. It adds inflight deduplication, waiting for local execution,
 /// recovery, and epoch change handling.
 pub struct TransactionOrchestrator<A: Clone> {
-    // QuorumDriverHandler for the normal flow. Always present if P-COOL flow is disabled, and
-    // None if P-COOL flow is enabled.
-    quorum_driver_handler: Option<Arc<QuorumDriverHandler<A>>>,
-    /// Optional TransactionDriver for the P-COOL direct-to-consensus flow.
-    transaction_driver: Option<Arc<TransactionDriver<A>>>,
+    driver: Driver<A>,
     validator_state: Arc<AuthorityState>,
     _local_executor_handle: Option<JoinHandle<()>>,
     pending_tx_log: Arc<WritePathPendingTransactionLog>,
@@ -161,71 +167,53 @@ where
         let epoch_store = validator_state.load_epoch_store_one_call_per_task();
         let use_transaction_driver = epoch_store.protocol_config().enable_pcool_flow();
 
-        let qd_metrics = Arc::new(QuorumDriverMetrics::new(prometheus_registry));
         let notifier = Arc::new(NotifyRead::new());
-
-        // Create QuorumDriver only if P-COOL is NOT enabled
-        let (quorum_driver_handler, effects_receiver) = if !use_transaction_driver {
-            let reconfig_observer = Arc::new(
-                reconfig_observer
-                    .expect("QuorumDriver reconfig observer required when P-COOL is disabled"),
-            );
-            let handler = Arc::new(
-                QuorumDriverHandlerBuilder::new(validators.clone(), qd_metrics)
-                    .with_notifier(notifier.clone())
-                    .with_reconfig_observer(reconfig_observer)
-                    .start(),
-            );
-            let receiver = handler.subscribe_to_effects();
-            (Some(handler), Some(receiver))
-        } else {
-            (None, None)
-        };
-
-        // Create TransactionDriver only if P-COOL is enabled
-        let transaction_driver = if use_transaction_driver {
-            let td_metrics = Arc::new(TransactionDriverMetrics::new(prometheus_registry));
-            let client_metrics = Arc::new(ValidatorClientMetrics::new(prometheus_registry));
-            let observer = td_reconfig_observer
-                .expect("TransactionDriver reconfig observer required when P-COOL is enabled");
-            Some(TransactionDriver::new(
-                validators,
-                Arc::new(observer),
-                td_metrics,
-                node_config,
-                client_metrics,
-            ))
-        } else {
-            None
-        };
-
         let metrics = Arc::new(TransactionOrchestratorMetrics::new(prometheus_registry));
         let pending_tx_log = Arc::new(WritePathPendingTransactionLog::new(
             parent_path.join("fullnode_pending_transactions"),
         ));
 
-        // Start pending transaction log cleanup only if QuorumDriver is used
-        let _local_executor_handle =
-            if let (Some(handler), Some(receiver)) = (&quorum_driver_handler, effects_receiver) {
-                let pending_tx_log_clone = pending_tx_log.clone();
-                let res = Some(spawn_monitored_task!(async move {
-                    Self::loop_pending_transaction_log(receiver, pending_tx_log_clone).await;
-                }));
-
-                // Schedule pending transaction recovery (QuorumDriver mode only;
-                // TransactionDriver does not track pending certificates)
-                Self::schedule_txes_in_log(pending_tx_log.clone(), handler.clone());
-
-                res
-            } else {
-                // TransactionDriver mode: no pending tx log cleanup needed
-                // (transactions go directly to consensus, no certificate tracking)
-                None
-            };
+        let (driver, _local_executor_handle) = if !use_transaction_driver {
+            let qd_metrics = Arc::new(QuorumDriverMetrics::new(prometheus_registry));
+            let reconfig_observer = Arc::new(
+                reconfig_observer
+                    .expect("QuorumDriver reconfig observer required when P-COOL is disabled"),
+            );
+            let handler = Arc::new(
+                QuorumDriverHandlerBuilder::new(validators, qd_metrics)
+                    .with_notifier(notifier.clone())
+                    .with_reconfig_observer(reconfig_observer)
+                    .start(),
+            );
+            let effects_receiver = handler.subscribe_to_effects();
+            let pending_tx_log_clone = pending_tx_log.clone();
+            let local_executor_handle = spawn_monitored_task!(async move {
+                Self::loop_pending_transaction_log(effects_receiver, pending_tx_log_clone).await;
+            });
+            // Pending-transaction recovery is QuorumDriver-only; the
+            // TransactionDriver goes directly to consensus and tracks no
+            // pending certificates.
+            Self::schedule_txes_in_log(pending_tx_log.clone(), handler.clone());
+            (Driver::Quorum(handler), Some(local_executor_handle))
+        } else {
+            let td_metrics = Arc::new(TransactionDriverMetrics::new(prometheus_registry));
+            let client_metrics = Arc::new(ValidatorClientMetrics::new(prometheus_registry));
+            let observer = td_reconfig_observer
+                .expect("TransactionDriver reconfig observer required when P-COOL is enabled");
+            (
+                Driver::Transaction(TransactionDriver::new(
+                    validators,
+                    Arc::new(observer),
+                    td_metrics,
+                    node_config,
+                    client_metrics,
+                )),
+                None,
+            )
+        };
 
         Self {
-            quorum_driver_handler,
-            transaction_driver,
+            driver,
             validator_state,
             _local_executor_handle,
             pending_tx_log,
@@ -272,12 +260,12 @@ where
         );
         let tx_digest = *transaction.digest();
 
-        let (mut response, seq) = match (&self.transaction_driver, wait_for_local_execution) {
-            (Some(td), true) => {
+        let (mut response, seq) = match (&self.driver, wait_for_local_execution) {
+            (Driver::Transaction(td), true) => {
                 self.submit_with_checkpoint_race(td.clone(), request, client_addr, tx_digest)
                     .await?
             }
-            (Some(td), false) => (
+            (Driver::Transaction(td), false) => (
                 Some(
                     self.submit_with_transaction_driver(td.clone(), request, client_addr, false)
                         .await
@@ -285,9 +273,9 @@ where
                 ),
                 None,
             ),
-            (None, _) => {
+            (Driver::Quorum(qd), _) => {
                 let (_, qd_resp) = self
-                    .execute_transaction_impl(&epoch_store, request, client_addr)
+                    .execute_transaction_impl(qd, &epoch_store, request, client_addr)
                     .await?;
                 (Some(quorum_driver_response_to_v1(qd_resp)), None)
             }
@@ -516,27 +504,30 @@ where
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
         let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
 
-        if let Some(td) = &self.transaction_driver {
-            // v1 does not do an internal wait; callers (e.g. the gRPC
-            // execution service) are responsible for their own
-            // `wait_for_checkpoint_inclusion` when they need it, and will
-            // reconcile the response from the cache there.
-            epoch_store
-                .verify_transaction(request.transaction.clone())
-                .map_err(QuorumDriverError::InvalidUserSignature)?;
-            return self
-                .submit_with_transaction_driver(
-                    td.clone(),
-                    request,
-                    client_addr,
-                    skip_certification,
-                )
-                .await
-                .map_err(map_td_error_to_qd);
-        }
+        let qd = match &self.driver {
+            Driver::Transaction(td) => {
+                // v1 does not do an internal wait; callers (e.g. the gRPC
+                // execution service) are responsible for their own
+                // `wait_for_checkpoint_inclusion` when they need it, and will
+                // reconcile the response from the cache there.
+                epoch_store
+                    .verify_transaction(request.transaction.clone())
+                    .map_err(QuorumDriverError::InvalidUserSignature)?;
+                return self
+                    .submit_with_transaction_driver(
+                        td.clone(),
+                        request,
+                        client_addr,
+                        skip_certification,
+                    )
+                    .await
+                    .map_err(map_td_error_to_qd);
+            }
+            Driver::Quorum(qd) => qd,
+        };
 
         let qd_resp = self
-            .execute_transaction_impl(&epoch_store, request, client_addr)
+            .execute_transaction_impl(qd, &epoch_store, request, client_addr)
             .await
             .map(|(_, r)| r)?;
 
@@ -688,8 +679,9 @@ where
     // Note: since EffectsCert is not stored today, we need to gather that from
     // validators (and maybe store it for caching purposes)
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.transaction.digest()))]
-    pub async fn execute_transaction_impl(
+    async fn execute_transaction_impl(
         &self,
+        quorum_driver: &Arc<QuorumDriverHandler<A>>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
@@ -732,6 +724,7 @@ where
 
         let ticket = self
             .submit(
+                quorum_driver,
                 epoch_store.clone(),
                 transaction.clone(),
                 request,
@@ -772,6 +765,7 @@ where
     #[instrument(name = "tx_orchestrator_submit", level = "trace", skip_all)]
     async fn submit(
         &self,
+        quorum_driver: &Arc<QuorumDriverHandler<A>>,
         epoch_store: Arc<AuthorityPerEpochStore>,
         transaction: VerifiedTransaction,
         request: ExecuteTransactionRequestV1,
@@ -787,7 +781,7 @@ where
             .await?
         {
             debug!(?tx_digest, "no pending request in flight, submitting.");
-            self.quorum_driver()
+            quorum_driver
                 .submit_transaction_no_ticket(request.clone(), client_addr)
                 .await?;
         }
@@ -797,7 +791,7 @@ where
         // want to ask quorum driver to form a certificate for us again, to
         // serve this request.
         let cache_reader = self.validator_state.get_transaction_cache_reader().clone();
-        let qd = self.clone_quorum_driver();
+        let qd = quorum_driver.clone();
         Ok(async move {
             let digests = [tx_digest];
             let effects_await = epoch_store
@@ -911,38 +905,39 @@ where
         }
     }
 
-    pub fn quorum_driver(&self) -> &Arc<QuorumDriverHandler<A>> {
-        self.quorum_driver_handler
-            .as_ref()
-            .expect("QuorumDriverHandler is not initialized.")
+    /// Returns the quorum driver, or `None` under the P-COOL flow.
+    pub fn quorum_driver(&self) -> Option<&Arc<QuorumDriverHandler<A>>> {
+        match &self.driver {
+            Driver::Quorum(handler) => Some(handler),
+            Driver::Transaction(_) => None,
+        }
     }
 
-    pub fn clone_quorum_driver(&self) -> Arc<QuorumDriverHandler<A>> {
-        self.quorum_driver_handler
-            .clone()
-            .expect("QuorumDriverHandler is not initialized.")
+    /// Returns the quorum driver, or `None` under the P-COOL flow.
+    pub fn clone_quorum_driver(&self) -> Option<Arc<QuorumDriverHandler<A>>> {
+        self.quorum_driver().cloned()
     }
 
+    /// Returns the transaction driver, or `None` when the P-COOL flow is
+    /// disabled.
     pub fn transaction_driver(&self) -> Option<&Arc<TransactionDriver<A>>> {
-        self.transaction_driver.as_ref()
+        match &self.driver {
+            Driver::Quorum(_) => None,
+            Driver::Transaction(td) => Some(td),
+        }
     }
 
+    /// Returns the authority aggregator of the active driver.
     pub fn clone_authority_aggregator(&self) -> Arc<AuthorityAggregator<A>> {
-        // Under P-COOL the quorum driver is absent and the aggregator lives
-        // on the transaction driver instead.
-        if let Some(td) = &self.transaction_driver {
-            td.authority_aggregator().load_full()
-        } else {
-            self.quorum_driver().authority_aggregator().load_full()
+        match &self.driver {
+            Driver::Quorum(qd) => qd.authority_aggregator().load_full(),
+            Driver::Transaction(td) => td.authority_aggregator().load_full(),
         }
     }
 
-    pub fn subscribe_to_effects_queue(&self) -> Receiver<QuorumDriverEffectsQueueResult> {
-        if let Some(handler) = &self.quorum_driver_handler {
-            handler.subscribe_to_effects()
-        } else {
-            panic!("QuorumDriverHandler is not initialized, cannot subscribe to effects queue.");
-        }
+    /// Returns `None` under the P-COOL flow, which has no effects broadcast.
+    pub fn subscribe_to_effects_queue(&self) -> Option<Receiver<QuorumDriverEffectsQueueResult>> {
+        self.quorum_driver().map(|qd| qd.subscribe_to_effects())
     }
 
     fn update_metrics(

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -928,7 +928,13 @@ where
     }
 
     pub fn clone_authority_aggregator(&self) -> Arc<AuthorityAggregator<A>> {
-        self.quorum_driver().authority_aggregator().load_full()
+        // Under P-COOL the quorum driver is absent and the aggregator lives
+        // on the transaction driver instead.
+        if let Some(td) = &self.transaction_driver {
+            td.authority_aggregator().load_full()
+        } else {
+            self.quorum_driver().authority_aggregator().load_full()
+        }
     }
 
     pub fn subscribe_to_effects_queue(&self) -> Receiver<QuorumDriverEffectsQueueResult> {

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -504,7 +504,7 @@ where
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
         let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
 
-        let qd = match &self.driver {
+        match &self.driver {
             Driver::Transaction(td) => {
                 // v1 does not do an internal wait; callers (e.g. the gRPC
                 // execution service) are responsible for their own
@@ -513,25 +513,23 @@ where
                 epoch_store
                     .verify_transaction(request.transaction.clone())
                     .map_err(QuorumDriverError::InvalidUserSignature)?;
-                return self
-                    .submit_with_transaction_driver(
-                        td.clone(),
-                        request,
-                        client_addr,
-                        skip_certification,
-                    )
-                    .await
-                    .map_err(map_td_error_to_qd);
+                self.submit_with_transaction_driver(
+                    td.clone(),
+                    request,
+                    client_addr,
+                    skip_certification,
+                )
+                .await
+                .map_err(map_td_error_to_qd)
             }
-            Driver::Quorum(qd) => qd,
-        };
-
-        let qd_resp = self
-            .execute_transaction_impl(qd, &epoch_store, request, client_addr)
-            .await
-            .map(|(_, r)| r)?;
-
-        Ok(quorum_driver_response_to_v1(qd_resp))
+            Driver::Quorum(qd) => {
+                let qd_resp = self
+                    .execute_transaction_impl(qd, &epoch_store, request, client_addr)
+                    .await
+                    .map(|(_, r)| r)?;
+                Ok(quorum_driver_response_to_v1(qd_resp))
+            }
+        }
     }
 
     /// Submit on the skip-effect-certification path while concurrently

--- a/crates/iota-e2e-tests/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/iota-e2e-tests/tests/onsite_reconfig_observer_tests.rs
@@ -26,6 +26,7 @@ async fn test_onsite_reconfig_observer_basic() {
         node.transaction_orchestrator()
             .unwrap()
             .clone_quorum_driver()
+            .expect("quorum driver should be present when P-COOL is disabled")
     });
     assert_eq!(qd.current_epoch(), 0);
     let rx = fullnode.with(|node| node.subscribe_to_epoch_change());
@@ -50,6 +51,7 @@ async fn test_onsite_reconfig_observer_basic() {
         node.transaction_orchestrator()
             .unwrap()
             .clone_quorum_driver()
+            .expect("quorum driver should be present when P-COOL is disabled")
     });
     assert_eq!(qd.current_epoch(), 1);
     assert_eq!(

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -61,6 +61,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let digest = *txn.digest();
     orchestrator
         .quorum_driver()
+        .expect("quorum driver should be present when P-COOL is disabled")
         .submit_transaction_no_ticket(
             ExecuteTransactionRequestV1::new(txn),
             Some(make_socket_addr()),
@@ -198,6 +199,7 @@ async fn test_transaction_orchestrator_reconfig() {
         node.transaction_orchestrator()
             .unwrap()
             .quorum_driver()
+            .expect("quorum driver should be present when P-COOL is disabled")
             .current_epoch()
     });
     assert_eq!(epoch, 0);
@@ -214,6 +216,7 @@ async fn test_transaction_orchestrator_reconfig() {
                 node.transaction_orchestrator()
                     .unwrap()
                     .quorum_driver()
+                    .expect("quorum driver should be present when P-COOL is disabled")
                     .current_epoch()
             });
             if epoch == 1 {

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -605,6 +605,45 @@ async fn test_skip_effect_cert_timeout_without_quorum() -> Result<(), anyhow::Er
     Ok(())
 }
 
+/// Under P-COOL the orchestrator has no quorum driver, so the authority
+/// aggregator must come from the transaction driver — and it must track
+/// reconfiguration, since test infra polls its committee epoch.
+#[sim_test]
+async fn test_authority_aggregator_accessor_under_pcool() {
+    let _env_guard = enable_pcool_env();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let test_cluster = TestClusterBuilder::new().build().await;
+
+    let epoch = test_cluster
+        .fullnode_handle
+        .iota_node
+        .with(|node| node.clone_authority_aggregator().unwrap().committee.epoch);
+    assert_eq!(epoch, 0);
+
+    test_cluster.force_new_epoch().await;
+
+    // The aggregator is swapped asynchronously after the reconfig message,
+    // so poll with a timeout.
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let epoch = test_cluster
+                .fullnode_handle
+                .iota_node
+                .with(|node| node.clone_authority_aggregator().unwrap().committee.epoch);
+            if epoch == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("transaction driver's authority aggregator should reconfigure to epoch 1");
+}
+
 #[sim_test]
 async fn execute_transaction_v1_staking_transaction() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await;

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1872,9 +1872,9 @@ impl IotaNode {
     // self.state.db()
     // }
 
-    /// Clone an AuthorityAggregator currently used in this node's
-    /// QuorumDriver, if the node is a fullnode. After reconfig,
-    /// QuorumDriver builds a new AuthorityAggregator. The caller
+    /// Clone the AuthorityAggregator currently used by this node's
+    /// transaction orchestrator, if the node is a fullnode. After reconfig,
+    /// the active driver builds a new AuthorityAggregator. The caller
     /// of this function will mostly likely want to call this again
     /// to get a fresh one.
     pub fn clone_authority_aggregator(
@@ -1896,8 +1896,11 @@ impl IotaNode {
     ) -> Result<tokio::sync::broadcast::Receiver<QuorumDriverEffectsQueueResult>> {
         self.transaction_orchestrator
             .as_ref()
-            .map(|to| to.subscribe_to_effects_queue())
-            .ok_or_else(|| anyhow::anyhow!("Transaction Orchestrator is not enabled in this node."))
+            .ok_or_else(|| {
+                anyhow::anyhow!("Transaction Orchestrator is not enabled in this node.")
+            })?
+            .subscribe_to_effects_queue()
+            .ok_or_else(|| anyhow::anyhow!("Effects queue is not available under the P-COOL flow."))
     }
 
     /// This function awaits the completion of checkpoint execution of the


### PR DESCRIPTION
# Description of change

`TransactionOrchestrator::clone_authority_aggregator` unconditionally went through the quorum driver, which is only constructed when the P-COOL flow is disabled. On a P-COOL fullnode any call to it panicked with `QuorumDriverHandler is not initialized.` — reachable from `TestCluster::wait_for_epoch_all_nodes`, `TestCluster::authority_aggregator()`, and the public `IotaNode::clone_authority_aggregator`, blocking reconfiguration testing under P-COOL.

The first commit fixes the accessor to return the active driver's aggregator (the `TransactionDriver` maintains its own `ArcSwap<AuthorityAggregator>` which its reconfig observer swaps on epoch change) and adds an e2e regression test that exercises the accessor across an epoch change under P-COOL.

The second commit removes the underlying hazard class: the orchestrator held two mutually-exclusive `Option` fields (`quorum_driver_handler`, `transaction_driver`) behind infallible accessors, so a mode mismatch compiled fine and only panicked at runtime once the protocol flag flipped. They are replaced with a single `Driver` enum (`Quorum`/`Transaction`), making the both/neither states unrepresentable and forcing every access through a `match`. The mode-specific accessors (`quorum_driver()`, `clone_quorum_driver()`, `subscribe_to_effects_queue()`) now return `Option` instead of panicking, the quorum-driver handle is threaded as a parameter through the QD-only internal path instead of re-fetched via a panicking getter, and `IotaNode::subscribe_to_transaction_orchestrator_effects` surfaces a clear error under P-COOL (which has no effects broadcast).

No behavior change in transaction processing; mode selection is still driven by the existing `enable_pcool_flow` protocol flag.

## Links to any relevant issues

-

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New `test_authority_aggregator_accessor_under_pcool` fails with the panic before the fix and passes after. Full `transaction_orchestrator_tests` (11 tests) and `onsite_reconfig_observer_tests` suites pass under `cargo simtest`; workspace-wide `cargo check --all-targets` and scoped clippy with `-D warnings` are clean.