### PR TITLE
refactor(iota-core): remove dead post-consensus load-shedding branch, replace retry-after magic number with a const

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3411,8 +3411,6 @@ impl AuthorityPerEpochStore {
                             authority_metrics
                                 .consensus_handler_load_shedding_dropped_transactions
                                 .inc();
-                            // The retry-after hint matches the pre-consensus
-                            // load-shedding window in `overload_monitor.rs`.
                             load_shedding_dropped.push((
                                 digest,
                                 IotaError::ValidatorOverloadedRetryAfter {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -145,6 +145,13 @@ const RECONFIG_STATE_INDEX: u64 = 0;
 const OVERRIDE_PROTOCOL_UPGRADE_BUFFER_STAKE_INDEX: u64 = 0;
 pub const EPOCH_DB_PREFIX: &str = "epoch_";
 
+/// Retry-after hint returned when a transaction is dropped by post-consensus
+/// load shedding. Chosen to align with the pre-consensus hint
+/// (`SEED_UPDATE_DURATION_SECS`) so clients see a consistent backoff - but it's
+/// an independent knob: the post-consensus seed is the consensus round, not a
+/// time-based seed, so the seed-rotation rationale doesn't apply here.
+const POST_CONSENSUS_LOAD_SHEDDING_RETRY_AFTER_SECS: u64 = 30;
+
 // Types for randomness DKG.
 pub(crate) type PkG = bls12381::G2Element;
 pub(crate) type EncG = bls12381::G2Element;
@@ -3388,28 +3395,13 @@ impl AuthorityPerEpochStore {
             } else if tx.0.is_system() {
                 system_transactions.push(tx);
             // In the P-COOL flow, randomness transactions are separated
-            // later in the flow to preserve ordering in conflict resolution, so
-            // should be included with the regular transactions here.
+            // later in the flow to preserve ordering in conflict resolution,
+            // so they should be included with the regular transactions in the
+            // else branch. The branch below is therefore reachable only
+            // when `!enable_pcool`, in which case `drop_percentage == 0`
+            // (load shedding is off) - hence no shedding check here, unlike
+            // the else branch.
             } else if !enable_pcool && tx.0.is_user_tx_with_randomness() {
-                // Only user-originated transactions are eligible for load shedding
-                if drop_percentage > 0 {
-                    if let Some(digest) = tx.0.transaction.user_transaction_digest() {
-                        if should_reject_tx(drop_percentage, digest, drop_seed) {
-                            authority_metrics
-                                .consensus_handler_load_shedding_dropped_transactions
-                                .inc();
-                            // The retry-after hint matches the pre-consensus
-                            // load-shedding window in `overload_monitor.rs`.
-                            load_shedding_dropped.push((
-                                digest,
-                                IotaError::ValidatorOverloadedRetryAfter {
-                                    retry_after_secs: 30,
-                                },
-                            ));
-                            continue;
-                        }
-                    }
-                }
                 current_commit_sequenced_randomness_transactions.push(tx);
             } else {
                 // Only user-originated transactions are eligible for load shedding
@@ -3424,7 +3416,7 @@ impl AuthorityPerEpochStore {
                             load_shedding_dropped.push((
                                 digest,
                                 IotaError::ValidatorOverloadedRetryAfter {
-                                    retry_after_secs: 30,
+                                    retry_after_secs: POST_CONSENSUS_LOAD_SHEDDING_RETRY_AFTER_SECS,
                                 },
                             ));
                             continue;


### PR DESCRIPTION
# Description of change

This PR

- removes the unreachable post-consensus load-shedding block in the randomness branch—it is only entered when `!enable_pcool` (certificate-based flow), where `drop_percentage` is always 0—and
- replaces the retry-after magic number with a named `POST_CONSENSUS_LOAD_SHEDDING_RETRY_AFTER_SECS` constant.
 
The changes are behavior-preserving.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes