### PR TITLE
feat(iota-types,iota-config): add DenyRuleSet/DenyRuleProposal types 

### DIFF
--- a/crates/iota-config/src/transaction_deny_config.rs
+++ b/crates/iota-config/src/transaction_deny_config.rs
@@ -5,6 +5,7 @@
 use std::collections::HashSet;
 
 use iota_sdk_types::{Address, ObjectId};
+use iota_types::deny_rule_governance::DenyRuleConfig;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
@@ -176,5 +177,99 @@ impl TransactionDenyConfigBuilder {
     pub fn disable_move_authenticator(mut self) -> Self {
         self.config.move_authenticator_disabled = true;
         self
+    }
+}
+
+impl DenyRuleConfig for TransactionDenyConfig {
+    fn is_address_denied(&self, address: &Address) -> bool {
+        self.get_address_deny_set().contains(address)
+    }
+
+    fn is_object_denied(&self, id: &ObjectId) -> bool {
+        self.get_object_deny_set().contains(id)
+    }
+
+    fn is_package_denied(&self, id: &ObjectId) -> bool {
+        self.get_package_deny_set().contains(id)
+    }
+
+    fn has_denied_addresses(&self) -> bool {
+        !self.address_deny_list.is_empty()
+    }
+
+    fn has_denied_objects(&self) -> bool {
+        !self.object_deny_list.is_empty()
+    }
+
+    fn has_denied_packages(&self) -> bool {
+        !self.package_deny_list.is_empty()
+    }
+
+    fn package_publish_disabled(&self) -> bool {
+        self.package_publish_disabled
+    }
+
+    fn package_upgrade_disabled(&self) -> bool {
+        self.package_upgrade_disabled
+    }
+
+    fn shared_object_disabled(&self) -> bool {
+        self.shared_object_disabled
+    }
+
+    fn user_transaction_disabled(&self) -> bool {
+        self.user_transaction_disabled
+    }
+
+    fn receiving_objects_disabled(&self) -> bool {
+        self.receiving_objects_disabled
+    }
+
+    fn move_authenticator_disabled(&self) -> bool {
+        self.move_authenticator_disabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_sdk_types::{Address, ObjectId};
+
+    use super::{DenyRuleConfig, TransactionDenyConfig, TransactionDenyConfigBuilder};
+
+    #[test]
+    fn trait_impl_reflects_config() {
+        let addr = Address::new([1u8; 32]);
+        let obj = ObjectId::new([2u8; 32]);
+        let pkg = ObjectId::new([3u8; 32]);
+        let config = TransactionDenyConfigBuilder::new()
+            .add_denied_address(addr)
+            .add_denied_object(obj)
+            .add_denied_package(pkg)
+            .disable_user_transaction()
+            .disable_shared_object_transaction()
+            .disable_move_authenticator()
+            .build();
+
+        // Exercise the trait via dynamic dispatch, exactly as the deny checks do.
+        let deny: &dyn DenyRuleConfig = &config;
+        assert!(deny.is_address_denied(&addr));
+        assert!(!deny.is_address_denied(&Address::new([9u8; 32])));
+        assert!(deny.is_object_denied(&obj));
+        assert!(!deny.is_object_denied(&ObjectId::new([9u8; 32])));
+        assert!(deny.is_package_denied(&pkg));
+        assert!(deny.has_denied_addresses());
+        assert!(deny.has_denied_objects());
+        assert!(deny.has_denied_packages());
+        assert!(deny.user_transaction_disabled());
+        assert!(deny.shared_object_disabled());
+        assert!(deny.move_authenticator_disabled());
+        assert!(!deny.package_publish_disabled());
+        assert!(!deny.package_upgrade_disabled());
+        assert!(!deny.receiving_objects_disabled());
+
+        let empty: &dyn DenyRuleConfig = &TransactionDenyConfig::default();
+        assert!(!empty.has_denied_addresses());
+        assert!(!empty.has_denied_objects());
+        assert!(!empty.has_denied_packages());
     }
 }

--- a/crates/iota-types/src/deny_rule_governance.rs
+++ b/crates/iota-types/src/deny_rule_governance.rs
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+
+use iota_sdk_types::{Address, ObjectId};
+use serde::{Deserialize, Serialize};
+
+use crate::base_types::AuthorityName;
+
+/// Read access to a set of transaction deny rules.
+///
+/// Implemented by both a validator's local `TransactionDenyConfig` and the
+/// consensus-governed [`DenyRuleSet`], so the deny checks can run against
+/// either source without knowing which one is in effect.
+pub trait DenyRuleConfig {
+    /// Whether `address` is denied as a transaction sender or gas sponsor.
+    fn is_address_denied(&self, address: &Address) -> bool;
+    /// Whether the object `id` is denied as an input or receiving object.
+    fn is_object_denied(&self, id: &ObjectId) -> bool;
+    /// Whether the package `id` is denied as a (transitive) dependency.
+    fn is_package_denied(&self, id: &ObjectId) -> bool;
+    /// Whether any address is denied; lets checks skip scanning signers when
+    /// there are none.
+    fn has_denied_addresses(&self) -> bool;
+    /// Whether any object is denied; lets checks skip scanning input and
+    /// receiving objects when there are none.
+    fn has_denied_objects(&self) -> bool;
+    /// Whether any package is denied; lets checks skip resolving package
+    /// dependencies (which loads packages from the store) when there are none.
+    fn has_denied_packages(&self) -> bool;
+    fn package_publish_disabled(&self) -> bool;
+    fn package_upgrade_disabled(&self) -> bool;
+    fn shared_object_disabled(&self) -> bool;
+    fn user_transaction_disabled(&self) -> bool;
+    fn receiving_objects_disabled(&self) -> bool;
+    fn move_authenticator_disabled(&self) -> bool;
+}
+
+/// A complete set of deny rules.
+///
+/// Deny lists use `BTreeSet` so the BCS encoding is deterministic across
+/// validators (a requirement for the consensus messages that carry this type).
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DenyRuleSet {
+    /// Addresses denied as transaction sender or gas sponsor. A denied
+    /// address can still receive objects.
+    pub denied_addresses: BTreeSet<Address>,
+    /// Objects denied as transaction inputs or receiving objects.
+    pub denied_objects: BTreeSet<ObjectId>,
+    /// Packages denied as a (transitive) dependency of any command; upgrading
+    /// a denied package is denied too.
+    pub denied_packages: BTreeSet<ObjectId>,
+    /// Denies all package publishing.
+    pub package_publish_disabled: bool,
+    /// Denies all package upgrades.
+    pub package_upgrade_disabled: bool,
+    /// Denies transactions that use shared objects as inputs.
+    pub shared_object_disabled: bool,
+    /// Denies all user transactions (kill switch).
+    pub user_transaction_disabled: bool,
+    /// Denies transactions that contain receiving objects.
+    pub receiving_objects_disabled: bool,
+    /// Denies transactions signed with a Move authenticator.
+    pub move_authenticator_disabled: bool,
+}
+
+impl DenyRuleConfig for DenyRuleSet {
+    fn is_address_denied(&self, address: &Address) -> bool {
+        self.denied_addresses.contains(address)
+    }
+
+    fn is_object_denied(&self, id: &ObjectId) -> bool {
+        self.denied_objects.contains(id)
+    }
+
+    fn is_package_denied(&self, id: &ObjectId) -> bool {
+        self.denied_packages.contains(id)
+    }
+
+    fn has_denied_addresses(&self) -> bool {
+        !self.denied_addresses.is_empty()
+    }
+
+    fn has_denied_objects(&self) -> bool {
+        !self.denied_objects.is_empty()
+    }
+
+    fn has_denied_packages(&self) -> bool {
+        !self.denied_packages.is_empty()
+    }
+
+    fn package_publish_disabled(&self) -> bool {
+        self.package_publish_disabled
+    }
+
+    fn package_upgrade_disabled(&self) -> bool {
+        self.package_upgrade_disabled
+    }
+
+    fn shared_object_disabled(&self) -> bool {
+        self.shared_object_disabled
+    }
+
+    fn user_transaction_disabled(&self) -> bool {
+        self.user_transaction_disabled
+    }
+
+    fn receiving_objects_disabled(&self) -> bool {
+        self.receiving_objects_disabled
+    }
+
+    fn move_authenticator_disabled(&self) -> bool {
+        self.move_authenticator_disabled
+    }
+}
+
+/// A validator's full-state proposal for the network deny rules, announced
+/// through consensus.
+///
+/// Each proposal carries the authority's complete proposed rule set; the latest
+/// generation per authority supersedes earlier ones. The active rule set the
+/// network enforces is the stake-weighted aggregate of all current proposals.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DenyRuleProposal {
+    /// The authority announcing this proposal.
+    pub authority: AuthorityName,
+    /// Per-authority counter used to deduplicate proposals; a higher generation
+    /// supersedes earlier proposals from the same authority.
+    pub generation: u64,
+    /// The complete set of rules this authority proposes.
+    pub proposed_rules: DenyRuleSet,
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_sdk_types::{Address, ObjectId};
+
+    use crate::{
+        crypto::AuthorityPublicKeyBytes,
+        deny_rule_governance::{DenyRuleConfig, DenyRuleProposal, DenyRuleSet},
+    };
+
+    fn sample_rule_set() -> DenyRuleSet {
+        DenyRuleSet {
+            denied_addresses: [Address::new([1u8; 32]), Address::new([2u8; 32])]
+                .into_iter()
+                .collect(),
+            denied_objects: [ObjectId::new([3u8; 32])].into_iter().collect(),
+            denied_packages: [ObjectId::new([4u8; 32])].into_iter().collect(),
+            package_publish_disabled: true,
+            package_upgrade_disabled: false,
+            shared_object_disabled: true,
+            user_transaction_disabled: false,
+            receiving_objects_disabled: true,
+            move_authenticator_disabled: false,
+        }
+    }
+
+    #[test]
+    fn deny_rule_set_bcs_round_trip() {
+        let rules = sample_rule_set();
+        let bytes = bcs::to_bytes(&rules).unwrap();
+        assert_eq!(rules, bcs::from_bytes(&bytes).unwrap());
+    }
+
+    #[test]
+    fn deny_rule_proposal_bcs_round_trip() {
+        let proposal = DenyRuleProposal {
+            authority: AuthorityPublicKeyBytes::ZERO,
+            generation: 42,
+            proposed_rules: sample_rule_set(),
+        };
+        let bytes = bcs::to_bytes(&proposal).unwrap();
+        assert_eq!(proposal, bcs::from_bytes(&bytes).unwrap());
+    }
+
+    #[test]
+    fn deny_rule_config_reflects_set_contents() {
+        let rules = sample_rule_set();
+
+        assert!(rules.is_address_denied(&Address::new([1u8; 32])));
+        assert!(!rules.is_address_denied(&Address::new([9u8; 32])));
+        assert!(rules.is_object_denied(&ObjectId::new([3u8; 32])));
+        assert!(!rules.is_object_denied(&ObjectId::new([9u8; 32])));
+        assert!(rules.is_package_denied(&ObjectId::new([4u8; 32])));
+        assert!(!rules.is_package_denied(&ObjectId::new([9u8; 32])));
+
+        assert!(rules.has_denied_addresses());
+        assert!(rules.has_denied_objects());
+        assert!(rules.has_denied_packages());
+
+        assert!(rules.package_publish_disabled());
+        assert!(!rules.package_upgrade_disabled());
+        assert!(rules.shared_object_disabled());
+        assert!(!rules.user_transaction_disabled());
+        assert!(rules.receiving_objects_disabled());
+        assert!(!rules.move_authenticator_disabled());
+    }
+
+    /// An empty set denies nothing.
+    #[test]
+    fn empty_deny_rule_set_denies_nothing() {
+        let rules = DenyRuleSet::default();
+        assert!(!rules.is_address_denied(&Address::new([1u8; 32])));
+        assert!(!rules.is_object_denied(&ObjectId::new([1u8; 32])));
+        assert!(!rules.has_denied_addresses());
+        assert!(!rules.has_denied_objects());
+        assert!(!rules.has_denied_packages());
+        assert!(!rules.user_transaction_disabled());
+    }
+}

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -46,6 +46,7 @@ pub mod committee;
 pub mod config;
 pub mod crypto;
 pub mod deny_list_v1;
+pub mod deny_rule_governance;
 pub mod derived_object;
 pub mod digests;
 pub mod display;


### PR DESCRIPTION
# Description of change
Adds the core types and abstraction layer for consensus-governed deny rules (deny governance, #10749). Pure additive — nothing consumes these yet, so there is no behavior change; routing the deny checks through the trait follows in the next PR.

## Links to any relevant issues
fixes #12090

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
