### PR TITLE
feat(core): replace `full_checkpoint_content` table with a size-bounded in-memory cache

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -46,6 +46,9 @@ pub const DEFAULT_VALIDATOR_GAS_PRICE: u64 = iota_types::transaction::DEFAULT_VA
 /// Default commission rate of 2%
 pub const DEFAULT_COMMISSION_RATE: u64 = 200;
 
+/// Default budget in MiB for the in-memory full-checkpoint-contents cache.
+pub const DEFAULT_FULL_CHECKPOINT_CONTENTS_CACHE_SIZE_MB: usize = 1024;
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct NodeConfig {
@@ -226,6 +229,15 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub execution_cache_config: ExecutionCacheConfig,
+
+    /// Approximate memory budget in MiB for the in-memory cache of full
+    /// checkpoint contents, which serves the checkpoint executor's bulk
+    /// transaction loads and checkpoint-contents requests from state-sync
+    /// peers. When the budget is exceeded, the oldest checkpoints are evicted
+    /// first. Set to 0 to disable the cache; consumers then fall back to
+    /// reconstructing contents from the transaction and effects stores.
+    #[serde(default = "default_full_checkpoint_contents_cache_size_mb")]
+    pub full_checkpoint_contents_cache_size_mb: usize,
 
     #[serde(default = "bool_true")]
     pub enable_validator_tx_finalizer: bool,
@@ -679,6 +691,10 @@ pub fn default_concurrency_limit() -> Option<usize> {
 
 pub fn default_end_of_epoch_broadcast_channel_capacity() -> usize {
     128
+}
+
+pub fn default_full_checkpoint_contents_cache_size_mb() -> usize {
+    DEFAULT_FULL_CHECKPOINT_CONTENTS_CACHE_SIZE_MB
 }
 
 pub fn bool_true() -> bool {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -230,12 +230,16 @@ pub struct NodeConfig {
     #[serde(default)]
     pub execution_cache_config: ExecutionCacheConfig,
 
-    /// Approximate memory budget in MiB for the in-memory cache of full
-    /// checkpoint contents, which serves the checkpoint executor's bulk
-    /// transaction loads and checkpoint-contents requests from state-sync
-    /// peers. When the budget is exceeded, the oldest checkpoints are evicted
-    /// first. Set to 0 to disable the cache; consumers then fall back to
+    /// Memory budget in MiB for the in-memory cache of full checkpoint
+    /// contents, which serves the checkpoint executor's bulk transaction
+    /// loads and checkpoint-contents requests from state-sync peers. When
+    /// the budget is exceeded, the oldest checkpoints are evicted first.
+    /// Set to 0 to disable the cache; consumers then fall back to
     /// reconstructing contents from the transaction and effects stores.
+    ///
+    /// The budget is accounted in serialized (BCS) bytes; the resident
+    /// memory of a full cache is somewhat higher than the configured value
+    /// due to in-memory representation overhead.
     #[serde(default = "default_full_checkpoint_contents_cache_size_mb")]
     pub full_checkpoint_contents_cache_size_mb: usize,
 

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -302,10 +302,6 @@ impl AuthorityStorePruner {
             checkpoint_content_to_prune.iter().map(|ckpt| ckpt.digest());
         checkpoints_batch.delete_batch(
             &checkpoint_db.tables.checkpoint_content,
-            checkpoint_content_digests.clone(),
-        )?;
-        checkpoints_batch.delete_batch(
-            &checkpoint_db.tables.checkpoint_sequence_by_contents_digest,
             checkpoint_content_digests,
         )?;
 

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -724,7 +724,6 @@ impl CheckpointExecutor {
             .get_full_checkpoint_contents_by_sequence_number(seq)
             .tap_some(|_| debug!("loaded full checkpoint contents in bulk for sequence {seq}"))
         {
-            let full_contents = full_contents.as_ref().clone();
             let num_txns = full_contents.size();
             let mut tx_digests = Vec::with_capacity(num_txns);
             let mut transactions = Vec::with_capacity(num_txns);
@@ -732,7 +731,7 @@ impl CheckpointExecutor {
             let mut fx_digests = Vec::with_capacity(num_txns);
 
             full_contents
-                .into_iter()
+                .iter()
                 .zip(checkpoint_contents.iter())
                 .for_each(|(execution_data, digests)| {
                     let tx_digest = digests.transaction;
@@ -742,11 +741,11 @@ impl CheckpointExecutor {
 
                     tx_digests.push(tx_digest);
                     transactions.push(VerifiedExecutableTransaction::new_from_checkpoint(
-                        VerifiedTransaction::new_unchecked(execution_data.transaction),
+                        VerifiedTransaction::new_unchecked(execution_data.transaction.clone()),
                         epoch,
                         seq,
                     ));
-                    effects.push(execution_data.effects);
+                    effects.push(execution_data.effects.clone());
                     fx_digests.push(fx_digest);
                 });
 

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -29,14 +29,14 @@ use iota_config::node::{CheckpointExecutorConfig, RunWithRange};
 use iota_macros::fail_point;
 use iota_sdk_types::{RandomnessRound, TransactionKind};
 use iota_types::{
-    base_types::{TransactionDigest, TransactionEffectsDigest},
+    base_types::{ExecutionData, TransactionDigest, TransactionEffectsDigest},
     effects::{TransactionEffects, TransactionEffectsAPI},
     executable_transaction::VerifiedExecutableTransaction,
     full_checkpoint_content::CheckpointData,
     global_state_hash::GlobalStateHash,
     messages_checkpoint::{
         CheckpointContents, CheckpointContentsExt, CheckpointSequenceNumber, CheckpointSummaryExt,
-        VerifiedCheckpoint,
+        FullCheckpointContents, VerifiedCheckpoint,
     },
     transaction::{TransactionDataAPI, TransactionKey, VerifiedTransaction},
 };
@@ -774,7 +774,7 @@ impl CheckpointExecutor {
 
             let (tx_digests, fx_digests): (Vec<_>, Vec<_>) =
                 digests.iter().map(|d| (d.transaction, d.effects)).unzip();
-            let transactions = self
+            let verified_transactions: Vec<VerifiedTransaction> = self
                 .transaction_cache_reader
                 .multi_get_transaction_blocks(&tx_digests)
                 .into_iter()
@@ -782,11 +782,10 @@ impl CheckpointExecutor {
                 .map(|(i, tx)| {
                     let tx = tx
                         .unwrap_or_else(|| fatal!("transaction not found for {:?}", tx_digests[i]));
-                    let tx = Arc::try_unwrap(tx).unwrap_or_else(|tx| (*tx).clone());
-                    VerifiedExecutableTransaction::new_from_checkpoint(tx, epoch, seq)
+                    Arc::try_unwrap(tx).unwrap_or_else(|tx| (*tx).clone())
                 })
                 .collect();
-            let effects = self
+            let effects: Vec<TransactionEffects> = self
                 .transaction_cache_reader
                 .multi_get_effects(&fx_digests)
                 .into_iter()
@@ -796,6 +795,28 @@ impl CheckpointExecutor {
                         fatal!("checkpoint effect not found for {:?}", digests[i])
                     })
                 })
+                .collect();
+
+            // Landing here means the contents were not synced via state sync
+            // but produced locally (or the cache entry was evicted). Cache the
+            // assembled contents so state-sync peers — e.g. a validator's
+            // SSFNs — are served the freshest checkpoints without
+            // reconstruction, speeding up checkpoint propagation.
+            let execution_data = verified_transactions
+                .iter()
+                .zip(effects.iter())
+                .map(|(tx, fx)| ExecutionData::new(tx.clone().into_inner(), fx.clone()));
+            let full_contents = FullCheckpointContents::from_contents_and_execution_data(
+                checkpoint_contents.clone(),
+                execution_data,
+            );
+            self.checkpoint_store
+                .cache_full_checkpoint_contents(&checkpoint, full_contents)
+                .expect("failed to serialize full checkpoint contents");
+
+            let transactions = verified_transactions
+                .into_iter()
+                .map(|tx| VerifiedExecutableTransaction::new_from_checkpoint(tx, epoch, seq))
                 .collect();
 
             let executed_fx_digests = self

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -798,15 +798,12 @@ impl CheckpointExecutor {
 
             // Landing here means the contents were not synced via state sync
             // but produced locally (or the cache entry was evicted). Cache the
-            // assembled contents so state-sync peers — e.g. a validator's
-            // SSFNs — are served the freshest checkpoints without
-            // reconstruction, speeding up checkpoint propagation.
+            // assembled contents so state-sync peers are served the freshest
+            // checkpoints without reconstruction, speeding up checkpoint
+            // propagation.
             //
             // The assembly clones every transaction and effect, so skip it
-            // when the cache wouldn't retain the entry: cache disabled, or
-            // deep catch-up, where the cache window rides the state-sync
-            // frontier far ahead of the executor and would evict this entry
-            // immediately.
+            // when the cache wouldn't retain the entry (see `should_cache`).
             if self
                 .checkpoint_store
                 .should_cache_full_checkpoint_contents(seq)

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -820,8 +820,7 @@ impl CheckpointExecutor {
                     execution_data,
                 );
                 self.checkpoint_store
-                    .cache_full_checkpoint_contents(&checkpoint, full_contents)
-                    .expect("failed to serialize full checkpoint contents");
+                    .cache_full_checkpoint_contents(&checkpoint, full_contents);
             }
 
             let transactions = verified_transactions

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -802,17 +802,28 @@ impl CheckpointExecutor {
             // assembled contents so state-sync peers — e.g. a validator's
             // SSFNs — are served the freshest checkpoints without
             // reconstruction, speeding up checkpoint propagation.
-            let execution_data = verified_transactions
-                .iter()
-                .zip(effects.iter())
-                .map(|(tx, fx)| ExecutionData::new(tx.clone().into_inner(), fx.clone()));
-            let full_contents = FullCheckpointContents::from_contents_and_execution_data(
-                checkpoint_contents.clone(),
-                execution_data,
-            );
-            self.checkpoint_store
-                .cache_full_checkpoint_contents(&checkpoint, full_contents)
-                .expect("failed to serialize full checkpoint contents");
+            //
+            // The assembly clones every transaction and effect, so skip it
+            // when the cache wouldn't retain the entry: cache disabled, or
+            // deep catch-up, where the cache window rides the state-sync
+            // frontier far ahead of the executor and would evict this entry
+            // immediately.
+            if self
+                .checkpoint_store
+                .should_cache_full_checkpoint_contents(seq)
+            {
+                let execution_data = verified_transactions
+                    .iter()
+                    .zip(effects.iter())
+                    .map(|(tx, fx)| ExecutionData::new(tx.clone().into_inner(), fx.clone()));
+                let full_contents = FullCheckpointContents::from_contents_and_execution_data(
+                    checkpoint_contents.clone(),
+                    execution_data,
+                );
+                self.checkpoint_store
+                    .cache_full_checkpoint_contents(&checkpoint, full_contents)
+                    .expect("failed to serialize full checkpoint contents");
+            }
 
             let transactions = verified_transactions
                 .into_iter()

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -722,9 +722,9 @@ impl CheckpointExecutor {
         if let Some(full_contents) = self
             .checkpoint_store
             .get_full_checkpoint_contents_by_sequence_number(seq)
-            .expect("Failed to get checkpoint contents from store")
             .tap_some(|_| debug!("loaded full checkpoint contents in bulk for sequence {seq}"))
         {
+            let full_contents = full_contents.as_ref().clone();
             let num_txns = full_contents.size();
             let mut tx_digests = Vec::with_capacity(num_txns);
             let mut transactions = Vec::with_capacity(num_txns);
@@ -929,8 +929,7 @@ impl CheckpointExecutor {
             .await;
     }
 
-    // Increment the highest executed checkpoint watermark and prune old
-    // full-checkpoint contents
+    // Increment the highest executed checkpoint watermark
     #[instrument(level = "debug", skip_all)]
     fn bump_highest_executed_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
         // Ensure that we are not skipping checkpoints at any point
@@ -946,35 +945,6 @@ impl CheckpointExecutor {
             assert_eq!(seq, 0);
         }
         fail_point!("highest-executed-checkpoint");
-
-        // We store a fixed number of additional FullCheckpointContents after execution
-        // is complete for use in state sync.
-        const NUM_SAVED_FULL_CHECKPOINT_CONTENTS: u64 = 5_000;
-        if seq >= NUM_SAVED_FULL_CHECKPOINT_CONTENTS {
-            let prune_seq = seq - NUM_SAVED_FULL_CHECKPOINT_CONTENTS;
-            if let Some(prune_checkpoint) = self
-                .checkpoint_store
-                .get_checkpoint_by_sequence_number(prune_seq)
-                .expect("Failed to fetch checkpoint")
-            {
-                self.checkpoint_store
-                    .delete_full_checkpoint_contents(prune_seq)
-                    .expect("Failed to delete full checkpoint contents");
-                self.checkpoint_store
-                    .delete_contents_digest_sequence_number_mapping(
-                        &prune_checkpoint.content_digest,
-                    )
-                    .expect("Failed to delete contents digest -> sequence number mapping");
-            } else {
-                // If this is directly after a snapshot restore with skiplisting,
-                // this is expected for the first `NUM_SAVED_FULL_CHECKPOINT_CONTENTS`
-                // checkpoints.
-                debug!(
-                    "Failed to fetch checkpoint with sequence number {:?}",
-                    prune_seq
-                );
-            }
-        }
 
         self.checkpoint_store
             .update_highest_executed_checkpoint(checkpoint)

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -796,11 +796,11 @@ impl CheckpointExecutor {
                 })
                 .collect();
 
-            // Landing here means the contents were not synced via state sync
-            // but produced locally (or the cache entry was evicted). Cache the
-            // assembled contents so state-sync peers are served the freshest
-            // checkpoints without reconstruction, speeding up checkpoint
-            // propagation.
+            // Reached when the contents were not already cached: a fullnode
+            // syncing from a peer, or a node catching up. Cache the assembled
+            // contents so this node can in turn serve state-sync peers without
+            // reconstruction. (Validators' locally built checkpoints are cached
+            // by the checkpoint builder and take the bulk path above instead.)
             //
             // The assembly clones every transaction and effect, so skip it
             // when the cache wouldn't retain the entry (see `should_cache`).
@@ -816,8 +816,11 @@ impl CheckpointExecutor {
                     checkpoint_contents.clone(),
                     execution_data,
                 );
-                self.checkpoint_store
-                    .cache_full_checkpoint_contents(&checkpoint, full_contents);
+                self.checkpoint_store.cache_full_checkpoint_contents(
+                    seq,
+                    checkpoint.content_digest,
+                    full_contents,
+                );
             }
 
             let transactions = verified_transactions

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -113,7 +113,11 @@ pub async fn test_fallback_load_skips_contents_cache_below_window() {
     let frontier_seq = 10_000;
     let frontier_contents = FullCheckpointContents::random_for_testing();
     let frontier_checkpoint = test_checkpoint_with_contents(frontier_seq, &frontier_contents);
-    checkpoint_store.cache_full_checkpoint_contents(&frontier_checkpoint, frontier_contents);
+    checkpoint_store.cache_full_checkpoint_contents(
+        frontier_checkpoint.sequence_number(),
+        frontier_checkpoint.content_digest,
+        frontier_contents,
+    );
 
     let checkpoint = sync_new_checkpoints(&checkpoint_store, 1, None, &committee)
         .pop()

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -27,7 +27,7 @@ use crate::{
         test_authority_builder::TestAuthorityBuilder,
     },
     checkpoints::{
-        CheckpointStore, FullCheckpointContentsCache, FullContentsCacheMetrics,
+        CheckpointStore, FullCheckpointContentsCache, FullCheckpointContentsCacheMetrics,
         test_checkpoint_with_contents,
     },
     global_state_hasher::GlobalStateHasher,
@@ -77,7 +77,7 @@ pub async fn test_fallback_load_skips_contents_cache_when_disabled() {
     let tmp_dir = iota_common::tempdir();
     let checkpoint_store = CheckpointStore::new_with_contents_cache(
         tmp_dir.path(),
-        FullCheckpointContentsCache::new(0, FullContentsCacheMetrics::new_for_tests()),
+        FullCheckpointContentsCache::new(0, FullCheckpointContentsCacheMetrics::new_for_tests()),
     );
     let (_state, executor, _hasher, committee) = init_executor_test(checkpoint_store.clone()).await;
 
@@ -105,7 +105,7 @@ pub async fn test_fallback_load_skips_contents_cache_below_window() {
         tmp_dir.path(),
         // A 1-byte budget any real entry exceeds, so the cache is at budget
         // as soon as the frontier entry below lands.
-        FullCheckpointContentsCache::new(1, FullContentsCacheMetrics::new_for_tests()),
+        FullCheckpointContentsCache::new(1, FullCheckpointContentsCacheMetrics::new_for_tests()),
     );
     let (_state, executor, _hasher, committee) = init_executor_test(checkpoint_store.clone()).await;
 

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -10,11 +10,9 @@ use iota_sdk_types::{CheckpointCommitment, gas::GasCostSummary};
 use iota_swarm_config::test_utils::{CommitteeFixture, empty_contents};
 use iota_types::{
     committee::ProtocolVersion,
-    crypto::AuthorityStrongQuorumSignInfo,
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemState,
     messages_checkpoint::{
-        CheckpointSummary, ECMHLiveObjectSetDigest, EndOfEpochData, VerifiedCheckpoint,
-        VerifiedCheckpointContents,
+        ECMHLiveObjectSetDigest, EndOfEpochData, VerifiedCheckpoint, VerifiedCheckpointContents,
     },
     supported_protocol_versions::SupportedProtocolVersions,
 };
@@ -28,7 +26,10 @@ use crate::{
         epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
         test_authority_builder::TestAuthorityBuilder,
     },
-    checkpoints::{CheckpointStore, FullCheckpointContentsCache, FullContentsCacheMetrics},
+    checkpoints::{
+        CheckpointStore, FullCheckpointContentsCache, FullContentsCacheMetrics,
+        test_checkpoint_with_contents,
+    },
     global_state_hasher::GlobalStateHasher,
 };
 
@@ -60,7 +61,7 @@ pub async fn test_fallback_load_populates_contents_cache() {
         .expect("fallback load should populate the contents cache");
     assert_eq!(
         cached.checkpoint_contents().digest(),
-        &checkpoint.content_digest
+        checkpoint.content_digest
     );
     // The peer-serving lookup by contents digest must hit too.
     assert!(
@@ -111,7 +112,7 @@ pub async fn test_fallback_load_skips_contents_cache_below_window() {
     // Simulate the state-sync frontier far ahead of the executor.
     let frontier_seq = 10_000;
     let frontier_contents = FullCheckpointContents::random_for_testing();
-    let frontier_checkpoint = fabricated_checkpoint(frontier_seq, &frontier_contents);
+    let frontier_checkpoint = test_checkpoint_with_contents(frontier_seq, &frontier_contents);
     checkpoint_store.cache_full_checkpoint_contents(&frontier_checkpoint, frontier_contents);
 
     let checkpoint = sync_new_checkpoints(&checkpoint_store, 1, None, &committee)
@@ -131,35 +132,6 @@ pub async fn test_fallback_load_skips_contents_cache_below_window() {
             .get_full_checkpoint_contents_by_sequence_number(frontier_seq)
             .is_some()
     );
-}
-
-/// A verified checkpoint over the given contents, with a placeholder
-/// signature; usable wherever verification is not re-run.
-fn fabricated_checkpoint(
-    sequence_number: CheckpointSequenceNumber,
-    full_contents: &FullCheckpointContents,
-) -> VerifiedCheckpoint {
-    let contents = full_contents.checkpoint_contents();
-    let summary = CheckpointSummary {
-        epoch: 0,
-        sequence_number,
-        network_total_transactions: 0,
-        content_digest: *contents.digest(),
-        previous_digest: None,
-        epoch_rolling_gas_cost_summary: Default::default(),
-        end_of_epoch_data: None,
-        timestamp_ms: 0,
-        version_specific_data: Vec::new(),
-        checkpoint_commitments: Vec::new(),
-    };
-    let sig = AuthorityStrongQuorumSignInfo {
-        epoch: 0,
-        signature: Default::default(),
-        signers_map: Default::default(),
-    };
-    VerifiedCheckpoint::new_unchecked(
-        iota_types::message_envelope::Envelope::new_from_data_and_sig(summary, sig),
-    )
 }
 
 /// Test checkpoint executor happy path, test that checkpoint executor correctly

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -10,9 +10,11 @@ use iota_sdk_types::{CheckpointCommitment, gas::GasCostSummary};
 use iota_swarm_config::test_utils::{CommitteeFixture, empty_contents};
 use iota_types::{
     committee::ProtocolVersion,
+    crypto::AuthorityStrongQuorumSignInfo,
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemState,
     messages_checkpoint::{
-        ECMHLiveObjectSetDigest, EndOfEpochData, VerifiedCheckpoint, VerifiedCheckpointContents,
+        CheckpointSummary, ECMHLiveObjectSetDigest, EndOfEpochData, VerifiedCheckpoint,
+        VerifiedCheckpointContents,
     },
     supported_protocol_versions::SupportedProtocolVersions,
 };
@@ -26,9 +28,139 @@ use crate::{
         epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
         test_authority_builder::TestAuthorityBuilder,
     },
-    checkpoints::CheckpointStore,
+    checkpoints::{CheckpointStore, FullCheckpointContentsCache, FullContentsCacheMetrics},
     global_state_hasher::GlobalStateHasher,
 };
+
+/// The fallback (per-item) load path runs when contents were not synced via
+/// state sync — the validator case. It must populate the contents cache so
+/// state-sync peers can be served without reconstruction.
+#[tokio::test]
+pub async fn test_fallback_load_populates_contents_cache() {
+    let tmp_dir = iota_common::tempdir();
+    let checkpoint_store = CheckpointStore::new(tmp_dir.path());
+    let (_state, executor, _hasher, committee) = init_executor_test(checkpoint_store.clone()).await;
+
+    // sync_new_checkpoints persists only the digest-form contents, like a
+    // validator's checkpoint builder, so the executor takes the fallback path.
+    let checkpoint = sync_new_checkpoints(&checkpoint_store, 1, None, &committee)
+        .pop()
+        .unwrap();
+    let seq = checkpoint.sequence_number();
+    assert!(
+        checkpoint_store
+            .get_full_checkpoint_contents_by_sequence_number(seq)
+            .is_none()
+    );
+
+    executor.load_checkpoint_transactions(checkpoint.clone());
+
+    let cached = checkpoint_store
+        .get_full_checkpoint_contents_by_sequence_number(seq)
+        .expect("fallback load should populate the contents cache");
+    assert_eq!(
+        cached.checkpoint_contents().digest(),
+        &checkpoint.content_digest
+    );
+    // The peer-serving lookup by contents digest must hit too.
+    assert!(
+        checkpoint_store
+            .get_full_checkpoint_contents_by_digest(&checkpoint.content_digest)
+            .is_some()
+    );
+}
+
+/// With the cache disabled (budget 0), the fallback load must not populate it.
+#[tokio::test]
+pub async fn test_fallback_load_skips_contents_cache_when_disabled() {
+    let tmp_dir = iota_common::tempdir();
+    let checkpoint_store = CheckpointStore::new_with_contents_cache(
+        tmp_dir.path(),
+        FullCheckpointContentsCache::new(0, FullContentsCacheMetrics::new_for_tests()),
+    );
+    let (_state, executor, _hasher, committee) = init_executor_test(checkpoint_store.clone()).await;
+
+    let checkpoint = sync_new_checkpoints(&checkpoint_store, 1, None, &committee)
+        .pop()
+        .unwrap();
+    let seq = checkpoint.sequence_number();
+
+    executor.load_checkpoint_transactions(checkpoint);
+
+    assert!(
+        checkpoint_store
+            .get_full_checkpoint_contents_by_sequence_number(seq)
+            .is_none()
+    );
+}
+
+/// During deep catch-up the cache window rides the state-sync frontier far
+/// ahead of the executor; the fallback load must not displace it with entries
+/// that lowest-seq eviction would remove immediately.
+#[tokio::test]
+pub async fn test_fallback_load_skips_contents_cache_below_window() {
+    let tmp_dir = iota_common::tempdir();
+    let checkpoint_store = CheckpointStore::new_with_contents_cache(
+        tmp_dir.path(),
+        // A 1-byte budget any real entry exceeds, so the cache is at budget
+        // as soon as the frontier entry below lands.
+        FullCheckpointContentsCache::new(1, FullContentsCacheMetrics::new_for_tests()),
+    );
+    let (_state, executor, _hasher, committee) = init_executor_test(checkpoint_store.clone()).await;
+
+    // Simulate the state-sync frontier far ahead of the executor.
+    let frontier_seq = 10_000;
+    let frontier_contents = FullCheckpointContents::random_for_testing();
+    let frontier_checkpoint = fabricated_checkpoint(frontier_seq, &frontier_contents);
+    checkpoint_store.cache_full_checkpoint_contents(&frontier_checkpoint, frontier_contents);
+
+    let checkpoint = sync_new_checkpoints(&checkpoint_store, 1, None, &committee)
+        .pop()
+        .unwrap();
+    let seq = checkpoint.sequence_number();
+
+    executor.load_checkpoint_transactions(checkpoint);
+
+    assert!(
+        checkpoint_store
+            .get_full_checkpoint_contents_by_sequence_number(seq)
+            .is_none()
+    );
+    assert!(
+        checkpoint_store
+            .get_full_checkpoint_contents_by_sequence_number(frontier_seq)
+            .is_some()
+    );
+}
+
+/// A verified checkpoint over the given contents, with a placeholder
+/// signature; usable wherever verification is not re-run.
+fn fabricated_checkpoint(
+    sequence_number: CheckpointSequenceNumber,
+    full_contents: &FullCheckpointContents,
+) -> VerifiedCheckpoint {
+    let contents = full_contents.checkpoint_contents();
+    let summary = CheckpointSummary {
+        epoch: 0,
+        sequence_number,
+        network_total_transactions: 0,
+        content_digest: *contents.digest(),
+        previous_digest: None,
+        epoch_rolling_gas_cost_summary: Default::default(),
+        end_of_epoch_data: None,
+        timestamp_ms: 0,
+        version_specific_data: Vec::new(),
+        checkpoint_commitments: Vec::new(),
+    };
+    let sig = AuthorityStrongQuorumSignInfo {
+        epoch: 0,
+        signature: Default::default(),
+        signers_map: Default::default(),
+    };
+    VerifiedCheckpoint::new_unchecked(
+        iota_types::message_envelope::Envelope::new_from_data_and_sig(summary, sig),
+    )
+}
 
 /// Test checkpoint executor happy path, test that checkpoint executor correctly
 /// picks up where it left off in the event of a mid-epoch node crash.

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -99,6 +99,22 @@ struct Inner {
     total_bytes: usize,
 }
 
+impl Inner {
+    /// Removes the digest mapping of an entry leaving `by_seq`, unless the
+    /// mapping points to a different sequence number: distinct checkpoints
+    /// can share a contents digest (e.g. consecutive empty checkpoints), and
+    /// the mapping must keep serving the entry that is still cached.
+    fn remove_digest_mapping(
+        &mut self,
+        digest: &CheckpointContentsDigest,
+        seq: CheckpointSequenceNumber,
+    ) {
+        if self.seq_by_digest.get(digest) == Some(&seq) {
+            self.seq_by_digest.remove(digest);
+        }
+    }
+}
+
 /// A size-bounded in-memory cache of [`FullCheckpointContents`], keyed by
 /// checkpoint sequence number with a secondary contents-digest index.
 ///
@@ -200,15 +216,15 @@ impl FullCheckpointContentsCache {
             },
         ) {
             inner.total_bytes -= old.bytes;
-            inner.seq_by_digest.remove(&old.digest);
+            inner.remove_digest_mapping(&old.digest, seq);
         }
         inner.total_bytes += bytes;
         inner.seq_by_digest.insert(digest, seq);
 
         while inner.total_bytes > self.max_bytes && inner.by_seq.len() > 1 {
-            let (_, evicted) = inner.by_seq.pop_first().expect("cache is not empty");
+            let (evicted_seq, evicted) = inner.by_seq.pop_first().expect("cache is not empty");
             inner.total_bytes -= evicted.bytes;
-            inner.seq_by_digest.remove(&evicted.digest);
+            inner.remove_digest_mapping(&evicted.digest, evicted_seq);
             self.metrics.evictions.inc();
         }
 
@@ -361,6 +377,26 @@ mod tests {
         ));
         assert_eq!(cache.metrics.total_bytes.get(), 60);
         assert_eq!(cache.metrics.entries.get(), 1);
+    }
+
+    #[test]
+    fn eviction_keeps_digest_mapping_of_newer_entry_with_same_digest() {
+        let cache =
+            FullCheckpointContentsCache::new(250, FullContentsCacheMetrics::new_for_tests());
+        // Distinct checkpoints can share a contents digest, e.g. consecutive
+        // empty checkpoints.
+        let (digest, contents) = entry(1);
+        cache.insert(0, digest, contents.clone(), 100);
+        cache.insert(1, digest, contents, 100);
+
+        // Push seq 0 out of the window.
+        let (digest_b, contents_b) = entry(2);
+        cache.insert(2, digest_b, contents_b, 100);
+
+        assert!(cache.get_by_seq(0).is_none());
+        assert!(cache.get_by_seq(1).is_some());
+        // The digest lookup must keep serving the still-cached seq 1.
+        assert!(cache.get_by_digest(&digest).is_some());
     }
 
     #[test]

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -115,6 +115,9 @@ struct Inner {
 /// are skipped, since eviction would remove them immediately. A single entry
 /// larger than the whole budget is still cached until the next insert
 /// displaces it. A budget of zero disables the cache entirely.
+///
+/// The budget is accounted in serialized (BCS) bytes — the resident heap
+/// footprint of a full cache is somewhat higher than the budget.
 pub struct FullCheckpointContentsCache {
     max_bytes: usize,
     metrics: Arc<FullContentsCacheMetrics>,

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -1,0 +1,303 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+
+use iota_config::node::DEFAULT_FULL_CHECKPOINT_CONTENTS_CACHE_SIZE_MB;
+use iota_types::{
+    digests::CheckpointContentsDigest,
+    messages_checkpoint::{CheckpointSequenceNumber, FullCheckpointContents},
+};
+use parking_lot::Mutex;
+use prometheus_filtered::{
+    IntCounter, IntGauge, Registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry,
+};
+
+pub struct FullContentsCacheMetrics {
+    pub hits: IntCounter,
+    pub misses: IntCounter,
+    pub evictions: IntCounter,
+    pub entries: IntGauge,
+    pub total_bytes: IntGauge,
+}
+
+impl FullContentsCacheMetrics {
+    pub fn new(registry: &Registry) -> Arc<Self> {
+        Arc::new(Self {
+            hits: register_int_counter_with_registry!(
+                "full_checkpoint_contents_cache_hits",
+                "Number of full-checkpoint-contents cache lookups served from the cache",
+                registry
+            )
+            .unwrap(),
+            misses: register_int_counter_with_registry!(
+                "full_checkpoint_contents_cache_misses",
+                "Number of full-checkpoint-contents cache lookups that missed the cache",
+                registry
+            )
+            .unwrap(),
+            evictions: register_int_counter_with_registry!(
+                "full_checkpoint_contents_cache_evictions",
+                "Number of entries evicted from the full-checkpoint-contents cache",
+                registry
+            )
+            .unwrap(),
+            entries: register_int_gauge_with_registry!(
+                "full_checkpoint_contents_cache_entries",
+                "Number of entries currently held in the full-checkpoint-contents cache",
+                registry
+            )
+            .unwrap(),
+            total_bytes: register_int_gauge_with_registry!(
+                "full_checkpoint_contents_cache_bytes",
+                "Approximate serialized size of the full-checkpoint-contents cache in bytes",
+                registry
+            )
+            .unwrap(),
+        })
+    }
+
+    pub fn new_for_tests() -> Arc<Self> {
+        Self::new(&Registry::new())
+    }
+}
+
+struct CacheEntry {
+    digest: CheckpointContentsDigest,
+    contents: Arc<FullCheckpointContents>,
+    bytes: usize,
+}
+
+#[derive(Default)]
+struct Inner {
+    by_seq: BTreeMap<CheckpointSequenceNumber, CacheEntry>,
+    seq_by_digest: HashMap<CheckpointContentsDigest, CheckpointSequenceNumber>,
+    total_bytes: usize,
+}
+
+/// A size-bounded in-memory cache of [`FullCheckpointContents`], keyed by
+/// checkpoint sequence number with a secondary contents-digest index.
+///
+/// This replaces the former `full_checkpoint_content` RocksDB table as the
+/// fast path for the checkpoint executor's bulk transaction load and for
+/// serving checkpoint contents to state-sync peers. All consumers have
+/// fallbacks that reconstruct the contents from the permanent stores, so
+/// entries can be evicted (or the cache disabled with a zero budget) without
+/// affecting correctness.
+///
+/// When the byte budget is exceeded, entries with the lowest sequence numbers
+/// are evicted first, keeping the newest window of checkpoints — the ones
+/// tip-following peers request. A single entry larger than the whole budget is
+/// still cached until the next insert displaces it. A budget of zero disables
+/// the cache entirely.
+pub struct FullCheckpointContentsCache {
+    max_bytes: usize,
+    metrics: Arc<FullContentsCacheMetrics>,
+    inner: Mutex<Inner>,
+}
+
+impl Default for FullCheckpointContentsCache {
+    /// A cache with the default byte budget and unregistered metrics, for
+    /// contexts without a node config or metrics registry (tools, tests).
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_FULL_CHECKPOINT_CONTENTS_CACHE_SIZE_MB * 1024 * 1024,
+            FullContentsCacheMetrics::new_for_tests(),
+        )
+    }
+}
+
+impl FullCheckpointContentsCache {
+    pub fn new(max_bytes: usize, metrics: Arc<FullContentsCacheMetrics>) -> Self {
+        Self {
+            max_bytes,
+            metrics,
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    /// Inserts the contents for a checkpoint and evicts the lowest sequence
+    /// numbers until the cache fits its byte budget again.
+    pub fn insert(
+        &self,
+        seq: CheckpointSequenceNumber,
+        digest: CheckpointContentsDigest,
+        contents: Arc<FullCheckpointContents>,
+        bytes: usize,
+    ) {
+        if self.max_bytes == 0 {
+            return;
+        }
+        let mut inner = self.inner.lock();
+
+        if let Some(old) = inner.by_seq.insert(
+            seq,
+            CacheEntry {
+                digest,
+                contents,
+                bytes,
+            },
+        ) {
+            inner.total_bytes -= old.bytes;
+            inner.seq_by_digest.remove(&old.digest);
+        }
+        inner.total_bytes += bytes;
+        inner.seq_by_digest.insert(digest, seq);
+
+        while inner.total_bytes > self.max_bytes && inner.by_seq.len() > 1 {
+            let (_, evicted) = inner.by_seq.pop_first().expect("cache is not empty");
+            inner.total_bytes -= evicted.bytes;
+            inner.seq_by_digest.remove(&evicted.digest);
+            self.metrics.evictions.inc();
+        }
+
+        self.metrics.entries.set(inner.by_seq.len() as i64);
+        self.metrics.total_bytes.set(inner.total_bytes as i64);
+    }
+
+    pub fn get_by_seq(&self, seq: CheckpointSequenceNumber) -> Option<Arc<FullCheckpointContents>> {
+        let contents = self
+            .inner
+            .lock()
+            .by_seq
+            .get(&seq)
+            .map(|entry| entry.contents.clone());
+        self.record_lookup(contents.is_some());
+        contents
+    }
+
+    pub fn get_by_digest(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<Arc<FullCheckpointContents>> {
+        let inner = self.inner.lock();
+        let contents = inner
+            .seq_by_digest
+            .get(digest)
+            .and_then(|seq| inner.by_seq.get(seq))
+            .map(|entry| entry.contents.clone());
+        drop(inner);
+        self.record_lookup(contents.is_some());
+        contents
+    }
+
+    fn record_lookup(&self, hit: bool) {
+        if hit {
+            self.metrics.hits.inc();
+        } else {
+            self.metrics.misses.inc();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(seed: u8) -> (CheckpointContentsDigest, Arc<FullCheckpointContents>) {
+        let contents = FullCheckpointContents::random_for_testing();
+        (
+            CheckpointContentsDigest::new([seed; 32]),
+            Arc::new(contents),
+        )
+    }
+
+    #[test]
+    fn insert_and_get_by_seq_and_digest() {
+        let cache =
+            FullCheckpointContentsCache::new(1000, FullContentsCacheMetrics::new_for_tests());
+        let (digest, contents) = entry(1);
+        cache.insert(7, digest, contents.clone(), 100);
+
+        assert!(Arc::ptr_eq(&cache.get_by_seq(7).unwrap(), &contents));
+        assert!(Arc::ptr_eq(
+            &cache.get_by_digest(&digest).unwrap(),
+            &contents
+        ));
+        assert!(cache.get_by_seq(8).is_none());
+        assert!(
+            cache
+                .get_by_digest(&CheckpointContentsDigest::new([9; 32]))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn evicts_lowest_sequence_numbers_first() {
+        let cache =
+            FullCheckpointContentsCache::new(250, FullContentsCacheMetrics::new_for_tests());
+        for seq in 0..3 {
+            let (digest, contents) = entry(seq as u8);
+            cache.insert(seq, digest, contents, 100);
+        }
+
+        // 300 bytes exceed the 250-byte budget: seq 0 must be gone, 1 and 2 remain.
+        assert!(cache.get_by_seq(0).is_none());
+        assert!(cache.get_by_seq(1).is_some());
+        assert!(cache.get_by_seq(2).is_some());
+        assert_eq!(cache.metrics.evictions.get(), 1);
+        assert_eq!(cache.metrics.entries.get(), 2);
+        assert_eq!(cache.metrics.total_bytes.get(), 200);
+    }
+
+    #[test]
+    fn digest_index_is_consistent_after_eviction() {
+        let cache =
+            FullCheckpointContentsCache::new(150, FullContentsCacheMetrics::new_for_tests());
+        let (digest_a, contents_a) = entry(1);
+        let (digest_b, contents_b) = entry(2);
+        cache.insert(0, digest_a, contents_a, 100);
+        cache.insert(1, digest_b, contents_b, 100);
+
+        assert!(cache.get_by_digest(&digest_a).is_none());
+        assert!(cache.get_by_digest(&digest_b).is_some());
+    }
+
+    #[test]
+    fn oversized_entry_is_kept_until_displaced() {
+        let cache = FullCheckpointContentsCache::new(50, FullContentsCacheMetrics::new_for_tests());
+        let (digest_a, contents_a) = entry(1);
+        cache.insert(0, digest_a, contents_a, 100);
+
+        // A single entry may exceed the budget rather than being uncacheable.
+        assert!(cache.get_by_seq(0).is_some());
+
+        let (digest_b, contents_b) = entry(2);
+        cache.insert(1, digest_b, contents_b, 100);
+        assert!(cache.get_by_seq(0).is_none());
+        assert!(cache.get_by_seq(1).is_some());
+    }
+
+    #[test]
+    fn reinsert_same_sequence_replaces_entry_and_accounting() {
+        let cache =
+            FullCheckpointContentsCache::new(1000, FullContentsCacheMetrics::new_for_tests());
+        let (digest_a, contents_a) = entry(1);
+        let (digest_b, contents_b) = entry(2);
+        cache.insert(0, digest_a, contents_a, 100);
+        cache.insert(0, digest_b, contents_b.clone(), 60);
+
+        assert!(Arc::ptr_eq(&cache.get_by_seq(0).unwrap(), &contents_b));
+        assert!(cache.get_by_digest(&digest_a).is_none());
+        assert!(Arc::ptr_eq(
+            &cache.get_by_digest(&digest_b).unwrap(),
+            &contents_b
+        ));
+        assert_eq!(cache.metrics.total_bytes.get(), 60);
+        assert_eq!(cache.metrics.entries.get(), 1);
+    }
+
+    #[test]
+    fn zero_budget_disables_the_cache() {
+        let cache = FullCheckpointContentsCache::new(0, FullContentsCacheMetrics::new_for_tests());
+        let (digest_a, contents_a) = entry(1);
+        cache.insert(0, digest_a, contents_a, 100);
+
+        assert!(cache.get_by_seq(0).is_none());
+        assert!(cache.get_by_digest(&digest_a).is_none());
+    }
+}

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -171,9 +171,8 @@ impl FullCheckpointContentsCache {
     }
 
     /// Whether contents for `seq` are worth assembling and inserting: false
-    /// when the cache is disabled, and false when the cache is at budget and
-    /// `seq` is older than everything cached — lowest-seq eviction would
-    /// remove the entry immediately.
+    /// when the cache is disabled, and false when `seq` is older than
+    /// everything cached — lowest-seq eviction would drop the entry again.
     ///
     /// Lets callers skip the expensive contents assembly that precedes
     /// [`Self::insert`], e.g. the checkpoint executor during deep catch-up,
@@ -183,12 +182,12 @@ impl FullCheckpointContentsCache {
         if self.max_bytes == 0 {
             return false;
         }
+
         let inner = self.inner.lock();
-        inner.total_bytes < self.max_bytes
-            || inner
-                .by_seq
-                .first_key_value()
-                .is_none_or(|(lowest, _)| seq >= *lowest)
+        inner
+            .by_seq
+            .first_key_value()
+            .is_none_or(|(lowest, _)| seq >= *lowest)
     }
 
     /// Inserts the contents for a checkpoint and evicts the lowest sequence
@@ -446,38 +445,36 @@ mod tests {
     }
 
     #[test]
-    fn skips_inserts_below_the_window_of_a_full_cache() {
+    fn skips_below_window_inserts_after_eviction_under_budget() {
         let cache = FullCheckpointContentsCache::new(
-            200,
+            250,
             FullCheckpointContentsCacheMetrics::new_for_tests(),
         );
-        let (digest_a, contents_a) = entry(1);
-        let (digest_b, contents_b) = entry(2);
-        cache.insert(10, digest_a, contents_a, 100);
-        cache.insert(11, digest_b, contents_b, 100);
+        // Overflow the budget so an eviction fires and total_bytes lands
+        // strictly under budget — the realistic steady state, not the
+        // exact-at-budget edge.
+        cache.insert(10, entry(1).0, entry(1).1, 100);
+        cache.insert(11, entry(2).0, entry(2).1, 100);
+        cache.insert(12, entry(3).0, entry(3).1, 100);
+        assert!(cache.get_by_seq(10).is_none());
+        assert_eq!(cache.metrics.evictions.get(), 1);
+        assert_eq!(cache.metrics.total_bytes.get(), 200); // under the 250 budget
 
-        // At budget: entries older than the cached window would be evicted
-        // immediately, newer ones displace the window.
+        // Below the window: skipped even with headroom, since eviction would
+        // drop it again.
         assert!(!cache.should_cache(5));
-        assert!(cache.should_cache(12));
+        // In or above the window: worth caching.
+        assert!(cache.should_cache(11));
+        assert!(cache.should_cache(13));
 
-        let (digest_c, contents_c) = entry(3);
-        cache.insert(5, digest_c, contents_c, 100);
+        // insert enforces the same guard: a below-window entry that would
+        // exceed the budget is dropped without disturbing the window.
+        let (digest_e, contents_e) = entry(4);
+        cache.insert(5, digest_e, contents_e, 100);
         assert!(cache.get_by_seq(5).is_none());
-        assert!(cache.get_by_digest(&digest_c).is_none());
-        assert!(cache.get_by_seq(10).is_some());
+        assert!(cache.get_by_digest(&digest_e).is_none());
         assert!(cache.get_by_seq(11).is_some());
-        assert_eq!(cache.metrics.evictions.get(), 0);
-
-        // With byte headroom, entries below the window are retained.
-        let (digest_d, contents_d) = entry(4);
-        let roomy = FullCheckpointContentsCache::new(
-            1000,
-            FullCheckpointContentsCacheMetrics::new_for_tests(),
-        );
-        roomy.insert(10, digest_a, entry(1).1, 100);
-        assert!(roomy.should_cache(5));
-        roomy.insert(5, digest_d, contents_d, 100);
-        assert!(roomy.get_by_seq(5).is_some());
+        assert!(cache.get_by_seq(12).is_some());
+        assert_eq!(cache.metrics.evictions.get(), 1);
     }
 }

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -13,13 +13,29 @@ use iota_types::{
 };
 use parking_lot::Mutex;
 use prometheus_filtered::{
-    IntCounter, IntGauge, Registry, register_int_counter_with_registry,
-    register_int_gauge_with_registry,
+    IntCounter, IntCounterVec, IntGauge, Registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, register_int_gauge_with_registry,
 };
 
+/// Value of the `lookup` metrics label for sequence-number lookups: the
+/// checkpoint executor's bulk load and `ReadStore` reads by sequence number.
+const LOOKUP_BY_SEQ: &str = "by_seq";
+/// Value of the `lookup` metrics label for contents-digest lookups: serving
+/// checkpoint-contents requests from state-sync peers.
+const LOOKUP_BY_DIGEST: &str = "by_digest";
+
 pub struct FullContentsCacheMetrics {
-    pub hits: IntCounter,
-    pub misses: IntCounter,
+    /// Lookups served from the cache, partitioned by the `lookup` label
+    /// ([`LOOKUP_BY_SEQ`] / [`LOOKUP_BY_DIGEST`]).
+    pub hits: IntCounterVec,
+    /// Lookups that missed the cache, with the same `lookup` label split as
+    /// `hits`.
+    ///
+    /// On validators, `by_seq` misses accrue once per self-produced
+    /// checkpoint by design: the executor checks the cache before inserting
+    /// the entry it then produces. `by_digest` is the health signal for
+    /// whether peers are served from memory or fall back to reconstruction.
+    pub misses: IntCounterVec,
     pub evictions: IntCounter,
     pub entries: IntGauge,
     pub total_bytes: IntGauge,
@@ -28,15 +44,19 @@ pub struct FullContentsCacheMetrics {
 impl FullContentsCacheMetrics {
     pub fn new(registry: &Registry) -> Arc<Self> {
         Arc::new(Self {
-            hits: register_int_counter_with_registry!(
+            hits: register_int_counter_vec_with_registry!(
                 "full_checkpoint_contents_cache_hits",
-                "Number of full-checkpoint-contents cache lookups served from the cache",
+                "Number of full-checkpoint-contents cache lookups served from the cache, \
+                partitioned by lookup kind",
+                &["lookup"],
                 registry
             )
             .unwrap(),
-            misses: register_int_counter_with_registry!(
+            misses: register_int_counter_vec_with_registry!(
                 "full_checkpoint_contents_cache_misses",
-                "Number of full-checkpoint-contents cache lookups that missed the cache",
+                "Number of full-checkpoint-contents cache lookups that missed the cache, \
+                partitioned by lookup kind",
+                &["lookup"],
                 registry
             )
             .unwrap(),
@@ -159,6 +179,11 @@ impl FullCheckpointContentsCache {
         self.metrics.total_bytes.set(inner.total_bytes as i64);
     }
 
+    /// Looks up contents by sequence number.
+    ///
+    /// Recorded under the `by_seq` metrics label; see
+    /// [`FullContentsCacheMetrics::misses`] for how to interpret it per node
+    /// role.
     pub fn get_by_seq(&self, seq: CheckpointSequenceNumber) -> Option<Arc<FullCheckpointContents>> {
         let contents = self
             .inner
@@ -166,10 +191,15 @@ impl FullCheckpointContentsCache {
             .by_seq
             .get(&seq)
             .map(|entry| entry.contents.clone());
-        self.record_lookup(contents.is_some());
+        self.record_lookup(contents.is_some(), LOOKUP_BY_SEQ);
         contents
     }
 
+    /// Looks up contents by contents digest.
+    ///
+    /// Recorded under the `by_digest` metrics label; see
+    /// [`FullContentsCacheMetrics::misses`] for how to interpret it per node
+    /// role.
     pub fn get_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -181,15 +211,15 @@ impl FullCheckpointContentsCache {
             .and_then(|seq| inner.by_seq.get(seq))
             .map(|entry| entry.contents.clone());
         drop(inner);
-        self.record_lookup(contents.is_some());
+        self.record_lookup(contents.is_some(), LOOKUP_BY_DIGEST);
         contents
     }
 
-    fn record_lookup(&self, hit: bool) {
+    fn record_lookup(&self, hit: bool, lookup: &str) {
         if hit {
-            self.metrics.hits.inc();
+            self.metrics.hits.with_label_values(&[lookup]).inc();
         } else {
-            self.metrics.misses.inc();
+            self.metrics.misses.with_label_values(&[lookup]).inc();
         }
     }
 }
@@ -224,6 +254,11 @@ mod tests {
                 .get_by_digest(&CheckpointContentsDigest::new([9; 32]))
                 .is_none()
         );
+
+        for lookup in [LOOKUP_BY_SEQ, LOOKUP_BY_DIGEST] {
+            assert_eq!(cache.metrics.hits.with_label_values(&[lookup]).get(), 1);
+            assert_eq!(cache.metrics.misses.with_label_values(&[lookup]).get(), 1);
+        }
     }
 
     #[test]

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -27,7 +27,7 @@ const LOOKUP_BY_DIGEST: &str = "by_digest";
 /// The hit/miss counters are exported as `IntCounterVec`s with a `lookup`
 /// label; the per-label children are resolved once at construction so the
 /// lookup paths increment plain counters.
-pub struct FullContentsCacheMetrics {
+pub struct FullCheckpointContentsCacheMetrics {
     /// Sequence-number lookups served from the cache (`lookup="by_seq"`).
     pub hits_by_seq: IntCounter,
     /// Contents-digest lookups served from the cache (`lookup="by_digest"`).
@@ -47,7 +47,7 @@ pub struct FullContentsCacheMetrics {
     pub total_bytes: IntGauge,
 }
 
-impl FullContentsCacheMetrics {
+impl FullCheckpointContentsCacheMetrics {
     pub fn new(registry: &Registry) -> Arc<Self> {
         let hits = register_int_counter_vec_with_registry!(
             "full_checkpoint_contents_cache_hits",
@@ -146,7 +146,7 @@ impl Inner {
 /// footprint of a full cache is somewhat higher than the budget.
 pub struct FullCheckpointContentsCache {
     max_bytes: usize,
-    metrics: Arc<FullContentsCacheMetrics>,
+    metrics: Arc<FullCheckpointContentsCacheMetrics>,
     inner: Mutex<Inner>,
 }
 
@@ -156,13 +156,13 @@ impl Default for FullCheckpointContentsCache {
     fn default() -> Self {
         Self::new(
             DEFAULT_FULL_CHECKPOINT_CONTENTS_CACHE_SIZE_MB * 1024 * 1024,
-            FullContentsCacheMetrics::new_for_tests(),
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
         )
     }
 }
 
 impl FullCheckpointContentsCache {
-    pub fn new(max_bytes: usize, metrics: Arc<FullContentsCacheMetrics>) -> Self {
+    pub fn new(max_bytes: usize, metrics: Arc<FullCheckpointContentsCacheMetrics>) -> Self {
         Self {
             max_bytes,
             metrics,
@@ -253,8 +253,8 @@ impl FullCheckpointContentsCache {
     /// Looks up contents by sequence number.
     ///
     /// Recorded under the `by_seq` metrics label; see
-    /// [`FullContentsCacheMetrics::misses_by_seq`] for how to interpret it
-    /// per node role.
+    /// [`FullCheckpointContentsCacheMetrics::misses_by_seq`] for how to
+    /// interpret it per node role.
     pub fn get_by_seq(&self, seq: CheckpointSequenceNumber) -> Option<Arc<FullCheckpointContents>> {
         let contents = self
             .inner
@@ -273,8 +273,8 @@ impl FullCheckpointContentsCache {
     /// Looks up contents by contents digest.
     ///
     /// Recorded under the `by_digest` metrics label; see
-    /// [`FullContentsCacheMetrics::misses_by_digest`] for how to interpret
-    /// it per node role.
+    /// [`FullCheckpointContentsCacheMetrics::misses_by_digest`] for how to
+    /// interpret it per node role.
     pub fn get_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -309,8 +309,10 @@ mod tests {
 
     #[test]
     fn insert_and_get_by_seq_and_digest() {
-        let cache =
-            FullCheckpointContentsCache::new(1000, FullContentsCacheMetrics::new_for_tests());
+        let cache = FullCheckpointContentsCache::new(
+            1000,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         let (digest, contents) = entry(1);
         cache.insert(7, digest, contents.clone(), 100);
 
@@ -334,8 +336,10 @@ mod tests {
 
     #[test]
     fn evicts_lowest_sequence_numbers_first() {
-        let cache =
-            FullCheckpointContentsCache::new(250, FullContentsCacheMetrics::new_for_tests());
+        let cache = FullCheckpointContentsCache::new(
+            250,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         for seq in 0..3 {
             let (digest, contents) = entry(seq as u8);
             cache.insert(seq, digest, contents, 100);
@@ -352,8 +356,10 @@ mod tests {
 
     #[test]
     fn digest_index_is_consistent_after_eviction() {
-        let cache =
-            FullCheckpointContentsCache::new(150, FullContentsCacheMetrics::new_for_tests());
+        let cache = FullCheckpointContentsCache::new(
+            150,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         let (digest_a, contents_a) = entry(1);
         let (digest_b, contents_b) = entry(2);
         cache.insert(0, digest_a, contents_a, 100);
@@ -365,7 +371,10 @@ mod tests {
 
     #[test]
     fn oversized_entry_is_kept_until_displaced() {
-        let cache = FullCheckpointContentsCache::new(50, FullContentsCacheMetrics::new_for_tests());
+        let cache = FullCheckpointContentsCache::new(
+            50,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         let (digest_a, contents_a) = entry(1);
         cache.insert(0, digest_a, contents_a, 100);
 
@@ -380,8 +389,10 @@ mod tests {
 
     #[test]
     fn reinsert_same_sequence_replaces_entry_and_accounting() {
-        let cache =
-            FullCheckpointContentsCache::new(1000, FullContentsCacheMetrics::new_for_tests());
+        let cache = FullCheckpointContentsCache::new(
+            1000,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         let (digest_a, contents_a) = entry(1);
         let (digest_b, contents_b) = entry(2);
         cache.insert(0, digest_a, contents_a, 100);
@@ -399,8 +410,10 @@ mod tests {
 
     #[test]
     fn eviction_keeps_digest_mapping_of_newer_entry_with_same_digest() {
-        let cache =
-            FullCheckpointContentsCache::new(250, FullContentsCacheMetrics::new_for_tests());
+        let cache = FullCheckpointContentsCache::new(
+            250,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         // Distinct checkpoints can share a contents digest, e.g. consecutive
         // empty checkpoints.
         let (digest, contents) = entry(1);
@@ -419,7 +432,10 @@ mod tests {
 
     #[test]
     fn zero_budget_disables_the_cache() {
-        let cache = FullCheckpointContentsCache::new(0, FullContentsCacheMetrics::new_for_tests());
+        let cache = FullCheckpointContentsCache::new(
+            0,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         let (digest_a, contents_a) = entry(1);
 
         assert!(!cache.should_cache(0));
@@ -431,8 +447,10 @@ mod tests {
 
     #[test]
     fn skips_inserts_below_the_window_of_a_full_cache() {
-        let cache =
-            FullCheckpointContentsCache::new(200, FullContentsCacheMetrics::new_for_tests());
+        let cache = FullCheckpointContentsCache::new(
+            200,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         let (digest_a, contents_a) = entry(1);
         let (digest_b, contents_b) = entry(2);
         cache.insert(10, digest_a, contents_a, 100);
@@ -453,8 +471,10 @@ mod tests {
 
         // With byte headroom, entries below the window are retained.
         let (digest_d, contents_d) = entry(4);
-        let roomy =
-            FullCheckpointContentsCache::new(1000, FullContentsCacheMetrics::new_for_tests());
+        let roomy = FullCheckpointContentsCache::new(
+            1000,
+            FullCheckpointContentsCacheMetrics::new_for_tests(),
+        );
         roomy.insert(10, digest_a, entry(1).1, 100);
         assert!(roomy.should_cache(5));
         roomy.insert(5, digest_d, contents_d, 100);

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -13,7 +13,7 @@ use iota_types::{
 };
 use parking_lot::Mutex;
 use prometheus_filtered::{
-    IntCounter, IntCounterVec, IntGauge, Registry, register_int_counter_vec_with_registry,
+    IntCounter, IntGauge, Registry, register_int_counter_vec_with_registry,
     register_int_counter_with_registry, register_int_gauge_with_registry,
 };
 
@@ -24,18 +24,24 @@ const LOOKUP_BY_SEQ: &str = "by_seq";
 /// checkpoint-contents requests from state-sync peers.
 const LOOKUP_BY_DIGEST: &str = "by_digest";
 
+/// The hit/miss counters are exported as `IntCounterVec`s with a `lookup`
+/// label; the per-label children are resolved once at construction so the
+/// lookup paths increment plain counters.
 pub struct FullContentsCacheMetrics {
-    /// Lookups served from the cache, partitioned by the `lookup` label
-    /// ([`LOOKUP_BY_SEQ`] / [`LOOKUP_BY_DIGEST`]).
-    pub hits: IntCounterVec,
-    /// Lookups that missed the cache, with the same `lookup` label split as
-    /// `hits`.
+    /// Sequence-number lookups served from the cache (`lookup="by_seq"`).
+    pub hits_by_seq: IntCounter,
+    /// Contents-digest lookups served from the cache (`lookup="by_digest"`).
+    pub hits_by_digest: IntCounter,
+    /// Sequence-number lookups that missed the cache (`lookup="by_seq"`).
     ///
-    /// On validators, `by_seq` misses accrue once per self-produced
-    /// checkpoint by design: the executor checks the cache before inserting
-    /// the entry it then produces. `by_digest` is the health signal for
-    /// whether peers are served from memory or fall back to reconstruction.
-    pub misses: IntCounterVec,
+    /// On validators these accrue once per self-produced checkpoint by
+    /// design: the executor checks the cache before inserting the entry it
+    /// then produces.
+    pub misses_by_seq: IntCounter,
+    /// Contents-digest lookups that missed the cache (`lookup="by_digest"`)
+    /// — the health signal for whether peers are served from memory or fall
+    /// back to reconstruction.
+    pub misses_by_digest: IntCounter,
     pub evictions: IntCounter,
     pub entries: IntGauge,
     pub total_bytes: IntGauge,
@@ -43,23 +49,27 @@ pub struct FullContentsCacheMetrics {
 
 impl FullContentsCacheMetrics {
     pub fn new(registry: &Registry) -> Arc<Self> {
+        let hits = register_int_counter_vec_with_registry!(
+            "full_checkpoint_contents_cache_hits",
+            "Number of full-checkpoint-contents cache lookups served from the cache, \
+            partitioned by lookup kind",
+            &["lookup"],
+            registry
+        )
+        .unwrap();
+        let misses = register_int_counter_vec_with_registry!(
+            "full_checkpoint_contents_cache_misses",
+            "Number of full-checkpoint-contents cache lookups that missed the cache, \
+            partitioned by lookup kind",
+            &["lookup"],
+            registry
+        )
+        .unwrap();
         Arc::new(Self {
-            hits: register_int_counter_vec_with_registry!(
-                "full_checkpoint_contents_cache_hits",
-                "Number of full-checkpoint-contents cache lookups served from the cache, \
-                partitioned by lookup kind",
-                &["lookup"],
-                registry
-            )
-            .unwrap(),
-            misses: register_int_counter_vec_with_registry!(
-                "full_checkpoint_contents_cache_misses",
-                "Number of full-checkpoint-contents cache lookups that missed the cache, \
-                partitioned by lookup kind",
-                &["lookup"],
-                registry
-            )
-            .unwrap(),
+            hits_by_seq: hits.with_label_values(&[LOOKUP_BY_SEQ]),
+            hits_by_digest: hits.with_label_values(&[LOOKUP_BY_DIGEST]),
+            misses_by_seq: misses.with_label_values(&[LOOKUP_BY_SEQ]),
+            misses_by_digest: misses.with_label_values(&[LOOKUP_BY_DIGEST]),
             evictions: register_int_counter_with_registry!(
                 "full_checkpoint_contents_cache_evictions",
                 "Number of entries evicted from the full-checkpoint-contents cache",
@@ -235,8 +245,8 @@ impl FullCheckpointContentsCache {
     /// Looks up contents by sequence number.
     ///
     /// Recorded under the `by_seq` metrics label; see
-    /// [`FullContentsCacheMetrics::misses`] for how to interpret it per node
-    /// role.
+    /// [`FullContentsCacheMetrics::misses_by_seq`] for how to interpret it
+    /// per node role.
     pub fn get_by_seq(&self, seq: CheckpointSequenceNumber) -> Option<Arc<FullCheckpointContents>> {
         let contents = self
             .inner
@@ -244,15 +254,19 @@ impl FullCheckpointContentsCache {
             .by_seq
             .get(&seq)
             .map(|entry| entry.contents.clone());
-        self.record_lookup(contents.is_some(), LOOKUP_BY_SEQ);
+        if contents.is_some() {
+            self.metrics.hits_by_seq.inc();
+        } else {
+            self.metrics.misses_by_seq.inc();
+        }
         contents
     }
 
     /// Looks up contents by contents digest.
     ///
     /// Recorded under the `by_digest` metrics label; see
-    /// [`FullContentsCacheMetrics::misses`] for how to interpret it per node
-    /// role.
+    /// [`FullContentsCacheMetrics::misses_by_digest`] for how to interpret
+    /// it per node role.
     pub fn get_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
@@ -264,16 +278,12 @@ impl FullCheckpointContentsCache {
             .and_then(|seq| inner.by_seq.get(seq))
             .map(|entry| entry.contents.clone());
         drop(inner);
-        self.record_lookup(contents.is_some(), LOOKUP_BY_DIGEST);
-        contents
-    }
-
-    fn record_lookup(&self, hit: bool, lookup: &str) {
-        if hit {
-            self.metrics.hits.with_label_values(&[lookup]).inc();
+        if contents.is_some() {
+            self.metrics.hits_by_digest.inc();
         } else {
-            self.metrics.misses.with_label_values(&[lookup]).inc();
+            self.metrics.misses_by_digest.inc();
         }
+        contents
     }
 }
 
@@ -308,10 +318,10 @@ mod tests {
                 .is_none()
         );
 
-        for lookup in [LOOKUP_BY_SEQ, LOOKUP_BY_DIGEST] {
-            assert_eq!(cache.metrics.hits.with_label_values(&[lookup]).get(), 1);
-            assert_eq!(cache.metrics.misses.with_label_values(&[lookup]).get(), 1);
-        }
+        assert_eq!(cache.metrics.hits_by_seq.get(), 1);
+        assert_eq!(cache.metrics.misses_by_seq.get(), 1);
+        assert_eq!(cache.metrics.hits_by_digest.get(), 1);
+        assert_eq!(cache.metrics.misses_by_digest.get(), 1);
     }
 
     #[test]

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -217,6 +217,10 @@ impl FullCheckpointContentsCache {
             return;
         }
 
+        // Hold displaced entries so their (potentially multi-MB) contents are
+        // freed after the lock is released, not under it.
+        let mut displaced = Vec::new();
+
         if let Some(old) = inner.by_seq.insert(
             seq,
             CacheEntry {
@@ -227,6 +231,7 @@ impl FullCheckpointContentsCache {
         ) {
             inner.total_bytes -= old.bytes;
             inner.remove_digest_mapping(&old.digest, seq);
+            displaced.push(old.contents);
         }
         inner.total_bytes += bytes;
         inner.seq_by_digest.insert(digest, seq);
@@ -235,11 +240,14 @@ impl FullCheckpointContentsCache {
             let (evicted_seq, evicted) = inner.by_seq.pop_first().expect("cache is not empty");
             inner.total_bytes -= evicted.bytes;
             inner.remove_digest_mapping(&evicted.digest, evicted_seq);
+            displaced.push(evicted.contents);
             self.metrics.evictions.inc();
         }
 
         self.metrics.entries.set(inner.by_seq.len() as i64);
         self.metrics.total_bytes.set(inner.total_bytes as i64);
+        drop(inner);
+        drop(displaced);
     }
 
     /// Looks up contents by sequence number.

--- a/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
+++ b/crates/iota-core/src/checkpoints/full_checkpoint_contents_cache.rs
@@ -111,9 +111,10 @@ struct Inner {
 ///
 /// When the byte budget is exceeded, entries with the lowest sequence numbers
 /// are evicted first, keeping the newest window of checkpoints — the ones
-/// tip-following peers request. A single entry larger than the whole budget is
-/// still cached until the next insert displaces it. A budget of zero disables
-/// the cache entirely.
+/// tip-following peers request. Inserts older than the window of a full cache
+/// are skipped, since eviction would remove them immediately. A single entry
+/// larger than the whole budget is still cached until the next insert
+/// displaces it. A budget of zero disables the cache entirely.
 pub struct FullCheckpointContentsCache {
     max_bytes: usize,
     metrics: Arc<FullContentsCacheMetrics>,
@@ -140,6 +141,27 @@ impl FullCheckpointContentsCache {
         }
     }
 
+    /// Whether contents for `seq` are worth assembling and inserting: false
+    /// when the cache is disabled, and false when the cache is at budget and
+    /// `seq` is older than everything cached — lowest-seq eviction would
+    /// remove the entry immediately.
+    ///
+    /// Lets callers skip the expensive contents assembly that precedes
+    /// [`Self::insert`], e.g. the checkpoint executor during deep catch-up,
+    /// where the cache window rides the state-sync frontier far ahead of the
+    /// executor.
+    pub fn should_cache(&self, seq: CheckpointSequenceNumber) -> bool {
+        if self.max_bytes == 0 {
+            return false;
+        }
+        let inner = self.inner.lock();
+        inner.total_bytes < self.max_bytes
+            || inner
+                .by_seq
+                .first_key_value()
+                .is_none_or(|(lowest, _)| seq >= *lowest)
+    }
+
     /// Inserts the contents for a checkpoint and evicts the lowest sequence
     /// numbers until the cache fits its byte budget again.
     pub fn insert(
@@ -153,6 +175,18 @@ impl FullCheckpointContentsCache {
             return;
         }
         let mut inner = self.inner.lock();
+
+        // An entry that would push the cache over budget while being older
+        // than everything cached gets removed first by lowest-seq eviction —
+        // skip the pointless insert.
+        if inner.total_bytes + bytes > self.max_bytes
+            && inner
+                .by_seq
+                .first_key_value()
+                .is_some_and(|(lowest, _)| seq < *lowest)
+        {
+            return;
+        }
 
         if let Some(old) = inner.by_seq.insert(
             seq,
@@ -330,9 +364,43 @@ mod tests {
     fn zero_budget_disables_the_cache() {
         let cache = FullCheckpointContentsCache::new(0, FullContentsCacheMetrics::new_for_tests());
         let (digest_a, contents_a) = entry(1);
+
+        assert!(!cache.should_cache(0));
         cache.insert(0, digest_a, contents_a, 100);
 
         assert!(cache.get_by_seq(0).is_none());
         assert!(cache.get_by_digest(&digest_a).is_none());
+    }
+
+    #[test]
+    fn skips_inserts_below_the_window_of_a_full_cache() {
+        let cache =
+            FullCheckpointContentsCache::new(200, FullContentsCacheMetrics::new_for_tests());
+        let (digest_a, contents_a) = entry(1);
+        let (digest_b, contents_b) = entry(2);
+        cache.insert(10, digest_a, contents_a, 100);
+        cache.insert(11, digest_b, contents_b, 100);
+
+        // At budget: entries older than the cached window would be evicted
+        // immediately, newer ones displace the window.
+        assert!(!cache.should_cache(5));
+        assert!(cache.should_cache(12));
+
+        let (digest_c, contents_c) = entry(3);
+        cache.insert(5, digest_c, contents_c, 100);
+        assert!(cache.get_by_seq(5).is_none());
+        assert!(cache.get_by_digest(&digest_c).is_none());
+        assert!(cache.get_by_seq(10).is_some());
+        assert!(cache.get_by_seq(11).is_some());
+        assert_eq!(cache.metrics.evictions.get(), 0);
+
+        // With byte headroom, entries below the window are retained.
+        let (digest_d, contents_d) = entry(4);
+        let roomy =
+            FullCheckpointContentsCache::new(1000, FullContentsCacheMetrics::new_for_tests());
+        roomy.insert(10, digest_a, entry(1).1, 100);
+        assert!(roomy.should_cache(5));
+        roomy.insert(5, digest_d, contents_d, 100);
+        assert!(roomy.get_by_seq(5).is_some());
     }
 }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -72,7 +72,9 @@ pub use crate::checkpoints::{
     checkpoint_output::{
         LogCheckpointOutput, SendCheckpointToStateSync, SubmitCheckpointToConsensus,
     },
-    full_checkpoint_contents_cache::{FullCheckpointContentsCache, FullContentsCacheMetrics},
+    full_checkpoint_contents_cache::{
+        FullCheckpointContentsCache, FullCheckpointContentsCacheMetrics,
+    },
     metrics::CheckpointMetrics,
 };
 use crate::{

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -3043,42 +3043,60 @@ mod tests {
             .build()
             .await;
 
-        let dummy_tx = VerifiedTransaction::new_genesis_transaction(vec![], vec![]);
-        let dummy_tx_with_data = VerifiedTransaction::new_genesis_transaction(
-            vec![GenesisObject::new(
-                ObjectData::Package(
-                    MovePackage::new(
-                        ObjectId::random(),
-                        SequenceNumber::default(),
-                        BTreeMap::from([(Identifier::new_unchecked("m"), vec![0u8; 40000])]),
-                        100_000,
-                        // no modules so empty type_origin_table as no types are defined in this
-                        // package
-                        Vec::new(),
-                        // no modules so empty linkage_table as no dependencies of this package
-                        // exist
-                        BTreeMap::new(),
-                    )
-                    .unwrap(),
-                ),
-                Owner::Immutable,
-            )],
-            vec![],
-        );
-        for i in 0..15 {
+        // Build distinct genesis transactions and assign their digests to
+        // indices so that, within any pending checkpoint, digest order matches
+        // index order: `CausalOrder` orders non-dependent transactions by
+        // digest, and the assertions below rely on that order. Transactions
+        // 15..20 carry a large payload to exercise size-based checkpoint
+        // splitting.
+        let make_tx = |seed: u8, payload_size: usize| {
+            let mut id = [0u8; 32];
+            id[0] = seed;
+            VerifiedTransaction::new_genesis_transaction(
+                vec![GenesisObject::new(
+                    ObjectData::Package(
+                        MovePackage::new(
+                            ObjectId::new(id),
+                            SequenceNumber::default(),
+                            BTreeMap::from([(
+                                Identifier::new_unchecked("m"),
+                                vec![0u8; payload_size],
+                            )]),
+                            100_000,
+                            // no modules so empty type_origin_table as no types are defined in
+                            // this package
+                            Vec::new(),
+                            // no modules so empty linkage_table as no dependencies of this package
+                            // exist
+                            BTreeMap::new(),
+                        )
+                        .unwrap(),
+                    ),
+                    Owner::Immutable,
+                )],
+                vec![],
+            )
+        };
+
+        let mut small: Vec<_> = (0..15).map(|seed| make_tx(seed, 1)).collect();
+        small.sort_by_key(|tx| *tx.digest());
+
+        let mut large: Vec<_> = (0..5).map(|seed| make_tx(100 + seed, 40000)).collect();
+        large.sort_by_key(|tx| *tx.digest());
+
+        let txns: Vec<_> = small.into_iter().chain(large).collect();
+        let digests: Vec<TransactionDigest> = txns.iter().map(|tx| *tx.digest()).collect();
+
+        // Digest for test index `i`; ascending within the small (0..15) and
+        // large (15..20) pools, so index order implies digest order per pool.
+        let d = |i: u8| digests[i as usize];
+
+        for (tx, digest) in txns.iter().zip(&digests) {
             state
                 .database_for_testing()
                 .perpetual_tables
                 .transactions
-                .insert(&d(i), dummy_tx.serializable_ref())
-                .unwrap();
-        }
-        for i in 15..20 {
-            state
-                .database_for_testing()
-                .perpetual_tables
-                .transactions
-                .insert(&d(i), dummy_tx_with_data.serializable_ref())
+                .insert(digest, tx.serializable_ref())
                 .unwrap();
         }
 
@@ -3152,7 +3170,7 @@ mod tests {
 
         let checkpoint_service = CheckpointService::build(
             state.clone(),
-            checkpoint_store,
+            checkpoint_store.clone(),
             epoch_store.clone(),
             store,
             Arc::downgrade(&global_state_hasher),
@@ -3165,22 +3183,28 @@ mod tests {
         let _tasks = checkpoint_service.spawn(None).await;
 
         checkpoint_service
-            .write_and_notify_checkpoint_for_testing(&epoch_store, p(0, vec![4], 0))
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(0, vec![d(4)], 0))
             .unwrap();
         checkpoint_service
-            .write_and_notify_checkpoint_for_testing(&epoch_store, p(1, vec![1, 3], 2000))
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(1, vec![d(1), d(3)], 2000))
             .unwrap();
         checkpoint_service
-            .write_and_notify_checkpoint_for_testing(&epoch_store, p(2, vec![10, 11, 12, 13], 3000))
+            .write_and_notify_checkpoint_for_testing(
+                &epoch_store,
+                p(2, vec![d(10), d(11), d(12), d(13)], 3000),
+            )
             .unwrap();
         checkpoint_service
-            .write_and_notify_checkpoint_for_testing(&epoch_store, p(3, vec![15, 16, 17], 4000))
+            .write_and_notify_checkpoint_for_testing(
+                &epoch_store,
+                p(3, vec![d(15), d(16), d(17)], 4000),
+            )
             .unwrap();
         checkpoint_service
-            .write_and_notify_checkpoint_for_testing(&epoch_store, p(4, vec![5], 4001))
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(4, vec![d(5)], 4001))
             .unwrap();
         checkpoint_service
-            .write_and_notify_checkpoint_for_testing(&epoch_store, p(5, vec![6], 5000))
+            .write_and_notify_checkpoint_for_testing(&epoch_store, p(5, vec![d(6)], 5000))
             .unwrap();
 
         let (c1c, c1s) = result.recv().await.unwrap();
@@ -3203,6 +3227,20 @@ mod tests {
             c2s.epoch_rolling_gas_cost_summary,
             GasCostSummary::new(104, 104, 108, 104, 4)
         );
+
+        // The builder caches the full contents of each locally built checkpoint.
+        // The cached contents must match the checkpoint's transactions and hash
+        // to its content digest, so state-sync peers can be served from memory.
+        for (summary, digest_contents) in [(&c1s, &c1c), (&c2s, &c2c)] {
+            let cached = checkpoint_store
+                .get_full_checkpoint_contents_by_sequence_number(summary.sequence_number)
+                .expect("builder should cache full contents of a locally built checkpoint");
+            assert_eq!(&cached.checkpoint_contents(), digest_contents);
+            assert_eq!(
+                cached.checkpoint_contents().digest(),
+                summary.content_digest
+            );
+        }
 
         // Pending at index 2 had 4 transactions, and we configured 3 transactions max.
         // Verify that we split into 2 checkpoints.
@@ -3354,24 +3392,15 @@ mod tests {
         }
     }
 
-    fn p(i: u64, t: Vec<u8>, timestamp_ms: u64) -> PendingCheckpoint {
+    fn p(i: u64, roots: Vec<TransactionDigest>, timestamp_ms: u64) -> PendingCheckpoint {
         PendingCheckpoint::V1(PendingCheckpointContentsV1 {
-            roots: t
-                .into_iter()
-                .map(|t| TransactionKey::Digest(d(t)))
-                .collect(),
+            roots: roots.into_iter().map(TransactionKey::Digest).collect(),
             details: PendingCheckpointInfo {
                 timestamp_ms,
                 last_of_epoch: false,
                 checkpoint_height: i,
             },
         })
-    }
-
-    fn d(i: u8) -> TransactionDigest {
-        let mut bytes: [u8; 32] = Default::default();
-        bytes[0] = i;
-        TransactionDigest::new(bytes)
     }
 
     fn e(

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -821,6 +821,14 @@ impl CheckpointStore {
         self.cache_full_checkpoint_contents(checkpoint, full_contents)
     }
 
+    /// Whether [`Self::cache_full_checkpoint_contents`] would retain contents
+    /// for this sequence number, so callers can skip assembling contents that
+    /// the cache would reject (disabled cache, or an entry the lowest-seq
+    /// eviction would remove immediately).
+    pub fn should_cache_full_checkpoint_contents(&self, seq: CheckpointSequenceNumber) -> bool {
+        self.full_checkpoint_contents_cache.should_cache(seq)
+    }
+
     /// Caches full checkpoint contents in memory without writing anything to
     /// disk, so state-sync peers can be served without reconstructing the
     /// contents.

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2836,6 +2836,37 @@ fn poll_count<Fut>(future: Fut) -> PollCounter<Fut> {
     PollCounter::new(future)
 }
 
+/// A verified checkpoint over the given contents at the given sequence
+/// number, with a placeholder signature; usable wherever verification is
+/// not re-run and no committee is needed.
+#[cfg(test)]
+pub(crate) fn test_checkpoint_with_contents(
+    sequence_number: CheckpointSequenceNumber,
+    full_contents: &FullCheckpointContents,
+) -> VerifiedCheckpoint {
+    let contents = full_contents.checkpoint_contents();
+    let summary = CheckpointSummary {
+        epoch: 0,
+        sequence_number,
+        network_total_transactions: full_contents.size() as u64,
+        content_digest: contents.digest(),
+        previous_digest: None,
+        epoch_rolling_gas_cost_summary: GasCostSummary::default(),
+        end_of_epoch_data: None,
+        timestamp_ms: 0,
+        version_specific_data: Vec::new(),
+        checkpoint_commitments: Vec::new(),
+    };
+    let sig = AuthorityStrongQuorumSignInfo {
+        epoch: 0,
+        signature: Default::default(),
+        signers_map: Default::default(),
+    };
+    VerifiedCheckpoint::new_unchecked(
+        iota_types::message_envelope::Envelope::new_from_data_and_sig(summary, sig),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -2864,40 +2895,13 @@ mod tests {
     use super::*;
     use crate::authority::test_authority_builder::TestAuthorityBuilder;
 
-    /// A verified checkpoint at sequence 0 with random full contents, for
-    /// store-level tests that don't need a committee.
-    fn test_checkpoint_with_contents() -> (VerifiedCheckpoint, FullCheckpointContents) {
-        let full_contents = FullCheckpointContents::random_for_testing();
-        let contents = full_contents.checkpoint_contents();
-        let summary = CheckpointSummary {
-            epoch: 0,
-            sequence_number: 0,
-            network_total_transactions: full_contents.size() as u64,
-            content_digest: contents.digest(),
-            previous_digest: None,
-            epoch_rolling_gas_cost_summary: GasCostSummary::default(),
-            end_of_epoch_data: None,
-            timestamp_ms: 0,
-            version_specific_data: Vec::new(),
-            checkpoint_commitments: Vec::new(),
-        };
-        let sig = AuthorityStrongQuorumSignInfo {
-            epoch: 0,
-            signature: Default::default(),
-            signers_map: Default::default(),
-        };
-        let checkpoint = VerifiedCheckpoint::new_unchecked(
-            iota_types::message_envelope::Envelope::new_from_data_and_sig(summary, sig),
-        );
-        (checkpoint, full_contents)
-    }
-
     #[tokio::test]
     async fn insert_verified_checkpoint_contents_persists_digests_and_caches_full_contents() {
         let tempdir = iota_common::tempdir();
         let path = tempdir.path();
 
-        let (checkpoint, full_contents) = test_checkpoint_with_contents();
+        let full_contents = FullCheckpointContents::random_for_testing();
+        let checkpoint = test_checkpoint_with_contents(0, &full_contents);
         let content_digest = checkpoint.content_digest;
 
         {
@@ -2958,7 +2962,8 @@ mod tests {
     #[tokio::test]
     async fn cache_full_checkpoint_contents_serves_reads_without_disk_writes() {
         let store = CheckpointStore::new_for_tests();
-        let (checkpoint, full_contents) = test_checkpoint_with_contents();
+        let full_contents = FullCheckpointContents::random_for_testing();
+        let checkpoint = test_checkpoint_with_contents(0, &full_contents);
         let content_digest = checkpoint.content_digest;
 
         store.cache_full_checkpoint_contents(&checkpoint, full_contents.clone());

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -818,7 +818,8 @@ impl CheckpointStore {
             .checkpoint_content
             .insert(&contents.digest(), &contents)?;
 
-        self.cache_full_checkpoint_contents(checkpoint, full_contents)
+        self.cache_full_checkpoint_contents(checkpoint, full_contents);
+        Ok(())
     }
 
     /// Whether [`Self::cache_full_checkpoint_contents`] would retain contents
@@ -836,20 +837,31 @@ impl CheckpointStore {
     /// Used by the checkpoint executor on nodes that execute transactions
     /// without syncing contents via state sync (validators), where the
     /// digest-form contents and the transactions are already durable.
+    ///
+    /// Best-effort: a serialization failure is logged and the insert skipped;
+    /// readers fall back to reconstructing the contents from the durable
+    /// stores.
     pub fn cache_full_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         full_contents: FullCheckpointContents,
-    ) -> Result<(), TypedStoreError> {
-        let size = bcs::serialized_size(&full_contents)
-            .map_err(|e| TypedStoreError::Serialization(e.to_string()))?;
+    ) {
+        let size = match bcs::serialized_size(&full_contents) {
+            Ok(size) => size,
+            Err(e) => {
+                warn!(
+                    sequence_number = checkpoint.sequence_number(),
+                    "failed to serialize full checkpoint contents for caching: {e}"
+                );
+                return;
+            }
+        };
         self.full_checkpoint_contents_cache.insert(
             checkpoint.sequence_number(),
             checkpoint.content_digest,
             Arc::new(full_contents),
             size,
         );
-        Ok(())
     }
 
     pub fn get_epoch_last_checkpoint(
@@ -2949,9 +2961,7 @@ mod tests {
         let (checkpoint, full_contents) = test_checkpoint_with_contents();
         let content_digest = checkpoint.content_digest;
 
-        store
-            .cache_full_checkpoint_contents(&checkpoint, full_contents.clone())
-            .unwrap();
+        store.cache_full_checkpoint_contents(&checkpoint, full_contents.clone());
 
         assert_eq!(
             store

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -811,9 +811,6 @@ impl CheckpointStore {
         full_contents: VerifiedCheckpointContents,
     ) -> Result<(), TypedStoreError> {
         let full_contents = full_contents.into_inner();
-        let size = bcs::serialized_size(&full_contents)
-            .map_err(|e| TypedStoreError::Serialization(e.to_string()))?;
-
         let contents = full_contents.checkpoint_contents();
         assert_eq!(checkpoint.content_digest, contents.digest());
 
@@ -821,6 +818,23 @@ impl CheckpointStore {
             .checkpoint_content
             .insert(&contents.digest(), &contents)?;
 
+        self.cache_full_checkpoint_contents(checkpoint, full_contents)
+    }
+
+    /// Caches full checkpoint contents in memory without writing anything to
+    /// disk, so state-sync peers can be served without reconstructing the
+    /// contents.
+    ///
+    /// Used by the checkpoint executor on nodes that execute transactions
+    /// without syncing contents via state sync (validators), where the
+    /// digest-form contents and the transactions are already durable.
+    pub fn cache_full_checkpoint_contents(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+        full_contents: FullCheckpointContents,
+    ) -> Result<(), TypedStoreError> {
+        let size = bcs::serialized_size(&full_contents)
+            .map_err(|e| TypedStoreError::Serialization(e.to_string()))?;
         self.full_checkpoint_contents_cache.insert(
             checkpoint.sequence_number(),
             checkpoint.content_digest,
@@ -2830,19 +2844,16 @@ mod tests {
     use super::*;
     use crate::authority::test_authority_builder::TestAuthorityBuilder;
 
-    #[tokio::test]
-    async fn insert_verified_checkpoint_contents_persists_digests_and_caches_full_contents() {
-        let tempdir = iota_common::tempdir();
-        let path = tempdir.path();
-
+    /// A verified checkpoint at sequence 0 with random full contents, for
+    /// store-level tests that don't need a committee.
+    fn test_checkpoint_with_contents() -> (VerifiedCheckpoint, FullCheckpointContents) {
         let full_contents = FullCheckpointContents::random_for_testing();
         let contents = full_contents.checkpoint_contents();
-        let content_digest = contents.digest();
         let summary = CheckpointSummary {
             epoch: 0,
             sequence_number: 0,
             network_total_transactions: full_contents.size() as u64,
-            content_digest,
+            content_digest: contents.digest(),
             previous_digest: None,
             epoch_rolling_gas_cost_summary: GasCostSummary::default(),
             end_of_epoch_data: None,
@@ -2858,6 +2869,16 @@ mod tests {
         let checkpoint = VerifiedCheckpoint::new_unchecked(
             iota_types::message_envelope::Envelope::new_from_data_and_sig(summary, sig),
         );
+        (checkpoint, full_contents)
+    }
+
+    #[tokio::test]
+    async fn insert_verified_checkpoint_contents_persists_digests_and_caches_full_contents() {
+        let tempdir = iota_common::tempdir();
+        let path = tempdir.path();
+
+        let (checkpoint, full_contents) = test_checkpoint_with_contents();
+        let content_digest = checkpoint.content_digest;
 
         {
             let store = CheckpointStore::new(path);
@@ -2911,6 +2932,39 @@ mod tests {
                 .get_checkpoint_contents(&content_digest)
                 .unwrap()
                 .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_full_checkpoint_contents_serves_reads_without_disk_writes() {
+        let store = CheckpointStore::new_for_tests();
+        let (checkpoint, full_contents) = test_checkpoint_with_contents();
+        let content_digest = checkpoint.content_digest;
+
+        store
+            .cache_full_checkpoint_contents(&checkpoint, full_contents.clone())
+            .unwrap();
+
+        assert_eq!(
+            store
+                .get_full_checkpoint_contents_by_sequence_number(0)
+                .unwrap()
+                .as_ref(),
+            &full_contents
+        );
+        assert_eq!(
+            store
+                .get_full_checkpoint_contents_by_digest(&content_digest)
+                .unwrap()
+                .as_ref(),
+            &full_contents
+        );
+        // Cache-only: the digest-form contents row is untouched.
+        assert!(
+            store
+                .get_checkpoint_contents(&content_digest)
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -28,7 +28,7 @@ use iota_metrics::{MonitoredFutureExt, monitored_future, monitored_scope};
 use iota_network::default_iota_network_config;
 use iota_sdk_types::{GasCostSummary, TransactionKind};
 use iota_types::{
-    base_types::{AuthorityName, ConciseableName, EpochId, TransactionDigest},
+    base_types::{AuthorityName, ConciseableName, EpochId, ExecutionData, TransactionDigest},
     committee::StakeUnit,
     crypto::AuthorityStrongQuorumSignInfo,
     digests::{CheckpointContentsDigest, CheckpointDigest},
@@ -49,7 +49,7 @@ use iota_types::{
     messages_consensus::ConsensusTransactionKey,
     signature::GenericSignature,
     storage::EpochInfoV2,
-    transaction::{TransactionDataAPI, TransactionKey},
+    transaction::{Transaction, TransactionDataAPI, TransactionKey},
 };
 use itertools::Itertools;
 use nonempty::NonEmpty;
@@ -820,7 +820,11 @@ impl CheckpointStore {
             .checkpoint_content
             .insert(&contents.digest(), &contents)?;
 
-        self.cache_full_checkpoint_contents(checkpoint, full_contents);
+        self.cache_full_checkpoint_contents(
+            checkpoint.sequence_number(),
+            checkpoint.content_digest,
+            full_contents,
+        );
         Ok(())
     }
 
@@ -834,33 +838,30 @@ impl CheckpointStore {
 
     /// Caches full checkpoint contents in memory without writing anything to
     /// disk, so state-sync peers can be served without reconstructing the
-    /// contents.
-    ///
-    /// Used by the checkpoint executor on nodes that execute transactions
-    /// without syncing contents via state sync (validators), where the
-    /// digest-form contents and the transactions are already durable.
+    /// contents. `content_digest` must be the digest of `full_contents`.
     ///
     /// Best-effort: a serialization failure is logged and the insert skipped;
     /// readers fall back to reconstructing the contents from the durable
     /// stores.
     pub fn cache_full_checkpoint_contents(
         &self,
-        checkpoint: &VerifiedCheckpoint,
+        sequence_number: CheckpointSequenceNumber,
+        content_digest: CheckpointContentsDigest,
         full_contents: FullCheckpointContents,
     ) {
         let size = match bcs::serialized_size(&full_contents) {
             Ok(size) => size,
             Err(e) => {
                 warn!(
-                    sequence_number = checkpoint.sequence_number(),
+                    sequence_number,
                     "failed to serialize full checkpoint contents for caching: {e}"
                 );
                 return;
             }
         };
         self.full_checkpoint_contents_cache.insert(
-            checkpoint.sequence_number(),
-            checkpoint.content_digest,
+            sequence_number,
+            content_digest,
             Arc::new(full_contents),
             size,
         );
@@ -1470,15 +1471,15 @@ impl CheckpointBuilder {
     #[expect(clippy::type_complexity)]
     fn split_checkpoint_chunks(
         &self,
-        effects_and_transaction_sizes: Vec<(TransactionEffects, usize)>,
+        transactions_effects_and_sizes: Vec<(Transaction, TransactionEffects, usize)>,
         signatures: Vec<Vec<GenericSignature>>,
-    ) -> anyhow::Result<Vec<Vec<(TransactionEffects, Vec<GenericSignature>)>>> {
+    ) -> anyhow::Result<Vec<Vec<(Transaction, TransactionEffects, Vec<GenericSignature>)>>> {
         let _guard = monitored_scope("CheckpointBuilder::split_checkpoint_chunks");
         let mut chunks = Vec::new();
         let mut chunk = Vec::new();
         let mut chunk_size: usize = 0;
-        for ((effects, transaction_size), signatures) in
-            effects_and_transaction_sizes.into_iter().zip(signatures)
+        for ((transaction, effects, transaction_size), signatures) in
+            transactions_effects_and_sizes.into_iter().zip(signatures)
         {
             // Roll over to a new chunk after either max count or max size is reached.
             // The size calculation here is intended to estimate the size of the
@@ -1503,7 +1504,7 @@ impl CheckpointBuilder {
                 }
             }
 
-            chunk.push((effects, signatures));
+            chunk.push((transaction, effects, signatures));
             chunk_size += size;
         }
 
@@ -1648,7 +1649,12 @@ impl CheckpointBuilder {
             signatures.len()
         );
 
-        let chunks = self.split_checkpoint_chunks(all_effects_and_transaction_sizes, signatures)?;
+        let transactions_effects_and_sizes = transactions
+            .into_iter()
+            .zip(all_effects_and_transaction_sizes)
+            .map(|(transaction, (effects, size))| (transaction.into_inner(), effects, size))
+            .collect();
+        let chunks = self.split_checkpoint_chunks(transactions_effects_and_sizes, signatures)?;
         let chunks_count = chunks.len();
 
         let mut checkpoints = Vec::with_capacity(chunks_count);
@@ -1658,7 +1664,7 @@ impl CheckpointBuilder {
         );
 
         let epoch = self.epoch_store.epoch();
-        for (index, transactions) in chunks.into_iter().enumerate() {
+        for (index, chunk) in chunks.into_iter().enumerate() {
             let first_checkpoint_of_epoch = index == 0
                 && last_checkpoint
                     .as_ref()
@@ -1686,7 +1692,11 @@ impl CheckpointBuilder {
                 }
             }
 
-            let (mut effects, mut signatures): (Vec<_>, Vec<_>) = transactions.into_iter().unzip();
+            let (chunk_transactions, mut effects, mut signatures): (
+                Vec<Transaction>,
+                Vec<TransactionEffects>,
+                Vec<Vec<GenericSignature>>,
+            ) = chunk.into_iter().multiunzip();
             let epoch_rolling_gas_cost_summary =
                 self.get_epoch_total_gas_cost(last_checkpoint.as_ref().map(|(_, c)| c), &effects);
 
@@ -1816,6 +1826,30 @@ impl CheckpointBuilder {
                         .report_epoch_metrics_at_last_checkpoint(stats);
                 }
             }
+
+            // Cache the full contents for faster checkpoint propagation to peers.
+            // End-of-epoch checkpoints carry an appended change-epoch transaction not
+            // tracked here; the executor caches those via its synced path.
+            if !last_checkpoint_of_epoch
+                && self
+                    .store
+                    .should_cache_full_checkpoint_contents(sequence_number)
+            {
+                let execution_data = chunk_transactions
+                    .into_iter()
+                    .zip(effects.iter().cloned())
+                    .map(|(transaction, effects)| ExecutionData::new(transaction, effects));
+                let full_contents = FullCheckpointContents::from_contents_and_execution_data(
+                    contents.clone(),
+                    execution_data,
+                );
+                self.store.cache_full_checkpoint_contents(
+                    sequence_number,
+                    summary.content_digest,
+                    full_contents,
+                );
+            }
+
             last_checkpoint = Some((sequence_number, summary.clone()));
             checkpoints.push((summary, contents));
         }
@@ -2968,7 +3002,11 @@ mod tests {
         let checkpoint = test_checkpoint_with_contents(0, &full_contents);
         let content_digest = checkpoint.content_digest;
 
-        store.cache_full_checkpoint_contents(&checkpoint, full_contents.clone());
+        store.cache_full_checkpoint_contents(
+            checkpoint.sequence_number(),
+            content_digest,
+            full_contents.clone(),
+        );
 
         assert_eq!(
             store

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -6,6 +6,7 @@ mod causal_order;
 pub mod checkpoint_executor;
 mod checkpoint_output;
 mod epoch_info;
+mod full_checkpoint_contents_cache;
 mod metrics;
 
 use std::{
@@ -71,6 +72,7 @@ pub use crate::checkpoints::{
     checkpoint_output::{
         LogCheckpointOutput, SendCheckpointToStateSync, SubmitCheckpointToConsensus,
     },
+    full_checkpoint_contents_cache::{FullCheckpointContentsCache, FullContentsCacheMetrics},
     metrics::CheckpointMetrics,
 };
 use crate::{
@@ -158,17 +160,21 @@ pub struct CheckpointStoreTables {
     /// Maps checkpoint contents digest to checkpoint contents
     pub(crate) checkpoint_content: DBMap<CheckpointContentsDigest, CheckpointContents>,
 
-    /// Maps checkpoint contents digest to checkpoint sequence number.
-    /// Entries from this table are deleted after state accumulation has
-    /// completed together with the corresponding full_checkpoint_content.
-    pub(crate) checkpoint_sequence_by_contents_digest:
-        DBMap<CheckpointContentsDigest, CheckpointSequenceNumber>,
+    /// Deprecated: the contents-digest to sequence-number mapping moved to
+    /// the in-memory [`FullCheckpointContentsCache`]. Dropped on open; not
+    /// migrated (entries were a short-lived cache).
+    #[allow(dead_code)]
+    #[deprecated_db_map]
+    checkpoint_sequence_by_contents_digest: Option<DBMap<(), ()>>,
 
-    /// Stores entire checkpoint contents from state sync, indexed by sequence
-    /// number, for efficient reads of full checkpoints. Entries from this
-    /// table are deleted after state accumulation has completed. See
-    /// NUM_SAVED_FULL_CHECKPOINT_CONTENTS.
-    full_checkpoint_content: DBMap<CheckpointSequenceNumber, FullCheckpointContents>,
+    /// Deprecated: full checkpoint contents moved to the in-memory
+    /// [`FullCheckpointContentsCache`]. Dropped on open; not migrated
+    /// (entries were a short-lived cache, and readers can reconstruct full
+    /// contents from `checkpoint_content` plus the transaction and effects
+    /// stores).
+    #[allow(dead_code)]
+    #[deprecated_db_map]
+    full_checkpoint_content: Option<DBMap<(), ()>>,
 
     /// Stores certified checkpoints
     pub(crate) certified_checkpoints: DBMap<CheckpointSequenceNumber, TrustedCheckpoint>,
@@ -229,15 +235,24 @@ impl CheckpointStoreTables {
 
 pub struct CheckpointStore {
     pub(crate) tables: CheckpointStoreTables,
+    full_checkpoint_contents_cache: FullCheckpointContentsCache,
     synced_checkpoint_notify_read: NotifyRead<CheckpointSequenceNumber, VerifiedCheckpoint>,
     executed_checkpoint_notify_read: NotifyRead<CheckpointSequenceNumber, VerifiedCheckpoint>,
 }
 
 impl CheckpointStore {
     pub fn new(path: &Path) -> Arc<Self> {
+        Self::new_with_contents_cache(path, FullCheckpointContentsCache::default())
+    }
+
+    pub fn new_with_contents_cache(
+        path: &Path,
+        contents_cache: FullCheckpointContentsCache,
+    ) -> Arc<Self> {
         let tables = CheckpointStoreTables::new(path, "checkpoint");
         Arc::new(Self {
             tables,
+            full_checkpoint_contents_cache: contents_cache,
             synced_checkpoint_notify_read: NotifyRead::new(),
             executed_checkpoint_notify_read: NotifyRead::new(),
         })
@@ -252,6 +267,7 @@ impl CheckpointStore {
         let tables = CheckpointStoreTables::new(path, "db_checkpoint");
         Arc::new(Self {
             tables,
+            full_checkpoint_contents_cache: FullCheckpointContentsCache::default(),
             synced_checkpoint_notify_read: NotifyRead::new(),
             executed_checkpoint_notify_read: NotifyRead::new(),
         })
@@ -332,26 +348,17 @@ impl CheckpointStore {
             .get(&sequence_number)
     }
 
-    /// Get checkpoint sequence number by contents digest.
+    /// Get full checkpoint contents by contents digest from the in-memory
+    /// contents cache.
     ///
-    /// Entries from this table are deleted after state accumulation has
-    /// completed together with the corresponding full_checkpoint_content.
-    pub fn get_sequence_number_by_contents_digest(
+    /// Returns `None` once the entry has been evicted; callers reconstruct
+    /// full contents from `checkpoint_content` and the transaction and
+    /// effects stores instead.
+    pub fn get_full_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
-        self.tables
-            .checkpoint_sequence_by_contents_digest
-            .get(digest)
-    }
-
-    pub fn delete_contents_digest_sequence_number_mapping(
-        &self,
-        digest: &CheckpointContentsDigest,
-    ) -> Result<(), TypedStoreError> {
-        self.tables
-            .checkpoint_sequence_by_contents_digest
-            .remove(digest)
+    ) -> Option<Arc<FullCheckpointContents>> {
+        self.full_checkpoint_contents_cache.get_by_digest(digest)
     }
 
     pub fn get_latest_certified_checkpoint(
@@ -489,11 +496,15 @@ impl CheckpointStore {
         self.tables.checkpoint_content.get(digest)
     }
 
+    /// Get full checkpoint contents from the in-memory contents cache.
+    ///
+    /// Returns `None` once the entry has been evicted; callers fall back to
+    /// loading the individual transactions and effects from their stores.
     pub fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         seq: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
-        self.tables.full_checkpoint_content.get(&seq)
+    ) -> Option<Arc<FullCheckpointContents>> {
+        self.full_checkpoint_contents_cache.get_by_seq(seq)
     }
 
     fn prune_local_summaries(&self) -> IotaResult {
@@ -787,44 +798,36 @@ impl CheckpointStore {
             .insert(&contents.digest(), &contents)
     }
 
-    /// Inserts the full checkpoint contents along with the mapping from
-    /// contents digest to sequence number, and the checkpoint contents.
+    /// Persists the checkpoint contents in digest form and caches the full
+    /// contents in memory, where they serve the checkpoint executor's bulk
+    /// transaction loads and contents requests from state-sync peers.
     ///
-    /// The entries for mapping the contents digest to sequence number,
-    /// and the full_checkpoint_content are deleted after state accumulation has
-    /// completed. See NUM_SAVED_FULL_CHECKPOINT_CONTENTS.
+    /// The caller must have durably written the contained transactions and
+    /// effects beforehand: once the cache evicts the entry (or after a
+    /// restart), readers reconstruct the full contents from those stores.
     pub fn insert_verified_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         full_contents: VerifiedCheckpointContents,
     ) -> Result<(), TypedStoreError> {
-        let mut batch = self.tables.full_checkpoint_content.batch();
-        batch.insert_batch(
-            &self.tables.checkpoint_sequence_by_contents_digest,
-            [(&checkpoint.content_digest, checkpoint.sequence_number())],
-        )?;
         let full_contents = full_contents.into_inner();
-        batch.insert_batch(
-            &self.tables.full_checkpoint_content,
-            [(checkpoint.sequence_number(), &full_contents)],
-        )?;
+        let size = bcs::serialized_size(&full_contents)
+            .map_err(|e| TypedStoreError::Serialization(e.to_string()))?;
 
-        let contents = full_contents.into_checkpoint_contents();
+        let contents = full_contents.checkpoint_contents();
         assert_eq!(checkpoint.content_digest, contents.digest());
 
-        batch.insert_batch(
-            &self.tables.checkpoint_content,
-            [(contents.digest(), &contents)],
-        )?;
+        self.tables
+            .checkpoint_content
+            .insert(&contents.digest(), &contents)?;
 
-        batch.write()
-    }
-
-    pub fn delete_full_checkpoint_contents(
-        &self,
-        seq: CheckpointSequenceNumber,
-    ) -> Result<(), TypedStoreError> {
-        self.tables.full_checkpoint_content.remove(&seq)
+        self.full_checkpoint_contents_cache.insert(
+            checkpoint.sequence_number(),
+            checkpoint.content_digest,
+            Arc::new(full_contents),
+            size,
+        );
+        Ok(())
     }
 
     pub fn get_epoch_last_checkpoint(
@@ -2826,6 +2829,90 @@ mod tests {
 
     use super::*;
     use crate::authority::test_authority_builder::TestAuthorityBuilder;
+
+    #[tokio::test]
+    async fn insert_verified_checkpoint_contents_persists_digests_and_caches_full_contents() {
+        let tempdir = iota_common::tempdir();
+        let path = tempdir.path();
+
+        let full_contents = FullCheckpointContents::random_for_testing();
+        let contents = full_contents.checkpoint_contents();
+        let content_digest = contents.digest();
+        let summary = CheckpointSummary {
+            epoch: 0,
+            sequence_number: 0,
+            network_total_transactions: full_contents.size() as u64,
+            content_digest,
+            previous_digest: None,
+            epoch_rolling_gas_cost_summary: GasCostSummary::default(),
+            end_of_epoch_data: None,
+            timestamp_ms: 0,
+            version_specific_data: Vec::new(),
+            checkpoint_commitments: Vec::new(),
+        };
+        let sig = AuthorityStrongQuorumSignInfo {
+            epoch: 0,
+            signature: Default::default(),
+            signers_map: Default::default(),
+        };
+        let checkpoint = VerifiedCheckpoint::new_unchecked(
+            iota_types::message_envelope::Envelope::new_from_data_and_sig(summary, sig),
+        );
+
+        {
+            let store = CheckpointStore::new(path);
+            store
+                .insert_verified_checkpoint_contents(
+                    &checkpoint,
+                    VerifiedCheckpointContents::new_unchecked(full_contents.clone()),
+                )
+                .unwrap();
+
+            // Full contents are served from the in-memory cache.
+            assert_eq!(
+                store
+                    .get_full_checkpoint_contents_by_sequence_number(0)
+                    .unwrap()
+                    .as_ref(),
+                &full_contents
+            );
+            assert_eq!(
+                store
+                    .get_full_checkpoint_contents_by_digest(&content_digest)
+                    .unwrap()
+                    .as_ref(),
+                &full_contents
+            );
+            // The digest-form contents are durable.
+            assert_eq!(
+                store
+                    .get_checkpoint_contents(&content_digest)
+                    .unwrap()
+                    .map(|c| c.digest()),
+                Some(content_digest)
+            );
+        }
+
+        // Reopening drops the in-memory cache, but the digest-form contents
+        // survive for readers to reconstruct full contents from.
+        let store = CheckpointStore::new(path);
+        assert!(
+            store
+                .get_full_checkpoint_contents_by_sequence_number(0)
+                .is_none()
+        );
+        assert!(
+            store
+                .get_full_checkpoint_contents_by_digest(&content_digest)
+                .is_none()
+        );
+        assert!(
+            store
+                .get_checkpoint_contents(&content_digest)
+                .unwrap()
+                .is_some()
+        );
+    }
 
     #[sim_test]
     pub async fn checkpoint_builder_test() {

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -126,36 +126,26 @@ impl ReadStore for RocksDbStore {
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointContents>, StorageError> {
-        self.checkpoint_store
+        Ok(self
+            .checkpoint_store
             .get_full_checkpoint_contents_by_sequence_number(sequence_number)
-            .map_err(Into::into)
+            .map(|contents| contents.as_ref().clone()))
     }
 
     fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>, StorageError> {
-        // First look to see if we saved the complete contents already.
-        if let Some(seq_num) = self
+        // First look to see if the in-memory cache still holds the complete
+        // contents.
+        if let Some(contents) = self
             .checkpoint_store
-            .get_sequence_number_by_contents_digest(digest)
-            .map_err(iota_types::storage::error::Error::custom)?
+            .get_full_checkpoint_contents_by_digest(digest)
         {
-            let contents = self
-                .checkpoint_store
-                .get_full_checkpoint_contents_by_sequence_number(seq_num)
-                .map_err(iota_types::storage::error::Error::custom)?;
-            if contents.is_some() {
-                return Ok(contents);
-            }
+            return Ok(Some(contents.as_ref().clone()));
         }
 
         // Otherwise gather it from the individual components.
-        // Note we can't insert the constructed contents into `full_checkpoint_content`,
-        // because it needs to be inserted along with
-        // `checkpoint_sequence_by_contents_digest` and `checkpoint_content`.
-        // However at this point it's likely we don't know the corresponding
-        // sequence number yet.
         self.checkpoint_store
             .get_checkpoint_contents(digest)
             .map_err(iota_types::storage::error::Error::custom)?

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -50,8 +50,8 @@ use iota_core::{
     },
     checkpoint_progress_tracker::CheckpointProgressTracker,
     checkpoints::{
-        CheckpointMetrics, CheckpointService, CheckpointStore, SendCheckpointToStateSync,
-        SubmitCheckpointToConsensus,
+        CheckpointMetrics, CheckpointService, CheckpointStore, FullCheckpointContentsCache,
+        FullContentsCacheMetrics, SendCheckpointToStateSync, SubmitCheckpointToConsensus,
         checkpoint_executor::{CheckpointExecutor, StopReason, metrics::CheckpointExecutorMetrics},
     },
     connection_monitor::ConnectionMonitor,
@@ -448,7 +448,13 @@ impl IotaNode {
         let is_genesis = perpetual_tables
             .database_is_empty()
             .expect("Database read should not fail at init.");
-        let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));
+        let checkpoint_store = CheckpointStore::new_with_contents_cache(
+            &config.db_path().join("checkpoints"),
+            FullCheckpointContentsCache::new(
+                config.full_checkpoint_contents_cache_size_mb * 1024 * 1024,
+                FullContentsCacheMetrics::new(&prometheus_registry),
+            ),
+        );
         let backpressure_manager =
             BackpressureManager::new_from_checkpoint_store(&checkpoint_store);
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -51,7 +51,7 @@ use iota_core::{
     checkpoint_progress_tracker::CheckpointProgressTracker,
     checkpoints::{
         CheckpointMetrics, CheckpointService, CheckpointStore, FullCheckpointContentsCache,
-        FullContentsCacheMetrics, SendCheckpointToStateSync, SubmitCheckpointToConsensus,
+        FullCheckpointContentsCacheMetrics, SendCheckpointToStateSync, SubmitCheckpointToConsensus,
         checkpoint_executor::{CheckpointExecutor, StopReason, metrics::CheckpointExecutorMetrics},
     },
     connection_monitor::ConnectionMonitor,
@@ -454,7 +454,7 @@ impl IotaNode {
                 config
                     .full_checkpoint_contents_cache_size_mb
                     .saturating_mul(1024 * 1024),
-                FullContentsCacheMetrics::new(&prometheus_registry),
+                FullCheckpointContentsCacheMetrics::new(&prometheus_registry),
             ),
         );
         let backpressure_manager =

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -451,7 +451,9 @@ impl IotaNode {
         let checkpoint_store = CheckpointStore::new_with_contents_cache(
             &config.db_path().join("checkpoints"),
             FullCheckpointContentsCache::new(
-                config.full_checkpoint_contents_cache_size_mb * 1024 * 1024,
+                config
+                    .full_checkpoint_contents_cache_size_mb
+                    .saturating_mul(1024 * 1024),
                 FullContentsCacheMetrics::new(&prometheus_registry),
             ),
         );

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -17,6 +17,7 @@ use iota_config::{
         ExecutionCacheConfig, ExpensiveSafetyCheckConfig, Genesis, GrpcApiConfig, KeyPairWithPath,
         RunWithRange, StateArchiveConfig, StateSnapshotConfig, default_enable_index_processing,
         default_end_of_epoch_broadcast_channel_capacity,
+        default_full_checkpoint_contents_cache_size_mb,
     },
     p2p::{DiscoveryConfig, P2pConfig, SeedPeer, StateSyncConfig},
     verifier_signing_config::VerifierSigningConfig,
@@ -227,6 +228,8 @@ impl ValidatorConfigBuilder {
             transaction_kv_store_write_config: None,
             authority_overload_config: self.authority_overload_config.unwrap_or_default(),
             execution_cache_config: self.execution_cache_config.unwrap_or_default(),
+            full_checkpoint_contents_cache_size_mb: default_full_checkpoint_contents_cache_size_mb(
+            ),
             run_with_range: None,
             jsonrpc_server_type: None,
             policy_config: self.policy_config,
@@ -582,6 +585,8 @@ impl FullnodeConfigBuilder {
             policy_config: self.policy_config,
             firewall_config: self.fw_config,
             execution_cache_config: ExecutionCacheConfig::default(),
+            full_checkpoint_contents_cache_size_mb: default_full_checkpoint_contents_cache_size_mb(
+            ),
             // This is a validator specific feature.
             enable_validator_tx_finalizer: false,
             // No effect on a fullnode (soft-locking runs only in the validator

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -93,6 +93,7 @@ validator_configs:
       max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
+    full-checkpoint-contents-cache-size-mb: 1024
     enable-validator-tx-finalizer: true
     enable-soft-locking: true
     verifier-signing-config:
@@ -193,6 +194,7 @@ validator_configs:
       max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
+    full-checkpoint-contents-cache-size-mb: 1024
     enable-validator-tx-finalizer: true
     enable-soft-locking: true
     verifier-signing-config:
@@ -293,6 +295,7 @@ validator_configs:
       max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
+    full-checkpoint-contents-cache-size-mb: 1024
     enable-validator-tx-finalizer: true
     enable-soft-locking: true
     verifier-signing-config:
@@ -393,6 +396,7 @@ validator_configs:
       max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
+    full-checkpoint-contents-cache-size-mb: 1024
     enable-validator-tx-finalizer: true
     enable-soft-locking: true
     verifier-signing-config:
@@ -493,6 +497,7 @@ validator_configs:
       max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
+    full-checkpoint-contents-cache-size-mb: 1024
     enable-validator-tx-finalizer: true
     enable-soft-locking: true
     verifier-signing-config:
@@ -593,6 +598,7 @@ validator_configs:
       max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
+    full-checkpoint-contents-cache-size-mb: 1024
     enable-validator-tx-finalizer: true
     enable-soft-locking: true
     verifier-signing-config:
@@ -693,6 +699,7 @@ validator_configs:
       max-transaction-manager-queue-length-soft-limit-pct: 50
     execution-cache-config:
       writeback-cache: {}
+    full-checkpoint-contents-cache-size-mb: 1024
     enable-validator-tx-finalizer: true
     enable-soft-locking: true
     verifier-signing-config:


### PR DESCRIPTION
## Description

Every checkpoint synced via p2p state sync had its full contents (transactions + effects + signatures) written to disk twice: once into the perpetual store (transactions/effects) and once as a serialized blob into the `full_checkpoint_content` RocksDB table — only for the blob to be deleted again ~5,000 checkpoints later by the checkpoint executor. This is pure write amplification plus tombstone/compaction churn for data that lives minutes to hours.

The table was purely a read optimization: every consumer already has a complete fallback that reconstructs `FullCheckpointContents` from the permanent `checkpoint_content` table plus the transaction and effects stores. Validators never populated the table at all (they don't sync contents via p2p), so the reconstruction path has always been the production serving path on validators.

This PR replaces the table with a size-bounded in-memory cache:

- **New `FullCheckpointContentsCache`** (`iota-core/src/checkpoints/full_checkpoint_contents_cache.rs`): keyed by sequence number with a contents-digest index, byte-accounted via `bcs::serialized_size`, evicting lowest sequence numbers first when over budget (keeps the newest window — what tip-following peers request). It serves the checkpoint executor's bulk transaction loads, peer requests via state sync, and the state-sync re-check.
- **New config knob** `full-checkpoint-contents-cache-size-mb` in `NodeConfig` (default **1024 MiB**, `0` disables the cache; consumers then always use the reconstruction fallback).
- **Dropped column families**: `full_checkpoint_content` and `checkpoint_sequence_by_contents_digest` are marked `#[deprecated_db_map]` and auto-dropped on the first open after upgrade. No migration needed — the data was a short-lived cache and is reconstructable.
- **Removed** the hardcoded `NUM_SAVED_FULL_CHECKPOINT_CONTENTS = 5_000` pruning block in the checkpoint executor and the digest-mapping delete in the authority store pruner.
- **Validators populate the cache from the checkpoint executor**: nodes that execute without syncing contents via state sync assemble transactions and effects when loading a checkpoint anyway; the executor now caches the assembled `FullCheckpointContents` (memory-only, nothing written to disk), so a validator serves the freshest checkpoints to its SSFNs straight from memory instead of reconstructing them — speeding up checkpoint propagation and end-to-end confirmation.
- **No wasted work when the cache wouldn't keep the entry**: the executor's contents assembly (clones every transaction/effect + a BCS size pass) is gated on a `should_cache()` pre-check — skipped when the cache is disabled (budget 0) and during deep catch-up, where the cache window rides the state-sync frontier far ahead of the executor and lowest-seq eviction would drop the entry immediately. `insert()` itself also rejects entries older than the window of a full cache.
- **New metrics**: `full_checkpoint_contents_cache_{hits,misses,evictions,entries,bytes}`. Hits/misses carry a `lookup` label: `by_seq` (executor bulk loads and sequence-number reads) vs `by_digest` (peer serving). Note that on validators, `by_seq` misses accrue once per checkpoint by design — the executor checks the cache before inserting the entry it then produces — so `by_digest` is the serving-health signal there.

### Behavior notes

- After a restart the cache is empty, so the executor's catch-up window and the first peer requests use the per-item / reconstruction fallback until the cache refills (and re-populates it as checkpoints execute). Transactions and effects are always durably written before the cache insert, so no data can be lost.
- During deep catch-up, if execution lags sync by more than the cache budget, the executor degrades to per-item loads of data state sync just wrote (hot in RocksDB caches). Hit/miss metrics make this observable; raising the knob is the mitigation.
- The peer-facing `lowest_available_checkpoint` watermark is governed by the epoch-based pruner and is unaffected.

### Ops notes

- The two CFs are dropped automatically on first start after the upgrade (one-time disk/compaction win, no operator action). Downgrade is safe: older binaries recreate the CFs empty, which is the normal validator state.
- Per-CF RocksDB `DBMetrics` for the two dropped tables disappear; new cache metrics replace them.
- The budget is accounted in serialized (BCS) bytes, so a full cache's resident memory runs somewhat above the configured value (default 1024 MiB) due to in-memory representation overhead. Memory-constrained deployments can lower the knob or set it to `0` — with the cache disabled, all cache-related work (including the executor's contents assembly) is skipped, not just the storage.

## Test plan

- New unit tests for the cache (insert/lookup by seq and digest, byte accounting, lowest-seq eviction, oversized entries, re-insert accounting, zero-budget disable).
- New `CheckpointStore` test: insert populates cache + durable `checkpoint_content` row; reopening yields a cache miss while the digest-form contents survive for reconstruction.
- New checkpoint-executor tests pinning the produce-path behavior: the fallback load populates the contents cache (retrievable by sequence number and contents digest), skips it when the cache is disabled, and skips it when the cache window rides the state-sync frontier ahead of the executing sequence (deep catch-up).
- `cargo nextest run -p iota-core --lib` (689 passed), `-p typed-store -p iota-network -p iota-archival --lib` (109 passed, incl. state-sync + archive-sync tests).
- `cargo simtest -p iota-e2e-tests`: `basic_checkpoints_integration_test`, `test_checkpoint_timestamps_non_decreasing`, `test_full_node_cold_sync`, `test_full_node_sync_flood` — all pass.
- `cargo ci-clippy` clean; full workspace `--all-targets` compiles.






### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Replace the on-disk `full_checkpoint_content` table with a size-bounded in-memory cache for serving checkpoint contents to state-sync peers; validators populate it from the checkpoint builder. Adds an optional node config `full-checkpoint-contents-cache-size-mb` (default `1024`; set `0` to disable). The `full_checkpoint_content` and `checkpoint_sequence_by_contents_digest` RocksDB column families are dropped automatically on first start.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

#### Breaking Changes Rollout

No breaking changes. The new config parameter is additive with a default, and the dropped column families are removed automatically on first start (downgrade-safe: older binaries recreate them empty).
