### PR TITLE
chore: remove `SystemPackage` re-export

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -46,8 +46,8 @@ use iota_metrics::{
 };
 use iota_sdk_types::{
     Address, EndOfEpochTransactionKind, Event, ExecutionStatus, GasPayment, ObjectId,
-    ObjectReference, Owner, RandomnessRound, StructTag, TransactionExpiration, TransactionKind,
-    TypeTag, Version,
+    ObjectReference, Owner, RandomnessRound, StructTag, SystemPackage, TransactionExpiration,
+    TransactionKind, TypeTag, Version,
     crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
     gas::GasCostSummary,
 };

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -10,13 +10,12 @@ use iota_sdk_types::{
     ChangeEpoch as NativeChangeEpochTransaction, ChangeEpochV2 as NativeChangeEpochTransactionV2,
     ChangeEpochV3 as NativeChangeEpochTransactionV3,
     ChangeEpochV4 as NativeChangeEpochTransactionV4,
-    EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind,
+    EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind, SystemPackage,
 };
 use iota_types::{
     committee::{EpochId, ProtocolVersion},
     digests::TransactionDigest,
     object::Object as NativeObject,
-    transaction::SystemPackage,
 };
 use move_binary_format::{CompiledModule, errors::PartialVMResult};
 

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -25,9 +25,7 @@ use iota_sdk_types::{
     TransactionKind, TransferObjects, TypeTag, Upgrade, Version,
     crypto::{Intent, IntentMessage, IntentScope},
 };
-pub use iota_sdk_types::{
-    SystemPackage, Transaction as TransactionData, TransactionV1 as TransactionDataV1,
-};
+pub use iota_sdk_types::{Transaction as TransactionData, TransactionV1 as TransactionDataV1};
 use itertools::Either;
 use nonempty::{NonEmpty, nonempty};
 use serde::{Deserialize, Serialize};

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -32,7 +32,8 @@ use iota_config::{
 use iota_node_storage::{GrpcIndexes, GrpcStateReader};
 use iota_protocol_config::ProtocolVersion;
 use iota_sdk_types::{
-    Address, EndOfEpochTransactionKind, GasPayment, ObjectId, StructTag, TransactionKind,
+    Address, EndOfEpochTransactionKind, GasPayment, ObjectId, StructTag, SystemPackage,
+    TransactionKind,
 };
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_swarm_config::{
@@ -307,7 +308,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let epoch_start_timestamp_ms = inner.store.get_clock().timestamp_ms();
         drop(inner);
 
-        let next_epoch_system_package_bytes: Vec<iota_types::transaction::SystemPackage> = vec![];
+        let next_epoch_system_package_bytes: Vec<SystemPackage> = vec![];
         let kinds = vec![EndOfEpochTransactionKind::new_change_epoch_v3(
             next_epoch,
             next_epoch_protocol_version.as_u64(),

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -20,7 +20,7 @@ mod checked {
         Address, Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command,
         EndOfEpochTransactionKind, ExecutionStatus, GasPayment, GenesisTransaction, Identifier,
         ObjectId, ProgrammableTransaction, RandomnessStateUpdate, SharedObjectReference,
-        TransactionKind, Version, gas::GasCostSummary,
+        SystemPackage, TransactionKind, Version, gas::GasCostSummary,
     };
     #[cfg(msim)]
     use iota_types::iota_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -49,9 +49,7 @@ mod checked {
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         randomness_state::RANDOMNESS_STATE_UPDATE_FUNCTION_NAME,
         storage::{BackingStore, Storage},
-        transaction::{
-            CallArg, CheckedInputObjects, InputObjects, SystemPackage, TransactionKindExt,
-        },
+        transaction::{CallArg, CheckedInputObjects, InputObjects, TransactionKindExt},
     };
     use move_binary_format::CompiledModule;
     use move_trace_format::format::MoveTraceBuilder;


### PR DESCRIPTION
# Description of change

Removes the `SystemPackage` re-export from `iota-types`. The handful of call sites that use `iota_sdk_types::SystemPackage` (previously reached via `iota_types::transaction::SystemPackage`) now import it directly.

Note: `SystemPackage` is an overloaded name — `iota-framework` and `iota-package-management` each define their own unrelated `SystemPackage` struct. Only the SDK-type call sites are changed; those local types are untouched. Not an alias, so no rename.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/11567

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage) — N/A, mechanical re-export removal
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check --workspace --all-targets` is clean; `cargo +nightly fmt` applied. Clippy and the full test suite run in CI. Draft while the sibling re-export PRs ahead are still un-merged.
