### PR TITLE
feat(graphql): Support fallback for tx by checkpoint queries

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
@@ -50,7 +50,7 @@ Epoch advanced: 2
 
 task 10, line 46:
 //# run Test::M::bump --sender A --args object(2,0)
-events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AQAAAAAAAAA=" }
 mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
 

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.move
@@ -111,9 +111,9 @@ module Test::M {
 }
 
 //# run-graphql --cursors {"c":11,"t":3,"i":false}
-# G: `after` cursor below the checkpoint's transaction range. All of the
-# checkpoint's transactions come back and `hasPreviousPage` is false — there
-# is no transaction at or below the cursor in this checkpoint.
+# G: `after` cursor below the checkpoint's transaction range. No transaction
+# in this checkpoint sits at the cursor, so the bound is invalid and the
+# connection comes back empty, as for other transaction queries.
 {
   transactionBlocks(filter: { atCheckpoint: 11 }, after: "@{cursor_0}") {
     pageInfo { hasPreviousPage hasNextPage }

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.move
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transaction queries filtered by checkpoint under
+// pruning, with no historical fallback configured. Covers:
+// - `Query.transactionBlocks(filter: { atCheckpoint })`
+// - `Checkpoint.transactionBlocks`
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public struct Foo has key, store { id: UID, v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: Query.transactionBlocks(filter: { atCheckpoint: <pruned> }) — no fallback.
+# The checkpoint has been pruned, so the request errors with DATA_PRUNED.
+{
+  transactionBlocks(filter: { atCheckpoint: 1 }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# B: Query.transactionBlocks(filter: { atCheckpoint: <unpruned> }) resolves.
+{
+  transactionBlocks(filter: { atCheckpoint: 8 }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# C: Checkpoint.transactionBlocks on a pruned checkpoint — no fallback.
+# The parent `checkpoint(...)` resolves to null, so no nested field is
+# fetched.
+{
+  checkpoint(id: { sequenceNumber: 1 }) {
+    transactionBlocks {
+      nodes { digest }
+    }
+  }
+}
+
+//# run-graphql
+# D: Checkpoint.transactionBlocks on an unpruned checkpoint.
+{
+  checkpoint(id: { sequenceNumber: 8 }) {
+    transactionBlocks {
+      nodes { digest }
+    }
+  }
+}
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# run-graphql
+# E: a checkpoint holding several transactions. The cursors printed here are
+# the inputs for the window in F.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }) {
+    pageInfo { startCursor endCursor }
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":11,"t":7,"i":false} {"c":11,"t":9,"i":false}
+# F: both cursors set — the window between the first and the last transaction
+# of checkpoint 11. Only the middle transaction is inside the window
+# (cursors are exclusive). Both page flags are true because transactions
+# exist at the cursor positions, outside the window.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":11,"t":3,"i":false}
+# G: `after` cursor below the checkpoint's transaction range. All of the
+# checkpoint's transactions come back and `hasPreviousPage` is false — there
+# is no transaction at or below the cursor in this checkpoint.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.snap
@@ -194,17 +194,7 @@ task 24, lines 113-122:
 Response: {
   "data": {
     "transactionBlocks": {
-      "nodes": [
-        {
-          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
-        },
-        {
-          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
-        },
-        {
-          "digest": "ACqVVgcSRS3QDERCcJm7arkawv2rGbu153oNrTcGTiuy"
-        }
-      ],
+      "nodes": [],
       "pageInfo": {
         "hasNextPage": false,
         "hasPreviousPage": false

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.snap
@@ -1,0 +1,214 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 25 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-18:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5236400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 20:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 24:
+//# advance-epoch
+Epoch advanced: 0
+
+task 5, line 26:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 6, line 28:
+//# advance-epoch
+Epoch advanced: 1
+
+task 7, line 30:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 8, line 32:
+//# advance-epoch
+Epoch advanced: 2
+
+task 9, line 34:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 10, line 36:
+//# run Test::M::create --sender A
+created: object(10,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 11, line 38:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 12, line 40:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 13, line 42:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 14, lines 44-51:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: checkpoint 1 has been pruned (min available: 7)",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 15, lines 53-59:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        }
+      ]
+    }
+  }
+}
+
+task 16, lines 61-71:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": null
+  }
+}
+
+task 17, lines 73-81:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 18, line 83:
+//# run Test::M::create --sender A
+created: object(18,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 19, line 85:
+//# run Test::M::create --sender A
+created: object(19,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 20, line 87:
+//# run Test::M::create --sender A
+created: object(20,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 21, line 89:
+//# create-checkpoint
+Checkpoint created: 11
+
+task 22, lines 91-99:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        },
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        },
+        {
+          "digest": "ACqVVgcSRS3QDERCcJm7arkawv2rGbu153oNrTcGTiuy"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJjIjoxMSwidCI6OSwiaSI6ZmFsc2V9",
+        "startCursor": "eyJjIjoxMSwidCI6NywiaSI6ZmFsc2V9"
+      }
+    }
+  }
+}
+
+task 23, lines 101-111:
+//# run-graphql --cursors {"c":11,"t":7,"i":false} {"c":11,"t":9,"i":false}
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 24, lines 113-122:
+//# run-graphql --cursors {"c":11,"t":3,"i":false}
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        },
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        },
+        {
+          "digest": "ACqVVgcSRS3QDERCcJm7arkawv2rGbu153oNrTcGTiuy"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/src/types/cursor.rs
+++ b/crates/iota-graphql-rpc/src/types/cursor.rs
@@ -411,7 +411,11 @@ impl<C: CursorType + ScanLimited + Eq + Clone + Send + Sync + 'static> Page<C> {
     /// in the range, followed by an iterator of values in the page, fetched
     /// from the database. The values returned implement `Target<C>`, so are
     /// able to compute their own cursors.
-    fn paginate_results<T>(
+    ///
+    /// `results` must be sorted in ascending cursor order and fetched with
+    /// inclusive cursor bounds, so that the rows at the `after`/`before`
+    /// cursors are part of the result set (see [`Page::apply`]).
+    pub(crate) fn paginate_results<T>(
         &self,
         f_cursor: Option<C>,
         l_cursor: Option<C>,

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -130,6 +130,16 @@ impl TransactionBlockFilter {
             || self.transaction_ids.is_some()
     }
 
+    /// Returns the checkpoint sequence number when `at_checkpoint` is the
+    /// only filter set.
+    pub(crate) fn only_at_checkpoint(&self) -> Option<UInt53> {
+        if self.has_filters() || self.after_checkpoint.is_some() || self.before_checkpoint.is_some()
+        {
+            return None;
+        }
+        self.at_checkpoint
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.before_checkpoint == Some(UInt53::from(0))
             || matches!(

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Bound,
+};
 
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
@@ -522,61 +525,37 @@ impl TransactionBlock {
             return Ok(ScanConnection::new(false, false));
         }
 
-        let is_from_front = page.is_from_front();
-        let limit = page.limit();
-        let after_seq = page.after().map(|c| c.tx_sequence_number);
-        let before_seq = page.before().map(|c| c.tx_sequence_number);
-
-        // Fetch the page plus one row on each side, to later compute
-        // `has_next`/`has_prev`. Cursors are exclusive.
-        let fetch_cursor = if is_from_front {
-            after_seq.and_then(|seq| seq.checked_sub(1))
-        } else {
-            before_seq.and_then(|seq| seq.checked_add(1))
-        };
-        let fetched = db
+        // Fetch the page plus the rows at the cursors, to later compute
+        // `has_next`/`has_prev` via `paginate_results`. The bounds are
+        // inclusive so that the cursor rows themselves are fetched.
+        let tx_seq_range = (
+            page.after()
+                .map_or(Bound::Unbounded, |c| Bound::Included(c.tx_sequence_number)),
+            page.before()
+                .map_or(Bound::Unbounded, |c| Bound::Included(c.tx_sequence_number)),
+        );
+        let mut results = db
             .inner
             .query_stored_transactions_by_checkpoint_seq_with_fallback(
                 at_checkpoint,
-                fetch_cursor,
-                limit + 2,
-                !is_from_front,
+                tx_seq_range,
+                page.limit() + 2,
+                !page.is_from_front(),
             )
             .await
             .map_err(Error::from)?;
-
-        // The inclusive window of rows the client asked for using cursors (cursors are
-        // exclusive).
-        let window_lo = after_seq.map_or(0, |after| after.saturating_add(1));
-        let window_hi = before_seq.map_or(u64::MAX, |before| before.saturating_sub(1));
-
-        // Fill the page with up to `limit` rows. Any row that does
-        // not make it into the page sets `has_prev`/`has_next` accordingly.
-        let mut page_rows: Vec<StoredTransaction> = Vec::with_capacity(limit);
-        let mut has_prev = false;
-        let mut has_next = false;
-        for row in fetched {
-            let seq = row.tx_sequence_number as u64;
-            if seq < window_lo {
-                has_prev = true;
-            } else if seq > window_hi {
-                has_next = true;
-            } else if page_rows.len() < limit {
-                page_rows.push(row);
-            } else if is_from_front {
-                has_next = true;
-            } else {
-                has_prev = true;
-            }
+        if !page.is_from_front() {
+            results.reverse();
         }
 
-        // We always serve the result in ascending order
-        if !is_from_front {
-            page_rows.reverse();
-        }
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
 
-        let mut conn = ScanConnection::new(has_prev, has_next);
-        for stored in page_rows {
+        let mut conn = ScanConnection::new(prev, next);
+        for stored in results {
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
             let inner = TransactionBlockInner::try_from(stored)?;
             conn.edges.push(Edge::new(

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -405,6 +405,18 @@ impl TransactionBlock {
         let db: &Db = ctx.data_unchecked();
         let is_from_front = page.is_from_front();
 
+        // For the only-`atCheckpoint` case, we support fallback.
+        // `scan_limit` is ignored here
+        if let Some(at_checkpoint) = filter.only_at_checkpoint() {
+            return Self::paginate_at_checkpoint_with_fallback(
+                db,
+                page,
+                u64::from(at_checkpoint),
+                checkpoint_viewed_at,
+            )
+            .await;
+        }
+
         use transactions::dsl as tx;
         let (prev, next, transactions, tx_bounds): (
             bool,
@@ -497,6 +509,85 @@ impl TransactionBlock {
     /// Returns whether this transaction block is within the available range.
     pub(crate) fn is_available(&self) -> bool {
         self.checkpoint_viewed_at < UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
+    }
+
+    /// Paginates transactions in a single checkpoint with fallback support.
+    async fn paginate_at_checkpoint_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        at_checkpoint: u64,
+        checkpoint_viewed_at: u64,
+    ) -> Result<ScanConnection<String, TransactionBlock>, Error> {
+        if at_checkpoint > checkpoint_viewed_at {
+            return Ok(ScanConnection::new(false, false));
+        }
+
+        let is_from_front = page.is_from_front();
+        let limit = page.limit();
+        let after_seq = page.after().map(|c| c.tx_sequence_number);
+        let before_seq = page.before().map(|c| c.tx_sequence_number);
+
+        // Fetch the page plus one row on each side, to later compute
+        // `has_next`/`has_prev`. Cursors are exclusive.
+        let fetch_cursor = if is_from_front {
+            after_seq.and_then(|seq| seq.checked_sub(1))
+        } else {
+            before_seq.and_then(|seq| seq.checked_add(1))
+        };
+        let fetched = db
+            .inner
+            .query_stored_transactions_by_checkpoint_seq_with_fallback(
+                at_checkpoint,
+                fetch_cursor,
+                limit + 2,
+                !is_from_front,
+            )
+            .await
+            .map_err(Error::from)?;
+
+        // The inclusive window of rows the client asked for using cursors (cursors are
+        // exclusive).
+        let window_lo = after_seq.map_or(0, |after| after.saturating_add(1));
+        let window_hi = before_seq.map_or(u64::MAX, |before| before.saturating_sub(1));
+
+        // Fill the page with up to `limit` rows. Any row that does
+        // not make it into the page sets `has_prev`/`has_next` accordingly.
+        let mut page_rows: Vec<StoredTransaction> = Vec::with_capacity(limit);
+        let mut has_prev = false;
+        let mut has_next = false;
+        for row in fetched {
+            let seq = row.tx_sequence_number as u64;
+            if seq < window_lo {
+                has_prev = true;
+            } else if seq > window_hi {
+                has_next = true;
+            } else if page_rows.len() < limit {
+                page_rows.push(row);
+            } else if is_from_front {
+                has_next = true;
+            } else {
+                has_prev = true;
+            }
+        }
+
+        // We always serve the result in ascending order
+        if !is_from_front {
+            page_rows.reverse();
+        }
+
+        let mut conn = ScanConnection::new(has_prev, has_next);
+        for stored in page_rows {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            let inner = TransactionBlockInner::try_from(stored)?;
+            conn.edges.push(Edge::new(
+                cursor,
+                TransactionBlock {
+                    inner,
+                    checkpoint_viewed_at,
+                },
+            ));
+        }
+        Ok(conn)
     }
 }
 

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -25,7 +25,7 @@ use iota_types::{
     },
     object::Object,
 };
-use itertools::{Either, Itertools, izip};
+use itertools::{Itertools, izip};
 use moka::sync::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
 use prometheus_filtered::Registry;
 
@@ -51,6 +51,16 @@ use crate::{
 pub type InputObjects = Vec<Object>;
 /// Represents the Output objects of a transaction.
 pub type OutputObjects = Vec<Object>;
+
+/// Which transaction inside a checkpoint the cursor refers to. Used by
+/// [`HistoricalFallbackReader::checkpoint_transactions`].
+#[derive(Clone, Copy)]
+pub enum CheckpointTxCursor {
+    /// The transaction with this digest.
+    Digest(TransactionDigest),
+    /// The transaction with this `tx_sequence_number`.
+    Seq(u64),
+}
 
 /// A high-level client to interact with the historical fallback storage.
 ///
@@ -440,9 +450,12 @@ impl HistoricalFallbackReader {
     /// | `None`     | `true`     | Starts from last transaction in checkpoint  |
     /// | `Some(tx)` | `false`    | Starts after `tx`, ascending                |
     /// | `Some(tx)` | `true`     | Starts after `tx`, descending               |
+    ///
+    /// `tx` is given either by its digest or by its `tx_sequence_number`
+    /// (see [`CheckpointTxCursor`]).
     pub(crate) async fn checkpoint_transactions(
         &self,
-        cursor: Option<TransactionDigest>,
+        cursor: Option<CheckpointTxCursor>,
         checkpoint_sequence_number: CheckpointSequenceNumber,
         limit: usize,
         is_descending: bool,
@@ -451,55 +464,58 @@ impl HistoricalFallbackReader {
             return Ok(vec![]);
         }
 
-        let Some(contents) = self
-            .client
-            .multi_get_checkpoints_contents(&[checkpoint_sequence_number])
-            .await?
-            .into_iter()
-            .next()
-            .flatten()
+        let seqs = [checkpoint_sequence_number];
+        let (summaries, contents) = tokio::try_join!(
+            self.client
+                .multi_get_checkpoints_summaries_by_sequence_numbers(&seqs),
+            self.client.multi_get_checkpoints_contents(&seqs),
+        )?;
+        let (Some(Some(summary)), Some(Some(contents))) =
+            (summaries.into_iter().next(), contents.into_iter().next())
         else {
             return Ok(vec![]);
         };
 
-        let tx_digests = contents.iter().map(|b| b.transaction);
+        // (seq, digest) pairs sorted by tx_sequence_number, ascending
+        let mut seq_digest_pairs: Vec<(u64, TransactionDigest)> = contents
+            .enumerate_transactions(&summary)
+            .map(|(seq, exec)| (seq, exec.transaction))
+            .collect();
+        if is_descending {
+            seq_digest_pairs.reverse();
+        }
 
-        // apply ordering
-        let tx_digests = if is_descending {
-            Either::Left(tx_digests.rev())
-        } else {
-            Either::Right(tx_digests)
+        // Resolve any cursor to a `tx_sequence_number`. A digest cursor that
+        // isn't in this checkpoint results in empty response.
+        let cursor_seq = match cursor {
+            Some(CheckpointTxCursor::Digest(digest)) => {
+                let Some((seq, _)) = seq_digest_pairs.iter().find(|(_, d)| *d == digest) else {
+                    return Ok(vec![]);
+                };
+                Some(*seq)
+            }
+            Some(CheckpointTxCursor::Seq(seq)) => Some(seq),
+            None => None,
         };
 
-        // apply cursor: skip transactions until after the cursor.
-        //
-        // This relies on transactions being ordered within checkpoint contents,
-        // so we can skip until we find the cursor, then skip the cursor itself.
-        let tx_digests = if let Some(cursor) = cursor {
-            Either::Left(
-                tx_digests
-                    .skip_while(move |digest| *digest != cursor)
-                    .skip(1), // skip the cursor itself
-            )
-        } else {
-            Either::Right(tx_digests)
-        };
-
-        // apply limit
-        let tx_digests = tx_digests
+        let tx_digests: Vec<TransactionDigest> = seq_digest_pairs
             .into_iter()
+            .filter(|(seq, _)| match cursor_seq {
+                Some(cursor) if is_descending => *seq < cursor,
+                Some(cursor) => *seq > cursor,
+                None => true,
+            })
             .take(limit)
-            .collect::<Vec<TransactionDigest>>();
+            .map(|(_, digest)| digest)
+            .collect();
 
         let transactions = self.transactions(&tx_digests).await?;
-
         if transactions.iter().any(|tx| tx.is_none()) {
             return Err(IndexerError::HistoricalFallbackStorageError(format!(
                 "KV doesn't have full transaction data for checkpoint {checkpoint_sequence_number}"
             )));
         }
-
-        Ok(transactions.into_iter().flatten().collect::<Vec<_>>())
+        Ok(transactions.into_iter().flatten().collect())
     }
 
     /// Fetches events for a specific transaction.

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -9,7 +9,10 @@
 //! the indexer is unable to fetch data from the database, which is especially
 //! useful when pruning is enabled.
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    ops::{Bound, RangeBounds},
+};
 
 use futures::future;
 use iota_json_rpc_types::{CheckpointId, IotaEvent};
@@ -25,7 +28,7 @@ use iota_types::{
     },
     object::Object,
 };
-use itertools::{Itertools, izip};
+use itertools::{Either, Itertools, izip};
 use moka::sync::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
 use prometheus_filtered::Registry;
 
@@ -51,16 +54,6 @@ use crate::{
 pub type InputObjects = Vec<Object>;
 /// Represents the Output objects of a transaction.
 pub type OutputObjects = Vec<Object>;
-
-/// Which transaction inside a checkpoint the cursor refers to. Used by
-/// [`HistoricalFallbackReader::checkpoint_transactions`].
-#[derive(Clone, Copy)]
-pub enum CheckpointTxCursor {
-    /// The transaction with this digest.
-    Digest(TransactionDigest),
-    /// The transaction with this `tx_sequence_number`.
-    Seq(u64),
-}
 
 /// A high-level client to interact with the historical fallback storage.
 ///
@@ -450,13 +443,75 @@ impl HistoricalFallbackReader {
     /// | `None`     | `true`     | Starts from last transaction in checkpoint  |
     /// | `Some(tx)` | `false`    | Starts after `tx`, ascending                |
     /// | `Some(tx)` | `true`     | Starts after `tx`, descending               |
-    ///
-    /// `tx` is given either by its digest or by its `tx_sequence_number`
-    /// (see [`CheckpointTxCursor`]).
     pub(crate) async fn checkpoint_transactions(
         &self,
-        cursor: Option<CheckpointTxCursor>,
+        cursor: Option<TransactionDigest>,
         checkpoint_sequence_number: CheckpointSequenceNumber,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+
+        let Some(contents) = self
+            .client
+            .multi_get_checkpoints_contents(&[checkpoint_sequence_number])
+            .await?
+            .into_iter()
+            .next()
+            .flatten()
+        else {
+            return Ok(vec![]);
+        };
+
+        let tx_digests = contents.iter().map(|b| b.transaction);
+
+        // apply ordering
+        let tx_digests = if is_descending {
+            Either::Left(tx_digests.rev())
+        } else {
+            Either::Right(tx_digests)
+        };
+
+        // apply cursor: skip transactions until after the cursor.
+        //
+        // This relies on transactions being ordered within checkpoint contents,
+        // so we can skip until we find the cursor, then skip the cursor itself.
+        let tx_digests = if let Some(cursor) = cursor {
+            Either::Left(
+                tx_digests
+                    .skip_while(move |digest| *digest != cursor)
+                    .skip(1), // skip the cursor itself
+            )
+        } else {
+            Either::Right(tx_digests)
+        };
+
+        // apply limit
+        let tx_digests = tx_digests
+            .into_iter()
+            .take(limit)
+            .collect::<Vec<TransactionDigest>>();
+
+        let transactions = self.transactions(&tx_digests).await?;
+        if transactions.iter().any(|tx| tx.is_none()) {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "KV doesn't have full transaction data for checkpoint {checkpoint_sequence_number}"
+            )));
+        }
+        Ok(transactions.into_iter().flatten().collect())
+    }
+
+    /// Fetches transactions belonging to a specific checkpoint whose
+    /// `tx_sequence_number` falls within the given range.
+    ///
+    /// Returns up to `limit` transactions ordered by `tx_sequence_number`,
+    /// in order determined by `is_descending`.
+    pub(crate) async fn checkpoint_transactions_in_seq_range(
+        &self,
+        checkpoint_sequence_number: CheckpointSequenceNumber,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
@@ -476,38 +531,20 @@ impl HistoricalFallbackReader {
             return Ok(vec![]);
         };
 
-        // (seq, digest) pairs sorted by tx_sequence_number, ascending
-        let mut seq_digest_pairs: Vec<(u64, TransactionDigest)> = contents
+        // digests sorted by tx_sequence_number, ascending
+        let in_range = contents
             .enumerate_transactions(&summary)
-            .map(|(seq, exec)| (seq, exec.transaction))
-            .collect();
-        if is_descending {
-            seq_digest_pairs.reverse();
-        }
+            .filter(|(seq, _)| tx_seq_range.contains(seq))
+            .map(|(_, digests)| digests.transaction);
 
-        // Resolve any cursor to a `tx_sequence_number`. A digest cursor that
-        // isn't in this checkpoint results in empty response.
-        let cursor_seq = match cursor {
-            Some(CheckpointTxCursor::Digest(digest)) => {
-                let Some((seq, _)) = seq_digest_pairs.iter().find(|(_, d)| *d == digest) else {
-                    return Ok(vec![]);
-                };
-                Some(*seq)
-            }
-            Some(CheckpointTxCursor::Seq(seq)) => Some(seq),
-            None => None,
+        let tx_digests: Vec<TransactionDigest> = if is_descending {
+            let mut tx_digests: Vec<_> = in_range.collect();
+            tx_digests.reverse();
+            tx_digests.truncate(limit);
+            tx_digests
+        } else {
+            in_range.take(limit).collect()
         };
-
-        let tx_digests: Vec<TransactionDigest> = seq_digest_pairs
-            .into_iter()
-            .filter(|(seq, _)| match cursor_seq {
-                Some(cursor) if is_descending => *seq < cursor,
-                Some(cursor) => *seq > cursor,
-                None => true,
-            })
-            .take(limit)
-            .map(|(_, digest)| digest)
-            .collect();
 
         let transactions = self.transactions(&tx_digests).await?;
         if transactions.iter().any(|tx| tx.is_none()) {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -61,7 +61,7 @@ use crate::{
     apis::GovernanceReadApi,
     db::{ConnectionConfig, ConnectionPool, ConnectionPoolConfig},
     errors::{Context, IndexerError},
-    historical_fallback::reader::HistoricalFallbackReader,
+    historical_fallback::reader::{CheckpointTxCursor, HistoricalFallbackReader},
     ingestion::common::persist::CommitterTables,
     models::{
         address_metrics::StoredAddressMetrics,
@@ -1292,7 +1292,12 @@ impl IndexerReader {
             (db_res.as_ref(), self.fallback_reader())
         {
             kv_reader
-                .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
+                .checkpoint_transactions(
+                    cursor.map(CheckpointTxCursor::Digest),
+                    checkpoint_seq,
+                    limit,
+                    is_descending,
+                )
                 .await
                 .context(&format!("fallback triggered by {err}"))?
         } else {
@@ -1300,6 +1305,42 @@ impl IndexerReader {
         };
         self.stored_transaction_to_transaction_block(stored_txs, options)
             .await
+    }
+
+    /// Fetches transactions belonging to a checkpoint, paginated by
+    /// `tx_sequence_number` (exclusive cursor). Falls back to the historical
+    /// storage (when configured) if the checkpoint has been pruned from
+    /// Postgres.
+    pub async fn query_stored_transactions_by_checkpoint_seq_with_fallback(
+        &self,
+        checkpoint_seq: u64,
+        cursor_tx_seq: Option<u64>,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let db_res = self
+            .db()
+            .query_transactions_by_checkpoint_seq_with_seq_cursor(
+                checkpoint_seq,
+                cursor_tx_seq,
+                limit,
+                is_descending,
+            )
+            .await;
+        if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.fallback_reader())
+        {
+            return kv_reader
+                .checkpoint_transactions(
+                    cursor_tx_seq.map(CheckpointTxCursor::Seq),
+                    checkpoint_seq,
+                    limit,
+                    is_descending,
+                )
+                .await
+                .context(&format!("fallback triggered by {err}"));
+        }
+        db_res
     }
 
     /// Fetches a paginated list of transactions that affect a given address,
@@ -2875,6 +2916,28 @@ impl<'a> DBReader<'a> {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
+        let cursor_tx_seq = match cursor {
+            Some(cursor) => Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await? as u64),
+            None => None,
+        };
+        self.query_transactions_by_checkpoint_seq_with_seq_cursor(
+            checkpoint_seq,
+            cursor_tx_seq,
+            limit,
+            is_descending,
+        )
+        .await
+    }
+
+    /// Same as [`Self::query_transactions_by_checkpoint_seq`], but the cursor
+    /// is a `tx_sequence_number` (exclusive) instead of a transaction digest.
+    async fn query_transactions_by_checkpoint_seq_with_seq_cursor(
+        &self,
+        checkpoint_seq: u64,
+        cursor_tx_seq: Option<u64>,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
         self.main_reader.ensure_data_not_pruned_for_checkpoint(
             checkpoint_seq,
             &[
@@ -2898,22 +2961,17 @@ impl<'a> DBReader<'a> {
         })
         .context("failed to get transaction range from pruner_cp_watermark table")?;
 
-        let cursor_tx_seq = if let Some(cursor) = cursor {
-            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
-        } else {
-            None
-        };
-
         let mut query = transactions::dsl::transactions
             .filter(transactions::tx_sequence_number.between(tx_range.0, tx_range.1))
             .into_boxed();
 
-        // Translate transaction digest cursor to tx sequence number
         if let Some(cursor_tx_seq) = cursor_tx_seq {
             if is_descending {
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(cursor_tx_seq));
+                query =
+                    query.filter(transactions::dsl::tx_sequence_number.lt(cursor_tx_seq as i64));
             } else {
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(cursor_tx_seq));
+                query =
+                    query.filter(transactions::dsl::tx_sequence_number.gt(cursor_tx_seq as i64));
             }
         }
         if is_descending {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -7,6 +7,7 @@ use std::{
     cmp::Reverse,
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
+    ops::Bound,
     sync::{Arc, Mutex},
 };
 
@@ -61,7 +62,7 @@ use crate::{
     apis::GovernanceReadApi,
     db::{ConnectionConfig, ConnectionPool, ConnectionPoolConfig},
     errors::{Context, IndexerError},
-    historical_fallback::reader::{CheckpointTxCursor, HistoricalFallbackReader},
+    historical_fallback::reader::HistoricalFallbackReader,
     ingestion::common::persist::CommitterTables,
     models::{
         address_metrics::StoredAddressMetrics,
@@ -1292,12 +1293,7 @@ impl IndexerReader {
             (db_res.as_ref(), self.fallback_reader())
         {
             kv_reader
-                .checkpoint_transactions(
-                    cursor.map(CheckpointTxCursor::Digest),
-                    checkpoint_seq,
-                    limit,
-                    is_descending,
-                )
+                .checkpoint_transactions(cursor, checkpoint_seq, limit, is_descending)
                 .await
                 .context(&format!("fallback triggered by {err}"))?
         } else {
@@ -1307,22 +1303,22 @@ impl IndexerReader {
             .await
     }
 
-    /// Fetches transactions belonging to a checkpoint, paginated by
-    /// `tx_sequence_number` (exclusive cursor). Falls back to the historical
-    /// storage (when configured) if the checkpoint has been pruned from
-    /// Postgres.
+    /// Fetches transactions belonging to a checkpoint whose
+    /// `tx_sequence_number` falls within the given range. Falls back to the
+    /// historical storage (when configured) if the checkpoint has been pruned
+    /// from Postgres.
     pub async fn query_stored_transactions_by_checkpoint_seq_with_fallback(
         &self,
         checkpoint_seq: u64,
-        cursor_tx_seq: Option<u64>,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
         let db_res = self
             .db()
-            .query_transactions_by_checkpoint_seq_with_seq_cursor(
+            .query_transactions_by_checkpoint_seq_in_range(
                 checkpoint_seq,
-                cursor_tx_seq,
+                tx_seq_range,
                 limit,
                 is_descending,
             )
@@ -1331,9 +1327,9 @@ impl IndexerReader {
             (db_res.as_ref(), self.fallback_reader())
         {
             return kv_reader
-                .checkpoint_transactions(
-                    cursor_tx_seq.map(CheckpointTxCursor::Seq),
+                .checkpoint_transactions_in_seq_range(
                     checkpoint_seq,
+                    tx_seq_range,
                     limit,
                     is_descending,
                 )
@@ -2916,25 +2912,32 @@ impl<'a> DBReader<'a> {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
-        let cursor_tx_seq = match cursor {
-            Some(cursor) => Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await? as u64),
-            None => None,
+        let tx_seq_range = match cursor {
+            Some(cursor) => {
+                let cursor_tx_seq = self.resolve_cursor_tx_digest_to_seq_num(cursor).await? as u64;
+                if is_descending {
+                    (Bound::Unbounded, Bound::Excluded(cursor_tx_seq))
+                } else {
+                    (Bound::Excluded(cursor_tx_seq), Bound::Unbounded)
+                }
+            }
+            None => (Bound::Unbounded, Bound::Unbounded),
         };
-        self.query_transactions_by_checkpoint_seq_with_seq_cursor(
+        self.query_transactions_by_checkpoint_seq_in_range(
             checkpoint_seq,
-            cursor_tx_seq,
+            tx_seq_range,
             limit,
             is_descending,
         )
         .await
     }
 
-    /// Same as [`Self::query_transactions_by_checkpoint_seq`], but the cursor
-    /// is a `tx_sequence_number` (exclusive) instead of a transaction digest.
-    async fn query_transactions_by_checkpoint_seq_with_seq_cursor(
+    /// Same as [`Self::query_transactions_by_checkpoint_seq`], but bounded by
+    /// a `tx_sequence_number` range instead of a digest cursor.
+    async fn query_transactions_by_checkpoint_seq_in_range(
         &self,
         checkpoint_seq: u64,
-        cursor_tx_seq: Option<u64>,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
@@ -2965,15 +2968,25 @@ impl<'a> DBReader<'a> {
             .filter(transactions::tx_sequence_number.between(tx_range.0, tx_range.1))
             .into_boxed();
 
-        if let Some(cursor_tx_seq) = cursor_tx_seq {
-            if is_descending {
-                query =
-                    query.filter(transactions::dsl::tx_sequence_number.lt(cursor_tx_seq as i64));
-            } else {
-                query =
-                    query.filter(transactions::dsl::tx_sequence_number.gt(cursor_tx_seq as i64));
+        let (min_tx_seq, max_tx_seq) = tx_seq_range;
+        query = match min_tx_seq {
+            Bound::Included(min) => {
+                query.filter(transactions::dsl::tx_sequence_number.ge(min as i64))
             }
-        }
+            Bound::Excluded(min) => {
+                query.filter(transactions::dsl::tx_sequence_number.gt(min as i64))
+            }
+            Bound::Unbounded => query,
+        };
+        query = match max_tx_seq {
+            Bound::Included(max) => {
+                query.filter(transactions::dsl::tx_sequence_number.le(max as i64))
+            }
+            Bound::Excluded(max) => {
+                query.filter(transactions::dsl::tx_sequence_number.lt(max as i64))
+            }
+            Bound::Unbounded => query,
+        };
         if is_descending {
             query = query.order(transactions::dsl::tx_sequence_number.desc());
         } else {


### PR DESCRIPTION
# Description of change

Adds historical fallback for GraphQL queries that list the transactions of a single checkpoint. Covered paths:

- `Query.transactionBlocks(filter: { atCheckpoint: ... })`
- `Checkpoint.transactionBlocks`

Queries with only the `atCheckpoint` filter are served by the new `IndexerReader::query_stored_transactions_by_checkpoint_seq_with_fallback` method. A pruned checkpoint is served from the historical storage when configured, and returns a `DATA_PRUNED` error otherwise (before this change, the page came back empty). Queries with other filters keep using the SQL path.

The fallback reader's `checkpoint_transactions` now takes the cursor either by transaction digest (used by JSON-RPC) or by `tx_sequence_number` (used by GraphQL, see `CheckpointTxCursor`). The page is fetched with one extra row on each side, so `hasPreviousPage`/`hasNextPage` can be filled.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11936

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.


### Release Notes

- [x] GraphQL: `Query.transactionBlocks(filter: { atCheckpoint })` and `Checkpoint.transactionBlocks` can now read pruned transactions from the fallback KV store when it is configured.
