### PR TITLE
feat(starfish-core,starfish-config): stream fast commit sync fetch processing on both ends

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -135,8 +135,10 @@ pub struct Parameters {
 
     /// Soft cap on total serialized transaction bytes accepted per fast commit
     /// sync fetch. When reached, the fetch finishes with the covered commit
-    /// prefix and the scheduler requeues the remainder. Also sent to the server
-    /// as a stream budget hint. 0 disables.
+    /// prefix and the scheduler requeues the remainder. At least the first
+    /// commit of the range is always fetched in full so the fetch makes forward
+    /// progress even when that commit alone exceeds the cap. Also sent to the
+    /// server as a stream budget hint. 0 disables.
     #[serde(default = "Parameters::default_fast_commit_sync_max_fetch_bytes")]
     pub fast_commit_sync_max_fetch_bytes: usize,
 

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -133,6 +133,13 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_fast_commit_sync_batch_size")]
     pub fast_commit_sync_batch_size: u32,
 
+    /// Soft cap on total serialized transaction bytes accepted per fast commit
+    /// sync fetch. When reached, the fetch finishes with the covered commit
+    /// prefix and the scheduler requeues the remainder. Also sent to the server
+    /// as a stream budget hint. 0 disables.
+    #[serde(default = "Parameters::default_fast_commit_sync_max_fetch_bytes")]
+    pub fast_commit_sync_max_fetch_bytes: usize,
+
     // Gap threshold for switching between commit syncers. When the gap between quorum and local
     // commit index is larger than this threshold, FastCommitSyncer fetches. Otherwise,
     // CommitSyncer fetches.
@@ -403,6 +410,16 @@ impl Parameters {
         }
     }
 
+    pub(crate) fn default_fast_commit_sync_max_fetch_bytes() -> usize {
+        if cfg!(msim) {
+            // Small enough that simtests routinely hit the cap, exercising
+            // cap-stop -> covered prefix -> requeue.
+            1 << 10
+        } else {
+            128 << 20
+        }
+    }
+
     pub(crate) fn default_commit_sync_gap_threshold() -> u32 {
         if cfg!(msim) {
             // Use smaller threshold for testing.
@@ -453,6 +470,8 @@ impl Default for Parameters {
             max_shards_per_bundle: Parameters::default_max_shards_per_bundle(),
             tonic: TonicParameters::default(),
             fast_commit_sync_batch_size: Parameters::default_fast_commit_sync_batch_size(),
+            fast_commit_sync_max_fetch_bytes: Parameters::default_fast_commit_sync_max_fetch_bytes(
+            ),
             commit_sync_gap_threshold: Parameters::default_commit_sync_gap_threshold(),
             enable_fast_commit_syncer: Parameters::default_enable_fast_commit_syncer(),
             enable_starfish_speed_adaptive_acknowledgments:

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -47,6 +47,7 @@ tonic:
     max_transaction_fetches_per_peer: 0
     max_commit_fetches_per_peer: 0
 fast_commit_sync_batch_size: 1000
+fast_commit_sync_max_fetch_bytes: 134217728
 commit_sync_gap_threshold: 1000
 enable_fast_commit_syncer: true
 enable_starfish_speed_adaptive_acknowledgments: true

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1468,13 +1468,15 @@ struct TransactionCursor {
     /// Number of leading refs that belong to the first commit; the budget stop
     /// is deferred until all of them have been served.
     first_commit_ref_count: usize,
-    /// Index of the next ref to read.
+    /// Index of the next ref to read from storage.
     pos: usize,
     /// Serialized bytes served across all chunks so far, for the budget check.
     served_bytes: usize,
-    /// A serialized element that did not fit the previous chunk and heads the
-    /// next one.
-    carry: Option<Bytes>,
+    /// Elements decoded from storage in an earlier poll but not yet served,
+    /// each paired with its ref index. Draining these before the next storage
+    /// read keeps a chunk boundary from forcing a re-read of the sub-batch
+    /// tail.
+    pending: VecDeque<(usize, Bytes)>,
     /// Byte budget hint; `0` means unlimited.
     max_transaction_bytes: usize,
     /// Set once the budget has been crossed so the next poll ends the stream.
@@ -1571,7 +1573,7 @@ fn transaction_chunk_stream(
         first_commit_ref_count,
         pos: 0,
         served_bytes: 0,
-        carry: None,
+        pending: VecDeque::new(),
         max_transaction_bytes,
         finished: false,
     };
@@ -1583,35 +1585,53 @@ fn transaction_chunk_stream(
 
         let mut chunk: Vec<Bytes> = Vec::new();
         let mut chunk_bytes = 0usize;
-        if let Some(carried) = cursor.carry.take() {
-            chunk_bytes += carried.len();
-            chunk.push(carried);
+
+        // Serve elements decoded in an earlier poll before reading more.
+        while let Some((_, element)) = cursor.pending.front() {
+            if !chunk.is_empty() && chunk_bytes + element.len() > MAX_FETCH_RESPONSE_BYTES {
+                break;
+            }
+            let (_, element) = cursor
+                .pending
+                .pop_front()
+                .expect("front just returned Some");
+            chunk_bytes += element.len();
+            chunk.push(element);
         }
 
-        'fill: while cursor.pos < cursor.refs.len() {
-            let end = (cursor.pos + TRANSACTION_CURSOR_READ_BATCH).min(cursor.refs.len());
+        // Read further sub-batches only once the decoded tail is exhausted, so
+        // no ref is ever read from storage twice.
+        while cursor.pending.is_empty() && cursor.pos < cursor.refs.len() {
+            let start = cursor.pos;
+            let end = (start + TRANSACTION_CURSOR_READ_BATCH).min(cursor.refs.len());
+            // Re-read per sub-batch: if GC advances between reading this round
+            // and reading the dag state, the only effect is that some refs read
+            // as missing, which the client recovers through its covered-prefix
+            // logic.
             let gc_round = cursor.dag_state.read().gc_round_for_last_solid_commit();
             let batch = read_serialized_transaction_batch(
                 &cursor.store,
                 &cursor.dag_state,
-                &cursor.refs[cursor.pos..end],
+                &cursor.refs[start..end],
                 gc_round,
             )?;
+            cursor.pos = end;
 
             for (offset, element) in batch.into_iter().enumerate() {
                 let Some(element) = element else {
                     continue;
                 };
-                if !chunk.is_empty() && chunk_bytes + element.len() > MAX_FETCH_RESPONSE_BYTES {
-                    // Carry the overflow element and resume at the ref after it.
-                    cursor.pos += offset + 1;
-                    cursor.carry = Some(element);
-                    break 'fill;
+                if cursor.pending.is_empty()
+                    && (chunk.is_empty() || chunk_bytes + element.len() <= MAX_FETCH_RESPONSE_BYTES)
+                {
+                    chunk_bytes += element.len();
+                    chunk.push(element);
+                } else {
+                    // Once one element overflows, the rest of the sub-batch is
+                    // held decoded for the next poll rather than re-read.
+                    cursor.pending.push_back((start + offset, element));
                 }
-                chunk_bytes += element.len();
-                chunk.push(element);
             }
-            cursor.pos = end;
         }
 
         if chunk.is_empty() {
@@ -1624,10 +1644,12 @@ fn transaction_chunk_stream(
         metrics
             .commit_sync_fetch_tx_bytes_served
             .inc_by(chunk_bytes as u64);
-        // Refs whose elements have all been emitted in this or an earlier
-        // chunk. The carried element (at `pos - 1`) heads the next chunk and is
-        // not yet served, so it is excluded.
-        let served_ref_boundary = cursor.pos - usize::from(cursor.carry.is_some());
+        // Refs whose elements have all been emitted or skipped. Anything still
+        // pending is not yet served, so the boundary is the front pending ref.
+        let served_ref_boundary = cursor
+            .pending
+            .front()
+            .map_or(cursor.pos, |(index, _)| *index);
         if cursor.max_transaction_bytes != 0
             && cursor.served_bytes >= cursor.max_transaction_bytes
             && served_ref_boundary >= cursor.first_commit_ref_count
@@ -4966,5 +4988,17 @@ mod tests {
             polled_store.refs_read() < total_refs,
             "one poll must read far fewer than all {total_refs} refs"
         );
+
+        // A 64-ref sub-batch of ~300 KiB payloads spans several 4 MiB chunks, so
+        // the next poll is served entirely from the decoded tail without a
+        // second store read.
+        let second = stream.next().await;
+        assert!(second.is_some(), "the second poll should yield a chunk");
+        assert_eq!(
+            polled_store.read_calls(),
+            1,
+            "the decoded sub-batch tail is reused, not re-read"
+        );
+        assert_eq!(polled_store.refs_read(), TRANSACTION_CURSOR_READ_BATCH);
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1293,6 +1293,15 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .flat_map(|commit| commit.committed_transactions())
             .collect();
 
+        // Number of leading refs that belong to the first commit. The budget
+        // stop is deferred until these have all been served so the client
+        // always receives a fully covered first commit and can make forward
+        // progress.
+        let first_commit_ref_count = commits
+            .first()
+            .map(|commit| commit.committed_transactions().len())
+            .unwrap_or(0);
+
         let serialized_commits: Vec<Bytes> = commits
             .into_iter()
             .map(|c| c.serialized().clone())
@@ -1308,6 +1317,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             self.dag_state.clone(),
             self.context.clone(),
             transaction_refs,
+            first_commit_ref_count,
             max_transaction_bytes,
         );
         Ok((serialized_commits, serialized_headers, transaction_stream))
@@ -1455,6 +1465,9 @@ struct TransactionCursor {
     context: Arc<Context>,
     /// Committed transaction refs in strict commit order.
     refs: Vec<GenericTransactionRef>,
+    /// Number of leading refs that belong to the first commit; the budget stop
+    /// is deferred until all of them have been served.
+    first_commit_ref_count: usize,
     /// Index of the next ref to read.
     pos: usize,
     /// Serialized bytes served across all chunks so far, for the budget check.
@@ -1537,13 +1550,17 @@ fn read_serialized_transaction_batch(
 /// element larger than the limit travels alone. Missing refs are skipped (the
 /// client recovers the covered prefix). When the served bytes cross
 /// `max_transaction_bytes` (`0` = unlimited) the crossing chunk is served in
-/// full and the stream then ends cleanly. Store read errors surface as a
-/// terminal `Err` item. Dropping the stream stops all further work.
+/// full and the stream then ends cleanly, except that the stop is held off
+/// until the first commit's refs (`first_commit_ref_count`) have all been
+/// served so the client always receives a fully covered first commit. Store
+/// read errors surface as a terminal `Err` item. Dropping the stream stops all
+/// further work.
 fn transaction_chunk_stream(
     store: Arc<dyn Store>,
     dag_state: Arc<RwLock<DagState>>,
     context: Arc<Context>,
     refs: Vec<GenericTransactionRef>,
+    first_commit_ref_count: usize,
     max_transaction_bytes: usize,
 ) -> TransactionChunkStream {
     let cursor = TransactionCursor {
@@ -1551,6 +1568,7 @@ fn transaction_chunk_stream(
         dag_state,
         context,
         refs,
+        first_commit_ref_count,
         pos: 0,
         served_bytes: 0,
         carry: None,
@@ -1606,7 +1624,13 @@ fn transaction_chunk_stream(
         metrics
             .commit_sync_fetch_tx_bytes_served
             .inc_by(chunk_bytes as u64);
-        if cursor.max_transaction_bytes != 0 && cursor.served_bytes >= cursor.max_transaction_bytes
+        // Refs whose elements have all been emitted in this or an earlier
+        // chunk. The carried element (at `pos - 1`) heads the next chunk and is
+        // not yet served, so it is excluded.
+        let served_ref_boundary = cursor.pos - usize::from(cursor.carry.is_some());
+        if cursor.max_transaction_bytes != 0
+            && cursor.served_bytes >= cursor.max_transaction_bytes
+            && served_ref_boundary >= cursor.first_commit_ref_count
         {
             metrics.commit_sync_fetch_budget_stops.inc();
             cursor.finished = true;
@@ -4643,7 +4667,7 @@ mod tests {
 
         // The store returns a payload for every below-GC ref it is asked for.
         let store = Arc::new(CountingStore::new(TxResponse::Present(128)));
-        let stream = transaction_chunk_stream(store, dag_state, context, refs.clone(), 0);
+        let stream = transaction_chunk_stream(store, dag_state, context, refs.clone(), 0, 0);
         let served: Vec<GenericTransactionRef> = collect_chunk_results(stream)
             .await
             .into_iter()
@@ -4677,6 +4701,7 @@ mod tests {
             dag_state,
             context,
             refs.to_vec(),
+            0,
             0,
         ))
         .await
@@ -4730,6 +4755,7 @@ mod tests {
                 context.clone(),
                 refs.clone(),
                 0,
+                0,
             ))
             .await
             .into_iter()
@@ -4744,14 +4770,16 @@ mod tests {
             .commit_sync_fetch_budget_stops
             .get();
 
-        // A budget of 1 byte is crossed by the first chunk; it must still be
-        // served whole, then the stream ends cleanly with no further chunks.
+        // A budget of 1 byte is crossed by the first chunk; with the first
+        // commit fully covered by that chunk, it must still be served whole,
+        // then the stream ends cleanly with no further chunks.
         let store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
         let bounded = collect_chunk_results(transaction_chunk_stream(
             store,
             dag_state.clone(),
             context.clone(),
             refs.clone(),
+            0,
             1,
         ))
         .await
@@ -4774,9 +4802,10 @@ mod tests {
         let store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
         let edge = collect_chunk_results(transaction_chunk_stream(
             store,
-            dag_state,
-            context,
-            refs,
+            dag_state.clone(),
+            context.clone(),
+            refs.clone(),
+            0,
             chunk0_bytes,
         ))
         .await
@@ -4784,6 +4813,45 @@ mod tests {
         .map(|item| item.expect("cursor should not error"))
         .collect::<Vec<_>>();
         assert_eq!(edge.len(), 1, "budget at the exact chunk edge still stops");
+
+        // Symmetric case: when the whole range is a single first commit whose
+        // transactions span all three chunks, a 1-byte budget must not end the
+        // stream mid-commit. Every chunk is served so the first commit is fully
+        // covered, and only then is the budget stop honored.
+        let budget_stops_before = context
+            .metrics
+            .node_metrics
+            .commit_sync_fetch_budget_stops
+            .get();
+        let store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
+        let first_commit = collect_chunk_results(transaction_chunk_stream(
+            store,
+            dag_state,
+            context.clone(),
+            refs.clone(),
+            refs.len(),
+            1,
+        ))
+        .await
+        .into_iter()
+        .map(|item| item.expect("cursor should not error"))
+        .collect::<Vec<_>>();
+        assert_eq!(
+            first_commit.len(),
+            3,
+            "all of the first commit's chunks are served before the budget stop"
+        );
+        let served: Vec<GenericTransactionRef> =
+            first_commit.iter().flat_map(|c| chunk_refs(c)).collect();
+        assert_eq!(served, refs, "the first commit is served in full");
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .commit_sync_fetch_budget_stops
+                .get(),
+            budget_stops_before + 1,
+        );
     }
 
     #[tokio::test]
@@ -4805,6 +4873,7 @@ mod tests {
             dag_state,
             context,
             refs.clone(),
+            0,
             0,
         ))
         .await
@@ -4831,9 +4900,10 @@ mod tests {
         let store = Arc::new(
             CountingStore::new(TxResponse::Present(128)).with_response(refs[1], TxResponse::Error),
         );
-        let items =
-            collect_chunk_results(transaction_chunk_stream(store, dag_state, context, refs, 0))
-                .await;
+        let items = collect_chunk_results(transaction_chunk_stream(
+            store, dag_state, context, refs, 0, 0,
+        ))
+        .await;
 
         assert_eq!(items.len(), 1, "the error item is terminal");
         assert!(
@@ -4870,6 +4940,7 @@ mod tests {
                 context.clone(),
                 refs.clone(),
                 0,
+                0,
             );
         }
         assert_eq!(
@@ -4882,7 +4953,7 @@ mod tests {
         // Polling once reads at most one sub-batch, far fewer than all refs.
         let polled_store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
         let mut stream =
-            transaction_chunk_stream(polled_store.clone(), dag_state, context, refs, 0);
+            transaction_chunk_stream(polled_store.clone(), dag_state, context, refs, 0, 0);
         let first = stream.next().await;
         assert!(first.is_some(), "the first poll should yield a chunk");
         assert_eq!(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -43,7 +43,8 @@ use crate::{
     network::{
         BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
         SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactionsV2,
-        TransactionFetchMode,
+        TransactionChunkStream, TransactionFetchMode,
+        tonic_network::{MAX_FETCH_RESPONSE_BYTES, chunk_data},
     },
     shard_reconstructor::TransactionMessage,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -1280,7 +1281,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         &self,
         peer: AuthorityIndex,
         commit_range: CommitRange,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        _max_transaction_bytes: usize,
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
         fail_point_async!("consensus-rpc-response");
 
         let (commits, certifier_block_headers) = self
@@ -1306,10 +1308,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .map(|h| h.serialized().clone())
             .collect();
 
+        let transaction_chunks =
+            chunk_data(serialized_transactions, MAX_FETCH_RESPONSE_BYTES).into_iter();
         Ok((
             serialized_commits,
             serialized_headers,
-            serialized_transactions,
+            stream::iter(transaction_chunks.map(Ok)).boxed(),
         ))
     }
 
@@ -1716,7 +1720,7 @@ mod tests {
         network::{
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
-            SerializedTransactionsV2, TransactionFetchMode,
+            SerializedTransactionsV2, TransactionChunkStream, TransactionFetchMode,
         },
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
@@ -1773,7 +1777,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -43,8 +43,7 @@ use crate::{
     network::{
         BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
         SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactionsV2,
-        TransactionChunkStream, TransactionFetchMode,
-        tonic_network::{MAX_FETCH_RESPONSE_BYTES, chunk_data},
+        TransactionChunkStream, TransactionFetchMode, tonic_network::MAX_FETCH_RESPONSE_BYTES,
     },
     shard_reconstructor::TransactionMessage,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -1281,7 +1280,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         &self,
         peer: AuthorityIndex,
         commit_range: CommitRange,
-        _max_transaction_bytes: usize,
+        max_transaction_bytes: usize,
     ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
         fail_point_async!("consensus-rpc-response");
 
@@ -1294,10 +1293,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .flat_map(|commit| commit.committed_transactions())
             .collect();
 
-        let serialized_transactions = self
-            .handle_fetch_transactions(peer, transaction_refs, TransactionFetchMode::FastCommitSync)
-            .await?;
-
         let serialized_commits: Vec<Bytes> = commits
             .into_iter()
             .map(|c| c.serialized().clone())
@@ -1308,13 +1303,14 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .map(|h| h.serialized().clone())
             .collect();
 
-        let transaction_chunks =
-            chunk_data(serialized_transactions, MAX_FETCH_RESPONSE_BYTES).into_iter();
-        Ok((
-            serialized_commits,
-            serialized_headers,
-            stream::iter(transaction_chunks.map(Ok)).boxed(),
-        ))
+        let transaction_stream = transaction_chunk_stream(
+            self.store.clone(),
+            self.dag_state.clone(),
+            self.context.clone(),
+            transaction_refs,
+            max_transaction_bytes,
+        );
+        Ok((serialized_commits, serialized_headers, transaction_stream))
     }
 
     async fn handle_fetch_latest_block_headers(
@@ -1374,10 +1370,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // Apply truncation based on fetch mode
         match fetch_mode {
-            TransactionFetchMode::FastCommitSync => {
-                // No truncation for fast commit sync - all transactions
-                // referenced by commits must be fetched.
-            }
             TransactionFetchMode::TransactionSync => {
                 let max_transactions = max(
                     self.context
@@ -1450,6 +1442,179 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         Ok(result)
     }
+}
+
+/// Number of transaction refs read from storage per cursor sub-batch before
+/// re-reading the GC boundary and reassembling in ref order.
+const TRANSACTION_CURSOR_READ_BATCH: usize = 64;
+
+/// Mutable state threaded through the fast commit sync transaction cursor.
+struct TransactionCursor {
+    store: Arc<dyn Store>,
+    dag_state: Arc<RwLock<DagState>>,
+    context: Arc<Context>,
+    /// Committed transaction refs in strict commit order.
+    refs: Vec<GenericTransactionRef>,
+    /// Index of the next ref to read.
+    pos: usize,
+    /// Serialized bytes served across all chunks so far, for the budget check.
+    served_bytes: usize,
+    /// A serialized element that did not fit the previous chunk and heads the
+    /// next one.
+    carry: Option<Bytes>,
+    /// Byte budget hint; `0` means unlimited.
+    max_transaction_bytes: usize,
+    /// Set once the budget has been crossed so the next poll ends the stream.
+    finished: bool,
+}
+
+/// Reads one sub-batch of transaction refs, splitting reads below the GC round
+/// (from the store) and at-or-above it (from the in-memory dag) while
+/// reassembling the serialized `SerializedTransactionsV2` elements back into
+/// the requested ref order. Missing refs yield `None` at their position.
+fn read_serialized_transaction_batch(
+    store: &Arc<dyn Store>,
+    dag_state: &Arc<RwLock<DagState>>,
+    refs: &[GenericTransactionRef],
+    gc_round: Round,
+) -> ConsensusResult<Vec<Option<Bytes>>> {
+    let mut below_gc_indices = Vec::new();
+    let mut below_gc_refs = Vec::new();
+    let mut above_gc_indices = Vec::new();
+    let mut above_gc_refs = Vec::new();
+    for (i, r) in refs.iter().enumerate() {
+        if r.round() < gc_round {
+            below_gc_indices.push(i);
+            below_gc_refs.push(*r);
+        } else {
+            above_gc_indices.push(i);
+            above_gc_refs.push(*r);
+        }
+    }
+
+    let mut raw: Vec<Option<Bytes>> = vec![None; refs.len()];
+    if !below_gc_refs.is_empty() {
+        for (idx, tx) in below_gc_indices
+            .iter()
+            .zip(store.read_serialized_transactions(&below_gc_refs)?)
+        {
+            raw[*idx] = tx;
+        }
+    }
+    if !above_gc_refs.is_empty() {
+        for (idx, tx) in above_gc_indices
+            .iter()
+            .zip(dag_state.read().get_serialized_transactions(&above_gc_refs))
+        {
+            raw[*idx] = tx;
+        }
+    }
+
+    let mut elements = Vec::with_capacity(refs.len());
+    for (i, tx) in raw.into_iter().enumerate() {
+        match tx {
+            Some(serialized_tx) => {
+                let transaction_ref = refs[i].expect_transaction_ref()?;
+                let serialized = bcs::to_bytes(&SerializedTransactionsV2 {
+                    transaction_ref,
+                    serialized_transactions: serialized_tx,
+                })
+                .map_err(ConsensusError::SerializationFailure)?;
+                elements.push(Some(Bytes::from(serialized)));
+            }
+            None => elements.push(None),
+        }
+    }
+    Ok(elements)
+}
+
+/// Lazily generates fast commit sync transaction chunks in strict commit order.
+///
+/// Each poll reads at most one chunk worth of transactions: it consumes refs in
+/// [`TRANSACTION_CURSOR_READ_BATCH`]-sized sub-batches, re-reading the GC round
+/// per sub-batch, and accumulates serialized elements until adding the next one
+/// would exceed [`MAX_FETCH_RESPONSE_BYTES`]. An element is never split; an
+/// element larger than the limit travels alone. Missing refs are skipped (the
+/// client recovers the covered prefix). When the served bytes cross
+/// `max_transaction_bytes` (`0` = unlimited) the crossing chunk is served in
+/// full and the stream then ends cleanly. Store read errors surface as a
+/// terminal `Err` item. Dropping the stream stops all further work.
+fn transaction_chunk_stream(
+    store: Arc<dyn Store>,
+    dag_state: Arc<RwLock<DagState>>,
+    context: Arc<Context>,
+    refs: Vec<GenericTransactionRef>,
+    max_transaction_bytes: usize,
+) -> TransactionChunkStream {
+    let cursor = TransactionCursor {
+        store,
+        dag_state,
+        context,
+        refs,
+        pos: 0,
+        served_bytes: 0,
+        carry: None,
+        max_transaction_bytes,
+        finished: false,
+    };
+
+    stream::try_unfold(cursor, |mut cursor| async move {
+        if cursor.finished {
+            return Ok(None);
+        }
+
+        let mut chunk: Vec<Bytes> = Vec::new();
+        let mut chunk_bytes = 0usize;
+        if let Some(carried) = cursor.carry.take() {
+            chunk_bytes += carried.len();
+            chunk.push(carried);
+        }
+
+        'fill: while cursor.pos < cursor.refs.len() {
+            let end = (cursor.pos + TRANSACTION_CURSOR_READ_BATCH).min(cursor.refs.len());
+            let gc_round = cursor.dag_state.read().gc_round_for_last_solid_commit();
+            let batch = read_serialized_transaction_batch(
+                &cursor.store,
+                &cursor.dag_state,
+                &cursor.refs[cursor.pos..end],
+                gc_round,
+            )?;
+
+            for (offset, element) in batch.into_iter().enumerate() {
+                let Some(element) = element else {
+                    continue;
+                };
+                if !chunk.is_empty() && chunk_bytes + element.len() > MAX_FETCH_RESPONSE_BYTES {
+                    // Carry the overflow element and resume at the ref after it.
+                    cursor.pos += offset + 1;
+                    cursor.carry = Some(element);
+                    break 'fill;
+                }
+                chunk_bytes += element.len();
+                chunk.push(element);
+            }
+            cursor.pos = end;
+        }
+
+        if chunk.is_empty() {
+            return Ok(None);
+        }
+
+        cursor.served_bytes += chunk_bytes;
+        let metrics = &cursor.context.metrics.node_metrics;
+        metrics.commit_sync_fetch_tx_chunks_served.inc();
+        metrics
+            .commit_sync_fetch_tx_bytes_served
+            .inc_by(chunk_bytes as u64);
+        if cursor.max_transaction_bytes != 0 && cursor.served_bytes >= cursor.max_transaction_bytes
+        {
+            metrics.commit_sync_fetch_budget_stops.inc();
+            cursor.finished = true;
+        }
+
+        Ok(Some((chunk, cursor)))
+    })
+    .boxed()
 }
 
 struct Counter {
@@ -1676,7 +1841,10 @@ mod tests {
     use std::{
         cmp::min,
         collections::{BTreeMap, BTreeSet},
-        sync::Arc,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
         time::Duration,
     };
 
@@ -1695,6 +1863,7 @@ mod tests {
         CommitConsumer, Round, Transaction, TransactionClient,
         authority_service::{
             AuthorityService, BroadcastedBlockStream, MAX_FILTER_SIZE, SubscriptionCounter,
+            TRANSACTION_CURSOR_READ_BATCH, transaction_chunk_stream,
         },
         block_header::{
             BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
@@ -1721,11 +1890,12 @@ mod tests {
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
             SerializedTransactionsV2, TransactionChunkStream, TransactionFetchMode,
+            tonic_network::MAX_FETCH_RESPONSE_BYTES,
         },
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
         transaction::TransactionConsumer,
-        transaction_ref::GenericTransactionRef,
+        transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
         transactions_synchronizer::TransactionsSynchronizer,
     };
 
@@ -4145,5 +4315,585 @@ mod tests {
             TransactionsCommitment::default(),
         );
         check_shard_version(&shard_v2).unwrap();
+    }
+
+    /// Response the [`CountingStore`] serves for a requested transaction ref.
+    #[derive(Clone)]
+    enum TxResponse {
+        /// A serialized transaction payload of the given number of bytes.
+        Present(usize),
+        /// The ref is absent from storage.
+        Missing,
+        /// The store read fails for any batch containing this ref.
+        Error,
+    }
+
+    /// A [`Store`] wrapper over [`MemStore`] that serves controlled
+    /// `read_serialized_transactions` responses and counts how many times it is
+    /// called and how many refs it reads, so cursor laziness can be observed.
+    /// Every other method delegates to the wrapped store.
+    struct CountingStore {
+        inner: Arc<MemStore>,
+        responses: BTreeMap<GenericTransactionRef, TxResponse>,
+        default_response: TxResponse,
+        read_calls: AtomicUsize,
+        read_refs: AtomicUsize,
+    }
+
+    impl CountingStore {
+        fn new(default_response: TxResponse) -> Self {
+            Self {
+                inner: Arc::new(MemStore::new()),
+                responses: BTreeMap::new(),
+                default_response,
+                read_calls: AtomicUsize::new(0),
+                read_refs: AtomicUsize::new(0),
+            }
+        }
+
+        fn with_response(mut self, r: GenericTransactionRef, resp: TxResponse) -> Self {
+            self.responses.insert(r, resp);
+            self
+        }
+
+        fn read_calls(&self) -> usize {
+            self.read_calls.load(Ordering::SeqCst)
+        }
+
+        fn refs_read(&self) -> usize {
+            self.read_refs.load(Ordering::SeqCst)
+        }
+    }
+
+    impl Store for CountingStore {
+        fn read_serialized_transactions(
+            &self,
+            refs: &[GenericTransactionRef],
+        ) -> ConsensusResult<Vec<Option<Bytes>>> {
+            self.read_calls.fetch_add(1, Ordering::SeqCst);
+            self.read_refs.fetch_add(refs.len(), Ordering::SeqCst);
+            let mut out = Vec::with_capacity(refs.len());
+            for r in refs {
+                let response = self
+                    .responses
+                    .get(r)
+                    .cloned()
+                    .unwrap_or_else(|| self.default_response.clone());
+                match response {
+                    TxResponse::Present(n) => out.push(Some(Bytes::from(vec![0u8; n]))),
+                    TxResponse::Missing => out.push(None),
+                    TxResponse::Error => {
+                        return Err(ConsensusError::RocksDBFailure(
+                            typed_store::TypedStoreError::RocksDB(
+                                "injected read failure".to_string(),
+                            ),
+                        ));
+                    }
+                }
+            }
+            Ok(out)
+        }
+
+        fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()> {
+            self.inner.write(write_batch)
+        }
+
+        fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
+            self.inner.read_blocks(refs)
+        }
+
+        fn read_verified_block_headers(
+            &self,
+            refs: &[BlockRef],
+        ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+            self.inner.read_verified_block_headers(refs)
+        }
+
+        fn read_serialized_block_headers(
+            &self,
+            refs: &[BlockRef],
+        ) -> ConsensusResult<Vec<Option<Bytes>>> {
+            self.inner.read_serialized_block_headers(refs)
+        }
+
+        fn read_verified_transactions(
+            &self,
+            refs: &[GenericTransactionRef],
+        ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
+            self.inner.read_verified_transactions(refs)
+        }
+
+        fn contains_transactions(
+            &self,
+            refs: &[GenericTransactionRef],
+        ) -> ConsensusResult<Vec<bool>> {
+            self.inner.contains_transactions(refs)
+        }
+
+        fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
+            self.inner.contains_block_headers(refs)
+        }
+
+        fn contains_block_at_slot(&self, slot: crate::block_header::Slot) -> ConsensusResult<bool> {
+            self.inner.contains_block_at_slot(slot)
+        }
+
+        fn scan_blocks_by_author(
+            &self,
+            _authority: AuthorityIndex,
+            _start_round: Round,
+        ) -> ConsensusResult<Vec<VerifiedBlock>> {
+            unimplemented!("CountingStore only serves transaction reads for the cursor")
+        }
+
+        fn scan_last_blocks_by_author(
+            &self,
+            author: AuthorityIndex,
+            num_of_rounds: u64,
+            before_round: Option<Round>,
+        ) -> ConsensusResult<Vec<VerifiedBlock>> {
+            self.inner
+                .scan_last_blocks_by_author(author, num_of_rounds, before_round)
+        }
+
+        fn scan_block_references_by_author(
+            &self,
+            author: AuthorityIndex,
+            start_round: Round,
+        ) -> ConsensusResult<Vec<BlockRef>> {
+            self.inner
+                .scan_block_references_by_author(author, start_round)
+        }
+
+        fn scan_transaction_references_by_author(
+            &self,
+            author: AuthorityIndex,
+            start_round: Round,
+        ) -> ConsensusResult<Vec<crate::transaction_ref::TransactionRef>> {
+            self.inner
+                .scan_transaction_references_by_author(author, start_round)
+        }
+
+        fn scan_misbehavior_counts(
+            &self,
+        ) -> ConsensusResult<BTreeMap<AuthorityIndex, MisbehaviorCounts>> {
+            self.inner.scan_misbehavior_counts()
+        }
+
+        fn read_last_commit(&self) -> ConsensusResult<Option<crate::commit::TrustedCommit>> {
+            self.inner.read_last_commit()
+        }
+
+        fn scan_commits(
+            &self,
+            range: CommitRange,
+        ) -> ConsensusResult<Vec<crate::commit::TrustedCommit>> {
+            self.inner.scan_commits(range)
+        }
+
+        fn read_commit_votes(
+            &self,
+            commit_index: crate::CommitIndex,
+            commit_digest: CommitDigest,
+        ) -> ConsensusResult<Vec<BlockRef>> {
+            self.inner.read_commit_votes(commit_index, commit_digest)
+        }
+
+        fn read_highest_commit_index_with_votes(
+            &self,
+            up_to_index: crate::CommitIndex,
+        ) -> ConsensusResult<Option<crate::CommitIndex>> {
+            self.inner.read_highest_commit_index_with_votes(up_to_index)
+        }
+
+        fn read_lowest_commit_index_with_votes(
+            &self,
+            from_index: crate::CommitIndex,
+        ) -> ConsensusResult<Option<crate::CommitIndex>> {
+            self.inner.read_lowest_commit_index_with_votes(from_index)
+        }
+
+        fn read_last_commit_info(
+            &self,
+        ) -> ConsensusResult<Option<(CommitRef, crate::commit::CommitInfo)>> {
+            self.inner.read_last_commit_info()
+        }
+
+        fn read_voting_block_headers(
+            &self,
+            refs: &[BlockRef],
+        ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+            self.inner.read_voting_block_headers(refs)
+        }
+
+        fn read_fast_sync_ongoing(&self) -> ConsensusResult<bool> {
+            self.inner.read_fast_sync_ongoing()
+        }
+    }
+
+    /// Builds a `DagState` whose GC boundary is bumped above genesis so that
+    /// transaction refs can be routed either to the store (below GC) or to the
+    /// in-memory dag (at or above GC). Returns the shared context, dag state,
+    /// the builder holding the transaction refs, and the resulting GC round.
+    fn cursor_setup(
+        rounds: Round,
+        gc_depth: u32,
+    ) -> (Arc<Context>, Arc<RwLock<DagState>>, DagBuilder, Round) {
+        let validators = 4;
+        let (mut context, _key_pairs) = Context::new_for_test(validators);
+        context.protocol_config.set_gc_depth_for_testing(gc_depth);
+        let context = Arc::new(context);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=rounds).build();
+        dag_builder.persist_all_blocks(dag_state.clone());
+
+        let leader_ref = dag_builder
+            .block_headers(rounds..=rounds)
+            .first()
+            .unwrap()
+            .reference();
+        dag_state
+            .write()
+            .update_last_solid_subdag_base(crate::commit::SubDagBase {
+                leader: leader_ref,
+                headers: vec![],
+                committed_header_refs: vec![],
+                timestamp_ms: 0,
+                commit_ref: CommitRef::new(1, CommitDigest::MIN),
+                reputation_scores_desc: vec![],
+            });
+        let gc_round = dag_state.read().gc_round_for_last_solid_commit();
+        (context, dag_state, dag_builder, gc_round)
+    }
+
+    /// Collects the transaction refs referenced by all block headers in the
+    /// given (inclusive) round range, in round then author order.
+    fn refs_for_rounds(
+        dag_builder: &DagBuilder,
+        start: Round,
+        end: Round,
+    ) -> Vec<GenericTransactionRef> {
+        (start..=end)
+            .flat_map(|round| {
+                dag_builder
+                    .block_headers(round..=round)
+                    .into_iter()
+                    .map(|bh| GenericTransactionRef::TransactionRef(bh.transaction_ref()))
+            })
+            .collect()
+    }
+
+    /// Drains a transaction chunk stream into the raw per-item results.
+    async fn collect_chunk_results(
+        mut stream: TransactionChunkStream,
+    ) -> Vec<ConsensusResult<Vec<Bytes>>> {
+        let mut items = Vec::new();
+        while let Some(item) = stream.next().await {
+            items.push(item);
+        }
+        items
+    }
+
+    /// Decodes the transaction refs carried by one served chunk, in order.
+    fn chunk_refs(chunk: &[Bytes]) -> Vec<GenericTransactionRef> {
+        chunk
+            .iter()
+            .map(|bytes| {
+                let decoded: SerializedTransactionsV2 = bcs::from_bytes(bytes)
+                    .expect("chunk element must be a SerializedTransactionsV2");
+                GenericTransactionRef::TransactionRef(decoded.transaction_ref)
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn cursor_preserves_strict_commit_order_across_gc_boundary() {
+        let rounds = 20;
+        let gc_depth = 5;
+        let (context, dag_state, dag_builder, gc_round) = cursor_setup(rounds, gc_depth);
+        assert!(
+            gc_round > GENESIS_ROUND && gc_round < rounds,
+            "GC round {gc_round} should split the ref range"
+        );
+
+        // Interleave below-GC refs (served from the store) with at-or-above-GC
+        // refs (served from the in-memory dag) so both read paths contribute.
+        let below = refs_for_rounds(&dag_builder, 1, gc_round - 1);
+        let above = refs_for_rounds(&dag_builder, gc_round, rounds);
+        let mut refs = Vec::new();
+        let mut below = below.into_iter();
+        let mut above = above.into_iter();
+        loop {
+            match (below.next(), above.next()) {
+                (Some(b), Some(a)) => {
+                    refs.push(b);
+                    refs.push(a);
+                }
+                (Some(b), None) => refs.push(b),
+                (None, Some(a)) => refs.push(a),
+                (None, None) => break,
+            }
+        }
+        assert!(refs.iter().any(|r| r.round() < gc_round));
+        assert!(refs.iter().any(|r| r.round() >= gc_round));
+
+        // The store returns a payload for every below-GC ref it is asked for.
+        let store = Arc::new(CountingStore::new(TxResponse::Present(128)));
+        let stream = transaction_chunk_stream(store, dag_state, context, refs.clone(), 0);
+        let served: Vec<GenericTransactionRef> = collect_chunk_results(stream)
+            .await
+            .into_iter()
+            .flat_map(|item| chunk_refs(&item.expect("cursor should not error")))
+            .collect();
+
+        assert_eq!(served, refs, "served refs must match request order exactly");
+    }
+
+    #[tokio::test]
+    async fn cursor_packs_elements_without_splitting_and_serves_oversized_alone() {
+        let rounds = 30;
+        let gc_depth = 5;
+        let (context, dag_state, dag_builder, gc_round) = cursor_setup(rounds, gc_depth);
+        // All refs below GC so every read goes through the counting store.
+        let refs = refs_for_rounds(&dag_builder, 1, 4);
+        assert!(refs.iter().all(|r| r.round() < gc_round));
+
+        // ~1.8 MiB payloads: two fit in a 4 MiB chunk, a third overflows. The
+        // second ref carries a payload larger than a whole chunk.
+        let normal = 1_800_000;
+        let oversized = MAX_FETCH_RESPONSE_BYTES + 1_000;
+        let refs = &refs[..4];
+        let store = Arc::new(
+            CountingStore::new(TxResponse::Present(normal))
+                .with_response(refs[1], TxResponse::Present(oversized)),
+        );
+
+        let chunks: Vec<Vec<Bytes>> = collect_chunk_results(transaction_chunk_stream(
+            store,
+            dag_state,
+            context,
+            refs.to_vec(),
+            0,
+        ))
+        .await
+        .into_iter()
+        .map(|item| item.expect("cursor should not error"))
+        .collect();
+
+        // No chunk exceeds the size limit except a lone oversized element, and
+        // no element is ever split across chunks.
+        let served: Vec<GenericTransactionRef> =
+            chunks.iter().flat_map(|c| chunk_refs(c)).collect();
+        assert_eq!(served, refs.to_vec(), "all elements served in ref order");
+
+        for chunk in &chunks {
+            let chunk_bytes: usize = chunk.iter().map(|b| b.len()).sum();
+            if chunk_bytes > MAX_FETCH_RESPONSE_BYTES {
+                assert_eq!(
+                    chunk.len(),
+                    1,
+                    "an oversized chunk must hold a single element"
+                );
+            }
+        }
+        // The oversized element (refs[1]) travels alone in its own chunk.
+        let oversized_chunk = chunks
+            .iter()
+            .find(|c| chunk_refs(c) == vec![refs[1]])
+            .expect("oversized element should occupy a chunk by itself");
+        assert_eq!(oversized_chunk.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cursor_serves_crossing_chunk_fully_then_ends_at_budget() {
+        let rounds = 30;
+        let gc_depth = 5;
+        let (context, dag_state, dag_builder, gc_round) = cursor_setup(rounds, gc_depth);
+        let refs = refs_for_rounds(&dag_builder, 1, 6);
+        let refs = refs[..6].to_vec();
+        assert!(refs.iter().all(|r| r.round() < gc_round));
+
+        // ~1.8 MiB payloads => two elements per 4 MiB chunk, three chunks total
+        // when unbounded.
+        let payload = 1_800_000;
+
+        // First measure the unbounded chunking to learn chunk 0's exact size.
+        let unbounded = {
+            let store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
+            collect_chunk_results(transaction_chunk_stream(
+                store,
+                dag_state.clone(),
+                context.clone(),
+                refs.clone(),
+                0,
+            ))
+            .await
+            .into_iter()
+            .map(|item| item.expect("cursor should not error"))
+            .collect::<Vec<_>>()
+        };
+        assert_eq!(unbounded.len(), 3, "expected three chunks when unbounded");
+        let chunk0_bytes: usize = unbounded[0].iter().map(|b| b.len()).sum();
+        let budget_stops_before = context
+            .metrics
+            .node_metrics
+            .commit_sync_fetch_budget_stops
+            .get();
+
+        // A budget of 1 byte is crossed by the first chunk; it must still be
+        // served whole, then the stream ends cleanly with no further chunks.
+        let store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
+        let bounded = collect_chunk_results(transaction_chunk_stream(
+            store,
+            dag_state.clone(),
+            context.clone(),
+            refs.clone(),
+            1,
+        ))
+        .await
+        .into_iter()
+        .map(|item| item.expect("cursor should not error"))
+        .collect::<Vec<_>>();
+        assert_eq!(bounded.len(), 1, "only the crossing chunk is served");
+        assert_eq!(chunk_refs(&bounded[0]), chunk_refs(&unbounded[0]));
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .commit_sync_fetch_budget_stops
+                .get(),
+            budget_stops_before + 1,
+        );
+
+        // A budget equal to chunk 0's exact byte size crosses at the chunk edge
+        // and still ends after serving that chunk (>= comparison).
+        let store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
+        let edge = collect_chunk_results(transaction_chunk_stream(
+            store,
+            dag_state,
+            context,
+            refs,
+            chunk0_bytes,
+        ))
+        .await
+        .into_iter()
+        .map(|item| item.expect("cursor should not error"))
+        .collect::<Vec<_>>();
+        assert_eq!(edge.len(), 1, "budget at the exact chunk edge still stops");
+    }
+
+    #[tokio::test]
+    async fn cursor_skips_missing_refs() {
+        let rounds = 30;
+        let gc_depth = 5;
+        let (context, dag_state, dag_builder, gc_round) = cursor_setup(rounds, gc_depth);
+        let refs = refs_for_rounds(&dag_builder, 1, 4);
+        let refs = refs[..4].to_vec();
+        assert!(refs.iter().all(|r| r.round() < gc_round));
+
+        let store = Arc::new(
+            CountingStore::new(TxResponse::Present(128))
+                .with_response(refs[1], TxResponse::Missing)
+                .with_response(refs[2], TxResponse::Missing),
+        );
+        let served: Vec<GenericTransactionRef> = collect_chunk_results(transaction_chunk_stream(
+            store,
+            dag_state,
+            context,
+            refs.clone(),
+            0,
+        ))
+        .await
+        .into_iter()
+        .flat_map(|item| chunk_refs(&item.expect("cursor should not error")))
+        .collect();
+
+        assert_eq!(
+            served,
+            vec![refs[0], refs[3]],
+            "missing refs are skipped, order kept"
+        );
+    }
+
+    #[tokio::test]
+    async fn cursor_emits_terminal_error_on_store_failure() {
+        let rounds = 30;
+        let gc_depth = 5;
+        let (context, dag_state, dag_builder, gc_round) = cursor_setup(rounds, gc_depth);
+        let refs = refs_for_rounds(&dag_builder, 1, 4);
+        let refs = refs[..3].to_vec();
+        assert!(refs.iter().all(|r| r.round() < gc_round));
+
+        let store = Arc::new(
+            CountingStore::new(TxResponse::Present(128)).with_response(refs[1], TxResponse::Error),
+        );
+        let items =
+            collect_chunk_results(transaction_chunk_stream(store, dag_state, context, refs, 0))
+                .await;
+
+        assert_eq!(items.len(), 1, "the error item is terminal");
+        assert!(
+            matches!(items[0], Err(ConsensusError::RocksDBFailure(_))),
+            "store read error should surface as a terminal Err item"
+        );
+    }
+
+    #[tokio::test]
+    async fn cursor_is_lazy_and_bounds_work_per_poll() {
+        let rounds = 40;
+        let gc_depth = 5;
+        let (context, dag_state, dag_builder, gc_round) = cursor_setup(rounds, gc_depth);
+        // Many below-GC refs, more than one read sub-batch.
+        let refs = refs_for_rounds(&dag_builder, 1, gc_round - 1);
+        assert!(refs.iter().all(|r| r.round() < gc_round));
+        assert!(
+            refs.len() > TRANSACTION_CURSOR_READ_BATCH,
+            "need more refs than one sub-batch to prove laziness, got {}",
+            refs.len()
+        );
+        let total_refs = refs.len();
+
+        // ~300 KiB payloads => a 4 MiB chunk fills well within one 64-ref
+        // sub-batch, so one poll reads at most one sub-batch.
+        let payload = 300_000;
+
+        // Dropping the stream unpolled performs zero reads.
+        let unpolled_store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
+        {
+            let _stream = transaction_chunk_stream(
+                unpolled_store.clone(),
+                dag_state.clone(),
+                context.clone(),
+                refs.clone(),
+                0,
+            );
+        }
+        assert_eq!(
+            unpolled_store.read_calls(),
+            0,
+            "unpolled stream must not read"
+        );
+        assert_eq!(unpolled_store.refs_read(), 0);
+
+        // Polling once reads at most one sub-batch, far fewer than all refs.
+        let polled_store = Arc::new(CountingStore::new(TxResponse::Present(payload)));
+        let mut stream =
+            transaction_chunk_stream(polled_store.clone(), dag_state, context, refs, 0);
+        let first = stream.next().await;
+        assert!(first.is_some(), "the first poll should yield a chunk");
+        assert_eq!(
+            polled_store.read_calls(),
+            1,
+            "one poll reads exactly one sub-batch"
+        );
+        assert_eq!(polled_store.refs_read(), TRANSACTION_CURSOR_READ_BATCH);
+        assert!(
+            polled_store.refs_read() < total_refs,
+            "one poll must read far fewer than all {total_refs} refs"
+        );
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -43,7 +43,7 @@ use crate::{
     network::{
         BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
         SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactionsV2,
-        TransactionChunkStream, TransactionFetchMode, tonic_network::MAX_FETCH_RESPONSE_BYTES,
+        TransactionChunkStream, tonic_network::MAX_FETCH_RESPONSE_BYTES,
     },
     shard_reconstructor::TransactionMessage,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -1370,7 +1370,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         &self,
         peer: AuthorityIndex,
         mut committed_transactions_refs: Vec<GenericTransactionRef>,
-        fetch_mode: TransactionFetchMode,
     ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
 
@@ -1378,22 +1377,17 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             return Ok(Vec::new());
         }
 
-        // Apply truncation based on fetch mode
-        match fetch_mode {
-            TransactionFetchMode::TransactionSync => {
-                let max_transactions = max(
-                    self.context
-                        .parameters
-                        .max_transactions_per_commit_sync_fetch,
-                    self.context
-                        .parameters
-                        .max_transactions_per_transaction_sync_fetch,
-                );
-
-                if committed_transactions_refs.len() > max_transactions {
-                    committed_transactions_refs.truncate(max_transactions);
-                }
-            }
+        // Truncate to respect the maximum transaction limits.
+        let max_transactions = max(
+            self.context
+                .parameters
+                .max_transactions_per_commit_sync_fetch,
+            self.context
+                .parameters
+                .max_transactions_per_transaction_sync_fetch,
+        );
+        if committed_transactions_refs.len() > max_transactions {
+            committed_transactions_refs.truncate(max_transactions);
         }
 
         // Some quick validation of the requested transactions refs
@@ -1935,7 +1929,7 @@ mod tests {
         network::{
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
-            SerializedTransactionsV2, TransactionChunkStream, TransactionFetchMode,
+            SerializedTransactionsV2, TransactionChunkStream,
             tonic_network::MAX_FETCH_RESPONSE_BYTES,
         },
         storage::{Store, WriteBatch, mem_store::MemStore},
@@ -4056,11 +4050,7 @@ mod tests {
 
         let peer = context.committee.to_authority_index(1).unwrap();
         let serialized_transactions = authority_service
-            .handle_fetch_transactions(
-                peer,
-                block_refs_to_request_first_batch.clone(),
-                TransactionFetchMode::TransactionSync,
-            )
+            .handle_fetch_transactions(peer, block_refs_to_request_first_batch.clone())
             .await
             .expect("We should expect a correct return of serialized transactions");
 
@@ -4110,11 +4100,7 @@ mod tests {
         );
 
         let serialized_transactions = authority_service
-            .handle_fetch_transactions(
-                peer,
-                block_refs_to_request_second_batch.clone(),
-                TransactionFetchMode::TransactionSync,
-            )
+            .handle_fetch_transactions(peer, block_refs_to_request_second_batch.clone())
             .await
             .expect("Should return an empty vector");
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+use bytes::Bytes;
 use iota_metrics::spawn_logged_monitored_task;
 use parking_lot::RwLock;
 #[cfg(not(test))]
@@ -544,7 +545,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         shared_fetch_loop(inner, commit_range, 2, Self::fetch_once).await
     }
 
-    // Fetches commits and transactions from a single authority.
+    // Fetches commits and transactions from a single authority. When the
+    // response covers only part of the range, returns the prefix of commits
+    // whose transactions were all fetched.
     async fn fetch_once(
         inner: Arc<Inner<C>>,
         target_authority: AuthorityIndex,
@@ -571,7 +574,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         //    returned commit, and the returned commits are chained by digest,
         // so earlier commits are certified as well.
         let max_commits = inner.sync_type.max_commits_per_response(&inner.context);
-        let (commits, voting_block_headers) = Handle::current()
+        let (mut commits, voting_block_headers) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
                 move || {
@@ -623,15 +626,32 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             }
         }
 
-        // Check if any committed transactions were not fetched (committed_tx_refs
-        // should be empty now)
+        // The response may be missing transactions for a suffix of the commits,
+        // e.g. when the stream was cut off by the response byte limit or a
+        // mid-stream network error. Keep the prefix of commits whose
+        // transactions were all fetched so the fetch makes forward progress;
+        // the scheduler requeues the range after the prefix.
         if !committed_tx_refs.is_empty() {
-            // TODO: create subdags for prefix of commits
-            return Err(ConsensusError::FetchedTransactionsMismatch {
-                peer: target_authority,
-                expected: committed_tx_refs.len() + fetched_transactions.len(),
-                received: fetched_transactions.len(),
-            });
+            let fetched_commits = commits.len();
+            truncate_to_fully_fetched_prefix(
+                target_authority,
+                &mut commits,
+                &mut fetched_transactions,
+            )?;
+            info!(
+                "[{}] Fetched transactions cover only {} out of {} commits received from {}, processing the covered prefix",
+                inner.sync_type.as_str(),
+                commits.len(),
+                fetched_commits,
+                target_authority,
+            );
+            inner
+                .context
+                .metrics
+                .node_metrics
+                .commit_sync_truncated_fetches
+                .with_label_values(&[inner.sync_type.as_str()])
+                .inc();
         }
 
         // 5. Verify transactions
@@ -873,6 +893,50 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
     }
 }
 
+/// Truncates verified `commits` to the longest prefix whose committed
+/// transactions are all present in `fetched_transactions`, and drops fetched
+/// transactions not referenced by that prefix. Commits verified by
+/// `verify_commits` are chained by digest up to a vote-certified last commit,
+/// so any prefix of them remains trusted on its own.
+///
+/// Returns an error attributed to `peer` when even the first commit is missing
+/// transactions, since the response then allows no forward progress.
+fn truncate_to_fully_fetched_prefix(
+    peer: AuthorityIndex,
+    commits: &mut Vec<TrustedCommit>,
+    fetched_transactions: &mut BTreeMap<GenericTransactionRef, Bytes>,
+) -> ConsensusResult<()> {
+    let prefix_len = commits
+        .iter()
+        .take_while(|commit| {
+            commit
+                .committed_transactions()
+                .iter()
+                .all(|tx_ref| fetched_transactions.contains_key(tx_ref))
+        })
+        .count();
+    if prefix_len == 0 {
+        let committed_tx_refs: BTreeSet<GenericTransactionRef> = commits
+            .iter()
+            .flat_map(|commit| commit.committed_transactions())
+            .collect();
+        return Err(ConsensusError::FetchedTransactionsMismatch {
+            peer,
+            expected: committed_tx_refs.len(),
+            received: fetched_transactions.len(),
+        });
+    }
+    if prefix_len < commits.len() {
+        commits.truncate(prefix_len);
+        let prefix_tx_refs: BTreeSet<GenericTransactionRef> = commits
+            .iter()
+            .flat_map(|commit| commit.committed_transactions())
+            .collect();
+        fetched_transactions.retain(|tx_ref, _| prefix_tx_refs.contains(tx_ref));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -893,6 +957,401 @@ mod tests {
         authority_node::tests::make_authority_with_params, commit::CommittedSubDag,
         commit_consumer::CommitConsumerMonitor,
     };
+
+    mod fetch_once {
+        use std::{sync::Arc, time::Duration};
+
+        use bytes::Bytes;
+        use parking_lot::RwLock;
+        use starfish_config::AuthorityIndex;
+
+        use crate::{
+            CommitConsumerMonitor, Round, Transaction,
+            block_header::{
+                BlockHeaderDigest, BlockRef, TestBlockHeader, TransactionsCommitment,
+                VerifiedBlockHeader,
+            },
+            block_verifier::NoopBlockVerifier,
+            commit::{CommitDigest, CommitRange, TrustedCommit},
+            commit_syncer::{CommitSyncType, Inner, fast::FastCommitSyncer},
+            commit_vote_monitor::CommitVoteMonitor,
+            context::Context,
+            core_thread::tests::MockCoreThreadDispatcher,
+            dag_state::DagState,
+            encoder::create_encoder,
+            error::ConsensusResult,
+            header_synchronizer::HeaderSynchronizer,
+            misbehavior_store::MisbehaviorStore,
+            network::{BlockBundleStream, NetworkClient, SerializedTransactionsV2},
+            storage::{Store, mem_store::MemStore},
+            transaction_ref::{GenericTransactionRef, TransactionRef},
+            transactions_synchronizer::TransactionsSynchronizer,
+        };
+
+        /// Serves a canned `fetch_commits_and_transactions` response; all
+        /// other endpoints are unused by `fetch_once`.
+        struct FakeFetchClient {
+            response: (Vec<Bytes>, Vec<Bytes>, Vec<Bytes>),
+        }
+
+        #[async_trait::async_trait]
+        impl NetworkClient for FakeFetchClient {
+            async fn subscribe_block_bundles(
+                &self,
+                _peer: AuthorityIndex,
+                _last_received: Round,
+                _timeout: Duration,
+            ) -> ConsensusResult<BlockBundleStream> {
+                unimplemented!("Unimplemented")
+            }
+
+            async fn fetch_block_headers(
+                &self,
+                _peer: AuthorityIndex,
+                _block_refs: Vec<BlockRef>,
+                _highest_accepted_rounds: Vec<Round>,
+                _timeout: Duration,
+            ) -> ConsensusResult<Vec<Bytes>> {
+                unimplemented!("Unimplemented")
+            }
+
+            async fn fetch_commits(
+                &self,
+                _peer: AuthorityIndex,
+                _commit_range: CommitRange,
+                _timeout: Duration,
+            ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+                unimplemented!("Unimplemented")
+            }
+
+            async fn fetch_transactions(
+                &self,
+                _peer: AuthorityIndex,
+                _block_refs: Vec<GenericTransactionRef>,
+                _timeout: Duration,
+            ) -> ConsensusResult<Vec<Bytes>> {
+                unimplemented!("Unimplemented")
+            }
+
+            async fn fetch_commits_and_transactions(
+                &self,
+                _peer: AuthorityIndex,
+                _commit_range: CommitRange,
+                _timeout: Duration,
+            ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+                Ok(self.response.clone())
+            }
+
+            async fn fetch_latest_block_headers(
+                &self,
+                _peer: AuthorityIndex,
+                _authorities: Vec<AuthorityIndex>,
+                _timeout: Duration,
+            ) -> ConsensusResult<Vec<Bytes>> {
+                unimplemented!("Unimplemented")
+            }
+        }
+
+        fn make_inner(
+            context: Arc<Context>,
+            network_client: Arc<FakeFetchClient>,
+        ) -> Arc<Inner<FakeFetchClient>> {
+            let block_verifier = Arc::new(NoopBlockVerifier {});
+            let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+            let store: Arc<dyn Store> = Arc::new(MemStore::new());
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+            let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+            let transactions_synchronizer = TransactionsSynchronizer::start(
+                network_client.clone(),
+                context.clone(),
+                core_thread_dispatcher.clone(),
+                dag_state.clone(),
+            );
+            let header_synchronizer = HeaderSynchronizer::start(
+                network_client.clone(),
+                context.clone(),
+                core_thread_dispatcher.clone(),
+                commit_vote_monitor.clone(),
+                transactions_synchronizer,
+                block_verifier.clone(),
+                dag_state.clone(),
+                false,
+                None,
+                misbehavior_store.clone(),
+            );
+            Arc::new(Inner {
+                context,
+                core_thread_dispatcher,
+                commit_vote_monitor,
+                commit_consumer_monitor: Arc::new(CommitConsumerMonitor::new(0)),
+                network_client,
+                block_verifier,
+                dag_state,
+                header_synchronizer,
+                misbehavior_store,
+                sync_type: CommitSyncType::Fast,
+                fast_sync_active: None,
+            })
+        }
+
+        /// A response whose transaction payload covers only some of the
+        /// returned commits (e.g. the stream was cut off by the response byte
+        /// limit) must still produce output for the covered prefix of commits
+        /// instead of failing the whole fetch.
+        #[tokio::test]
+        async fn returns_covered_prefix_of_truncated_response() {
+            let (mut context, _) = Context::new_for_test(4);
+            context
+                .protocol_config
+                .set_consensus_fast_commit_sync_for_testing(true);
+            let context = Arc::new(context);
+            let mut encoder = create_encoder(&context);
+
+            // Two chained commits, each committing one transaction.
+            let mut transaction_refs = Vec::new();
+            let mut serialized_transactions = Vec::new();
+            for round in 1..=2u32 {
+                let serialized =
+                    Transaction::serialize(&[Transaction::new(vec![round as u8; 16])]).unwrap();
+                let commitment = TransactionsCommitment::compute_transactions_commitment(
+                    &serialized,
+                    &context,
+                    &mut encoder,
+                )
+                .unwrap();
+                transaction_refs.push(TransactionRef {
+                    round,
+                    author: AuthorityIndex::new_for_test(0),
+                    transactions_commitment: commitment,
+                });
+                serialized_transactions.push(serialized);
+            }
+            let leader_1 =
+                BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN);
+            let commit_1 = TrustedCommit::new_for_test(
+                &context,
+                1,
+                CommitDigest::MIN,
+                0,
+                leader_1,
+                vec![leader_1],
+                vec![GenericTransactionRef::TransactionRef(transaction_refs[0])],
+            );
+            let leader_2 =
+                BlockRef::new(2, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN);
+            let commit_2 = TrustedCommit::new_for_test(
+                &context,
+                2,
+                commit_1.digest(),
+                0,
+                leader_2,
+                vec![leader_2],
+                vec![GenericTransactionRef::TransactionRef(transaction_refs[1])],
+            );
+
+            // Vote headers from a quorum, certifying the last commit.
+            let vote_headers: Vec<Bytes> = (0..3)
+                .map(|author| {
+                    let header = TestBlockHeader::new(3, author)
+                        .set_commit_votes(vec![commit_2.reference()])
+                        .build();
+                    VerifiedBlockHeader::new_for_test(header)
+                        .serialized()
+                        .clone()
+                })
+                .collect();
+
+            // The response carries both commits but only the first commit's
+            // transaction, as if the transaction stream was cut off.
+            let response_transactions = vec![
+                bcs::to_bytes(&SerializedTransactionsV2 {
+                    transaction_ref: transaction_refs[0],
+                    serialized_transactions: serialized_transactions[0].clone(),
+                })
+                .unwrap()
+                .into(),
+            ];
+            let network_client = Arc::new(FakeFetchClient {
+                response: (
+                    vec![commit_1.serialized().clone(), commit_2.serialized().clone()],
+                    vote_headers,
+                    response_transactions,
+                ),
+            });
+            let inner = make_inner(context.clone(), network_client);
+
+            let output = FastCommitSyncer::fetch_once(
+                inner,
+                AuthorityIndex::new_for_test(1),
+                (1..=2).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap();
+
+            // Only the covered first commit is returned; the scheduler
+            // requeues the remainder of the range.
+            assert_eq!(output.commits.len(), 1);
+            assert_eq!(output.commits[0].reference(), commit_1.reference());
+            assert_eq!(output.committed_subdags.len(), 1);
+            assert_eq!(output.committed_subdags[0].commit_ref, commit_1.reference());
+            assert_eq!(output.committed_subdags[0].transactions.len(), 1);
+            assert_eq!(output.voting_block_headers.len(), 3);
+            assert_eq!(
+                context
+                    .metrics
+                    .node_metrics
+                    .commit_sync_truncated_fetches
+                    .with_label_values(&[CommitSyncType::Fast.as_str()])
+                    .get(),
+                1
+            );
+        }
+    }
+
+    mod truncate_to_fully_fetched_prefix {
+        use std::{collections::BTreeMap, sync::Arc};
+
+        use bytes::Bytes;
+        use starfish_config::AuthorityIndex;
+
+        use crate::{
+            BlockRef, Round,
+            block_header::{BlockHeaderDigest, TransactionsCommitment},
+            commit::{CommitDigest, TrustedCommit},
+            commit_syncer::fast::truncate_to_fully_fetched_prefix,
+            context::Context,
+            error::ConsensusError,
+            transaction_ref::{GenericTransactionRef, TransactionRef},
+        };
+
+        fn transaction_ref(round: Round) -> GenericTransactionRef {
+            GenericTransactionRef::TransactionRef(TransactionRef {
+                round,
+                author: AuthorityIndex::new_for_test(0),
+                transactions_commitment: TransactionsCommitment::MIN,
+            })
+        }
+
+        fn commit(
+            context: &Arc<Context>,
+            index: u32,
+            transactions: &[GenericTransactionRef],
+        ) -> TrustedCommit {
+            let leader = BlockRef::new(
+                index,
+                AuthorityIndex::new_for_test(0),
+                BlockHeaderDigest::MIN,
+            );
+            TrustedCommit::new_for_test(
+                context,
+                index,
+                CommitDigest::MIN,
+                0,
+                leader,
+                vec![leader],
+                transactions.to_vec(),
+            )
+        }
+
+        fn fetched(refs: &[GenericTransactionRef]) -> BTreeMap<GenericTransactionRef, Bytes> {
+            refs.iter().map(|r| (*r, Bytes::new())).collect()
+        }
+
+        #[test]
+        fn keeps_all_commits_when_all_transactions_fetched() {
+            let (context, _) = Context::new_for_test(4);
+            let context = Arc::new(context);
+            let (tx_a, tx_b, tx_c) = (transaction_ref(1), transaction_ref(2), transaction_ref(3));
+            let mut commits = vec![
+                commit(&context, 1, &[tx_a]),
+                commit(&context, 2, &[tx_b, tx_c]),
+            ];
+            let mut transactions = fetched(&[tx_a, tx_b, tx_c]);
+
+            truncate_to_fully_fetched_prefix(
+                AuthorityIndex::new_for_test(1),
+                &mut commits,
+                &mut transactions,
+            )
+            .unwrap();
+
+            assert_eq!(commits.len(), 2);
+            assert_eq!(transactions.len(), 3);
+        }
+
+        #[test]
+        fn truncates_to_prefix_and_drops_unreferenced_transactions() {
+            let (context, _) = Context::new_for_test(4);
+            let context = Arc::new(context);
+            let (tx_a, tx_b, tx_c, tx_d) = (
+                transaction_ref(1),
+                transaction_ref(2),
+                transaction_ref(3),
+                transaction_ref(4),
+            );
+            let first = commit(&context, 1, &[tx_a]);
+            let mut commits = vec![
+                first.clone(),
+                // tx_b was not fetched, so the prefix ends before this commit.
+                commit(&context, 2, &[tx_b, tx_c]),
+                commit(&context, 3, &[tx_d]),
+            ];
+            let mut transactions = fetched(&[tx_a, tx_c, tx_d]);
+
+            truncate_to_fully_fetched_prefix(
+                AuthorityIndex::new_for_test(1),
+                &mut commits,
+                &mut transactions,
+            )
+            .unwrap();
+
+            assert_eq!(commits, vec![first]);
+            assert_eq!(transactions.into_keys().collect::<Vec<_>>(), vec![tx_a]);
+        }
+
+        #[test]
+        fn errors_when_first_commit_transactions_missing() {
+            let (context, _) = Context::new_for_test(4);
+            let context = Arc::new(context);
+            let (tx_a, tx_b) = (transaction_ref(1), transaction_ref(2));
+            let peer = AuthorityIndex::new_for_test(1);
+            let mut commits = vec![commit(&context, 1, &[tx_a]), commit(&context, 2, &[tx_b])];
+            let mut transactions = fetched(&[tx_b]);
+
+            let result = truncate_to_fully_fetched_prefix(peer, &mut commits, &mut transactions);
+
+            assert!(matches!(
+                result,
+                Err(ConsensusError::FetchedTransactionsMismatch {
+                    peer: error_peer,
+                    expected: 2,
+                    received: 1,
+                }) if error_peer == peer
+            ));
+        }
+
+        #[test]
+        fn commit_without_transactions_counts_toward_prefix() {
+            let (context, _) = Context::new_for_test(4);
+            let context = Arc::new(context);
+            let tx_a = transaction_ref(1);
+            let empty = commit(&context, 1, &[]);
+            let mut commits = vec![empty.clone(), commit(&context, 2, &[tx_a])];
+            let mut transactions = fetched(&[]);
+
+            truncate_to_fully_fetched_prefix(
+                AuthorityIndex::new_for_test(1),
+                &mut commits,
+                &mut transactions,
+            )
+            .unwrap();
+
+            assert_eq!(commits, vec![empty]);
+            assert!(transactions.is_empty());
+        }
+    }
 
     /// Drains all ready committed subdags from the running validators (those
     /// whose index is not in `stopped`), asserting commit indices advance

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -623,6 +623,15 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         //    below recovers; any other error means the peer violated the protocol and
         //    fails the fetch.
         let max_fetch_bytes = inner.context.parameters.fast_commit_sync_max_fetch_bytes;
+        // Forward progress after a cap stop requires the covered prefix to
+        // include at least the first commit; otherwise the truncation below
+        // rejects the response and the range is retried forever. The cap stop
+        // is therefore deferred until every transaction of the first commit has
+        // been fetched.
+        let first_commit_tx_refs: Vec<GenericTransactionRef> = commits
+            .first()
+            .map(|commit| commit.committed_transactions().to_vec())
+            .unwrap_or_default();
         let mut transactions_map: BTreeMap<GenericTransactionRef, VerifiedTransactions> =
             BTreeMap::new();
         let mut accepted_bytes = 0usize;
@@ -685,19 +694,24 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         }
                     })
                     .await
-                    .expect("Spawn blocking should not fail")?;
+                    .expect("Tokio runtime should accept blocking tasks")?;
                 transactions_map.extend(verified);
             }
 
             if max_fetch_bytes != 0 && accepted_bytes >= max_fetch_bytes {
-                inner
-                    .context
-                    .metrics
-                    .node_metrics
-                    .commit_sync_fetch_cap_stops
-                    .with_label_values(&[inner.sync_type.as_str()])
-                    .inc();
-                break;
+                let first_commit_covered = first_commit_tx_refs
+                    .iter()
+                    .all(|tx_ref| transactions_map.contains_key(tx_ref));
+                if first_commit_covered {
+                    inner
+                        .context
+                        .metrics
+                        .node_metrics
+                        .commit_sync_fetch_cap_stops
+                        .with_label_values(&[inner.sync_type.as_str()])
+                        .inc();
+                    break;
+                }
             }
         }
 
@@ -1172,6 +1186,82 @@ mod tests {
             context
         }
 
+        /// Builds digest-chained commits, one per entry in `tx_counts`, where
+        /// each commit commits that many transactions (each transaction at its
+        /// own round with a distinct payload). Returns the commits, the
+        /// serialized `SerializedTransactionsV2` wire elements grouped per
+        /// commit (in commit and ref order), and a quorum of vote headers
+        /// certifying the last commit.
+        fn chained_commits_with_tx_counts(
+            context: &Arc<Context>,
+            tx_counts: &[u32],
+        ) -> (Vec<TrustedCommit>, Vec<Vec<Bytes>>, Vec<Bytes>) {
+            let mut encoder = create_encoder(context);
+            let mut commits = Vec::new();
+            let mut tx_elements = Vec::new();
+            let mut previous_digest = CommitDigest::MIN;
+            let mut round: u32 = 0;
+            for (i, &count) in tx_counts.iter().enumerate() {
+                let index = (i + 1) as u32;
+                let mut refs = Vec::new();
+                let mut commit_tx_elements = Vec::new();
+                for _ in 0..count {
+                    round += 1;
+                    let serialized =
+                        Transaction::serialize(&[Transaction::new(vec![round as u8; 16])]).unwrap();
+                    let commitment = TransactionsCommitment::compute_transactions_commitment(
+                        &serialized,
+                        context,
+                        &mut encoder,
+                    )
+                    .unwrap();
+                    let transaction_ref = TransactionRef {
+                        round,
+                        author: AuthorityIndex::new_for_test(0),
+                        transactions_commitment: commitment,
+                    };
+                    refs.push(GenericTransactionRef::TransactionRef(transaction_ref));
+                    commit_tx_elements.push(
+                        bcs::to_bytes(&SerializedTransactionsV2 {
+                            transaction_ref,
+                            serialized_transactions: serialized,
+                        })
+                        .unwrap()
+                        .into(),
+                    );
+                }
+                let leader = BlockRef::new(
+                    index,
+                    AuthorityIndex::new_for_test(((index - 1) % 4) as u8),
+                    BlockHeaderDigest::MIN,
+                );
+                let commit = TrustedCommit::new_for_test(
+                    context,
+                    index,
+                    previous_digest,
+                    0,
+                    leader,
+                    vec![leader],
+                    refs,
+                );
+                previous_digest = commit.digest();
+                commits.push(commit);
+                tx_elements.push(commit_tx_elements);
+            }
+            let last = commits.last().unwrap().reference();
+            let vote_headers = (0..3)
+                .map(|author| {
+                    let header = TestBlockHeader::new(round + 1, author)
+                        .set_commit_votes(vec![last])
+                        .build();
+                    VerifiedBlockHeader::new_for_test(header)
+                        .serialized()
+                        .clone()
+                })
+                .collect();
+            (commits, tx_elements, vote_headers)
+        }
+
         /// Builds `num_commits` digest-chained commits, each committing a
         /// single transaction, plus a quorum of vote headers certifying
         /// the last commit. Returns the commits, the serialized
@@ -1181,60 +1271,9 @@ mod tests {
             context: &Arc<Context>,
             num_commits: u32,
         ) -> (Vec<TrustedCommit>, Vec<Bytes>, Vec<Bytes>) {
-            let mut encoder = create_encoder(context);
-            let mut commits = Vec::new();
-            let mut tx_elements = Vec::new();
-            let mut previous_digest = CommitDigest::MIN;
-            for round in 1..=num_commits {
-                let serialized =
-                    Transaction::serialize(&[Transaction::new(vec![round as u8; 16])]).unwrap();
-                let commitment = TransactionsCommitment::compute_transactions_commitment(
-                    &serialized,
-                    context,
-                    &mut encoder,
-                )
-                .unwrap();
-                let transaction_ref = TransactionRef {
-                    round,
-                    author: AuthorityIndex::new_for_test(0),
-                    transactions_commitment: commitment,
-                };
-                let leader = BlockRef::new(
-                    round,
-                    AuthorityIndex::new_for_test(((round - 1) % 4) as u8),
-                    BlockHeaderDigest::MIN,
-                );
-                let commit = TrustedCommit::new_for_test(
-                    context,
-                    round,
-                    previous_digest,
-                    0,
-                    leader,
-                    vec![leader],
-                    vec![GenericTransactionRef::TransactionRef(transaction_ref)],
-                );
-                previous_digest = commit.digest();
-                tx_elements.push(
-                    bcs::to_bytes(&SerializedTransactionsV2 {
-                        transaction_ref,
-                        serialized_transactions: serialized,
-                    })
-                    .unwrap()
-                    .into(),
-                );
-                commits.push(commit);
-            }
-            let last = commits.last().unwrap().reference();
-            let vote_headers = (0..3)
-                .map(|author| {
-                    let header = TestBlockHeader::new(num_commits + 1, author)
-                        .set_commit_votes(vec![last])
-                        .build();
-                    VerifiedBlockHeader::new_for_test(header)
-                        .serialized()
-                        .clone()
-                })
-                .collect();
+            let (commits, tx_elements, vote_headers) =
+                chained_commits_with_tx_counts(context, &vec![1; num_commits as usize]);
+            let tx_elements = tx_elements.into_iter().flatten().collect();
             (commits, tx_elements, vote_headers)
         }
 
@@ -1387,6 +1426,54 @@ mod tests {
             // the first commit is covered.
             assert_eq!(output.commits.len(), 1);
             assert_eq!(output.commits[0].reference(), commits[0].reference());
+            assert_eq!(cap_stops(&context), 1);
+            assert_eq!(truncated_fetches(&context), 1);
+        }
+
+        /// When the first commit's transactions alone span more bytes than the
+        /// per-fetch cap and arrive across several chunks, the fetch must keep
+        /// consuming until that commit is fully covered before stopping, so the
+        /// covered prefix is non-empty and the fetch makes forward progress.
+        #[tokio::test]
+        async fn covers_first_commit_before_byte_cap_stop() {
+            let mut context = test_context();
+            // Any accepted transaction trips the cap after the first chunk, well
+            // before the first commit's three transactions are all fetched.
+            context.parameters.fast_commit_sync_max_fetch_bytes = 1;
+            let context = Arc::new(context);
+            // Commit 1 commits three transactions, commit 2 commits one.
+            let (commits, tx_elements, voting_headers) =
+                chained_commits_with_tx_counts(&context, &[3, 1]);
+
+            // Each transaction travels in its own chunk, so the cap is crossed
+            // long before commit 1 is covered.
+            let transaction_chunks: Vec<Vec<Bytes>> = tx_elements
+                .iter()
+                .flatten()
+                .map(|e| vec![e.clone()])
+                .collect();
+            let network_client = Arc::new(FakeFetchClient {
+                commits: commits.iter().map(|c| c.serialized().clone()).collect(),
+                voting_headers,
+                transaction_chunks,
+            });
+            let inner = make_inner(context.clone(), network_client);
+
+            let output = FastCommitSyncer::fetch_once(
+                inner,
+                AuthorityIndex::new_for_test(1),
+                (1..=2).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap();
+
+            // The first commit is fully covered (all three transactions), and the
+            // fetch stops after it rather than erroring on an empty prefix.
+            assert_eq!(output.commits.len(), 1);
+            assert_eq!(output.commits[0].reference(), commits[0].reference());
+            assert_eq!(output.committed_subdags.len(), 1);
+            assert_eq!(output.committed_subdags[0].transactions.len(), 3);
             assert_eq!(cap_stops(&context), 1);
             assert_eq!(truncated_fetches(&context), 1);
         }

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -634,7 +634,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .unwrap_or_default();
         let mut transactions_map: BTreeMap<GenericTransactionRef, VerifiedTransactions> =
             BTreeMap::new();
-        let mut accepted_bytes = 0usize;
+        let mut received_bytes = 0usize;
         while let Some(chunk) = transaction_chunks.next().await {
             let chunk = match chunk {
                 Ok(chunk) => chunk,
@@ -650,6 +650,12 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 }
                 Err(e) => return Err(e),
             };
+
+            // Every received element counts toward the cap, including
+            // undecodable ones skipped below, so a peer cannot stream unbounded
+            // garbage without tripping it. This also mirrors the server's
+            // served-bytes accounting.
+            received_bytes += chunk.iter().map(|element| element.len()).sum::<usize>();
 
             let mut chunk_transactions = BTreeMap::new();
             for serialized_transaction in chunk {
@@ -672,7 +678,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         received: GenericTransactionRef::TransactionRef(transaction_ref),
                     });
                 }
-                accepted_bytes += serialized_transaction.len();
                 chunk_transactions.insert(
                     GenericTransactionRef::TransactionRef(transaction_ref),
                     tx_v2.serialized_transactions,
@@ -698,7 +703,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 transactions_map.extend(verified);
             }
 
-            if max_fetch_bytes != 0 && accepted_bytes >= max_fetch_bytes {
+            if max_fetch_bytes != 0 && received_bytes >= max_fetch_bytes {
                 let first_commit_covered = first_commit_tx_refs
                     .iter()
                     .all(|tx_ref| transactions_map.contains_key(tx_ref));
@@ -1424,6 +1429,59 @@ mod tests {
 
             // Only the first chunk was accepted before the cap tripped, so only
             // the first commit is covered.
+            assert_eq!(output.commits.len(), 1);
+            assert_eq!(output.commits[0].reference(), commits[0].reference());
+            assert_eq!(cap_stops(&context), 1);
+            assert_eq!(truncated_fetches(&context), 1);
+        }
+
+        /// Undecodable stream elements count toward the byte cap just like
+        /// accepted ones, so a peer cannot stream unbounded garbage without
+        /// tripping the cap. The first-commit progress guarantee still holds:
+        /// the garbage is only allowed to end the fetch once the first commit
+        /// is covered.
+        #[tokio::test]
+        async fn undecodable_elements_count_toward_byte_cap() {
+            let mut context = test_context();
+            let (commits, tx_elements, voting_headers) =
+                chained_commits_with_tx_counts(&Arc::new(context.clone()), &[1, 1]);
+            // Cap just above the first commit's single transaction, so only the
+            // trailing garbage can push accepted bytes over it.
+            let first_tx_len = tx_elements[0][0].len();
+            context.parameters.fast_commit_sync_max_fetch_bytes = first_tx_len + 1;
+            let context = Arc::new(context);
+
+            // A large blob that is not a valid SerializedTransactionsV2.
+            let garbage = Bytes::from(vec![0xffu8; 1024]);
+            assert!(
+                bcs::from_bytes::<SerializedTransactionsV2>(&garbage).is_err(),
+                "fixture garbage must be undecodable"
+            );
+
+            let network_client = Arc::new(FakeFetchClient {
+                commits: commits.iter().map(|c| c.serialized().clone()).collect(),
+                voting_headers,
+                // Commit 1's transaction, then garbage, then commit 2's
+                // transaction (which must never be reached).
+                transaction_chunks: vec![
+                    vec![tx_elements[0][0].clone()],
+                    vec![garbage],
+                    vec![tx_elements[1][0].clone()],
+                ],
+            });
+            let inner = make_inner(context.clone(), network_client);
+
+            let output = FastCommitSyncer::fetch_once(
+                inner,
+                AuthorityIndex::new_for_test(1),
+                (1..=2).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap();
+
+            // The garbage tripped the cap after commit 1 was covered, so commit
+            // 2 is never fetched.
             assert_eq!(output.commits.len(), 1);
             assert_eq!(output.commits[0].reference(), commits[0].reference());
             assert_eq!(cap_stops(&context), 1);

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 
-use bytes::Bytes;
+use futures::StreamExt as _;
 use iota_metrics::spawn_logged_monitored_task;
 use parking_lot::RwLock;
 #[cfg(not(test))]
@@ -565,10 +565,32 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // 1. Fetch commits, voting headers, and transactions in the commit range from
         //    the target authority. Each transaction is serialized as
         //    SerializedTransactionsV2 which includes the TransactionRef.
-        let (serialized_commits, serialized_proof_for_last_commit, serialized_transactions) = inner
+        let (serialized_commits, serialized_proof_for_last_commit, mut transaction_chunks) = inner
             .network_client
             .fetch_commits_and_transactions(target_authority, commit_range.clone(), timeout)
             .await?;
+
+        // Drain the transaction chunk stream. A network error mid-stream leaves a
+        // usable transaction prefix, so keep what was received and let the prefix
+        // truncation below recover the covered commits; any other error means the
+        // peer violated the protocol and fails the fetch.
+        let mut serialized_transactions = Vec::new();
+        while let Some(chunk) = transaction_chunks.next().await {
+            match chunk {
+                Ok(chunk) => serialized_transactions.extend(chunk),
+                Err(
+                    e @ (ConsensusError::NetworkRequest(_)
+                    | ConsensusError::NetworkRequestTimeout(_)),
+                ) => {
+                    warn!(
+                        "[{}] fetch_commits_and_transactions transaction stream failed: {e:?}",
+                        inner.sync_type.as_str()
+                    );
+                    break;
+                }
+                Err(e) => return Err(e),
+            }
+        }
 
         // 2. Verify the response contains block headers that can certify the last
         //    returned commit, and the returned commits are chained by digest,
@@ -901,10 +923,10 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 ///
 /// Returns an error attributed to `peer` when even the first commit is missing
 /// transactions, since the response then allows no forward progress.
-fn truncate_to_fully_fetched_prefix(
+fn truncate_to_fully_fetched_prefix<V>(
     peer: AuthorityIndex,
     commits: &mut Vec<TrustedCommit>,
-    fetched_transactions: &mut BTreeMap<GenericTransactionRef, Bytes>,
+    fetched_transactions: &mut BTreeMap<GenericTransactionRef, V>,
 ) -> ConsensusResult<()> {
     let prefix_len = commits
         .iter()
@@ -962,6 +984,7 @@ mod tests {
         use std::{sync::Arc, time::Duration};
 
         use bytes::Bytes;
+        use futures::{StreamExt as _, stream};
         use parking_lot::RwLock;
         use starfish_config::AuthorityIndex;
 
@@ -982,7 +1005,9 @@ mod tests {
             error::ConsensusResult,
             header_synchronizer::HeaderSynchronizer,
             misbehavior_store::MisbehaviorStore,
-            network::{BlockBundleStream, NetworkClient, SerializedTransactionsV2},
+            network::{
+                BlockBundleStream, NetworkClient, SerializedTransactionsV2, TransactionChunkStream,
+            },
             storage::{Store, mem_store::MemStore},
             transaction_ref::{GenericTransactionRef, TransactionRef},
             transactions_synchronizer::TransactionsSynchronizer,
@@ -1038,8 +1063,13 @@ mod tests {
                 _peer: AuthorityIndex,
                 _commit_range: CommitRange,
                 _timeout: Duration,
-            ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
-                Ok(self.response.clone())
+            ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
+                let (commits, headers, transactions) = self.response.clone();
+                Ok((
+                    commits,
+                    headers,
+                    stream::iter(vec![Ok(transactions)]).boxed(),
+                ))
             }
 
             async fn fetch_latest_block_headers(

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -26,10 +26,10 @@ use crate::{
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, CommittedSubDag, TrustedCommit},
     commit_syncer::{
-        CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
-        handle_fetch_join_error, requeue_partial_range, schedule_commit_ranges,
-        try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
-        verify_transactions_with_transactions_refs,
+        AVG_TX_ROUNDS_PER_COMMIT, CommitSyncType, CommitSyncerHandle, Inner,
+        fetch_loop as shared_fetch_loop, handle_fetch_join_error, requeue_partial_range,
+        schedule_commit_ranges, try_start_fetches as shared_try_start_fetches,
+        verify_fetched_headers, verify_transactions_with_transactions_refs,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -570,31 +570,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .fetch_commits_and_transactions(target_authority, commit_range.clone(), timeout)
             .await?;
 
-        // Drain the transaction chunk stream. A network error mid-stream leaves a
-        // usable transaction prefix, so keep what was received and let the prefix
-        // truncation below recover the covered commits; any other error means the
-        // peer violated the protocol and fails the fetch.
-        let mut serialized_transactions = Vec::new();
-        while let Some(chunk) = transaction_chunks.next().await {
-            match chunk {
-                Ok(chunk) => serialized_transactions.extend(chunk),
-                Err(
-                    e @ (ConsensusError::NetworkRequest(_)
-                    | ConsensusError::NetworkRequestTimeout(_)),
-                ) => {
-                    warn!(
-                        "[{}] fetch_commits_and_transactions transaction stream failed: {e:?}",
-                        inner.sync_type.as_str()
-                    );
-                    break;
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
         // 2. Verify the response contains block headers that can certify the last
-        //    returned commit, and the returned commits are chained by digest,
-        // so earlier commits are certified as well.
+        //    returned commit, and the returned commits are chained by digest, so
+        //    earlier commits are certified as well.
         let max_commits = inner.sync_type.max_commits_per_response(&inner.context);
         let (mut commits, voting_block_headers) = Handle::current()
             .spawn_blocking({
@@ -612,53 +590,128 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .await
             .expect("Spawn blocking should not fail")?;
 
-        // 3. Collect all committed transaction block refs from commits
+        // 3. Collect all committed transaction block refs from commits.
         let mut committed_tx_refs: BTreeSet<TransactionRef> = commits
             .iter()
             .flat_map(|c| c.committed_transactions())
             .filter_map(|gen_tr_ref| gen_tr_ref.expect_transaction_ref().ok())
             .collect();
 
-        // 4. Process fetched transactions. Each serialized_transaction is a
-        //    SerializedTransactionsV2 containing both the TransactionRef and the actual
-        //    transaction data.
-        let mut fetched_transactions = BTreeMap::new();
-        for serialized_transaction in serialized_transactions {
-            if let Ok(tx_v2) = bcs::from_bytes::<SerializedTransactionsV2>(&serialized_transaction)
-            {
+        // Anti-malicious envelope. Honest commits reference at most the
+        // transactions the committee can produce over `AVG_TX_ROUNDS_PER_COMMIT`
+        // rounds per commit, plus a gc-depth of trailing rounds; a range
+        // referencing more is rejected up front with peer attribution. Since
+        // every accepted element must clear a ref from `committed_tx_refs`, this
+        // one check also bounds the incremental accepted count by construction.
+        let committee_size = inner.context.committee.size();
+        let gc_depth = inner.context.protocol_config.gc_depth() as usize;
+        let envelope =
+            committee_size.saturating_mul(AVG_TX_ROUNDS_PER_COMMIT * commits.len() + gc_depth);
+        if committed_tx_refs.len() > envelope {
+            return Err(ConsensusError::TooManyCommittedTransactionsInRange {
+                peer: target_authority,
+                count: committed_tx_refs.len(),
+                limit: envelope,
+            });
+        }
+
+        // 4. Consume the transaction chunk stream incrementally, verifying each chunk
+        //    on arrival and dropping its raw bytes right after. Each element is a
+        //    SerializedTransactionsV2 carrying both the TransactionRef and the
+        //    transaction data. A soft (transport) error mid-stream, or reaching the
+        //    per-fetch byte cap, leaves a usable transaction prefix that the truncation
+        //    below recovers; any other error means the peer violated the protocol and
+        //    fails the fetch.
+        let max_fetch_bytes = inner.context.parameters.fast_commit_sync_max_fetch_bytes;
+        let mut transactions_map: BTreeMap<GenericTransactionRef, VerifiedTransactions> =
+            BTreeMap::new();
+        let mut accepted_bytes = 0usize;
+        while let Some(chunk) = transaction_chunks.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(
+                    e @ (ConsensusError::NetworkRequest(_)
+                    | ConsensusError::NetworkRequestTimeout(_)),
+                ) => {
+                    warn!(
+                        "[{}] fetch_commits_and_transactions transaction stream failed: {e:?}",
+                        inner.sync_type.as_str()
+                    );
+                    break;
+                }
+                Err(e) => return Err(e),
+            };
+
+            let mut chunk_transactions = BTreeMap::new();
+            for serialized_transaction in chunk {
+                let Ok(tx_v2) =
+                    bcs::from_bytes::<SerializedTransactionsV2>(&serialized_transaction)
+                else {
+                    debug!(
+                        "[{}] Failed to deserialize SerializedTransactionsV2: {:?}",
+                        inner.sync_type.as_str(),
+                        serialized_transaction
+                    );
+                    continue;
+                };
                 let transaction_ref = tx_v2.transaction_ref;
-                if !committed_tx_refs.contains(&transaction_ref) {
+                // A ref that is not (or no longer) expected is junk or a
+                // duplicate; either way the peer violated the protocol.
+                if !committed_tx_refs.remove(&transaction_ref) {
                     return Err(ConsensusError::UnexpectedTransactionForCommit {
                         peer: target_authority,
                         received: GenericTransactionRef::TransactionRef(transaction_ref),
                     });
                 }
-                fetched_transactions.insert(
+                accepted_bytes += serialized_transaction.len();
+                chunk_transactions.insert(
                     GenericTransactionRef::TransactionRef(transaction_ref),
                     tx_v2.serialized_transactions,
                 );
-                committed_tx_refs.remove(&transaction_ref);
-            } else {
-                debug!(
-                    "[{}] Failed to deserialize SerializedTransactionsV2: {:?}",
-                    inner.sync_type.as_str(),
-                    serialized_transaction
-                );
-                continue;
+            }
+            // The raw chunk bytes are dropped here; only the accepted payloads
+            // carry over into verification and the accumulated map.
+
+            if !chunk_transactions.is_empty() {
+                let verified = Handle::current()
+                    .spawn_blocking({
+                        let context = inner.context.clone();
+                        move || {
+                            verify_transactions_with_transactions_refs(
+                                &context,
+                                target_authority,
+                                chunk_transactions,
+                            )
+                        }
+                    })
+                    .await
+                    .expect("Spawn blocking should not fail")?;
+                transactions_map.extend(verified);
+            }
+
+            if max_fetch_bytes != 0 && accepted_bytes >= max_fetch_bytes {
+                inner
+                    .context
+                    .metrics
+                    .node_metrics
+                    .commit_sync_fetch_cap_stops
+                    .with_label_values(&[inner.sync_type.as_str()])
+                    .inc();
+                break;
             }
         }
 
         // The response may be missing transactions for a suffix of the commits,
-        // e.g. when the stream was cut off by the response byte limit or a
-        // mid-stream network error. Keep the prefix of commits whose
-        // transactions were all fetched so the fetch makes forward progress;
-        // the scheduler requeues the range after the prefix.
+        // e.g. when the stream was cut off by the byte cap or a mid-stream
+        // network error. Keep the prefix of commits whose transactions were all
+        // fetched so the fetch makes forward progress; the scheduler requeues the
+        // range after the prefix.
         if !committed_tx_refs.is_empty() {
             let fetched_commits = commits.len();
             truncate_to_fully_fetched_prefix(
                 target_authority,
                 &mut commits,
-                &mut fetched_transactions,
+                &mut transactions_map,
             )?;
             info!(
                 "[{}] Fetched transactions cover only {} out of {} commits received from {}, processing the covered prefix",
@@ -676,27 +729,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .inc();
         }
 
-        // 5. Verify transactions
-        let mut transactions_map = if !fetched_transactions.is_empty() {
-            Handle::current()
-                .spawn_blocking({
-                    let context = inner.context.clone();
-
-                    move || {
-                        verify_transactions_with_transactions_refs(
-                            &context,
-                            target_authority,
-                            fetched_transactions,
-                        )
-                    }
-                })
-                .await
-                .expect("Spawn blocking should not fail")?
-        } else {
-            BTreeMap::new()
-        };
-
-        // 6. Now create the CommittedSubDags with the fetched transactions.
+        // 5. Now create the CommittedSubDags with the fetched transactions.
         // For fast commit sync, we use block headers refs and reputation scores from
         // the commit.
         let mut committed_subdags = Vec::new();
@@ -996,13 +1029,15 @@ mod tests {
             },
             block_verifier::NoopBlockVerifier,
             commit::{CommitDigest, CommitRange, TrustedCommit},
-            commit_syncer::{CommitSyncType, Inner, fast::FastCommitSyncer},
+            commit_syncer::{
+                AVG_TX_ROUNDS_PER_COMMIT, CommitSyncType, Inner, fast::FastCommitSyncer,
+            },
             commit_vote_monitor::CommitVoteMonitor,
             context::Context,
             core_thread::tests::MockCoreThreadDispatcher,
             dag_state::DagState,
             encoder::create_encoder,
-            error::ConsensusResult,
+            error::{ConsensusError, ConsensusResult},
             header_synchronizer::HeaderSynchronizer,
             misbehavior_store::MisbehaviorStore,
             network::{
@@ -1013,10 +1048,13 @@ mod tests {
             transactions_synchronizer::TransactionsSynchronizer,
         };
 
-        /// Serves a canned `fetch_commits_and_transactions` response; all
-        /// other endpoints are unused by `fetch_once`.
+        /// Serves a canned `fetch_commits_and_transactions` response,
+        /// delivering the transactions as the given sequence of chunks;
+        /// all other endpoints are unused by `fetch_once`.
         struct FakeFetchClient {
-            response: (Vec<Bytes>, Vec<Bytes>, Vec<Bytes>),
+            commits: Vec<Bytes>,
+            voting_headers: Vec<Bytes>,
+            transaction_chunks: Vec<Vec<Bytes>>,
         }
 
         #[async_trait::async_trait]
@@ -1064,11 +1102,12 @@ mod tests {
                 _commit_range: CommitRange,
                 _timeout: Duration,
             ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
-                let (commits, headers, transactions) = self.response.clone();
+                let chunks: Vec<ConsensusResult<Vec<Bytes>>> =
+                    self.transaction_chunks.iter().cloned().map(Ok).collect();
                 Ok((
-                    commits,
-                    headers,
-                    stream::iter(vec![Ok(transactions)]).boxed(),
+                    self.commits.clone(),
+                    self.voting_headers.clone(),
+                    stream::iter(chunks).boxed(),
                 ))
             }
 
@@ -1125,89 +1164,113 @@ mod tests {
             })
         }
 
-        /// A response whose transaction payload covers only some of the
-        /// returned commits (e.g. the stream was cut off by the response byte
-        /// limit) must still produce output for the covered prefix of commits
-        /// instead of failing the whole fetch.
-        #[tokio::test]
-        async fn returns_covered_prefix_of_truncated_response() {
+        fn test_context() -> Context {
             let (mut context, _) = Context::new_for_test(4);
             context
                 .protocol_config
                 .set_consensus_fast_commit_sync_for_testing(true);
-            let context = Arc::new(context);
-            let mut encoder = create_encoder(&context);
+            context
+        }
 
-            // Two chained commits, each committing one transaction.
-            let mut transaction_refs = Vec::new();
-            let mut serialized_transactions = Vec::new();
-            for round in 1..=2u32 {
+        /// Builds `num_commits` digest-chained commits, each committing a
+        /// single transaction, plus a quorum of vote headers certifying
+        /// the last commit. Returns the commits, the serialized
+        /// `SerializedTransactionsV2` wire element for each commit (in
+        /// commit order), and the serialized vote headers.
+        fn chained_commits(
+            context: &Arc<Context>,
+            num_commits: u32,
+        ) -> (Vec<TrustedCommit>, Vec<Bytes>, Vec<Bytes>) {
+            let mut encoder = create_encoder(context);
+            let mut commits = Vec::new();
+            let mut tx_elements = Vec::new();
+            let mut previous_digest = CommitDigest::MIN;
+            for round in 1..=num_commits {
                 let serialized =
                     Transaction::serialize(&[Transaction::new(vec![round as u8; 16])]).unwrap();
                 let commitment = TransactionsCommitment::compute_transactions_commitment(
                     &serialized,
-                    &context,
+                    context,
                     &mut encoder,
                 )
                 .unwrap();
-                transaction_refs.push(TransactionRef {
+                let transaction_ref = TransactionRef {
                     round,
                     author: AuthorityIndex::new_for_test(0),
                     transactions_commitment: commitment,
-                });
-                serialized_transactions.push(serialized);
+                };
+                let leader = BlockRef::new(
+                    round,
+                    AuthorityIndex::new_for_test(((round - 1) % 4) as u8),
+                    BlockHeaderDigest::MIN,
+                );
+                let commit = TrustedCommit::new_for_test(
+                    context,
+                    round,
+                    previous_digest,
+                    0,
+                    leader,
+                    vec![leader],
+                    vec![GenericTransactionRef::TransactionRef(transaction_ref)],
+                );
+                previous_digest = commit.digest();
+                tx_elements.push(
+                    bcs::to_bytes(&SerializedTransactionsV2 {
+                        transaction_ref,
+                        serialized_transactions: serialized,
+                    })
+                    .unwrap()
+                    .into(),
+                );
+                commits.push(commit);
             }
-            let leader_1 =
-                BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN);
-            let commit_1 = TrustedCommit::new_for_test(
-                &context,
-                1,
-                CommitDigest::MIN,
-                0,
-                leader_1,
-                vec![leader_1],
-                vec![GenericTransactionRef::TransactionRef(transaction_refs[0])],
-            );
-            let leader_2 =
-                BlockRef::new(2, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN);
-            let commit_2 = TrustedCommit::new_for_test(
-                &context,
-                2,
-                commit_1.digest(),
-                0,
-                leader_2,
-                vec![leader_2],
-                vec![GenericTransactionRef::TransactionRef(transaction_refs[1])],
-            );
-
-            // Vote headers from a quorum, certifying the last commit.
-            let vote_headers: Vec<Bytes> = (0..3)
+            let last = commits.last().unwrap().reference();
+            let vote_headers = (0..3)
                 .map(|author| {
-                    let header = TestBlockHeader::new(3, author)
-                        .set_commit_votes(vec![commit_2.reference()])
+                    let header = TestBlockHeader::new(num_commits + 1, author)
+                        .set_commit_votes(vec![last])
                         .build();
                     VerifiedBlockHeader::new_for_test(header)
                         .serialized()
                         .clone()
                 })
                 .collect();
+            (commits, tx_elements, vote_headers)
+        }
 
-            // The response carries both commits but only the first commit's
-            // transaction, as if the transaction stream was cut off.
-            let response_transactions = vec![
-                bcs::to_bytes(&SerializedTransactionsV2 {
-                    transaction_ref: transaction_refs[0],
-                    serialized_transactions: serialized_transactions[0].clone(),
-                })
-                .unwrap()
-                .into(),
-            ];
+        fn truncated_fetches(context: &Arc<Context>) -> u64 {
+            context
+                .metrics
+                .node_metrics
+                .commit_sync_truncated_fetches
+                .with_label_values(&[CommitSyncType::Fast.as_str()])
+                .get()
+        }
+
+        fn cap_stops(context: &Arc<Context>) -> u64 {
+            context
+                .metrics
+                .node_metrics
+                .commit_sync_fetch_cap_stops
+                .with_label_values(&[CommitSyncType::Fast.as_str()])
+                .get()
+        }
+
+        /// A response whose transaction stream ends before covering every
+        /// returned commit (e.g. the transport was cut) must still produce
+        /// output for the covered prefix of commits instead of failing the
+        /// whole fetch.
+        #[tokio::test]
+        async fn returns_covered_prefix_of_truncated_response() {
+            let context = Arc::new(test_context());
+            let (commits, tx_elements, voting_headers) = chained_commits(&context, 2);
+
+            // The stream carries only the first commit's transaction, as if it
+            // was cut off before the second.
             let network_client = Arc::new(FakeFetchClient {
-                response: (
-                    vec![commit_1.serialized().clone(), commit_2.serialized().clone()],
-                    vote_headers,
-                    response_transactions,
-                ),
+                commits: commits.iter().map(|c| c.serialized().clone()).collect(),
+                voting_headers,
+                transaction_chunks: vec![vec![tx_elements[0].clone()]],
             });
             let inner = make_inner(context.clone(), network_client);
 
@@ -1223,20 +1286,177 @@ mod tests {
             // Only the covered first commit is returned; the scheduler
             // requeues the remainder of the range.
             assert_eq!(output.commits.len(), 1);
-            assert_eq!(output.commits[0].reference(), commit_1.reference());
+            assert_eq!(output.commits[0].reference(), commits[0].reference());
             assert_eq!(output.committed_subdags.len(), 1);
-            assert_eq!(output.committed_subdags[0].commit_ref, commit_1.reference());
+            assert_eq!(
+                output.committed_subdags[0].commit_ref,
+                commits[0].reference()
+            );
             assert_eq!(output.committed_subdags[0].transactions.len(), 1);
             assert_eq!(output.voting_block_headers.len(), 3);
-            assert_eq!(
-                context
-                    .metrics
-                    .node_metrics
-                    .commit_sync_truncated_fetches
-                    .with_label_values(&[CommitSyncType::Fast.as_str()])
-                    .get(),
-                1
+            assert_eq!(truncated_fetches(&context), 1);
+        }
+
+        /// Transactions spread across multiple chunks are all accepted and the
+        /// full commit range is covered.
+        #[tokio::test]
+        async fn covers_all_commits_across_multiple_chunks() {
+            let context = Arc::new(test_context());
+            let (commits, tx_elements, voting_headers) = chained_commits(&context, 3);
+
+            let network_client = Arc::new(FakeFetchClient {
+                commits: commits.iter().map(|c| c.serialized().clone()).collect(),
+                voting_headers,
+                // One transaction per chunk.
+                transaction_chunks: tx_elements.iter().map(|e| vec![e.clone()]).collect(),
+            });
+            let inner = make_inner(context.clone(), network_client);
+
+            let output = FastCommitSyncer::fetch_once(
+                inner,
+                AuthorityIndex::new_for_test(1),
+                (1..=3).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(output.commits.len(), 3);
+            assert_eq!(output.committed_subdags.len(), 3);
+            assert_eq!(truncated_fetches(&context), 0);
+            assert_eq!(cap_stops(&context), 0);
+        }
+
+        /// Chunks delivered out of commit order (as an old server serving
+        /// below-gc commits first may do) still yield full coverage, because
+        /// subdags are assembled from the accumulated map at stream end.
+        #[tokio::test]
+        async fn accepts_transaction_chunks_in_any_order() {
+            let context = Arc::new(test_context());
+            let (commits, mut tx_elements, voting_headers) = chained_commits(&context, 3);
+            tx_elements.reverse();
+
+            let network_client = Arc::new(FakeFetchClient {
+                commits: commits.iter().map(|c| c.serialized().clone()).collect(),
+                voting_headers,
+                transaction_chunks: tx_elements.iter().map(|e| vec![e.clone()]).collect(),
+            });
+            let inner = make_inner(context.clone(), network_client);
+
+            let output = FastCommitSyncer::fetch_once(
+                inner,
+                AuthorityIndex::new_for_test(1),
+                (1..=3).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(output.commits.len(), 3);
+            assert_eq!(output.committed_subdags.len(), 3);
+            assert_eq!(truncated_fetches(&context), 0);
+        }
+
+        /// Reaching the per-fetch byte cap stops the fetch at the covered
+        /// commit prefix and bumps the cap-stop metric.
+        #[tokio::test]
+        async fn stops_at_covered_prefix_when_byte_cap_hit() {
+            let mut context = test_context();
+            // Any accepted transaction trips the cap after the first chunk.
+            context.parameters.fast_commit_sync_max_fetch_bytes = 1;
+            let context = Arc::new(context);
+            let (commits, tx_elements, voting_headers) = chained_commits(&context, 3);
+
+            let network_client = Arc::new(FakeFetchClient {
+                commits: commits.iter().map(|c| c.serialized().clone()).collect(),
+                voting_headers,
+                transaction_chunks: tx_elements.iter().map(|e| vec![e.clone()]).collect(),
+            });
+            let inner = make_inner(context.clone(), network_client);
+
+            let output = FastCommitSyncer::fetch_once(
+                inner,
+                AuthorityIndex::new_for_test(1),
+                (1..=3).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap();
+
+            // Only the first chunk was accepted before the cap tripped, so only
+            // the first commit is covered.
+            assert_eq!(output.commits.len(), 1);
+            assert_eq!(output.commits[0].reference(), commits[0].reference());
+            assert_eq!(cap_stops(&context), 1);
+            assert_eq!(truncated_fetches(&context), 1);
+        }
+
+        /// A range referencing more committed transactions than the honest
+        /// envelope allows is rejected up front with peer attribution.
+        #[tokio::test]
+        async fn rejects_range_exceeding_transaction_envelope() {
+            let context = Arc::new(test_context());
+            let committee_size = context.committee.size();
+            let gc_depth = context.protocol_config.gc_depth() as usize;
+            let envelope = committee_size * (AVG_TX_ROUNDS_PER_COMMIT + gc_depth);
+
+            // One commit referencing one transaction more than the envelope for a
+            // single-commit range permits.
+            let over = (envelope + 1) as u32;
+            let refs: Vec<GenericTransactionRef> = (1..=over)
+                .map(|round| {
+                    GenericTransactionRef::TransactionRef(TransactionRef {
+                        round,
+                        author: AuthorityIndex::new_for_test(0),
+                        transactions_commitment: TransactionsCommitment::MIN,
+                    })
+                })
+                .collect();
+            let leader = BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN);
+            let commit = TrustedCommit::new_for_test(
+                &context,
+                1,
+                CommitDigest::MIN,
+                0,
+                leader,
+                vec![leader],
+                refs,
             );
+            let voting_headers = (0..3)
+                .map(|author| {
+                    let header = TestBlockHeader::new(2, author)
+                        .set_commit_votes(vec![commit.reference()])
+                        .build();
+                    VerifiedBlockHeader::new_for_test(header)
+                        .serialized()
+                        .clone()
+                })
+                .collect();
+
+            let network_client = Arc::new(FakeFetchClient {
+                commits: vec![commit.serialized().clone()],
+                voting_headers,
+                transaction_chunks: vec![],
+            });
+            let inner = make_inner(context.clone(), network_client);
+
+            let peer = AuthorityIndex::new_for_test(1);
+            let result = FastCommitSyncer::fetch_once(
+                inner,
+                peer,
+                (1..=1).into(),
+                Duration::from_millis(100),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(ConsensusError::TooManyCommittedTransactionsInRange {
+                    peer: error_peer,
+                    count,
+                    limit,
+                }) if error_peer == peer && count == over as usize && limit == envelope
+            ));
         }
     }
 

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -73,6 +73,13 @@ use crate::{
 // author, so a response never needs more than one header per authority.
 pub(crate) const MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY: usize = 2;
 
+/// Expected upper bound on the number of transaction rounds each commit
+/// advances the DAG. A commit advances at least once per wave (3 rounds); the
+/// extra round adds slack for skipped leaders. Used to derive the honest
+/// envelope bounding how many committed transactions a fetch response may
+/// reference.
+pub(crate) const AVG_TX_ROUNDS_PER_COMMIT: usize = 4;
+
 pub(crate) enum CommitSyncType {
     Fast,
     Regular,

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -801,7 +801,7 @@ mod tests {
         error::ConsensusResult,
         header_synchronizer::HeaderSynchronizer,
         misbehavior_store::MisbehaviorStore,
-        network::{BlockBundleStream, NetworkClient},
+        network::{BlockBundleStream, NetworkClient, TransactionChunkStream},
         storage::{Store, mem_store::MemStore},
         transaction_ref::GenericTransactionRef,
     };
@@ -854,7 +854,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -292,6 +292,9 @@ pub(crate) enum ConsensusError {
         received: usize,
     },
 
+    #[error("Peer {peer} sent commit data after transactions in a fetch response")]
+    UnexpectedCommitDataAfterTransactions { peer: AuthorityIndex },
+
     #[error("RocksDB failure: {0}")]
     RocksDBFailure(#[from] TypedStoreError),
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -295,6 +295,15 @@ pub(crate) enum ConsensusError {
     #[error("Peer {peer} sent commit data after transactions in a fetch response")]
     UnexpectedCommitDataAfterTransactions { peer: AuthorityIndex },
 
+    #[error(
+        "Commit range from peer {peer} references {count} committed transactions, exceeding the allowed envelope of {limit}"
+    )]
+    TooManyCommittedTransactionsInRange {
+        peer: AuthorityIndex,
+        count: usize,
+        limit: usize,
+    },
+
     #[error("RocksDB failure: {0}")]
     RocksDBFailure(#[from] TypedStoreError),
 

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -1633,7 +1633,7 @@ mod tests {
             InflightBlockHeadersMap, SyncMethod,
         },
         misbehavior_store::MisbehaviorStore,
-        network::{BlockBundleStream, NetworkClient},
+        network::{BlockBundleStream, NetworkClient, TransactionChunkStream},
         storage::mem_store::MemStore,
         transaction_ref::GenericTransactionRef,
         transactions_synchronizer::TransactionsSynchronizer,
@@ -1777,7 +1777,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
             unimplemented!("fetch_commits_and_transactions not implemented in mock")
         }
     }

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -227,7 +227,7 @@ mod tests {
         encoder::create_encoder,
         error::ConsensusResult,
         leader_timeout::LeaderTimeoutTask,
-        network::{BlockBundleStream, NetworkClient},
+        network::{BlockBundleStream, NetworkClient, TransactionChunkStream},
         storage::mem_store::MemStore,
         transaction_ref::GenericTransactionRef,
         transactions_synchronizer::TransactionsSynchronizer,
@@ -290,7 +290,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -257,6 +257,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_highest_fetched_index: IntGaugeVec,
     pub(crate) commit_sync_local_index: IntGauge,
     pub(crate) commit_sync_gap_on_processing: IntCounterVec,
+    pub(crate) commit_sync_truncated_fetches: IntCounterVec,
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
     pub(crate) commit_sync_fetch_once_latency: HistogramVec,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
@@ -1085,6 +1086,12 @@ impl NodeMetrics {
             commit_sync_gap_on_processing: register_int_counter_vec_with_registry!(
                 "commit_sync_gap_on_processing",
                 "Number of instances where a gap was found in fetched commit processing",
+                &["source"],
+                registry,
+            ).unwrap(),
+            commit_sync_truncated_fetches: register_int_counter_vec_with_registry!(
+                "commit_sync_truncated_fetches",
+                "Number of fetches whose response covered only a prefix of the returned commits",
                 &["source"],
                 registry,
             ).unwrap(),

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -259,6 +259,9 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_gap_on_processing: IntCounterVec,
     pub(crate) commit_sync_truncated_fetches: IntCounterVec,
     pub(crate) commit_sync_fetch_cap_stops: IntCounterVec,
+    pub(crate) commit_sync_fetch_tx_chunks_served: IntCounter,
+    pub(crate) commit_sync_fetch_tx_bytes_served: IntCounter,
+    pub(crate) commit_sync_fetch_budget_stops: IntCounter,
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
     pub(crate) commit_sync_fetch_once_latency: HistogramVec,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
@@ -1100,6 +1103,21 @@ impl NodeMetrics {
                 "commit_sync_fetch_cap_stops",
                 "Number of fast commit sync fetches stopped early by the per-fetch transaction byte cap",
                 &["source"],
+                registry,
+            ).unwrap(),
+            commit_sync_fetch_tx_chunks_served: register_int_counter_with_registry!(
+                "commit_sync_fetch_tx_chunks_served",
+                "Number of fast commit sync transaction chunks generated and served by the server cursor",
+                registry,
+            ).unwrap(),
+            commit_sync_fetch_tx_bytes_served: register_int_counter_with_registry!(
+                "commit_sync_fetch_tx_bytes_served",
+                "Total serialized transaction bytes served by the fast commit sync server cursor",
+                registry,
+            ).unwrap(),
+            commit_sync_fetch_budget_stops: register_int_counter_with_registry!(
+                "commit_sync_fetch_budget_stops",
+                "Number of fast commit sync fetches the server cursor ended early after crossing the client-provided transaction byte budget",
                 registry,
             ).unwrap(),
             commit_sync_fetch_loop_latency: register_histogram_with_registry!(

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -258,6 +258,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_local_index: IntGauge,
     pub(crate) commit_sync_gap_on_processing: IntCounterVec,
     pub(crate) commit_sync_truncated_fetches: IntCounterVec,
+    pub(crate) commit_sync_fetch_cap_stops: IntCounterVec,
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
     pub(crate) commit_sync_fetch_once_latency: HistogramVec,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
@@ -1092,6 +1093,12 @@ impl NodeMetrics {
             commit_sync_truncated_fetches: register_int_counter_vec_with_registry!(
                 "commit_sync_truncated_fetches",
                 "Number of fetches whose response covered only a prefix of the returned commits",
+                &["source"],
+                registry,
+            ).unwrap(),
+            commit_sync_fetch_cap_stops: register_int_counter_vec_with_registry!(
+                "commit_sync_fetch_cap_stops",
+                "Number of fast commit sync fetches stopped early by the per-fetch transaction byte cap",
                 &["source"],
                 registry,
             ).unwrap(),

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -62,15 +62,6 @@ use crate::{
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
 
-/// Controls transaction fetching truncation behavior for different sync modes
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TransactionFetchMode {
-    /// Truncate to the maximum of max_transactions_per_commit_sync_fetch and
-    /// max_transactions_per_transaction_sync_fetch- used by regular commit sync
-    /// and transactions synchronizer
-    TransactionSync,
-}
-
 /// A stream of serialized blocks with additional information such as headers or
 /// shards.
 pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBundle> + Send>>;
@@ -221,13 +212,11 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<Vec<Bytes>>;
 
     /// Handles the request to fetch transactions by references from the peer.
-    /// The `fetch_mode` parameter controls whether results should be truncated
-    /// to respect maximum transaction limits.
+    /// Results are truncated to respect the maximum transaction limits.
     async fn handle_fetch_transactions(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<GenericTransactionRef>,
-        fetch_mode: TransactionFetchMode,
     ) -> ConsensusResult<Vec<Bytes>>;
 }
 

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -78,6 +78,12 @@ pub(crate) enum TransactionFetchMode {
 /// shards.
 pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBundle> + Send>>;
 
+/// A stream of transaction chunks served by `fetch_commits_and_transactions`.
+/// Each item is one wire message worth of serialized `SerializedTransactionsV2`
+/// elements (~4 MiB). An error item is terminal: no further items follow it.
+pub(crate) type TransactionChunkStream =
+    Pin<Box<dyn Stream<Item = ConsensusResult<Vec<Bytes>>> + Send>>;
+
 /// Network client for communicating with peers.
 ///
 /// NOTE: the timeout parameters help saving resources at client and potentially
@@ -131,14 +137,17 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
     /// Fetches serialized commits in the commit range from a peer, headers
     /// voting for the last commit, and all transactions from these commits.
     /// Returns serialized commits, serialized headers voting for the last
-    /// commit, and serialized transactions (as SerializedTransactionsV2 which
-    /// includes TransactionRef). Used in the fast commit syncer.
+    /// commit, and a stream of transaction chunks (each transaction serialized
+    /// as SerializedTransactionsV2 which includes the TransactionRef). Commits
+    /// and voting headers are drained eagerly and fully validated before the
+    /// stream is returned; transactions are delivered lazily through the
+    /// stream. Used in the fast commit syncer.
     async fn fetch_commits_and_transactions(
         &self,
         peer: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)>;
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)>;
 
     /// Fetches the latest block from `peer` for the requested `authorities`.
     /// The latest blocks are returned in the serialised format of
@@ -194,14 +203,17 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
 
     /// Handles the request to fetch commits and transactions by index range
     /// from the peer. Used in fast commit sync.
-    /// Returns (commits, certifier_block_headers, transactions) as serialized
-    /// bytes. Each transaction is serialized as SerializedTransactionsV2
-    /// which includes the TransactionRef.
+    /// Returns (commits, certifier_block_headers, transaction_chunk_stream) as
+    /// serialized bytes. Each transaction is serialized as
+    /// SerializedTransactionsV2 which includes the TransactionRef.
+    /// `max_transaction_bytes` bounds the total transaction bytes served, where
+    /// `0` means unlimited.
     async fn handle_fetch_commits_and_transactions(
         &self,
         peer: AuthorityIndex,
         commit_range: CommitRange,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)>;
+        max_transaction_bytes: usize,
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)>;
 
     /// Handles the request to fetch the latest block headers for the provided
     /// `authorities`.

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -65,9 +65,6 @@ use crate::{
 /// Controls transaction fetching truncation behavior for different sync modes
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TransactionFetchMode {
-    /// No truncation - used by fast commit sync which fetches all transactions
-    /// referenced by commits in a batch
-    FastCommitSync,
     /// Truncate to the maximum of max_transactions_per_commit_sync_fetch and
     /// max_transactions_per_transaction_sync_fetch- used by regular commit sync
     /// and transactions synchronizer

--- a/crates/starfish/core/src/network/network_tests.rs
+++ b/crates/starfish/core/src/network/network_tests.rs
@@ -12,7 +12,7 @@ use rstest::rstest;
 use super::{
     NetworkClient, SerializedBlockBundle, test_network::TestService, tonic_network::TonicManager,
 };
-use crate::{Round, context::Context};
+use crate::{Round, commit::CommitRange, context::Context};
 
 fn serialized_block_bundle_for_round(round: Round) -> SerializedBlockBundle {
     SerializedBlockBundle {
@@ -91,4 +91,55 @@ async fn subscribe_and_receive_block_bundles() {
         .await
         .unwrap();
     assert!(receive_stream_1.next().await.is_none());
+}
+
+/// The client's configured `fast_commit_sync_max_fetch_bytes` cap reaches the
+/// server as the `max_transaction_bytes` argument to
+/// `handle_fetch_commits_and_transactions`, over a real client/server round
+/// trip, instead of the hardcoded `0` the tonic layer used to pass.
+#[rstest]
+#[tokio::test]
+async fn fetch_commits_and_transactions_forwards_configured_byte_cap() {
+    let (context, keys) = Context::new_for_test(4);
+    const CONFIGURED_CAP: usize = 12_345;
+
+    let mut parameters = context.parameters.clone();
+    parameters.fast_commit_sync_max_fetch_bytes = CONFIGURED_CAP;
+    let context_0 = Arc::new(
+        context
+            .clone()
+            .with_parameters(parameters)
+            .with_authority_index(context.committee.to_authority_index(0).unwrap()),
+    );
+    let manager_0 = TonicManager::<Mutex<TestService>>::new(context_0.clone(), keys[0].0.clone());
+    let client_0 = manager_0.client();
+
+    let context_1 = Arc::new(
+        context
+            .clone()
+            .with_authority_index(context.committee.to_authority_index(1).unwrap()),
+    );
+    let mut manager_1 = TonicManager::new(context_1.clone(), keys[1].0.clone());
+    let service_1 = Arc::new(Mutex::new(TestService::new()));
+    manager_1.install_service(service_1.clone()).await;
+
+    let commit_range: CommitRange = (1..=5).into();
+    let peer_1 = context_0.committee.to_authority_index(1).unwrap();
+    let _ = client_0
+        .fetch_commits_and_transactions(peer_1, commit_range.clone(), Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let calls = service_1
+        .lock()
+        .handle_fetch_commits_and_transactions
+        .clone();
+    assert_eq!(calls.len(), 1);
+    let (received_peer, received_range, received_cap) = &calls[0];
+    assert_eq!(
+        *received_peer,
+        context_0.committee.to_authority_index(0).unwrap()
+    );
+    assert_eq!(*received_range, commit_range);
+    assert_eq!(*received_cap, CONFIGURED_CAP);
 }

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -128,7 +128,6 @@ impl NetworkService for Mutex<TestService> {
         &self,
         _peer: AuthorityIndex,
         _block_refs: Vec<GenericTransactionRef>,
-        _fetch_mode: crate::network::TransactionFetchMode,
     ) -> ConsensusResult<Vec<Bytes>> {
         unimplemented!("Unimplemented")
     }

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -15,7 +15,7 @@ use crate::{
     commit_syncer::CommitSyncType,
     encoder::ShardEncoder,
     error::ConsensusResult,
-    network::{BlockBundleStream, NetworkService, SerializedBlockBundle},
+    network::{BlockBundleStream, NetworkService, SerializedBlockBundle, TransactionChunkStream},
     transaction_ref::GenericTransactionRef,
 };
 
@@ -104,7 +104,8 @@ impl NetworkService for Mutex<TestService> {
         &self,
         _peer: AuthorityIndex,
         _commit_range: CommitRange,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        _max_transaction_bytes: usize,
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
         unimplemented!("Unimplemented")
     }
 

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -24,6 +24,7 @@ pub(crate) struct TestService {
     pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,
     pub(crate) handle_fetch_block_headers: Vec<(AuthorityIndex, Vec<BlockRef>)>,
     pub(crate) handle_fetch_commits: Vec<(AuthorityIndex, CommitRange)>,
+    pub(crate) handle_fetch_commits_and_transactions: Vec<(AuthorityIndex, CommitRange, usize)>,
     pub(crate) own_block_bundles: Vec<SerializedBlockBundle>,
 }
 
@@ -35,6 +36,7 @@ impl TestService {
             handle_subscribed_block_bundle_requests: Vec::new(),
             handle_fetch_block_headers: Vec::new(),
             handle_fetch_commits: Vec::new(),
+            handle_fetch_commits_and_transactions: Vec::new(),
         }
     }
 
@@ -102,11 +104,16 @@ impl NetworkService for Mutex<TestService> {
 
     async fn handle_fetch_commits_and_transactions(
         &self,
-        _peer: AuthorityIndex,
-        _commit_range: CommitRange,
-        _max_transaction_bytes: usize,
+        peer: AuthorityIndex,
+        commit_range: CommitRange,
+        max_transaction_bytes: usize,
     ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
-        unimplemented!("Unimplemented")
+        self.lock().handle_fetch_commits_and_transactions.push((
+            peer,
+            commit_range,
+            max_transaction_bytes,
+        ));
+        Ok((vec![], vec![], Box::pin(stream::empty())))
     }
 
     async fn handle_fetch_latest_block_headers(

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -28,7 +28,8 @@ use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, TraceLayer};
 use tracing::{debug, error, info, trace, warn};
 
 use super::{
-    BlockBundleStream, NetworkClient, NetworkService, SerializedBlockBundle, TransactionFetchMode,
+    BlockBundleStream, NetworkClient, NetworkService, SerializedBlockBundle,
+    TransactionChunkStream, TransactionFetchMode,
     admission::{Admission, AdmissionGuard, PerPeerAdmission, PermitGuardedStream, RpcGroup},
     metrics_layer::{MetricsCallbackMaker, MetricsResponseCallback, SizedRequest, SizedResponse},
     tonic_gen::{
@@ -53,7 +54,7 @@ use crate::{
 
 // Maximum bytes size in a single fetch_blocks()response.
 // TODO: put max RPC response size in protocol config.
-const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+pub(crate) const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 
 // Upper bound on the total bytes a peer may stream in response to a fetch,
 // terminating the stream once exceeded. Each bound mirrors the matching
@@ -431,7 +432,7 @@ impl NetworkClient for TonicClient {
         peer: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
         let mut client = self.get_client(peer, timeout).await?;
         let mut request = Request::new(FetchCommitsAndTransactionsRequest {
             start: commit_range.start(),
@@ -454,17 +455,16 @@ impl NetworkClient for TonicClient {
             })?
             .into_inner();
 
-        // First chunk contains commits and certifier headers.
-        //
-        // Bound the response per element and per category while streaming, since
-        // `verify_commits` only runs on the fully-received buffers and so cannot
-        // protect them from a malicious server. Commits and certifier headers
-        // carry the same count caps `verify_commits` applies
+        // Commits and certifier headers arrive first, ahead of the transaction
+        // chunks. Drain them eagerly here, bounding the response per element and
+        // per category, since `verify_commits` only runs on the fully-received
+        // buffers and so cannot protect them from a malicious server. Commits and
+        // certifier headers carry the same count caps `verify_commits` applies
         // (`2 * fast_commit_sync_batch_size` and two headers per authority).
         // Transactions have no count cap on the fast path — the server returns
         // every transaction the committed range references — so only their
-        // per-element size is enforced here; their count is validated against
-        // the commits downstream, and the coarse total below bounds the buffer.
+        // per-element size is enforced, downstream in the returned chunk stream;
+        // their count is validated against the commits by the caller.
         let committee_size = self.context.committee.size();
         let gc_depth = self.context.protocol_config.gc_depth() as usize;
         let max_commits = CommitSyncType::Fast.max_commits_per_response(&self.context);
@@ -473,24 +473,9 @@ impl NetworkClient for TonicClient {
         let max_commit_size = max_commit_bytes(committee_size, gc_depth);
         let max_header_size = max_signed_block_header_bytes(committee_size);
         let max_transaction_size = serialized_transactions_size_limit(&self.context);
-        // Coarse total backstop for the buffer. The commit and certifier-header
-        // terms reuse the per-category caps above so the total never trips
-        // before them; the transaction term uses the commit-sync fetch cap as a
-        // coarse allowance, since the fast path has no transaction count cap.
-        let max_allowed_bytes = max_commits
-            .saturating_mul(max_commit_size)
-            .saturating_add(max_certifier_headers.saturating_mul(max_header_size))
-            .saturating_add(
-                self.context
-                    .parameters
-                    .max_transactions_per_commit_sync_fetch
-                    .saturating_mul(max_transaction_size),
-            );
 
         let mut commits = Vec::new();
         let mut certifier_block_headers = Vec::new();
-        let mut transactions = Vec::new();
-        let mut total_fetched_bytes = 0;
 
         loop {
             match stream.message().await {
@@ -511,7 +496,6 @@ impl NetworkClient for TonicClient {
                                 limit: max_commit_size,
                             });
                         }
-                        total_fetched_bytes += c.len();
                     }
                     commits.extend(response.commits);
 
@@ -534,34 +518,29 @@ impl NetworkClient for TonicClient {
                                 limit: max_header_size,
                             });
                         }
-                        total_fetched_bytes += h.len();
                     }
                     certifier_block_headers.extend(response.certifier_block_headers);
 
-                    // Transactions (streamed in subsequent chunks): per-element size only.
-                    for t in &response.transactions {
-                        if t.len() > max_transaction_size {
-                            return Err(ConsensusError::SerializedTransactionsTooLarge {
-                                size: t.len(),
-                                limit: max_transaction_size,
-                            });
-                        }
-                        total_fetched_bytes += t.len();
-                    }
-                    transactions.extend(response.transactions);
-
-                    // Coarse total backstop bounding the transaction buffer, which
-                    // has no precise count cap on the fast path.
-                    if total_fetched_bytes > max_allowed_bytes {
-                        info!(
-                            "fetch_commits_and_transactions() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, max_allowed_bytes,
-                        );
-                        break;
+                    // The first message carrying transactions marks the end of the
+                    // head. Retain it, prepend it to the remaining stream, and hand
+                    // the tail to the chunk adapter.
+                    if !response.transactions.is_empty() {
+                        let first = FetchCommitsAndTransactionsResponse {
+                            commits: vec![],
+                            certifier_block_headers: vec![],
+                            transactions: response.transactions,
+                        };
+                        let tail = stream::once(std::future::ready(Ok::<_, tonic::Status>(first)))
+                            .chain(stream);
+                        return Ok((
+                            commits,
+                            certifier_block_headers,
+                            transaction_chunk_stream_adapter(tail, max_transaction_size, peer),
+                        ));
                     }
                 }
                 Ok(None) => {
-                    break;
+                    return Ok((commits, certifier_block_headers, stream::empty().boxed()));
                 }
                 Err(e) => {
                     if commits.is_empty() {
@@ -575,14 +554,73 @@ impl NetworkClient for TonicClient {
                         )));
                     } else {
                         warn!("fetch_commits_and_transactions failed mid-stream: {e:?}");
-                        break;
+                        return Ok((commits, certifier_block_headers, stream::empty().boxed()));
                     }
                 }
             }
         }
-
-        Ok((commits, certifier_block_headers, transactions))
     }
+}
+
+/// Wraps the transaction tail of a `fetch_commits_and_transactions` response
+/// stream into a [`TransactionChunkStream`]. Each source message must carry
+/// only transactions; every transaction is bounded to `max_transaction_size`.
+/// The first violation — an oversized transaction, commit data appearing after
+/// transactions, or a transport error — is emitted as a terminal error item,
+/// after which the stream ends.
+fn transaction_chunk_stream_adapter<S>(
+    responses: S,
+    max_transaction_size: usize,
+    peer: AuthorityIndex,
+) -> TransactionChunkStream
+where
+    S: Stream<Item = Result<FetchCommitsAndTransactionsResponse, tonic::Status>> + Send + 'static,
+{
+    responses
+        .scan(false, move |terminated, item| {
+            let output = if *terminated {
+                None
+            } else {
+                let result = adapt_transaction_response(item, max_transaction_size, peer);
+                if result.is_err() {
+                    *terminated = true;
+                }
+                Some(result)
+            };
+            std::future::ready(output)
+        })
+        .boxed()
+}
+
+/// Validates one transaction-tail message and extracts its transaction chunk.
+fn adapt_transaction_response(
+    item: Result<FetchCommitsAndTransactionsResponse, tonic::Status>,
+    max_transaction_size: usize,
+    peer: AuthorityIndex,
+) -> ConsensusResult<Vec<Bytes>> {
+    let response = item.map_err(|e| {
+        if e.code() == tonic::Code::DeadlineExceeded {
+            ConsensusError::NetworkRequestTimeout(format!(
+                "fetch_commits_and_transactions failed mid-stream: {e:?}"
+            ))
+        } else {
+            ConsensusError::NetworkRequest(format!(
+                "fetch_commits_and_transactions failed mid-stream: {e:?}"
+            ))
+        }
+    })?;
+    if !response.commits.is_empty() || !response.certifier_block_headers.is_empty() {
+        return Err(ConsensusError::UnexpectedCommitDataAfterTransactions { peer });
+    }
+    for t in &response.transactions {
+        if t.len() > max_transaction_size {
+            return Err(ConsensusError::SerializedTransactionsTooLarge {
+                size: t.len(),
+                limit: max_transaction_size,
+            });
+        }
+    }
+    Ok(response.transactions)
 }
 
 // Tonic channel wrapped with layers.
@@ -908,15 +946,20 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         };
         let permit = self.admit(RpcGroup::CommitFetch, peer_index)?;
         let request = request.into_inner();
-        let (serialized_commits, serialized_headers, serialized_transactions) = self
+        let (serialized_commits, serialized_headers, transaction_chunks) = self
             .service
-            .handle_fetch_commits_and_transactions(peer_index, (request.start..=request.end).into())
+            .handle_fetch_commits_and_transactions(
+                peer_index,
+                (request.start..=request.end).into(),
+                0,
+            )
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
 
         // Build response as a stream of chunks to stay under gRPC message size limit.
-        // Commits and transactions are chunked by size. Certifier headers are small
+        // Commits are chunked by size and sent first. Certifier headers are small
         // enough to fit in a single chunk and are sent with the first commit chunk.
+        // Transaction chunks follow as the tail of the stream.
         let mut responses = Vec::new();
 
         let commit_chunks = chunk_data(serialized_commits, MAX_FETCH_RESPONSE_BYTES);
@@ -940,17 +983,16 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             }));
         }
 
-        let tx_chunks = chunk_data(serialized_transactions, MAX_FETCH_RESPONSE_BYTES);
-        for txs_chunk in tx_chunks {
-            responses.push(Ok(FetchCommitsAndTransactionsResponse {
+        let tx_tail = transaction_chunks.map(|chunk| match chunk {
+            Ok(transactions) => Ok(FetchCommitsAndTransactionsResponse {
                 commits: vec![],
                 certifier_block_headers: vec![],
-                transactions: txs_chunk,
-            }));
-        }
-
-        let stream = PermitGuardedStream::new(iter(responses), permit).boxed();
-        Ok(Response::new(stream))
+                transactions,
+            }),
+            Err(e) => Err(tonic::Status::internal(format!("{e:?}"))),
+        });
+        let stream = PermitGuardedStream::new(iter(responses).chain(tx_tail).boxed(), permit);
+        Ok(Response::new(stream.boxed()))
     }
 
     type FetchLatestBlockHeadersStream =
@@ -1622,7 +1664,7 @@ pub(crate) struct FetchTransactionsResponse {
 // Splits a list of byte sequences into chunks where each chunk's total size
 // does not exceed the specified `chunk_limit`.
 // Returns a vector of chunks, each being a vector of `Bytes`.
-fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
+pub(crate) fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
     let mut chunks = vec![];
     let mut chunk = vec![];
     let mut chunk_size = 0;
@@ -1646,10 +1688,18 @@ fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
 mod tests {
     use std::sync::Arc;
 
-    use super::{max_fetch_block_headers_response_bytes, max_fetch_transactions_response_bytes};
+    use bytes::Bytes;
+    use futures::{StreamExt as _, stream};
+    use starfish_config::AuthorityIndex;
+
+    use super::{
+        FetchCommitsAndTransactionsResponse, max_fetch_block_headers_response_bytes,
+        max_fetch_transactions_response_bytes, transaction_chunk_stream_adapter,
+    };
     use crate::{
         block_header::max_signed_block_header_bytes,
         block_verifier::serialized_transactions_size_limit, context::Context,
+        error::ConsensusError,
     };
 
     /// The per-fetch response budgets track the matching server-side count cap:
@@ -1684,5 +1734,131 @@ mod tests {
             max_fetch_transactions_response_bytes(&context),
             9 * serialized_transactions_size_limit(&context)
         );
+    }
+
+    const MAX_TRANSACTION_SIZE: usize = 8;
+
+    fn peer() -> AuthorityIndex {
+        AuthorityIndex::new_for_test(2)
+    }
+
+    fn tx_response(transactions: Vec<Bytes>) -> FetchCommitsAndTransactionsResponse {
+        FetchCommitsAndTransactionsResponse {
+            commits: vec![],
+            certifier_block_headers: vec![],
+            transactions,
+        }
+    }
+
+    fn adapt(
+        items: Vec<Result<FetchCommitsAndTransactionsResponse, tonic::Status>>,
+    ) -> super::TransactionChunkStream {
+        transaction_chunk_stream_adapter(stream::iter(items), MAX_TRANSACTION_SIZE, peer())
+    }
+
+    /// The retained first transaction batch is prepended ahead of the rest of
+    /// the tonic stream, and chunks come out in wire order, one item per
+    /// message.
+    #[tokio::test]
+    async fn adapter_yields_prepended_first_batch_then_tail_in_order() {
+        let first = tx_response(vec![Bytes::from_static(b"a")]);
+        let tail = stream::iter(vec![
+            Ok(tx_response(vec![
+                Bytes::from_static(b"b"),
+                Bytes::from_static(b"c"),
+            ])),
+            Ok(tx_response(vec![Bytes::from_static(b"d")])),
+        ]);
+        let prepended = stream::once(std::future::ready(Ok(first))).chain(tail);
+        let mut stream = transaction_chunk_stream_adapter(prepended, MAX_TRANSACTION_SIZE, peer());
+
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            vec![Bytes::from_static(b"a")]
+        );
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            vec![Bytes::from_static(b"b"), Bytes::from_static(b"c")]
+        );
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            vec![Bytes::from_static(b"d")]
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    /// A transaction element exceeding the per-element size limit surfaces as
+    /// a terminal error: nothing after it is yielded, not even valid chunks.
+    #[tokio::test]
+    async fn adapter_rejects_oversized_transaction_terminally() {
+        let oversized = Bytes::from(vec![0u8; MAX_TRANSACTION_SIZE + 1]);
+        let mut stream = adapt(vec![
+            Ok(tx_response(vec![Bytes::from_static(b"ok")])),
+            Ok(tx_response(vec![oversized])),
+            Ok(tx_response(vec![Bytes::from_static(b"after")])),
+        ]);
+
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            vec![Bytes::from_static(b"ok")]
+        );
+        assert!(matches!(
+            stream.next().await.unwrap(),
+            Err(ConsensusError::SerializedTransactionsTooLarge {
+                size,
+                limit: MAX_TRANSACTION_SIZE,
+            }) if size == MAX_TRANSACTION_SIZE + 1
+        ));
+        assert!(stream.next().await.is_none());
+    }
+
+    /// Commits or certifier headers arriving after the transaction tail has
+    /// started violate the response framing and terminate the stream.
+    #[tokio::test]
+    async fn adapter_rejects_commit_data_after_transactions() {
+        let mut framing_violation = tx_response(vec![Bytes::from_static(b"tx")]);
+        framing_violation.commits = vec![Bytes::from_static(b"commit")];
+        let mut stream = adapt(vec![
+            Ok(tx_response(vec![Bytes::from_static(b"ok")])),
+            Ok(framing_violation),
+            Ok(tx_response(vec![Bytes::from_static(b"after")])),
+        ]);
+
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            vec![Bytes::from_static(b"ok")]
+        );
+        assert!(matches!(
+            stream.next().await.unwrap(),
+            Err(ConsensusError::UnexpectedCommitDataAfterTransactions { peer: p })
+                if p == peer()
+        ));
+        assert!(stream.next().await.is_none());
+    }
+
+    /// Transport errors map to the same consensus errors as before the tail
+    /// became a stream: deadline exceeded to `NetworkRequestTimeout`, anything
+    /// else to `NetworkRequest`; both are terminal.
+    #[tokio::test]
+    async fn adapter_maps_transport_errors() {
+        let mut stream = adapt(vec![
+            Err(tonic::Status::deadline_exceeded("too slow")),
+            Ok(tx_response(vec![Bytes::from_static(b"after")])),
+        ]);
+        assert!(matches!(
+            stream.next().await.unwrap(),
+            Err(ConsensusError::NetworkRequestTimeout(_))
+        ));
+        assert!(stream.next().await.is_none());
+
+        let mut stream = adapt(vec![
+            Err(tonic::Status::internal("boom")),
+            Ok(tx_response(vec![Bytes::from_static(b"after")])),
+        ]);
+        assert!(matches!(
+            stream.next().await.unwrap(),
+            Err(ConsensusError::NetworkRequest(_))
+        ));
+        assert!(stream.next().await.is_none());
     }
 }

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -437,6 +437,7 @@ impl NetworkClient for TonicClient {
         let mut request = Request::new(FetchCommitsAndTransactionsRequest {
             start: commit_range.start(),
             end: commit_range.end(),
+            max_transaction_bytes: self.context.parameters.fast_commit_sync_max_fetch_bytes as u64,
         });
         request.set_timeout(timeout);
         let mut stream = client
@@ -951,7 +952,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .handle_fetch_commits_and_transactions(
                 peer_index,
                 (request.start..=request.end).into(),
-                0,
+                request.max_transaction_bytes as usize,
             )
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
@@ -1608,6 +1609,11 @@ pub(crate) struct FetchCommitsAndTransactionsRequest {
     start: CommitIndex,
     #[prost(uint32, tag = "2")]
     end: CommitIndex,
+    // Client's per-fetch transaction byte budget, forwarded as a hint for the
+    // server's transaction stream cursor. 0 means unlimited; older clients
+    // that don't set this field also decode to 0.
+    #[prost(uint64, tag = "3")]
+    max_transaction_bytes: u64,
 }
 
 #[derive(Clone, prost::Message)]

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -29,7 +29,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use super::{
     BlockBundleStream, NetworkClient, NetworkService, SerializedBlockBundle,
-    TransactionChunkStream, TransactionFetchMode,
+    TransactionChunkStream,
     admission::{Admission, AdmissionGuard, PerPeerAdmission, PermitGuardedStream, RpcGroup},
     metrics_layer::{MetricsCallbackMaker, MetricsResponseCallback, SizedRequest, SizedResponse},
     tonic_gen::{
@@ -73,7 +73,7 @@ fn max_fetch_block_headers_response_bytes(context: &Context, commit_sync: bool) 
 
 /// Transaction-fetch budget: the per-fetch transaction count cap times the
 /// maximum serialized per-block transaction payload. The larger of the two
-/// sync caps is used, matching `TransactionFetchMode::TransactionSync`.
+/// sync caps is used, matching `handle_fetch_transactions`' truncation.
 fn max_fetch_transactions_response_bytes(context: &Context) -> usize {
     let max_transactions = context
         .parameters
@@ -1090,11 +1090,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
 
         let vec_serialized_transactions = self
             .service
-            .handle_fetch_transactions(
-                peer_index,
-                committed_transactions_refs,
-                TransactionFetchMode::TransactionSync,
-            )
+            .handle_fetch_transactions(peer_index, committed_transactions_refs)
             .await
             .map_err(|e| tonic::Status::internal(format!("fetch_transactions failed: {e:?}")))?;
 

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -274,7 +274,10 @@ mod test {
         block_header::BlockRef,
         commit::CommitRange,
         error::ConsensusResult,
-        network::{BlockBundleStream, SerializedBlockBundle, test_network::TestService},
+        network::{
+            BlockBundleStream, SerializedBlockBundle, TransactionChunkStream,
+            test_network::TestService,
+        },
         storage::mem_store::MemStore,
         transaction_ref::GenericTransactionRef,
     };
@@ -348,7 +351,7 @@ mod test {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1092,7 +1092,7 @@ mod tests {
         core_thread::CoreError,
         dag_state::{DagState, DataSource},
         encoder::create_encoder,
-        network::{BlockBundleStream, NetworkClient},
+        network::{BlockBundleStream, NetworkClient, TransactionChunkStream},
         storage::mem_store::MemStore,
     };
 
@@ -2386,7 +2386,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, TransactionChunkStream)> {
             unimplemented!("fetch_commits_and_transactions not implemented in mock")
         }
     }


### PR DESCRIPTION
# Description of change

Follow-up to #12119: makes the `fetch_commits_and_transactions` fast-sync path actually stream on both ends instead of materializing entire ranges. The endpoint was already server-streaming with the right framing (commits + certifier headers first, then transaction chunks), but the server buffered all referenced transactions into `Vec`s before chunking (tens of GiB resident in the honest worst case) and the client drained the whole stream before processing anything.

Stacked, each commit independently green:

- `refactor`: a shared `TransactionChunkStream` is threaded through `NetworkClient`/`NetworkService` and the tonic client/server; the client head-drain keeps the exact commit/header caps and a unit-tested tail adapter enforces per-element size and framing with terminal-error semantics. The coarse ~505 MiB total-bytes backstop is removed (its transaction term mirrored no real cap).
- `feat`: `fetch_once` consumes chunks incrementally, verifying commitments per chunk in `spawn_blocking` and dropping raw bytes immediately. A new `fast_commit_sync_max_fetch_bytes` parameter (128 MiB production, 1 KiB under msim so simtests exercise the path) stops the fetch at a covered commit prefix, which the existing prefix recovery + `requeue_partial_range` machinery from #12119 turns into forward progress. An anti-malicious envelope check bounds the referenced-transaction count at `committee × (4 × commits + gc_depth)` with a new `TooManyCommittedTransactionsInRange` error.
- `feat`: the server replaces eager materialization with a lazy `try_unfold` cursor in strict commit order — 64-ref sub-batches, per-sub-batch GC re-read, indexed store/dag reassembly, never-split chunk packing with a decoded pending tail carried across polls. Dropping the client stream cancels remaining server work. A counting-store test proves laziness (0 reads unpolled).
- `feat`: a backward-compatible `max_transaction_bytes` request field (tag 3, 0 = unlimited) lets the server end the stream cleanly at the client's budget instead of the client discarding an overshoot chunk; client-side enforcement remains authoritative.
- Two `fix` commits from review: both ends guarantee the range's first commit is fully served/accepted before stopping at the cap/budget, so a single commit larger than the cap degrades to one-commit-per-fetch progress instead of an all-peer retry livelock; and undecodable elements now count toward the cap so garbage streams are bounded by it rather than only by the request timeout.
- Cleanup: `TransactionFetchMode` had become a single-variant enum once the eager path was gone and is removed; `TransactionSync` fetch behavior is byte-for-byte unchanged.

Open question for reviewers: the envelope uses the proposed `AVG_TX_ROUNDS_PER_COMMIT = 4` slack constant. A sustained >~25% skipped-leader rate across a 2000-commit batch could make honest responses exceed it; deriving the bound from the actual round span of the verified commits (`committee × (last_leader_round − first_leader_round + gc_depth)`) would remove both the constant and that failure mode. Happy to switch in this PR or a follow-up.

Note: based on `consensus/fix/fast-commit-sync-prefix-progress`; retarget to `develop` once #12119 merges.

## Links to any relevant issues

relates to #11984

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo nextest run -p starfish-core -p starfish-config --lib` (355 passed) and `cargo simtest -p starfish-simtests` (30 passed; the 1 KiB msim cap exercises cap-stop → prefix → requeue in the restart tests) both green. New coverage: adapter framing/size tests, cap/envelope/multi-chunk/old-server-order `fetch_once` tests, cursor order/packing/budget/laziness tests, a client↔server round-trip for the budget field, and first-commit-larger-than-cap progress tests on both ends.