### PR TITLE
feat(iota-core): add deny rule proposal persistence, stake aggregation, and active-set cache (#12151)

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 
-use arc_swap::ArcSwapOption;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use dashmap::DashMap;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::{groups::bls12381, traits::ToFromBytes};
@@ -31,7 +31,7 @@ use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
 use iota_sdk_types::{
-    CancelledTransaction, CheckpointTimestamp, ObjectId, ObjectReference, RandomnessRound,
+    Address, CancelledTransaction, CheckpointTimestamp, ObjectId, ObjectReference, RandomnessRound,
     TransactionDigest, TransactionEffectsDigest, TransactionKind, Version, VersionAssignment,
 };
 use iota_storage::mutex_table::{MutexGuard, MutexTable};
@@ -39,6 +39,7 @@ use iota_types::{
     base_types::{AuthorityName, CommitRound, ConciseableName, EpochId},
     committee::{Committee, CommitteeTrait, StakeUnit},
     crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo},
+    deny_rule_governance::{DenyRuleProposal, DenyRuleSet},
     digests::ChainIdentifier,
     effects::TransactionEffects,
     error::{IotaError, IotaResult},
@@ -698,6 +699,12 @@ pub struct AuthorityPerEpochStore {
     /// `Rejected` response instead of waiting for the gRPC deadline.
     dropped_tx_status_cache: super::dropped_tx_status_cache::DroppedTxStatusCache,
 
+    /// The active deny rule set: the stake-weighted aggregate of the recorded
+    /// deny rule proposals. Recomputed via
+    /// `update_active_transaction_deny_rules` and seeded from the
+    /// `deny_rule_proposals` table on construction.
+    active_transaction_deny_rules: ArcSwap<DenyRuleSet>,
+
     /// Pre-consensus soft locks for owned objects (P-COOL flow).
     ///
     /// Set via `OnceCell` rather than passed through the constructor because
@@ -873,6 +880,11 @@ pub struct AuthorityEpochTables {
     /// (0-100). Overwrites on each new notification from the same
     /// authority.
     authority_overload_notifications: DBMap<AuthorityName, u8>,
+
+    /// Record of the latest deny rule proposal from each authority, received
+    /// via DenyRuleProposal consensus transactions. A newer generation
+    /// overwrites an older one from the same authority.
+    deny_rule_proposals: DBMap<AuthorityName, DenyRuleProposal>,
 
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
@@ -1220,6 +1232,19 @@ impl AuthorityPerEpochStore {
             .collect::<Result<HashMap<AuthorityName, u8>, _>>()
             .expect("AuthorityEpochTables should contain valid overload notifications");
 
+        // Seed the quarantine's deny-rule-proposal cache from the persisted
+        // table and derive the active rule set. A mid-epoch restart resumes
+        // with the rules from all flushed commits; proposals from unflushed
+        // commits are re-recorded by consensus replay.
+        let cached_deny_rule_proposals: BTreeMap<AuthorityName, DenyRuleProposal> = tables
+            .deny_rule_proposals
+            .safe_iter()
+            .collect::<Result<BTreeMap<_, _>, _>>()
+            .expect("AuthorityEpochTables should contain valid deny rule proposals");
+        let active_transaction_deny_rules = ArcSwap::from_pointee(
+            Self::compute_active_transaction_deny_rules(&cached_deny_rule_proposals, &committee),
+        );
+
         let committee_size = committee.num_members();
         let report_version = MisbehaviorReportVersion::from_protocol(&protocol_config);
         let misbehavior_monitor = MisbehaviorMonitor::new(name, report_version, committee_size);
@@ -1249,6 +1274,7 @@ impl AuthorityPerEpochStore {
             consensus_quarantine: RwLock::new(ConsensusOutputQuarantine::new(
                 highest_executed_checkpoint,
                 cached_overload_notifications,
+                cached_deny_rule_proposals,
                 metrics.clone(),
             )),
             parent_path: parent_path.to_path_buf(),
@@ -1265,6 +1291,7 @@ impl AuthorityPerEpochStore {
             executed_digests_notify_read: NotifyRead::new(),
             signed_effects_digests_cache,
             dropped_tx_status_cache: super::dropped_tx_status_cache::DroppedTxStatusCache::new(),
+            active_transaction_deny_rules,
             soft_locks: OnceCell::new(),
             end_of_publish: Mutex::new(end_of_publish),
             pending_consensus_certificates: RwLock::new(pending_consensus_certificates),
@@ -2943,6 +2970,105 @@ impl AuthorityPerEpochStore {
         0
     }
 
+    /// Loads the current deny rule proposals keyed by authority: the
+    /// quarantine's in-memory cache of the persisted `deny_rule_proposals`
+    /// table with every queued (processed-but-not-yet-flushed) commit's
+    /// proposals overlaid on top.
+    pub(crate) fn load_deny_rule_proposals(
+        &self,
+    ) -> IotaResult<BTreeMap<AuthorityName, DenyRuleProposal>> {
+        Ok(self
+            .consensus_quarantine
+            .read()
+            .current_deny_rule_proposals())
+    }
+
+    /// Whether `proposal` is newer than the recorded proposal (if any) from
+    /// the same authority and should therefore be recorded.
+    pub fn should_record_deny_rule_proposal(&self, proposal: &DenyRuleProposal) -> bool {
+        !self
+            .consensus_quarantine
+            .read()
+            .deny_rule_proposal_generation(&proposal.authority)
+            .is_some_and(|generation| generation >= proposal.generation)
+    }
+
+    /// Returns the active deny rule set derived from the recorded proposals.
+    pub fn get_active_transaction_deny_rules(&self) -> Arc<DenyRuleSet> {
+        self.active_transaction_deny_rules.load_full()
+    }
+
+    /// Recomputes the active deny rule set from the current proposals and
+    /// swaps it in. Returns true when the active set changed.
+    pub fn update_active_transaction_deny_rules(&self) -> IotaResult<bool> {
+        let proposals = self.load_deny_rule_proposals()?;
+        let rules = Self::compute_active_transaction_deny_rules(&proposals, self.committee());
+        if *self.active_transaction_deny_rules.load_full() == rules {
+            return Ok(false);
+        }
+        info!(?rules, "active deny rules changed");
+        self.active_transaction_deny_rules.store(Arc::new(rules));
+        Ok(true)
+    }
+
+    /// Computes the stake-weighted aggregate of the given deny rule proposals:
+    /// a deny list entry is active with f+1 supporting stake, a kill switch
+    /// with 2f+1. Pure function of the proposals and committee, so every
+    /// validator derives the same set from the same consensus state.
+    pub(crate) fn compute_active_transaction_deny_rules(
+        proposals: &BTreeMap<AuthorityName, DenyRuleProposal>,
+        committee: &Committee,
+    ) -> DenyRuleSet {
+        let mut address_stakes: BTreeMap<Address, StakeUnit> = BTreeMap::new();
+        let mut object_stakes: BTreeMap<ObjectId, StakeUnit> = BTreeMap::new();
+        let mut package_stakes: BTreeMap<ObjectId, StakeUnit> = BTreeMap::new();
+
+        for (authority, proposal) in proposals {
+            // Non-members weigh 0, so stale proposals cannot contribute.
+            let stake = committee.weight(authority);
+            let rules = &proposal.proposed_rules;
+            for address in &rules.denied_addresses {
+                *address_stakes.entry(*address).or_default() += stake;
+            }
+            for object in &rules.denied_objects {
+                *object_stakes.entry(*object).or_default() += stake;
+            }
+            for package in &rules.denied_packages {
+                *package_stakes.entry(*package).or_default() += stake;
+            }
+        }
+
+        fn activated<T: Ord>(stakes: BTreeMap<T, StakeUnit>, threshold: StakeUnit) -> BTreeSet<T> {
+            stakes
+                .into_iter()
+                .filter(|(_, stake)| *stake >= threshold)
+                .map(|(entry, _)| entry)
+                .collect()
+        }
+
+        let validity_threshold = committee.validity_threshold();
+        let quorum_threshold = committee.quorum_threshold();
+        let switch_active = |enabled: fn(&DenyRuleSet) -> bool| {
+            proposals
+                .iter()
+                .filter(|(_, proposal)| enabled(&proposal.proposed_rules))
+                .map(|(authority, _)| committee.weight(authority))
+                .sum::<StakeUnit>()
+                >= quorum_threshold
+        };
+        DenyRuleSet {
+            denied_addresses: activated(address_stakes, validity_threshold),
+            denied_objects: activated(object_stakes, validity_threshold),
+            denied_packages: activated(package_stakes, validity_threshold),
+            package_publish_disabled: switch_active(|rules| rules.package_publish_disabled),
+            package_upgrade_disabled: switch_active(|rules| rules.package_upgrade_disabled),
+            shared_object_disabled: switch_active(|rules| rules.shared_object_disabled),
+            user_transaction_disabled: switch_active(|rules| rules.user_transaction_disabled),
+            receiving_objects_disabled: switch_active(|rules| rules.receiving_objects_disabled),
+            move_authenticator_disabled: switch_active(|rules| rules.move_authenticator_disabled),
+        }
+    }
+
     pub fn get_quarantined_owned_object_lock(
         &self,
         obj_ref: &ObjectReference,
@@ -3013,6 +3139,16 @@ impl AuthorityPerEpochStore {
         self.consensus_quarantine
             .write()
             .apply_cached_overload_notification_for_test(authority, percentage);
+    }
+
+    /// Advances the quarantine's in-memory deny-rule-proposal cache, as the
+    /// commit flush loop does for a real commit. See
+    /// `apply_overload_notification_to_cache_for_test`.
+    #[cfg(test)]
+    pub(crate) fn apply_deny_rule_proposal_to_cache_for_test(&self, proposal: DenyRuleProposal) {
+        self.consensus_quarantine
+            .write()
+            .apply_cached_deny_rule_proposal_for_test(proposal);
     }
 
     fn process_user_signatures<'a>(

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -12,6 +12,7 @@ use iota_sdk_types::{
 };
 use iota_types::{
     base_types::AuthorityName,
+    deny_rule_governance::DenyRuleProposal,
     error::IotaResult,
     messages_checkpoint::{CheckpointContents, CheckpointContentsExt, CheckpointSequenceNumber},
     messages_consensus::VersionedDkgConfirmation,
@@ -95,6 +96,11 @@ pub(crate) struct ConsensusCommitOutput {
     // `authority_overload_notifications` atomically with `last_consensus_stats`
     // so a partial pre-flush state can never be observed on disk.
     overload_notifications: BTreeMap<AuthorityName, u8>,
+
+    // Newest deny rule proposal from each authority received during this
+    // commit. Flushed to `deny_rule_proposals` atomically with
+    // `last_consensus_stats`.
+    deny_rule_proposals: BTreeMap<AuthorityName, DenyRuleProposal>,
 }
 
 impl ConsensusCommitOutput {
@@ -239,6 +245,21 @@ impl ConsensusCommitOutput {
         self.overload_notifications.insert(authority, percentage);
     }
 
+    /// Records `proposal`, keeping the newest generation per authority.
+    // TODO(#10749): remove cfg(test) once the consensus handler records
+    // proposals.
+    #[cfg(test)]
+    pub fn record_deny_rule_proposal(&mut self, proposal: DenyRuleProposal) {
+        if self
+            .deny_rule_proposals
+            .get(&proposal.authority)
+            .is_none_or(|existing| existing.generation < proposal.generation)
+        {
+            self.deny_rule_proposals
+                .insert(proposal.authority, proposal);
+        }
+    }
+
     pub fn write_to_batch(
         self,
         epoch_store: &AuthorityPerEpochStore,
@@ -367,6 +388,8 @@ impl ConsensusCommitOutput {
             &tables.authority_overload_notifications,
             self.overload_notifications,
         )?;
+
+        batch.insert_batch(&tables.deny_rule_proposals, self.deny_rule_proposals)?;
 
         Ok(())
     }
@@ -575,6 +598,12 @@ pub(crate) struct ConsensusOutputQuarantine {
     // `current_overload_notifications`.
     cached_overload_notifications: HashMap<AuthorityName, u8>,
 
+    // In-memory cache of the `deny_rule_proposals` table, maintained exactly
+    // like `cached_overload_notifications`: seeded at construction, advanced
+    // as commits are flushed, overlaid with queued commits by
+    // `current_deny_rule_proposals`.
+    cached_deny_rule_proposals: BTreeMap<AuthorityName, DenyRuleProposal>,
+
     metrics: Arc<EpochMetrics>,
 }
 
@@ -582,6 +611,7 @@ impl ConsensusOutputQuarantine {
     pub(super) fn new(
         highest_executed_checkpoint: CheckpointSequenceNumber,
         cached_overload_notifications: HashMap<AuthorityName, u8>,
+        cached_deny_rule_proposals: BTreeMap<AuthorityName, DenyRuleProposal>,
         authority_metrics: Arc<EpochMetrics>,
     ) -> Self {
         Self {
@@ -596,6 +626,7 @@ impl ConsensusOutputQuarantine {
             processed_consensus_messages: RefCountedHashMap::new(),
             owned_object_locks: HashMap::new(),
             cached_overload_notifications,
+            cached_deny_rule_proposals,
             metrics: authority_metrics,
         }
     }
@@ -752,11 +783,13 @@ impl ConsensusOutputQuarantine {
                 self.remove_processed_consensus_messages(&output);
                 self.remove_congestion_control_debts(&output);
                 self.remove_owned_object_locks(&output);
-                // Advance the in-memory cache in lockstep with the table write
-                // below, so it stays equal to the persisted state once this
-                // commit leaves the queue.
+                // Advance the in-memory caches in lockstep with the table
+                // writes below, so they stay equal to the persisted state once
+                // this commit leaves the queue.
                 self.cached_overload_notifications
                     .extend(&output.overload_notifications);
+                self.cached_deny_rule_proposals
+                    .extend(output.deny_rule_proposals.clone());
                 epoch_store.remove_shared_version_assignments(
                     output
                         .pending_checkpoints
@@ -978,6 +1011,37 @@ impl ConsensusOutputQuarantine {
     ) {
         self.cached_overload_notifications
             .insert(authority, percentage);
+    }
+
+    /// Returns the current deny rule proposals keyed by authority: the
+    /// in-memory cache of the persisted table with every queued
+    /// (processed-but-not-yet-flushed) commit's proposals layered on top.
+    pub(super) fn current_deny_rule_proposals(&self) -> BTreeMap<AuthorityName, DenyRuleProposal> {
+        let mut proposals = self.cached_deny_rule_proposals.clone();
+        for output in &self.output_queue {
+            for (authority, proposal) in &output.deny_rule_proposals {
+                proposals.insert(*authority, proposal.clone());
+            }
+        }
+        proposals
+    }
+
+    /// Returns the generation of `authority`'s newest recorded proposal, if
+    /// any. The record path keeps generations monotonic, so the newest queued
+    /// entry (or, failing that, the flushed one) is the maximum.
+    pub(super) fn deny_rule_proposal_generation(&self, authority: &AuthorityName) -> Option<u64> {
+        self.output_queue
+            .iter()
+            .rev()
+            .find_map(|output| output.deny_rule_proposals.get(authority))
+            .or_else(|| self.cached_deny_rule_proposals.get(authority))
+            .map(|proposal| proposal.generation)
+    }
+
+    #[cfg(test)]
+    pub(super) fn apply_cached_deny_rule_proposal_for_test(&mut self, proposal: DenyRuleProposal) {
+        self.cached_deny_rule_proposals
+            .insert(proposal.authority, proposal);
     }
 
     pub(super) fn get_randomness_last_round_timestamp(&self) -> Option<CheckpointTimestamp> {

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -98,7 +98,7 @@ impl fmt::Display for EpochFlag {
 }
 
 /// Parameters of the epoch fixed at epoch start.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[enum_dispatch(EpochStartConfigTrait)]
 pub enum EpochStartConfiguration {
     V1(EpochStartConfigurationV1),
@@ -174,7 +174,7 @@ impl EpochStartConfiguration {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct EpochStartConfigurationV1 {
     system_state: EpochStartSystemState,
     epoch_digest: CheckpointDigest,
@@ -209,7 +209,7 @@ impl EpochStartConfigTrait for EpochStartConfigurationV1 {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct EpochStartConfigurationV2 {
     system_state: EpochStartSystemState,
     epoch_digest: CheckpointDigest,

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -3,12 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     time::{Duration, Instant},
 };
 
-use iota_sdk_types::TransactionDigest;
-use iota_types::base_types::AuthorityName;
+use iota_config::node::ExpensiveSafetyCheckConfig;
+use iota_sdk_types::{Address, ObjectId, TransactionDigest};
+use iota_types::{
+    base_types::AuthorityName,
+    committee::Committee,
+    crypto::KeypairTraits,
+    deny_rule_governance::{DenyRuleProposal, DenyRuleSet},
+};
 use tokio::time::timeout;
 use typed_store::rocks::DBBatch;
 
@@ -332,4 +338,329 @@ async fn test_load_overload_notifications_invariant_under_disk_queue_split() {
         fresh_store.get_quorum_load_shedding_percentage().unwrap(),
         80,
     );
+}
+
+fn deny_proposal(
+    authority: AuthorityName,
+    generation: u64,
+    proposed_rules: DenyRuleSet,
+) -> DenyRuleProposal {
+    DenyRuleProposal {
+        authority,
+        generation,
+        proposed_rules,
+    }
+}
+
+fn rules_denying_address(address: Address) -> DenyRuleSet {
+    DenyRuleSet {
+        denied_addresses: [address].into(),
+        ..Default::default()
+    }
+}
+
+/// Records a deny rule proposal through the same path
+/// `process_consensus_transaction` will use: buffer it in
+/// `ConsensusCommitOutput` and flush via `write_to_batch`. See
+/// `flush_overload_notification`.
+fn flush_deny_rule_proposal(store: &AuthorityPerEpochStore, proposal: DenyRuleProposal) {
+    let mut output = ConsensusCommitOutput::new(0);
+    output.record_deny_rule_proposal(proposal.clone());
+    output.set_default_commit_stats_for_testing();
+    let mut batch: DBBatch = store.db_batch_for_test();
+    output.write_to_batch(store, &mut batch).unwrap();
+    batch.write().unwrap();
+    store.apply_deny_rule_proposal_to_cache_for_test(proposal);
+}
+
+/// Deny list entries activate at f+1 supporting stake, kill switches at 2f+1,
+/// and non-members contribute nothing. With the 4-validator equal-stake test
+/// committee (2500 each, normalized to 10000): 2 supporters = 5000 clears
+/// f+1 (3334) but not 2f+1 (6667); 3 supporters = 7500 clears both.
+#[test]
+fn compute_active_transaction_deny_rules_applies_stake_thresholds() {
+    let (committee, keys) = Committee::new_simple_test_committee();
+    let names: Vec<AuthorityName> = keys.iter().map(|key| key.public().into()).collect();
+    let active_address = Address::new([1u8; 32]);
+    let minority_address = Address::new([2u8; 32]);
+    let non_member_address = Address::new([3u8; 32]);
+    let active_object = ObjectId::new([4u8; 32]);
+    let minority_object = ObjectId::new([5u8; 32]);
+    let active_package = ObjectId::new([6u8; 32]);
+    let minority_package = ObjectId::new([7u8; 32]);
+
+    let mut proposals: BTreeMap<AuthorityName, DenyRuleProposal> = BTreeMap::new();
+    // Two members support the `active_*` entries; switch support ranges from
+    // 3 members (receiving/move authenticator) through 2 (shared object,
+    // package publish) and 1 (user transaction) to 0 (package upgrade).
+    proposals.insert(
+        names[0],
+        deny_proposal(
+            names[0],
+            1,
+            DenyRuleSet {
+                denied_addresses: [active_address, minority_address].into(),
+                denied_objects: [active_object, minority_object].into(),
+                denied_packages: [active_package, minority_package].into(),
+                shared_object_disabled: true,
+                user_transaction_disabled: true,
+                package_publish_disabled: true,
+                receiving_objects_disabled: true,
+                move_authenticator_disabled: true,
+                ..Default::default()
+            },
+        ),
+    );
+    proposals.insert(
+        names[1],
+        deny_proposal(
+            names[1],
+            1,
+            DenyRuleSet {
+                denied_addresses: [active_address].into(),
+                denied_objects: [active_object].into(),
+                denied_packages: [active_package].into(),
+                shared_object_disabled: true,
+                package_publish_disabled: true,
+                receiving_objects_disabled: true,
+                move_authenticator_disabled: true,
+                ..Default::default()
+            },
+        ),
+    );
+    proposals.insert(
+        names[2],
+        deny_proposal(
+            names[2],
+            1,
+            DenyRuleSet {
+                receiving_objects_disabled: true,
+                move_authenticator_disabled: true,
+                ..Default::default()
+            },
+        ),
+    );
+    // A non-member's proposal must weigh 0.
+    let non_member = AuthorityName::ZERO;
+    proposals.insert(
+        non_member,
+        deny_proposal(
+            non_member,
+            1,
+            DenyRuleSet {
+                denied_addresses: [non_member_address, minority_address].into(),
+                denied_objects: [minority_object].into(),
+                denied_packages: [minority_package].into(),
+                user_transaction_disabled: true,
+                package_upgrade_disabled: true,
+                ..Default::default()
+            },
+        ),
+    );
+
+    let active =
+        AuthorityPerEpochStore::compute_active_transaction_deny_rules(&proposals, &committee);
+    // Deny lists: 5000 >= f+1 active; 2500 (+0 from the non-member) < f+1.
+    assert!(active.denied_addresses.contains(&active_address));
+    assert!(!active.denied_addresses.contains(&minority_address));
+    assert!(!active.denied_addresses.contains(&non_member_address));
+    assert!(active.denied_objects.contains(&active_object));
+    assert!(!active.denied_objects.contains(&minority_object));
+    assert!(active.denied_packages.contains(&active_package));
+    assert!(!active.denied_packages.contains(&minority_package));
+    // Kill switches: 7500 >= 2f+1 on; 5000, 2500 (+0), and 0 stay off.
+    assert!(active.receiving_objects_disabled);
+    assert!(active.move_authenticator_disabled);
+    assert!(!active.shared_object_disabled);
+    assert!(!active.user_transaction_disabled);
+    assert!(!active.package_publish_disabled);
+    assert!(!active.package_upgrade_disabled);
+}
+
+/// A proposal replaces the recorded one from the same authority only when its
+/// generation is strictly newer, both across commits
+/// (`should_record_deny_rule_proposal`) and within one commit
+/// (`ConsensusCommitOutput::record_deny_rule_proposal`).
+#[tokio::test]
+async fn deny_rule_proposals_dedup_by_strictly_newer_generation() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+    let old_rules = rules_denying_address(Address::new([1u8; 32]));
+    let new_rules = rules_denying_address(Address::new([2u8; 32]));
+
+    flush_deny_rule_proposal(&store, deny_proposal(me, 5, old_rules.clone()));
+    assert!(!store.should_record_deny_rule_proposal(&deny_proposal(me, 3, new_rules.clone())));
+    assert!(!store.should_record_deny_rule_proposal(&deny_proposal(me, 5, new_rules.clone())));
+    assert!(store.should_record_deny_rule_proposal(&deny_proposal(me, 6, new_rules.clone())));
+
+    // Within one commit the output itself keeps only the newest generation.
+    let mut output = ConsensusCommitOutput::default();
+    output.record_deny_rule_proposal(deny_proposal(me, 8, new_rules.clone()));
+    output.record_deny_rule_proposal(deny_proposal(me, 7, old_rules.clone()));
+    output.set_default_commit_stats_for_testing();
+    store.push_consensus_output_for_tests(output);
+
+    let recorded = store.load_deny_rule_proposals().unwrap();
+    assert_eq!(recorded.get(&me).unwrap().generation, 8);
+    assert_eq!(recorded.get(&me).unwrap().proposed_rules, new_rules);
+
+    // The staleness check must see the queued generation (8), not the flushed
+    // one (5).
+    assert!(!store.should_record_deny_rule_proposal(&deny_proposal(me, 7, new_rules.clone())));
+    assert!(!store.should_record_deny_rule_proposal(&deny_proposal(me, 8, new_rules.clone())));
+    assert!(store.should_record_deny_rule_proposal(&deny_proposal(me, 9, new_rules.clone())));
+
+    // A newer generation recorded after an older one replaces it.
+    let mut output = ConsensusCommitOutput::default();
+    output.record_deny_rule_proposal(deny_proposal(me, 9, old_rules));
+    output.record_deny_rule_proposal(deny_proposal(me, 10, new_rules.clone()));
+    output.set_default_commit_stats_for_testing();
+    store.push_consensus_output_for_tests(output);
+
+    let recorded = store.load_deny_rule_proposals().unwrap();
+    assert_eq!(recorded.get(&me).unwrap().generation, 10);
+    assert_eq!(recorded.get(&me).unwrap().proposed_rules, new_rules);
+}
+
+/// `update_active_transaction_deny_rules` recomputes from the recorded
+/// proposals and reports whether the active set changed. A newer full-state
+/// proposal that omits an entry withdraws that vote, deactivating the entry
+/// (drop-to-remove).
+#[tokio::test]
+async fn update_active_transaction_deny_rules_drops_withdrawn_rules() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    // The single-validator test committee holds all stake, clearing both
+    // thresholds alone.
+    let me = store.name;
+    let address = Address::new([1u8; 32]);
+
+    assert_eq!(
+        *store.get_active_transaction_deny_rules(),
+        DenyRuleSet::default()
+    );
+    assert!(!store.update_active_transaction_deny_rules().unwrap());
+
+    flush_deny_rule_proposal(
+        &store,
+        deny_proposal(
+            me,
+            1,
+            DenyRuleSet {
+                denied_addresses: [address].into(),
+                user_transaction_disabled: true,
+                ..Default::default()
+            },
+        ),
+    );
+    assert!(store.update_active_transaction_deny_rules().unwrap());
+    let active = store.get_active_transaction_deny_rules();
+    assert!(active.denied_addresses.contains(&address));
+    assert!(active.user_transaction_disabled);
+
+    // Newer proposal without the switch withdraws it; the address stays.
+    flush_deny_rule_proposal(&store, deny_proposal(me, 2, rules_denying_address(address)));
+    assert!(store.update_active_transaction_deny_rules().unwrap());
+    let active = store.get_active_transaction_deny_rules();
+    assert!(active.denied_addresses.contains(&address));
+    assert!(!active.user_transaction_disabled);
+
+    // An empty proposal withdraws everything.
+    flush_deny_rule_proposal(&store, deny_proposal(me, 3, DenyRuleSet::default()));
+    assert!(store.update_active_transaction_deny_rules().unwrap());
+    assert_eq!(
+        *store.get_active_transaction_deny_rules(),
+        DenyRuleSet::default()
+    );
+    assert!(!store.update_active_transaction_deny_rules().unwrap());
+}
+
+/// `load_deny_rule_proposals` must return the same map whether an authority's
+/// newest proposal lives in the persisted `deny_rule_proposals` DBMap or in a
+/// still-queued `ConsensusCommitOutput`. See
+/// `test_load_overload_notifications_invariant_under_disk_queue_split`.
+#[tokio::test]
+async fn load_deny_rule_proposals_invariant_under_disk_queue_split() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+
+    // Disk holds an earlier proposal.
+    flush_deny_rule_proposal(
+        &store,
+        deny_proposal(me, 1, rules_denying_address(Address::new([1u8; 32]))),
+    );
+
+    // A later commit's proposal is queued, not yet flushed; the read must
+    // surface it over the stale on-disk one.
+    let queued_rules = rules_denying_address(Address::new([2u8; 32]));
+    let mut later = ConsensusCommitOutput::default();
+    later.record_deny_rule_proposal(deny_proposal(me, 2, queued_rules.clone()));
+    later.set_default_commit_stats_for_testing();
+    store.push_consensus_output_for_tests(later);
+
+    let from_queue = store.load_deny_rule_proposals().unwrap();
+    assert_eq!(from_queue.get(&me).unwrap().generation, 2);
+    assert_eq!(from_queue.get(&me).unwrap().proposed_rules, queued_rules);
+
+    // The same logical state held fully on disk with nothing queued, as a
+    // freshly started authority sees it.
+    let fresh_state = TestAuthorityBuilder::new().build().await;
+    let fresh_store = fresh_state.epoch_store_for_testing();
+    let fresh_me = fresh_store.name;
+    flush_deny_rule_proposal(
+        &fresh_store,
+        deny_proposal(fresh_me, 2, queued_rules.clone()),
+    );
+
+    let from_disk = fresh_store.load_deny_rule_proposals().unwrap();
+    assert_eq!(from_disk.get(&fresh_me).unwrap().generation, 2);
+    assert_eq!(
+        from_disk.get(&fresh_me).unwrap().proposed_rules,
+        queued_rules
+    );
+}
+
+/// A restart must resume with the persisted deny rules: reopening the epoch
+/// store over the same DB re-seeds the proposal cache and derives the active
+/// set from the `deny_rule_proposals` table alone, with no cache priming or
+/// update call.
+#[tokio::test]
+async fn restart_seed_restores_persisted_deny_rules() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+    let address = Address::new([1u8; 32]);
+    let rules = DenyRuleSet {
+        denied_addresses: [address].into(),
+        user_transaction_disabled: true,
+        ..Default::default()
+    };
+    flush_deny_rule_proposal(&store, deny_proposal(me, 1, rules.clone()));
+
+    // Reopen over the same epoch DB, as a restart does.
+    store.release_db_handles();
+    let reopened = AuthorityPerEpochStore::new(
+        store.name,
+        store.committee().clone(),
+        &store.parent_path,
+        store.db_options.clone(),
+        store.metrics.clone(),
+        (*store.epoch_start_configuration).clone(),
+        authority_state.get_backing_package_store().clone(),
+        store.execution_component.metrics(),
+        store.signature_verifier.metrics.clone(),
+        &ExpensiveSafetyCheckConfig::default(),
+        store.chain,
+        0,
+    )
+    .unwrap();
+
+    let persisted = reopened.load_deny_rule_proposals().unwrap();
+    assert_eq!(persisted.get(&me).unwrap().generation, 1);
+    assert_eq!(persisted.get(&me).unwrap().proposed_rules, rules);
+    let active = reopened.get_active_transaction_deny_rules();
+    assert!(active.denied_addresses.contains(&address));
+    assert!(active.user_transaction_disabled);
 }


### PR DESCRIPTION
# Description of change

Adds the data layer for deny governance (#10749), mirroring the `OverloadNotificationV1` pattern: per-authority proposal storage, stake-weighted aggregation into the active rule set, and a crash-safe in-memory cache. No consensus wiring yet — nothing records proposals in production (the recording entry point is `#[cfg(test)]` until the consensus handler lands), so the change is behavior-neutral and unit-tested in isolation.

- **Persistence:** epoch-scoped `deny_rule_proposals: DBMap<AuthorityName, DenyRuleProposal>`; proposals recorded into `ConsensusCommitOutput` and flushed atomically with `last_consensus_stats`; quarantine cache seeded at construction, advanced in lockstep at flush, overlaid with queued commits by `current_deny_rule_proposals()`.
- **Generation dedup:** a proposal supersedes only with a strictly newer generation, both across commits (`should_record_deny_rule_proposal`, backed by a no-clone `deny_rule_proposal_generation` lookup) and within one commit (`ConsensusCommitOutput::record_deny_rule_proposal`).
- **Aggregation:** `compute_active_deny_rules(proposals, committee)` — pure function; deny-list entries activate at f+1 (`validity_threshold`), kill switches at 2f+1 (`quorum_threshold`); non-members weigh 0. Each switch is tallied through a named field accessor (no positional coupling).
- **Active set:** `active_deny_rules: ArcSwap<DenyRuleSet>` + `get_active_deny_rules()`; seeded in `new()` by recomputing from the persisted table, so a mid-epoch restart resumes with the rules from all flushed commits (unflushed commits are re-recorded by consensus replay). `update_active_deny_rules()` reports whether the set changed — the seam a future on-chain materialization attaches to.
- `EpochStartConfiguration` (+V1/V2) gains `Clone`, enabling same-epoch store reconstruction in tests.


## Links to any relevant issues

Fixes #12151.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes