### PR TITLE
fix(core): migrate legacy V1 store objects at object read sites

### DIFF
--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -1192,31 +1192,55 @@ mod tests {
     #[tokio::test]
     async fn compaction_filter_handles_legacy_v1_row() {
         use bincode::Options;
+        use iota_sdk_types::Owner;
         use typed_store::rocksdb::compaction_filter::Decision;
 
         use super::ObjectsCompactionFilter;
         use crate::authority::{
-            authority_store_tables::AuthorityPrunerTables, authority_store_types::StoreObjectV1,
+            authority_store_tables::AuthorityPrunerTables,
+            authority_store_types::{StoreData, StoreObjectV1, StoreObjectValue},
         };
 
-        // `into_inner()` panics on any un-migrated V1 wrapper, so a tombstone
-        // is a sufficient stand-in for the raw on-disk bytes a pre-V2 binary
-        // wrote.
+        // A V1 `Value` row is what a pre-V2 binary wrote for a live object;
+        // only `Value` rows reach the tombstone lookup.
+        let object_key = ObjectKey(ObjectId::random(), SequenceNumber::from_u64(1));
+        let v1_value = StoreObjectValue {
+            data: StoreData::Coin(42),
+            owner: Owner::Immutable,
+            previous_transaction: TransactionDigest::random(),
+            storage_rebate: 7,
+        };
         let key_bytes = bincode::DefaultOptions::new()
             .with_big_endian()
             .with_fixint_encoding()
-            .serialize(&ObjectKey(ObjectId::ZERO, SequenceNumber::from_u64(1)))
+            .serialize(&object_key)
             .unwrap();
-        let value_bytes = bcs::to_bytes(&StoreObjectWrapper::V1(StoreObjectV1::Wrapped)).unwrap();
+        let value_bytes = bcs::to_bytes(&StoreObjectWrapper::V1(StoreObjectV1::Value(Box::new(
+            v1_value,
+        ))))
+        .unwrap();
 
-        // Keep the pruner DB alive so the filter's `Weak` stays upgradeable.
+        // The filter holds only a `Weak`, so keep a strong ref alive for the
+        // tombstone lookup to run.
         let tmp_dir = iota_common::tempdir();
         let pruner_db = Arc::new(AuthorityPrunerTables::open(tmp_dir.path()));
-        let mut filter = ObjectsCompactionFilter::new(pruner_db, &Registry::default());
+        let mut filter = ObjectsCompactionFilter::new(pruner_db.clone(), &Registry::default());
 
+        // No tombstone: the row must survive.
         let decision = filter
             .filter(&key_bytes, &value_bytes)
             .expect("legacy V1 row must not panic");
         assert!(matches!(decision, Decision::Keep));
+
+        // Tombstoned at this version: the row must be compacted away, which
+        // proves the migrated row reached the tombstone-lookup branch.
+        pruner_db
+            .object_tombstones
+            .insert(&object_key.0, &object_key.1)
+            .unwrap();
+        let decision = filter
+            .filter(&key_bytes, &value_bytes)
+            .expect("legacy V1 row must not panic");
+        assert!(matches!(decision, Decision::Remove));
     }
 }

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -878,7 +878,9 @@ impl ObjectsCompactionFilter {
             .with_fixint_encoding()
             .deserialize(key)?;
         let object: StoreObjectWrapper = bcs::from_bytes(value)?;
-        if matches!(object.into_inner(), StoreObject::Value(_)) {
+        // Compaction sees raw on-disk rows, which may be legacy V1; migrate
+        // before `into_inner()`, which panics on an un-migrated V1.
+        if matches!(object.migrate().into_inner(), StoreObject::Value(_)) {
             if let Some(db) = self.db.upgrade() {
                 match db.object_tombstones.get(&object_id)? {
                     Some(gc_version) => {
@@ -1181,5 +1183,40 @@ mod tests {
         );
         ma::assert_le!(after_compaction_size, before_compaction_size);
         Ok(())
+    }
+
+    /// A legacy V1 row reaching the objects compaction filter (a pre-V2 object
+    /// left on disk after an in-place upgrade or a V1 formal-snapshot restore)
+    /// must be migrated before `into_inner()`, which panics on an un-migrated
+    /// V1 wrapper.
+    #[tokio::test]
+    async fn compaction_filter_handles_legacy_v1_row() {
+        use bincode::Options;
+        use typed_store::rocksdb::compaction_filter::Decision;
+
+        use super::ObjectsCompactionFilter;
+        use crate::authority::{
+            authority_store_tables::AuthorityPrunerTables, authority_store_types::StoreObjectV1,
+        };
+
+        // `into_inner()` panics on any un-migrated V1 wrapper, so a tombstone
+        // is a sufficient stand-in for the raw on-disk bytes a pre-V2 binary
+        // wrote.
+        let key_bytes = bincode::DefaultOptions::new()
+            .with_big_endian()
+            .with_fixint_encoding()
+            .serialize(&ObjectKey(ObjectId::ZERO, SequenceNumber::from_u64(1)))
+            .unwrap();
+        let value_bytes = bcs::to_bytes(&StoreObjectWrapper::V1(StoreObjectV1::Wrapped)).unwrap();
+
+        // Keep the pruner DB alive so the filter's `Weak` stays upgradeable.
+        let tmp_dir = iota_common::tempdir();
+        let pruner_db = Arc::new(AuthorityPrunerTables::open(tmp_dir.path()));
+        let mut filter = ObjectsCompactionFilter::new(pruner_db, &Registry::default());
+
+        let decision = filter
+            .filter(&key_bytes, &value_bytes)
+            .expect("legacy V1 row must not panic");
+        assert!(matches!(decision, Decision::Keep));
     }
 }

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -338,7 +338,9 @@ impl AuthorityPerpetualTables {
 
         if let Some(Ok((object_key, value))) = iterator.next() {
             if object_key.0 == object_id {
-                return Ok(Some((object_key, value)));
+                // Migrate legacy V1 rows before returning; callers inspect the
+                // wrapper via `inner()`, which panics on an un-migrated V1.
+                return Ok(Some((object_key, value.migrate())));
             }
         }
         Ok(None)
@@ -818,5 +820,46 @@ mod tests {
             Some(distinct_checkpoint),
             "LiveSetIter must surface the on-row checkpoint, not a default"
         );
+    }
+
+    /// A legacy V1 row (written by a pre-V2 binary, e.g. restored from a V1
+    /// formal snapshot) must be migrated to the latest version at the read
+    /// boundary. `get_latest_object_or_tombstone` feeds its result to
+    /// `tombstone_reference`, which reaches `StoreObjectWrapper::inner()` and
+    /// panics on an un-migrated V1 wrapper.
+    #[tokio::test]
+    async fn get_latest_object_or_tombstone_migrates_legacy_v1_row() {
+        let tmp_dir = iota_common::tempdir();
+        let perpetual_db = AuthorityPerpetualTables::open(tmp_dir.path(), None);
+
+        let object_id = ObjectId::random();
+        let object = Object::immutable_with_id_for_testing(object_id);
+        let object_ref = object.object_ref();
+        perpetual_db
+            .insert_store_object_v1_test_only(object)
+            .unwrap();
+
+        let (object_key, wrapper) = perpetual_db
+            .get_latest_object_or_tombstone(object_id)
+            .unwrap()
+            .expect("row must be found");
+        assert!(
+            matches!(wrapper, StoreObjectWrapper::V2(_)),
+            "read boundary must migrate the V1 row to V2"
+        );
+
+        // Both consumers of the returned wrapper must run without panicking.
+        assert!(
+            perpetual_db
+                .tombstone_reference(&object_key, &wrapper)
+                .unwrap()
+                .is_none(),
+            "a live value is not a tombstone"
+        );
+        let reconstructed = perpetual_db
+            .object(&object_key, wrapper)
+            .unwrap()
+            .expect("value must reconstruct");
+        assert_eq!(reconstructed.object_ref(), object_ref);
     }
 }

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -596,14 +596,17 @@ impl GrpcReader {
     }
 
     pub fn get_latest_checkpoint(&self) -> anyhow::Result<CertifiedCheckpointSummary> {
-        let seq = latest_checkpoint_seq(&*self.state_reader)?.ok_or_else(|| {
-            anyhow::anyhow!("Unable to determine current epoch: no checkpoints available")
-        })?;
-        self.state_reader
-            .try_get_checkpoint_by_sequence_number(seq)
-            .map_err(anyhow::Error::from)?
-            .map(CertifiedCheckpointSummary::from)
-            .ok_or_else(|| anyhow::anyhow!("Checkpoint {seq} not found"))
+        match self.state_reader.try_get_latest_checkpoint() {
+            Ok(checkpoint) => Ok(CertifiedCheckpointSummary::from(checkpoint)),
+            Err(e) => match e.kind() {
+                Kind::Missing => Err(anyhow::anyhow!(
+                    "Unable to determine current epoch: no checkpoints available"
+                )),
+                _ => Err(anyhow::anyhow!(
+                    "Storage error getting latest checkpoint: {e}"
+                )),
+            },
+        }
     }
 
     pub fn get_lowest_available_checkpoint(&self) -> anyhow::Result<u64> {


### PR DESCRIPTION
# Description of change

Now `StoreObjectWrapper::inner()`/`into_inner()` panic on un-migrated V1 rows, but two read sites reached the accessor without first calling migrate(): PerpetualTables::get_latest_object_or_tombstone (via tombstone_reference) and the objects compaction filter. Any node holding pre-V2 rows panicked on the first cold object read during checkpoint execution, or during background compaction. Migrate at both sites and add V1-row regression tests for each.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes