### PR TITLE
chore: remove `Digest` re-export

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -45,7 +45,7 @@ use iota_metrics::{
     TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX, monitored_scope, spawn_monitored_task,
 };
 use iota_sdk_types::{
-    Address, EndOfEpochTransactionKind, Event, ExecutionStatus, GasPayment, ObjectId,
+    Address, Digest, EndOfEpochTransactionKind, Event, ExecutionStatus, GasPayment, ObjectId,
     ObjectReference, Owner, RandomnessRound, StructTag, SystemPackage, TransactionExpiration,
     TransactionKind, TypeTag, Version,
     crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
@@ -70,7 +70,7 @@ use iota_types::{
     committee::{Committee, EpochId, ProtocolVersion},
     crypto::{AuthorityPublicKey, AuthoritySignInfo, AuthoritySignature, Signer},
     deny_list_v1::check_coin_deny_list_v1,
-    digests::{ChainIdentifier, Digest, ObjectDigest, TransactionDigest, TransactionEffectsDigest},
+    digests::{ChainIdentifier, ObjectDigest, TransactionDigest, TransactionEffectsDigest},
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, visitor as DFV},
     effects::{
         InputSharedObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -26,9 +26,10 @@ use iota_protocol_config::{
 };
 use iota_sdk_types::{
     Address, Argument, CancelledTransaction, CheckpointSequenceNumber, Command,
-    ConsensusDeterminedVersionAssignments, EpochId, ExecutionError, ExecutionStatus, GasPayment,
-    Identifier, MoveStruct, ObjectData, ObjectId, ObjectReference, Owner, ProgrammableTransaction,
-    SharedObjectReference, StructTag, TransactionKind, TypeTag, Version, VersionAssignment,
+    ConsensusDeterminedVersionAssignments, Digest, EpochId, ExecutionError, ExecutionStatus,
+    GasPayment, Identifier, MoveStruct, ObjectData, ObjectId, ObjectReference, Owner,
+    ProgrammableTransaction, SharedObjectReference, StructTag, TransactionKind, TypeTag, Version,
+    VersionAssignment,
 };
 use iota_types::{
     base_types::{AuthorityName, TxContext, dbg_addr, dbg_object_id, random_object_ref},
@@ -37,7 +38,7 @@ use iota_types::{
         AccountKeyPair, AuthorityKeyPair, AuthorityPublicKey, IotaSignature, Signature,
         get_key_pair, random_committee_key_pairs_of_size,
     },
-    digests::{Digest, ObjectDigest, TransactionDigest},
+    digests::{ObjectDigest, TransactionDigest},
     dynamic_field::{DynamicFieldInfo, DynamicFieldType},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
     epoch_data::EpochData,

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -12,12 +12,11 @@ use std::{
 use iota_move_build::BuildConfig;
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
-    Address, Argument, CommandArgumentError, ExecutionError, ExecutionStatus, Identifier, ObjectId,
-    ObjectReference, Owner, PackageUpgradeError, ProgrammableTransaction, StructTag,
+    Address, Argument, CommandArgumentError, Digest, ExecutionError, ExecutionStatus, Identifier,
+    ObjectId, ObjectReference, Owner, PackageUpgradeError, ProgrammableTransaction, StructTag,
 };
 use iota_types::{
     crypto::{AccountKeyPair, get_key_pair},
-    digests::Digest,
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::{IotaError, UserInputError},
     execution_config_utils::to_binary_config,

--- a/crates/iota-json-rpc-types/src/iota_checkpoint.rs
+++ b/crates/iota-json-rpc-types/src/iota_checkpoint.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_protocol_config::ProtocolVersion;
-use iota_sdk_types::{gas::GasCostSummary, validator::ValidatorCommitteeMember};
+use iota_sdk_types::{Digest, gas::GasCostSummary, validator::ValidatorCommitteeMember};
 use iota_types::{
     base_types::{AuthorityName, TransactionDigest},
     committee::{EpochId, StakeUnit},
     crypto::AggregateAuthoritySignature,
-    digests::{CheckpointDigest, Digest},
+    digests::CheckpointDigest,
     iota_serde::BigInt,
     messages_checkpoint::{
         CheckpointCommitment, CheckpointContents, CheckpointContentsExt, CheckpointSequenceNumber,

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -15,10 +15,9 @@ use anemo::{
 use fastcrypto::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use futures::StreamExt;
 use iota_config::p2p::{AccessType, DiscoveryConfig, P2pConfig, SeedPeer};
-use iota_sdk_types::crypto::IntentScope;
+use iota_sdk_types::{Digest, crypto::IntentScope};
 use iota_types::{
     crypto::{NetworkKeyPair, Signer, ToFromBytes, VerifyingKey},
-    digests::Digest,
     message_envelope::{Envelope, Message, VerifiedEnvelope},
     multiaddr::Multiaddr,
 };

--- a/crates/iota-types/src/auth_context/mod.rs
+++ b/crates/iota-types/src/auth_context/mod.rs
@@ -4,7 +4,7 @@
 mod fields_v1;
 
 pub use fields_v1::*;
-use iota_sdk_types::ProgrammableTransaction;
+use iota_sdk_types::{Digest, ProgrammableTransaction};
 use move_binary_format::{CompiledModule, file_format::SignatureToken};
 use move_bytecode_utils::resolve_struct;
 use move_core_types::{
@@ -17,7 +17,7 @@ use crate::{
     account_abstraction::authenticator_function::{
         AuthenticatorFunctionRef, AuthenticatorFunctionRefV1,
     },
-    digests::{Digest, MoveAuthenticatorDigest},
+    digests::MoveAuthenticatorDigest,
 };
 
 pub const AUTH_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("auth_context");

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -7,7 +7,7 @@ use std::{env, fmt};
 use fastcrypto::encoding::{Base58, Encoding, Hex};
 use iota_protocol_config::Chain;
 pub use iota_sdk_types::{
-    CertificateDigest, CheckpointContentsDigest, CheckpointDigest, ConsensusCommitDigest, Digest,
+    CertificateDigest, CheckpointContentsDigest, CheckpointDigest, ConsensusCommitDigest,
     EffectsAuxDataDigest, MisbehaviorReportDigest, MoveAuthenticatorDigest, ObjectDigest,
     SenderSignedDataDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest,
 };

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use fastcrypto::hash::MultisetHash;
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
-    CheckpointContentsV1, RandomnessRound,
+    CheckpointContentsV1, Digest, RandomnessRound,
     checkpoint::CheckpointTransactionInfo,
     crypto::{Intent, IntentScope, UserSignature},
     gas::GasCostSummary,
@@ -33,7 +33,6 @@ use crate::{
         AccountKeyPair, AggregateAuthoritySignature, AuthoritySignInfo, AuthoritySignInfoTrait,
         AuthorityStrongQuorumSignInfo, default_hash, get_key_pair,
     },
-    digests::Digest,
     effects::{TestEffectsBuilder, TransactionEffectsAPI},
     error::{IotaError, IotaResult},
     global_state_hash::GlobalStateHash,

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -13,7 +13,7 @@ use std::{
 use byteorder::{BigEndian, ReadBytesExt};
 use fastcrypto::{error::FastCryptoResult, groups::bls12381, hash::HashFunction};
 use fastcrypto_tbls::dkg_v1;
-use iota_sdk_types::{ObjectReference, crypto::IntentScope};
+use iota_sdk_types::{Digest, ObjectReference, crypto::IntentScope};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -21,7 +21,7 @@ use tracing::warn;
 use crate::{
     base_types::{AuthorityName, ConciseableName, TransactionDigest},
     crypto::{AuthoritySignature, DefaultHash, default_hash},
-    digests::{Digest, MisbehaviorReportDigest},
+    digests::MisbehaviorReportDigest,
     message_envelope::{Envelope, Message, VerifiedEnvelope},
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
     supported_protocol_versions::{

--- a/crates/iota-types/src/supported_protocol_versions.rs
+++ b/crates/iota-types/src/supported_protocol_versions.rs
@@ -6,9 +6,10 @@ use std::ops::RangeInclusive;
 
 use fastcrypto::hash::HashFunction;
 pub use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+use iota_sdk_types::Digest;
 use serde::{Deserialize, Serialize};
 
-use crate::{crypto::DefaultHash, digests::Digest};
+use crate::crypto::DefaultHash;
 
 /// Models the set of protocol versions supported by a validator.
 /// The `iota-node` binary will always use the SYSTEM_DEFAULT constant, but for

--- a/crates/iota-types/src/unit_tests/base_types_tests.rs
+++ b/crates/iota-types/src/unit_tests/base_types_tests.rs
@@ -13,7 +13,7 @@ use fastcrypto::{
 };
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
-    Owner,
+    Digest, Owner,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 use move_binary_format::file_format;
@@ -27,7 +27,7 @@ use crate::{
         bcs_signable_test::{Bar, Foo},
         get_key_pair, get_key_pair_from_bytes,
     },
-    digests::{Digest, TransactionDigest},
+    digests::TransactionDigest,
     dynamic_field::DynamicFieldInfo,
     gas_coin::GasCoin,
     object::Object,

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -12,7 +12,7 @@
 use std::collections::HashSet;
 
 use iota_config::transaction_deny_config::TransactionDenyConfig;
-use iota_sdk_types::{Address, Event, ObjectId, ObjectReference};
+use iota_sdk_types::{Address, Digest, Event, ObjectId, ObjectReference};
 use iota_types::{
     account_abstraction::authenticator_function::{
         AuthenticatorFunctionRefForExecution,
@@ -304,10 +304,7 @@ pub(super) fn execute_with_move_authenticators(
     store: &dyn BackingStore,
     prepared: PreparedTransaction,
     authenticators: Vec<MoveAuthenticator>,
-    auth_digests: (
-        iota_types::digests::Digest,
-        Option<iota_types::digests::Digest>,
-    ),
+    auth_digests: (Digest, Option<Digest>),
     check_coin_deny_list: bool,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
 ) -> Result<
@@ -483,10 +480,7 @@ pub(super) fn prepare_authenticators(
 pub(super) fn build_auth_context_data(
     transaction: &TransactionData,
     prepared_auths: &[PreparedAuthenticator],
-    auth_digests: (
-        iota_types::digests::Digest,
-        Option<iota_types::digests::Digest>,
-    ),
+    auth_digests: (Digest, Option<Digest>),
 ) -> Result<AuthContextData, VmSdkError> {
     let tx_data_bytes = bcs::to_bytes(transaction)
         .map_err(|e| VmError::new(format!("serialize transaction data: {e}")))?;

--- a/iota-execution/latest/iota-move-natives/src/authentication_context.rs
+++ b/iota-execution/latest/iota-move-natives/src/authentication_context.rs
@@ -4,10 +4,11 @@
 use std::{cell::RefCell, rc::Rc};
 
 use better_any::{Tid, TidAble};
+use iota_sdk_types::Digest;
 use iota_types::{
     account_abstraction::authenticator_function::AuthenticatorFunctionRefV1,
     auth_context::{AuthContext, MoveCallArg, MoveCommand},
-    digests::{Digest, MoveAuthenticatorDigest},
+    digests::MoveAuthenticatorDigest,
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{


### PR DESCRIPTION
# Description of change

Removes the `Digest` re-export from `iota-types` (`digests.rs`). Call sites now import `Digest` directly from `iota_sdk_types`.

Notes:
- Not aliased — the name stays `Digest`, so this is pure import-path rewiring, no rename, no wire/BCS/behaviour change.
- The other digest types re-exported on the same block (`ObjectDigest`, `TransactionDigest`, `CheckpointDigest`, …) are deliberately kept — they are not part of this checklist item.
- `iota-graphql-rpc` has its own unrelated `pub(crate) struct Digest`; it is untouched.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/11567

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage) — N/A, mechanical re-export removal
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, pure import rewiring
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check --workspace --all-targets` is clean (no unused-import warnings); `cargo +nightly fmt --check` is clean; the example workspaces don't reference the type. Clippy and the full test suite run in CI. Draft while the sibling re-export PRs ahead are still un-merged.
