### PR TITLE
chore: source fastcrypto from crates.io (=0.1.11)

### DIFF
--- a/.github/workflows/_rust_lints.yml
+++ b/.github/workflows/_rust_lints.yml
@@ -103,6 +103,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  fastcrypto-single-version:
+    if: (!cancelled() && inputs.isRust)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check fastcrypto resolves to a single version
+        run: ./scripts/check_fastcrypto_single_version.sh
+
+  fastcrypto-single-version-cancel:
+    needs: [fastcrypto-single-version]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   examples:
     if: (!cancelled() && inputs.isRustExample)
     uses: ./.github/workflows/_rust_examples.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -586,7 +597,7 @@ version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12fcdb3f1d03f69d3ec26ac67645a8fe3f878d77b5ebb0b15d64a116c212985"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -728,7 +739,7 @@ version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69efcd706420e52cd44f5c4358d279801993846d1c2a8e52111853d61d55a619"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -3942,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d0311319519303515667f714eb6d2d6363843c1d569e7e05a69f2e163a2f81"
+checksum = "b7ba8f556d75586dd5d9148df99ca02d8afbab9ba230a4f028de54eb0d3bfced"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3964,6 +3975,7 @@ dependencies = [
  "bs58 0.4.0",
  "bulletproofs",
  "cbc",
+ "ciborium",
  "ctr",
  "curve25519-dalek",
  "derive_more 0.99.18",
@@ -3982,10 +3994,12 @@ dependencies = [
  "num-bigint 0.4.6",
  "once_cell",
  "p256",
+ "p384",
  "rand 0.8.6",
  "readonly",
  "rfc6979",
  "rsa",
+ "rustls-pki-types",
  "schemars",
  "secp256k1",
  "serde",
@@ -3999,6 +4013,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typenum",
+ "x509-parser",
  "zeroize",
 ]
 
@@ -4015,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?tag=fastcrypto-v0.1.10#feddd0d27a857cc9355fbee41e59af2526f2c35f"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -4023,8 +4038,8 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "rand 0.8.6",
+ "reed-solomon-erasure",
  "serde",
- "serde-big-array",
  "sha3 0.10.8",
  "tap",
  "tracing",
@@ -4035,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?tag=fastcrypto-v0.1.10#feddd0d27a857cc9355fbee41e59af2526f2c35f"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -4052,7 +4067,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.4"
-source = "git+https://github.com/MystenLabs/fastcrypto?tag=fastcrypto-v0.1.10#feddd0d27a857cc9355fbee41e59af2526f2c35f"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4693,6 +4708,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -4700,7 +4718,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -4709,7 +4727,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -8932,6 +8950,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
@@ -9828,7 +9855,7 @@ name = "msim"
 version = "0.1.0"
 source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.52.2#2d1ddbb6e2d07f2d3541c4ee5710c725819ec917"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "async-task",
  "bytes",
  "cc",
@@ -10618,6 +10645,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "packable"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10792,7 +10831,7 @@ version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb15796ac6f56b429fd99e33ba133783ad75b27c36b4b5ce06f1f82cc97754e"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
@@ -12042,6 +12081,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "reed-solomon-erasure"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
+dependencies = [
+ "libm",
+ "lru 0.7.8",
+ "parking_lot 0.11.2",
+ "smallvec",
+ "spin",
+]
+
+[[package]]
 name = "reed-solomon-simd"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12660,15 +12712,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -13354,7 +13397,7 @@ dependencies = [
 name = "starfish-core"
 version = "0.1.0"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "async-trait",
  "base64 0.21.7",
  "bcs",
@@ -15883,6 +15926,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,20 +3739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "ed25519-zebra"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,6 +3971,7 @@ dependencies = [
  "elliptic-curve",
  "fastcrypto-derive",
  "generic-array",
+ "getrandom 0.2.15",
  "hex",
  "hex-literal",
  "hkdf",
@@ -7539,13 +7526,14 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
  "bech32 0.11.1",
  "bip32",
  "bip39",
  "blst",
- "ed25519-dalek",
+ "ed25519",
+ "fastcrypto",
  "iota-sdk-types",
  "k256",
  "p256",
@@ -7557,12 +7545,13 @@ dependencies = [
  "signature 2.2.0",
  "slip10_ed25519",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7591,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7599,7 +7588,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7618,7 +7607,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7634,7 +7623,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7653,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,7 +179,7 @@ dependencies = [
  "http 1.4.0",
  "matchit 0.5.0",
  "pin-project-lite",
- "pkcs8 0.10.2",
+ "pkcs8",
  "quinn",
  "quinn-proto",
  "rand 0.8.6",
@@ -449,6 +464,17 @@ dependencies = [
  "ark-ff",
  "ark-std",
  "tracing",
+]
+
+[[package]]
+name = "ark-secp256k1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -2030,6 +2056,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bulletproofs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "012e2e5f88332083bd4235d445ae78081c00b2558443821a9ca5adfe1070073d"
+dependencies = [
+ "byteorder",
+ "clear_on_drop",
+ "curve25519-dalek",
+ "digest 0.10.7",
+ "group",
+ "merlin",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_derive",
+ "sha3 0.10.8",
+ "subtle",
+ "thiserror 1.0.64",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2411,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmov"
@@ -2914,7 +2970,10 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
+ "group",
+ "rand_core 0.6.4",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -3228,23 +3287,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -3645,12 +3693,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.9",
+ "der",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature 2.2.0",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -3659,7 +3707,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
+ "pkcs8",
  "signature 2.2.0",
  "zeroize",
 ]
@@ -3726,8 +3774,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "serde_json",
@@ -3894,25 +3942,30 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto"
-version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d0311319519303515667f714eb6d2d6363843c1d569e7e05a69f2e163a2f81"
 dependencies = [
  "aes",
  "aes-gcm",
+ "aes-gcm-siv",
  "ark-ec",
  "ark-ff",
+ "ark-secp256k1",
  "ark-secp256r1",
  "ark-serialize",
  "auto_ops",
  "base64ct",
+ "bcs",
  "bech32 0.9.1",
  "bincode",
  "blake2",
  "blst",
  "bs58 0.4.0",
+ "bulletproofs",
  "cbc",
  "ctr",
- "curve25519-dalek-ng",
+ "curve25519-dalek",
  "derive_more 0.99.18",
  "digest 0.10.7",
  "ecdsa",
@@ -3923,14 +3976,16 @@ dependencies = [
  "hex",
  "hex-literal",
  "hkdf",
+ "itertools 0.12.1",
  "lazy_static",
+ "merlin",
  "num-bigint 0.4.6",
  "once_cell",
  "p256",
  "rand 0.8.6",
  "readonly",
  "rfc6979",
- "rsa 0.8.2",
+ "rsa",
  "schemars",
  "secp256k1",
  "serde",
@@ -3942,14 +3997,16 @@ dependencies = [
  "static_assertions",
  "thiserror 1.0.64",
  "tokio",
+ "tracing",
  "typenum",
  "zeroize",
 ]
 
 [[package]]
 name = "fastcrypto-derive"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea839b19e2241156eb78b1c33066df25266e893ba85a6b283ceb3bd8a1a6d21b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3958,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?tag=fastcrypto-v0.1.10#feddd0d27a857cc9355fbee41e59af2526f2c35f"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -3967,6 +4024,7 @@ dependencies = [
  "itertools 0.10.5",
  "rand 0.8.6",
  "serde",
+ "serde-big-array",
  "sha3 0.10.8",
  "tap",
  "tracing",
@@ -3977,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?tag=fastcrypto-v0.1.10#feddd0d27a857cc9355fbee41e59af2526f2c35f"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -3993,8 +4051,8 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto-zkp"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.4"
+source = "git+https://github.com/MystenLabs/fastcrypto?tag=fastcrypto-v0.1.10#feddd0d27a857cc9355fbee41e59af2526f2c35f"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -7473,8 +7531,8 @@ dependencies = [
  "iota-sdk-types",
  "k256",
  "p256",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "roaring",
  "sha2 0.10.9",
@@ -7927,7 +7985,7 @@ dependencies = [
  "axum-server",
  "ed25519",
  "fastcrypto",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand 0.8.6",
  "rcgen",
  "reqwest",
@@ -9003,6 +9061,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak 0.1.6",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "miette"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10072,11 +10142,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -10124,9 +10193,9 @@ dependencies = [
 
 [[package]]
 name = "num-modular"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
@@ -10134,32 +10203,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-modular"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
-
-[[package]]
 name = "num-order"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
 dependencies = [
- "num-modular 0.6.1",
+ "num-modular",
 ]
 
 [[package]]
 name = "num-prime"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238432a7881ec7164503ccc516c014bf009be7984cde1ba56837862543bdec3"
+checksum = "b285c575532a33ef6fdd3a57640d0b1c70e6ca48644d6df7bbd4b7a0cfbbb12d"
 dependencies = [
  "bitvec 1.0.1",
  "either",
- "lru 0.12.4",
+ "lru 0.16.3",
  "num-bigint 0.4.6",
  "num-integer",
- "num-modular 0.5.1",
+ "num-modular",
  "num-traits",
  "rand 0.8.6",
 ]
@@ -10864,15 +10927,6 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
@@ -11038,35 +11092,13 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
-dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.9",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -11075,8 +11107,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.9",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -12246,41 +12278,21 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.8.2"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
-dependencies = [
- "byteorder",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-iter",
- "num-traits",
- "pkcs1 0.4.1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature 2.2.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid 0.9.6",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1 0.7.5",
- "pkcs8 0.10.2",
+ "pkcs1",
+ "pkcs8",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature 2.2.0",
- "spki 0.7.3",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -12568,9 +12580,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.9",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "serdect",
  "subtle",
  "zeroize",
@@ -12648,6 +12660,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -13226,7 +13247,7 @@ checksum = "2f1c0c8818bb7400e821b166075ec771c8e8a012af41a8982b34eefaad4739fd"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
- "rsa 0.9.6",
+ "rsa",
  "serde",
  "sha2 0.10.9",
  "thiserror 1.0.64",
@@ -13286,22 +13307,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.9",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,9 +402,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "559083b9e901e53008f15d85d50df7f007c681ba" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "559083b9e901e53008f15d85d50df7f007c681ba" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -443,9 +443,9 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,10 +273,11 @@ either = "1.8.0"
 enum_dispatch = "^0.3"
 expect-test = "1.4.0"
 eyre = "0.6.8"
-fastcrypto = "0.1.10"
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", tag = "fastcrypto-v0.1.10" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", tag = "fastcrypto-v0.1.10", features = ["experimental"] }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", tag = "fastcrypto-v0.1.10", package = "fastcrypto-zkp" }
+fastcrypto = "=0.1.11"
+# Pinned by revision (a tag can be moved); keep in sync with the fastcrypto version above.
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a", features = ["experimental"] }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a", package = "fastcrypto-zkp" }
 flate2 = "1.0.28"
 fs_extra = "1.3.0"
 futures = "0.3.28"
@@ -505,4 +506,4 @@ typed-store-error = { path = "crates/typed-store-error" }
 # pull fastcrypto via an in-repo path dep. Redirect it to the crates.io release
 # so the workspace shares a single fastcrypto instead of two conflicting copies.
 [patch."https://github.com/MystenLabs/fastcrypto"]
-fastcrypto = "0.1.10"
+fastcrypto = "=0.1.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,10 +273,10 @@ either = "1.8.0"
 enum_dispatch = "^0.3"
 expect-test = "1.4.0"
 eyre = "0.6.8"
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", features = ["experimental"] }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto-zkp" }
+fastcrypto = "0.1.10"
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", tag = "fastcrypto-v0.1.10" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", tag = "fastcrypto-v0.1.10", features = ["experimental"] }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", tag = "fastcrypto-v0.1.10", package = "fastcrypto-zkp" }
 flate2 = "1.0.28"
 fs_extra = "1.3.0"
 futures = "0.3.28"
@@ -500,3 +500,9 @@ transaction-fuzzer = { path = "crates/transaction-fuzzer" }
 typed-store = { path = "crates/typed-store" }
 typed-store-derive = { path = "crates/typed-store-derive" }
 typed-store-error = { path = "crates/typed-store-error" }
+
+# fastcrypto-tbls/-vdf/-zkp are only on git (vdf unpublished, tbls stale) and
+# pull fastcrypto via an in-repo path dep. Redirect it to the crates.io release
+# so the workspace shares a single fastcrypto instead of two conflicting copies.
+[patch."https://github.com/MystenLabs/fastcrypto"]
+fastcrypto = "0.1.10"

--- a/crates/iota-e2e-tests/tests/passkey_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/passkey_e2e_tests.rs
@@ -324,7 +324,7 @@ async fn test_passkey_fails_to_verify_sig() {
     assert_eq!(
         err,
         IotaError::InvalidSignature {
-            error: "Invalid passkey authentication: signature error".to_string()
+            error: "Invalid passkey authentication: signature error: Invalid signature was given to the function".to_string()
         }
     );
 
@@ -349,7 +349,7 @@ async fn test_passkey_fails_to_verify_sig() {
     assert_eq!(
         err,
         IotaError::InvalidSignature {
-            error: "Invalid passkey authentication: signature error".to_string()
+            error: "Invalid passkey authentication: signature error: Invalid signature was given to the function".to_string()
         }
     );
 }

--- a/crates/iota-framework/packages/iota-framework/tests/crypto/poseidon_tests.move
+++ b/crates/iota-framework/packages/iota-framework/tests/crypto/poseidon_tests.move
@@ -40,9 +40,14 @@ fun test_poseidon_bn254_hash() {
     let expected = 4203130618016961831408770638653325366880478848856764494148034853759773445968u256;
     let actual = poseidon_bn254(&msg);
     assert!(actual == expected);
+}
 
+#[test]
+// poseidon_bn254 accepts at most 16 inputs; more are rejected by the native and
+// surface as ENonCanonicalInput.
+#[expected_failure(abort_code = iota::poseidon::ENonCanonicalInput)]
+fun test_poseidon_bn254_too_many_inputs() {
     let msg = vector[
-        0u256,
         1u256,
         2u256,
         3u256,
@@ -60,62 +65,8 @@ fun test_poseidon_bn254_hash() {
         15u256,
         16u256,
         17u256,
-        18u256,
-        19u256,
-        20u256,
-        21u256,
-        22u256,
-        23u256,
-        24u256,
-        25u256,
-        26u256,
-        27u256,
-        28u256,
-        29u256,
     ];
-    let expected = 4123755143677678663754455867798672266093104048057302051129414708339780424023u256;
-    let actual = poseidon_bn254(&msg);
-    assert!(actual == expected);
-
-    let msg = vector[
-        0u256,
-        1u256,
-        2u256,
-        3u256,
-        4u256,
-        5u256,
-        6u256,
-        7u256,
-        8u256,
-        9u256,
-        10u256,
-        11u256,
-        12u256,
-        13u256,
-        14u256,
-        15u256,
-        16u256,
-        17u256,
-        18u256,
-        19u256,
-        20u256,
-        21u256,
-        22u256,
-        23u256,
-        24u256,
-        25u256,
-        26u256,
-        27u256,
-        28u256,
-        29u256,
-        30u256,
-        31u256,
-        32u256,
-    ];
-    let expected =
-        15368023340287843142129781602124963668572853984788169144128906033251913623349u256;
-    let actual = poseidon_bn254(&msg);
-    assert!(actual == expected);
+    poseidon_bn254(&msg);
 }
 
 #[test]

--- a/crates/iota-framework/packages/iota-framework/tests/crypto/poseidon_tests.move
+++ b/crates/iota-framework/packages/iota-framework/tests/crypto/poseidon_tests.move
@@ -42,9 +42,9 @@ fun test_poseidon_bn254_hash() {
     assert!(actual == expected);
 }
 
-#[test]
 // poseidon_bn254 accepts at most 16 inputs; more are rejected by the native and
 // surface as ENonCanonicalInput.
+#[test]
 #[expected_failure(abort_code = iota::poseidon::ENonCanonicalInput)]
 fun test_poseidon_bn254_too_many_inputs() {
     let msg = vector[

--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -646,7 +646,8 @@ impl RandomnessEventLoop {
 
         // Try to verify the aggregated signature all at once. (Should work in the happy
         // path.)
-        if ThresholdBls12381MinSig::verify(vss_pk.c0(), &round.signature_message(), &sig).is_err() {
+        if ThresholdBls12381MinSig::verify(&vss_pk.c0(), &round.signature_message(), &sig).is_err()
+        {
             // If verification fails, some of the inputs must be invalid. We have to go
             // through one-by-one to find which.
             // TODO: add test for individual sig verification.
@@ -690,7 +691,7 @@ impl RandomnessEventLoop {
                 }
             };
             if let Err(e) =
-                ThresholdBls12381MinSig::verify(vss_pk.c0(), &round.signature_message(), &sig)
+                ThresholdBls12381MinSig::verify(&vss_pk.c0(), &round.signature_message(), &sig)
             {
                 error!(
                     "error while verifying randomness partial signatures after removing invalid partials: {e:?}"
@@ -750,7 +751,7 @@ impl RandomnessEventLoop {
         }
 
         if let Err(e) =
-            ThresholdBls12381MinSig::verify(vss_pk.c0(), &round.signature_message(), &sig)
+            ThresholdBls12381MinSig::verify(&vss_pk.c0(), &round.signature_message(), &sig)
         {
             info!("received invalid full signature from peer {peer_id}: {e:?}");
             if let Some(sender) = self.mailbox_sender.upgrade() {
@@ -1098,7 +1099,7 @@ impl RandomnessEventLoop {
             &dkg_output.vss_pk
         };
 
-        ThresholdBls12381MinSig::verify(vss_pk.c0(), &round.signature_message(), &sig)
+        ThresholdBls12381MinSig::verify(&vss_pk.c0(), &round.signature_message(), &sig)
             .map_err(|e| anyhow::anyhow!("invalid full signature: {e:?}"))?;
 
         self.process_valid_full_signature(self.epoch, round, sig);

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 iota-grpc-client = { workspace = true, optional = true }
 iota-grpc-types = { workspace = true, optional = true }
 iota-sdk-crypto = { workspace = true, optional = true }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", optional = true }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", default-features = false, optional = true }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b", optional = true }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b", default-features = false, optional = true }
 iota-sdk-types = { workspace = true, optional = true }
 
 [features]

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -49,6 +49,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,7 +131,7 @@ dependencies = [
  "http",
  "matchit 0.5.0",
  "pin-project-lite",
- "pkcs8 0.10.2",
+ "pkcs8",
  "quinn",
  "quinn-proto",
  "rand 0.8.6",
@@ -353,6 +379,17 @@ dependencies = [
  "ark-ff",
  "ark-std",
  "tracing",
+]
+
+[[package]]
+name = "ark-secp256k1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -965,6 +1002,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bulletproofs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "012e2e5f88332083bd4235d445ae78081c00b2558443821a9ca5adfe1070073d"
+dependencies = [
+ "byteorder",
+ "clear_on_drop",
+ "curve25519-dalek",
+ "digest 0.10.7",
+ "group",
+ "merlin",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_derive",
+ "sha3 0.10.9",
+ "subtle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1211,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmake"
@@ -1424,7 +1491,10 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
+ "group",
+ "rand_core 0.6.4",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -1563,23 +1633,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1832,12 +1891,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature 2.2.0",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -1846,7 +1905,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
+ "pkcs8",
  "signature 2.2.0",
  "zeroize",
 ]
@@ -1863,20 +1922,6 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
  "zeroize",
 ]
 
@@ -1898,8 +1943,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1994,25 +2039,31 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto"
-version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ba8f556d75586dd5d9148df99ca02d8afbab9ba230a4f028de54eb0d3bfced"
 dependencies = [
  "aes",
  "aes-gcm",
+ "aes-gcm-siv",
  "ark-ec",
  "ark-ff",
+ "ark-secp256k1",
  "ark-secp256r1",
  "ark-serialize",
  "auto_ops",
  "base64ct",
+ "bcs",
  "bech32",
  "bincode",
  "blake2",
  "blst",
  "bs58 0.4.0",
+ "bulletproofs",
  "cbc",
+ "ciborium",
  "ctr",
- "curve25519-dalek-ng",
+ "curve25519-dalek",
  "derive_more 0.99.20",
  "digest 0.10.7",
  "ecdsa",
@@ -2020,17 +2071,22 @@ dependencies = [
  "elliptic-curve",
  "fastcrypto-derive",
  "generic-array",
+ "getrandom 0.2.17",
  "hex",
  "hex-literal",
  "hkdf",
+ "itertools 0.12.1",
  "lazy_static",
+ "merlin",
  "num-bigint 0.4.6",
  "once_cell",
  "p256",
+ "p384",
  "rand 0.8.6",
  "readonly",
  "rfc6979",
  "rsa",
+ "rustls-pki-types",
  "schemars 0.8.22",
  "secp256k1",
  "serde",
@@ -2042,14 +2098,17 @@ dependencies = [
  "static_assertions",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "typenum",
+ "x509-parser",
  "zeroize",
 ]
 
 [[package]]
 name = "fastcrypto-derive"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea839b19e2241156eb78b1c33066df25266e893ba85a6b283ceb3bd8a1a6d21b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2058,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -2066,6 +2125,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "rand 0.8.6",
+ "reed-solomon-erasure",
  "serde",
  "sha3 0.10.9",
  "tap",
@@ -2077,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -2093,8 +2153,8 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto-zkp"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.4"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a#47f8f6b747900bbc1662c4d4eecd2f7e7a29e16a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2208,6 +2268,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -2570,6 +2636,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2577,7 +2646,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2594,7 +2663,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2820,7 +2900,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -3476,7 +3556,7 @@ dependencies = [
  "bcs",
  "iota-sdk-types",
  "iota-types",
- "lru",
+ "lru 0.12.5",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
@@ -3552,22 +3632,21 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
- "ed25519-dalek",
+ "fastcrypto",
  "iota-sdk-types",
- "k256",
- "p256",
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "signature 2.2.0",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0135f905e0479728ef8c87cea324a882e50e1b5b#0135f905e0479728ef8c87cea324a882e50e1b5b"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3601,7 +3680,7 @@ dependencies = [
  "axum-server",
  "ed25519",
  "fastcrypto",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rcgen",
  "reqwest 0.12.28",
  "rustls",
@@ -3657,7 +3736,7 @@ dependencies = [
  "iota-sdk-crypto",
  "iota-sdk-types",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -4171,11 +4250,29 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4235,6 +4332,18 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak 0.1.6",
+ "rand_core 0.6.4",
+ "zeroize",
+]
 
 [[package]]
 name = "mime"
@@ -4898,9 +5007,9 @@ dependencies = [
 
 [[package]]
 name = "num-modular"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
@@ -4909,13 +5018,13 @@ dependencies = [
 
 [[package]]
 name = "num-prime"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238432a7881ec7164503ccc516c014bf009be7984cde1ba56837862543bdec3"
+checksum = "b285c575532a33ef6fdd3a57640d0b1c70e6ca48644d6df7bbd4b7a0cfbbb12d"
 dependencies = [
  "bitvec 1.0.1",
  "either",
- "lru",
+ "lru 0.16.4",
  "num-bigint 0.4.6",
  "num-integer",
  "num-modular",
@@ -5136,6 +5245,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "packed_struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5327,15 +5448,6 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
@@ -5429,24 +5541,13 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
-version = "0.4.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -5455,8 +5556,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -6098,6 +6199,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "reed-solomon-erasure"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
+dependencies = [
+ "libm",
+ "lru 0.7.8",
+ "parking_lot 0.11.2",
+ "smallvec",
+ "spin",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6290,21 +6404,21 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.8.2"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "byteorder",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.9.0",
+ "pkcs8",
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "signature 2.2.0",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -6560,9 +6674,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.10",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -7008,22 +7122,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -8222,7 +8326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -8233,19 +8337,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -8254,10 +8346,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -8267,20 +8359,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -8288,17 +8369,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8328,7 +8398,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -8339,17 +8409,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8830,6 +8891,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 # external dependencies
 anyhow = "1.0"
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
+fastcrypto = "=0.1.11"
 hex = "0.4.3"
 reqwest = { version = "0.13.1", features = ["json"] }
 serde = "1.0.228"
@@ -96,3 +96,9 @@ path = "abstract_account/authenticator-tx-data-cryptographic-protection.rs"
 ignored = [
   "move-binary-format", # `serialize` method is gated by its `fuzzing` feature
 ]
+
+# fastcrypto-tbls/-vdf/-zkp (pulled transitively via the monorepo crates) fetch
+# fastcrypto through an in-repo path dep. Redirect it to the crates.io release
+# so this workspace shares a single fastcrypto instead of two conflicting copies.
+[patch."https://github.com/MystenLabs/fastcrypto"]
+fastcrypto = "=0.1.11"

--- a/examples/custom-indexer/rust/Cargo.toml
+++ b/examples/custom-indexer/rust/Cargo.toml
@@ -30,3 +30,9 @@ path = "hybrid_reader.rs"
 [[bin]]
 name = "remote_reader_with_filters"
 path = "remote_reader_with_filters.rs"
+
+# fastcrypto-tbls/-vdf/-zkp (pulled transitively via the monorepo crates) fetch
+# fastcrypto through an in-repo path dep. Redirect it to the crates.io release
+# so this workspace shares a single fastcrypto instead of two conflicting copies.
+[patch."https://github.com/MystenLabs/fastcrypto"]
+fastcrypto = "=0.1.11"

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0135f905e0479728ef8c87cea324a882e50e1b5b" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 bcs = "0.1"
 clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }
 dirs = "6.0"
-fastcrypto = "0.1"
+fastcrypto = "=0.1.11"
 serde = { version = "1.0", features = ["derive"] }
 # Pinned: time 0.3.48 introduces a coherence conflict with rcgen 0.13.2 that
 # fails to compile. Declared directly (it is otherwise a transitive dep via
@@ -28,3 +28,9 @@ iota-types = { path = "../../../crates/iota-types" }
 ignored = [
   "time", # declared only to pin the version of a transitive dep (see above)
 ]
+
+# fastcrypto-tbls/-vdf/-zkp (pulled transitively via the monorepo crates) fetch
+# fastcrypto through an in-repo path dep. Redirect it to the crates.io release
+# so this workspace shares a single fastcrypto instead of two conflicting copies.
+[patch."https://github.com/MystenLabs/fastcrypto"]
+fastcrypto = "=0.1.11"

--- a/scripts/check_fastcrypto_single_version.sh
+++ b/scripts/check_fastcrypto_single_version.sh
@@ -1,19 +1,61 @@
 #!/usr/bin/env bash
-# Fail if Cargo.lock has more than one fastcrypto: it is shared with the
-# iota-rust-sdk (via iota-sdk-crypto) and both must resolve to one version.
+# fastcrypto is shared with the iota-rust-sdk (via iota-sdk-crypto), so the whole
+# tree must resolve to one fastcrypto. This checks two things in Cargo.lock:
+#   1. there is exactly one fastcrypto version; and
+#   2. the crates.io fastcrypto we patch to was published from the same commit the
+#      git-pinned fastcrypto-tbls/-vdf/-zkp reference (compared via the crate's
+#      .cargo_vcs_info.json), so a matching version number can't hide a different
+#      source.
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 lockfile="$root/Cargo.lock"
 
+# 1) exactly one fastcrypto version
 count=$(grep -c '^name = "fastcrypto"$' "$lockfile" || true)
-
 if [ "$count" != "1" ]; then
   echo "error: expected exactly one 'fastcrypto' entry in Cargo.lock, found ${count}."
   echo "The iota workspace and iota-rust-sdk (iota-sdk-crypto) must use the same fastcrypto version."
-  echo "See the [patch.\"https://github.com/MystenLabs/fastcrypto\"] section in the root Cargo.toml."
   grep -A2 '^name = "fastcrypto"$' "$lockfile" | grep -E '^(name|version|source) ' || true
   exit 1
 fi
 
-echo "fastcrypto: single version in Cargo.lock — OK"
+version=$(grep -A1 '^name = "fastcrypto"$' "$lockfile" | sed -n 's/^version = "\(.*\)"$/\1/p')
+
+# 2) the git revision the fastcrypto-tbls/-vdf/-zkp sub-crates are pinned to (if any)
+rev=$(grep -oE 'git\+https://github.com/[^"#]*fastcrypto[^"#]*#[0-9a-f]{40}' "$lockfile" \
+  | grep -oE '[0-9a-f]{40}$' | sort -u)
+if [ -z "$rev" ]; then
+  echo "fastcrypto: single version ${version}, no git-pinned sub-crates — OK"
+  exit 0
+fi
+if [ "$(printf '%s\n' "$rev" | wc -l | tr -d ' ')" != "1" ]; then
+  echo "error: fastcrypto sub-crates are pinned to multiple git revisions:"
+  printf '%s\n' "$rev"
+  exit 1
+fi
+
+# 3) the commit crates.io published this fastcrypto version from
+crate_url="https://static.crates.io/crates/fastcrypto/fastcrypto-${version}.crate"
+tmp=$(mktemp)
+if ! curl -sSL --retry 3 "$crate_url" -o "$tmp"; then
+  echo "warning: could not download ${crate_url}; skipped git-revision cross-check (single-version check passed)."
+  rm -f "$tmp"
+  exit 0
+fi
+vcs_sha=$(tar -xzOf "$tmp" "fastcrypto-${version}/.cargo_vcs_info.json" 2>/dev/null | grep -oE '[0-9a-f]{40}' | head -1 || true)
+rm -f "$tmp"
+
+if [ -z "$vcs_sha" ]; then
+  echo "warning: fastcrypto-${version} has no .cargo_vcs_info.json; skipped git-revision cross-check (single-version check passed)."
+  exit 0
+fi
+
+if [ "$vcs_sha" != "$rev" ]; then
+  echo "error: crates.io fastcrypto ${version} was published from ${vcs_sha},"
+  echo "but fastcrypto-tbls/-vdf/-zkp are pinned to ${rev}."
+  echo "Point the sub-crate 'rev' at the commit crates.io published fastcrypto ${version} from."
+  exit 1
+fi
+
+echo "fastcrypto: single version ${version}; git rev ${rev} matches the crates.io publish — OK"

--- a/scripts/check_fastcrypto_single_version.sh
+++ b/scripts/check_fastcrypto_single_version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Fail if Cargo.lock has more than one fastcrypto: it is shared with the
+# iota-rust-sdk (via iota-sdk-crypto) and both must resolve to one version.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+lockfile="$root/Cargo.lock"
+
+count=$(grep -c '^name = "fastcrypto"$' "$lockfile" || true)
+
+if [ "$count" != "1" ]; then
+  echo "error: expected exactly one 'fastcrypto' entry in Cargo.lock, found ${count}."
+  echo "The iota workspace and iota-rust-sdk (iota-sdk-crypto) must use the same fastcrypto version."
+  echo "See the [patch.\"https://github.com/MystenLabs/fastcrypto\"] section in the root Cargo.toml."
+  grep -A2 '^name = "fastcrypto"$' "$lockfile" | grep -E '^(name|version|source) ' || true
+  exit 1
+fi
+
+echo "fastcrypto: single version in Cargo.lock — OK"

--- a/scripts/simtest/config-patch
+++ b/scripts/simtest/config-patch
@@ -15,10 +15,10 @@ diff --git a/Cargo.toml b/Cargo.toml
 index 9701e17bf1..515b760349 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -507,3 +507,7 @@ transaction-fuzzer = { path = "crates/transaction-fuzzer" }
- typed-store = { path = "crates/typed-store" }
- typed-store-derive = { path = "crates/typed-store-derive" }
- typed-store-error = { path = "crates/typed-store-error" }
+@@ -507,3 +507,7 @@ typed-store-error = { path = "crates/typed-store-error" }
+ # so the workspace shares a single fastcrypto instead of two conflicting copies.
+ [patch."https://github.com/MystenLabs/fastcrypto"]
+ fastcrypto = "=0.1.11"
 +
 +[patch.crates-io]
 +tokio = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.52.2" }


### PR DESCRIPTION
Source the main `fastcrypto` from crates.io, pinned to an exact `=0.1.11`, instead of a floating git revision.

- `-tbls`/`-vdf`/`-zkp` aren't on crates.io yet, so they're pinned by git revision (the `fastcrypto-v0.1.11` tag commit — a tag can be moved) and a `[patch]` unifies everything onto the crates.io release: one fastcrypto, no duplicate copy.
- Adds a CI guard that fails if the workspace ever resolves more than one fastcrypto, keeping this repo and the SDK (`iota-sdk-crypto`) in sync.
- Bumps the `iota-rust-sdk` git dependencies to the matching SDK commit (ed25519/secp256r1/secp256k1 moved onto fastcrypto).

**Behavior change:** fastcrypto 0.1.11 lowers the `poseidon_bn254` input limit from 32 to 16 — inputs above 16 are now rejected by the native. zklogin, the main consumer of large poseidon inputs, is disabled (and stays disabled), so on-chain impact is nil. Framework tests updated accordingly.

Companion SDK change: iotaledger/iota-rust-sdk#1248

🤖 Generated with [Claude Code](https://claude.com/claude-code)