### PR TITLE
chore: ignore quick-xml DoS advisories in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,7 @@ ignore = [
   # released `object_store` pulls it yet (latest 0.14.0 requires ^0.40.1), so
   # there is no upgrade path. Remove once `object_store` updates quick-xml.
   "RUSTSEC-2026-0194",
+  # Same as above
   "RUSTSEC-2026-0195",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score

--- a/deny.toml
+++ b/deny.toml
@@ -68,6 +68,12 @@ ignore = [
   # proc-macro-error2 is unmaintained
   # Can be removed once `getset` updates: https://github.com/jbaublitz/getset/issues/132
   "RUSTSEC-2026-0173",
+  # quick-xml DoS advisories, only reachable transitively via `object_store`
+  # (cloud-storage list XML parsing). Fixed in quick-xml >=0.41.0, but no
+  # released `object_store` pulls it yet (latest 0.14.0 requires ^0.40.1), so
+  # there is no upgrade path. Remove once `object_store` updates quick-xml.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
# Description of change

The nightly `cargo deny check advisories` job fails on two new quick-xml advisories:

- **RUSTSEC-2026-0194** — quadratic runtime checking a start tag for duplicate attribute names (CPU DoS).
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` (memory DoS).

Both are fixed in `quick-xml >= 0.41.0`, but quick-xml is only reached transitively through `object_store` (cloud-storage list XML parsing). No released `object_store` pulls the fixed version yet — the latest `0.14.0` still requires `quick-xml ^0.40.1` — so there is no upgrade path today.

Following the repo's established practice for advisories without an upstream fix, both IDs are added to the `[advisories] ignore` list in `deny.toml` with a note to remove them once `object_store` bumps quick-xml.

[run-ci]

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHaV6U2jpnfTNDq8CuBpLb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHaV6U2jpnfTNDq8CuBpLb)_