### PR TITLE
fix: bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
# Description of change

Bumps `crossbeam-epoch` from `0.9.18` to `0.9.20` in the `external-crates/move` workspace lockfile to resolve [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204).

- The advisory flags an invalid pointer dereference in the `fmt::Display` impl for `Atomic`/`Shared` when the underlying pointer is null (e.g. `Atomic::null` / `Shared::null`). Fixed in `0.9.20`.
- Lockfile-only change (`cargo update -p crossbeam-epoch`); no source or API changes.

> Note: the root workspace `Cargo.lock` also pins `crossbeam-epoch 0.9.18`. This PR is scoped to `external-crates/move` (the workspace flagged by `cargo deny`); the root workspace can be bumped separately if desired.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

Verified `cargo update` resolves to `crossbeam-epoch 0.9.20` (checksum `2d6914...`), clearing the advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GckkZymvJEnaCMGwFvgBq