### PR TITLE
chore: extend writing conventions to PR/issue descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,10 +133,24 @@ iota/
 - [`RUST_CONVENTIONS.md`](RUST_CONVENTIONS.md) — full list of Rust style and safety rules (panics, error handling, naming, module layout, comment style, etc.).
 - [`REVIEW.md`](REVIEW.md) — review depth tiers, cross-cutting checks (license headers, breaking changes, dependency hygiene), and language-specific review guidance.
 
-### Comment style
+## Writing style
+
+These rules cover everything you write: code comments, commit messages, and PR and issue descriptions.
+
+### Code comments
 
 When writing or modifying comments, follow the **Comments** rules in [`RUST_CONVENTIONS.md`](RUST_CONVENTIONS.md#comments). In short:
 
 - Doc comments are for the **caller** — what they need to know to call it correctly, not how it works inside.
 - Inline comments explain a non-obvious **why**, never a **what**; default to none.
 - Never embed conversational or change history ("added for X", "as discussed", PR/issue numbers) — that belongs in the PR description or commit message, not the code.
+
+### PR and issue descriptions
+
+- Keep them compact and concise; no large blocks of written-out prose.
+- Prefer bullet points over full paragraphs.
+- Still state _why_ the change was made — the reviewer needs the intent (see [`REVIEW.md`](REVIEW.md)).
+
+### Plain language, no coined terms
+
+Applies to all of the above, and to review comments and reports: use plain words and terms already used in the project or the established domain, so a reader can follow the text without terminology the project doesn't already use. Do not invent a label for a concept and then reuse it as if it were established vocabulary. See [Plain Language, No Coined Terms](RUST_CONVENTIONS.md#plain-language-no-coined-terms) for the full rule.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,9 +147,8 @@ When writing or modifying comments, follow the **Comments** rules in [`RUST_CONV
 
 ### PR and issue descriptions
 
-- Keep them compact and concise; no large blocks of written-out prose.
-- Prefer bullet points over full paragraphs.
-- Still state _why_ the change was made — the reviewer needs the intent (see [`REVIEW.md`](REVIEW.md)).
+- Keep them compact and concise; bullet points over full paragraphs.
+- Say at a high level _what_ the change does and _why_ — the code-level details belong in the diff, not the description (see [`REVIEW.md`](REVIEW.md)).
 
 ### Plain language, no coined terms
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,4 +152,8 @@ When writing or modifying comments, follow the **Comments** rules in [`RUST_CONV
 
 ### Plain language, no coined terms
 
-Applies to all of the above, and to review comments and reports: use plain words and terms already used in the project or the established domain, so a reader can follow the text without terminology the project doesn't already use. Do not invent a label for a concept and then reuse it as if it were established vocabulary. See [Plain Language, No Coined Terms](RUST_CONVENTIONS.md#plain-language-no-coined-terms) for the full rule.
+Applies to all of the above, and to review comments and reports — all prose, not just code.
+
+Use plain words and terms already used in the codebase or the established domain, so a reader can follow the text without terminology the project doesn't already use. Do not invent a label for a concept and then reuse it as if it were established vocabulary — this is a recurring problem, treat it as a hard rule. Before naming a concept, check whether the repo already has a word for it and reuse that. If a phrase wouldn't appear in the code or a standard reference, drop the label and describe the thing directly.
+
+Self-check before submitting: scan for any noun phrase acting as a _name_ for an idea. If you coined it — not the codebase, not the domain — delete the label and state the idea in plain words.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ iota/
 
 ## Writing style
 
-These rules cover everything you write: code comments, commit messages, and PR and issue descriptions.
+These rules cover everything you write: function and variable names, code comments, commit messages, and PR and issue descriptions.
 
 ### Code comments
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -212,6 +212,8 @@ For each finding: state the file and line, describe the problem precisely, expla
 
 ### Additional guidelines
 
+Write the comment in plain language: bullet points over prose, and no coined terms or metaphors — use only vocabulary already used in the project or the established domain (see [Plain Language, No Coined Terms](RUST_CONVENTIONS.md#plain-language-no-coined-terms)).
+
 Do not flag formatting or style issues enforced by CI (`rustfmt`, Prettier, ESLint auto-fixable rules). These are not review concerns.
 
 Acknowledge when you lack sufficient context to assess correctness deeply (e.g., consensus algorithm changes requiring knowledge of the protocol state machine). Say so clearly rather than producing a shallow review that appears thorough.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -212,7 +212,7 @@ For each finding: state the file and line, describe the problem precisely, expla
 
 ### Additional guidelines
 
-Write the comment in plain language: bullet points over prose, and no coined terms or metaphors — use only vocabulary already used in the project or the established domain (see [Plain Language, No Coined Terms](RUST_CONVENTIONS.md#plain-language-no-coined-terms)).
+Write the comment in plain language: bullet points over prose, and no coined terms or metaphors — use only vocabulary already used in the project or the established domain (see [Plain language, no coined terms](AGENTS.md#plain-language-no-coined-terms)).
 
 Do not flag formatting or style issues enforced by CI (`rustfmt`, Prettier, ESLint auto-fixable rules). These are not review concerns.
 

--- a/RUST_CONVENTIONS.md
+++ b/RUST_CONVENTIONS.md
@@ -117,6 +117,20 @@ pub fn next_committee(epoch: Epoch) -> Result<Committee, EpochError> { ... }
 
 If the stake-vs-VRF choice matters for a reader of the body, the comment goes inside the function at the sort step — not in the header.
 
+#### Plain Language, No Coined Terms
+
+This rule applies to every comment, and equally to PR and issue descriptions, review comments, and reports — all prose,
+not just code.
+
+Use plain words and the terms already used in the codebase or the established domain. Do not invent a label for a
+concept and then reuse it as if it were established vocabulary — this is a recurring problem, treat it as a hard rule. A
+reader should be able to follow the text without terminology the project doesn't already use. Before naming a concept,
+check whether the repo already has a word for it and reuse that. If a phrase wouldn't appear in the code or a standard
+reference, drop the label and describe the thing directly.
+
+Self-check before submitting: scan for any noun phrase acting as a _name_ for an idea. If you coined it — not the
+codebase, not the domain — delete the label and state the idea in plain words.
+
 ### Organization
 
 #### Absolute Imports

--- a/RUST_CONVENTIONS.md
+++ b/RUST_CONVENTIONS.md
@@ -117,20 +117,6 @@ pub fn next_committee(epoch: Epoch) -> Result<Committee, EpochError> { ... }
 
 If the stake-vs-VRF choice matters for a reader of the body, the comment goes inside the function at the sort step — not in the header.
 
-#### Plain Language, No Coined Terms
-
-This rule applies to every comment, and equally to PR and issue descriptions, review comments, and reports — all prose,
-not just code.
-
-Use plain words and the terms already used in the codebase or the established domain. Do not invent a label for a
-concept and then reuse it as if it were established vocabulary — this is a recurring problem, treat it as a hard rule. A
-reader should be able to follow the text without terminology the project doesn't already use. Before naming a concept,
-check whether the repo already has a word for it and reuse that. If a phrase wouldn't appear in the code or a standard
-reference, drop the label and describe the thing directly.
-
-Self-check before submitting: scan for any noun phrase acting as a _name_ for an idea. If you coined it — not the
-codebase, not the domain — delete the label and state the idea in plain words.
-
 ### Organization
 
 #### Absolute Imports


### PR DESCRIPTION
# Description of change

AI-generated comments and PR/issue text tend to be too long and lean on invented terminology. This extends the writing conventions to push back on that: keep prose concise, use plain language, and stick to terms already used in the project.

Applies to code comments (as before) plus PR/issue descriptions, reviews, and reports.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

Docs-only; no code affected, so no release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)