### PR TITLE
feat(iota-indexer): reach JSON-RPC test parity with iota-json-rpc-tests

### DIFF
--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -187,6 +187,22 @@ pub async fn start_test_cluster_with_read_write_indexer_and_url(
     // start indexer in read mode
     let indexer_port = start_indexer_reader(cluster.grpc_url(), database_name);
 
+    // The reader is spawned on a background task; wait until its JSON-RPC
+    // server actually accepts connections, so callers can issue requests
+    // right away. This also surfaces a failed startup (e.g. a lost port
+    // race) as a clear panic instead of connection-refused errors later.
+    let indexer_address = format!("{DEFAULT_INDEXER_IP}:{indexer_port}");
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while tokio::net::TcpStream::connect(&indexer_address)
+            .await
+            .is_err()
+        {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("indexer JSON-RPC reader did not start listening");
+
     // create an RPC client by using the indexer url
     let rpc_url = format!("http://{DEFAULT_INDEXER_IP}:{indexer_port}");
     let rpc_client = HttpClientBuilder::default().build(&rpc_url).unwrap();

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -146,6 +146,23 @@ pub async fn start_test_cluster_with_read_write_indexer(
     builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
     pruning_options: Option<PruningOptions>,
 ) -> (TestCluster, PgIndexerStore, HttpClient) {
+    let (cluster, pg_store, rpc_client, _rpc_url) =
+        start_test_cluster_with_read_write_indexer_and_url(
+            database_name,
+            builder_modifier,
+            pruning_options,
+        )
+        .await;
+    (cluster, pg_store, rpc_client)
+}
+
+/// Same as [`start_test_cluster_with_read_write_indexer`], but also returns the
+/// indexer JSON-RPC URL for tests that need to issue raw HTTP requests.
+pub async fn start_test_cluster_with_read_write_indexer_and_url(
+    database_name: impl Into<Option<&str>>,
+    builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
+    pruning_options: Option<PruningOptions>,
+) -> (TestCluster, PgIndexerStore, HttpClient, String) {
     let database_name = database_name.into();
     let mut builder = TestClusterBuilder::new().with_fullnode_enable_grpc_api(true);
 
@@ -171,11 +188,10 @@ pub async fn start_test_cluster_with_read_write_indexer(
     let indexer_port = start_indexer_reader(cluster.grpc_url(), database_name);
 
     // create an RPC client by using the indexer url
-    let rpc_client = HttpClientBuilder::default()
-        .build(format!("http://{DEFAULT_INDEXER_IP}:{indexer_port}"))
-        .unwrap();
+    let rpc_url = format!("http://{DEFAULT_INDEXER_IP}:{indexer_port}");
+    let rpc_client = HttpClientBuilder::default().build(&rpc_url).unwrap();
 
-    (cluster, pg_store, rpc_client)
+    (cluster, pg_store, rpc_client, rpc_url)
 }
 
 /// Wait for the indexer to catch up to the given checkpoint sequence number

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -15,6 +15,7 @@ use iota_json_rpc_types::{
     IotaTransactionBlockResponseOptions, IotaTypeTag, TransactionBlockBytes,
 };
 use iota_keys::keystore::AccountKeystore;
+use iota_sdk::PagedFn;
 use iota_sdk_types::{Address, Identifier, ObjectId, StructTag, TypeTag};
 use iota_types::{
     balance::Supply,
@@ -264,6 +265,88 @@ fn get_all_coins_with_limit() {
 
         assert_eq!(limited_result.data.len(), tested_limit);
         assert_eq!(expected_data, limited_result.data);
+    });
+}
+
+#[test]
+fn get_all_coins_with_cursor_and_limit() {
+    let ApiTestSetup {
+        runtime,
+        client,
+        cluster,
+        ..
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (owner, _, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
+
+        let all_coins = client.get_all_coins(*owner, None, None).await.unwrap();
+        assert!(!all_coins.data.is_empty());
+        assert!(!all_coins.has_next_page);
+
+        // Paginating through all coins two at a time must yield exactly the same set.
+        let collected_coins = PagedFn::collect::<Vec<_>>(async |cursor| {
+            client.get_all_coins(*owner, cursor, Some(2)).await
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(all_coins.data.len(), collected_coins.len());
+        assert_eq!(all_coins.data, collected_coins);
+    });
+}
+
+#[test]
+fn get_all_coins_with_cursor_boundaries() {
+    let ApiTestSetup {
+        runtime,
+        client,
+        cluster,
+        ..
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (owner, _, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
+
+        let full_result = client.get_all_coins(*owner, None, None).await.unwrap();
+        assert!(!full_result.data.is_empty());
+
+        // The cursor is exclusive: starting at the last coin returns nothing.
+        let last_coin = full_result.data.last().unwrap();
+        let result = client
+            .get_all_coins(*owner, Some(last_coin.coin_object_id), None)
+            .await
+            .unwrap();
+        assert!(
+            result.data.is_empty(),
+            "should return no coins when cursor is at the last coin"
+        );
+
+        // Starting at the first coin returns everything except the first one.
+        let first_coin = full_result.data.first().unwrap();
+        let result = client
+            .get_all_coins(*owner, Some(first_coin.coin_object_id), None)
+            .await
+            .unwrap();
+        assert_eq!(full_result.data.len() - 1, result.data.len());
+    });
+}
+
+#[test]
+fn get_all_coins_limit_zero() {
+    let ApiTestSetup {
+        runtime,
+        client,
+        cluster,
+        ..
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (owner, _, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
+
+        // A limit of 0 falls back to the default `QUERY_MAX_RESULT_LIMIT` (50) rather
+        // than returning an empty page.
+        let all_coins = client.get_all_coins(*owner, None, Some(0)).await.unwrap();
+
+        assert!(!all_coins.data.is_empty());
+        assert!(all_coins.data.len() <= 50);
     });
 }
 

--- a/crates/iota-indexer/tests/rpc-tests/governance_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/governance_api.rs
@@ -1,27 +1,88 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
+
 use iota_json_rpc_api::{GovernanceReadApiClient, TransactionBuilderClient};
 use iota_json_rpc_types::{
     DelegatedStake, DelegatedTimelockedStake, StakeStatus, TransactionBlockBytes,
 };
 use iota_protocol_config::ProtocolVersion;
-use iota_sdk_types::{Identifier, ObjectId, StructTag, TypeTag};
+use iota_sdk_types::{Address, Identifier, ObjectId, StructTag, TypeTag};
+use iota_swarm_config::genesis_config::{ValidatorGenesisConfig, ValidatorGenesisConfigBuilder};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     crypto::{AccountKeyPair, get_key_pair},
     gas_coin::GAS,
+    governance::MIN_VALIDATOR_JOINING_STAKE_NANOS,
     iota_system_state::iota_system_state_summary::IotaSystemStateSummary,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::CallArg,
     utils::to_sender_signed_transaction,
 };
+use rand::rngs::OsRng;
+use test_cluster::TestCluster;
 
 use crate::common::{
     ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_latest_checkpoint,
     indexer_wait_for_object, indexer_wait_for_transaction,
     start_test_cluster_with_read_write_indexer,
 };
+
+/// Execute the sequence of transactions to onboard a validator: register the
+/// candidate, stake the required amount, and request to join the active set.
+/// This does not trigger reconfiguration and asserts nothing about the
+/// node-internal system state.
+async fn execute_add_validator_transactions(
+    cluster: &TestCluster,
+    new_validator: &ValidatorGenesisConfig,
+) {
+    let address: Address = (&new_validator.account_key_pair.public()).into();
+    let gas = cluster
+        .wallet
+        .get_one_gas_object_owned_by_address(address)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let rgp = cluster.get_reference_gas_price().await;
+    let tx = TestTransactionBuilder::new(address, gas, rgp)
+        .call_request_add_validator_candidate(
+            &new_validator.to_validator_info_with_random_name().into(),
+        )
+        .build_and_sign(&new_validator.account_key_pair);
+    cluster.execute_transaction(tx).await;
+
+    let stake_coin = cluster
+        .wallet
+        .gas_for_owner_budget(
+            address,
+            MIN_VALIDATOR_JOINING_STAKE_NANOS,
+            Default::default(),
+        )
+        .await
+        .unwrap()
+        .1
+        .object_ref();
+    let gas = cluster
+        .wallet
+        .gas_for_owner_budget(address, 0, BTreeSet::from([stake_coin.object_id]))
+        .await
+        .unwrap()
+        .1
+        .object_ref();
+
+    let stake_tx = TestTransactionBuilder::new(address, gas, rgp)
+        .call_staking(stake_coin, address)
+        .build_and_sign(&new_validator.account_key_pair);
+    cluster.execute_transaction(stake_tx).await;
+
+    let gas = cluster.wallet.get_object_ref(gas.object_id).await.unwrap();
+    let tx = TestTransactionBuilder::new(address, gas, rgp)
+        .call_request_add_validator()
+        .build_and_sign(&new_validator.account_key_pair);
+    cluster.execute_transaction(tx).await;
+}
 
 #[test]
 fn test_staking() {
@@ -596,5 +657,98 @@ fn get_validators_apy() {
 
         assert_eq!(apys.len(), 4);
         assert!(apys.iter().any(|apy| apy.apy >= 0.0));
+    });
+}
+
+#[test]
+fn get_stakes_with_new_validator() {
+    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        // Create the keypair for the new validator candidate.
+        let new_validator = ValidatorGenesisConfigBuilder::new().build(&mut OsRng);
+        let address: Address = (&new_validator.account_key_pair.public()).into();
+
+        let (mut cluster, store, client) = start_test_cluster_with_read_write_indexer(
+            Some("test_get_stakes_with_new_validator"),
+            Some(Box::new(move |b| {
+                b.with_validator_candidates([address])
+                    .with_num_validators(4)
+            })),
+            None,
+        )
+        .await;
+
+        indexer_wait_for_checkpoint(&store, 1).await;
+
+        assert!(client.get_stakes(address).await.unwrap().is_empty());
+
+        // Add candidate, stake the required tokens, and request to join the set.
+        execute_add_validator_transactions(&cluster, &new_validator).await;
+        indexer_wait_for_latest_checkpoint(&store, &cluster).await;
+
+        // The validator was just added; it is not active yet, so the initial stake
+        // request is pending.
+        let stakes = client.get_stakes(address).await.unwrap();
+        let stake = stakes[0]
+            .stakes
+            .iter()
+            .find(|s| s.stake_request_epoch == 0)
+            .unwrap();
+        assert!(matches!(stake.status, StakeStatus::Pending));
+
+        cluster.force_new_epoch().await;
+        // Keep the handle alive until the end of the test so the validator stays up.
+        let _new_validator_handle = cluster.spawn_new_validator(new_validator).await;
+        cluster.wait_for_epoch_all_nodes(1).await;
+        indexer_wait_for_latest_checkpoint(&store, &cluster).await;
+
+        // After one epoch the validator is active but not yet part of the committee;
+        // the stake is active with no reward.
+        let stakes = client.get_stakes(address).await.unwrap();
+        let stake = stakes[0]
+            .stakes
+            .iter()
+            .find(|s| s.stake_request_epoch == 0)
+            .unwrap();
+        assert!(matches!(
+            stake.status,
+            StakeStatus::Active {
+                estimated_reward: 0
+            }
+        ));
+
+        cluster.force_new_epoch().await;
+        cluster.wait_for_epoch_all_nodes(2).await;
+        indexer_wait_for_latest_checkpoint(&store, &cluster).await;
+
+        // The validator has now joined the committee but has not earned rewards yet.
+        let stakes = client.get_stakes(address).await.unwrap();
+        let stake = stakes[0]
+            .stakes
+            .iter()
+            .find(|s| s.stake_request_epoch == 0)
+            .unwrap();
+        assert!(matches!(
+            stake.status,
+            StakeStatus::Active {
+                estimated_reward: 0
+            }
+        ));
+
+        cluster.force_new_epoch().await;
+        indexer_wait_for_latest_checkpoint(&store, &cluster).await;
+
+        // After one epoch in the committee the stake earns a non-zero reward.
+        let stakes = client.get_stakes(address).await.unwrap();
+        let stake = stakes[0]
+            .stakes
+            .iter()
+            .find(|s| s.stake_request_epoch == 0)
+            .unwrap();
+        assert!(matches!(
+            stake.status,
+            StakeStatus::Active { estimated_reward } if estimated_reward > 0
+        ));
     });
 }

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -20,6 +20,9 @@ mod move_utils;
 mod read_api;
 
 #[cfg(feature = "shared_test_runtime")]
+mod transaction_api;
+
+#[cfg(feature = "shared_test_runtime")]
 mod transaction_builder;
 
 #[cfg(feature = "shared_test_runtime")]

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -15,7 +15,7 @@ use iota_json_rpc_api::{IndexerApiClient, ReadApiClient, TransactionBuilderClien
 use iota_json_rpc_types::{
     CheckpointId, IotaGetPastObjectRequest, IotaObjectDataOptions, IotaObjectResponse,
     IotaObjectResponseError, IotaObjectResponseQuery, IotaPastObjectResponse,
-    IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
+    IotaTransactionBlockDataAPI, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
     IotaTransactionBlockResponseOptions, IotaTransactionBlockResponseQueryV2, ObjectChange,
     TransactionFilterV2,
 };
@@ -46,6 +46,7 @@ use crate::{
         indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
         indexer_wait_for_transaction, publish_test_move_package, rpc_call_error_msg_matches,
         start_test_cluster_with_read_write_indexer,
+        start_test_cluster_with_read_write_indexer_and_url,
     },
     write_api::{create_basic_object, deploy_basics_pkg},
 };
@@ -1917,6 +1918,415 @@ fn try_get_object_before_version() {
             }
             _ => panic!("expected VersionFound response, got: {result:?}"),
         }
+    });
+}
+
+/// Assert a past-object response contains exactly the fields requested by
+/// `options`.
+fn assert_past_object_matches_options(
+    response: &IotaPastObjectResponse,
+    options: &IotaObjectDataOptions,
+) {
+    let obj = response
+        .object()
+        .expect("expected a VersionFound past-object response");
+    let derived_options = IotaObjectDataOptions {
+        show_type: obj.type_.is_some(),
+        show_owner: obj.owner.is_some(),
+        show_previous_transaction: obj.previous_transaction.is_some(),
+        show_display: obj.display.is_some(),
+        show_content: obj.content.is_some(),
+        show_bcs: obj.bcs.is_some(),
+        show_storage_rebate: obj.storage_rebate.is_some(),
+    };
+    assert_eq!(&derived_options, options);
+}
+
+/// Fetch a past object at a fixed version from both the fullnode and the
+/// indexer with the given options and assert the responses are identical and
+/// contain exactly the requested fields. This verifies the indexer honors
+/// every `IotaObjectDataOptions` variant for historical objects, matching the
+/// fullnode.
+fn try_get_past_object_with_options(options: IotaObjectDataOptions) {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, _): (_, AccountKeyPair) = get_key_pair();
+        let (gas_ref, tx_digest) = cluster
+            .fund_address_and_return_gas_and_tx(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        wait_for_objects_history(tx_digest, store, client).await;
+
+        let fullnode_past_obj = cluster
+            .rpc_client()
+            .try_get_past_object(
+                gas_ref.object_id,
+                gas_ref.version.into(),
+                Some(options.clone()),
+            )
+            .await
+            .unwrap();
+
+        let indexer_past_obj = client
+            .try_get_past_object(
+                gas_ref.object_id,
+                gas_ref.version.into(),
+                Some(options.clone()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(fullnode_past_obj, indexer_past_obj);
+        assert_past_object_matches_options(&indexer_past_obj, &options);
+    });
+}
+
+/// Same as [`try_get_past_object_with_options`], but for the batched
+/// `try_multi_get_past_objects` endpoint.
+fn try_multi_get_past_objects_with_options(options: IotaObjectDataOptions) {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, _): (_, AccountKeyPair) = get_key_pair();
+        let (gas_ref_1, tx_digest_1) = cluster
+            .fund_address_and_return_gas_and_tx(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        let (gas_ref_2, tx_digest_2) = cluster
+            .fund_address_and_return_gas_and_tx(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        wait_for_objects_history(tx_digest_1, store, client).await;
+        wait_for_objects_history(tx_digest_2, store, client).await;
+
+        let requests = vec![
+            IotaGetPastObjectRequest {
+                object_id: gas_ref_1.object_id,
+                version: gas_ref_1.version,
+            },
+            IotaGetPastObjectRequest {
+                object_id: gas_ref_2.object_id,
+                version: gas_ref_2.version,
+            },
+        ];
+
+        let fullnode_past_objs = cluster
+            .rpc_client()
+            .try_multi_get_past_objects(requests.clone(), Some(options.clone()))
+            .await
+            .unwrap();
+
+        let indexer_past_objs = client
+            .try_multi_get_past_objects(requests, Some(options.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(fullnode_past_objs, indexer_past_objs);
+        for past_obj in &indexer_past_objs {
+            assert_past_object_matches_options(past_obj, &options);
+        }
+    });
+}
+
+#[test]
+fn try_get_past_object_with_bcs_lossless() {
+    try_get_past_object_with_options(IotaObjectDataOptions::bcs_lossless());
+}
+
+#[test]
+fn try_get_past_object_with_full_content() {
+    try_get_past_object_with_options(IotaObjectDataOptions::full_content());
+}
+
+#[test]
+fn try_get_past_object_with_bcs() {
+    try_get_past_object_with_options(IotaObjectDataOptions::default().with_bcs());
+}
+
+#[test]
+fn try_get_past_object_with_content() {
+    try_get_past_object_with_options(IotaObjectDataOptions::default().with_content());
+}
+
+#[test]
+fn try_get_past_object_with_display() {
+    try_get_past_object_with_options(IotaObjectDataOptions::default().with_display());
+}
+
+#[test]
+fn try_get_past_object_with_owner() {
+    try_get_past_object_with_options(IotaObjectDataOptions::default().with_owner());
+}
+
+#[test]
+fn try_get_past_object_with_previous_transaction() {
+    try_get_past_object_with_options(IotaObjectDataOptions::default().with_previous_transaction());
+}
+
+#[test]
+fn try_get_past_object_with_type() {
+    try_get_past_object_with_options(IotaObjectDataOptions::default().with_type());
+}
+
+#[test]
+fn try_get_past_object_with_storage_rebate() {
+    try_get_past_object_with_options(IotaObjectDataOptions {
+        show_storage_rebate: true,
+        ..Default::default()
+    });
+}
+
+#[test]
+fn try_multi_get_past_objects_with_bcs_lossless() {
+    try_multi_get_past_objects_with_options(IotaObjectDataOptions::bcs_lossless());
+}
+
+#[test]
+fn try_multi_get_past_objects_with_full_content() {
+    try_multi_get_past_objects_with_options(IotaObjectDataOptions::full_content());
+}
+
+#[test]
+fn try_multi_get_past_objects_with_bcs() {
+    try_multi_get_past_objects_with_options(IotaObjectDataOptions::default().with_bcs());
+}
+
+#[test]
+fn try_multi_get_past_objects_with_content() {
+    try_multi_get_past_objects_with_options(IotaObjectDataOptions::default().with_content());
+}
+
+#[test]
+fn try_multi_get_past_objects_with_display() {
+    try_multi_get_past_objects_with_options(IotaObjectDataOptions::default().with_display());
+}
+
+#[test]
+fn try_multi_get_past_objects_with_owner() {
+    try_multi_get_past_objects_with_options(IotaObjectDataOptions::default().with_owner());
+}
+
+#[test]
+fn try_multi_get_past_objects_with_previous_transaction() {
+    try_multi_get_past_objects_with_options(
+        IotaObjectDataOptions::default().with_previous_transaction(),
+    );
+}
+
+#[test]
+fn try_multi_get_past_objects_with_type() {
+    try_multi_get_past_objects_with_options(IotaObjectDataOptions::default().with_type());
+}
+
+#[test]
+fn try_multi_get_past_objects_with_storage_rebate() {
+    try_multi_get_past_objects_with_options(IotaObjectDataOptions {
+        show_storage_rebate: true,
+        ..Default::default()
+    });
+}
+
+#[test]
+fn try_get_object_before_version_not_exists() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let object_id = ObjectId::random();
+        let result = client
+            .try_get_object_before_version(object_id, SequenceNumber::from_u64(1))
+            .await
+            .expect("rpc call should succeed");
+
+        assert_eq!(result, IotaPastObjectResponse::ObjectNotExists(object_id));
+    });
+}
+
+/// Requesting a system package with the display option must not error; the
+/// package simply has no display data.
+#[test]
+fn get_package_with_display_should_not_fail() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let response = client
+            .get_object(
+                ObjectId::FRAMEWORK,
+                Some(IotaObjectDataOptions::new().with_display()),
+            )
+            .await;
+        assert!(response.is_ok());
+        assert!(
+            response
+                .unwrap()
+                .into_object()
+                .unwrap()
+                .display
+                .unwrap()
+                .data
+                .is_none()
+        );
+    });
+}
+
+#[test]
+fn get_transaction_block_timestamp() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        // A user transaction must come back with a checkpoint timestamp.
+        let (sender, _): (_, AccountKeyPair) = get_key_pair();
+        let (_, tx_digest) = cluster
+            .fund_address_and_return_gas_and_tx(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_transaction(tx_digest, store, client).await;
+
+        let tx = client
+            .get_transaction_block(
+                tx_digest,
+                Some(IotaTransactionBlockResponseOptions::default()),
+            )
+            .await
+            .unwrap();
+
+        assert!(tx.timestamp_ms.is_some());
+    });
+}
+
+/// System transactions have empty balance changes; serializing such a response
+/// must not panic.
+#[test]
+fn display_transaction_block_with_empty_balance_changes() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let checkpoint_seq_num: u64 = 1;
+        indexer_wait_for_checkpoint(store, checkpoint_seq_num).await;
+
+        let rpc_checkpoint = client
+            .get_checkpoint(checkpoint_seq_num.into())
+            .await
+            .unwrap();
+
+        // Empty balance changes occur for system transactions. On the shared
+        // cluster other tests may add user transactions to this checkpoint, so
+        // search for a system transaction (gas price 1, budget 0) instead of
+        // assuming a position.
+        let mut system_tx = None;
+        for digest in &rpc_checkpoint.transactions {
+            let tx = client
+                .get_transaction_block(
+                    *digest,
+                    Some(IotaTransactionBlockResponseOptions::full_content()),
+                )
+                .await
+                .unwrap();
+            let gas_data = tx.transaction.as_ref().unwrap().data.gas_data();
+            if gas_data.price == 1 && gas_data.budget == 0 {
+                system_tx = Some(tx);
+                break;
+            }
+        }
+        let rpc_transaction = system_tx.expect("checkpoint should contain a system transaction");
+
+        assert!(rpc_transaction.balance_changes.is_some());
+        assert!(rpc_transaction.balance_changes.as_ref().unwrap().is_empty());
+
+        let _ = rpc_transaction.to_string();
+    });
+}
+
+/// A well-formed `iota_tryGetPastObject` request (version as a bare integer,
+/// `null` options) must not be rejected as invalid params by the indexer's
+/// JSON-RPC server.
+#[test]
+fn try_get_past_object_valid_params() {
+    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (_cluster, _store, _client, rpc_url) =
+            start_test_cluster_with_read_write_indexer_and_url(
+                Some("test_try_get_past_object_valid_params"),
+                None,
+                None,
+            )
+            .await;
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "iota_tryGetPastObject",
+            "params": [ObjectId::ZERO.to_string(), 7, null],
+        });
+
+        let response: Value = reqwest::Client::new()
+            .post(&rpc_url)
+            .json(&request)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+
+        assert_ne!(
+            response["error"]["code"].as_i64(),
+            Some(jsonrpsee::types::error::INVALID_PARAMS_CODE as i64),
+            "{response}",
+        );
     });
 }
 

--- a/crates/iota-indexer/tests/rpc-tests/transaction_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_api.rs
@@ -1,0 +1,130 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_json_rpc_api::{ReadApiClient, TransactionBuilderClient, WriteApiClient};
+use iota_json_rpc_types::{IotaTransactionBlockResponseOptions, TransactionBlockBytes};
+use iota_sdk_types::Address;
+use iota_types::{
+    base_types::ObjectRef,
+    crypto::{AccountKeyPair, get_key_pair},
+    quorum_driver_types::ExecuteTransactionRequestType,
+    transaction::SenderSignedData,
+    utils::to_sender_signed_transaction,
+};
+
+use crate::common::{
+    ApiTestSetup, execute_tx_and_wait_for_indexer_checkpoint, indexer_wait_for_checkpoint,
+    indexer_wait_for_object,
+};
+
+/// Fund an address with a gas coin and an object to transfer, waiting for both
+/// to be indexed.
+async fn fund_gas_and_object(setup: &ApiTestSetup, sender: Address) -> (ObjectRef, ObjectRef) {
+    let ApiTestSetup {
+        cluster, client, ..
+    } = setup;
+
+    let rgp = cluster.get_reference_gas_price().await;
+    let gas = cluster
+        .fund_address_and_return_gas(rgp, Some(10_000_000_000), sender)
+        .await;
+    let object = cluster
+        .fund_address_and_return_gas(rgp, Some(10_000_000_000), sender)
+        .await;
+    indexer_wait_for_object(client, gas.object_id, gas.version).await;
+    indexer_wait_for_object(client, object.object_id, object.version).await;
+    (gas, object)
+}
+
+#[test]
+fn get_transaction_block() {
+    let setup = ApiTestSetup::get_or_init();
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = setup;
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
+        let (receiver, _): (_, AccountKeyPair) = get_key_pair();
+
+        let (gas, object) = fund_gas_and_object(setup, sender).await;
+
+        let tx_bytes: TransactionBlockBytes = client
+            .transfer_object(
+                sender,
+                object.object_id,
+                Some(gas.object_id),
+                10_000_000.into(),
+                receiver,
+            )
+            .await
+            .unwrap();
+        let digest =
+            execute_tx_and_wait_for_indexer_checkpoint(client, store, tx_bytes, &keypair).await;
+
+        // The executed transaction can be fetched back from the indexer by digest.
+        let tx = client
+            .get_transaction_block(digest, Some(IotaTransactionBlockResponseOptions::new()))
+            .await
+            .unwrap();
+        assert_eq!(tx.digest, digest);
+    });
+}
+
+#[test]
+fn get_raw_transaction() {
+    let setup = ApiTestSetup::get_or_init();
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = setup;
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
+        let (receiver, _): (_, AccountKeyPair) = get_key_pair();
+
+        let (gas, object) = fund_gas_and_object(setup, sender).await;
+
+        let transaction_bytes: TransactionBlockBytes = client
+            .transfer_object(
+                sender,
+                object.object_id,
+                Some(gas.object_id),
+                10_000_000.into(),
+                receiver,
+            )
+            .await
+            .unwrap();
+
+        // `sender` is a freshly generated address (funded via the faucet), so it must
+        // be signed with its own key, not the cluster wallet.
+        let txn = to_sender_signed_transaction(transaction_bytes.to_data().unwrap(), &keypair);
+        let original_sender_signed_data = txn.data().clone();
+
+        let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
+
+        let response = client
+            .execute_transaction_block(
+                tx_bytes,
+                signatures,
+                Some(IotaTransactionBlockResponseOptions::new().with_raw_input()),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution.into()),
+            )
+            .await
+            .unwrap();
+
+        // The raw transaction bytes returned round-trip back to the original data.
+        let decoded_sender_signed_data: SenderSignedData =
+            bcs::from_bytes(&response.raw_transaction).unwrap();
+        assert_eq!(decoded_sender_signed_data, original_sender_signed_data);
+    });
+}

--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -1,18 +1,20 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
+use std::{path::Path, str::FromStr};
 
 use iota_indexer::store::PgIndexerStore;
-use iota_json::{call_args, type_args};
+use iota_json::{call_arg, call_args, type_args};
 use iota_json_rpc_api::{
     CoinReadApiClient, GovernanceReadApiClient, IndexerApiClient, ReadApiClient,
-    TransactionBuilderClient,
+    TransactionBuilderClient, WriteApiClient,
 };
 use iota_json_rpc_types::{
-    IotaObjectDataOptions, IotaObjectResponseQuery, MoveCallParams, ObjectsPage, PtbInput,
+    IotaArgument, IotaObjectDataOptions, IotaObjectResponseQuery, IotaTransactionBlockEffectsAPI,
+    IotaTransactionBlockResponseOptions, MoveCallParams, ObjectsPage, PtbInput,
     RPCTransactionRequestParams, StakeStatus, TransactionBlockBytes, TransferObjectParams,
 };
+use iota_move_build::BuildConfig;
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{Address, ObjectData, ObjectId, Owner, StructTag};
 use iota_swarm_config::genesis_config::AccountConfig;
@@ -23,10 +25,12 @@ use iota_types::{
     id::UID,
     iota_system_state::iota_system_state_summary::IotaSystemStateSummary,
     object::{MoveObject, MoveObjectExt, OBJECT_START_VERSION, ObjectInner},
+    quorum_driver_types::ExecuteTransactionRequestType,
     timelock::{
         label::label_struct_tag_to_string, stardust_upgrade_label::stardust_upgrade_label_type,
         timelock::TimeLock,
     },
+    utils::to_sender_signed_transaction,
 };
 use jsonrpsee::http_client::HttpClient;
 use test_cluster::TestCluster;
@@ -34,7 +38,7 @@ use test_cluster::TestCluster;
 use crate::common::{
     ApiTestSetup, execute_tx_and_wait_for_indexer_checkpoint, execute_tx_must_succeed,
     indexer_wait_for_checkpoint, indexer_wait_for_latest_checkpoint, indexer_wait_for_object,
-    start_test_cluster_with_read_write_indexer,
+    indexer_wait_for_transaction, start_test_cluster_with_read_write_indexer,
 };
 const FUNDED_BALANCE_PER_COIN: u64 = 10_000_000_000;
 
@@ -437,6 +441,222 @@ fn batch_transaction() {
             assert_eq!(sender_balances.len(), 3);
             assert_eq!(sender_balances[0..2], [amount_to_split, amount_to_leave]);
             assert_eq!(receiver_balances, [FUNDED_BALANCE_PER_COIN]);
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn batch_transaction_with_result() {
+    let ApiTestSetup {
+        runtime,
+        store: _,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime
+        .block_on(async move {
+            let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
+            let (receiver, _): (_, AccountKeyPair) = get_key_pair();
+
+            let sender_coins = create_coins_and_wait_for_indexer(cluster, client, sender, 2).await;
+            let coin_to_split = sender_coins[0];
+            let gas = sender_coins[1];
+            let amount_to_split = 10;
+
+            // The second command consumes the result of the first (the split-off coin)
+            // via a PTB result reference.
+            let tx_bytes: TransactionBlockBytes = client
+                .batch_transaction(
+                    sender,
+                    vec![
+                        RPCTransactionRequestParams::MoveCallRequestParams(MoveCallParams {
+                            package_object_id: ObjectId::FRAMEWORK,
+                            module: "coin".to_string(),
+                            function: "split".to_string(),
+                            type_arguments: type_args![StructTag::new_gas()]?,
+                            arguments: call_args!(coin_to_split, amount_to_split)?
+                                .into_iter()
+                                .map(PtbInput::CallArg)
+                                .collect(),
+                        }),
+                        RPCTransactionRequestParams::MoveCallRequestParams(MoveCallParams {
+                            package_object_id: ObjectId::FRAMEWORK,
+                            module: "transfer".to_string(),
+                            function: "public_transfer".to_string(),
+                            type_arguments: type_args![StructTag::new_gas_coin()]?,
+                            arguments: vec![
+                                PtbInput::PtbRef(IotaArgument::Result(0)),
+                                PtbInput::CallArg(call_arg!(receiver)?),
+                            ],
+                        }),
+                    ],
+                    Some(gas),
+                    10_000_000.into(),
+                    None,
+                )
+                .await?;
+            execute_tx_must_succeed(client, tx_bytes, &keypair).await;
+
+            // The split-off coin was transferred to the receiver.
+            let receiver_balances = get_address_balances(client, receiver).await;
+            assert_eq!(receiver_balances, [amount_to_split]);
+
+            // The sender keeps the remainder of the split coin.
+            let split_coin_balances: Vec<_> = client
+                .get_coins(sender, None, None, None)
+                .await?
+                .data
+                .into_iter()
+                .filter(|coin| coin.coin_object_id == coin_to_split)
+                .map(|coin| coin.balance)
+                .collect();
+            assert_eq!(
+                split_coin_balances,
+                [FUNDED_BALANCE_PER_COIN - amount_to_split]
+            );
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn publish() {
+    let ApiTestSetup {
+        runtime,
+        store: _,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime
+        .block_on(async move {
+            let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
+            let coins = create_coins_and_wait_for_indexer(cluster, client, sender, 1).await;
+            let gas = coins[0];
+
+            let compiled_package =
+                BuildConfig::new_for_testing().build(Path::new("../../examples/move/basics"))?;
+            let compiled_modules_bytes =
+                compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+            let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+            let tx_bytes: TransactionBlockBytes = client
+                .publish(
+                    sender,
+                    compiled_modules_bytes,
+                    dependencies,
+                    Some(gas),
+                    100_000_000.into(),
+                )
+                .await?;
+
+            let txn = to_sender_signed_transaction(tx_bytes.to_data()?, &keypair);
+            let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
+            let tx_response = client
+                .execute_transaction_block(
+                    tx_bytes,
+                    signatures,
+                    Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+                    Some(ExecuteTransactionRequestType::WaitForLocalExecution.into()),
+                )
+                .await?;
+
+            assert_eq!(tx_response.status_ok(), Some(true));
+            assert!(
+                !tx_response.effects.unwrap().created().is_empty(),
+                "publishing a package should create objects"
+            );
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn staking_multiple_coins() {
+    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
+
+    runtime
+        .block_on(async move {
+            let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
+                Some("transaction_builder_staking_multiple_coins"),
+                None,
+                None,
+            )
+            .await;
+
+            let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
+            let coins = create_coins_and_wait_for_indexer(cluster, client, sender, 5).await;
+            let validator = get_validator(client).await;
+            let stake_amount: u64 = 1_000_000_000;
+
+            // Stake three coins; they should be merged and the remainder returned.
+            let transaction_bytes: TransactionBlockBytes = client
+                .request_add_stake(
+                    sender,
+                    vec![coins[0], coins[1], coins[2]],
+                    Some(stake_amount.into()),
+                    validator,
+                    Some(coins[3]),
+                    100_000_000.into(),
+                )
+                .await?;
+
+            let txn = to_sender_signed_transaction(transaction_bytes.to_data()?, &keypair);
+            let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
+
+            let dryrun_response = client.dry_run_transaction_block(tx_bytes.clone()).await?;
+
+            let executed_response = client
+                .execute_transaction_block(
+                    tx_bytes,
+                    signatures,
+                    Some(
+                        IotaTransactionBlockResponseOptions::new()
+                            .with_balance_changes()
+                            .with_input(),
+                    ),
+                    Some(ExecuteTransactionRequestType::WaitForLocalExecution.into()),
+                )
+                .await?;
+
+            // Dry run must predict the same balance changes and inputs as execution.
+            assert_eq!(
+                dryrun_response.balance_changes,
+                executed_response.balance_changes.clone().unwrap()
+            );
+            assert_eq!(
+                dryrun_response.input,
+                executed_response.transaction.clone().unwrap().data
+            );
+
+            indexer_wait_for_transaction(executed_response.digest, store, client).await;
+
+            // A single pending stake with the requested principal.
+            let staked_iota = client.get_stakes(sender).await?;
+            assert_eq!(1, staked_iota.len());
+            assert_eq!(stake_amount, staked_iota[0].stakes[0].principal);
+            assert!(matches!(
+                staked_iota[0].stakes[0].status,
+                StakeStatus::Pending
+            ));
+
+            // The three staked coins were merged: the sender is left with the merged
+            // remainder, the gas coin, and the untouched fifth coin.
+            let coins_after = client.get_coins(sender, None, None, None).await?.data;
+            assert_eq!(3, coins_after.len());
+            let remainder = coins_after
+                .iter()
+                .find(|coin| coin.balance > FUNDED_BALANCE_PER_COIN)
+                .unwrap();
+            assert_eq!(
+                remainder.balance,
+                FUNDED_BALANCE_PER_COIN * 3 - stake_amount
+            );
 
             Ok::<(), anyhow::Error>(())
         })


### PR DESCRIPTION
# Description of change

This PR is part of the effort to remove the JSON-RPC API served by `iota-node`: bring the indexer-backed JSON-RPC test suite (`crates/iota-indexer/tests/rpc-tests/`) to parity with the node-backed `crates/iota-json-rpc-tests`, so that the latter can be deleted in a follow-up PR **without losing coverage of the JSON-RPC surface** (which will continue to be served by the indexer).

What was ported / added:

- **read_api**: past-object reads with every `IotaObjectDataOptions` variant (single + multi-get), including asserts that the response contains exactly the requested fields; `try_get_object_before_version`; user-transaction timestamps; system-transaction display with empty balance changes (searched within the checkpoint, safe on the shared cluster).
- **coin_api**: all-coins pagination gap fills.
- **governance_api**: stake lifecycle with a freshly joined validator (`Pending` → `Active(0)` → `Active(>0)`) on a dedicated cluster/database.
- **transaction_builder**: batch transactions with PTB result references (incl. sender-side remainder assertion), publish, staking with multiple coins.
- **transaction_api** (new file): transaction execution/read coverage.
- **common**: `start_test_cluster_with_read_write_indexer_and_url` for tests that need a dedicated cluster + indexer database.

No production code is touched.

## Links to any relevant issues

Part of the node JSON-RPC removal effort.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

All ported tests pass locally against Postgres via
`cargo test -p iota-indexer --test rpc-tests --features shared_test_runtime`.