### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 in root Cargo.lock (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
# Description of change

Bumps `crossbeam-epoch` from `0.9.18` to `0.9.20` in the root `Cargo.lock` to resolve **RUSTSEC-2026-0204** (invalid pointer dereference in the `fmt::Display` impl for `Atomic`/`Shared` on a null pointer), which has been failing `cargo deny check advisories` in nightly CI.

- Lockfile-only change: `cargo update -p crossbeam-epoch` touched exactly the single entry, no transitive churn.
- #12166 already fixed the `external-crates/move` workspace lockfile but scoped itself to that workspace; this covers the root `Cargo.lock` follow-up.

## Links to any relevant issues

fixes #12172

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Verified the lockfile now pins `crossbeam-epoch 0.9.20`; relying on CI's `cargo deny check advisories` to confirm the advisory clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdYQshNeDhuVVZFCZ2ppWP

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdYQshNeDhuVVZFCZ2ppWP)_