### PR TITLE
feat(config+node): per-service concurrency limits for the validator gRPC server

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -4,6 +4,7 @@
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -123,8 +124,11 @@ pub struct NodeConfig {
     /// in-flight work so a request flood cannot grow queues and memory
     /// without limit, it does not throttle normal load. Operators wanting
     /// hard load-shedding can lower it and set `grpc_load_shed`.
+    ///
+    /// A value of zero is rejected at config load: it would not disable the
+    /// limit, it would block every request.
     #[serde(default = "default_grpc_concurrency_limit_per_core")]
-    pub grpc_concurrency_limit_per_core: usize,
+    pub grpc_concurrency_limit_per_core: NonZeroUsize,
 
     /// Configuration struct for P2P.
     #[serde(default)]
@@ -714,8 +718,8 @@ pub fn default_grpc_api_config() -> Option<GrpcApiConfig> {
     Some(GrpcApiConfig::default())
 }
 
-pub fn default_grpc_concurrency_limit_per_core() -> usize {
-    1000
+pub fn default_grpc_concurrency_limit_per_core() -> NonZeroUsize {
+    NonZeroUsize::new(1000).unwrap()
 }
 
 pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -39,9 +39,6 @@ use crate::{
     transaction_deny_config::TransactionDenyConfig, verifier_signing_config::VerifierSigningConfig,
 };
 
-// Default max number of concurrent requests served
-pub const DEFAULT_GRPC_CONCURRENCY_LIMIT: usize = 20000000000;
-
 /// Default gas price of 1000 Nanos
 pub const DEFAULT_VALIDATOR_GAS_PRICE: u64 = iota_types::transaction::DEFAULT_VALIDATOR_GAS_PRICE;
 
@@ -107,14 +104,27 @@ pub struct NodeConfig {
     /// - 'both' for both a websocket and http based service (deprecated)
     pub jsonrpc_server_type: Option<ServerType>,
 
-    /// Flag to enable gRPC load shedding to manage and
-    /// mitigate overload conditions by shedding excess
-    /// load with `LoadShedLayer` middleware.
+    /// Flag to enable gRPC load shedding: requests over a service's
+    /// concurrency limit are rejected immediately with `RESOURCE_EXHAUSTED`
+    /// instead of waiting for a slot.
     #[serde(default)]
     pub grpc_load_shed: Option<bool>,
 
-    #[serde(default = "default_concurrency_limit")]
-    pub grpc_concurrency_limit: Option<usize>,
+    /// Maximum number of concurrent in-flight requests per CPU core, applied
+    /// to each service of the validator gRPC server separately (`Validator`,
+    /// `ValidatorV2`, `ValidatorPeer`), so a flood of client transaction
+    /// submissions cannot crowd validator-peer RPCs out of admission slots.
+    /// The effective per-service limit is this value multiplied by the CPU
+    /// cores of the machine at server startup, so the same config file scales
+    /// with the hardware.
+    ///
+    /// Most request time is spent awaiting locks, I/O or consensus rather
+    /// than on-CPU, so the default ceiling is generous: it bounds total
+    /// in-flight work so a request flood cannot grow queues and memory
+    /// without limit, it does not throttle normal load. Operators wanting
+    /// hard load-shedding can lower it and set `grpc_load_shed`.
+    #[serde(default = "default_grpc_concurrency_limit_per_core")]
+    pub grpc_concurrency_limit_per_core: usize,
 
     /// Configuration struct for P2P.
     #[serde(default)]
@@ -704,8 +714,8 @@ pub fn default_grpc_api_config() -> Option<GrpcApiConfig> {
     Some(GrpcApiConfig::default())
 }
 
-pub fn default_concurrency_limit() -> Option<usize> {
-    Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
+pub fn default_grpc_concurrency_limit_per_core() -> usize {
+    1000
 }
 
 pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {

--- a/crates/iota-network-stack/src/concurrency.rs
+++ b/crates/iota-network-stack/src/concurrency.rs
@@ -7,9 +7,17 @@
 //! server, [`ServiceConcurrencyLimit`] bounds the in-flight requests of a
 //! single gRPC service, so services sharing one listener cannot crowd each
 //! other out of admission slots.
+//!
+//! Tower's per-service [`tower::limit::ConcurrencyLimitLayer`] cannot be used
+//! here: its `ConcurrencyLimit` wrapper does not implement tonic's
+//! [`NamedService`], which `Routes::add_service` requires for routing, and
+//! shedding through tower's `LoadShed` surfaces as a `BoxError`, incompatible
+//! with the router's `Error = Infallible` bound — over-limit requests must be
+//! answered in-band with a gRPC `RESOURCE_EXHAUSTED` response instead.
 
 use std::{
     convert::Infallible,
+    num::NonZeroUsize,
     sync::Arc,
     task::{Context, Poll},
 };
@@ -37,13 +45,13 @@ pub struct ServiceConcurrencyLimit<S> {
 }
 
 impl<S> ServiceConcurrencyLimit<S> {
-    pub fn new(inner: S, limit: usize, load_shed: bool) -> Self {
+    pub fn new(inner: S, limit: NonZeroUsize, load_shed: bool) -> Self {
         Self {
             inner,
             // Clamp: `Semaphore::new` panics above `MAX_PERMITS`, and
             // effectively-unlimited configs multiply large values by the CPU
             // core count.
-            semaphore: Arc::new(Semaphore::new(limit.min(Semaphore::MAX_PERMITS))),
+            semaphore: Arc::new(Semaphore::new(limit.get().min(Semaphore::MAX_PERMITS))),
             load_shed,
         }
     }
@@ -66,6 +74,15 @@ where
     }
 
     fn call(&mut self, request: Request<Body>) -> Self::Future {
+        // Admission happens here rather than in `poll_ready` (where
+        // `tower::limit::ConcurrencyLimit` acquires its permit): a shed
+        // request must be answered with a gRPC response, and `poll_ready`
+        // can only signal Ready or Pending — converting Pending into an
+        // error via an outer load-shed layer is ruled out by the router's
+        // `Error = Infallible` bound. Readiness-based acquisition would
+        // also buy no upstream backpressure: the axum router dispatches
+        // every request on a fresh clone of this service.
+        //
         // Take the instance that was driven to readiness and leave the clone
         // for later calls, as `poll_ready` readiness does not transfer to
         // clones.
@@ -146,7 +163,7 @@ mod tests {
             BlockingService {
                 release: release.clone(),
             },
-            1,
+            NonZeroUsize::MIN,
             true,
         );
 
@@ -171,7 +188,7 @@ mod tests {
             BlockingService {
                 release: release.clone(),
             },
-            1,
+            NonZeroUsize::MIN,
             false,
         );
 
@@ -194,8 +211,8 @@ mod tests {
         let blocking = BlockingService {
             release: release.clone(),
         };
-        let saturated = ServiceConcurrencyLimit::new(blocking.clone(), 1, true);
-        let other = ServiceConcurrencyLimit::new(blocking, 1, true);
+        let saturated = ServiceConcurrencyLimit::new(blocking.clone(), NonZeroUsize::MIN, true);
+        let other = ServiceConcurrencyLimit::new(blocking, NonZeroUsize::MIN, true);
 
         let in_flight = tokio::spawn(saturated.clone().oneshot(request()));
         tokio::task::yield_now().await;

--- a/crates/iota-network-stack/src/concurrency.rs
+++ b/crates/iota-network-stack/src/concurrency.rs
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-service concurrency limiting for gRPC servers.
+//!
+//! Unlike [`tower::limit::GlobalConcurrencyLimitLayer`] applied around a whole
+//! server, [`ServiceConcurrencyLimit`] bounds the in-flight requests of a
+//! single gRPC service, so services sharing one listener cannot crowd each
+//! other out of admission slots.
+
+use std::{
+    convert::Infallible,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::future::BoxFuture;
+use tokio::sync::Semaphore;
+use tonic::{
+    body::Body,
+    codegen::http::{Request, Response},
+    server::NamedService,
+};
+use tower::Service;
+
+/// Bounds the number of concurrent in-flight requests to the wrapped gRPC
+/// service, independently of any other service registered on the same server.
+///
+/// With `load_shed` enabled, requests over the limit are rejected immediately
+/// with gRPC `RESOURCE_EXHAUSTED`; otherwise they wait for a slot to free up.
+/// Clones share the same limit.
+#[derive(Clone)]
+pub struct ServiceConcurrencyLimit<S> {
+    inner: S,
+    semaphore: Arc<Semaphore>,
+    load_shed: bool,
+}
+
+impl<S> ServiceConcurrencyLimit<S> {
+    pub fn new(inner: S, limit: usize, load_shed: bool) -> Self {
+        Self {
+            inner,
+            // Clamp: `Semaphore::new` panics above `MAX_PERMITS`, and
+            // effectively-unlimited configs multiply large values by the CPU
+            // core count.
+            semaphore: Arc::new(Semaphore::new(limit.min(Semaphore::MAX_PERMITS))),
+            load_shed,
+        }
+    }
+}
+
+impl<S> Service<Request<Body>> for ServiceConcurrencyLimit<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Response<Body>, Infallible>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        // Take the instance that was driven to readiness and leave the clone
+        // for later calls, as `poll_ready` readiness does not transfer to
+        // clones.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let semaphore = self.semaphore.clone();
+        let load_shed = self.load_shed;
+
+        Box::pin(async move {
+            // The permit is held until the response future resolves, mirroring
+            // `tower::limit::ConcurrencyLimit`.
+            let _permit = if load_shed {
+                match semaphore.try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        return Ok(tonic::Status::resource_exhausted(
+                            "service concurrency limit reached",
+                        )
+                        .into_http());
+                    }
+                }
+            } else {
+                semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("the semaphore is never closed")
+            };
+            inner.call(request).await
+        })
+    }
+}
+
+impl<S: NamedService> NamedService for ServiceConcurrencyLimit<S> {
+    const NAME: &'static str = S::NAME;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tower::ServiceExt;
+
+    use super::*;
+
+    /// Inner service whose responses only complete once `release` is
+    /// notified, keeping requests in flight for as long as the test needs.
+    #[derive(Clone)]
+    struct BlockingService {
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    impl Service<Request<Body>> for BlockingService {
+        type Response = Response<Body>;
+        type Error = Infallible;
+        type Future = BoxFuture<'static, Result<Response<Body>, Infallible>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: Request<Body>) -> Self::Future {
+            let release = self.release.clone();
+            Box::pin(async move {
+                release.notified().await;
+                Ok(Response::new(Body::default()))
+            })
+        }
+    }
+
+    fn request() -> Request<Body> {
+        Request::new(Body::default())
+    }
+
+    #[tokio::test]
+    async fn load_shedding_rejects_requests_over_the_limit() {
+        let release = Arc::new(tokio::sync::Notify::new());
+        let service = ServiceConcurrencyLimit::new(
+            BlockingService {
+                release: release.clone(),
+            },
+            1,
+            true,
+        );
+
+        let in_flight = tokio::spawn(service.clone().oneshot(request()));
+        tokio::task::yield_now().await;
+
+        let shed = service.clone().oneshot(request()).await.unwrap();
+        assert_eq!(
+            shed.headers().get("grpc-status").unwrap(),
+            &(tonic::Code::ResourceExhausted as i32).to_string()
+        );
+
+        release.notify_one();
+        let response = in_flight.await.unwrap().unwrap();
+        assert!(response.headers().get("grpc-status").is_none());
+    }
+
+    #[tokio::test]
+    async fn without_load_shedding_requests_over_the_limit_wait() {
+        let release = Arc::new(tokio::sync::Notify::new());
+        let service = ServiceConcurrencyLimit::new(
+            BlockingService {
+                release: release.clone(),
+            },
+            1,
+            false,
+        );
+
+        let first = tokio::spawn(service.clone().oneshot(request()));
+        tokio::task::yield_now().await;
+
+        let mut second = tokio::spawn(service.clone().oneshot(request()));
+        let waiting = tokio::time::timeout(Duration::from_millis(50), &mut second).await;
+        assert!(waiting.is_err(), "second request should wait for a slot");
+
+        release.notify_one();
+        first.await.unwrap().unwrap();
+        release.notify_one();
+        second.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn limits_are_independent_per_service() {
+        let release = Arc::new(tokio::sync::Notify::new());
+        let blocking = BlockingService {
+            release: release.clone(),
+        };
+        let saturated = ServiceConcurrencyLimit::new(blocking.clone(), 1, true);
+        let other = ServiceConcurrencyLimit::new(blocking, 1, true);
+
+        let in_flight = tokio::spawn(saturated.clone().oneshot(request()));
+        tokio::task::yield_now().await;
+
+        // The other service has its own semaphore and still admits requests.
+        let admitted = tokio::spawn(other.oneshot(request()));
+        tokio::task::yield_now().await;
+
+        release.notify_waiters();
+        assert!(
+            in_flight
+                .await
+                .unwrap()
+                .unwrap()
+                .headers()
+                .get("grpc-status")
+                .is_none()
+        );
+        assert!(
+            admitted
+                .await
+                .unwrap()
+                .unwrap()
+                .headers()
+                .get("grpc-status")
+                .is_none()
+        );
+    }
+}

--- a/crates/iota-network-stack/src/lib.rs
+++ b/crates/iota-network-stack/src/lib.rs
@@ -6,6 +6,7 @@ pub mod anemo_ext;
 pub mod callback;
 pub mod client;
 pub mod codec;
+pub mod concurrency;
 pub mod config;
 pub mod grpc_timeout;
 pub mod metrics;

--- a/crates/iota-network-stack/src/server.rs
+++ b/crates/iota-network-stack/src/server.rs
@@ -4,6 +4,7 @@
 
 use std::{
     convert::Infallible,
+    num::NonZeroUsize,
     task::{Context, Poll},
 };
 
@@ -77,7 +78,7 @@ impl<M: MetricsCallbackProvider> ServerBuilder<M> {
     pub fn add_service_with_concurrency_limit<S>(
         mut self,
         svc: S,
-        limit: usize,
+        limit: NonZeroUsize,
         load_shed: bool,
     ) -> Self
     where

--- a/crates/iota-network-stack/src/server.rs
+++ b/crates/iota-network-stack/src/server.rs
@@ -20,6 +20,7 @@ use tower_http::{
 };
 
 use crate::{
+    concurrency::ServiceConcurrencyLimit,
     config::Config,
     metrics::{
         DefaultMetricsCallbackProvider, GRPC_ENDPOINT_PATH_HEADER, MetricsCallbackProvider,
@@ -64,6 +65,33 @@ impl<M: MetricsCallbackProvider> ServerBuilder<M> {
         S::Future: Send + 'static,
     {
         self.router = self.router.add_service(svc);
+        self
+    }
+
+    /// Add a new service to this Server with its own concurrency limit,
+    /// enforced independently of every other service on this server.
+    ///
+    /// With `load_shed` enabled, requests over the limit are rejected
+    /// immediately with gRPC `RESOURCE_EXHAUSTED`; otherwise they wait for a
+    /// slot to free up.
+    pub fn add_service_with_concurrency_limit<S>(
+        mut self,
+        svc: S,
+        limit: usize,
+        load_shed: bool,
+    ) -> Self
+    where
+        S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Future: Send + 'static,
+    {
+        self.router = self
+            .router
+            .add_service(ServiceConcurrencyLimit::new(svc, limit, load_shed));
         self
     }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1625,14 +1625,35 @@ impl IotaNode {
             soft_locks,
         );
 
-        let mut server_conf = iota_network_stack::config::Config::new();
-        server_conf.global_concurrency_limit = config.grpc_concurrency_limit;
-        server_conf.load_shed = config.grpc_load_shed;
+        // Each service gets its own concurrency limit so that a flood of client
+        // transaction submissions (Validator / ValidatorV2) cannot crowd the
+        // validator-peer RPCs sharing this listener out of admission slots.
+        // The config value is per core, so the same config scales with the
+        // hardware; the effective limit is computed on the machine the server
+        // actually runs on.
+        let concurrency_limit = config
+            .grpc_concurrency_limit_per_core
+            .saturating_mul(iota_core::runtime::available_cpu_cores());
+        let load_shed = config.grpc_load_shed.unwrap_or_default();
+
+        let server_conf = iota_network_stack::config::Config::new();
         let server_builder =
             ServerBuilder::from_config(&server_conf, GrpcMetrics::new(prometheus_registry))
-                .add_service(ValidatorServer::new(validator_service.clone()))
-                .add_service(ValidatorV2Server::new(validator_service.clone()))
-                .add_service(ValidatorPeerServer::new(validator_service));
+                .add_service_with_concurrency_limit(
+                    ValidatorServer::new(validator_service.clone()),
+                    concurrency_limit,
+                    load_shed,
+                )
+                .add_service_with_concurrency_limit(
+                    ValidatorV2Server::new(validator_service.clone()),
+                    concurrency_limit,
+                    load_shed,
+                )
+                .add_service_with_concurrency_limit(
+                    ValidatorPeerServer::new(validator_service),
+                    concurrency_limit,
+                    load_shed,
+                );
 
         let tls_config = iota_tls::create_rustls_server_config(
             config.network_key_pair().copy().private(),

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
     collections::HashMap,
     fmt,
     future::Future,
+    num::NonZeroUsize,
     path::PathBuf,
     sync::{Arc, Weak},
     time::Duration,
@@ -1631,9 +1632,10 @@ impl IotaNode {
         // The config value is per core, so the same config scales with the
         // hardware; the effective limit is computed on the machine the server
         // actually runs on.
-        let concurrency_limit = config
-            .grpc_concurrency_limit_per_core
-            .saturating_mul(iota_core::runtime::available_cpu_cores());
+        let concurrency_limit = config.grpc_concurrency_limit_per_core.saturating_mul(
+            NonZeroUsize::new(iota_core::runtime::available_cpu_cores())
+                .unwrap_or(NonZeroUsize::MIN),
+        );
         let load_shed = config.grpc_load_shed.unwrap_or_default();
 
         let server_conf = iota_network_stack::config::Config::new();

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf};
 
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -210,7 +210,7 @@ impl ValidatorConfigBuilder {
             grpc_load_shed: None,
             // Effectively unlimited: tests and benchmarks must not be
             // throttled.
-            grpc_concurrency_limit_per_core: 500_000_000,
+            grpc_concurrency_limit_per_core: NonZeroUsize::new(500_000_000).unwrap(),
             p2p_config,
             authority_store_pruning_config: pruning_config,
             end_of_epoch_broadcast_channel_capacity:
@@ -561,7 +561,7 @@ impl FullnodeConfigBuilder {
             grpc_load_shed: None,
             // Effectively unlimited: tests and benchmarks must not be
             // throttled.
-            grpc_concurrency_limit_per_core: 500_000_000,
+            grpc_concurrency_limit_per_core: NonZeroUsize::new(500_000_000).unwrap(),
             p2p_config,
             authority_store_pruning_config: pruning_config,
             end_of_epoch_broadcast_channel_capacity:

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -13,9 +13,9 @@ use iota_config::{
     IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME, NodeConfig, local_ip_utils,
     node::{
         AuthorityKeyPairWithPath, AuthorityOverloadConfig, AuthorityStorePruningConfig,
-        CheckpointExecutorConfig, DBCheckpointConfig, DEFAULT_GRPC_CONCURRENCY_LIMIT,
-        ExecutionCacheConfig, ExpensiveSafetyCheckConfig, Genesis, GrpcApiConfig, KeyPairWithPath,
-        RunWithRange, StateSnapshotConfig, default_enable_index_processing,
+        CheckpointExecutorConfig, DBCheckpointConfig, ExecutionCacheConfig,
+        ExpensiveSafetyCheckConfig, Genesis, GrpcApiConfig, KeyPairWithPath, RunWithRange,
+        StateSnapshotConfig, default_enable_index_processing,
         default_end_of_epoch_broadcast_channel_capacity,
         default_full_checkpoint_contents_cache_size_mb,
     },
@@ -208,7 +208,9 @@ impl ValidatorConfigBuilder {
             genesis: Genesis::new_empty(),
             migration_tx_data_path,
             grpc_load_shed: None,
-            grpc_concurrency_limit: Some(DEFAULT_GRPC_CONCURRENCY_LIMIT),
+            // Effectively unlimited: tests and benchmarks must not be
+            // throttled.
+            grpc_concurrency_limit_per_core: 500_000_000,
             p2p_config,
             authority_store_pruning_config: pruning_config,
             end_of_epoch_broadcast_channel_capacity:
@@ -557,7 +559,9 @@ impl FullnodeConfigBuilder {
             genesis,
             migration_tx_data_path,
             grpc_load_shed: None,
-            grpc_concurrency_limit: None,
+            // Effectively unlimited: tests and benchmarks must not be
+            // throttled.
+            grpc_concurrency_limit_per_core: 500_000_000,
             p2p_config,
             authority_store_pruning_config: pruning_config,
             end_of_epoch_broadcast_channel_capacity:

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -26,7 +26,7 @@ validator_configs:
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
-    grpc-concurrency-limit: 20000000000
+    grpc-concurrency-limit-per-core: 500000000
     p2p-config:
       listen-address: "0.0.0.0:1"
       state-sync:
@@ -122,7 +122,7 @@ validator_configs:
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
-    grpc-concurrency-limit: 20000000000
+    grpc-concurrency-limit-per-core: 500000000
     p2p-config:
       listen-address: "0.0.0.0:1"
       state-sync:
@@ -218,7 +218,7 @@ validator_configs:
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
-    grpc-concurrency-limit: 20000000000
+    grpc-concurrency-limit-per-core: 500000000
     p2p-config:
       listen-address: "0.0.0.0:1"
       state-sync:
@@ -314,7 +314,7 @@ validator_configs:
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
-    grpc-concurrency-limit: 20000000000
+    grpc-concurrency-limit-per-core: 500000000
     p2p-config:
       listen-address: "0.0.0.0:1"
       state-sync:
@@ -410,7 +410,7 @@ validator_configs:
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
-    grpc-concurrency-limit: 20000000000
+    grpc-concurrency-limit-per-core: 500000000
     p2p-config:
       listen-address: "0.0.0.0:1"
       state-sync:
@@ -506,7 +506,7 @@ validator_configs:
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
-    grpc-concurrency-limit: 20000000000
+    grpc-concurrency-limit-per-core: 500000000
     p2p-config:
       listen-address: "0.0.0.0:1"
       state-sync:
@@ -602,7 +602,7 @@ validator_configs:
     enable-index-processing: true
     jsonrpc-server-type: ~
     grpc-load-shed: ~
-    grpc-concurrency-limit: 20000000000
+    grpc-concurrency-limit-per-core: 500000000
     p2p-config:
       listen-address: "0.0.0.0:1"
       state-sync:


### PR DESCRIPTION
# Description of change

## Problem

Two related issues with admission control on the validator gRPC server:

1. **The default concurrency limit is effectively unlimited.** `grpc_concurrency_limit` defaults to `20000000000`, so a flood of incoming requests can grow queues and memory without bound. Runtime isolation (#12046) prevents a flood from starving the node core of worker threads, but without a finite admission bound the failure mode just moves from starvation to OOM.

2. **The limit is global per listener, not per service.** The single `GlobalConcurrencyLimitLayer` wraps the whole server, which hosts three services on one listener: `Validator` and `ValidatorV2` (client transaction submission / certificate processing — the flood source) and `ValidatorPeer` (read-only `GetCheckpoint` plus rare control-plane RPCs between validators). Once the limit is finite, a client flood that exhausts it also crowds validator-peer RPCs out of admission slots.

## Approach

- **`iota-network-stack`**: new `ServiceConcurrencyLimit` middleware (`concurrency.rs`) — a semaphore-based concurrency bound around a single gRPC service that preserves `NamedService` so tonic routing still works, plus `ServerBuilder::add_service_with_concurrency_limit`. With `load_shed` enabled, requests over the limit are rejected immediately with `RESOURCE_EXHAUSTED` (previously, global load shedding surfaced as a transport-level error rather than a proper gRPC status); otherwise they wait for a slot, matching `tower::limit::ConcurrencyLimit` permit semantics. Covered by unit tests (shed over limit, queue without shed, independence of limits).

- **`iota-config`**: `grpc_concurrency_limit` (absolute) is replaced by **`grpc_concurrency_limit_per_core`** (default: 1000). The effective per-service limit is the configured value multiplied by the machine's CPU cores at server startup, so the same config file scales with the hardware and never bakes in a machine-specific number. The per-core default is generous by design (most request time is spent awaiting locks, I/O or consensus, not on-CPU): it bounds worst-case in-flight work, it does not throttle normal load. Operators wanting hard load-shedding can lower it and set `grpc_load_shed`. The `DEFAULT_GRPC_CONCURRENCY_LIMIT` (20e9) constant is removed entirely; test/swarm validator configs set an effectively-unlimited per-core value instead so tests and benchmarks are never throttled.

- **`iota-node`**: the validator gRPC server no longer sets `global_concurrency_limit` / `load_shed` on the server config; instead each of the three services is added with its own limit computed from `grpc_concurrency_limit_per_core` x CPU cores (clamped to tokio's `Semaphore::MAX_PERMITS`) and `grpc_load_shed`.

## Behavioral / config notes

- The default changes from effectively unlimited (`20000000000` global) to `1000 x cores` **per service**. Worst-case total in-flight across the three services is 3x the per-service limit.
- **The old `grpc_concurrency_limit` config field is removed, not aliased.** An absolute value silently reinterpreted as per-core would be a large jump, so configs still setting the old key have it ignored and get the new default; operators who tuned it must set `grpc_concurrency_limit_per_core` instead.
- With `grpc_load_shed` enabled, rejected requests now get a clean gRPC `RESOURCE_EXHAUSTED` status per service instead of a connection-level error from the global load-shed layer.
- `grpc_concurrency_limit_per_core` is `NonZeroUsize`: a config setting it to `0` is rejected at config load, since zero would not disable the limit, it would block (or shed) every request.
- Swarm/test config snapshots change accordingly (renamed field, explicit unlimited value for validators).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): The validator gRPC server now enforces a concurrency limit per service (Validator, ValidatorV2, ValidatorPeer) instead of one global limit, so a flood of client transaction submissions cannot crowd out validator-peer RPCs. The `grpc_concurrency_limit` config field is replaced by `grpc_concurrency_limit_per_core` (default 1000); the effective per-service limit is that value times the machine's CPU cores (previously effectively unlimited). With `grpc_load_shed`, excess requests are rejected with `RESOURCE_EXHAUSTED`.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
