### PR TITLE
chore: remove `GasData` re-export

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -45,8 +45,9 @@ use iota_metrics::{
     TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX, monitored_scope, spawn_monitored_task,
 };
 use iota_sdk_types::{
-    Address, EndOfEpochTransactionKind, Event, ExecutionStatus, ObjectId, ObjectReference, Owner,
-    RandomnessRound, StructTag, TransactionExpiration, TransactionKind, TypeTag, Version,
+    Address, EndOfEpochTransactionKind, Event, ExecutionStatus, GasPayment, ObjectId,
+    ObjectReference, Owner, RandomnessRound, StructTag, TransactionExpiration, TransactionKind,
+    TypeTag, Version,
     crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
     gas::GasCostSummary,
 };
@@ -2475,7 +2476,7 @@ impl AuthorityState {
         let mut transaction = TransactionData::V1(TransactionDataV1 {
             kind: transaction_kind.clone(),
             sender,
-            gas_payment: GasData {
+            gas_payment: GasPayment {
                 objects: payment,
                 owner,
                 price,

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -15,7 +15,7 @@ use iota_macros::*;
 use iota_node::IotaNodeHandle;
 use iota_sdk::wallet_context::WalletContext;
 use iota_sdk_types::{
-    Address, Identifier, ObjectId, ObjectReference, Owner, TransactionKind, Version,
+    Address, GasPayment, Identifier, ObjectId, ObjectReference, Owner, TransactionKind, Version,
 };
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
@@ -38,7 +38,7 @@ use iota_types::{
     },
     storage::ObjectStore,
     transaction::{
-        CallArg, GasData, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        CallArg, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         TransactionData, TransactionDataAPI,
     },
     utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
@@ -154,7 +154,7 @@ async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
     let tx_data = TransactionData::new_with_gas_data(
         kind,
         sender,
-        GasData {
+        GasPayment {
             objects: vec![gas_obj],
             owner: sponsor,
             price: rgp,

--- a/crates/iota-graphql-rpc/src/types/gas.rs
+++ b/crates/iota-graphql-rpc/src/types/gas.rs
@@ -3,11 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::{connection::Connection, *};
-use iota_sdk_types::gas::GasCostSummary as NativeGasCostSummary;
-use iota_types::{
-    effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
-    transaction::GasData,
-};
+use iota_sdk_types::{GasPayment, gas::GasCostSummary as NativeGasCostSummary};
+use iota_types::effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI};
 
 use crate::types::{
     address::Address,
@@ -176,7 +173,7 @@ impl GasInput {
     /// which this `GasInput` was queried for. This is stored on `GasInput`
     /// so that when viewing that entity's state, it will be as if it was
     /// read at the same checkpoint.
-    pub(crate) fn from(s: &GasData, checkpoint_viewed_at: u64) -> Self {
+    pub(crate) fn from(s: &GasPayment, checkpoint_viewed_at: u64) -> Self {
         Self {
             owner: s.owner.into(),
             price: s.price,

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -25,7 +25,9 @@ use iota_json_rpc_types::{
 use iota_open_rpc::Module;
 use iota_package_resolver::{PackageStore, Resolver};
 use iota_protocol_config::Chain;
-use iota_sdk_types::{Address, ObjectId, TransactionExpiration, TransactionKind, Version};
+use iota_sdk_types::{
+    Address, GasPayment, ObjectId, TransactionExpiration, TransactionKind, Version,
+};
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     digests::TransactionDigest,
@@ -34,9 +36,7 @@ use iota_types::{
     iota_serde::BigInt,
     object::{Object, PastObjectRead},
     signature::GenericSignature,
-    transaction::{
-        GasData, SenderSignedData, TransactionData, TransactionDataAPI, TransactionDataV1,
-    },
+    transaction::{SenderSignedData, TransactionData, TransactionDataAPI, TransactionDataV1},
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
 
@@ -226,7 +226,7 @@ impl WriteApi {
         let transaction_data = TransactionData::V1(TransactionDataV1 {
             kind,
             sender: sender_address,
-            gas_payment: GasData {
+            gas_payment: GasPayment {
                 objects: payment,
                 owner,
                 price,

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -19,7 +19,7 @@ use iota_json_rpc_types::{
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk::{IotaClient, IotaClientBuilder};
 use iota_sdk_types::{
-    ObjectData, ObjectId, ObjectReference, Owner, StructTag, TransactionKind, Version,
+    GasPayment, ObjectData, ObjectId, ObjectReference, Owner, StructTag, TransactionKind, Version,
 };
 use iota_types::{
     IOTA_DENY_LIST_OBJECT_ID,
@@ -48,9 +48,8 @@ use iota_types::{
         get_module_by_id,
     },
     transaction::{
-        CheckedInputObjects, GasData, InputObjectKind, InputObjects, ObjectReadResult,
-        ObjectReadResultKind, SenderSignedData, Transaction, TransactionDataAPI,
-        VerifiedTransaction,
+        CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
+        SenderSignedData, Transaction, TransactionDataAPI, VerifiedTransaction,
     },
 };
 use move_binary_format::CompiledModule;
@@ -784,7 +783,7 @@ impl LocalExec {
             )
             .expect("Failed to create gas status")
         };
-        let gas_data = GasData {
+        let gas_data = GasPayment {
             objects: tx_info.gas.clone(),
             owner: tx_info.gas_owner.unwrap_or(tx_info.sender),
             price: tx_info.gas_price,
@@ -947,7 +946,7 @@ impl LocalExec {
         trace!(target: "replay_gas_info", "{}", Pretty(gas_status));
 
         let skip_checks = true;
-        let gas_data = GasData {
+        let gas_data = GasPayment {
             objects: tx_info.gas.clone(),
             owner: tx_info.gas_owner.unwrap_or(tx_info.sender),
             price: tx_info.gas_price,

--- a/crates/iota-types/src/gas_model/gas_v1.rs
+++ b/crates/iota-types/src/gas_model/gas_v1.rs
@@ -175,7 +175,7 @@ mod checked {
         cost_table: IotaCostTable,
         /// Gas budget for this gas status instance.
         /// Typically the gas budget as defined in the
-        /// `TransactionData::GasData`
+        /// `TransactionData::GasPayment`
         gas_budget: u64,
         /// Computation cost after execution. This is the result of the gas used
         /// by the `GasStatus` properly bucketized.

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -18,16 +18,15 @@ use fastcrypto::{encoding::Base64, hash::HashFunction};
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Address, Argument, CancelledTransaction, Command, ConsensusCommitPrologueV1,
-    ConsensusDeterminedVersionAssignments, Digest, EndOfEpochTransactionKind, Event, GenesisObject,
-    GenesisTransaction, Identifier, Input, MakeMoveVector, MergeCoins, MoveCall, ObjectId,
-    ObjectReference, Owner, ProgrammableTransaction, Publish, RandomnessRound,
+    ConsensusDeterminedVersionAssignments, Digest, EndOfEpochTransactionKind, Event, GasPayment,
+    GenesisObject, GenesisTransaction, Identifier, Input, MakeMoveVector, MergeCoins, MoveCall,
+    ObjectId, ObjectReference, Owner, ProgrammableTransaction, Publish, RandomnessRound,
     RandomnessStateUpdate, SharedObjectReference, SplitCoins, TransactionExpiration,
     TransactionKind, TransferObjects, TypeTag, Upgrade, Version,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 pub use iota_sdk_types::{
-    GasPayment as GasData, SystemPackage, Transaction as TransactionData,
-    TransactionV1 as TransactionDataV1,
+    SystemPackage, Transaction as TransactionData, TransactionV1 as TransactionDataV1,
 };
 use itertools::Either;
 use nonempty::{NonEmpty, nonempty};
@@ -973,7 +972,7 @@ pub trait TransactionDataAPI {
 
     /// Returns a reference to the gas data (owner, payment objects, price,
     /// budget).
-    fn gas_data(&self) -> &GasData;
+    fn gas_data(&self) -> &GasPayment;
 
     /// Returns the address that owns the gas payment objects.
     fn gas_owner(&self) -> Address;
@@ -1035,7 +1034,7 @@ pub trait TransactionDataAPI {
     fn sender_mut_for_testing(&mut self) -> &mut Address;
 
     /// Returns a mutable reference to the gas data.
-    fn gas_data_mut(&mut self) -> &mut GasData;
+    fn gas_data_mut(&mut self) -> &mut GasPayment;
 
     /// Returns a mutable reference to the expiration. **Testing only.**
     fn expiration_mut_for_testing(&mut self) -> &mut TransactionExpiration;
@@ -1077,11 +1076,11 @@ pub trait TransactionDataAPI {
         gas_sponsor: Address,
     ) -> TransactionData;
 
-    /// Creates a new transaction from a pre-built [`GasData`] struct.
+    /// Creates a new transaction from a pre-built [`GasPayment`] struct.
     fn new_with_gas_data(
         kind: TransactionKind,
         sender: Address,
-        gas_data: GasData,
+        gas_data: GasPayment,
     ) -> TransactionData;
 
     /// Creates a transaction that calls a single Move function with a single
@@ -1246,7 +1245,7 @@ pub trait TransactionDataAPI {
 
     /// Consumes self and returns the transaction kind, sender address, and
     /// gas payment object references as a tuple.
-    fn execution_parts(&self) -> (TransactionKind, Address, GasData);
+    fn execution_parts(&self) -> (TransactionKind, Address, GasPayment);
 }
 
 impl TransactionDataAPI for TransactionData {
@@ -1286,7 +1285,7 @@ impl TransactionDataAPI for TransactionData {
         signers
     }
 
-    fn gas_data(&self) -> &GasData {
+    fn gas_data(&self) -> &GasPayment {
         match self {
             Self::V1(v1) => &v1.gas_payment,
             _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
@@ -1392,7 +1391,7 @@ impl TransactionDataAPI for TransactionData {
         }
     }
 
-    fn gas_data_mut(&mut self) -> &mut GasData {
+    fn gas_data_mut(&mut self) -> &mut GasPayment {
         match self {
             Self::V1(v1) => &mut v1.gas_payment,
             _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
@@ -1412,7 +1411,7 @@ impl TransactionDataAPI for TransactionData {
         TransactionData::V1(TransactionDataV1 {
             kind,
             sender,
-            gas_payment: GasData {
+            gas_payment: GasPayment {
                 price: GAS_PRICE_FOR_SYSTEM_TX,
                 owner: sender,
                 objects: vec![ObjectReference::new(
@@ -1436,7 +1435,7 @@ impl TransactionDataAPI for TransactionData {
         TransactionData::V1(TransactionDataV1 {
             kind,
             sender,
-            gas_payment: GasData {
+            gas_payment: GasPayment {
                 price: gas_price,
                 owner: sender,
                 objects: vec![gas_payment],
@@ -1474,7 +1473,7 @@ impl TransactionDataAPI for TransactionData {
         TransactionData::V1(TransactionDataV1 {
             kind,
             sender,
-            gas_payment: GasData {
+            gas_payment: GasPayment {
                 price: gas_price,
                 owner: gas_sponsor,
                 objects: gas_payment,
@@ -1487,7 +1486,7 @@ impl TransactionDataAPI for TransactionData {
     fn new_with_gas_data(
         kind: TransactionKind,
         sender: Address,
-        gas_data: GasData,
+        gas_data: GasPayment,
     ) -> TransactionData {
         TransactionData::V1(TransactionDataV1 {
             kind,
@@ -1803,7 +1802,7 @@ impl TransactionDataAPI for TransactionData {
         }
     }
 
-    fn execution_parts(&self) -> (TransactionKind, Address, GasData) {
+    fn execution_parts(&self) -> (TransactionKind, Address, GasPayment) {
         (self.kind().clone(), self.sender(), self.gas_data().clone())
     }
 }

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -14,7 +14,8 @@ use fastcrypto::{
 };
 use iota_sdk_crypto::simple::SimpleKeypair;
 use iota_sdk_types::{
-    Address, ExecutionStatus, Owner, SharedObjectReference, StructTag, gas::GasCostSummary,
+    Address, ExecutionStatus, GasPayment, Owner, SharedObjectReference, StructTag,
+    gas::GasCostSummary,
 };
 use roaring::RoaringBitmap;
 
@@ -738,7 +739,7 @@ fn test_sponsored_transaction_message() {
     let gas_price = 10;
     let kind = TransactionKind::new_programmable(pt);
     let gas_obj_ref = random_object_ref();
-    let gas_data = GasData {
+    let gas_data = GasPayment {
         objects: vec![gas_obj_ref],
         owner: sponsor,
         price: gas_price,
@@ -828,7 +829,7 @@ fn test_sponsored_transaction_validity_check() {
     // This is a sponsored transaction
     let gas_price = 10;
     assert_ne!(sender, sponsor);
-    let gas_data = GasData {
+    let gas_data = GasPayment {
         objects: vec![random_object_ref()],
         owner: sponsor,
         price: gas_price,
@@ -1231,7 +1232,7 @@ fn test_unique_input_objects() {
     let sender = (&sender_kp.public()).into();
     let gas_price = 10;
     let gas_object_ref = random_object_ref();
-    let gas_data = GasData {
+    let gas_data = GasPayment {
         objects: vec![gas_object_ref],
         owner: sender,
         price: gas_price,

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -31,7 +31,9 @@ use iota_config::{
 };
 use iota_node_storage::{GrpcIndexes, GrpcStateReader};
 use iota_protocol_config::ProtocolVersion;
-use iota_sdk_types::{Address, EndOfEpochTransactionKind, ObjectId, StructTag, TransactionKind};
+use iota_sdk_types::{
+    Address, EndOfEpochTransactionKind, GasPayment, ObjectId, StructTag, TransactionKind,
+};
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_swarm_config::{
     genesis_config::AccountConfig, network_config::NetworkConfig,
@@ -58,7 +60,7 @@ use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     signature::VerifyParams,
     storage::{EpochInfoV2, ObjectStore, ReadStore, TransactionInfo},
-    transaction::{GasData, Transaction, TransactionData, TransactionDataAPI, VerifiedTransaction},
+    transaction::{Transaction, TransactionData, TransactionDataAPI, VerifiedTransaction},
 };
 use rand::rngs::OsRng;
 
@@ -448,7 +450,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
                 anyhow!("unable to find a coin with enough to satisfy request for {amount} Nanos")
             })?;
 
-        let gas_data = iota_types::transaction::GasData {
+        let gas_data = GasPayment {
             objects: vec![object.object_ref()],
             owner: sender,
             price: self.reference_gas_price(),
@@ -889,7 +891,7 @@ impl Simulacrum {
         };
 
         let kind = TransactionKind::Programmable(pt);
-        let gas_data = GasData {
+        let gas_data = GasPayment {
             objects: vec![object.object_ref()],
             owner: sender,
             price: self.reference_gas_price(),

--- a/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
+++ b/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
@@ -6,12 +6,14 @@
 use std::sync::Arc;
 
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Address, ExecutionError, ExecutionStatus, ObjectReference, TransactionKind};
+use iota_sdk_types::{
+    Address, ExecutionError, ExecutionStatus, GasPayment, ObjectReference, TransactionKind,
+};
 use iota_types::{
     error::{IotaError, UserInputError},
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{GasData, Transaction, TransactionData, TransactionDataAPI},
+    transaction::{Transaction, TransactionData, TransactionDataAPI},
     utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
 };
 use once_cell::sync::Lazy;
@@ -416,7 +418,7 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPriceRandomSponsorship {
         let tx_data = TransactionData::new_with_gas_data(
             kind,
             sender_address,
-            GasData {
+            GasPayment {
                 objects: gas_coin_refs,
                 owner: gas_payer,
                 price: self.gas_price,

--- a/crates/transaction-fuzzer/src/lib.rs
+++ b/crates/transaction-fuzzer/src/lib.rs
@@ -13,13 +13,12 @@ use std::fmt::Debug;
 
 use executor::Executor;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Address, ObjectId, Owner};
+use iota_sdk_types::{Address, GasPayment, ObjectId, Owner};
 use iota_types::{
     crypto::{AccountKeyPair, get_key_pair},
     digests::TransactionDigest,
     gas_coin::NANOS_PER_IOTA,
     object::{MoveObject, MoveObjectExt, OBJECT_START_VERSION, Object},
-    transaction::GasData,
 };
 use proptest::{collection::vec, prelude::*, test_runner::TestRunner};
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -85,7 +84,7 @@ fn generate_random_gas_data(
     );
 
     GasDataWithObjects {
-        gas_data: GasData {
+        gas_data: GasPayment {
             objects: object_refs,
             owner: sender,
             price: rng.gen_range(0..=ProtocolConfig::get_for_max_version_UNSAFE().max_gas_price()),
@@ -99,7 +98,7 @@ fn generate_random_gas_data(
 /// Need to have a wrapper struct here so we can implement Arbitrary for it.
 #[derive(Debug)]
 pub struct GasDataWithObjects {
-    pub gas_data: GasData,
+    pub gas_data: GasPayment,
     pub sender_key: AccountKeyPair,
     pub objects: Vec<Object>,
 }

--- a/crates/transaction-fuzzer/src/transaction_data_gen.rs
+++ b/crates/transaction-fuzzer/src/transaction_data_gen.rs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk_types::{
-    Address, ObjectId, ObjectReference, TransactionExpiration, TransactionKind, Version,
+    Address, GasPayment, ObjectId, ObjectReference, TransactionExpiration, TransactionKind, Version,
 };
 use iota_types::{
     digests::ObjectDigest,
-    transaction::{GasData, TransactionData, TransactionDataV1},
+    transaction::{TransactionData, TransactionDataV1},
 };
 use move_core_types::account_address::AccountAddress;
 use proptest::{arbitrary::*, collection::vec, prelude::*};
@@ -47,13 +47,13 @@ pub fn gen_object_ref() -> impl Strategy<Value = ObjectReference> {
     )
 }
 
-pub fn gen_gas_data(sender: Address) -> impl Strategy<Value = GasData> {
+pub fn gen_gas_data(sender: Address) -> impl Strategy<Value = GasPayment> {
     (
         vec(gen_object_ref(), 0..MAX_NUM_GAS_OBJS),
         gas_price_selection_strategy(),
         gas_budget_selection_strategy(),
     )
-        .prop_map(move |(obj_refs, price, budget)| GasData {
+        .prop_map(move |(obj_refs, price, budget)| GasPayment {
             objects: obj_refs,
             owner: sender,
             price,
@@ -77,7 +77,7 @@ pub fn transaction_data_gen(sender: Address) -> impl Strategy<Value = Transactio
 
 pub struct TransactionDataGenBuilder<
     K: Strategy<Value = TransactionKind>,
-    G: Strategy<Value = GasData>,
+    G: Strategy<Value = GasPayment>,
     E: Strategy<Value = TransactionExpiration>,
 > {
     pub kind: Option<K>,
@@ -88,7 +88,7 @@ pub struct TransactionDataGenBuilder<
 
 impl<
     K: Strategy<Value = TransactionKind>,
-    G: Strategy<Value = GasData>,
+    G: Strategy<Value = GasPayment>,
     E: Strategy<Value = TransactionExpiration>,
 > TransactionDataGenBuilder<K, G, E>
 {

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -18,9 +18,9 @@ mod checked {
     use iota_protocol_config::{LimitThresholdCrossed, ProtocolConfig, check_limit_by_meter};
     use iota_sdk_types::{
         Address, Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command,
-        EndOfEpochTransactionKind, ExecutionStatus, GenesisTransaction, Identifier, ObjectId,
-        ProgrammableTransaction, RandomnessStateUpdate, SharedObjectReference, TransactionKind,
-        Version, gas::GasCostSummary,
+        EndOfEpochTransactionKind, ExecutionStatus, GasPayment, GenesisTransaction, Identifier,
+        ObjectId, ProgrammableTransaction, RandomnessStateUpdate, SharedObjectReference,
+        TransactionKind, Version, gas::GasCostSummary,
     };
     #[cfg(msim)]
     use iota_types::iota_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -50,7 +50,7 @@ mod checked {
         randomness_state::RANDOMNESS_STATE_UPDATE_FUNCTION_NAME,
         storage::{BackingStore, Storage},
         transaction::{
-            CallArg, CheckedInputObjects, GasData, InputObjects, SystemPackage, TransactionKindExt,
+            CallArg, CheckedInputObjects, InputObjects, SystemPackage, TransactionKindExt,
         },
     };
     use move_binary_format::CompiledModule;
@@ -82,7 +82,7 @@ mod checked {
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
         store: &dyn BackingStore,
         input_objects: CheckedInputObjects,
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: Address,
@@ -301,7 +301,7 @@ mod checked {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         // Authentication
         authenticators: Vec<(
@@ -491,7 +491,7 @@ mod checked {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         // Authentication
         authenticators: Vec<(
@@ -1993,7 +1993,7 @@ mod checked {
         Ok(builder.finish())
     }
 
-    fn resolve_sponsor(gas_data: &GasData, transaction_signer: &Address) -> Option<Address> {
+    fn resolve_sponsor(gas_data: &GasPayment, transaction_signer: &Address) -> Option<Address> {
         let gas_owner = gas_data.owner;
         if &gas_owner == transaction_signer {
             None

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -5,7 +5,7 @@
 use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
 
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Address, ProgrammableTransaction, TransactionKind};
+use iota_sdk_types::{Address, GasPayment, ProgrammableTransaction, TransactionKind};
 use iota_types::{
     account_abstraction::authenticator_function::{
         AuthenticatorFunctionRef, AuthenticatorFunctionRefForExecution,
@@ -23,7 +23,7 @@ use iota_types::{
     metrics::LimitsMetrics,
     move_authenticator::MoveAuthenticator,
     storage::BackingStore,
-    transaction::{CheckedInputObjects, GasData},
+    transaction::CheckedInputObjects,
 };
 use move_trace_format::format::MoveTraceBuilder;
 
@@ -43,7 +43,7 @@ pub trait Executor {
         // Transaction Inputs
         input_objects: CheckedInputObjects,
         // Gas related
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         // Transaction
         transaction_kind: TransactionKind,
@@ -71,7 +71,7 @@ pub trait Executor {
         // Transaction Inputs
         input_objects: CheckedInputObjects,
         // Gas related
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         // Transaction
         transaction_kind: TransactionKind,
@@ -97,7 +97,7 @@ pub trait Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         // Authentication
         authenticators: Vec<(
@@ -131,7 +131,7 @@ pub trait Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         // Authentication
         authenticators: Vec<(

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -15,7 +15,7 @@ use iota_adapter_latest::{
 };
 use iota_move_natives_latest::all_natives;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{Address, ProgrammableTransaction, TransactionKind};
+use iota_sdk_types::{Address, GasPayment, ProgrammableTransaction, TransactionKind};
 use iota_types::{
     account_abstraction::authenticator_function::{
         AuthenticatorFunctionRef, AuthenticatorFunctionRefForExecution,
@@ -33,7 +33,7 @@ use iota_types::{
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
     move_authenticator::MoveAuthenticator,
     storage::BackingStore,
-    transaction::{CheckedInputObjects, GasData},
+    transaction::CheckedInputObjects,
 };
 use iota_verifier_latest::meter::IotaVerifierMeter;
 use move_binary_format::CompiledModule;
@@ -82,7 +82,7 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         input_objects: CheckedInputObjects,
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: Address,
@@ -123,7 +123,7 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         input_objects: CheckedInputObjects,
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: Address,
@@ -186,7 +186,7 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         // Authentication
         authenticators: Vec<(
@@ -239,7 +239,7 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         // Gas related
-        gas_data: GasData,
+        gas_data: GasPayment,
         gas_status: IotaGasStatus,
         // Authentication
         move_authenticators: Vec<(


### PR DESCRIPTION
# Description of change

Removes the `GasPayment as GasData` re-export from `iota-types`. Call sites now import `GasPayment` directly from `iota_sdk_types`.

Notes:
- `GasData` and `GasPayment` are the same `iota_sdk_types` type — no wire/BCS/behaviour change, a pure rename.
- Distinct compound names (`GasDataArgs`, `GasDataForTests`, `GasDataGenConfig`, `GasDataWithObjects`, `IotaGasData`) are intentionally left as-is.
- The sibling re-exports on the same line are separate #11567 checklist items.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/11567

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage) — N/A, mechanical re-export removal
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, pure rename
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check --workspace --all-targets` clean; `cargo +nightly fmt` applied; the example workspaces compile and `ci-fmt` is clean. Clippy and the full test suite run in CI. Draft while the sibling re-export PRs ahead are still un-merged.
