### PR TITLE
refactor(iota-transaction-checks): route deny checks through DenyRuleConfig trait (#12148)

### DIFF
--- a/crates/iota-transaction-checks/src/deny.rs
+++ b/crates/iota-transaction-checks/src/deny.rs
@@ -2,9 +2,9 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_config::transaction_deny_config::TransactionDenyConfig;
 use iota_sdk_types::{Command, ObjectReference};
 use iota_types::{
+    deny_rule_governance::DenyRuleConfig,
     error::{IotaError, IotaResult, UserInputError},
     signature::UserSignature,
     storage::BackingPackageStore,
@@ -31,7 +31,7 @@ pub fn check_transaction_for_validation(
     tx_signatures: &[UserSignature],
     input_object_kinds: &[InputObjectKind],
     receiving_objects: &[ObjectReference],
-    filter_config: &TransactionDenyConfig,
+    filter_config: &dyn DenyRuleConfig,
     package_store: &dyn BackingPackageStore,
 ) -> IotaResult {
     check_disabled_features(filter_config, tx_data, tx_signatures)?;
@@ -49,18 +49,19 @@ pub fn check_transaction_for_validation(
 
 #[instrument(level = "trace", skip_all)]
 fn check_receiving_objects(
-    filter_config: &TransactionDenyConfig,
+    filter_config: &dyn DenyRuleConfig,
     receiving_objects: &[ObjectReference],
 ) -> IotaResult {
     deny_if_true!(
         filter_config.receiving_objects_disabled() && !receiving_objects.is_empty(),
         "Receiving objects is temporarily disabled".to_string()
     );
+    if !filter_config.has_denied_objects() {
+        return Ok(());
+    }
     for receiving_object in receiving_objects {
         deny_if_true!(
-            filter_config
-                .get_object_deny_set()
-                .contains(&receiving_object.object_id),
+            filter_config.is_object_denied(&receiving_object.object_id),
             format!(
                 "Access to object {:?} is temporarily disabled",
                 receiving_object.object_id
@@ -72,7 +73,7 @@ fn check_receiving_objects(
 
 #[instrument(level = "trace", skip_all)]
 fn check_disabled_features(
-    filter_config: &TransactionDenyConfig,
+    filter_config: &dyn DenyRuleConfig,
     tx_data: &TransactionData,
     tx_signatures: &[UserSignature],
 ) -> IotaResult {
@@ -109,14 +110,13 @@ fn check_disabled_features(
 }
 
 #[instrument(level = "trace", skip_all)]
-fn check_signers(filter_config: &TransactionDenyConfig, tx_data: &TransactionData) -> IotaResult {
-    let deny_map = filter_config.get_address_deny_set();
-    if deny_map.is_empty() {
+fn check_signers(filter_config: &dyn DenyRuleConfig, tx_data: &TransactionData) -> IotaResult {
+    if !filter_config.has_denied_addresses() {
         return Ok(());
     }
     for signer in tx_data.signers() {
         deny_if_true!(
-            deny_map.contains(&signer),
+            filter_config.is_address_denied(&signer),
             format!(
                 "Access to account address {:?} is temporarily disabled",
                 signer
@@ -128,19 +128,18 @@ fn check_signers(filter_config: &TransactionDenyConfig, tx_data: &TransactionDat
 
 #[instrument(level = "trace", skip_all)]
 fn check_input_objects(
-    filter_config: &TransactionDenyConfig,
+    filter_config: &dyn DenyRuleConfig,
     input_object_kinds: &[InputObjectKind],
 ) -> IotaResult {
-    let deny_map = filter_config.get_object_deny_set();
     let shared_object_disabled = filter_config.shared_object_disabled();
-    if deny_map.is_empty() && !shared_object_disabled {
+    if !filter_config.has_denied_objects() && !shared_object_disabled {
         // No need to iterate through the input objects if no relevant policy is set.
         return Ok(());
     }
     for input_object_kind in input_object_kinds {
         let id = input_object_kind.object_id();
         deny_if_true!(
-            deny_map.contains(&id),
+            filter_config.is_object_denied(&id),
             format!("Access to input object {id} is temporarily disabled")
         );
         deny_if_true!(
@@ -153,12 +152,11 @@ fn check_input_objects(
 
 #[instrument(level = "trace", skip_all)]
 fn check_package_dependencies(
-    filter_config: &TransactionDenyConfig,
+    filter_config: &dyn DenyRuleConfig,
     tx_data: &TransactionData,
     package_store: &dyn BackingPackageStore,
 ) -> IotaResult {
-    let deny_map = filter_config.get_package_deny_set();
-    if deny_map.is_empty() {
+    if !filter_config.has_denied_packages() {
         return Ok(());
     }
     let mut dependencies = vec![];
@@ -208,7 +206,7 @@ fn check_package_dependencies(
     }
     for dep in dependencies {
         deny_if_true!(
-            deny_map.contains(&dep),
+            filter_config.is_package_denied(&dep),
             format!("Access to package {dep} is temporarily disabled")
         );
     }


### PR DESCRIPTION
# Description of change

Routes the deny checks through the `DenyRuleConfig` trait (#12090) so they can run against either the local config or the consensus-governed rule set (deny governance, #10749). Behavior-neutral — all callers keep passing `&self.config.transaction_deny_config`, which coerces to `&dyn DenyRuleConfig` with no call-site changes.

Stacked on the #12090 branch (PR #12147); rebase onto develop after that merges.

## Links to any relevant issues

Fixes #12148.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes