### PR TITLE
feat(grpc): add `balance_changes` and `object_changes` to `ExecutedTransaction`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6325,6 +6325,7 @@ dependencies = [
  "iota-test-transaction-builder",
  "iota-types",
  "itertools 0.13.0",
+ "move-binary-format",
  "move-core-types",
  "paste",
  "pin-project-lite",
@@ -7462,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "bech32 0.11.1",
  "bip32",
@@ -7485,7 +7486,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7514,7 +7515,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7522,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7541,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7557,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7576,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,9 +401,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "559083b9e901e53008f15d85d50df7f007c681ba" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "559083b9e901e53008f15d85d50df7f007c681ba" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -442,9 +442,9 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-e2e-tests/tests/grpc/utils.rs
+++ b/crates/iota-e2e-tests/tests/grpc/utils.rs
@@ -6,10 +6,11 @@ use std::collections::{HashMap, HashSet};
 use iota_grpc_client::{ReadMask, read_mask_fields::CheckpointResponseField};
 use iota_grpc_types::v1::types::{Address as ProtoAddress, ObjectId as ProtoObjectId};
 use iota_sdk_types::{
-    Address, ExecutionStatus, ObjectId, SignedTransaction, Transaction, TransactionDigest,
+    Address, ExecutionStatus, ObjectDigest, ObjectId, Owner, SignedTransaction, Transaction,
+    TransactionDigest, TypeTag,
 };
 use iota_test_transaction_builder::{TestTransactionBuilder, make_transfer_iota_transaction};
-use iota_types::effects::TransactionEffectsAPI;
+use iota_types::{effects::TransactionEffectsAPI, gas_coin::GAS};
 use test_cluster::{TestCluster, TestClusterBuilder};
 
 // --- Shared example package names used by filter tests ---
@@ -190,6 +191,231 @@ pub async fn wait_for_executed_transactions_checkpointed(
     let target_seq = baseline_seq + 2;
     cluster.wait_for_checkpoint(target_seq, None).await;
     target_seq
+}
+
+/// A balance change reduced to a comparable form for assertions:
+/// (owner, coin type, amount).
+pub type NormalizedBalanceChange = (Owner, TypeTag, i128);
+
+/// An object change reduced to a comparable form for assertions. Mirrors the
+/// variants the server can produce.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NormalizedObjectChange {
+    Published {
+        package_id: ObjectId,
+        version: u64,
+        digest: ObjectDigest,
+        modules: Vec<String>,
+    },
+    Mutated {
+        sender: Address,
+        owner: Owner,
+        object_type: String,
+        object_id: ObjectId,
+        version: u64,
+        previous_version: u64,
+        digest: ObjectDigest,
+    },
+    Deleted {
+        sender: Address,
+        object_type: String,
+        object_id: ObjectId,
+        version: u64,
+    },
+    Wrapped {
+        sender: Address,
+        object_type: String,
+        object_id: ObjectId,
+        version: u64,
+    },
+    Unwrapped {
+        sender: Address,
+        owner: Owner,
+        object_type: String,
+        object_id: ObjectId,
+        version: u64,
+        digest: ObjectDigest,
+    },
+    Created {
+        sender: Address,
+        owner: Owner,
+        object_type: String,
+        object_id: ObjectId,
+        version: u64,
+        digest: ObjectDigest,
+    },
+}
+
+/// Normalize the balance changes of a gRPC `ExecutedTransaction` into a
+/// sorted, comparable form.
+pub fn normalize_grpc_balance_changes(
+    executed_transaction: &iota_grpc_types::v1::transaction::ExecutedTransaction,
+) -> Vec<NormalizedBalanceChange> {
+    let mut changes = executed_transaction
+        .balance_changes()
+        .expect("balance_changes should be present")
+        .balance_changes
+        .iter()
+        .map(|change| {
+            (
+                change.owner().unwrap(),
+                change.coin_type().unwrap(),
+                change.amount_i128().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    changes.sort();
+    changes
+}
+
+/// Normalize the object changes of a gRPC `ExecutedTransaction` into a
+/// sorted, comparable form.
+pub fn normalize_grpc_object_changes(
+    executed_transaction: &iota_grpc_types::v1::transaction::ExecutedTransaction,
+) -> Vec<NormalizedObjectChange> {
+    use iota_grpc_types::v1::transaction::object_change::Kind;
+
+    let mut changes = executed_transaction
+        .object_changes()
+        .expect("object_changes should be present")
+        .object_changes
+        .iter()
+        .map(|change| match change.kind.as_ref().unwrap() {
+            Kind::Published(published) => NormalizedObjectChange::Published {
+                package_id: published.package_id().unwrap(),
+                version: published.version.unwrap(),
+                digest: published.digest().unwrap(),
+                modules: published.modules.clone(),
+            },
+            Kind::Mutated(mutated) => NormalizedObjectChange::Mutated {
+                sender: mutated.sender().unwrap(),
+                owner: mutated.owner().unwrap(),
+                object_type: mutated.object_type().unwrap().to_string(),
+                object_id: mutated.object_id().unwrap(),
+                version: mutated.version.unwrap(),
+                previous_version: mutated.previous_version.unwrap(),
+                digest: mutated.digest().unwrap(),
+            },
+            Kind::Deleted(deleted) => NormalizedObjectChange::Deleted {
+                sender: deleted.sender().unwrap(),
+                object_type: deleted.object_type().unwrap().to_string(),
+                object_id: deleted.object_id().unwrap(),
+                version: deleted.version.unwrap(),
+            },
+            Kind::Wrapped(wrapped) => NormalizedObjectChange::Wrapped {
+                sender: wrapped.sender().unwrap(),
+                object_type: wrapped.object_type().unwrap().to_string(),
+                object_id: wrapped.object_id().unwrap(),
+                version: wrapped.version.unwrap(),
+            },
+            Kind::Unwrapped(unwrapped) => NormalizedObjectChange::Unwrapped {
+                sender: unwrapped.sender().unwrap(),
+                owner: unwrapped.owner().unwrap(),
+                object_type: unwrapped.object_type().unwrap().to_string(),
+                object_id: unwrapped.object_id().unwrap(),
+                version: unwrapped.version.unwrap(),
+                digest: unwrapped.digest().unwrap(),
+            },
+            Kind::Created(created) => NormalizedObjectChange::Created {
+                sender: created.sender().unwrap(),
+                owner: created.owner().unwrap(),
+                object_type: created.object_type().unwrap().to_string(),
+                object_id: created.object_id().unwrap(),
+                version: created.version.unwrap(),
+                digest: created.digest().unwrap(),
+            },
+            kind => panic!("unknown object change kind: {kind:?}"),
+        })
+        .collect::<Vec<_>>();
+    changes.sort();
+    changes
+}
+
+/// Extract the net gas usage from the effects of a gRPC
+/// `ExecutedTransaction` (requires `effects` in the read mask).
+pub fn grpc_net_gas_usage(
+    executed_transaction: &iota_grpc_types::v1::transaction::ExecutedTransaction,
+) -> i64 {
+    executed_transaction
+        .effects()
+        .expect("effects should be present")
+        .effects()
+        .expect("effects should deserialize")
+        .as_v1()
+        .gas_cost_summary
+        .net_gas_usage()
+}
+
+/// Assert that a transaction transferring `amount` NANOS of IOTA from
+/// `sender` to `recipient` produced exactly the expected derived changes:
+///
+/// - balance changes: `-(amount + gas)` for the sender, `+amount` for the
+///   recipient (gas taken from the transaction's effects, so the read mask must
+///   include `effects`);
+/// - object changes: one coin `Created` for the recipient, all remaining
+///   entries gas-coin `Mutated` for the sender (source coin and/or gas coin).
+pub fn assert_transfer_derived_changes(
+    executed_transaction: &iota_grpc_types::v1::transaction::ExecutedTransaction,
+    sender: Address,
+    recipient: Address,
+    amount: i128,
+    scenario: &str,
+) {
+    let gas = grpc_net_gas_usage(executed_transaction) as i128;
+    let mut expected = vec![
+        (Owner::Address(sender), GAS::type_tag(), -(amount + gas)),
+        (Owner::Address(recipient), GAS::type_tag(), amount),
+    ];
+    expected.sort();
+    assert_eq!(
+        normalize_grpc_balance_changes(executed_transaction),
+        expected,
+        "{scenario}: unexpected balance changes"
+    );
+
+    let object_changes = normalize_grpc_object_changes(executed_transaction);
+    let gas_coin_type = iota_sdk_types::StructTag::new_gas_coin().to_string();
+    let created: Vec<_> = object_changes
+        .iter()
+        .filter(|change| {
+            matches!(
+                change,
+                NormalizedObjectChange::Created { sender: s, owner, object_type, .. }
+                    if *s == sender
+                        && *owner == Owner::Address(recipient)
+                        && *object_type == gas_coin_type
+            )
+        })
+        .collect();
+    assert_eq!(
+        created.len(),
+        1,
+        "{scenario}: expected exactly one coin created for the recipient: {object_changes:?}"
+    );
+    let mutated_count = object_changes
+        .iter()
+        .filter(|change| {
+            matches!(
+                change,
+                NormalizedObjectChange::Mutated {
+                    sender: s,
+                    owner,
+                    object_type,
+                    version,
+                    previous_version,
+                    ..
+                } if *s == sender
+                    && *owner == Owner::Address(sender)
+                    && *object_type == gas_coin_type
+                    && previous_version < version
+            )
+        })
+        .count();
+    assert_eq!(
+        mutated_count,
+        object_changes.len() - 1,
+        "{scenario}: all other object changes should be sender-owned coin mutations: {object_changes:?}"
+    );
 }
 
 /// Assert that a raw tonic result is an error with the expected status code.

--- a/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_checkpoints.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_checkpoints.rs
@@ -327,6 +327,17 @@ async fn get_checkpoint_readmask_scenarios() {
             vec!["transactions.transaction.digest", "transactions.timestamp"],
         ),
         (
+            "transactions derived changes (balance_changes + object_changes)",
+            Some(FieldMask::from_paths([
+                "transactions.balance_changes",
+                "transactions.object_changes",
+            ])),
+            vec![
+                "transactions.balance_changes",
+                "transactions.object_changes",
+            ],
+        ),
+        (
             "full readmask",
             Some(FieldMask::from_paths([
                 "checkpoint",
@@ -512,6 +523,17 @@ async fn stream_checkpoints_readmask_scenarios() {
                 "transactions.timestamp",
             ])),
             vec!["transactions.effects.digest", "transactions.timestamp"],
+        ),
+        (
+            "stream transactions derived changes (balance_changes + object_changes)",
+            Some(FieldMask::from_paths([
+                "transactions.balance_changes",
+                "transactions.object_changes",
+            ])),
+            vec![
+                "transactions.balance_changes",
+                "transactions.object_changes",
+            ],
         ),
         (
             "stream full readmask",

--- a/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_transactions.rs
@@ -15,8 +15,8 @@ use iota_sdk_types::{Digest, TransactionDigest};
 use prost_types::FieldMask;
 
 use crate::utils::{
-    assert_field_presence, comma_separated_field_mask_to_paths, execute_transaction_and_get_digest,
-    setup_grpc_test,
+    assert_field_presence, assert_transfer_derived_changes, comma_separated_field_mask_to_paths,
+    execute_transaction_and_get_digest, normalize_grpc_balance_changes, setup_grpc_test,
 };
 
 /// Helper function to make GetTransactions requests and validate responses..
@@ -199,6 +199,149 @@ async fn get_transactions_readmask_scenarios() {
         let total_transactions: usize = responses.iter().map(|r| r.transaction_results.len()).sum();
         assert_eq!(total_transactions, 1, "{scenario}: expected 1 transaction");
     }
+}
+
+#[sim_test]
+async fn get_transactions_derived_changes() {
+    use iota_test_transaction_builder::make_transfer_iota_transaction;
+    use iota_types::transaction::TransactionDataAPI as _;
+
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+
+    let mut ledger_client = client.ledger_service_client();
+
+    // Transfer to a distinct recipient so the balance moves between two owners
+    let recipient = iota_sdk_types::Address::random();
+    let transaction =
+        make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(1000)).await;
+    let sender = transaction.transaction_data().sender();
+    let transaction_digest = *transaction.digest();
+    test_cluster
+        .wallet
+        .execute_transaction_may_fail(transaction)
+        .await
+        .unwrap();
+
+    // Requesting only the derived fields (plus effects for the gas charge)
+    // must not leak the input/output objects they are computed from (asserted
+    // absent by assert_get_transactions_request)
+    let responses = assert_get_transactions_request(
+        &mut ledger_client,
+        vec![transaction_digest],
+        Some(FieldMask::from_paths([
+            "balance_changes",
+            "object_changes",
+            "effects",
+        ])),
+        None,
+        &["balance_changes", "object_changes", "effects"],
+        "derived changes only",
+    )
+    .await;
+
+    let Some(transaction_result::Result::ExecutedTransaction(executed_transaction)) =
+        &responses[0].transaction_results[0].result
+    else {
+        panic!("expected an executed transaction");
+    };
+
+    assert_transfer_derived_changes(
+        executed_transaction,
+        sender,
+        recipient,
+        1000,
+        "get_transactions derived changes",
+    );
+}
+
+#[sim_test]
+async fn get_transactions_derived_changes_failed_transaction() {
+    use iota_sdk_types::Command;
+    use iota_types::{
+        programmable_transaction_builder::ProgrammableTransactionBuilder,
+        transaction::{CallArg, TransactionData, TransactionDataAPI as _},
+    };
+
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+
+    let mut ledger_client = client.ledger_service_client();
+
+    // Build a transaction that fails at execution: split more coins than the
+    // input coin holds. It is still committed and charged gas.
+    let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
+    gas.sort_by_key(|object_ref| object_ref.object_id);
+    let gas_object = gas.last().unwrap();
+    let coin_to_split = gas.first().unwrap();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let coin_arg = builder
+        .obj(CallArg::ImmutableOrOwned(*coin_to_split))
+        .unwrap();
+    let huge_amount = builder.pure(u64::MAX).unwrap();
+    builder.command(Command::new_split_coins(coin_arg, vec![huge_amount]));
+    let transaction_data = TransactionData::new_programmable(
+        sender,
+        vec![*gas_object],
+        builder.finish(),
+        10_000_000,
+        test_cluster.get_reference_gas_price().await,
+    );
+    let transaction = test_cluster.wallet.sign_transaction(&transaction_data);
+    let transaction_digest = *transaction.digest();
+    test_cluster
+        .wallet
+        .execute_transaction_may_fail(transaction)
+        .await
+        .unwrap();
+
+    let responses = assert_get_transactions_request(
+        &mut ledger_client,
+        vec![transaction_digest],
+        Some(FieldMask::from_paths([
+            "balance_changes",
+            "object_changes",
+            "effects",
+        ])),
+        None,
+        &["balance_changes", "object_changes", "effects"],
+        "derived changes for failed transaction",
+    )
+    .await;
+
+    let Some(transaction_result::Result::ExecutedTransaction(executed_transaction)) =
+        &responses[0].transaction_results[0].result
+    else {
+        panic!("expected an executed transaction");
+    };
+
+    // A failed transaction reports exactly the gas charge and nothing else
+    let gas = crate::utils::grpc_net_gas_usage(executed_transaction) as i128;
+    assert!(gas > 0, "failed transaction should be charged gas: {gas}");
+    assert_eq!(
+        normalize_grpc_balance_changes(executed_transaction),
+        vec![(
+            iota_sdk_types::Owner::Address(sender),
+            iota_types::gas_coin::GAS::type_tag(),
+            -gas,
+        )],
+        "failed transaction should produce a single gas-only balance change"
+    );
+
+    // The intended split is rolled back; only sender-owned coin mutations
+    // (gas smashing) remain
+    let object_changes = crate::utils::normalize_grpc_object_changes(executed_transaction);
+    assert!(
+        !object_changes.is_empty(),
+        "gas coin mutation should be reported"
+    );
+    assert!(
+        object_changes.iter().all(|change| matches!(
+            change,
+            crate::utils::NormalizedObjectChange::Mutated { sender: s, owner, .. }
+                if *s == sender && *owner == iota_sdk_types::Owner::Address(sender)
+        )),
+        "failed transaction should only report sender-owned mutations: {object_changes:?}"
+    );
 }
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/grpc/v1/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/mod.rs
@@ -79,6 +79,8 @@ impl_field_presence_checker!(ExecutedTransaction {
     timestamp,
     input_objects,
     output_objects,
+    balance_changes,
+    object_changes,
 });
 impl_field_presence_checker!(Input { index });
 impl_field_presence_checker!(Result {

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
@@ -137,6 +137,44 @@ async fn execute_transaction_readmask_scenarios() {
 }
 
 #[sim_test]
+async fn execute_transaction_derived_changes() {
+    use iota_types::transaction::TransactionDataAPI as _;
+
+    let (test_cluster, client) = setup_grpc_test(None, None).await;
+
+    let mut exec_client = client.execution_service_client();
+
+    let recipient = Address::random();
+    let txn = make_transfer_iota_transaction(&test_cluster.wallet, Some(recipient), Some(9)).await;
+    let sender = txn.transaction_data().sender();
+    let item = build_item(&txn);
+
+    // Requesting only the derived fields (plus effects for the gas charge)
+    // must not leak the input/output objects they are computed from
+    let response = assert_execute_transaction_request(
+        &mut exec_client,
+        item,
+        Some(FieldMask::from_paths([
+            "balance_changes",
+            "object_changes",
+            "effects",
+        ])),
+        &["balance_changes", "object_changes", "effects"],
+        "derived changes only",
+    )
+    .await;
+
+    let executed_transaction = first_executed_transaction(&response);
+    crate::utils::assert_transfer_derived_changes(
+        executed_transaction,
+        sender,
+        recipient,
+        9,
+        "execute_transactions derived changes",
+    );
+}
+
+#[sim_test]
 async fn execute_transaction_invalid_bcs() {
     let (_test_cluster, client) = setup_grpc_test(None, None).await;
 

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
@@ -128,6 +128,68 @@ async fn assert_simulate_transaction_request(
 }
 
 #[sim_test]
+async fn simulate_transaction_derived_changes() {
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+
+    let mut exec_client = client.execution_service_client();
+
+    let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
+    gas.sort_by_key(|object_ref| object_ref.object_id);
+    let gas_object = gas.last().unwrap();
+    let coin_to_split = gas.first().unwrap();
+
+    let recipient = Address::random();
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .pay(vec![*coin_to_split], vec![recipient], vec![1000])
+        .unwrap();
+    let transaction_data = TransactionData::new_programmable(
+        sender,
+        vec![*gas_object],
+        builder.finish(),
+        10_000_000,
+        1000,
+    );
+    let proto_transaction = ProtoTransaction::default()
+        .with_bcs(BcsData::default().with_data(bcs::to_bytes(&transaction_data).unwrap()));
+
+    // Requesting only the derived fields (plus effects for the gas charge)
+    // must not leak the input/output objects they are computed from
+    let simulated = assert_simulate_transaction_request(
+        &mut exec_client,
+        proto_transaction,
+        Some(FieldMask::from_paths([
+            "executed_transaction.balance_changes",
+            "executed_transaction.object_changes",
+            "executed_transaction.effects",
+        ])),
+        &[
+            "executed_transaction.balance_changes",
+            "executed_transaction.object_changes",
+            "executed_transaction.effects",
+        ],
+        &[],
+        &[],
+        &[],
+        "derived changes only",
+    )
+    .await;
+
+    let executed_transaction = simulated
+        .executed_transaction
+        .as_ref()
+        .expect("executed_transaction should be present");
+
+    crate::utils::assert_transfer_derived_changes(
+        executed_transaction,
+        sender,
+        recipient,
+        1000,
+        "simulate_transactions derived changes",
+    );
+}
+
+#[sim_test]
 async fn simulate_transaction_zero_gas_budget_uses_max() {
     let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
 

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -44,4 +44,5 @@ prometheus-filtered.workspace = true
 [dev-dependencies]
 iota-grpc-client.workspace = true
 iota-test-transaction-builder.workspace = true
+move-binary-format.workspace = true
 typed-store-error.workspace = true

--- a/crates/iota-grpc-server/src/changes.rs
+++ b/crates/iota-grpc-server/src/changes.rs
@@ -1,0 +1,846 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Synchronous derivation of balance and object changes from a transaction's
+//! effects and its already-fetched input/output objects. Operates purely on
+//! in-memory data — no storage lookups.
+//!
+//! Objects missing from the provided sets (e.g. pruned from the object store)
+//! are an error rather than being skipped: a missing input coin would make a
+//! balance delta numerically wrong and a missing object would silently drop
+//! an object change, with no way for the client to detect the incomplete
+//! result. Erroring lets the client retry without the derived change fields.
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    ops::Neg,
+};
+
+use iota_grpc_types::v1::transaction as grpc_tx;
+use iota_sdk_types::{Address, ExecutionStatus, ObjectId, Owner, StructTag, TypeTag};
+use iota_types::{
+    base_types::SequenceNumber,
+    coin::Coin,
+    digests::ObjectDigest,
+    effects::{ObjectRemoveKind, TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
+    gas_coin::GAS,
+    object::Object,
+    storage::WriteKind,
+};
+
+/// Error deriving balance or object changes from a transaction's effects.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DeriveChangesError {
+    /// A required object was not in the provided input/output sets. On the
+    /// ledger read path this means it was pruned from the object store; on
+    /// the execute/simulate/checkpoint paths the sets are always complete,
+    /// so a miss there indicates a server bug.
+    MissingObject {
+        object_id: ObjectId,
+        version: SequenceNumber,
+    },
+    /// An object whose type is a coin had contents that are not a valid coin.
+    MalformedCoin {
+        object_id: ObjectId,
+        version: SequenceNumber,
+    },
+}
+
+impl std::fmt::Display for DeriveChangesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingObject { object_id, version } => write!(
+                f,
+                "object {object_id} at version {version} is unavailable (possibly pruned)"
+            ),
+            Self::MalformedCoin { object_id, version } => write!(
+                f,
+                "coin object {object_id} at version {version} has malformed contents"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DeriveChangesError {}
+
+impl From<DeriveChangesError> for crate::error::RpcError {
+    fn from(error: DeriveChangesError) -> Self {
+        Self::new(
+            tonic::Code::FailedPrecondition,
+            format!(
+                "cannot derive the requested change fields: {error}; \
+                 retry without balance_changes/object_changes in the read mask"
+            ),
+        )
+    }
+}
+
+/// The change in balance of one coin type for one owner, derived from a
+/// transaction's effects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedBalanceChange {
+    pub owner: Owner,
+    pub coin_type: TypeTag,
+    /// Negative amount means the net flow of value is away from the owner.
+    pub amount: i128,
+}
+
+/// A change to an object caused by a transaction, derived from its effects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DerivedObjectChange {
+    Published {
+        package_id: ObjectId,
+        version: SequenceNumber,
+        digest: ObjectDigest,
+        modules: Vec<String>,
+    },
+    Mutated {
+        sender: Address,
+        owner: Owner,
+        object_type: StructTag,
+        object_id: ObjectId,
+        version: SequenceNumber,
+        previous_version: SequenceNumber,
+        digest: ObjectDigest,
+    },
+    Deleted {
+        sender: Address,
+        object_type: StructTag,
+        object_id: ObjectId,
+        version: SequenceNumber,
+    },
+    Wrapped {
+        sender: Address,
+        object_type: StructTag,
+        object_id: ObjectId,
+        version: SequenceNumber,
+    },
+    Unwrapped {
+        sender: Address,
+        owner: Owner,
+        object_type: StructTag,
+        object_id: ObjectId,
+        version: SequenceNumber,
+        digest: ObjectDigest,
+    },
+    Created {
+        sender: Address,
+        owner: Owner,
+        object_type: StructTag,
+        object_id: ObjectId,
+        version: SequenceNumber,
+        digest: ObjectDigest,
+    },
+}
+
+/// Derive the balance changes of a transaction from its effects and its
+/// input/output objects.
+///
+/// `input_objects` must hold the objects at the versions given by
+/// `effects.modified_at_versions()` and `output_objects` the objects written
+/// by the transaction (created, mutated, unwrapped); this is exactly what the
+/// existing input/output object fetch paths produce.
+///
+/// For a failed transaction only the gas charge is reported (which requires
+/// no objects). `mocked_coin` excludes a gas coin mocked during simulation
+/// from the result.
+///
+/// Errors if a required object is missing from the sets — a missing input
+/// coin would silently corrupt the delta of any coin whose output is present.
+pub fn derive_balance_changes(
+    effects: &TransactionEffects,
+    input_objects: &[Object],
+    output_objects: &[Object],
+    mocked_coin: Option<ObjectId>,
+) -> Result<Vec<DerivedBalanceChange>, DeriveChangesError> {
+    let (_, gas_owner) = effects.gas_object();
+
+    // Only charge gas when the tx fails, skip all object parsing
+    if effects.status() != &ExecutionStatus::Success {
+        return Ok(vec![DerivedBalanceChange {
+            owner: gas_owner,
+            coin_type: GAS::type_tag(),
+            amount: (effects.gas_cost_summary().net_gas_usage() as i128).neg(),
+        }]);
+    }
+
+    let objects: BTreeMap<(ObjectId, SequenceNumber), &Object> = input_objects
+        .iter()
+        .chain(output_objects)
+        .map(|o| ((o.id(), o.version()), o))
+        .collect();
+
+    let unwrapped_then_deleted = effects
+        .unwrapped_then_deleted()
+        .iter()
+        .map(|object_ref| object_ref.object_id)
+        .collect::<HashSet<_>>();
+
+    let mut balances = BTreeMap::<(Owner, TypeTag), i128>::new();
+
+    // 1. subtract all input coins
+    for (id, version) in effects.modified_at_versions() {
+        // Skip the mocked gas coin, which is not present in the input objects
+        if matches!(mocked_coin, Some(coin) if id == coin) {
+            continue;
+        }
+        // Unwrapped-then-deleted objects have no stored input version
+        if unwrapped_then_deleted.contains(&id) {
+            continue;
+        }
+        if let Some((owner, coin_type, amount)) = coin_owner_type_value(&objects, id, version)? {
+            *balances.entry((owner, coin_type)).or_default() -= amount as i128;
+        }
+    }
+
+    // 2. add all mutated coins
+    for (object_ref, _, _) in effects.all_changed_objects() {
+        // Skip the mocked gas coin, which is not present in the output objects
+        if matches!(mocked_coin, Some(coin) if object_ref.object_id == coin) {
+            continue;
+        }
+        if let Some((owner, coin_type, amount)) =
+            coin_owner_type_value(&objects, object_ref.object_id, object_ref.version)?
+        {
+            *balances.entry((owner, coin_type)).or_default() += amount as i128;
+        }
+    }
+
+    Ok(balances
+        .into_iter()
+        .filter_map(|((owner, coin_type), amount)| {
+            if amount == 0 {
+                return None;
+            }
+            Some(DerivedBalanceChange {
+                owner,
+                coin_type,
+                amount,
+            })
+        })
+        .collect())
+}
+
+/// Look up an object and return its owner, coin type and balance if it is a
+/// coin. Returns `None` for non-coins; errors if the object is missing from
+/// the set or its coin contents are malformed.
+fn coin_owner_type_value(
+    objects: &BTreeMap<(ObjectId, SequenceNumber), &Object>,
+    id: ObjectId,
+    version: SequenceNumber,
+) -> Result<Option<(Owner, TypeTag, u64)>, DeriveChangesError> {
+    let Some(object) = objects.get(&(id, version)) else {
+        return Err(DeriveChangesError::MissingObject {
+            object_id: id,
+            version,
+        });
+    };
+    let Some(move_object_type) = object.type_() else {
+        return Ok(None);
+    };
+    if !move_object_type.is_coin() {
+        return Ok(None);
+    }
+    let malformed_coin = || DeriveChangesError::MalformedCoin {
+        object_id: id,
+        version,
+    };
+    let coin_type = move_object_type
+        .type_params()
+        .first()
+        .ok_or_else(malformed_coin)?
+        .clone();
+    let value = Coin::extract_balance_if_coin(object)
+        .ok()
+        .flatten()
+        .ok_or_else(malformed_coin)?;
+    Ok(Some((object.owner, coin_type, value)))
+}
+
+/// Derive the object changes of a transaction from its effects and its
+/// input/output objects.
+///
+/// `output_objects` must hold the objects written by the transaction and
+/// `input_objects` the objects at the versions given by
+/// `effects.modified_at_versions()` — the latter provide the types of deleted
+/// and wrapped objects.
+///
+/// Errors if a required object is missing from the sets — skipping it would
+/// silently drop an object change from the result.
+pub fn derive_object_changes(
+    sender: Address,
+    effects: &TransactionEffects,
+    input_objects: &[Object],
+    output_objects: &[Object],
+) -> Result<Vec<DerivedObjectChange>, DeriveChangesError> {
+    let mut object_changes = vec![];
+
+    let modified_at_versions = effects
+        .modified_at_versions()
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+    let outputs: BTreeMap<(ObjectId, SequenceNumber), &Object> = output_objects
+        .iter()
+        .map(|o| ((o.id(), o.version()), o))
+        .collect();
+
+    // Input objects are the objects at their modified-at versions, so they are
+    // unique per id and provide the pre-transaction state of removed objects.
+    let inputs_by_id: BTreeMap<ObjectId, &Object> =
+        input_objects.iter().map(|o| (o.id(), o)).collect();
+
+    for (changed_object, owner, kind) in effects.all_changed_objects() {
+        let object_id = changed_object.object_id;
+        let version = changed_object.version;
+        let digest = changed_object.digest;
+        let Some(object) = outputs.get(&(object_id, version)) else {
+            return Err(DeriveChangesError::MissingObject { object_id, version });
+        };
+        if let Some(move_object_type) = object.type_() {
+            let object_type: StructTag = move_object_type.clone().into();
+
+            match kind {
+                WriteKind::Mutate => object_changes.push(DerivedObjectChange::Mutated {
+                    sender,
+                    owner,
+                    object_type,
+                    object_id,
+                    version,
+                    // modified_at_versions should always hold mutated objects
+                    previous_version: modified_at_versions
+                        .get(&object_id)
+                        .copied()
+                        .unwrap_or_default(),
+                    digest,
+                }),
+                WriteKind::Create => object_changes.push(DerivedObjectChange::Created {
+                    sender,
+                    owner,
+                    object_type,
+                    object_id,
+                    version,
+                    digest,
+                }),
+                WriteKind::Unwrap => object_changes.push(DerivedObjectChange::Unwrapped {
+                    sender,
+                    owner,
+                    object_type,
+                    object_id,
+                    version,
+                    digest,
+                }),
+            }
+        } else if let Some(package) = object.data.as_opt_package() {
+            if kind == WriteKind::Create {
+                object_changes.push(DerivedObjectChange::Published {
+                    package_id: package.id(),
+                    version: package.version(),
+                    digest,
+                    modules: package
+                        .serialized_module_map()
+                        .keys()
+                        .map(|k| k.to_string())
+                        .collect(),
+                })
+            }
+        }
+    }
+
+    for (removed_object, kind) in effects.all_removed_objects() {
+        let object_id = removed_object.object_id;
+        let version = removed_object.version;
+        let Some(object) = inputs_by_id.get(&object_id) else {
+            // The input object lives at its modified-at version, not at the
+            // removed ref's (tombstone) version
+            return Err(DeriveChangesError::MissingObject {
+                object_id,
+                version: modified_at_versions
+                    .get(&object_id)
+                    .copied()
+                    .unwrap_or(version),
+            });
+        };
+        // Packages cannot be removed; skip non-Move objects
+        if let Some(move_object_type) = object.type_() {
+            let object_type: StructTag = move_object_type.clone().into();
+            match kind {
+                ObjectRemoveKind::Delete => object_changes.push(DerivedObjectChange::Deleted {
+                    sender,
+                    object_type,
+                    object_id,
+                    version,
+                }),
+                ObjectRemoveKind::Wrap => object_changes.push(DerivedObjectChange::Wrapped {
+                    sender,
+                    object_type,
+                    object_id,
+                    version,
+                }),
+            }
+        }
+    }
+
+    Ok(object_changes)
+}
+
+impl From<DerivedBalanceChange> for grpc_tx::BalanceChange {
+    fn from(change: DerivedBalanceChange) -> Self {
+        Self::default()
+            .with_owner(change.owner)
+            .with_coin_type(&change.coin_type)
+            .with_amount(change.amount.to_be_bytes().to_vec())
+    }
+}
+
+/// A Move object's type is always a struct; the proto carries it as the more
+/// general `TypeTag`, matching `BalanceChange.coin_type`.
+fn object_type_to_proto(object_type: StructTag) -> iota_grpc_types::v1::types::TypeTag {
+    (&TypeTag::Struct(Box::new(object_type))).into()
+}
+
+impl From<DerivedObjectChange> for grpc_tx::ObjectChange {
+    fn from(change: DerivedObjectChange) -> Self {
+        match change {
+            DerivedObjectChange::Published {
+                package_id,
+                version,
+                digest,
+                modules,
+            } => Self::default().with_published(
+                grpc_tx::ObjectChangePublished::default()
+                    .with_package_id(package_id)
+                    .with_version(version.as_u64())
+                    .with_digest(digest)
+                    .with_modules(modules),
+            ),
+            DerivedObjectChange::Mutated {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                previous_version,
+                digest,
+            } => Self::default().with_mutated(
+                grpc_tx::ObjectChangeMutated::default()
+                    .with_sender(sender)
+                    .with_owner(owner)
+                    .with_object_type(object_type_to_proto(object_type))
+                    .with_object_id(object_id)
+                    .with_version(version.as_u64())
+                    .with_previous_version(previous_version.as_u64())
+                    .with_digest(digest),
+            ),
+            DerivedObjectChange::Deleted {
+                sender,
+                object_type,
+                object_id,
+                version,
+            } => Self::default().with_deleted(
+                grpc_tx::ObjectChangeDeleted::default()
+                    .with_sender(sender)
+                    .with_object_type(object_type_to_proto(object_type))
+                    .with_object_id(object_id)
+                    .with_version(version.as_u64()),
+            ),
+            DerivedObjectChange::Wrapped {
+                sender,
+                object_type,
+                object_id,
+                version,
+            } => Self::default().with_wrapped(
+                grpc_tx::ObjectChangeWrapped::default()
+                    .with_sender(sender)
+                    .with_object_type(object_type_to_proto(object_type))
+                    .with_object_id(object_id)
+                    .with_version(version.as_u64()),
+            ),
+            DerivedObjectChange::Unwrapped {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => Self::default().with_unwrapped(
+                grpc_tx::ObjectChangeUnwrapped::default()
+                    .with_sender(sender)
+                    .with_owner(owner)
+                    .with_object_type(object_type_to_proto(object_type))
+                    .with_object_id(object_id)
+                    .with_version(version.as_u64())
+                    .with_digest(digest),
+            ),
+            DerivedObjectChange::Created {
+                sender,
+                owner,
+                object_type,
+                object_id,
+                version,
+                digest,
+            } => Self::default().with_created(
+                grpc_tx::ObjectChangeCreated::default()
+                    .with_sender(sender)
+                    .with_owner(owner)
+                    .with_object_type(object_type_to_proto(object_type))
+                    .with_object_id(object_id)
+                    .with_version(version.as_u64())
+                    .with_digest(digest),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_types::{
+        digests::TransactionDigest,
+        effects::{TestEffectsBuilder, TransactionEffectsAPIForTesting as _},
+        full_checkpoint_content::CheckpointTransaction,
+        test_checkpoint_data_builder::TestCheckpointDataBuilder,
+        transaction::TransactionDataAPI as _,
+    };
+
+    use super::*;
+
+    const SENDER: u8 = 0;
+    const RECIPIENT: u8 = 1;
+
+    fn sender_address() -> Address {
+        TestCheckpointDataBuilder::derive_address(SENDER)
+    }
+
+    fn recipient_address() -> Address {
+        TestCheckpointDataBuilder::derive_address(RECIPIENT)
+    }
+
+    fn object_id(object_idx: u64) -> ObjectId {
+        TestCheckpointDataBuilder::derive_object_id(object_idx)
+    }
+
+    /// A minimal transaction whose gas input is at version 0, so effects
+    /// built from it assign lamport version 1 — matching the initial version
+    /// of objects created by the `*_for_testing` constructors. Also returns
+    /// the gas coin at its input version (0) and output version (1) so the
+    /// derivation finds the mutated gas object.
+    fn version_zero_gas_transaction() -> (iota_types::transaction::SenderSignedData, Object, Object)
+    {
+        use iota_sdk_types::ObjectReference;
+        use iota_types::{
+            programmable_transaction_builder::ProgrammableTransactionBuilder,
+            transaction::{SenderSignedData, TransactionData},
+        };
+
+        let gas_id = ObjectId::random();
+        let gas_ref = ObjectReference::new(gas_id, 0u64.into(), ObjectDigest::MIN);
+        let transaction_data = TransactionData::new(
+            iota_sdk_types::TransactionKind::Programmable(
+                ProgrammableTransactionBuilder::new().finish(),
+            ),
+            sender_address(),
+            gas_ref,
+            1,
+            1,
+        );
+        let gas_owner = Owner::Address(sender_address());
+        (
+            SenderSignedData::new(transaction_data, vec![]),
+            Object::with_id_owner_version_for_testing(gas_id, 0u64.into(), gas_owner),
+            Object::with_id_owner_version_for_testing(gas_id, 1u64.into(), gas_owner),
+        )
+    }
+
+    /// Build a single-transaction checkpoint and return the builder along
+    /// with that transaction.
+    fn build_single_tx(
+        builder: TestCheckpointDataBuilder,
+        f: impl FnOnce(TestCheckpointDataBuilder) -> TestCheckpointDataBuilder,
+    ) -> (TestCheckpointDataBuilder, CheckpointTransaction) {
+        let mut builder = f(builder.start_transaction(SENDER)).finish_transaction();
+        let checkpoint = builder.build_checkpoint();
+        (builder, checkpoint.transactions.into_iter().next().unwrap())
+    }
+
+    fn balance_changes(tx: &CheckpointTransaction) -> Vec<DerivedBalanceChange> {
+        derive_balance_changes(&tx.effects, &tx.input_objects, &tx.output_objects, None).unwrap()
+    }
+
+    fn object_changes(tx: &CheckpointTransaction) -> Vec<DerivedObjectChange> {
+        derive_object_changes(
+            sender_address(),
+            &tx.effects,
+            &tx.input_objects,
+            &tx.output_objects,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn balance_changes_for_coin_transfer() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (builder, _) = build_single_tx(builder, |b| b.create_iota_object(0, 100));
+        let (_, tx) = build_single_tx(builder, |b| b.transfer_coin_balance(0, 1, RECIPIENT, 30));
+
+        let changes = balance_changes(&tx);
+        assert_eq!(
+            changes,
+            // BTreeMap iteration order: sorted by (owner, coin type)
+            {
+                let mut expected = vec![
+                    DerivedBalanceChange {
+                        owner: Owner::Address(sender_address()),
+                        coin_type: GAS::type_tag(),
+                        amount: -30,
+                    },
+                    DerivedBalanceChange {
+                        owner: Owner::Address(recipient_address()),
+                        coin_type: GAS::type_tag(),
+                        amount: 30,
+                    },
+                ];
+                expected.sort_by(|a, b| (a.owner, &a.coin_type).cmp(&(b.owner, &b.coin_type)));
+                expected
+            }
+        );
+    }
+
+    #[test]
+    fn balance_changes_grouped_by_owner_and_coin_type() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (builder, _) = build_single_tx(builder, |b| {
+            b.create_iota_object(0, 100).create_iota_object(1, 50)
+        });
+        // Two coins of the same type transferred to the same recipient must
+        // fold into a single entry per owner
+        let (_, tx) = build_single_tx(builder, |b| {
+            b.transfer_coin_balance(0, 2, RECIPIENT, 10)
+                .transfer_coin_balance(1, 3, RECIPIENT, 20)
+        });
+
+        let changes = balance_changes(&tx);
+        assert_eq!(changes.len(), 2);
+        for change in &changes {
+            match change.owner {
+                Owner::Address(address) if address == sender_address() => {
+                    assert_eq!(change.amount, -30)
+                }
+                Owner::Address(address) if address == recipient_address() => {
+                    assert_eq!(change.amount, 30)
+                }
+                _ => panic!("unexpected owner: {:?}", change.owner),
+            }
+        }
+    }
+
+    #[test]
+    fn balance_changes_zero_delta_dropped() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (builder, _) = build_single_tx(builder, |b| b.create_iota_object(0, 100));
+        // Mutating a coin without changing its balance must produce no entry
+        // (this also covers the automatically mutated gas coin)
+        let (_, tx) = build_single_tx(builder, |b| b.mutate_owned_object(0));
+
+        assert_eq!(balance_changes(&tx), vec![]);
+    }
+
+    #[test]
+    fn balance_changes_non_coin_objects_ignored() {
+        // A created non-coin Move object (a treasury cap) must not produce a
+        // balance change
+        let treasury_cap = Object::treasury_cap_for_testing(
+            iota_sdk_types::StructTag::new_gas(),
+            iota_types::coin::TreasuryCap {
+                id: iota_types::id::UID::new(ObjectId::random()),
+                total_supply: iota_types::balance::Supply { value: 0 },
+            },
+        );
+        let (transaction, gas_input, gas_output) = version_zero_gas_transaction();
+        let effects = TestEffectsBuilder::new(&transaction)
+            .with_created_objects([(treasury_cap.id(), *treasury_cap.owner())])
+            .build();
+
+        // The mutated gas coin cancels out; the treasury cap is not a coin
+        assert_eq!(
+            derive_balance_changes(&effects, &[gas_input], &[gas_output, treasury_cap], None),
+            Ok(vec![])
+        );
+    }
+
+    #[test]
+    fn balance_changes_failed_tx_charges_gas_only() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (_, tx) = build_single_tx(builder, |b| b.create_iota_object(0, 100));
+
+        // Rebuild the effects as a failed execution with a non-zero gas charge
+        let mut effects = TestEffectsBuilder::new(tx.transaction.data())
+            .with_status(ExecutionStatus::Failure {
+                error: iota_sdk_types::ExecutionError::InsufficientGas,
+                command: None,
+            })
+            .build();
+        effects.gas_cost_summary_mut_for_testing().computation_cost = 1000;
+
+        // The failed path needs no objects at all
+        let changes = derive_balance_changes(&effects, &[], &[], None);
+        assert_eq!(
+            changes,
+            Ok(vec![DerivedBalanceChange {
+                owner: Owner::Address(sender_address()),
+                coin_type: GAS::type_tag(),
+                amount: -1000,
+            }])
+        );
+    }
+
+    #[test]
+    fn balance_changes_mocked_coin_excluded() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (builder, _) = build_single_tx(builder, |b| b.create_iota_object(0, 100));
+        let (_, tx) = build_single_tx(builder, |b| b.transfer_coin_balance(0, 1, RECIPIENT, 30));
+
+        let changes = derive_balance_changes(
+            &tx.effects,
+            &tx.input_objects,
+            &tx.output_objects,
+            Some(object_id(0)),
+        );
+        assert_eq!(
+            changes,
+            Ok(vec![DerivedBalanceChange {
+                owner: Owner::Address(recipient_address()),
+                coin_type: GAS::type_tag(),
+                amount: 30,
+            }])
+        );
+    }
+
+    #[test]
+    fn balance_changes_missing_objects_error() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (builder, _) = build_single_tx(builder, |b| b.create_iota_object(0, 100));
+        let (_, tx) = build_single_tx(builder, |b| b.transfer_coin_balance(0, 1, RECIPIENT, 30));
+
+        // A missing input coin would corrupt the delta, so the derivation
+        // must refuse to produce a result
+        assert!(matches!(
+            derive_balance_changes(&tx.effects, &[], &tx.output_objects, None),
+            Err(DeriveChangesError::MissingObject { .. })
+        ));
+    }
+
+    #[test]
+    fn object_changes_created_and_mutated() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (builder, _) = build_single_tx(builder, |b| b.create_owned_object(0));
+        let (_, tx) = build_single_tx(builder, |b| {
+            b.create_owned_object(1).transfer_object(0, RECIPIENT)
+        });
+
+        let changes = object_changes(&tx);
+        // created object 1, transferred (mutated) object 0, mutated gas coin
+        assert_eq!(changes.len(), 3);
+        assert!(changes.iter().any(|change| matches!(
+            change,
+            DerivedObjectChange::Created { object_id: id, sender, owner, .. }
+                if *id == object_id(1)
+                    && *sender == sender_address()
+                    && *owner == Owner::Address(sender_address())
+        )));
+        let previous_version = tx
+            .effects
+            .modified_at_versions()
+            .into_iter()
+            .find_map(|(id, version)| (id == object_id(0)).then_some(version))
+            .unwrap();
+        assert!(changes.iter().any(|change| matches!(
+            change,
+            DerivedObjectChange::Mutated {
+                object_id: id,
+                owner,
+                previous_version: previous,
+                ..
+            } if *id == object_id(0)
+                && *owner == Owner::Address(recipient_address())
+                && *previous == previous_version
+        )));
+    }
+
+    #[test]
+    fn object_changes_wrapped_deleted_unwrapped() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (builder, _) =
+            build_single_tx(builder, |b| b.create_owned_object(0).create_owned_object(1));
+        let (builder, tx) = build_single_tx(builder, |b| b.wrap_object(0).delete_object(1));
+
+        let changes = object_changes(&tx);
+        assert!(changes.iter().any(|change| matches!(
+            change,
+            DerivedObjectChange::Wrapped { object_id: id, sender, .. }
+                if *id == object_id(0) && *sender == sender_address()
+        )));
+        assert!(changes.iter().any(|change| matches!(
+            change,
+            DerivedObjectChange::Deleted { object_id: id, .. } if *id == object_id(1)
+        )));
+
+        let (_, tx) = build_single_tx(builder, |b| b.unwrap_object(0));
+        let changes = object_changes(&tx);
+        assert!(changes.iter().any(|change| matches!(
+            change,
+            DerivedObjectChange::Unwrapped { object_id: id, .. } if *id == object_id(0)
+        )));
+    }
+
+    #[test]
+    fn object_changes_published_package() {
+        let module = move_binary_format::file_format::empty_module();
+        let package =
+            Object::new_package_for_testing(&[module], TransactionDigest::GENESIS_MARKER, [])
+                .unwrap();
+        let package_id = package.id();
+
+        let (transaction, gas_input, gas_output) = version_zero_gas_transaction();
+        let effects = TestEffectsBuilder::new(&transaction)
+            .with_created_objects([(package_id, Owner::Immutable)])
+            .build();
+        let created_version = effects
+            .all_changed_objects()
+            .into_iter()
+            .find_map(|(object_ref, _, kind)| {
+                (kind == WriteKind::Create).then_some(object_ref.version)
+            })
+            .unwrap();
+        assert_eq!(
+            created_version,
+            package.version(),
+            "test setup: package version must match the effects' created version"
+        );
+
+        let changes = derive_object_changes(
+            sender_address(),
+            &effects,
+            &[gas_input],
+            &[gas_output, package],
+        )
+        .unwrap();
+        assert!(changes.iter().any(|change| matches!(
+            change,
+            DerivedObjectChange::Published { package_id: id, modules, .. }
+                if *id == package_id && !modules.is_empty()
+        )));
+    }
+
+    #[test]
+    fn object_changes_missing_objects_error() {
+        let builder = TestCheckpointDataBuilder::new(1);
+        let (_, tx) = build_single_tx(builder, |b| b.create_owned_object(0));
+
+        // A missing object would silently drop an entry from the result, so
+        // the derivation must refuse to produce one
+        assert!(matches!(
+            derive_object_changes(sender_address(), &tx.effects, &[], &[]),
+            Err(DeriveChangesError::MissingObject { .. })
+        ));
+    }
+}

--- a/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_checkpoint.rs
@@ -69,6 +69,12 @@
 //!       - `transactions.output_objects.reference.digest` - the digest of the
 //!         output object contents
 //!     - `transactions.output_objects.bcs` - the full BCS-encoded object
+//!   - `transactions.balance_changes` - per-owner, per-coin-type balance deltas
+//!     derived from the transaction's effects and input/output objects. For a
+//!     failed transaction this contains only the gas charge.
+//!   - `transactions.object_changes` - structured object changes (created,
+//!     mutated, deleted, wrapped, unwrapped, published) derived from the
+//!     transaction's effects and input/output objects.
 //!
 //! ## Event Fields
 //! - `events` - includes all event fields (all events of all transactions in

--- a/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
@@ -93,6 +93,10 @@ pub(crate) fn validate_get_transaction_requests(
 ///   transaction
 ///
 /// ## Object Fields
+/// If a required object is unavailable (e.g. pruned from the object store),
+/// the transaction's result is a `FAILED_PRECONDITION` error rather than a
+/// silently incomplete list; narrow the read mask or fetch objects
+/// individually via `get_objects` for best-effort retrieval.
 /// - `input_objects` - includes all input object fields
 ///   - `input_objects.reference` - includes all reference fields
 ///     - `input_objects.reference.object_id` - the ID of the input object
@@ -116,7 +120,7 @@ pub(crate) fn validate_get_transaction_requests(
 /// Derived from the transaction's effects and input/output objects. If a
 /// required object is unavailable (e.g. pruned from the object store), the
 /// transaction's result is a `FAILED_PRECONDITION` error rather than a
-/// silently incomplete answer; retry without these fields.
+/// silently wrong answer; retry without these fields.
 /// - `balance_changes` - per-owner, per-coin-type balance deltas. For a failed
 ///   transaction this contains only the gas charge.
 /// - `object_changes` - structured object changes (created, mutated, deleted,

--- a/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
@@ -111,6 +111,16 @@ pub(crate) fn validate_get_transaction_requests(
 ///     - `output_objects.reference.digest` - the digest of the output object
 ///       contents, which can be used for integrity verification
 ///   - `output_objects.bcs` - the full BCS-encoded object
+///
+/// ## Derived Change Fields
+/// Derived from the transaction's effects and input/output objects. If a
+/// required object is unavailable (e.g. pruned from the object store), the
+/// transaction's result is a `FAILED_PRECONDITION` error rather than a
+/// silently incomplete answer; retry without these fields.
+/// - `balance_changes` - per-owner, per-coin-type balance deltas. For a failed
+///   transaction this contains only the gas charge.
+/// - `object_changes` - structured object changes (created, mutated, deleted,
+///   wrapped, unwrapped, published)
 #[tracing::instrument(skip(reader))]
 pub(crate) fn get_transactions(
     reader: Arc<GrpcReader>,
@@ -176,6 +186,7 @@ fn get_transaction_impl(
         timestamp_ms: tx_read.timestamp_ms,
         input_objects: tx_read.input_objects,
         output_objects: tx_read.output_objects,
+        mocked_coin: None,
     };
 
     ExecutedTransaction::merge_from(&source, read_mask)

--- a/crates/iota-grpc-server/src/lib.rs
+++ b/crates/iota-grpc-server/src/lib.rs
@@ -5,6 +5,7 @@
 mod macros;
 
 // Modules
+pub(crate) mod changes;
 pub mod constants;
 mod error;
 pub mod event_filter;

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -248,6 +248,13 @@ fn parse_transaction_proto(
 ///     - `output_objects.reference.digest` - the digest of the output object
 ///       contents
 ///   - `output_objects.bcs` - the full BCS-encoded object
+///
+/// ## Derived Change Fields
+/// Derived from the transaction's effects and input/output objects.
+/// - `balance_changes` - per-owner, per-coin-type balance deltas. For a failed
+///   transaction this contains only the gas charge.
+/// - `object_changes` - structured object changes (created, mutated, deleted,
+///   wrapped, unwrapped, published)
 #[tracing::instrument(skip(reader, executor))]
 pub async fn execute_transactions(
     reader: &Arc<GrpcReader>,
@@ -390,10 +397,18 @@ struct ReadFlags {
 
 impl ReadFlags {
     fn from_mask(mask: &FieldMaskTree) -> Self {
+        // Balance/object changes are derived from the input/output objects, so
+        // the executor must return them whenever the derived fields are
+        // requested.
+        let derives_changes = mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name)
+            || mask.contains(ExecutedTransaction::OBJECT_CHANGES_FIELD.name);
+
         Self {
             include_events: mask.contains(ExecutedTransaction::EVENTS_FIELD.name),
-            include_input_objects: mask.contains(ExecutedTransaction::INPUT_OBJECTS_FIELD.name),
-            include_output_objects: mask.contains(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name),
+            include_input_objects: mask.contains(ExecutedTransaction::INPUT_OBJECTS_FIELD.name)
+                || derives_changes,
+            include_output_objects: mask.contains(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name)
+                || derives_changes,
             needs_checkpoint: mask.contains(ExecutedTransaction::CHECKPOINT_FIELD.name),
             needs_timestamp: mask.contains(ExecutedTransaction::TIMESTAMP_FIELD.name),
         }
@@ -582,6 +597,7 @@ async fn rebuild_from_cache(
         },
         input_objects: cached.input_objects,
         output_objects: cached.output_objects,
+        mocked_coin: None,
     };
 
     let executed = ExecutedTransaction::merge_from(&source, read_mask)
@@ -641,9 +657,15 @@ async fn execute_single_transaction(
         })?;
 
     // Determine what to include in the request based on read mask.
+    // Balance/object changes are derived from the input/output objects, so the
+    // executor must return them whenever the derived fields are requested.
+    let derives_changes = read_mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name)
+        || read_mask.contains(ExecutedTransaction::OBJECT_CHANGES_FIELD.name);
     let include_events = read_mask.contains(ExecutedTransaction::EVENTS_FIELD.name);
-    let include_input_objects = read_mask.contains(ExecutedTransaction::INPUT_OBJECTS_FIELD.name);
-    let include_output_objects = read_mask.contains(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name);
+    let include_input_objects =
+        read_mask.contains(ExecutedTransaction::INPUT_OBJECTS_FIELD.name) || derives_changes;
+    let include_output_objects =
+        read_mask.contains(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name) || derives_changes;
 
     // Create execution request
     let exec_request = ExecuteTransactionRequestV1 {
@@ -700,6 +722,7 @@ async fn execute_single_transaction(
         timestamp_ms: None,
         input_objects,
         output_objects,
+        mocked_coin: None,
     };
 
     let executed = ExecutedTransaction::merge_from(&source, read_mask)

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -99,6 +99,13 @@ use crate::{
 ///         of the output object contents
 ///     - `executed_transaction.output_objects.bcs` - the full BCS-encoded
 ///       object
+///   - `executed_transaction.balance_changes` - per-owner, per-coin-type
+///     balance deltas derived from the simulated effects and input/output
+///     objects; a mocked gas coin is excluded. For a failed transaction this
+///     contains only the gas charge.
+///   - `executed_transaction.object_changes` - structured object changes
+///     (created, mutated, deleted, wrapped, unwrapped, published) derived from
+///     the simulated effects and input/output objects.
 ///
 /// ## Gas Fields
 /// - `suggested_gas_price` - the suggested gas price for the transaction,
@@ -235,7 +242,7 @@ async fn simulate_single_transaction(
         input_objects,
         output_objects,
         execution_result,
-        mock_gas_id: _,
+        mock_gas_id,
         suggested_gas_price,
     } = executor
         .simulate_transaction(transaction_data.clone(), vm_checks)
@@ -268,6 +275,7 @@ async fn simulate_single_transaction(
             timestamp_ms: None,
             input_objects: Some(input_objects.into_values().collect()),
             output_objects: Some(output_objects.into_values().collect()),
+            mocked_coin: mock_gas_id,
         };
 
         response.executed_transaction = Some(

--- a/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
@@ -29,6 +29,9 @@ pub struct TransactionReadSource<'a> {
     pub timestamp_ms: Option<u64>,
     pub input_objects: Option<Vec<iota_types::object::Object>>,
     pub output_objects: Option<Vec<iota_types::object::Object>>,
+    /// Simulate-only: gas coin mocked during simulation, excluded from derived
+    /// balance changes.
+    pub mocked_coin: Option<iota_sdk_types::ObjectId>,
 }
 
 impl Merge<&TransactionReadSource<'_>> for grpc_tx::ExecutedTransaction {
@@ -93,7 +96,82 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::ExecutedTransaction {
             )?);
         }
 
+        // Derive balance changes if requested. Every producer guarantees the
+        // required source data is present when the mask requests them, so a
+        // missing field here is a server bug — error out instead of silently
+        // returning wrong (empty) changes.
+        if mask.subtree(Self::BALANCE_CHANGES_FIELD.name).is_some() {
+            let (effects, input_objects, output_objects) = source.changes_source()?;
+            self.balance_changes = Some(
+                grpc_tx::BalanceChanges::default().with_balance_changes(
+                    crate::changes::derive_balance_changes(
+                        effects,
+                        input_objects,
+                        output_objects,
+                        source.mocked_coin,
+                    )?
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+                ),
+            );
+        }
+
+        // Derive object changes if requested
+        if mask.subtree(Self::OBJECT_CHANGES_FIELD.name).is_some() {
+            use iota_types::transaction::TransactionDataAPI as _;
+
+            let sender = source
+                .transaction
+                .as_ref()
+                .ok_or_else(|| RpcError::internal().with_context("missing transaction"))?
+                .sender();
+            let (effects, input_objects, output_objects) = source.changes_source()?;
+            self.object_changes = Some(
+                grpc_tx::ObjectChanges::default().with_object_changes(
+                    crate::changes::derive_object_changes(
+                        sender,
+                        effects,
+                        input_objects,
+                        output_objects,
+                    )?
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+                ),
+            );
+        }
+
         Ok(())
+    }
+}
+
+impl TransactionReadSource<'_> {
+    /// The (effects, input objects, output objects) triple the change
+    /// derivation runs on, erroring on fields the producer failed to supply.
+    fn changes_source(
+        &self,
+    ) -> Result<
+        (
+            &iota_types::effects::TransactionEffects,
+            &[iota_types::object::Object],
+            &[iota_types::object::Object],
+        ),
+        RpcError,
+    > {
+        let effects = self
+            .effects
+            .as_ref()
+            .ok_or_else(|| RpcError::internal().with_context("missing effects"))?;
+        let input_objects = self
+            .input_objects
+            .as_deref()
+            .ok_or_else(|| RpcError::internal().with_context("missing input objects"))?;
+        let output_objects = self
+            .output_objects
+            .as_deref()
+            .ok_or_else(|| RpcError::internal().with_context("missing output objects"))?;
+        Ok((effects, input_objects, output_objects))
     }
 }
 

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -1135,6 +1135,10 @@ impl GrpcReader {
     /// fetch of effects and input/output objects, and object changes force the
     /// transaction fetch (for the sender). Over-fetched data never leaks into
     /// the response — the `Merge` impls only populate mask-requested fields.
+    ///
+    /// Errors with `FAILED_PRECONDITION` if a required object is unavailable
+    /// (e.g. pruned): a silently incomplete object set would be undetectable
+    /// by the client and would corrupt derived change fields.
     #[tracing::instrument(skip(self))]
     pub fn get_transaction_read(
         &self,
@@ -1233,16 +1237,31 @@ impl GrpcReader {
                 None
             };
 
+            // The object sets must be complete: a silently missing object
+            // would shorten the input/output object lists and corrupt any
+            // derived change fields, with no way for the client to detect it
+            let require_object = |object_id: &iota_sdk_types::ObjectId,
+                                  version: iota_types::base_types::SequenceNumber|
+             -> Result<Object, crate::error::RpcError> {
+                self.state_reader
+                    .try_get_object_by_key(object_id, version)?
+                    .ok_or_else(|| {
+                        crate::error::RpcError::new(
+                            tonic::Code::FailedPrecondition,
+                            format!(
+                                "object {object_id} at version {version} required by the \
+                                 requested fields is unavailable (possibly pruned); narrow the \
+                                 read_mask or fetch objects individually via `get_objects` for best-effort retrieval"
+                            ),
+                        )
+                    })
+            };
+
             // Get input objects only if requested
             let input_objects = if fields.include_input_objects || include_derived_changes {
                 let mut objects = Vec::new();
                 for (object_id, version) in effects.modified_at_versions() {
-                    if let Some(obj) = self
-                        .state_reader
-                        .try_get_object_by_key(&object_id, version)?
-                    {
-                        objects.push(obj);
-                    }
+                    objects.push(require_object(&object_id, version)?);
                 }
                 Some(objects)
             } else {
@@ -1258,12 +1277,7 @@ impl GrpcReader {
                     .chain(effects.mutated())
                     .chain(effects.unwrapped())
                 {
-                    if let Some(obj) = self
-                        .state_reader
-                        .try_get_object_by_key(&object_ref.object_id, object_ref.version)?
-                    {
-                        objects.push(obj);
-                    }
+                    objects.push(require_object(&object_ref.object_id, object_ref.version)?);
                 }
                 Some(objects)
             } else {

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -53,6 +53,8 @@ pub struct TransactionReadFields {
     pub include_timestamp: bool,
     pub include_input_objects: bool,
     pub include_output_objects: bool,
+    pub include_balance_changes: bool,
+    pub include_object_changes: bool,
 }
 
 impl TransactionReadFields {
@@ -69,6 +71,8 @@ impl TransactionReadFields {
             include_timestamp: mask.contains(ExecutedTransaction::TIMESTAMP_FIELD.name),
             include_input_objects: mask.contains(ExecutedTransaction::INPUT_OBJECTS_FIELD.name),
             include_output_objects: mask.contains(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name),
+            include_balance_changes: mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name),
+            include_object_changes: mask.contains(ExecutedTransaction::OBJECT_CHANGES_FIELD.name),
         }
     }
 }
@@ -1127,21 +1131,27 @@ impl GrpcReader {
     /// callers to skip unnecessary reads. Effects are fetched when any of
     /// effects/events/input_objects/output_objects are requested since they
     /// provide the digests and references needed to fetch those fields.
+    /// Balance/object changes are derived fields: they additionally force the
+    /// fetch of effects and input/output objects, and object changes force the
+    /// transaction fetch (for the sender). Over-fetched data never leaks into
+    /// the response — the `Merge` impls only populate mask-requested fields.
     #[tracing::instrument(skip(self))]
     pub fn get_transaction_read(
         &self,
         digest: &TransactionDigest,
         fields: &TransactionReadFields,
     ) -> Result<TransactionReadData, crate::error::RpcError> {
-        let (transaction, signatures) = if fields.include_transaction || fields.include_signatures {
+        let (transaction, signatures) = if fields.include_transaction
+            || fields.include_signatures
+            || fields.include_object_changes
+        {
             // Get the transaction if transaction data or signatures are requested
             let transaction = self
                 .state_reader
                 .try_get_transaction(digest)?
                 .ok_or(crate::error::TransactionNotFoundError(*digest))?;
 
-            let transaction_data = fields
-                .include_transaction
+            let transaction_data = (fields.include_transaction || fields.include_object_changes)
                 .then(|| transaction.transaction_data().clone());
 
             let signatures_data = fields
@@ -1194,12 +1204,17 @@ impl GrpcReader {
             (None, None)
         };
 
+        // Derived change fields need effects plus the input/output objects
+        let include_derived_changes =
+            fields.include_balance_changes || fields.include_object_changes;
+
         // Get the effects if any of the following are requested: effects, events,
-        // checkpoint/timestamp, input/output objects
+        // checkpoint/timestamp, input/output objects, balance/object changes
         let (effects, events, input_objects, output_objects) = if fields.include_effects
             || fields.include_events
             || fields.include_input_objects
             || fields.include_output_objects
+            || include_derived_changes
         {
             // Effects are required for events and input/output objects, so we fetch them if
             // any of those are requested
@@ -1219,7 +1234,7 @@ impl GrpcReader {
             };
 
             // Get input objects only if requested
-            let input_objects = if fields.include_input_objects {
+            let input_objects = if fields.include_input_objects || include_derived_changes {
                 let mut objects = Vec::new();
                 for (object_id, version) in effects.modified_at_versions() {
                     if let Some(obj) = self
@@ -1235,7 +1250,7 @@ impl GrpcReader {
             };
 
             // Get output objects only if requested
-            let output_objects = if fields.include_output_objects {
+            let output_objects = if fields.include_output_objects || include_derived_changes {
                 let mut objects = Vec::new();
                 for (object_ref, _owner) in effects
                     .created()
@@ -1370,6 +1385,44 @@ impl Merge<CheckpointTransactionWithContext>
         // Set checkpoint timestamp if requested
         if mask.contains(Self::TIMESTAMP_FIELD.name) {
             self.timestamp = source.checkpoint_timestamp_ms.map(timestamp_ms_to_proto);
+        }
+
+        // Derive balance changes if requested. Checkpoint transactions always
+        // carry effects and input/output objects, so no extra fetches needed.
+        if mask.subtree(Self::BALANCE_CHANGES_FIELD.name).is_some() {
+            self.balance_changes = Some(
+                iota_grpc_types::v1::transaction::BalanceChanges::default().with_balance_changes(
+                    crate::changes::derive_balance_changes(
+                        &source.transaction.effects,
+                        &source.transaction.input_objects,
+                        &source.transaction.output_objects,
+                        None,
+                    )?
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+                ),
+            );
+        }
+
+        // Derive object changes if requested
+        if mask.subtree(Self::OBJECT_CHANGES_FIELD.name).is_some() {
+            use iota_types::transaction::TransactionDataAPI as _;
+
+            let sender = source.transaction.transaction.transaction_data().sender();
+            self.object_changes = Some(
+                iota_grpc_types::v1::transaction::ObjectChanges::default().with_object_changes(
+                    crate::changes::derive_object_changes(
+                        sender,
+                        &source.transaction.effects,
+                        &source.transaction.input_objects,
+                        &source.transaction.output_objects,
+                    )?
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+                ),
+            );
         }
 
         if let Some(submask) = mask.subtree(Self::INPUT_OBJECTS_FIELD.name) {

--- a/crates/iota-grpc-server/tests/checkpoint_stream.rs
+++ b/crates/iota-grpc-server/tests/checkpoint_stream.rs
@@ -14,14 +14,18 @@ use iota_grpc_client::{
 };
 use iota_grpc_server::GrpcServerHandle;
 use iota_grpc_types::v1::{filter, ledger_service::checkpoint_data};
-use iota_sdk_types::{Address, Event, Identifier, ObjectId, StructTag};
+use iota_sdk_types::{Address, Event, Identifier, ObjectId, Owner, StructTag};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     base_types::random_object_ref,
     crypto::{AccountKeyPair, get_key_pair},
-    effects::{TestEffectsBuilder, TransactionEvents},
+    effects::{
+        TestEffectsBuilder, TransactionEffects, TransactionEffectsAPI as _,
+        TransactionEffectsExt as _, TransactionEvents,
+    },
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
     messages_checkpoint::CheckpointSequenceNumber,
+    object::Object,
 };
 use prost::Message;
 use tokio_stream::StreamExt;
@@ -37,6 +41,33 @@ fn mock_checkpoint_data(sequence_number: u64) -> CheckpointData {
     }
 }
 
+/// Input/output object sets matching `effects` (all plain gas coins owned by
+/// `sender`). Checkpoint transactions must carry complete object sets — a
+/// wildcard read mask derives change fields from them and errors on gaps.
+fn objects_for_effects(
+    sender: Address,
+    effects: &TransactionEffects,
+) -> (Vec<Object>, Vec<Object>) {
+    let owner = Owner::Address(sender);
+    let input_objects = effects
+        .modified_at_versions()
+        .into_iter()
+        .map(|(id, version)| Object::with_id_owner_version_for_testing(id, version, owner))
+        .collect();
+    let output_objects = effects
+        .all_changed_objects()
+        .into_iter()
+        .map(|(object_ref, _, _)| {
+            Object::with_id_owner_version_for_testing(
+                object_ref.object_id,
+                object_ref.version,
+                owner,
+            )
+        })
+        .collect();
+    (input_objects, output_objects)
+}
+
 /// Create checkpoint data with a transaction from a specific sender.
 fn mock_checkpoint_data_with_sender(
     sequence_number: u64,
@@ -48,6 +79,7 @@ fn mock_checkpoint_data_with_sender(
         .transfer(random_object_ref(), sender)
         .build_and_sign(key);
     let effects = TestEffectsBuilder::new(transaction.data()).build();
+    let (input_objects, output_objects) = objects_for_effects(sender, &effects);
     CheckpointData {
         checkpoint_summary: common::mock_summary(
             sequence_number,
@@ -58,8 +90,8 @@ fn mock_checkpoint_data_with_sender(
             transaction,
             effects,
             events: None,
-            input_objects: vec![],
-            output_objects: vec![],
+            input_objects,
+            output_objects,
         }],
     }
 }
@@ -78,13 +110,14 @@ fn build_large_checkpoint_transactions() -> Vec<CheckpointTransaction> {
             .build_and_sign(&key);
 
         let effects = TestEffectsBuilder::new(transaction.data()).build();
+        let (input_objects, output_objects) = objects_for_effects(sender, &effects);
 
         transactions.push(CheckpointTransaction {
             transaction,
             effects,
             events: None,
-            input_objects: vec![],  // Empty for simplicity
-            output_objects: vec![], // Empty for simplicity
+            input_objects,
+            output_objects,
         });
     }
 
@@ -945,12 +978,13 @@ fn build_checkpoint_transactions_with_events(
         } else {
             None
         };
+        let (input_objects, output_objects) = objects_for_effects(sender, &effects);
         transactions.push(CheckpointTransaction {
             transaction,
             effects,
             events,
-            input_objects: vec![],
-            output_objects: vec![],
+            input_objects,
+            output_objects,
         });
     }
     transactions

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 iota-grpc-client = { workspace = true, optional = true }
 iota-grpc-types = { workspace = true, optional = true }
 iota-sdk-crypto = { workspace = true, optional = true }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b", optional = true }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b", default-features = false, optional = true }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", optional = true }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba", default-features = false, optional = true }
 iota-sdk-types = { workspace = true, optional = true }
 
 [features]

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "ed25519-dalek",
  "iota-sdk-types",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=9826f3bbcc96ff72d69f2532af7e9829abe61d9b#9826f3bbcc96ff72d69f2532af7e9829abe61d9b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=559083b9e901e53008f15d85d50df7f007c681ba#559083b9e901e53008f15d85d50df7f007c681ba"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "9826f3bbcc96ff72d69f2532af7e9829abe61d9b" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "559083b9e901e53008f15d85d50df7f007c681ba" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
# Description of change

Adds server-side support for `balance_changes` and `object_changes` on the gRPC API, the equivalent of the JSON-RPC `showBalanceChanges` / `showObjectChanges` response options. Both fields are strictly opt-in — populated only when the request's read mask names them — and are not part of any default read mask.

Companion PR adding the proto types: iotaledger/iota-rust-sdk#1255. This PR bumps the `iota-rust-sdk` rev to pick up those types; the rev should be re-pointed to the merge commit once https://github.com/iotaledger/iota-rust-sdk/pull/1255 lands.

## What & how

- New synchronous derivation module `crates/iota-grpc-server/src/changes.rs`. It computes both change sets from data the server already holds in memory — the transaction effects plus its input/output objects — so **no new lookup tables or indexes** are introduced. Semantics mirror `crates/iota-json-rpc/src/balance_changes.rs` and `object_changes.rs`, including the gas-only balance change for failed transactions and the mocked-gas-coin exclusion for simulations.
- Wired through all four `ExecutedTransaction` producers: `get_transactions`, `execute_transactions`, `simulate_transactions`, and the checkpoint endpoints (`get_checkpoint` / `stream_checkpoints`, as `transactions.balance_changes` / `transactions.object_changes`).
- The derived fields force the fetch of effects and input/output objects (and the transaction, for the sender) even when those aren't themselves in the mask; over-fetched data never leaks into the response, as the `Merge` impls only populate mask-requested fields.

## Completeness contract on pruned objects

Requesting `input_objects` / `output_objects` / `balance_changes` / `object_changes` for a transaction whose objects the node no longer has (e.g. pruned) now returns a per-item `FAILED_PRECONDITION` naming the unavailable object, instead of a silently shortened object list or a numerically wrong balance delta. Clients should narrow the read mask, or fetch objects individually via `get_objects` for best-effort retrieval. Previously the raw object fields silently dropped missing objects; that path is closed too.

## Links to any relevant issues

- Depends on iotaledger/iota-rust-sdk#1255 (proto types).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Unit tests in `changes.rs` cover the derivation (coin transfers, grouping, zero-delta drop, failed-tx gas-only, mocked-coin exclusion, the six object-change variants, and the missing-object error). E2e tests in `crates/iota-e2e-tests/tests/grpc/` exercise `get_transactions`, `execute_transactions`, `simulate_transactions`, the checkpoint endpoints, and a failed transaction, asserting the exact expected gRPC results (balance deltas from the transfer amount plus the gas charge read from the returned effects). `cargo ci-clippy`, `cargo +nightly fmt`, `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-grpc-server` (67 tests) and the full gRPC e2e suite (103 tests) pass; the new e2e tests also pass under `cargo simtest`.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Full node gRPC API can now derive and return per-transaction balance and object changes.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] gRPC: `ExecutedTransaction` responses can include opt-in `balance_changes` and `object_changes` (via the read mask) on `get_transactions`, `execute_transactions`, `simulate_transactions` and the checkpoint endpoints. `get_transactions` now returns `FAILED_PRECONDITION` when a requested `input_objects` / `output_objects` / `balance_changes` / `object_changes` field needs an object the node has pruned, instead of silently omitting it from the response.

#### Breaking Changes Rollout

No breaking changes — the new response fields are purely additive and opt-in, and default read masks are unchanged.

