### PR TITLE
fix(iota-grpc-server): feed embedded batch errors into the traffic-control error policy

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,6 +40,7 @@ retries = 4
 filter = '''
 (package(iota) and (test(test_faucet_batch) or test(test_faucet_batch_concurrent_requests)))
 or (package(iota-e2e-tests) and (test(test_reconfig_with_committee_change_stress_determinism) or test(test_full_node_load_migration_data) or test(test_full_node_sync_flood_determinism) or test(test_passive_reconfig_determinism) or test(test_hash_collections) or test(test_net_determinism) or test(test_apy) or test(test_fullnode_traffic_control_spam_delegated) or test(test_validator_traffic_control_error_blocked) or test(test_fullnode_traffic_control_spam_blocked) or test(test_fullnode_traffic_control_error_blocked) or test(test_validator_traffic_control_error_delegated)))
+or (package(iota-grpc-server) and binary(traffic_control))
 or (package(iota-graphql-rpc) and test(test_epoch_data))
 or (package(iota-network-stack) and test(ip6))
 '''

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6356,6 +6356,7 @@ version = "1.29.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
+ "async-trait",
  "bcs",
  "futures",
  "http 1.4.0",

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -394,11 +394,11 @@ fn default_grpc_api_max_simulate_transaction_batch_size() -> u32 {
 }
 
 fn default_grpc_api_max_get_objects_batch_size() -> u32 {
-    50
+    1000
 }
 
 fn default_grpc_api_max_get_transactions_batch_size() -> u32 {
-    50
+    1000
 }
 
 fn default_grpc_api_max_checkpoint_inclusion_timeout_ms() -> u64 {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -349,6 +349,15 @@ pub struct GrpcApiConfig {
     #[serde(default = "default_grpc_api_max_simulate_transaction_batch_size")]
     pub max_simulate_transaction_batch_size: u32,
 
+    /// Maximum number of objects allowed in a single GetObjects batch request.
+    #[serde(default = "default_grpc_api_max_get_objects_batch_size")]
+    pub max_get_objects_batch_size: u32,
+
+    /// Maximum number of transactions allowed in a single GetTransactions batch
+    /// request.
+    #[serde(default = "default_grpc_api_max_get_transactions_batch_size")]
+    pub max_get_transactions_batch_size: u32,
+
     /// Maximum allowed timeout in milliseconds for waiting for checkpoint
     /// inclusion in ExecuteTransactions requests. Client-specified timeouts
     /// are clamped to this value.
@@ -384,6 +393,14 @@ fn default_grpc_api_max_simulate_transaction_batch_size() -> u32 {
     20
 }
 
+fn default_grpc_api_max_get_objects_batch_size() -> u32 {
+    50
+}
+
+fn default_grpc_api_max_get_transactions_batch_size() -> u32 {
+    50
+}
+
 fn default_grpc_api_max_checkpoint_inclusion_timeout_ms() -> u64 {
     60_000 // 60 seconds
 }
@@ -401,6 +418,8 @@ impl Default for GrpcApiConfig {
             ),
             max_simulate_transaction_batch_size:
                 default_grpc_api_max_simulate_transaction_batch_size(),
+            max_get_objects_batch_size: default_grpc_api_max_get_objects_batch_size(),
+            max_get_transactions_batch_size: default_grpc_api_max_get_transactions_batch_size(),
             max_checkpoint_inclusion_timeout_ms:
                 default_grpc_api_max_checkpoint_inclusion_timeout_ms(),
         }

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -42,7 +42,10 @@ move-core-types.workspace = true
 prometheus-filtered.workspace = true
 
 [dev-dependencies]
+# external dependencies
 async-trait.workspace = true
+
+# internal dependencies
 iota-grpc-client.workspace = true
 iota-test-transaction-builder.workspace = true
 move-binary-format.workspace = true

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -42,6 +42,7 @@ move-core-types.workspace = true
 prometheus-filtered.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 iota-grpc-client.workspace = true
 iota-test-transaction-builder.workspace = true
 move-binary-format.workspace = true

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -110,9 +110,7 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         // transport-level traffic control: charge one request per requested
         // item so batching cannot dilute the spam rate.
         if let Some(tally_handle) = &tally_handle {
-            for _ in 0..item_count {
-                tally_handle.tally_item(tonic::Code::Ok);
-            }
+            tally_handle.tally_items((0..item_count).map(|_| tonic::Code::Ok));
         }
         Ok(append_info_headers!(response, self.reader.clone()))
     }
@@ -136,9 +134,7 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         // transport-level traffic control: charge one request per requested
         // item so batching cannot dilute the spam rate.
         if let Some(tally_handle) = &tally_handle {
-            for _ in 0..item_count {
-                tally_handle.tally_item(tonic::Code::Ok);
-            }
+            tally_handle.tally_items((0..item_count).map(|_| tonic::Code::Ok));
         }
         Ok(append_info_headers!(response, self.reader.clone()))
     }

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -10,12 +10,13 @@ mod get_transactions;
 
 use std::sync::Arc;
 
+use futures::StreamExt;
 use iota_config::node::GrpcApiConfig;
 use iota_grpc_types::v1::ledger_service::{self as grpc_ledger_service};
 use iota_protocol_config::Chain;
 use iota_types::digests::ChainIdentifier;
 use tokio_util::sync::CancellationToken;
-use tonic::{Request, Response, Status};
+use tonic::{Code, Request, Response, Status};
 
 use crate::{traffic_control::TallyHandle, types::*};
 
@@ -103,15 +104,25 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
             .as_ref()
             .map_or(0, |batch| batch.requests.len());
         validate_read_batch_size(item_count, self.config.max_get_objects_batch_size)?;
-        let response = get_objects::get_objects(self.reader.clone(), request)
-            .map(|stream| Response::new(Box::pin(stream) as Self::GetObjectsStream))
-            .map_err(tonic::Status::from)?;
+        let stream =
+            get_objects::get_objects(self.reader.clone(), request).map_err(tonic::Status::from)?;
         // The batch's items are streamed lazily and invisible to the
-        // transport-level traffic control: charge one request per requested
-        // item so batching cannot dilute the spam rate.
+        // transport-level traffic control. Mark the request as accounted so the
+        // layer skips its default per-request tally, then charge one request per
+        // item as it is produced, so batching cannot dilute the spam rate. Reads
+        // feed the spam policy only: a client cannot know an object or
+        // transaction was pruned, so per-item read failures must not count
+        // towards the error policy.
         if let Some(tally_handle) = &tally_handle {
-            tally_handle.tally_items((0..item_count).map(|_| tonic::Code::Ok));
+            tally_handle.mark_accounted();
         }
+        let stream = stream.map(move |result| {
+            if let (Some(tally_handle), Ok(response)) = (&tally_handle, &result) {
+                tally_handle.tally_items(response.objects.iter().map(|_| Code::Ok));
+            }
+            result
+        });
+        let response = Response::new(Box::pin(stream) as Self::GetObjectsStream);
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 
@@ -126,16 +137,26 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
             .as_ref()
             .map_or(0, |batch| batch.requests.len());
         validate_read_batch_size(item_count, self.config.max_get_transactions_batch_size)?;
-        let response =
+        let stream =
             get_transactions::get_transactions(self.reader.clone(), self.config.clone(), request)
-                .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))
                 .map_err(tonic::Status::from)?;
         // The batch's items are streamed lazily and invisible to the
-        // transport-level traffic control: charge one request per requested
-        // item so batching cannot dilute the spam rate.
+        // transport-level traffic control. Mark the request as accounted so the
+        // layer skips its default per-request tally, then charge one request per
+        // item as it is produced, so batching cannot dilute the spam rate. Reads
+        // feed the spam policy only: a client cannot know an object or
+        // transaction was pruned, so per-item read failures must not count
+        // towards the error policy.
         if let Some(tally_handle) = &tally_handle {
-            tally_handle.tally_items((0..item_count).map(|_| tonic::Code::Ok));
+            tally_handle.mark_accounted();
         }
+        let stream = stream.map(move |result| {
+            if let (Some(tally_handle), Ok(response)) = (&tally_handle, &result) {
+                tally_handle.tally_items(response.transaction_results.iter().map(|_| Code::Ok));
+            }
+            result
+        });
+        let response = Response::new(Box::pin(stream) as Self::GetTransactionsStream);
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -10,7 +10,7 @@ mod get_transactions;
 
 use std::sync::Arc;
 
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use iota_config::node::GrpcApiConfig;
 use iota_grpc_types::v1::ledger_service::{self as grpc_ledger_service};
 use iota_protocol_config::Chain;
@@ -61,6 +61,43 @@ fn validate_read_batch_size(item_count: usize, max: u32) -> Result<(), Status> {
     Ok(())
 }
 
+/// Charge a streaming batch read to the traffic controller as its response
+/// stream is consumed.
+///
+/// The batch's items are streamed lazily and invisible to the transport-level
+/// traffic control. The request is marked as accounted so the layer skips its
+/// default per-request tally, and is instead charged one request per produced
+/// item, so batching cannot dilute the spam rate; an empty batch produces no
+/// per-item tallies and is charged as one request up front instead. Per-item
+/// read failures ride inside `Ok` responses and are tallied as `Ok`: a client
+/// cannot know an object or transaction was pruned, so they must not feed the
+/// error policy. A stream-level error terminates the stream and is tallied by
+/// its status code, like a unary handler error.
+fn tally_read_stream<T>(
+    stream: impl Stream<Item = Result<T, Status>> + Send,
+    tally_handle: Option<TallyHandle>,
+    request_item_count: usize,
+    response_item_count: impl Fn(&T) -> usize + Send,
+) -> impl Stream<Item = Result<T, Status>> + Send {
+    if let Some(tally_handle) = &tally_handle {
+        if request_item_count == 0 {
+            tally_handle.tally_item(Code::Ok);
+        } else {
+            tally_handle.mark_accounted();
+        }
+    }
+    stream.map(move |result| {
+        if let Some(tally_handle) = &tally_handle {
+            match &result {
+                Ok(response) => tally_handle
+                    .tally_items(std::iter::repeat_n(Code::Ok, response_item_count(response))),
+                Err(status) => tally_handle.tally_item(status.code()),
+            }
+        }
+        result
+    })
+}
+
 #[tonic::async_trait]
 impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcService {
     type GetObjectsStream = crate::types::GetObjectsStream;
@@ -106,21 +143,8 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         validate_read_batch_size(item_count, self.config.max_get_objects_batch_size)?;
         let stream =
             get_objects::get_objects(self.reader.clone(), request).map_err(tonic::Status::from)?;
-        // The batch's items are streamed lazily and invisible to the
-        // transport-level traffic control. Mark the request as accounted so the
-        // layer skips its default per-request tally, then charge one request per
-        // item as it is produced, so batching cannot dilute the spam rate. Reads
-        // feed the spam policy only: a client cannot know an object or
-        // transaction was pruned, so per-item read failures must not count
-        // towards the error policy.
-        if let Some(tally_handle) = &tally_handle {
-            tally_handle.mark_accounted();
-        }
-        let stream = stream.map(move |result| {
-            if let (Some(tally_handle), Ok(response)) = (&tally_handle, &result) {
-                tally_handle.tally_items(response.objects.iter().map(|_| Code::Ok));
-            }
-            result
+        let stream = tally_read_stream(stream, tally_handle, item_count, |response| {
+            response.objects.len()
         });
         let response = Response::new(Box::pin(stream) as Self::GetObjectsStream);
         Ok(append_info_headers!(response, self.reader.clone()))
@@ -140,21 +164,8 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         let stream =
             get_transactions::get_transactions(self.reader.clone(), self.config.clone(), request)
                 .map_err(tonic::Status::from)?;
-        // The batch's items are streamed lazily and invisible to the
-        // transport-level traffic control. Mark the request as accounted so the
-        // layer skips its default per-request tally, then charge one request per
-        // item as it is produced, so batching cannot dilute the spam rate. Reads
-        // feed the spam policy only: a client cannot know an object or
-        // transaction was pruned, so per-item read failures must not count
-        // towards the error policy.
-        if let Some(tally_handle) = &tally_handle {
-            tally_handle.mark_accounted();
-        }
-        let stream = stream.map(move |result| {
-            if let (Some(tally_handle), Ok(response)) = (&tally_handle, &result) {
-                tally_handle.tally_items(response.transaction_results.iter().map(|_| Code::Ok));
-            }
-            result
+        let stream = tally_read_stream(stream, tally_handle, item_count, |response| {
+            response.transaction_results.len()
         });
         let response = Response::new(Box::pin(stream) as Self::GetTransactionsStream);
         Ok(append_info_headers!(response, self.reader.clone()))

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -47,6 +47,19 @@ impl LedgerGrpcService {
     }
 }
 
+/// Reject a read batch whose item count exceeds `max`. An empty batch is
+/// allowed and yields an empty stream. Bounding the count also bounds the
+/// per-item traffic-control tally so a large batch cannot flood the tally
+/// channel.
+fn validate_read_batch_size(item_count: usize, max: u32) -> Result<(), Status> {
+    if item_count > max as usize {
+        return Err(Status::invalid_argument(format!(
+            "batch size {item_count} exceeds maximum allowed ({max})"
+        )));
+    }
+    Ok(())
+}
+
 #[tonic::async_trait]
 impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcService {
     type GetObjectsStream = crate::types::GetObjectsStream;
@@ -89,6 +102,7 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
             .requests
             .as_ref()
             .map_or(0, |batch| batch.requests.len());
+        validate_read_batch_size(item_count, self.config.max_get_objects_batch_size)?;
         let response = get_objects::get_objects(self.reader.clone(), request)
             .map(|stream| Response::new(Box::pin(stream) as Self::GetObjectsStream))
             .map_err(tonic::Status::from)?;
@@ -113,6 +127,7 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
             .requests
             .as_ref()
             .map_or(0, |batch| batch.requests.len());
+        validate_read_batch_size(item_count, self.config.max_get_transactions_batch_size)?;
         let response =
             get_transactions::get_transactions(self.reader.clone(), self.config.clone(), request)
                 .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))

--- a/crates/iota-grpc-server/src/ledger_service/mod.rs
+++ b/crates/iota-grpc-server/src/ledger_service/mod.rs
@@ -17,7 +17,7 @@ use iota_types::digests::ChainIdentifier;
 use tokio_util::sync::CancellationToken;
 use tonic::{Request, Response, Status};
 
-use crate::types::*;
+use crate::{traffic_control::TallyHandle, types::*};
 
 pub struct LedgerGrpcService {
     pub config: GrpcApiConfig,
@@ -83,9 +83,23 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         &self,
         request: tonic::Request<grpc_ledger_service::GetObjectsRequest>,
     ) -> std::result::Result<tonic::Response<Self::GetObjectsStream>, tonic::Status> {
-        let response = get_objects::get_objects(self.reader.clone(), request.into_inner())
+        let tally_handle = request.extensions().get::<TallyHandle>().cloned();
+        let request = request.into_inner();
+        let item_count = request
+            .requests
+            .as_ref()
+            .map_or(0, |batch| batch.requests.len());
+        let response = get_objects::get_objects(self.reader.clone(), request)
             .map(|stream| Response::new(Box::pin(stream) as Self::GetObjectsStream))
             .map_err(tonic::Status::from)?;
+        // The batch's items are streamed lazily and invisible to the
+        // transport-level traffic control: charge one request per requested
+        // item so batching cannot dilute the spam rate.
+        if let Some(tally_handle) = &tally_handle {
+            for _ in 0..item_count {
+                tally_handle.tally_item(tonic::Code::Ok);
+            }
+        }
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 
@@ -93,13 +107,24 @@ impl grpc_ledger_service::ledger_service_server::LedgerService for LedgerGrpcSer
         &self,
         request: tonic::Request<grpc_ledger_service::GetTransactionsRequest>,
     ) -> std::result::Result<tonic::Response<Self::GetTransactionsStream>, tonic::Status> {
-        let response = get_transactions::get_transactions(
-            self.reader.clone(),
-            self.config.clone(),
-            request.into_inner(),
-        )
-        .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))
-        .map_err(tonic::Status::from)?;
+        let tally_handle = request.extensions().get::<TallyHandle>().cloned();
+        let request = request.into_inner();
+        let item_count = request
+            .requests
+            .as_ref()
+            .map_or(0, |batch| batch.requests.len());
+        let response =
+            get_transactions::get_transactions(self.reader.clone(), self.config.clone(), request)
+                .map(|stream| Response::new(Box::pin(stream) as Self::GetTransactionsStream))
+                .map_err(tonic::Status::from)?;
+        // The batch's items are streamed lazily and invisible to the
+        // transport-level traffic control: charge one request per requested
+        // item so batching cannot dilute the spam rate.
+        if let Some(tally_handle) = &tally_handle {
+            for _ in 0..item_count {
+                tally_handle.tally_item(tonic::Code::Ok);
+            }
+        }
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -4,11 +4,14 @@
 //! Tower [`Layer`] that wires the shared [`TrafficController`] into the
 //! gRPC server.
 //!
-//! The layer extracts the client IP and calls the traffic controller with a
-//! weight derived from the response's gRPC status code. Errors that a batch
-//! API embeds inside an otherwise successful response are invisible at this
-//! level; handlers report those through the [`ErrorTallyHandle`] request
-//! extension.
+//! The layer extracts the client IP and tallies each request against the
+//! traffic controller, deriving the error weight from the response's gRPC
+//! status code. A batch API's items are invisible at this level: their per-item
+//! errors are embedded in an otherwise successful response, and a batch would
+//! count as a single request regardless of how many items it carries. Handlers
+//! report each item through the [`TallyHandle`] request extension so it counts
+//! individually for the spam policy and feeds the error policy on client
+//! errors.
 //!
 //! [check]: iota_core::traffic_controller::TrafficController::check
 //! [tally]: iota_core::traffic_controller::TrafficController::tally
@@ -17,7 +20,10 @@ use std::{
     future::Future,
     net::IpAddr,
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     task::{Context, Poll},
     time::SystemTime,
 };
@@ -101,10 +107,15 @@ where
             }
         };
 
+        // A batch handler sets this through its `TallyHandle` once it has
+        // accounted for each item, so the layer skips its default
+        // one-tally-per-request accounting below.
+        let per_item_accounted = Arc::new(AtomicBool::new(false));
         let mut req = req;
-        req.extensions_mut().insert(ErrorTallyHandle {
+        req.extensions_mut().insert(TallyHandle {
             traffic_controller: traffic_controller.clone(),
             client,
+            per_item_accounted: per_item_accounted.clone(),
         });
 
         // Tower contract: `self.inner` is the ready one (poll_ready set it up),
@@ -119,43 +130,48 @@ where
 
             let result = inner.call(req).await;
             if let Ok(response) = &result {
-                let code =
-                    Status::from_header_map(response.headers()).map_or(Code::Ok, |s| s.code());
-                tally(&traffic_controller, client, code, Weight::one());
+                // Batch handlers account for each embedded item themselves; only
+                // tally the request here when a handler didn't.
+                if !per_item_accounted.load(Ordering::Relaxed) {
+                    let code =
+                        Status::from_header_map(response.headers()).map_or(Code::Ok, |s| s.code());
+                    tally(&traffic_controller, client, code);
+                }
             }
             result
         })
     }
 }
 
-/// Request extension through which handlers report application-level errors
-/// that are embedded in an otherwise successful gRPC response (per-item
-/// errors of batch APIs), so they still feed the error policy.
+/// Request extension through which a batch handler reports each per-item result
+/// to the traffic controller.
+///
+/// A batch API's items are invisible to the transport-level layer: their
+/// per-item errors are embedded in an otherwise successful response, and a
+/// batch would otherwise count as a single request no matter how many items it
+/// carries. Reporting each item makes it count as one request for the spam
+/// policy and, on a client error, feeds the error policy — so batching cannot
+/// dilute a client's request rate or hide its errors.
 #[derive(Clone)]
-pub struct ErrorTallyHandle {
+pub struct TallyHandle {
     traffic_controller: Arc<TrafficController>,
     client: Option<IpAddr>,
+    per_item_accounted: Arc<AtomicBool>,
 }
 
-impl ErrorTallyHandle {
-    /// Report an application-level error embedded in a successful response.
+impl TallyHandle {
+    /// Account for one item of a batch response: count it as one request for
+    /// the spam policy and, if `code` is a client error, feed the error policy.
     ///
-    /// Uses a zero spam weight: the enclosing request is already spam-tallied
-    /// by the layer when its response completes.
-    pub fn tally_error(&self, code: Code) {
-        if matches!(code, Code::Ok) {
-            return;
-        }
-        tally(&self.traffic_controller, self.client, code, Weight::zero());
+    /// Signals the layer to skip its default per-request tally, so a batch is
+    /// charged per item rather than once.
+    pub fn tally_item(&self, code: Code) {
+        self.per_item_accounted.store(true, Ordering::Relaxed);
+        tally(&self.traffic_controller, self.client, code);
     }
 }
 
-fn tally(
-    traffic_controller: &TrafficController,
-    client: Option<IpAddr>,
-    code: Code,
-    spam_weight: Weight,
-) {
+fn tally(traffic_controller: &TrafficController, client: Option<IpAddr>, code: Code) {
     let error_info = if matches!(code, Code::Ok) {
         None
     } else {
@@ -165,7 +181,7 @@ fn tally(
         direct: client,
         through_fullnode: None,
         error_info,
-        spam_weight,
+        spam_weight: Weight::one(),
         timestamp: SystemTime::now(),
     });
 }

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -12,9 +12,10 @@
 //! would count as a single request regardless of how many items it carries.
 //! Handlers report each item through the [`TallyHandle`] request extension: an
 //! item counts as one request for the spam policy, and a per-item client error
-//! additionally feeds the error policy. Handlers that account eagerly from the
-//! request's item count (the streaming reads, whose items are produced lazily)
-//! report each item as `Code::Ok`, so they contribute to the spam policy only.
+//! additionally feeds the error policy. Unary batch handlers report their items
+//! eagerly once the response is built; streaming handlers tally each item as
+//! its response stream is consumed, calling [`TallyHandle::mark_accounted`] up
+//! front so the layer still skips its default per-request tally.
 //!
 //! [check]: iota_core::traffic_controller::TrafficController::check
 //! [tally]: iota_core::traffic_controller::TrafficController::tally
@@ -174,13 +175,21 @@ impl TallyHandle {
         self.per_item_accounted.load(Ordering::Relaxed)
     }
 
+    /// Signal that the handler will account for this request's items itself, so
+    /// the layer skips its default one-tally-per-request accounting. Call this
+    /// when the per-item tallies happen later than the handler returns — e.g. a
+    /// streaming handler that tallies each item as its response stream is
+    /// consumed, after the layer has already checked the flag.
+    pub fn mark_accounted(&self) {
+        self.per_item_accounted.store(true, Ordering::Relaxed);
+    }
+
     /// Account for one item of a batch response: count it as one request for
     /// the spam policy and, if `code` is a client error, feed the error policy.
-    /// Passing `Code::Ok` (e.g. when accounting eagerly from a request's item
-    /// count) contributes to the spam policy only.
+    /// Passing `Code::Ok` contributes to the spam policy only.
     ///
-    /// Signals the layer to skip its default per-request tally, so a batch is
-    /// charged per item rather than once.
+    /// Also signals the layer to skip its default per-request tally, so a batch
+    /// is charged per item rather than once.
     pub fn tally_item(&self, code: Code) {
         self.per_item_accounted.store(true, Ordering::Relaxed);
         tally(&self.traffic_controller, self.client, code);

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -113,13 +113,9 @@ where
         // A batch handler sets this through its `TallyHandle` once it has
         // accounted for each item, so the layer skips its default
         // one-tally-per-request accounting below.
-        let per_item_accounted = Arc::new(AtomicBool::new(false));
+        let tally_handle = TallyHandle::new(traffic_controller.clone(), client);
         let mut req = req;
-        req.extensions_mut().insert(TallyHandle {
-            traffic_controller: traffic_controller.clone(),
-            client,
-            per_item_accounted: per_item_accounted.clone(),
-        });
+        req.extensions_mut().insert(tally_handle.clone());
 
         // Tower contract: `self.inner` is the ready one (poll_ready set it up),
         // so call it and leave the clone for the next request.
@@ -135,7 +131,7 @@ where
             if let Ok(response) = &result {
                 // Batch handlers account for each embedded item themselves; only
                 // tally the request here when a handler didn't.
-                if !per_item_accounted.load(Ordering::Relaxed) {
+                if !tally_handle.per_item_accounted() {
                     let code =
                         Status::from_header_map(response.headers()).map_or(Code::Ok, |s| s.code());
                     tally(&traffic_controller, client, code);
@@ -163,6 +159,20 @@ pub struct TallyHandle {
 }
 
 impl TallyHandle {
+    fn new(traffic_controller: Arc<TrafficController>, client: Option<IpAddr>) -> Self {
+        Self {
+            traffic_controller,
+            client,
+            per_item_accounted: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Whether a handler has accounted for this request's items itself, in which
+    /// case the layer skips its default one-tally-per-request accounting.
+    fn per_item_accounted(&self) -> bool {
+        self.per_item_accounted.load(Ordering::Relaxed)
+    }
+
     /// Account for one item of a batch response: count it as one request for
     /// the spam policy and, if `code` is a client error, feed the error policy.
     /// Passing `Code::Ok` (e.g. when accounting eagerly from a request's item
@@ -173,6 +183,14 @@ impl TallyHandle {
     pub fn tally_item(&self, code: Code) {
         self.per_item_accounted.store(true, Ordering::Relaxed);
         tally(&self.traffic_controller, self.client, code);
+    }
+
+    /// Account for each item of a batch response by its status code (see
+    /// [`Self::tally_item`]).
+    pub fn tally_items(&self, codes: impl IntoIterator<Item = Code>) {
+        for code in codes {
+            self.tally_item(code);
+        }
     }
 }
 

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -4,8 +4,11 @@
 //! Tower [`Layer`] that wires the shared [`TrafficController`] into the
 //! gRPC server.
 //!
-//! The layer extracts the client IP via and calls the traffic controller
-//! with a weight derived from the response's gRPC status code.
+//! The layer extracts the client IP and calls the traffic controller with a
+//! weight derived from the response's gRPC status code. Errors that a batch
+//! API embeds inside an otherwise successful response are invisible at this
+//! level; handlers report those through the [`ErrorTallyHandle`] request
+//! extension.
 //!
 //! [check]: iota_core::traffic_controller::TrafficController::check
 //! [tally]: iota_core::traffic_controller::TrafficController::tally
@@ -98,6 +101,12 @@ where
             }
         };
 
+        let mut req = req;
+        req.extensions_mut().insert(ErrorTallyHandle {
+            traffic_controller: traffic_controller.clone(),
+            client,
+        });
+
         // Tower contract: `self.inner` is the ready one (poll_ready set it up),
         // so call it and leave the clone for the next request.
         let cloned = self.inner.clone();
@@ -112,14 +121,41 @@ where
             if let Ok(response) = &result {
                 let code =
                     Status::from_header_map(response.headers()).map_or(Code::Ok, |s| s.code());
-                tally(&traffic_controller, client, code);
+                tally(&traffic_controller, client, code, Weight::one());
             }
             result
         })
     }
 }
 
-fn tally(traffic_controller: &TrafficController, client: Option<IpAddr>, code: Code) {
+/// Request extension through which handlers report application-level errors
+/// that are embedded in an otherwise successful gRPC response (per-item
+/// errors of batch APIs), so they still feed the error policy.
+#[derive(Clone)]
+pub struct ErrorTallyHandle {
+    traffic_controller: Arc<TrafficController>,
+    client: Option<IpAddr>,
+}
+
+impl ErrorTallyHandle {
+    /// Report an application-level error embedded in a successful response.
+    ///
+    /// Uses a zero spam weight: the enclosing request is already spam-tallied
+    /// by the layer when its response completes.
+    pub fn tally_error(&self, code: Code) {
+        if matches!(code, Code::Ok) {
+            return;
+        }
+        tally(&self.traffic_controller, self.client, code, Weight::zero());
+    }
+}
+
+fn tally(
+    traffic_controller: &TrafficController,
+    client: Option<IpAddr>,
+    code: Code,
+    spam_weight: Weight,
+) {
     let error_info = if matches!(code, Code::Ok) {
         None
     } else {
@@ -129,7 +165,7 @@ fn tally(traffic_controller: &TrafficController, client: Option<IpAddr>, code: C
         direct: client,
         through_fullnode: None,
         error_info,
-        spam_weight: Weight::one(),
+        spam_weight,
         timestamp: SystemTime::now(),
     });
 }

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -6,12 +6,13 @@
 //!
 //! The layer extracts the client IP and tallies each request against the
 //! traffic controller, deriving the error weight from the response's gRPC
-//! status code. A batch API's items are invisible at this level: their per-item
-//! errors are embedded in an otherwise successful response, and a batch would
-//! count as a single request regardless of how many items it carries. Handlers
-//! report each item through the [`TallyHandle`] request extension so it counts
-//! individually for the spam policy and feeds the error policy on client
-//! errors.
+//! status code. A batch API's items are invisible at this level: their results
+//! ride in the response body — embedded in a unary response or produced lazily
+//! by a stream — while the layer only inspects the response status, so a batch
+//! would count as a single request regardless of how many items it carries.
+//! Handlers report each item through the [`TallyHandle`] request extension so
+//! it counts individually for the spam policy and feeds the error policy on
+//! client errors.
 //!
 //! [check]: iota_core::traffic_controller::TrafficController::check
 //! [tally]: iota_core::traffic_controller::TrafficController::tally

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -167,8 +167,9 @@ impl TallyHandle {
         }
     }
 
-    /// Whether a handler has accounted for this request's items itself, in which
-    /// case the layer skips its default one-tally-per-request accounting.
+    /// Whether a handler has accounted for this request's items itself, in
+    /// which case the layer skips its default one-tally-per-request
+    /// accounting.
     fn per_item_accounted(&self) -> bool {
         self.per_item_accounted.load(Ordering::Relaxed)
     }

--- a/crates/iota-grpc-server/src/traffic_control.rs
+++ b/crates/iota-grpc-server/src/traffic_control.rs
@@ -10,9 +10,11 @@
 //! ride in the response body — embedded in a unary response or produced lazily
 //! by a stream — while the layer only inspects the response status, so a batch
 //! would count as a single request regardless of how many items it carries.
-//! Handlers report each item through the [`TallyHandle`] request extension so
-//! it counts individually for the spam policy and feeds the error policy on
-//! client errors.
+//! Handlers report each item through the [`TallyHandle`] request extension: an
+//! item counts as one request for the spam policy, and a per-item client error
+//! additionally feeds the error policy. Handlers that account eagerly from the
+//! request's item count (the streaming reads, whose items are produced lazily)
+//! report each item as `Code::Ok`, so they contribute to the spam policy only.
 //!
 //! [check]: iota_core::traffic_controller::TrafficController::check
 //! [tally]: iota_core::traffic_controller::TrafficController::tally
@@ -163,6 +165,8 @@ pub struct TallyHandle {
 impl TallyHandle {
     /// Account for one item of a batch response: count it as one request for
     /// the spam policy and, if `code` is a client error, feed the error policy.
+    /// Passing `Code::Ok` (e.g. when accounting eagerly from a request's item
+    /// count) contributes to the spam policy only.
     ///
     /// Signals the layer to skip its default per-request tally, so a batch is
     /// charged per item rather than once.

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -33,7 +33,7 @@ use prost_types::FieldMask;
 use tonic::{Request, Response};
 pub use transaction::{CommandResultsReadSource, TransactionReadSource};
 
-use crate::{error::RpcError, merge::Merge, traffic_control::ErrorTallyHandle, types::GrpcReader};
+use crate::{error::RpcError, merge::Merge, traffic_control::TallyHandle, types::GrpcReader};
 
 pub struct TransactionExecutionGrpcService {
     pub config: iota_config::node::GrpcApiConfig,
@@ -63,7 +63,7 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         &self,
         request: Request<ExecuteTransactionsRequest>,
     ) -> Result<Response<ExecuteTransactionsResponse>, tonic::Status> {
-        let error_tally = request.extensions().get::<ErrorTallyHandle>().cloned();
+        let tally_handle = request.extensions().get::<TallyHandle>().cloned();
         let response = execute_transactions(
             &self.reader,
             &self.executor,
@@ -73,13 +73,18 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         .await
         .map(Response::new)
         .map_err(tonic::Status::from)?;
-        // Per-item errors are embedded in a successful response, invisible to
-        // the transport-level traffic control; feed them to the error policy.
-        if let Some(error_tally) = &error_tally {
+        // Each batch item is invisible to the transport-level traffic control:
+        // account for every item so a batch is charged per item, and its
+        // embedded per-item errors feed the error policy.
+        if let Some(tally_handle) = &tally_handle {
             for result in &response.get_ref().transaction_results {
-                if let Some(execute_transaction_result::Result::Error(error)) = &result.result {
-                    error_tally.tally_error(tonic::Code::from(error.code));
-                }
+                let code = match &result.result {
+                    Some(execute_transaction_result::Result::Error(error)) => {
+                        tonic::Code::from(error.code)
+                    }
+                    _ => tonic::Code::Ok,
+                };
+                tally_handle.tally_item(code);
             }
         }
         Ok(append_info_headers!(response, self.reader.clone()))
@@ -89,7 +94,7 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         &self,
         request: Request<SimulateTransactionsRequest>,
     ) -> Result<Response<SimulateTransactionsResponse>, tonic::Status> {
-        let error_tally = request.extensions().get::<ErrorTallyHandle>().cloned();
+        let tally_handle = request.extensions().get::<TallyHandle>().cloned();
         let response = simulate::simulate_transactions(
             &self.reader,
             &self.executor,
@@ -99,13 +104,18 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         .await
         .map(Response::new)
         .map_err(tonic::Status::from)?;
-        // Per-item errors are embedded in a successful response, invisible to
-        // the transport-level traffic control; feed them to the error policy.
-        if let Some(error_tally) = &error_tally {
+        // Each batch item is invisible to the transport-level traffic control:
+        // account for every item so a batch is charged per item, and its
+        // embedded per-item errors feed the error policy.
+        if let Some(tally_handle) = &tally_handle {
             for result in &response.get_ref().transaction_results {
-                if let Some(simulate_transaction_result::Result::Error(error)) = &result.result {
-                    error_tally.tally_error(tonic::Code::from(error.code));
-                }
+                let code = match &result.result {
+                    Some(simulate_transaction_result::Result::Error(error)) => {
+                        tonic::Code::from(error.code)
+                    }
+                    _ => tonic::Code::Ok,
+                };
+                tally_handle.tally_item(code);
             }
         }
         Ok(append_info_headers!(response, self.reader.clone()))

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -77,14 +77,14 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         // account for every item so a batch is charged per item, and its
         // embedded per-item errors feed the error policy.
         if let Some(tally_handle) = &tally_handle {
-            tally_handle.tally_items(response.get_ref().transaction_results.iter().map(
-                |result| match &result.result {
+            tally_handle.tally_items(response.get_ref().transaction_results.iter().map(|result| {
+                match &result.result {
                     Some(execute_transaction_result::Result::Error(error)) => {
                         tonic::Code::from(error.code)
                     }
                     _ => tonic::Code::Ok,
-                },
-            ));
+                }
+            }));
         }
         Ok(append_info_headers!(response, self.reader.clone()))
     }
@@ -107,14 +107,14 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         // account for every item so a batch is charged per item, and its
         // embedded per-item errors feed the error policy.
         if let Some(tally_handle) = &tally_handle {
-            tally_handle.tally_items(response.get_ref().transaction_results.iter().map(
-                |result| match &result.result {
+            tally_handle.tally_items(response.get_ref().transaction_results.iter().map(|result| {
+                match &result.result {
                     Some(simulate_transaction_result::Result::Error(error)) => {
                         tonic::Code::from(error.code)
                     }
                     _ => tonic::Code::Ok,
-                },
-            ));
+                }
+            }));
         }
         Ok(append_info_headers!(response, self.reader.clone()))
     }

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -77,15 +77,14 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         // account for every item so a batch is charged per item, and its
         // embedded per-item errors feed the error policy.
         if let Some(tally_handle) = &tally_handle {
-            for result in &response.get_ref().transaction_results {
-                let code = match &result.result {
+            tally_handle.tally_items(response.get_ref().transaction_results.iter().map(
+                |result| match &result.result {
                     Some(execute_transaction_result::Result::Error(error)) => {
                         tonic::Code::from(error.code)
                     }
                     _ => tonic::Code::Ok,
-                };
-                tally_handle.tally_item(code);
-            }
+                },
+            ));
         }
         Ok(append_info_headers!(response, self.reader.clone()))
     }
@@ -108,15 +107,14 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         // account for every item so a batch is charged per item, and its
         // embedded per-item errors feed the error policy.
         if let Some(tally_handle) = &tally_handle {
-            for result in &response.get_ref().transaction_results {
-                let code = match &result.result {
+            tally_handle.tally_items(response.get_ref().transaction_results.iter().map(
+                |result| match &result.result {
                     Some(simulate_transaction_result::Result::Error(error)) => {
                         tonic::Code::from(error.code)
                     }
                     _ => tonic::Code::Ok,
-                };
-                tally_handle.tally_item(code);
-            }
+                },
+            ));
         }
         Ok(append_info_headers!(response, self.reader.clone()))
     }

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -19,7 +19,7 @@ use iota_grpc_types::{
         transaction_execution_service::{
             self as grpc_tx_service, ExecuteTransactionItem, ExecuteTransactionResult,
             ExecuteTransactionsRequest, ExecuteTransactionsResponse, SimulateTransactionsRequest,
-            SimulateTransactionsResponse, execute_transaction_result,
+            SimulateTransactionsResponse, execute_transaction_result, simulate_transaction_result,
         },
     },
 };
@@ -33,7 +33,7 @@ use prost_types::FieldMask;
 use tonic::{Request, Response};
 pub use transaction::{CommandResultsReadSource, TransactionReadSource};
 
-use crate::{error::RpcError, merge::Merge, types::GrpcReader};
+use crate::{error::RpcError, merge::Merge, traffic_control::ErrorTallyHandle, types::GrpcReader};
 
 pub struct TransactionExecutionGrpcService {
     pub config: iota_config::node::GrpcApiConfig,
@@ -63,6 +63,7 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         &self,
         request: Request<ExecuteTransactionsRequest>,
     ) -> Result<Response<ExecuteTransactionsResponse>, tonic::Status> {
+        let error_tally = request.extensions().get::<ErrorTallyHandle>().cloned();
         let response = execute_transactions(
             &self.reader,
             &self.executor,
@@ -72,6 +73,15 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         .await
         .map(Response::new)
         .map_err(tonic::Status::from)?;
+        // Per-item errors are embedded in a successful response, invisible to
+        // the transport-level traffic control; feed them to the error policy.
+        if let Some(error_tally) = &error_tally {
+            for result in &response.get_ref().transaction_results {
+                if let Some(execute_transaction_result::Result::Error(error)) = &result.result {
+                    error_tally.tally_error(tonic::Code::from(error.code));
+                }
+            }
+        }
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 
@@ -79,6 +89,7 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         &self,
         request: Request<SimulateTransactionsRequest>,
     ) -> Result<Response<SimulateTransactionsResponse>, tonic::Status> {
+        let error_tally = request.extensions().get::<ErrorTallyHandle>().cloned();
         let response = simulate::simulate_transactions(
             &self.reader,
             &self.executor,
@@ -88,6 +99,15 @@ impl grpc_tx_service::transaction_execution_service_server::TransactionExecution
         .await
         .map(Response::new)
         .map_err(tonic::Status::from)?;
+        // Per-item errors are embedded in a successful response, invisible to
+        // the transport-level traffic control; feed them to the error policy.
+        if let Some(error_tally) = &error_tally {
+            for result in &response.get_ref().transaction_results {
+                if let Some(simulate_transaction_result::Result::Error(error)) = &result.result {
+                    error_tally.tally_error(tonic::Code::from(error.code));
+                }
+            }
+        }
         Ok(append_info_headers!(response, self.reader.clone()))
     }
 }

--- a/crates/iota-grpc-server/tests/batching_stream.rs
+++ b/crates/iota-grpc-server/tests/batching_stream.rs
@@ -7,7 +7,7 @@ mod common;
 
 use std::{collections::HashMap, sync::Arc};
 
-use common::MockGrpcStateReader;
+use common::{MockGrpcStateReader, create_large_object};
 use iota_grpc_types::{
     field::FieldMaskUtil,
     v1::{
@@ -18,14 +18,12 @@ use iota_grpc_types::{
         types::ObjectReference,
     },
 };
-use iota_sdk_types::{MoveStruct, ObjectId, Owner, StructTag, TransactionDigest};
+use iota_sdk_types::TransactionDigest;
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     base_types::random_object_ref,
     crypto::{AccountKeyPair, get_key_pair},
     effects::{TestEffectsBuilder, TransactionEffects},
-    gas_coin::GasCoin,
-    object::{MoveStructExt, OBJECT_START_VERSION, Object},
     transaction::VerifiedTransaction,
 };
 use prost::Message;
@@ -33,28 +31,6 @@ use prost::Message;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Create a large object (~`padding_bytes` extra) so that a small number of
-/// objects exceeds the 1 MB minimum message size.
-fn create_large_object(padding_bytes_len: usize) -> (ObjectId, Object) {
-    let id = ObjectId::random();
-    let (owner, _) = get_key_pair::<AccountKeyPair>();
-    let mut contents = GasCoin::new(id, 100).to_bcs_bytes();
-    contents.extend(vec![0u8; padding_bytes_len]);
-    let move_obj = MoveStruct::new_from_execution_with_limit(
-        StructTag::new_gas_coin(),
-        OBJECT_START_VERSION,
-        contents,
-        u64::try_from(padding_bytes_len).unwrap() + 1024,
-    )
-    .unwrap();
-    let obj = Object::new_move(
-        move_obj,
-        Owner::Address(owner),
-        TransactionDigest::GENESIS_MARKER,
-    );
-    (id, obj)
-}
 
 /// Create a transaction and its effects so `get_transactions` can return it.
 fn create_test_transaction() -> (

--- a/crates/iota-grpc-server/tests/batching_stream.rs
+++ b/crates/iota-grpc-server/tests/batching_stream.rs
@@ -100,7 +100,10 @@ async fn test_get_objects_batching_within_limit() {
         ..Default::default()
     });
 
-    let (server_handle, _) = common::start_test_server(state_reader, |_| {}).await;
+    let (server_handle, _) = common::start_test_server(state_reader, |config| {
+        config.max_get_objects_batch_size = NUM_OBJECTS as u32;
+    })
+    .await;
     let addr = server_handle.address();
 
     // Use the raw tonic client instead of the high-level Client so we can
@@ -255,7 +258,10 @@ async fn test_get_transactions_batching_within_limit() {
         ..Default::default()
     });
 
-    let (server_handle, _) = common::start_test_server(state_reader, |_| {}).await;
+    let (server_handle, _) = common::start_test_server(state_reader, |config| {
+        config.max_get_transactions_batch_size = NUM_TXS as u32;
+    })
+    .await;
     let addr = server_handle.address();
 
     // Use the raw tonic client instead of the high-level Client so we can

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -14,19 +14,20 @@ use iota_config::{local_ip_utils, node::GrpcApiConfig};
 use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
 use iota_node_storage::GrpcStateReader;
 use iota_sdk_types::{
-    Address, CheckpointContentsDigest, CheckpointDigest, ObjectId, StructTag, TransactionDigest,
-    Version,
+    Address, CheckpointContentsDigest, CheckpointDigest, MoveStruct, ObjectId, Owner, StructTag,
+    TransactionDigest, Version,
     checkpoint::{CheckpointContents, CheckpointSummary},
 };
 use iota_types::{
-    crypto::AuthorityStrongQuorumSignInfo,
+    crypto::{AccountKeyPair, AuthorityStrongQuorumSignInfo, get_key_pair},
     effects::{TransactionEffects, TransactionEvents},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
+    gas_coin::GasCoin,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContentsExt, CheckpointSequenceNumber,
         VerifiedCheckpoint,
     },
-    object::Object,
+    object::{MoveStructExt, OBJECT_START_VERSION, Object},
     storage::error::Result as StorageResult,
     transaction::VerifiedTransaction,
 };
@@ -53,6 +54,28 @@ pub fn assert_messages_within_limit<M: prost::Message>(messages: &[M], limit: u3
 // ---------------------------------------------------------------------------
 // Mock helpers
 // ---------------------------------------------------------------------------
+
+/// Create a large object (~`padding_bytes` extra) so that a small number of
+/// objects exceeds the 1 MB minimum message size.
+pub fn create_large_object(padding_bytes_len: usize) -> (ObjectId, Object) {
+    let id = ObjectId::random();
+    let (owner, _) = get_key_pair::<AccountKeyPair>();
+    let mut contents = GasCoin::new(id, 100).to_bcs_bytes();
+    contents.extend(vec![0u8; padding_bytes_len]);
+    let move_obj = MoveStruct::new_from_execution_with_limit(
+        StructTag::new_gas_coin(),
+        OBJECT_START_VERSION,
+        contents,
+        u64::try_from(padding_bytes_len).unwrap() + 1024,
+    )
+    .unwrap();
+    let obj = Object::new_move(
+        move_obj,
+        Owner::Address(owner),
+        TransactionDigest::GENESIS_MARKER,
+    );
+    (id, obj)
+}
 
 /// Create a mock `CertifiedCheckpointSummary` for the given sequence number.
 pub fn mock_summary(

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -481,12 +481,15 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
 // Server setup helpers
 // ---------------------------------------------------------------------------
 
-/// Start a gRPC server backed by the given `MockGrpcStateReader`.
+/// Start a gRPC server backed by the given `MockGrpcStateReader`, with an
+/// optional transaction executor and traffic controller.
 ///
 /// Returns the server handle and the `GrpcReader` (callers may need it to
 /// create different client types).
-pub async fn start_test_server(
+async fn start_test_server_with(
     state_reader: Arc<MockGrpcStateReader>,
+    executor: Option<Arc<dyn iota_types::transaction_executor::TransactionExecutor>>,
+    traffic_controller: Option<Arc<iota_core::traffic_controller::TrafficController>>,
     config_customizer: impl FnOnce(&mut GrpcApiConfig),
 ) -> (GrpcServerHandle, Arc<GrpcReader>) {
     let grpc_reader = Arc::new(GrpcReader::new(state_reader, Some("test".to_string())));
@@ -501,18 +504,29 @@ pub async fn start_test_server(
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let server_handle = start_grpc_server(
         grpc_reader.clone(),
-        None,
+        executor,
         config,
         cancellation_token,
         iota_types::digests::ChainIdentifier::default(),
         None,
-        None,
+        traffic_controller,
         None,
     )
     .await
     .expect("Failed to start gRPC server");
 
     (server_handle, grpc_reader)
+}
+
+/// Start a gRPC server backed by the given `MockGrpcStateReader`.
+///
+/// Returns the server handle and the `GrpcReader` (callers may need it to
+/// create different client types).
+pub async fn start_test_server(
+    state_reader: Arc<MockGrpcStateReader>,
+    config_customizer: impl FnOnce(&mut GrpcApiConfig),
+) -> (GrpcServerHandle, Arc<GrpcReader>) {
+    start_test_server_with(state_reader, None, None, config_customizer).await
 }
 
 /// Like [`start_test_server`], but with the given traffic controller wired
@@ -524,27 +538,5 @@ pub async fn start_test_server_with_traffic_controller(
     traffic_controller: Arc<iota_core::traffic_controller::TrafficController>,
     executor: Option<Arc<dyn iota_types::transaction_executor::TransactionExecutor>>,
 ) -> (GrpcServerHandle, Arc<GrpcReader>) {
-    let grpc_reader = Arc::new(GrpcReader::new(state_reader, Some("test".to_string())));
-    let localhost = local_ip_utils::localhost_for_testing();
-    let port = local_ip_utils::get_available_port(&localhost);
-    let config = GrpcApiConfig {
-        address: format!("{localhost}:{port}").parse().unwrap(),
-        ..GrpcApiConfig::default()
-    };
-
-    let cancellation_token = tokio_util::sync::CancellationToken::new();
-    let server_handle = start_grpc_server(
-        grpc_reader.clone(),
-        executor,
-        config,
-        cancellation_token,
-        iota_types::digests::ChainIdentifier::default(),
-        None,
-        Some(traffic_controller),
-        None,
-    )
-    .await
-    .expect("Failed to start gRPC server");
-
-    (server_handle, grpc_reader)
+    start_test_server_with(state_reader, executor, Some(traffic_controller), |_| {}).await
 }

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -514,3 +514,37 @@ pub async fn start_test_server(
 
     (server_handle, grpc_reader)
 }
+
+/// Like [`start_test_server`], but with the given traffic controller wired
+/// into the server's `TrafficControlLayer` and an optional transaction
+/// executor (required for the `TransactionExecutionService` to be
+/// registered).
+pub async fn start_test_server_with_traffic_controller(
+    state_reader: Arc<MockGrpcStateReader>,
+    traffic_controller: Arc<iota_core::traffic_controller::TrafficController>,
+    executor: Option<Arc<dyn iota_types::transaction_executor::TransactionExecutor>>,
+) -> (GrpcServerHandle, Arc<GrpcReader>) {
+    let grpc_reader = Arc::new(GrpcReader::new(state_reader, Some("test".to_string())));
+    let localhost = local_ip_utils::localhost_for_testing();
+    let port = local_ip_utils::get_available_port(&localhost);
+    let config = GrpcApiConfig {
+        address: format!("{localhost}:{port}").parse().unwrap(),
+        ..GrpcApiConfig::default()
+    };
+
+    let cancellation_token = tokio_util::sync::CancellationToken::new();
+    let server_handle = start_grpc_server(
+        grpc_reader.clone(),
+        executor,
+        config,
+        cancellation_token,
+        iota_types::digests::ChainIdentifier::default(),
+        None,
+        Some(traffic_controller),
+        None,
+    )
+    .await
+    .expect("Failed to start gRPC server");
+
+    (server_handle, grpc_reader)
+}

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -6,10 +6,10 @@
 //! by both the spam and error policies.
 //!
 //! tonic returns a unary handler error as a trailers-only response, so its
-//! `grpc-status` lands in the HTTP response headers where the layer already sees
-//! it. A batch API's items instead ride inside the response body (embedded in a
-//! unary response or streamed lazily), so the handlers report each item to the
-//! traffic controller explicitly.
+//! `grpc-status` lands in the HTTP response headers where the layer already
+//! sees it. A batch API's items instead ride inside the response body (embedded
+//! in a unary response or streamed lazily), so the handlers report each item to
+//! the traffic controller explicitly.
 
 mod common;
 
@@ -30,8 +30,8 @@ use iota_grpc_types::v1::{
     },
     types::{Address as ProtoAddress, ObjectId as ProtoObjectId, ObjectReference},
 };
+use iota_sdk_types::TransactionDigest;
 use iota_types::{
-    digests::TransactionDigest,
     error::IotaError,
     messages_checkpoint::CheckpointSequenceNumber,
     quorum_driver_types::{
@@ -50,8 +50,8 @@ const ERROR_BLOCK_ATTEMPTS: u64 = 5;
 
 /// Spam policy threshold for the batch tests.
 const SPAM_THRESHOLD: u64 = 15;
-/// Items in the single batch used to prove per-item spam accounting; larger than
-/// [`SPAM_THRESHOLD`] so one batch alone exceeds it.
+/// Items in the single batch used to prove per-item spam accounting; larger
+/// than [`SPAM_THRESHOLD`] so one batch alone exceeds it.
 const SPAM_BATCH_SIZE: usize = 20;
 /// Probe attempts made after the oversized batch. Kept below [`SPAM_THRESHOLD`]
 /// so per-request accounting (the batch plus these probes) could not reach the
@@ -205,9 +205,9 @@ async fn handler_errors_feed_the_error_policy() {
     .await;
 }
 
-/// Batch APIs embed per-item errors inside a successful gRPC response, where the
-/// transport-level traffic control cannot see them. They must still feed the
-/// error policy and eventually block the client.
+/// Batch APIs embed per-item errors inside a successful gRPC response, where
+/// the transport-level traffic control cannot see them. They must still feed
+/// the error policy and eventually block the client.
 #[tokio::test]
 async fn embedded_batch_errors_feed_the_error_policy() {
     let handle = server_with_policy(
@@ -231,10 +231,10 @@ async fn embedded_batch_errors_feed_the_error_policy() {
     .await;
 }
 
-/// Each item of a batch request must count individually towards the spam policy,
-/// so a client cannot dilute its request rate by batching. A single batch
-/// carries more items than the threshold, so per-item accounting blocks the
-/// client while per-request accounting (one tally per batch) could not.
+/// Each item of a batch request must count individually towards the spam
+/// policy, so a client cannot dilute its request rate by batching. A single
+/// batch carries more items than the threshold, so per-item accounting blocks
+/// the client while per-request accounting (one tally per batch) could not.
 #[tokio::test]
 async fn batched_requests_accrue_spam_per_item() {
     let handle = server_with_policy(

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -13,23 +13,34 @@
 
 mod common;
 
-use std::{collections::BTreeMap, future::Future, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    future::Future,
+    sync::Arc,
+    time::Duration,
+};
 
-use common::{MockGrpcStateReader, start_test_server, start_test_server_with_traffic_controller};
+use common::{
+    MockGrpcStateReader, create_large_object, start_test_server,
+    start_test_server_with_traffic_controller,
+};
 use futures::StreamExt;
 use iota_core::traffic_controller::TrafficController;
 use iota_grpc_server::GrpcServerHandle;
-use iota_grpc_types::v1::{
-    ledger_service::{
-        GetObjectsRequest, ObjectRequest, ObjectRequests,
-        ledger_service_client::LedgerServiceClient,
+use iota_grpc_types::{
+    field::FieldMaskUtil,
+    v1::{
+        ledger_service::{
+            GetObjectsRequest, ObjectRequest, ObjectRequests,
+            ledger_service_client::LedgerServiceClient,
+        },
+        state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
+        transaction_execution_service::{
+            ExecuteTransactionItem, ExecuteTransactionsRequest,
+            transaction_execution_service_client::TransactionExecutionServiceClient,
+        },
+        types::{Address as ProtoAddress, ObjectId as ProtoObjectId, ObjectReference},
     },
-    state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
-    transaction_execution_service::{
-        ExecuteTransactionItem, ExecuteTransactionsRequest,
-        transaction_execution_service_client::TransactionExecutionServiceClient,
-    },
-    types::{Address as ProtoAddress, ObjectId as ProtoObjectId, ObjectReference},
 };
 use iota_sdk_types::TransactionDigest;
 use iota_types::{
@@ -305,6 +316,97 @@ async fn batched_reads_accrue_spam_per_item() {
     assert_client_blocked(SPAM_PROBE_ATTEMPTS, || {
         let mut client = client.clone();
         async move { client.get_objects(get_objects_batch(1)).await }
+    })
+    .await;
+}
+
+/// A stream-level error must be tallied like a unary handler error and feed
+/// the error policy. Here a single item exceeds the request's message size
+/// limit, so the stream's only element is an `InvalidArgument` — without the
+/// tally such a request would escape traffic control entirely.
+#[tokio::test]
+async fn stream_errors_feed_the_error_policy() {
+    // One stored object whose encoded size exceeds the 1 MiB minimum message
+    // size, so it can never fit into a stream message.
+    let (object_id, object) = create_large_object(2 * 1024 * 1024);
+    let state_reader = Arc::new(MockGrpcStateReader {
+        objects: HashMap::from([(object_id, object)]),
+        ..Default::default()
+    });
+    let traffic_controller = Arc::new(
+        TrafficController::init_for_test(
+            PolicyConfig {
+                connection_blocklist_ttl_sec: 120,
+                error_policy_type: PolicyType::TestNConnIP(ERROR_BLOCK_ATTEMPTS - 1),
+                dry_run: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await,
+    );
+    let (handle, _reader) =
+        start_test_server_with_traffic_controller(state_reader, traffic_controller, None).await;
+    let client = LedgerServiceClient::new(connect(&handle).await);
+
+    let request = GetObjectsRequest::default()
+        .with_requests(ObjectRequests::default().with_requests(vec![
+            ObjectRequest::default().with_object_ref(ObjectReference::default().with_object_id(
+                ProtoObjectId::default().with_object_id(object_id.into_bytes().to_vec()),
+            )),
+        ]))
+        .with_read_mask(prost_types::FieldMask::from_str("reference,bcs"))
+        .with_max_message_size_bytes(1024 * 1024);
+
+    assert_client_blocked(ERROR_BLOCK_ATTEMPTS as usize, || {
+        let mut client = client.clone();
+        let request = request.clone();
+        async move {
+            let mut stream = client.get_objects(request).await?.into_inner();
+            // Drain the stream; its only element is the client error under
+            // test, whose code differs from the block's `ResourceExhausted`.
+            while let Some(item) = stream.next().await {
+                item?;
+            }
+            Ok(())
+        }
+    })
+    .await;
+}
+
+/// An empty read batch produces no per-item tallies, so it must be charged as
+/// one request — otherwise a client could spam empty batches without ever
+/// feeding the spam policy.
+#[tokio::test]
+async fn empty_read_batches_accrue_spam() {
+    let handle = server_with_policy(
+        PolicyConfig {
+            connection_blocklist_ttl_sec: 120,
+            spam_policy_type: PolicyType::TestNConnIP(SPAM_THRESHOLD),
+            // Error policy off, so any block is attributable to the spam policy.
+            error_policy_type: PolicyType::NoOp,
+            // Count every tally deterministically.
+            spam_sample_rate: Weight::one(),
+            dry_run: false,
+            ..Default::default()
+        },
+        None,
+    )
+    .await;
+    let client = LedgerServiceClient::new(connect(&handle).await);
+
+    assert_client_blocked(SPAM_THRESHOLD as usize + SPAM_PROBE_ATTEMPTS, || {
+        let mut client = client.clone();
+        async move {
+            let mut stream = client
+                .get_objects(GetObjectsRequest::default())
+                .await?
+                .into_inner();
+            while let Some(item) = stream.next().await {
+                item?;
+            }
+            Ok(())
+        }
     })
     .await;
 }

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -16,6 +16,7 @@ mod common;
 use std::{collections::BTreeMap, future::Future, sync::Arc, time::Duration};
 
 use common::{MockGrpcStateReader, start_test_server, start_test_server_with_traffic_controller};
+use futures::StreamExt;
 use iota_core::traffic_controller::TrafficController;
 use iota_grpc_server::GrpcServerHandle;
 use iota_grpc_types::v1::{
@@ -289,12 +290,17 @@ async fn batched_reads_accrue_spam_per_item() {
     let mut client = LedgerServiceClient::new(connect(&handle).await);
 
     // One batch of object lookups: each requested item counts as one request for
-    // the spam policy. The lookups miss in the mock store, which does not affect
-    // the spam count.
-    client
+    // the spam policy, tallied as the response stream is consumed. The lookups
+    // miss in the mock store, which does not affect the spam count. Drain the
+    // stream so all items are tallied before probing.
+    let mut stream = client
         .get_objects(get_objects_batch(SPAM_BATCH_SIZE))
         .await
-        .expect("batch request itself should succeed");
+        .expect("batch request itself should succeed")
+        .into_inner();
+    while let Some(item) = stream.next().await {
+        item.expect("stream item should be Ok");
+    }
 
     assert_client_blocked(SPAM_PROBE_ATTEMPTS, || {
         let mut client = client.clone();
@@ -358,6 +364,43 @@ async fn successful_requests_do_not_feed_the_error_policy() {
             .list_owned_objects(request.clone())
             .await
             .expect("valid request should succeed");
+        // Yield so the tally task runs; a wrongly tallied error would block the
+        // next request.
+        tokio::task::yield_now().await;
+    }
+}
+
+/// Read endpoints must not feed the error policy: a client cannot know an
+/// object or transaction was pruned, so per-item read failures must not count
+/// towards blocking.
+#[tokio::test]
+async fn read_errors_do_not_feed_the_error_policy() {
+    let handle = server_with_policy(
+        PolicyConfig {
+            connection_blocklist_ttl_sec: 120,
+            // Block on the first error tally, so a read error wrongly fed to the
+            // error policy would block the client and fail this test.
+            error_policy_type: PolicyType::TestNConnIP(1),
+            dry_run: false,
+            ..Default::default()
+        },
+        None,
+    )
+    .await;
+    let mut client = LedgerServiceClient::new(connect(&handle).await);
+
+    // Every requested object misses in the mock store, so each item is an
+    // embedded per-item error. Draining the stream tallies each item; reads must
+    // tally spam only, never the error policy.
+    for _ in 0..5 {
+        let mut stream = client
+            .get_objects(get_objects_batch(3))
+            .await
+            .expect("read request should succeed")
+            .into_inner();
+        while let Some(item) = stream.next().await {
+            item.expect("stream item should be Ok");
+        }
         // Yield so the tally task runs; a wrongly tallied error would block the
         // next request.
         tokio::task::yield_now().await;

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -1,19 +1,23 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Integration tests for the traffic-control layer of the gRPC server, in
-//! particular that errors feed the error policy. tonic returns a unary handler
-//! error as a trailers-only response, so its `grpc-status` lands in the HTTP
-//! response headers where the layer already sees it; per-item errors of a batch
-//! API instead ride inside an otherwise successful response and must be
-//! reported explicitly.
+//! Integration tests for the traffic-control layer of the gRPC server: that
+//! client errors feed the error policy and that batch APIs are charged per item
+//! by both the spam and error policies.
+//!
+//! tonic returns a unary handler error as a trailers-only response, so its
+//! `grpc-status` lands in the HTTP response headers where the layer already sees
+//! it. A batch API's items instead ride inside the response body (embedded in a
+//! unary response or streamed lazily), so the handlers report each item to the
+//! traffic controller explicitly.
 
 mod common;
 
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, future::Future, sync::Arc, time::Duration};
 
 use common::{MockGrpcStateReader, start_test_server, start_test_server_with_traffic_controller};
 use iota_core::traffic_controller::TrafficController;
+use iota_grpc_server::GrpcServerHandle;
 use iota_grpc_types::v1::{
     ledger_service::{
         GetObjectsRequest, ObjectRequest, ObjectRequests,
@@ -21,7 +25,7 @@ use iota_grpc_types::v1::{
     },
     state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
     transaction_execution_service::{
-        ExecuteTransactionItem, ExecuteTransactionsRequest, execute_transaction_result,
+        ExecuteTransactionItem, ExecuteTransactionsRequest,
         transaction_execution_service_client::TransactionExecutionServiceClient,
     },
     types::{Address as ProtoAddress, ObjectId as ProtoObjectId, ObjectReference},
@@ -39,13 +43,101 @@ use iota_types::{
 };
 use tonic::{Code, transport::Channel};
 
-async fn connect_state_client(address: std::net::SocketAddr) -> StateServiceClient<Channel> {
-    let channel = Channel::from_shared(format!("http://{address}"))
+/// Error policy threshold for the block tests: the client is blocked once this
+/// many client errors have been tallied, so the block is expected within this
+/// many requests.
+const ERROR_BLOCK_ATTEMPTS: u64 = 5;
+
+/// Spam policy threshold for the batch tests.
+const SPAM_THRESHOLD: u64 = 15;
+/// Items in the single batch used to prove per-item spam accounting; larger than
+/// [`SPAM_THRESHOLD`] so one batch alone exceeds it.
+const SPAM_BATCH_SIZE: usize = 20;
+/// Probe attempts made after the oversized batch. Kept below [`SPAM_THRESHOLD`]
+/// so per-request accounting (the batch plus these probes) could not reach the
+/// threshold on its own — only per-item accounting can.
+const SPAM_PROBE_ATTEMPTS: usize = 3;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Start a gRPC server backed by an empty mock store, wired to a traffic
+/// controller running `policy_config`.
+async fn server_with_policy(
+    policy_config: PolicyConfig,
+    executor: Option<Arc<dyn TransactionExecutor>>,
+) -> GrpcServerHandle {
+    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
+    let (handle, _reader) = start_test_server_with_traffic_controller(
+        Arc::new(MockGrpcStateReader::default()),
+        traffic_controller,
+        executor,
+    )
+    .await;
+    handle
+}
+
+/// Connect a channel to the test server.
+async fn connect(handle: &GrpcServerHandle) -> Channel {
+    Channel::from_shared(format!("http://{}", handle.address()))
         .unwrap()
         .connect()
         .await
-        .expect("failed to connect to test gRPC server");
-    StateServiceClient::new(channel)
+        .expect("failed to connect to test gRPC server")
+}
+
+/// A `GetObjects` request for `n` distinct object lookups.
+fn get_objects_batch(n: usize) -> GetObjectsRequest {
+    let requests = (0..n)
+        .map(|i| {
+            ObjectRequest::default().with_object_ref(
+                ObjectReference::default()
+                    .with_object_id(ProtoObjectId::default().with_object_id(vec![i as u8; 32])),
+            )
+        })
+        .collect();
+    GetObjectsRequest::default().with_requests(ObjectRequests::default().with_requests(requests))
+}
+
+/// An `ExecuteTransactions` request carrying `n` empty (invalid) items.
+fn execute_batch(n: usize) -> ExecuteTransactionsRequest {
+    ExecuteTransactionsRequest::default()
+        .with_transactions(vec![ExecuteTransactionItem::default(); n])
+}
+
+/// Assert that the traffic controller blocks the client within `attempts`.
+///
+/// The blocklist is applied asynchronously by the background tally task, so a
+/// block becomes visible only some time after the offending requests complete.
+/// This yields between attempts and sleeps before the final one to give the
+/// tally task time to apply the block, then treats a `ResourceExhausted` /
+/// "Too many requests" response as success. Any other outcome is a not-yet-
+/// blocked request and the loop continues.
+async fn assert_client_blocked<F, Fut, T>(attempts: usize, mut request: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, tonic::Status>>,
+{
+    for attempt in 0..attempts {
+        // Give the background tally task time to apply the blocklist before the
+        // final attempt, which is expected to be rejected.
+        if attempt == attempts - 1 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        } else {
+            tokio::task::yield_now().await;
+        }
+        if let Err(status) = request().await {
+            if status.code() == Code::ResourceExhausted {
+                assert!(
+                    status.message().contains("Too many requests"),
+                    "unexpected block message: {status:?}"
+                );
+                return;
+            }
+        }
+    }
+    panic!("expected the traffic controller to block the client within {attempts} requests");
 }
 
 /// A `TransactionExecutor` for tests whose requests fail validation before
@@ -80,201 +172,135 @@ impl TransactionExecutor for UnreachableExecutor {
     }
 }
 
-/// Handler errors must count towards the error policy and eventually block
-/// the client.
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Handler errors must count towards the error policy and eventually block the
+/// client. A request without the required `owner` field is rejected by the
+/// handler with `InvalidArgument`, which reaches the client and feeds the error
+/// policy.
 #[tokio::test]
 async fn handler_errors_feed_the_error_policy() {
-    let n: u64 = 5;
-    let policy_config = PolicyConfig {
-        connection_blocklist_ttl_sec: 120,
-        error_policy_type: PolicyType::TestNConnIP(n - 1),
-        dry_run: false,
-        ..Default::default()
-    };
-    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
-    let (handle, _reader) = start_test_server_with_traffic_controller(
-        Arc::new(MockGrpcStateReader::default()),
-        traffic_controller,
+    let handle = server_with_policy(
+        PolicyConfig {
+            connection_blocklist_ttl_sec: 120,
+            error_policy_type: PolicyType::TestNConnIP(ERROR_BLOCK_ATTEMPTS - 1),
+            dry_run: false,
+            ..Default::default()
+        },
         None,
     )
     .await;
-    let mut client = connect_state_client(handle.address()).await;
+    let client = StateServiceClient::new(connect(&handle).await);
 
-    // A request without the required `owner` field is rejected by the handler
-    // with `InvalidArgument`, which reaches the client via the response
-    // trailers. The counter is updated only after the response is generated
-    // while the limit is checked before the request is handled, so allow a
-    // few extra requests before requiring the block.
-    for _ in 0..2 * n {
-        let status = client
-            .list_owned_objects(ListOwnedObjectsRequest::default())
-            .await
-            .expect_err("request without owner should be rejected");
-        if status.code() == Code::ResourceExhausted {
-            assert!(
-                status.message().contains("Too many requests"),
-                "unexpected block message: {status:?}"
-            );
-            return;
+    assert_client_blocked(ERROR_BLOCK_ATTEMPTS as usize, || {
+        let mut client = client.clone();
+        async move {
+            client
+                .list_owned_objects(ListOwnedObjectsRequest::default())
+                .await
         }
-        assert_eq!(
-            status.code(),
-            Code::InvalidArgument,
-            "unexpected error: {status:?}"
-        );
-        // Yield so the traffic controller's background tally task can process
-        // the pending tally and update the blocklist before the next request.
-        tokio::task::yield_now().await;
-    }
-    panic!(
-        "expected the error policy to block the client within {} requests",
-        2 * n
-    );
+    })
+    .await;
 }
 
-/// Each item of a batch request must count individually towards the spam
-/// policy, so a client cannot dilute its request rate by batching.
+/// Batch APIs embed per-item errors inside a successful gRPC response, where the
+/// transport-level traffic control cannot see them. They must still feed the
+/// error policy and eventually block the client.
 #[tokio::test]
-async fn batched_requests_accrue_spam_per_item() {
-    // The spam policy blocks a client once its request count reaches
-    // `spam_threshold`. A single batch carries more items than the threshold,
-    // so per-item accounting blocks the client while per-request accounting
-    // (one tally per batch) could not.
-    let batch_size: usize = 20;
-    let spam_threshold: u64 = 15;
-    let policy_config = PolicyConfig {
-        connection_blocklist_ttl_sec: 120,
-        spam_policy_type: PolicyType::TestNConnIP(spam_threshold),
-        // Error policy off, so any block is attributable to the spam policy.
-        error_policy_type: PolicyType::NoOp,
-        // Count every tally deterministically.
-        spam_sample_rate: Weight::one(),
-        dry_run: false,
-        ..Default::default()
-    };
-    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
-    let (handle, _reader) = start_test_server_with_traffic_controller(
-        Arc::new(MockGrpcStateReader::default()),
-        traffic_controller,
+async fn embedded_batch_errors_feed_the_error_policy() {
+    let handle = server_with_policy(
+        PolicyConfig {
+            connection_blocklist_ttl_sec: 120,
+            error_policy_type: PolicyType::TestNConnIP(ERROR_BLOCK_ATTEMPTS - 1),
+            dry_run: false,
+            ..Default::default()
+        },
         Some(Arc::new(UnreachableExecutor)),
     )
     .await;
-    let channel = Channel::from_shared(format!("http://{}", handle.address()))
-        .unwrap()
-        .connect()
-        .await
-        .expect("failed to connect to test gRPC server");
-    let mut client = TransactionExecutionServiceClient::new(channel);
+    let client = TransactionExecutionServiceClient::new(connect(&handle).await);
+
+    // An empty `ExecuteTransactionItem` fails validation, which the batch API
+    // reports as a per-item error embedded in an otherwise OK response.
+    assert_client_blocked(ERROR_BLOCK_ATTEMPTS as usize, || {
+        let mut client = client.clone();
+        async move { client.execute_transactions(execute_batch(1)).await }
+    })
+    .await;
+}
+
+/// Each item of a batch request must count individually towards the spam policy,
+/// so a client cannot dilute its request rate by batching. A single batch
+/// carries more items than the threshold, so per-item accounting blocks the
+/// client while per-request accounting (one tally per batch) could not.
+#[tokio::test]
+async fn batched_requests_accrue_spam_per_item() {
+    let handle = server_with_policy(
+        PolicyConfig {
+            connection_blocklist_ttl_sec: 120,
+            spam_policy_type: PolicyType::TestNConnIP(SPAM_THRESHOLD),
+            // Error policy off, so any block is attributable to the spam policy.
+            error_policy_type: PolicyType::NoOp,
+            // Count every tally deterministically.
+            spam_sample_rate: Weight::one(),
+            dry_run: false,
+            ..Default::default()
+        },
+        Some(Arc::new(UnreachableExecutor)),
+    )
+    .await;
+    let mut client = TransactionExecutionServiceClient::new(connect(&handle).await);
 
     // One batch of empty items: each fails validation and is reported as an
     // embedded per-item error, and each counts as one request for the spam
     // policy.
-    let batch = ExecuteTransactionsRequest::default()
-        .with_transactions(vec![ExecuteTransactionItem::default(); batch_size]);
     client
-        .execute_transactions(batch)
+        .execute_transactions(execute_batch(SPAM_BATCH_SIZE))
         .await
         .expect("batch request itself should succeed");
 
-    // The single batch already exceeds the spam threshold, so the client must
-    // be blocked within a handful of follow-up requests. The probe budget stays
-    // well below `spam_threshold` so per-request accounting (batch plus probes)
-    // could not reach the threshold on its own.
-    let probe = ExecuteTransactionsRequest::default()
-        .with_transactions(vec![ExecuteTransactionItem::default()]);
-    let probe_budget = 10;
-    for _ in 0..probe_budget {
-        // Yield so the background tally task drains the batch's tallies and
-        // updates the blocklist before the next check.
-        tokio::task::yield_now().await;
-        if let Err(status) = client.execute_transactions(probe.clone()).await {
-            assert_eq!(
-                status.code(),
-                Code::ResourceExhausted,
-                "unexpected error: {status:?}"
-            );
-            assert!(
-                status.message().contains("Too many requests"),
-                "unexpected block message: {status:?}"
-            );
-            return;
-        }
-    }
-    panic!("expected the batch's items to block the client via the spam policy");
+    assert_client_blocked(SPAM_PROBE_ATTEMPTS, || {
+        let mut client = client.clone();
+        async move { client.execute_transactions(execute_batch(1)).await }
+    })
+    .await;
 }
 
 /// A streaming batch read (`get_objects`) must also count each requested item
 /// individually towards the spam policy, charged from the request's item count.
 #[tokio::test]
 async fn batched_reads_accrue_spam_per_item() {
-    let batch_size: usize = 20;
-    let spam_threshold: u64 = 15;
-    let policy_config = PolicyConfig {
-        connection_blocklist_ttl_sec: 120,
-        spam_policy_type: PolicyType::TestNConnIP(spam_threshold),
-        // Error policy off, so any block is attributable to the spam policy.
-        error_policy_type: PolicyType::NoOp,
-        // Count every tally deterministically.
-        spam_sample_rate: Weight::one(),
-        dry_run: false,
-        ..Default::default()
-    };
-    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
-    let (handle, _reader) = start_test_server_with_traffic_controller(
-        Arc::new(MockGrpcStateReader::default()),
-        traffic_controller,
+    let handle = server_with_policy(
+        PolicyConfig {
+            connection_blocklist_ttl_sec: 120,
+            spam_policy_type: PolicyType::TestNConnIP(SPAM_THRESHOLD),
+            // Error policy off, so any block is attributable to the spam policy.
+            error_policy_type: PolicyType::NoOp,
+            // Count every tally deterministically.
+            spam_sample_rate: Weight::one(),
+            dry_run: false,
+            ..Default::default()
+        },
         None,
     )
     .await;
-    let channel = Channel::from_shared(format!("http://{}", handle.address()))
-        .unwrap()
-        .connect()
-        .await
-        .expect("failed to connect to test gRPC server");
-    let mut client = LedgerServiceClient::new(channel);
-
-    let object_request = |seed: u8| {
-        ObjectRequest::default().with_object_ref(
-            ObjectReference::default()
-                .with_object_id(ProtoObjectId::default().with_object_id(vec![seed; 32])),
-        )
-    };
+    let mut client = LedgerServiceClient::new(connect(&handle).await);
 
     // One batch of object lookups: each requested item counts as one request for
-    // the spam policy, charged from the request's item count. The lookups miss
-    // in the mock store, which does not affect the spam count.
-    let batch = GetObjectsRequest::default().with_requests(
-        ObjectRequests::default()
-            .with_requests((0..batch_size).map(|i| object_request(i as u8)).collect()),
-    );
+    // the spam policy. The lookups miss in the mock store, which does not affect
+    // the spam count.
     client
-        .get_objects(batch)
+        .get_objects(get_objects_batch(SPAM_BATCH_SIZE))
         .await
         .expect("batch request itself should succeed");
 
-    // The single batch already exceeds the spam threshold, so the client must be
-    // blocked within a probe budget kept well below the threshold (the bound a
-    // per-request policy would need to reach the threshold on its own).
-    let probe = GetObjectsRequest::default()
-        .with_requests(ObjectRequests::default().with_requests(vec![object_request(0)]));
-    for _ in 0..10 {
-        // Yield so the background tally task drains the batch's tallies and
-        // updates the blocklist before the next check.
-        tokio::task::yield_now().await;
-        if let Err(status) = client.get_objects(probe.clone()).await {
-            assert_eq!(
-                status.code(),
-                Code::ResourceExhausted,
-                "unexpected error: {status:?}"
-            );
-            assert!(
-                status.message().contains("Too many requests"),
-                "unexpected block message: {status:?}"
-            );
-            return;
-        }
-    }
-    panic!("expected the batch's items to block the client via the spam policy");
+    assert_client_blocked(SPAM_PROBE_ATTEMPTS, || {
+        let mut client = client.clone();
+        async move { client.get_objects(get_objects_batch(1)).await }
+    })
+    .await;
 }
 
 /// A read batch larger than the configured maximum is rejected. Bounding the
@@ -287,39 +313,18 @@ async fn oversized_read_batch_is_rejected() {
         config.max_get_objects_batch_size = max_batch;
     })
     .await;
-    let channel = Channel::from_shared(format!("http://{}", handle.address()))
-        .unwrap()
-        .connect()
-        .await
-        .expect("failed to connect to test gRPC server");
-    let mut client = LedgerServiceClient::new(channel);
-
-    let make_batch = |n: usize| {
-        GetObjectsRequest::default().with_requests(
-            ObjectRequests::default().with_requests(
-                (0..n)
-                    .map(|i| {
-                        ObjectRequest::default().with_object_ref(
-                            ObjectReference::default().with_object_id(
-                                ProtoObjectId::default().with_object_id(vec![i as u8; 32]),
-                            ),
-                        )
-                    })
-                    .collect(),
-            ),
-        )
-    };
+    let mut client = LedgerServiceClient::new(connect(&handle).await);
 
     // At the limit: accepted (per-item lookups miss in the mock store, which is
     // reported as embedded results, not a request-level error).
     client
-        .get_objects(make_batch(max_batch as usize))
+        .get_objects(get_objects_batch(max_batch as usize))
         .await
         .expect("batch at the limit should be accepted");
 
     // Over the limit: rejected with `InvalidArgument`.
     let status = client
-        .get_objects(make_batch(max_batch as usize + 1))
+        .get_objects(get_objects_batch(max_batch as usize + 1))
         .await
         .expect_err("batch over the limit should be rejected");
     assert_eq!(
@@ -329,26 +334,22 @@ async fn oversized_read_batch_is_rejected() {
     );
 }
 
-/// Successful requests must not count towards the error policy or get
-/// blocked.
+/// Successful requests must not count towards the error policy or get blocked.
 #[tokio::test]
 async fn successful_requests_do_not_feed_the_error_policy() {
-    let policy_config = PolicyConfig {
-        connection_blocklist_ttl_sec: 120,
-        // Block on the first error tally, so a successful request wrongly fed to
-        // the error policy would block the client and fail this test.
-        error_policy_type: PolicyType::TestNConnIP(1),
-        dry_run: false,
-        ..Default::default()
-    };
-    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
-    let (handle, _reader) = start_test_server_with_traffic_controller(
-        Arc::new(MockGrpcStateReader::default()),
-        traffic_controller,
+    let handle = server_with_policy(
+        PolicyConfig {
+            connection_blocklist_ttl_sec: 120,
+            // Block on the first error tally, so a successful request wrongly fed
+            // to the error policy would block the client and fail this test.
+            error_policy_type: PolicyType::TestNConnIP(1),
+            dry_run: false,
+            ..Default::default()
+        },
         None,
     )
     .await;
-    let mut client = connect_state_client(handle.address()).await;
+    let mut client = StateServiceClient::new(connect(&handle).await);
 
     let request = ListOwnedObjectsRequest::default()
         .with_owner(ProtoAddress::default().with_address(vec![1u8; 32]));
@@ -357,76 +358,8 @@ async fn successful_requests_do_not_feed_the_error_policy() {
             .list_owned_objects(request.clone())
             .await
             .expect("valid request should succeed");
+        // Yield so the tally task runs; a wrongly tallied error would block the
+        // next request.
         tokio::task::yield_now().await;
     }
-}
-
-/// Batch APIs embed per-item errors inside a successful gRPC response, where
-/// the transport-level traffic control cannot see them. They must still feed
-/// the error policy and eventually block the client.
-#[tokio::test]
-async fn embedded_batch_errors_feed_the_error_policy() {
-    let n: u64 = 5;
-    let policy_config = PolicyConfig {
-        connection_blocklist_ttl_sec: 120,
-        error_policy_type: PolicyType::TestNConnIP(n - 1),
-        dry_run: false,
-        ..Default::default()
-    };
-    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
-    let (handle, _reader) = start_test_server_with_traffic_controller(
-        Arc::new(MockGrpcStateReader::default()),
-        traffic_controller,
-        Some(Arc::new(UnreachableExecutor)),
-    )
-    .await;
-    let channel = Channel::from_shared(format!("http://{}", handle.address()))
-        .unwrap()
-        .connect()
-        .await
-        .expect("failed to connect to test gRPC server");
-    let mut client = TransactionExecutionServiceClient::new(channel);
-
-    // An empty `ExecuteTransactionItem` fails validation, which the batch API
-    // reports as a per-item error embedded in an OK response.
-    let request = ExecuteTransactionsRequest::default()
-        .with_transactions(vec![ExecuteTransactionItem::default()]);
-    for _ in 0..2 * n {
-        match client.execute_transactions(request.clone()).await {
-            Ok(response) => {
-                let result = response
-                    .get_ref()
-                    .transaction_results
-                    .first()
-                    .expect("response should contain one result");
-                assert!(
-                    matches!(
-                        &result.result,
-                        Some(execute_transaction_result::Result::Error(error))
-                            if Code::from(error.code) == Code::InvalidArgument
-                    ),
-                    "expected an embedded InvalidArgument error: {result:?}"
-                );
-            }
-            Err(status) => {
-                assert_eq!(
-                    status.code(),
-                    Code::ResourceExhausted,
-                    "unexpected error: {status:?}"
-                );
-                assert!(
-                    status.message().contains("Too many requests"),
-                    "unexpected block message: {status:?}"
-                );
-                return;
-            }
-        }
-        // Yield so the traffic controller's background tally task can process
-        // the pending tally and update the blocklist before the next request.
-        tokio::task::yield_now().await;
-    }
-    panic!(
-        "expected the error policy to block the client within {} requests",
-        2 * n
-    );
 }

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -29,7 +29,7 @@ use iota_types::{
     quorum_driver_types::{
         ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, QuorumDriverError,
     },
-    traffic_control::{PolicyConfig, PolicyType},
+    traffic_control::{PolicyConfig, PolicyType, Weight},
     transaction::TransactionData,
     transaction_executor::{SimulateTransactionResult, TransactionExecutor, VmChecks},
 };
@@ -126,6 +126,77 @@ async fn handler_errors_feed_the_error_policy() {
         "expected the error policy to block the client within {} requests",
         2 * n
     );
+}
+
+/// Each item of a batch request must count individually towards the spam
+/// policy, so a client cannot dilute its request rate by batching.
+#[tokio::test]
+async fn batched_requests_accrue_spam_per_item() {
+    // The spam policy blocks a client once its request count reaches
+    // `spam_threshold`. A single batch carries more items than the threshold,
+    // so per-item accounting blocks the client while per-request accounting
+    // (one tally per batch) could not.
+    let batch_size: usize = 20;
+    let spam_threshold: u64 = 15;
+    let policy_config = PolicyConfig {
+        connection_blocklist_ttl_sec: 120,
+        spam_policy_type: PolicyType::TestNConnIP(spam_threshold),
+        // Error policy off, so any block is attributable to the spam policy.
+        error_policy_type: PolicyType::NoOp,
+        // Count every tally deterministically.
+        spam_sample_rate: Weight::one(),
+        dry_run: false,
+        ..Default::default()
+    };
+    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
+    let (handle, _reader) = start_test_server_with_traffic_controller(
+        Arc::new(MockGrpcStateReader::default()),
+        traffic_controller,
+        Some(Arc::new(UnreachableExecutor)),
+    )
+    .await;
+    let channel = Channel::from_shared(format!("http://{}", handle.address()))
+        .unwrap()
+        .connect()
+        .await
+        .expect("failed to connect to test gRPC server");
+    let mut client = TransactionExecutionServiceClient::new(channel);
+
+    // One batch of empty items: each fails validation and is reported as an
+    // embedded per-item error, and each counts as one request for the spam
+    // policy.
+    let batch = ExecuteTransactionsRequest::default()
+        .with_transactions(vec![ExecuteTransactionItem::default(); batch_size]);
+    client
+        .execute_transactions(batch)
+        .await
+        .expect("batch request itself should succeed");
+
+    // The single batch already exceeds the spam threshold, so the client must
+    // be blocked within a handful of follow-up requests. The probe budget stays
+    // well below `spam_threshold` so per-request accounting (batch plus probes)
+    // could not reach the threshold on its own.
+    let probe = ExecuteTransactionsRequest::default()
+        .with_transactions(vec![ExecuteTransactionItem::default()]);
+    let probe_budget = 10;
+    for _ in 0..probe_budget {
+        // Yield so the background tally task drains the batch's tallies and
+        // updates the blocklist before the next check.
+        tokio::task::yield_now().await;
+        if let Err(status) = client.execute_transactions(probe.clone()).await {
+            assert_eq!(
+                status.code(),
+                Code::ResourceExhausted,
+                "unexpected error: {status:?}"
+            );
+            assert!(
+                status.message().contains("Too many requests"),
+                "unexpected block message: {status:?}"
+            );
+            return;
+        }
+    }
+    panic!("expected the batch's items to block the client via the spam policy");
 }
 
 /// Successful requests must not count towards the error policy or get

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the traffic-control layer of the gRPC server,
+//! in particular that handler errors — which tonic delivers in the response
+//! *trailers*, not the response headers — feed the error policy.
+
+mod common;
+
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use common::{MockGrpcStateReader, start_test_server_with_traffic_controller};
+use iota_core::traffic_controller::TrafficController;
+use iota_grpc_types::v1::{
+    state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
+    transaction_execution_service::{
+        ExecuteTransactionItem, ExecuteTransactionsRequest, execute_transaction_result,
+        transaction_execution_service_client::TransactionExecutionServiceClient,
+    },
+    types::Address as ProtoAddress,
+};
+use iota_types::{
+    digests::TransactionDigest,
+    error::IotaError,
+    messages_checkpoint::CheckpointSequenceNumber,
+    quorum_driver_types::{
+        ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, QuorumDriverError,
+    },
+    traffic_control::{PolicyConfig, PolicyType},
+    transaction::TransactionData,
+    transaction_executor::{SimulateTransactionResult, TransactionExecutor, VmChecks},
+};
+use tonic::{Code, transport::Channel};
+
+async fn connect_state_client(address: std::net::SocketAddr) -> StateServiceClient<Channel> {
+    let channel = Channel::from_shared(format!("http://{address}"))
+        .unwrap()
+        .connect()
+        .await
+        .expect("failed to connect to test gRPC server");
+    StateServiceClient::new(channel)
+}
+
+/// A `TransactionExecutor` for tests whose requests fail validation before
+/// reaching the executor.
+struct UnreachableExecutor;
+
+#[async_trait::async_trait]
+impl TransactionExecutor for UnreachableExecutor {
+    async fn execute_transaction(
+        &self,
+        _request: ExecuteTransactionRequestV1,
+        _skip_certification: bool,
+        _client_addr: Option<std::net::SocketAddr>,
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
+        unreachable!("test requests must fail validation before execution")
+    }
+
+    fn simulate_transaction(
+        &self,
+        _transaction: TransactionData,
+        _checks: VmChecks,
+    ) -> Result<SimulateTransactionResult, IotaError> {
+        unreachable!("test requests must fail validation before simulation")
+    }
+
+    async fn wait_for_checkpoint_inclusion(
+        &self,
+        _digests: &[TransactionDigest],
+        _timeout: Duration,
+    ) -> Result<BTreeMap<TransactionDigest, (CheckpointSequenceNumber, u64)>, IotaError> {
+        unreachable!("test requests must fail validation before execution")
+    }
+}
+
+/// Handler errors must count towards the error policy and eventually block
+/// the client.
+#[tokio::test]
+async fn handler_errors_feed_the_error_policy() {
+    let n: u64 = 5;
+    let policy_config = PolicyConfig {
+        connection_blocklist_ttl_sec: 120,
+        error_policy_type: PolicyType::TestNConnIP(n - 1),
+        dry_run: false,
+        ..Default::default()
+    };
+    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
+    let (handle, _reader) = start_test_server_with_traffic_controller(
+        Arc::new(MockGrpcStateReader::default()),
+        traffic_controller,
+        None,
+    )
+    .await;
+    let mut client = connect_state_client(handle.address()).await;
+
+    // A request without the required `owner` field is rejected by the handler
+    // with `InvalidArgument`, which reaches the client via the response
+    // trailers. The counter is updated only after the response is generated
+    // while the limit is checked before the request is handled, so allow a
+    // few extra requests before requiring the block.
+    for _ in 0..2 * n {
+        let status = client
+            .list_owned_objects(ListOwnedObjectsRequest::default())
+            .await
+            .expect_err("request without owner should be rejected");
+        if status.code() == Code::ResourceExhausted {
+            assert!(
+                status.message().contains("Too many requests"),
+                "unexpected block message: {status:?}"
+            );
+            return;
+        }
+        assert_eq!(
+            status.code(),
+            Code::InvalidArgument,
+            "unexpected error: {status:?}"
+        );
+        // Yield so the traffic controller's background tally task can process
+        // the pending tally and update the blocklist before the next request.
+        tokio::task::yield_now().await;
+    }
+    panic!(
+        "expected the error policy to block the client within {} requests",
+        2 * n
+    );
+}
+
+/// Successful requests must not count towards the error policy or get
+/// blocked.
+#[tokio::test]
+async fn successful_requests_do_not_feed_the_error_policy() {
+    let policy_config = PolicyConfig {
+        connection_blocklist_ttl_sec: 120,
+        // Panics inside the traffic controller if any error is ever tallied.
+        error_policy_type: PolicyType::TestPanicOnInvocation,
+        dry_run: false,
+        ..Default::default()
+    };
+    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
+    let (handle, _reader) = start_test_server_with_traffic_controller(
+        Arc::new(MockGrpcStateReader::default()),
+        traffic_controller,
+        None,
+    )
+    .await;
+    let mut client = connect_state_client(handle.address()).await;
+
+    let request = ListOwnedObjectsRequest::default()
+        .with_owner(ProtoAddress::default().with_address(vec![1u8; 32]));
+    for _ in 0..10 {
+        client
+            .list_owned_objects(request.clone())
+            .await
+            .expect("valid request should succeed");
+        tokio::task::yield_now().await;
+    }
+}
+
+/// Batch APIs embed per-item errors inside a successful gRPC response, where
+/// the transport-level traffic control cannot see them. They must still feed
+/// the error policy and eventually block the client.
+#[tokio::test]
+async fn embedded_batch_errors_feed_the_error_policy() {
+    let n: u64 = 5;
+    let policy_config = PolicyConfig {
+        connection_blocklist_ttl_sec: 120,
+        error_policy_type: PolicyType::TestNConnIP(n - 1),
+        dry_run: false,
+        ..Default::default()
+    };
+    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
+    let (handle, _reader) = start_test_server_with_traffic_controller(
+        Arc::new(MockGrpcStateReader::default()),
+        traffic_controller,
+        Some(Arc::new(UnreachableExecutor)),
+    )
+    .await;
+    let channel = Channel::from_shared(format!("http://{}", handle.address()))
+        .unwrap()
+        .connect()
+        .await
+        .expect("failed to connect to test gRPC server");
+    let mut client = TransactionExecutionServiceClient::new(channel);
+
+    // An empty `ExecuteTransactionItem` fails validation, which the batch API
+    // reports as a per-item error embedded in an OK response.
+    let request = ExecuteTransactionsRequest::default()
+        .with_transactions(vec![ExecuteTransactionItem::default()]);
+    for _ in 0..2 * n {
+        match client.execute_transactions(request.clone()).await {
+            Ok(response) => {
+                let result = response
+                    .get_ref()
+                    .transaction_results
+                    .first()
+                    .expect("response should contain one result");
+                assert!(
+                    matches!(
+                        &result.result,
+                        Some(execute_transaction_result::Result::Error(error))
+                            if Code::from(error.code) == Code::InvalidArgument
+                    ),
+                    "expected an embedded InvalidArgument error: {result:?}"
+                );
+            }
+            Err(status) => {
+                assert_eq!(
+                    status.code(),
+                    Code::ResourceExhausted,
+                    "unexpected error: {status:?}"
+                );
+                assert!(
+                    status.message().contains("Too many requests"),
+                    "unexpected block message: {status:?}"
+                );
+                return;
+            }
+        }
+        // Yield so the traffic controller's background tally task can process
+        // the pending tally and update the blocklist before the next request.
+        tokio::task::yield_now().await;
+    }
+    panic!(
+        "expected the error policy to block the client within {} requests",
+        2 * n
+    );
+}

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -12,7 +12,7 @@ mod common;
 
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
-use common::{MockGrpcStateReader, start_test_server_with_traffic_controller};
+use common::{MockGrpcStateReader, start_test_server, start_test_server_with_traffic_controller};
 use iota_core::traffic_controller::TrafficController;
 use iota_grpc_types::v1::{
     ledger_service::{
@@ -275,6 +275,58 @@ async fn batched_reads_accrue_spam_per_item() {
         }
     }
     panic!("expected the batch's items to block the client via the spam policy");
+}
+
+/// A read batch larger than the configured maximum is rejected. Bounding the
+/// count also bounds the per-item traffic-control tally so a large batch cannot
+/// flood the tally channel.
+#[tokio::test]
+async fn oversized_read_batch_is_rejected() {
+    let max_batch: u32 = 5;
+    let (handle, _reader) = start_test_server(Arc::new(MockGrpcStateReader::default()), |config| {
+        config.max_get_objects_batch_size = max_batch;
+    })
+    .await;
+    let channel = Channel::from_shared(format!("http://{}", handle.address()))
+        .unwrap()
+        .connect()
+        .await
+        .expect("failed to connect to test gRPC server");
+    let mut client = LedgerServiceClient::new(channel);
+
+    let make_batch = |n: usize| {
+        GetObjectsRequest::default().with_requests(
+            ObjectRequests::default().with_requests(
+                (0..n)
+                    .map(|i| {
+                        ObjectRequest::default().with_object_ref(
+                            ObjectReference::default().with_object_id(
+                                ProtoObjectId::default().with_object_id(vec![i as u8; 32]),
+                            ),
+                        )
+                    })
+                    .collect(),
+            ),
+        )
+    };
+
+    // At the limit: accepted (per-item lookups miss in the mock store, which is
+    // reported as embedded results, not a request-level error).
+    client
+        .get_objects(make_batch(max_batch as usize))
+        .await
+        .expect("batch at the limit should be accepted");
+
+    // Over the limit: rejected with `InvalidArgument`.
+    let status = client
+        .get_objects(make_batch(max_batch as usize + 1))
+        .await
+        .expect_err("batch over the limit should be rejected");
+    assert_eq!(
+        status.code(),
+        Code::InvalidArgument,
+        "unexpected error: {status:?}"
+    );
 }
 
 /// Successful requests must not count towards the error policy or get

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -15,12 +15,16 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use common::{MockGrpcStateReader, start_test_server_with_traffic_controller};
 use iota_core::traffic_controller::TrafficController;
 use iota_grpc_types::v1::{
+    ledger_service::{
+        GetObjectsRequest, ObjectRequest, ObjectRequests,
+        ledger_service_client::LedgerServiceClient,
+    },
     state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
     transaction_execution_service::{
         ExecuteTransactionItem, ExecuteTransactionsRequest, execute_transaction_result,
         transaction_execution_service_client::TransactionExecutionServiceClient,
     },
-    types::Address as ProtoAddress,
+    types::{Address as ProtoAddress, ObjectId as ProtoObjectId, ObjectReference},
 };
 use iota_types::{
     digests::TransactionDigest,
@@ -184,6 +188,80 @@ async fn batched_requests_accrue_spam_per_item() {
         // updates the blocklist before the next check.
         tokio::task::yield_now().await;
         if let Err(status) = client.execute_transactions(probe.clone()).await {
+            assert_eq!(
+                status.code(),
+                Code::ResourceExhausted,
+                "unexpected error: {status:?}"
+            );
+            assert!(
+                status.message().contains("Too many requests"),
+                "unexpected block message: {status:?}"
+            );
+            return;
+        }
+    }
+    panic!("expected the batch's items to block the client via the spam policy");
+}
+
+/// A streaming batch read (`get_objects`) must also count each requested item
+/// individually towards the spam policy, charged from the request's item count.
+#[tokio::test]
+async fn batched_reads_accrue_spam_per_item() {
+    let batch_size: usize = 20;
+    let spam_threshold: u64 = 15;
+    let policy_config = PolicyConfig {
+        connection_blocklist_ttl_sec: 120,
+        spam_policy_type: PolicyType::TestNConnIP(spam_threshold),
+        // Error policy off, so any block is attributable to the spam policy.
+        error_policy_type: PolicyType::NoOp,
+        // Count every tally deterministically.
+        spam_sample_rate: Weight::one(),
+        dry_run: false,
+        ..Default::default()
+    };
+    let traffic_controller = Arc::new(TrafficController::init_for_test(policy_config, None).await);
+    let (handle, _reader) = start_test_server_with_traffic_controller(
+        Arc::new(MockGrpcStateReader::default()),
+        traffic_controller,
+        None,
+    )
+    .await;
+    let channel = Channel::from_shared(format!("http://{}", handle.address()))
+        .unwrap()
+        .connect()
+        .await
+        .expect("failed to connect to test gRPC server");
+    let mut client = LedgerServiceClient::new(channel);
+
+    let object_request = |seed: u8| {
+        ObjectRequest::default().with_object_ref(
+            ObjectReference::default()
+                .with_object_id(ProtoObjectId::default().with_object_id(vec![seed; 32])),
+        )
+    };
+
+    // One batch of object lookups: each requested item counts as one request for
+    // the spam policy, charged from the request's item count. The lookups miss
+    // in the mock store, which does not affect the spam count.
+    let batch = GetObjectsRequest::default().with_requests(
+        ObjectRequests::default()
+            .with_requests((0..batch_size).map(|i| object_request(i as u8)).collect()),
+    );
+    client
+        .get_objects(batch)
+        .await
+        .expect("batch request itself should succeed");
+
+    // The single batch already exceeds the spam threshold, so the client must be
+    // blocked within a probe budget kept well below the threshold (the bound a
+    // per-request policy would need to reach the threshold on its own).
+    let probe = GetObjectsRequest::default()
+        .with_requests(ObjectRequests::default().with_requests(vec![object_request(0)]));
+    for _ in 0..10 {
+        // Yield so the background tally task drains the batch's tallies and
+        // updates the blocklist before the next check.
+        tokio::task::yield_now().await;
+        if let Err(status) = client.get_objects(probe.clone()).await {
             assert_eq!(
                 status.code(),
                 Code::ResourceExhausted,

--- a/crates/iota-grpc-server/tests/traffic_control.rs
+++ b/crates/iota-grpc-server/tests/traffic_control.rs
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Integration tests for the traffic-control layer of the gRPC server,
-//! in particular that handler errors — which tonic delivers in the response
-//! *trailers*, not the response headers — feed the error policy.
+//! Integration tests for the traffic-control layer of the gRPC server, in
+//! particular that errors feed the error policy. tonic returns a unary handler
+//! error as a trailers-only response, so its `grpc-status` lands in the HTTP
+//! response headers where the layer already sees it; per-item errors of a batch
+//! API instead ride inside an otherwise successful response and must be
+//! reported explicitly.
 
 mod common;
 
@@ -131,8 +134,9 @@ async fn handler_errors_feed_the_error_policy() {
 async fn successful_requests_do_not_feed_the_error_policy() {
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 120,
-        // Panics inside the traffic controller if any error is ever tallied.
-        error_policy_type: PolicyType::TestPanicOnInvocation,
+        // Block on the first error tally, so a successful request wrongly fed to
+        // the error policy would block the client and fail this test.
+        error_policy_type: PolicyType::TestNConnIP(1),
         dry_run: false,
         ..Default::default()
     };


### PR DESCRIPTION
# Description of change

The e2e migration of the traffic-control tests off the node JSON-RPC (#12130) surfaced gaps in the fullnode gRPC traffic control around **batch APIs**:

1. **Embedded per-item errors never fed the error policy.** Batch APIs report per-item failures as `google.rpc.Status` values embedded inside an otherwise *successful* gRPC response. The `TrafficControlLayer` derives its tally from the transport-level status only, so a client spamming e.g. invalid transactions produced `Code::Ok` tallies and could never be error-blocked.
2. **A batch counted as a single request under the spam policy**, regardless of how many items it carried — so a client could dilute its request rate simply by batching.

(The first gap was originally misdiagnosed as a headers-vs-trailers issue; the `handler_errors_feed_the_error_policy` test shows unary handler errors *are* visible to the layer — tonic returns them as a trailers-only response, so `grpc-status` is in the HTTP headers. The real blind spot is the batch response body.)

## Fix

- `TrafficControlLayer` injects a `TallyHandle` (client IP + traffic controller) into the request extensions.
- Batch handlers report **each item** through the handle: every item counts as one request for the spam policy and, on a client error, feeds the error policy. The layer skips its default per-request tally when a handler has accounted for the items (no double counting).
- Endpoints covered:
  - `ExecuteTransactions`, `SimulateTransactions` — unary; tallied per response item.
  - `GetObjects`, `GetTransactions` — server-streaming; tallied per item as the response stream is consumed. Per-item read failures ride inside `Ok` responses and are tallied as `Code::Ok` (a client cannot know an object or transaction was pruned), so they feed the spam policy only. A stream-level error (e.g. a single item exceeding the request's message size limit) terminates the stream and is tallied by its status code, like a unary handler error; an empty batch produces no per-item tallies and is charged as one request up front — either would otherwise escape traffic control entirely.
- `GetObjects` / `GetTransactions` batches are now size-capped (`max_get_objects_batch_size` / `max_get_transactions_batch_size`, default 1000) and oversized batches are rejected — previously they were unbounded, which meant unbounded storage lookups and an unbounded per-item tally that could flood the tally channel. Empty batches remain allowed.
- Pagination (`ListOwnedObjects`, …), the checkpoint subscription, and single-item reads are unchanged — they are not client-submitted batches of independent lookups.

Not changed (considered): the metrics layer still derives response-code metrics from the transport-level status; counting embedded application errors as transport `OK` is arguably correct for transport metrics.

## Tests

`crates/iota-grpc-server/tests/traffic_control.rs`:

- `handler_errors_feed_the_error_policy` — unary `InvalidArgument` blocks the client.
- `embedded_batch_errors_feed_the_error_policy` — per-item errors in OK `ExecuteTransactions` responses feed the error policy (**fails without the fix**).
- `batched_requests_accrue_spam_per_item` — a single `ExecuteTransactions` batch is charged per item under the spam policy (**fails without the fix**).
- `batched_reads_accrue_spam_per_item` — a single `GetObjects` batch is charged per item under the spam policy (**fails without the fix**).
- `stream_errors_feed_the_error_policy` — a streaming read whose only stream element is an error is still tallied and feeds the error policy (**fails without the fix**).
- `empty_read_batches_accrue_spam` — empty read batches are charged as one request under the spam policy (**fails without the fix**).
- `oversized_read_batch_is_rejected` — a `GetObjects` batch over the configured limit is rejected with `InvalidArgument`.
- `successful_requests_do_not_feed_the_error_policy` — valid requests never trigger the error policy.
- `read_errors_do_not_feed_the_error_policy` — per-item read misses never trigger the error policy.

## Links to any relevant issues

Gap found during #12130 (Phase 2 of the node JSON-RPC removal).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Full `iota-grpc-server` test suite green and clippy clean; the per-item, stream-error, and empty-batch tests verified to fail on the unpatched code.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Full node gRPC traffic control now accounts for batch APIs per item — each item of `ExecuteTransactions`, `SimulateTransactions`, `GetObjects`, and `GetTransactions` counts as one request for the spam policy, and per-item client errors feed the error policy — so batching can no longer dilute a client's request rate or hide its errors. `GetObjects` / `GetTransactions` batches are now size-capped via the new `max_get_objects_batch_size` / `max_get_transactions_batch_size` config (default 1000).
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] gRPC: Batch APIs are now tallied per item by the full node traffic control (spam rate and error policy), so batching cannot bypass rate limiting.
