### PR TITLE
upstream(iota-core,iota-types): pre-consensus dedup for duplicate transaction resubmissions

### DIFF
--- a/crates/iota-core/src/authority_server/metrics.rs
+++ b/crates/iota-core/src/authority_server/metrics.rs
@@ -37,6 +37,9 @@ pub struct ValidatorServiceMetrics {
     pub x_forwarded_for_num_hops: Gauge,
     pub num_rejected_tx_soft_lock_conflict: IntCounter,
     pub soft_lock_table_size: IntGauge,
+    pub num_rejected_tx_recently_resubmitted: IntCounter,
+    pub recently_submitted_cache_size: IntGauge,
+    pub recently_submitted_resubmission_interval: Histogram,
 }
 
 impl ValidatorServiceMetrics {
@@ -204,6 +207,25 @@ impl ValidatorServiceMetrics {
             soft_lock_table_size: register_int_gauge_with_registry!(
                 "validator_service_soft_lock_table_size",
                 "Current number of object refs held in the pre-consensus soft lock table",
+                registry,
+            )
+                .unwrap(),
+            num_rejected_tx_recently_resubmitted: register_int_counter_with_registry!(
+                "validator_service_num_rejected_tx_recently_resubmitted",
+                "Number of transactions rejected as duplicate resubmissions within the recent-submission window",
+                registry,
+            )
+                .unwrap(),
+            recently_submitted_cache_size: register_int_gauge_with_registry!(
+                "validator_service_recently_submitted_cache_size",
+                "Approximate number of transaction digests held in the recent-submission dedup cache",
+                registry,
+            )
+                .unwrap(),
+            recently_submitted_resubmission_interval: register_histogram_with_registry!(
+                "validator_service_recently_submitted_resubmission_interval_seconds",
+                "Time between a transaction being recorded and a duplicate resubmission of it being suppressed",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
                 .unwrap(),

--- a/crates/iota-core/src/authority_server/mod.rs
+++ b/crates/iota-core/src/authority_server/mod.rs
@@ -7,6 +7,7 @@ mod validator_peer;
 mod validator_v2;
 
 pub mod metrics;
+pub mod recent_submission;
 pub mod soft_lock;
 #[cfg(test)]
 mod test_server;
@@ -30,7 +31,7 @@ use tracing::error;
 
 use crate::{
     authority::AuthorityState,
-    authority_server::soft_lock::PreConsensusSoftLocks,
+    authority_server::{recent_submission::RecentSubmissions, soft_lock::PreConsensusSoftLocks},
     consensus_adapter::ConsensusAdapter,
     traffic_controller::{
         ClientIpStatus, TrafficController, get_client_ip, policies::TrafficTally,
@@ -51,6 +52,7 @@ pub struct ValidatorService {
     traffic_controller: Option<Arc<TrafficController>>,
     client_id_source: Option<ClientIdSource>,
     soft_locks: Arc<PreConsensusSoftLocks>,
+    recent_submissions: Arc<RecentSubmissions>,
 }
 
 impl ValidatorService {
@@ -70,6 +72,7 @@ impl ValidatorService {
             traffic_controller,
             client_id_source,
             soft_locks,
+            recent_submissions: Arc::new(RecentSubmissions::new()),
         }
     }
 
@@ -85,6 +88,7 @@ impl ValidatorService {
             traffic_controller: None,
             client_id_source: None,
             soft_locks: Arc::new(PreConsensusSoftLocks::new()),
+            recent_submissions: Arc::new(RecentSubmissions::new()),
         }
     }
 

--- a/crates/iota-core/src/authority_server/recent_submission.rs
+++ b/crates/iota-core/src/authority_server/recent_submission.rs
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Digest-keyed duplicate-suppression for the pcool (white-flag) submission
+//! path. Complements [`PreConsensusSoftLocks`] which is keyed on `ObjectRef`
+//! and is intentionally idempotent for same-digest resubmissions; this layer
+//! catches the same-digest case (including shared-object and gasless txs)
+//! before they reach consensus.
+//!
+//! The cache records when a digest was first submitted and rejects any
+//! resubmission seen within `window`. Entries auto-expire via the cache's
+//! time-to-live; no active release is required because the window is small
+//! (subsecond-to-second range) and bounded.
+//!
+//! # Edge cases
+//!
+//! | Case                                | Behavior                                                              |
+//! |-------------------------------------|-----------------------------------------------------------------------|
+//! | Same tx digest resubmitted in-window | Rejected with `IotaError::RecentlyResubmitted`                        |
+//! | Same digest resubmitted after window | Re-recorded; passes through                                           |
+//! | Concurrent submissions of same digest | First record wins; concurrent races may both pass — soft locks and consensus dedup catch the rest |
+//! | Crash / restart                     | Cache lost → clean slate; behaviour is best-effort defense-in-depth   |
+//! | Epoch boundary                      | Cache is not epoch-scoped; window is short enough that stale entries  |
+//! |                                     | are harmless across epochs                                            |
+
+use std::time::{Duration, Instant};
+
+use iota_types::{base_types::TransactionDigest, error::IotaError};
+use moka::sync::Cache;
+
+/// Default window during which a given transaction is allowed into consensus
+/// at most once. Short enough to permit legitimate retries promptly while
+/// suppressing resubmission storms within a block-formation window.
+pub const DEFAULT_RECENT_SUBMISSION_WINDOW: Duration = Duration::from_secs(1);
+
+/// Assumed peak distinct-submission rate, used to size the dedup cache.
+/// Memory backstop only — the window bounds normal occupancy.
+const RECENT_SUBMISSION_PEAK_TPS: u64 = 50_000;
+
+/// In-memory record of recently submitted transaction digests. Rejects
+/// duplicate resubmissions seen within `window`.
+#[derive(Debug)]
+pub struct RecentSubmissions {
+    cache: Cache<TransactionDigest, Instant>,
+    window: Duration,
+}
+
+impl Default for RecentSubmissions {
+    fn default() -> Self {
+        Self::with_window(DEFAULT_RECENT_SUBMISSION_WINDOW)
+    }
+}
+
+impl RecentSubmissions {
+    /// Creates a new instance with the default window.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new instance with a custom window (useful for tests).
+    pub fn with_window(window: Duration) -> Self {
+        let max_capacity = window.as_secs().max(1) * RECENT_SUBMISSION_PEAK_TPS;
+        let cache = Cache::builder()
+            .time_to_live(window)
+            .max_capacity(max_capacity)
+            .build();
+        Self { cache, window }
+    }
+
+    /// Returns the configured suppression window.
+    pub fn window(&self) -> Duration {
+        self.window
+    }
+
+    /// Approximate number of digests currently held in the cache.
+    pub fn entry_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
+
+    /// Checks whether `tx_digest` was recorded within the suppression window.
+    /// On hit, returns the elapsed time since the original recording (useful
+    /// for metrics). On miss, records the digest as recently submitted and
+    /// returns `Ok(())`.
+    pub fn try_record(&self, tx_digest: TransactionDigest) -> Result<(), Duration> {
+        if let Some(recorded_at) = self.cache.get(&tx_digest) {
+            let elapsed = recorded_at.elapsed();
+            if elapsed < self.window {
+                return Err(elapsed);
+            }
+        }
+        self.cache.insert(tx_digest, Instant::now());
+        Ok(())
+    }
+}
+
+/// Builds the rejection error returned when a duplicate resubmission is
+/// suppressed.
+pub fn recently_resubmitted_error(digest: TransactionDigest) -> IotaError {
+    IotaError::RecentlyResubmitted { digest }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread::sleep;
+
+    use iota_types::base_types::TransactionDigest;
+
+    use super::*;
+
+    #[test]
+    fn first_submission_records_and_passes() {
+        let r = RecentSubmissions::with_window(Duration::from_millis(500));
+        let d = TransactionDigest::random();
+        assert!(r.try_record(d).is_ok());
+    }
+
+    #[test]
+    fn duplicate_within_window_is_rejected() {
+        let r = RecentSubmissions::with_window(Duration::from_millis(500));
+        let d = TransactionDigest::random();
+        assert!(r.try_record(d).is_ok());
+        let elapsed = r.try_record(d).expect_err("duplicate must be rejected");
+        assert!(elapsed < Duration::from_millis(500));
+    }
+
+    #[test]
+    fn resubmission_after_window_passes() {
+        let r = RecentSubmissions::with_window(Duration::from_millis(50));
+        let d = TransactionDigest::random();
+        assert!(r.try_record(d).is_ok());
+        sleep(Duration::from_millis(120));
+        assert!(
+            r.try_record(d).is_ok(),
+            "resubmission after window must pass"
+        );
+    }
+
+    #[test]
+    fn distinct_digests_do_not_interfere() {
+        let r = RecentSubmissions::with_window(Duration::from_millis(500));
+        let d1 = TransactionDigest::random();
+        let d2 = TransactionDigest::random();
+        assert!(r.try_record(d1).is_ok());
+        assert!(r.try_record(d2).is_ok());
+    }
+}

--- a/crates/iota-core/src/authority_server/validator.rs
+++ b/crates/iota-core/src/authority_server/validator.rs
@@ -74,6 +74,7 @@ impl ValidatorService {
             traffic_controller: _,
             client_id_source: _,
             soft_locks: _,
+            recent_submissions: _,
         } = self.clone();
         let transaction = request.into_inner();
         let epoch_store = state.load_epoch_store_one_call_per_task();

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -54,6 +54,7 @@ use crate::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
     authority_server::{
         StreamResponse, ValidatorService, ValidatorServiceMetrics, normalize,
+        recent_submission::{RecentSubmissions, recently_resubmitted_error},
         soft_lock::PreConsensusSoftLocks,
     },
     consensus_adapter::ConsensusAdapter,
@@ -92,6 +93,7 @@ impl ValidatorService {
         let consensus_adapter = self.consensus_adapter.clone();
         let metrics = self.metrics.clone();
         let soft_locks = self.soft_locks.clone();
+        let recent_submissions = self.recent_submissions.clone();
 
         // Run per-tx tasks concurrently, capped by `MAX_CONCURRENT_SUBMIT_TASKS`.
         // Spawning lets CPU-heavy work run across worker threads; `buffer_unordered`
@@ -104,6 +106,7 @@ impl ValidatorService {
                     let consensus_adapter = consensus_adapter.clone();
                     let metrics = metrics.clone();
                     let soft_locks = soft_locks.clone();
+                    let recent_submissions = recent_submissions.clone();
                     spawn_monitored_task!(async move {
                         let tx_digest = *transaction.digest();
                         let (update, weight) = Self::submit_single_tx(
@@ -112,6 +115,7 @@ impl ValidatorService {
                             &metrics,
                             &epoch_store,
                             &soft_locks,
+                            &recent_submissions,
                             transaction,
                         )
                         .await;
@@ -150,6 +154,7 @@ impl ValidatorService {
         metrics: &Arc<ValidatorServiceMetrics>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         soft_locks: &Arc<PreConsensusSoftLocks>,
+        recent_submissions: &Arc<RecentSubmissions>,
         transaction: Transaction,
     ) -> (TxStatusUpdate, Weight) {
         let tx_digest = *transaction.digest();
@@ -195,6 +200,26 @@ impl ValidatorService {
         {
             return (build_executed(effects), Weight::one());
         }
+
+        // Suppress duplicate resubmissions of in-flight transactions. Placed
+        // before signature verification and validation so amplified
+        // resubmission storms are short-circuited cheaply. Soft locks
+        // (object-keyed) are intentionally idempotent for same-digest
+        // resubmission, so this digest-keyed check is the layer that catches
+        // them. Best-effort: concurrent races may both pass, but consensus
+        // is the authoritative dedup.
+        if let Err(elapsed) = recent_submissions.try_record(tx_digest) {
+            metrics.num_rejected_tx_recently_resubmitted.inc();
+            metrics
+                .recently_submitted_resubmission_interval
+                .observe(elapsed.as_secs_f64());
+            let error = recently_resubmitted_error(tx_digest);
+            let weight = normalize(&error);
+            return (TxStatusUpdate::Rejected { error }, weight);
+        }
+        metrics
+            .recently_submitted_cache_size
+            .set(recent_submissions.entry_count() as i64);
 
         // Verify user signature.
         let tx_verif_guard = metrics.tx_verification_latency.start_timer();

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -515,6 +515,8 @@ pub enum IotaError {
         new_epoch: EpochId,
         locked_by_tx: TransactionDigest,
     },
+    #[error("Transaction {digest:?} was recently submitted; duplicate resubmission suppressed.")]
+    RecentlyResubmitted { digest: TransactionDigest },
     #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{digest}]")]
     TransactionNotFound { digest: TransactionDigest },
     #[error("{TRANSACTIONS_NOT_FOUND_MSG_PREFIX} [{digests:?}]")]
@@ -847,6 +849,10 @@ impl IotaError {
 
             // Transient consensus failure — other validators likely unaffected
             IotaError::FailedToSubmitToConsensus(..) => true,
+
+            // Same digest already in flight — client should wait for the
+            // original to land or retry once the recent-submission window expires.
+            IotaError::RecentlyResubmitted { .. } => true,
 
             // Non retryable error
             IotaError::Execution(..) => false,


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#27069](https://github.com/MystenLabs/sui/pull/27069)
- Description: Adds a digest-keyed pre-consensus dedup layer that short-circuits duplicate transaction resubmissions within a short window (default 1s), so amplified resubmission storms are dropped before expensive signature verification.

Originally developed on the `consensus/feat/pcool-feature` stack (IOTA #11151); now that P-COOL has merged, this is rebased onto `develop` as a single commit. The only rebase conflict was an adjacency collision in `crates/iota-types/src/error.rs` (the new `RecentlyResubmitted` variant next to a reworded `TransactionNotFound`), resolved by keeping both.

Adapted to the fork:

- New `RecentSubmissions` sibling to `PreConsensusSoftLocks`: module `crates/iota-core/src/authority_server/recent_submission.rs` — a moka `Cache<TransactionDigest, Instant>` (TTL = window), `try_record` returning `Ok(())` on a miss and `Err(elapsed)` on a duplicate within the window. 4 unit tests cover first-insert, duplicate-within-window, expiry-after-window, and distinct-digests.
- Wired into `ValidatorService` (default 1s window) and into `submit_single_tx` (`authority_server/validator_v2.rs`) after the executed-effects short-circuit and before signature verification. This is orthogonal to the soft locks, which stay idempotent on the same digest by design: soft locks are object-keyed, whereas this dedup is digest-keyed and also covers shared-object and gasless transactions.
- New retryable error `IotaError::RecentlyResubmitted { digest }`, added to the retryable list so clients back off / wait for effects instead of treating it as a hard failure.
- Three Prometheus metrics: `validator_service_num_rejected_tx_recently_resubmitted`, `validator_service_recently_submitted_cache_size`, `validator_service_recently_submitted_resubmission_interval_seconds`.
- `DEFAULT_RECENT_SUBMISSION_WINDOW = 1s` is hard-coded to match the upstream default and stay consistent with `soft_lock.rs`'s hard-coded TTL; can be wired through `NodeConfig` later if per-deployment tuning is wanted.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
