### PR TITLE
fix(iota-core): expose `ValidatorClientMetrics` for `TransactionDriver:new` API

### DIFF
--- a/crates/iota-core/src/transaction_driver/mod.rs
+++ b/crates/iota-core/src/transaction_driver/mod.rs
@@ -31,11 +31,7 @@ use tokio::{
 use tracing::instrument;
 use transaction_submitter::*;
 
-// `validator_client_monitor` is crate-internal, but `ValidatorClientMetrics`
-// appears in the public `TransactionDriver::new` signature. Re-export it here so
-// external callers (e.g., clients implementing custom transaction drivers) have
-// a nameable path to the type; without it the public constructor would take an
-// unnameable argument.
+// `ValidatorClientMetrics` is used in public `TransactionDriver::new`
 pub use crate::validator_client_monitor::ValidatorClientMetrics;
 use crate::{
     authority_aggregator::AuthorityAggregator,

--- a/crates/iota-core/src/transaction_driver/mod.rs
+++ b/crates/iota-core/src/transaction_driver/mod.rs
@@ -31,12 +31,16 @@ use tokio::{
 use tracing::instrument;
 use transaction_submitter::*;
 
+// `validator_client_monitor` is crate-internal, but `ValidatorClientMetrics`
+// appears in the public `TransactionDriver::new` signature. Re-export it here so
+// external callers (e.g., clients implementing custom transaction drivers) have
+// a nameable path to the type; without it the public constructor would take an
+// unnameable argument.
+pub use crate::validator_client_monitor::ValidatorClientMetrics;
 use crate::{
     authority_aggregator::AuthorityAggregator,
     authority_client::AuthorityAPI,
-    validator_client_monitor::{
-        OperationFeedback, OperationType, ValidatorClientMetrics, ValidatorClientMonitor,
-    },
+    validator_client_monitor::{OperationFeedback, OperationType, ValidatorClientMonitor},
 };
 
 pub mod reconfig_observer;


### PR DESCRIPTION
# Description of change

`TransactionDriver::new` is public, but its `client_metrics: Arc<ValidatorClientMetrics>` parameter names a type that became unreachable outside the crate when #11007 changed the `validator_client_monitor` module to `pub(crate) mod`. The `ValidatorClientMetrics` type is declared `pub`, but its only path ran through the now crate-private module, so external callers (e.g., clients implementing their own transaction drivers) could not name the argument to call the `TransactionDriver::new` constructor.

This PR re-exports `ValidatorClientMetrics` from `transaction_driver`, giving it a public path (`iota_core::transaction_driver::ValidatorClientMetrics`) co-located with the constructor that requires it. This mirrors the existing `quorum_driver` pattern, where `QuorumDriverMetrics` is re-exported publicly next to `QuorumDriverHandlerBuilder::new` while the module internals stay private.

The genuinely internal types (`ValidatorClientMonitor`, `OperationType`, `OperationFeedback`) in the `validator_client_monitor` module stay crate-private. 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes