### PR TITLE
feat(core): execution-driven pruning

### DIFF
--- a/crates/iota-config/data/fullnode-template-with-path.yaml
+++ b/crates/iota-config/data/fullnode-template-with-path.yaml
@@ -20,9 +20,6 @@ migration-tx-data-path: "migration.blob"
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
   num-epochs-to-retain: 1
-  max-checkpoints-in-batch: 10
-  max-transactions-in-batch: 1000
-  pruning-run-delay-seconds: 60
 
 authority-key-pair:
   path: "authority.key"

--- a/crates/iota-config/data/fullnode-template.yaml
+++ b/crates/iota-config/data/fullnode-template.yaml
@@ -20,6 +20,3 @@ migration-tx-data-path: "/opt/iota/config/migration.blob"
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
   num-epochs-to-retain: 1
-  max-checkpoints-in-batch: 10
-  max-transactions-in-batch: 1000
-  pruning-run-delay-seconds: 60

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1016,16 +1016,6 @@ pub struct AuthorityStorePruningConfig {
     /// Use `u64::MAX` to disable the pruner for the objects.
     #[serde(default)]
     pub num_epochs_to_retain: u64,
-    /// pruner's runtime interval used for aggressive mode
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pruning_run_delay_seconds: Option<u64>,
-    /// maximum number of checkpoints in the pruning batch. Can be adjusted to
-    /// increase performance
-    #[serde(default = "default_max_checkpoints_in_batch")]
-    pub max_checkpoints_in_batch: usize,
-    /// maximum number of transaction in the pruning batch
-    #[serde(default = "default_max_transactions_in_batch")]
-    pub max_transactions_in_batch: usize,
     /// enables periodic background compaction for old SST files whose last
     /// modified time is older than `periodic_compaction_threshold_days`
     /// days. That ensures that all sst files eventually go through the
@@ -1054,14 +1044,6 @@ fn default_num_latest_epoch_dbs_to_retain() -> usize {
     3
 }
 
-fn default_max_transactions_in_batch() -> usize {
-    1000
-}
-
-fn default_max_checkpoints_in_batch() -> usize {
-    10
-}
-
 fn default_periodic_compaction_threshold_days() -> Option<usize> {
     Some(1)
 }
@@ -1071,9 +1053,6 @@ impl Default for AuthorityStorePruningConfig {
         Self {
             num_latest_epoch_dbs_to_retain: default_num_latest_epoch_dbs_to_retain(),
             num_epochs_to_retain: 0,
-            pruning_run_delay_seconds: if cfg!(msim) { Some(2) } else { None },
-            max_checkpoints_in_batch: default_max_checkpoints_in_batch(),
-            max_transactions_in_batch: default_max_transactions_in_batch(),
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints: if cfg!(msim) { Some(2) } else { None },
             enable_compaction_filter: cfg!(test) || cfg!(msim),

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -156,9 +156,7 @@ use crate::{
         authority_per_epoch_store::{AuthorityPerEpochStore, TxGuard},
         authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner,
         authority_store::{ExecutionLockReadGuard, ObjectLockStatus},
-        authority_store_pruner::{
-            AuthorityStorePruner, EPOCH_DURATION_MS_FOR_TESTING, PruningCoordinator,
-        },
+        authority_store_pruner::{AuthorityStorePruner, EPOCH_DURATION_MS_FOR_TESTING},
         authority_store_tables::AuthorityPrunerTables,
         epoch_start_configuration::{EpochStartConfigTrait, EpochStartConfiguration},
     },
@@ -868,10 +866,9 @@ pub struct AuthorityState {
     tx_execution_shutdown: Mutex<Option<oneshot::Sender<()>>>,
 
     pub metrics: Arc<AuthorityMetrics>,
-    _pruner: AuthorityStorePruner,
-    /// Shared handle used by the checkpoint executor to nudge the pruner after
-    /// each checkpoint and to be leashed if pruning falls behind.
-    pruning_coordinator: Arc<PruningCoordinator>,
+    /// The store pruner. The checkpoint executor uses it to nudge the pruner
+    /// after each checkpoint and to be leashed if pruning falls behind.
+    pruner: AuthorityStorePruner,
     authority_per_epoch_pruner: AuthorityPerEpochStorePruner,
     checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
 
@@ -3288,8 +3285,7 @@ impl AuthorityState {
                 .num_latest_epoch_dbs_to_retain,
         )
         .await;
-        let pruning_coordinator = PruningCoordinator::new();
-        let _pruner = AuthorityStorePruner::new(
+        let pruner = AuthorityStorePruner::new(
             store.perpetual_tables.clone(),
             checkpoint_store.clone(),
             grpc_indexes_store.clone(),
@@ -3301,7 +3297,6 @@ impl AuthorityState {
             archive_readers,
             pruner_db,
             checkpoint_progress_tracker.clone(),
-            pruning_coordinator.clone(),
         );
         let input_loader =
             TransactionInputLoader::new(execution_cache_trait_pointers.object_cache_reader.clone());
@@ -3336,8 +3331,7 @@ impl AuthorityState {
             transaction_manager,
             tx_execution_shutdown: Mutex::new(Some(tx_execution_shutdown)),
             metrics,
-            _pruner,
-            pruning_coordinator,
+            pruner,
             authority_per_epoch_pruner,
             checkpoint_progress_tracker,
             db_checkpoint_config: db_checkpoint_config.clone(),
@@ -4355,10 +4349,10 @@ impl AuthorityState {
         &self.checkpoint_store
     }
 
-    /// Shared handle the checkpoint executor uses to nudge the store pruner
+    /// The store pruner; the checkpoint executor uses it to nudge the pruner
     /// after each checkpoint and to be leashed when pruning falls behind.
-    pub fn pruning_coordinator(&self) -> &Arc<PruningCoordinator> {
-        &self.pruning_coordinator
+    pub fn pruner(&self) -> &AuthorityStorePruner {
+        &self.pruner
     }
 
     pub fn get_latest_checkpoint_sequence_number(&self) -> IotaResult<CheckpointSequenceNumber> {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -156,7 +156,9 @@ use crate::{
         authority_per_epoch_store::{AuthorityPerEpochStore, TxGuard},
         authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner,
         authority_store::{ExecutionLockReadGuard, ObjectLockStatus},
-        authority_store_pruner::{AuthorityStorePruner, EPOCH_DURATION_MS_FOR_TESTING},
+        authority_store_pruner::{
+            AuthorityStorePruner, EPOCH_DURATION_MS_FOR_TESTING, PruningCoordinator,
+        },
         authority_store_tables::AuthorityPrunerTables,
         epoch_start_configuration::{EpochStartConfigTrait, EpochStartConfiguration},
     },
@@ -867,6 +869,9 @@ pub struct AuthorityState {
 
     pub metrics: Arc<AuthorityMetrics>,
     _pruner: AuthorityStorePruner,
+    /// Shared handle used by the checkpoint executor to nudge the pruner after
+    /// each checkpoint and to be leashed if pruning falls behind.
+    pruning_coordinator: Arc<PruningCoordinator>,
     authority_per_epoch_pruner: AuthorityPerEpochStorePruner,
     checkpoint_progress_tracker: Option<Arc<CheckpointProgressTracker>>,
 
@@ -3283,6 +3288,7 @@ impl AuthorityState {
                 .num_latest_epoch_dbs_to_retain,
         )
         .await;
+        let pruning_coordinator = PruningCoordinator::new();
         let _pruner = AuthorityStorePruner::new(
             store.perpetual_tables.clone(),
             checkpoint_store.clone(),
@@ -3295,6 +3301,7 @@ impl AuthorityState {
             archive_readers,
             pruner_db,
             checkpoint_progress_tracker.clone(),
+            pruning_coordinator.clone(),
         );
         let input_loader =
             TransactionInputLoader::new(execution_cache_trait_pointers.object_cache_reader.clone());
@@ -3330,6 +3337,7 @@ impl AuthorityState {
             tx_execution_shutdown: Mutex::new(Some(tx_execution_shutdown)),
             metrics,
             _pruner,
+            pruning_coordinator,
             authority_per_epoch_pruner,
             checkpoint_progress_tracker,
             db_checkpoint_config: db_checkpoint_config.clone(),
@@ -4345,6 +4353,12 @@ impl AuthorityState {
 
     pub fn get_checkpoint_store(&self) -> &Arc<CheckpointStore> {
         &self.checkpoint_store
+    }
+
+    /// Shared handle the checkpoint executor uses to nudge the store pruner
+    /// after each checkpoint and to be leashed when pruning falls behind.
+    pub fn pruning_coordinator(&self) -> &Arc<PruningCoordinator> {
+        &self.pruning_coordinator
     }
 
     pub fn get_latest_checkpoint_sequence_number(&self) -> IotaResult<CheckpointSequenceNumber> {

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -30,7 +30,10 @@ use prometheus_filtered::{
     register_int_gauge_with_registry,
 };
 use tokio::{
-    sync::oneshot::{self, Sender},
+    sync::{
+        oneshot::{self, Sender},
+        watch,
+    },
     time::Instant,
 };
 use tracing::{debug, error, info, warn};
@@ -64,6 +67,35 @@ static PERIODIC_PRUNING_TABLES: Lazy<BTreeSet<String>> = Lazy::new(|| {
 pub const EPOCH_DURATION_MS_FOR_TESTING: u64 = 24 * 60 * 60 * 1000;
 pub const MIN_EPOCHS_TO_RETAIN_FOR_INDEXES: u64 = 7;
 
+/// Maximum number of checkpoints whose data is written in a single pruning
+/// `WriteBatch`. Bounds batch memory only; it does not cap total work per run,
+/// so it cannot cause the pruner to fall behind.
+const MAX_CHECKPOINTS_IN_BATCH: usize = 10;
+/// Maximum number of transactions whose effects are written in a single pruning
+/// `WriteBatch`. Bounds batch memory only (see [`MAX_CHECKPOINTS_IN_BATCH`]).
+const MAX_TRANSACTIONS_IN_BATCH: usize = 1000;
+
+/// Chain-time slack, in milliseconds, allowed on top of the retention window
+/// before the checkpoint executor is throttled by [`PruningCoordinator`]. It
+/// absorbs transient bursts of high-contention checkpoints so execution runs at
+/// the average prune rate rather than the peak; under sustained overload the
+/// retained span stabilizes at `window + PRUNING_LEASH_SLACK_MS`, which is
+/// negligible next to a multi-epoch window.
+const PRUNING_LEASH_SLACK_MS: u64 = 60 * 60 * 1000;
+
+/// While catching up (see [`PRUNING_DEBOUNCE_MIN_LAG`]), after a nudge wakes
+/// the pruner it waits this long before draining so that more executed
+/// checkpoints accumulate and their object deletions coalesce into larger,
+/// fewer batches — which measurably improves catch-up throughput. Negligible
+/// against the leash slack, so it never risks throttling execution.
+const PRUNING_NUDGE_DEBOUNCE: Duration = Duration::from_millis(1000);
+
+/// The debounce above is only applied while the node is catching up, i.e. when
+/// execution lags the highest synced checkpoint by more than this many
+/// checkpoints. Near the tip the lag is tiny, so pruning stays prompt
+/// (per-checkpoint) and does not incur the debounce delay.
+const PRUNING_DEBOUNCE_MIN_LAG: u64 = 100;
+
 /// The `AuthorityStorePruner` manages the pruning process for object stores
 /// within the `AuthorityStore`. It includes a cancellation handle that can be
 /// used to stop the pruning task for objects.
@@ -71,7 +103,78 @@ pub struct AuthorityStorePruner {
     _objects_pruner_cancel_handle: oneshot::Sender<()>,
 }
 
-static MIN_PRUNING_TICK_DURATION_MS: u64 = 10 * 1000;
+/// Coordinates the checkpoint executor (producer of new state) and the store
+/// pruner (consumer of aged-out state).
+///
+/// Pruning is driven by execution progress rather than a timer: the executor
+/// nudges the pruner after each checkpoint is made available, and the pruner
+/// drains fully to its chain-time retention cutoff on every nudge. To keep
+/// on-disk state bounded without a per-run rate cap (which could silently let
+/// the database grow under sustained load), the executor is *leashed*: it stops
+/// scheduling checkpoints while the pruner has fallen more than
+/// `PRUNING_LEASH_SLACK_MS` behind its retention target.
+pub struct PruningCoordinator {
+    /// Executor -> pruner: latest executed checkpoint sequence number. Updating
+    /// it both records progress and wakes the pruner to drain.
+    executed: watch::Sender<CheckpointSequenceNumber>,
+    executed_rx: watch::Receiver<CheckpointSequenceNumber>,
+    /// Pruner -> executor: the executed-checkpoint timestamp the pruner has
+    /// caught up to (the `highest_executed` it observed on its last completed
+    /// drain). The leash throttles execution while it runs more than
+    /// `PRUNING_LEASH_SLACK_MS` of chain-time ahead of this, i.e. ahead of
+    /// the pruner's last completed drain. Initialized to `u64::MAX` so the
+    /// executor is never leashed before the pruner has published a real
+    /// value.
+    frontier_ms: watch::Sender<CheckpointTimestamp>,
+    frontier_ms_rx: watch::Receiver<CheckpointTimestamp>,
+}
+
+impl PruningCoordinator {
+    pub fn new() -> Arc<Self> {
+        let (executed, executed_rx) = watch::channel(0);
+        let (frontier_ms, frontier_ms_rx) = watch::channel(u64::MAX);
+        Arc::new(Self {
+            executed,
+            executed_rx,
+            frontier_ms,
+            frontier_ms_rx,
+        })
+    }
+
+    /// Called by the executor after a checkpoint has been executed and made
+    /// available (watermark bumped, subscribers notified). Wakes the pruner.
+    pub fn nudge(&self, executed_seq: CheckpointSequenceNumber) {
+        self.executed.send_replace(executed_seq);
+    }
+
+    /// Called by the executor before scheduling a checkpoint with the given
+    /// timestamp. Returns once execution is within `PRUNING_LEASH_SLACK_MS` of
+    /// chain-time of the pruner's last completed drain, throttling execution
+    /// otherwise.
+    pub async fn await_leash(&self, executed_timestamp_ms: CheckpointTimestamp) {
+        let mut rx = self.frontier_ms_rx.clone();
+        loop {
+            let frontier = *rx.borrow_and_update();
+            if executed_timestamp_ms.saturating_sub(frontier) <= PRUNING_LEASH_SLACK_MS {
+                return;
+            }
+            // If the pruner is gone, do not block execution.
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// Pruner-side: a receiver that wakes on each executor nudge.
+    fn subscribe_executed(&self) -> watch::Receiver<CheckpointSequenceNumber> {
+        self.executed_rx.clone()
+    }
+
+    /// Pruner-side: publish the current pruning frontier for the leash.
+    fn set_frontier(&self, frontier_ms: CheckpointTimestamp) {
+        self.frontier_ms.send_replace(frontier_ms);
+    }
+}
 
 /// The `AuthorityStorePruningMetrics` tracks various metrics related to the
 /// pruning process of the `AuthorityStore`.
@@ -371,7 +474,6 @@ impl AuthorityStorePruner {
             pruned_checkpoint_number,
             max_eligible_checkpoint_number,
             cutoff_timestamp_ms,
-            config,
             metrics.clone(),
             progress_tracker,
         )
@@ -434,7 +536,6 @@ impl AuthorityStorePruner {
             pruned_checkpoint_number,
             max_eligible_checkpoint,
             cutoff_timestamp_ms,
-            config,
             metrics.clone(),
             progress_tracker,
         )
@@ -453,7 +554,6 @@ impl AuthorityStorePruner {
         starting_checkpoint_number: CheckpointSequenceNumber,
         max_eligible_checkpoint: CheckpointSequenceNumber,
         cutoff_timestamp_ms: CheckpointTimestamp,
-        config: AuthorityStorePruningConfig,
         metrics: Arc<AuthorityStorePruningMetrics>,
         progress_tracker: Option<&Arc<CheckpointProgressTracker>>,
     ) -> anyhow::Result<()> {
@@ -512,8 +612,8 @@ impl AuthorityStorePruner {
             checkpoint_content_to_prune.push(content);
             effects_to_prune.extend(effects.into_iter().flatten());
 
-            if effects_to_prune.len() >= config.max_transactions_in_batch
-                || checkpoints_to_prune.len() >= config.max_checkpoints_in_batch
+            if effects_to_prune.len() >= MAX_TRANSACTIONS_IN_BATCH
+                || checkpoints_to_prune.len() >= MAX_CHECKPOINTS_IN_BATCH
             {
                 match mode {
                     PruningMode::Objects => {
@@ -676,13 +776,6 @@ impl AuthorityStorePruner {
         Ok(Some(sst_file))
     }
 
-    /// Calculates the duration in milliseconds for a pruning tick based on the
-    /// provided epoch duration. The function returns the lesser of half the
-    /// epoch duration or 60 seconds.
-    fn pruning_tick_duration_ms(epoch_duration_ms: u64) -> u64 {
-        min(epoch_duration_ms / 2, MIN_PRUNING_TICK_DURATION_MS)
-    }
-
     fn setup_pruning(
         config: AuthorityStorePruningConfig,
         epoch_duration_ms: u64,
@@ -694,27 +787,16 @@ impl AuthorityStorePruner {
         metrics: Arc<AuthorityStorePruningMetrics>,
         archive_readers: ArchiveReaderBalancer,
         progress_tracker: Option<Arc<CheckpointProgressTracker>>,
+        coordinator: Arc<PruningCoordinator>,
     ) -> Sender<()> {
         let (sender, mut recv) = tokio::sync::oneshot::channel();
         debug!(
-            "Starting object pruning service with num_epochs_to_retain={}",
+            "Starting store pruner with num_epochs_to_retain={}",
             config.num_epochs_to_retain
         );
 
-        let tick_duration =
-            Duration::from_millis(Self::pruning_tick_duration_ms(epoch_duration_ms));
-        let pruning_initial_delay = if cfg!(msim) {
-            Duration::from_millis(1)
-        } else {
-            Duration::from_secs(config.pruning_run_delay_seconds.unwrap_or(60 * 60))
-        };
-        let mut objects_prune_interval =
-            tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
-        let mut checkpoints_prune_interval =
-            tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
-        let mut indexes_prune_interval =
-            tokio::time::interval_at(Instant::now() + pruning_initial_delay, tick_duration);
-
+        // Periodic background compaction of aged SST files, independent of the
+        // execution-driven pruning loop below.
         let perpetual_db_for_compaction = perpetual_db.clone();
         if let Some(delay_days) = config.periodic_compaction_threshold_days {
             spawn_monitored_task!(async move {
@@ -749,25 +831,120 @@ impl AuthorityStorePruner {
                 .unwrap_or_default() as i64,
         );
 
+        let prune_objects = config.num_epochs_to_retain != u64::MAX;
+        let prune_checkpoints = !matches!(
+            config.num_epochs_to_retain_for_checkpoints(),
+            None | Some(u64::MAX) | Some(0)
+        );
+        let prune_indexes = config.num_epochs_to_retain_for_indexes.is_some();
+        // The leash only makes sense when something is actually being pruned; if
+        // no pruner is enabled the frontier stays at u64::MAX and execution is
+        // never throttled.
+        let leash_enabled = prune_objects || prune_checkpoints;
+
+        // Execution-driven pruning: on every nudge from the checkpoint executor,
+        // drain each enabled pruner fully to its chain-time cutoff, then publish
+        // the pruning frontier for the executor's leash. Draining once before the
+        // first nudge handles any startup backlog. The `watch` nudge coalesces
+        // many executed checkpoints into a single drain.
         tokio::task::spawn(async move {
+            let mut executed_rx = coordinator.subscribe_executed();
             loop {
+                // The executed position this pass prunes up to. Published as the
+                // frontier once draining completes, so the leash measures how far
+                // execution has run ahead of the pruner's last completed drain —
+                // bounded and independent of epoch-duration variance, and free of
+                // the deadlock a `pruned + window` frontier could hit when the
+                // epoch guard or a mismatched `epoch_duration_ms` keeps that value
+                // permanently below `executed - slack`.
+                let highest_executed = checkpoint_store
+                    .get_highest_executed_checkpoint()
+                    .ok()
+                    .flatten();
+                let caught_up_to = highest_executed
+                    .as_ref()
+                    .map(|checkpoint| checkpoint.timestamp_ms)
+                    .unwrap_or(u64::MAX);
+
+                // Only batch (debounce) while catching up: if execution lags the
+                // highest synced checkpoint by more than the threshold there is a
+                // backlog to coalesce; near the tip the lag is tiny and we prune
+                // promptly.
+                let executed_seq = highest_executed
+                    .as_ref()
+                    .map(|checkpoint| checkpoint.sequence_number())
+                    .unwrap_or(0);
+                let synced_seq = checkpoint_store
+                    .get_highest_synced_checkpoint_seq_number()
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0);
+                let catching_up =
+                    synced_seq.saturating_sub(executed_seq) > PRUNING_DEBOUNCE_MIN_LAG;
+
+                if prune_objects {
+                    if let Err(err) = Self::prune_objects_for_eligible_epochs(
+                        &perpetual_db,
+                        &checkpoint_store,
+                        grpc_indexes_store.as_deref(),
+                        pruner_db.as_ref(),
+                        config.clone(),
+                        metrics.clone(),
+                        epoch_duration_ms,
+                        progress_tracker.as_ref(),
+                    )
+                    .await
+                    {
+                        error!("Failed to prune objects: {:?}", err);
+                    }
+                }
+                if prune_checkpoints {
+                    if let Err(err) = Self::prune_checkpoints_for_eligible_epochs(
+                        &perpetual_db,
+                        &checkpoint_store,
+                        grpc_indexes_store.as_deref(),
+                        pruner_db.as_ref(),
+                        config.clone(),
+                        metrics.clone(),
+                        archive_readers.clone(),
+                        epoch_duration_ms,
+                        progress_tracker.as_ref(),
+                    )
+                    .await
+                    {
+                        error!("Failed to prune checkpoints: {:?}", err);
+                    }
+                }
+                if prune_indexes {
+                    if let Err(err) = Self::prune_indexes(
+                        jsonrpc_index.as_deref(),
+                        &config,
+                        epoch_duration_ms,
+                        &metrics,
+                    ) {
+                        error!("Failed to prune indexes: {:?}", err);
+                    }
+                }
+
+                if leash_enabled {
+                    coordinator.set_frontier(caught_up_to);
+                }
+
                 tokio::select! {
-                    _ = objects_prune_interval.tick(), if config.num_epochs_to_retain != u64::MAX => {
-                        if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, grpc_indexes_store.as_deref(), pruner_db.as_ref(), config.clone(), metrics.clone(), epoch_duration_ms, progress_tracker.as_ref()).await {
-                            error!("Failed to prune objects: {:?}", err);
-                        }
-                    },
-                    _ = checkpoints_prune_interval.tick(), if !matches!(config.num_epochs_to_retain_for_checkpoints(), None | Some(u64::MAX) | Some(0)) => {
-                        if let Err(err) = Self::prune_checkpoints_for_eligible_epochs(&perpetual_db, &checkpoint_store, grpc_indexes_store.as_deref(), pruner_db.as_ref(), config.clone(), metrics.clone(), archive_readers.clone(), epoch_duration_ms, progress_tracker.as_ref()).await {
-                            error!("Failed to prune checkpoints: {:?}", err);
-                        }
-                    },
-                    _ = indexes_prune_interval.tick(), if config.num_epochs_to_retain_for_indexes.is_some() => {
-                        if let Err(err) = Self::prune_indexes(jsonrpc_index.as_deref(), &config, epoch_duration_ms, &metrics) {
-                            error!("Failed to prune indexes: {:?}", err);
+                    _ = &mut recv => break,
+                    res = executed_rx.changed() => {
+                        if res.is_err() {
+                            break;
                         }
                     }
-                    _ = &mut recv => break,
+                }
+
+                // Debounce only while catching up: let more executed checkpoints
+                // accumulate before the next drain so their object deletions
+                // coalesce into larger, fewer batches. Skipped near the tip so
+                // pruning stays prompt.
+                if catching_up {
+                    tokio::time::sleep(PRUNING_NUDGE_DEBOUNCE).await;
                 }
             }
         });
@@ -788,6 +965,7 @@ impl AuthorityStorePruner {
         archive_readers: ArchiveReaderBalancer,
         pruner_db: Option<Arc<AuthorityPrunerTables>>,
         progress_tracker: Option<Arc<CheckpointProgressTracker>>,
+        coordinator: Arc<PruningCoordinator>,
     ) -> Self {
         if pruning_config.num_epochs_to_retain > 0 && pruning_config.num_epochs_to_retain < u64::MAX
         {
@@ -814,6 +992,7 @@ impl AuthorityStorePruner {
                 AuthorityStorePruningMetrics::new(registry),
                 archive_readers,
                 progress_tracker,
+                coordinator,
             ),
         }
     }
@@ -902,7 +1081,6 @@ impl ObjectCompactionMetrics {
 mod tests {
     use std::{collections::HashSet, path::Path, sync::Arc, time::Duration};
 
-    use iota_config::node::AuthorityStorePruningConfig;
     use iota_sdk_types::{ObjectId, ObjectReference};
     use iota_swarm_config::test_utils::{CommitteeFixture, empty_contents};
     use iota_types::{
@@ -923,7 +1101,7 @@ mod tests {
         rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options},
     };
 
-    use super::{AuthorityStorePruner, PruningMode};
+    use super::{AuthorityStorePruner, PRUNING_LEASH_SLACK_MS, PruningCoordinator, PruningMode};
     use crate::{
         authority::{
             authority_store_pruner::AuthorityStorePruningMetrics,
@@ -1261,7 +1439,6 @@ mod tests {
             0,
             max_eligible_checkpoint,
             cutoff_timestamp_ms,
-            AuthorityStorePruningConfig::default(),
             metrics,
             None,
         )
@@ -1317,5 +1494,54 @@ mod tests {
         let timestamps: Vec<_> = (1..=9).map(|i| i * 1000).collect();
         let pruned = run_checkpoint_pruning(&timestamps, u64::MAX, u64::MAX, 1).await;
         assert_eq!(pruned, None);
+    }
+
+    // The leash passes without blocking while the executed timestamp is within
+    // the slack of the pruning frontier (and always before the pruner has run,
+    // when the frontier is u64::MAX).
+    #[tokio::test]
+    async fn test_leash_passes_within_slack() {
+        let coordinator = PruningCoordinator::new();
+        // Frontier starts at u64::MAX: never leashed before the pruner runs.
+        coordinator.await_leash(1_000_000).await;
+
+        coordinator.set_frontier(500);
+        // Gap exactly equals the slack -> still passes.
+        coordinator.await_leash(500 + PRUNING_LEASH_SLACK_MS).await;
+    }
+
+    // The leash blocks while the pruner is more than the slack behind, and
+    // releases once the frontier advances.
+    #[tokio::test]
+    async fn test_leash_blocks_until_frontier_advances() {
+        let coordinator = PruningCoordinator::new();
+        coordinator.set_frontier(0);
+        let executed_ts = PRUNING_LEASH_SLACK_MS + 10_000;
+
+        let waiter = coordinator.clone();
+        let handle = tokio::spawn(async move { waiter.await_leash(executed_ts).await });
+
+        // Let the spawned task run until it parks on the frontier watch.
+        tokio::task::yield_now().await;
+        assert!(
+            !handle.is_finished(),
+            "leash must block while the pruner is more than the slack behind"
+        );
+
+        // Once the pruner catches up, the leash releases.
+        coordinator.set_frontier(executed_ts);
+        handle
+            .await
+            .expect("leash should release after frontier advances");
+    }
+
+    // A nudge wakes the pruner-side subscription.
+    #[tokio::test]
+    async fn test_nudge_wakes_subscriber() {
+        let coordinator = PruningCoordinator::new();
+        let mut rx = coordinator.subscribe_executed();
+        coordinator.nudge(42);
+        rx.changed().await.expect("nudge should notify subscriber");
+        assert_eq!(*rx.borrow(), 42);
     }
 }

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -131,10 +131,16 @@ impl AuthorityStorePruner {
         self.executed.send_replace(executed_seq);
     }
 
-    /// Called by the executor before scheduling a checkpoint with the given
-    /// timestamp. Returns once execution is within `PRUNING_LEASH_SLACK_MS` of
-    /// chain-time of the pruner's last completed drain, throttling execution
-    /// otherwise.
+    /// Called by the executor before scheduling a checkpoint, passing the
+    /// timestamp of the current highest-executed checkpoint. Returns once the
+    /// pruner has caught up to within `PRUNING_LEASH_SLACK_MS` of chain-time of
+    /// that executed watermark, throttling execution otherwise.
+    ///
+    /// The argument is the *executed* watermark, never the candidate
+    /// checkpoint's timestamp: the pruner's frontier only ever advances to
+    /// timestamps that have already executed, so gating on a not-yet-executed
+    /// candidate could deadlock across a large chain-time gap between
+    /// checkpoints.
     pub async fn await_leash(&self, executed_timestamp_ms: CheckpointTimestamp) {
         let mut rx = self.frontier_ms.subscribe();
         while executed_timestamp_ms.saturating_sub(*rx.borrow_and_update()) > PRUNING_LEASH_SLACK_MS

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -117,7 +117,6 @@ pub struct PruningCoordinator {
     /// Executor -> pruner: latest executed checkpoint sequence number. Updating
     /// it both records progress and wakes the pruner to drain.
     executed: watch::Sender<CheckpointSequenceNumber>,
-    executed_rx: watch::Receiver<CheckpointSequenceNumber>,
     /// Pruner -> executor: the executed-checkpoint timestamp the pruner has
     /// caught up to (the `highest_executed` it observed on its last completed
     /// drain). The leash throttles execution while it runs more than
@@ -126,18 +125,13 @@ pub struct PruningCoordinator {
     /// executor is never leashed before the pruner has published a real
     /// value.
     frontier_ms: watch::Sender<CheckpointTimestamp>,
-    frontier_ms_rx: watch::Receiver<CheckpointTimestamp>,
 }
 
 impl PruningCoordinator {
     pub fn new() -> Arc<Self> {
-        let (executed, executed_rx) = watch::channel(0);
-        let (frontier_ms, frontier_ms_rx) = watch::channel(u64::MAX);
         Arc::new(Self {
-            executed,
-            executed_rx,
-            frontier_ms,
-            frontier_ms_rx,
+            executed: watch::channel(0).0,
+            frontier_ms: watch::channel(u64::MAX).0,
         })
     }
 
@@ -152,22 +146,18 @@ impl PruningCoordinator {
     /// chain-time of the pruner's last completed drain, throttling execution
     /// otherwise.
     pub async fn await_leash(&self, executed_timestamp_ms: CheckpointTimestamp) {
-        let mut rx = self.frontier_ms_rx.clone();
-        loop {
-            let frontier = *rx.borrow_and_update();
-            if executed_timestamp_ms.saturating_sub(frontier) <= PRUNING_LEASH_SLACK_MS {
-                return;
-            }
-            // If the pruner is gone, do not block execution.
-            if rx.changed().await.is_err() {
-                return;
-            }
+        let mut rx = self.frontier_ms.subscribe();
+        while executed_timestamp_ms.saturating_sub(*rx.borrow_and_update()) > PRUNING_LEASH_SLACK_MS
+        {
+            // `changed()` cannot error: the sender lives in `self`, which is
+            // borrowed for the duration of this call.
+            let _ = rx.changed().await;
         }
     }
 
     /// Pruner-side: a receiver that wakes on each executor nudge.
     fn subscribe_executed(&self) -> watch::Receiver<CheckpointSequenceNumber> {
-        self.executed_rx.clone()
+        self.executed.subscribe()
     }
 
     /// Pruner-side: publish the current pruning frontier for the leash.
@@ -932,11 +922,9 @@ impl AuthorityStorePruner {
 
                 tokio::select! {
                     _ = &mut recv => break,
-                    res = executed_rx.changed() => {
-                        if res.is_err() {
-                            break;
-                        }
-                    }
+                    // `changed()` cannot error: the sender lives in `coordinator`,
+                    // which is owned by this task.
+                    _ = executed_rx.changed() => {}
                 }
 
                 // Debounce only while catching up: let more executed checkpoints

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -76,7 +76,8 @@ const MAX_CHECKPOINTS_IN_BATCH: usize = 10;
 const MAX_TRANSACTIONS_IN_BATCH: usize = 1000;
 
 /// Chain-time slack, in milliseconds, allowed on top of the retention window
-/// before the checkpoint executor is throttled by [`PruningCoordinator`]. It
+/// before the checkpoint executor is throttled by the pruner's leash
+/// (`AuthorityStorePruner::await_leash`). It
 /// absorbs transient bursts of high-contention checkpoints so execution runs at
 /// the average prune rate rather than the peak; under sustained overload the
 /// retained span stabilizes at `window + PRUNING_LEASH_SLACK_MS`, which is
@@ -99,42 +100,31 @@ const PRUNING_DEBOUNCE_MIN_LAG: u64 = 100;
 /// The `AuthorityStorePruner` manages the pruning process for object stores
 /// within the `AuthorityStore`. It includes a cancellation handle that can be
 /// used to stop the pruning task for objects.
+///
+/// It also owns the coordination channels between the checkpoint executor
+/// (producer of new state) and the pruner task (consumer of aged-out state):
+/// pruning is driven by execution progress rather than a timer — the executor
+/// nudges after each checkpoint is made available, and the pruner drains fully
+/// to its chain-time retention cutoff on every nudge. To keep on-disk state
+/// bounded without a per-run rate cap (which could silently let the database
+/// grow under sustained load), the executor is *leashed*: it stops scheduling
+/// checkpoints while the pruner has fallen more than `PRUNING_LEASH_SLACK_MS`
+/// behind its retention target.
 pub struct AuthorityStorePruner {
     _objects_pruner_cancel_handle: oneshot::Sender<()>,
-}
-
-/// Coordinates the checkpoint executor (producer of new state) and the store
-/// pruner (consumer of aged-out state).
-///
-/// Pruning is driven by execution progress rather than a timer: the executor
-/// nudges the pruner after each checkpoint is made available, and the pruner
-/// drains fully to its chain-time retention cutoff on every nudge. To keep
-/// on-disk state bounded without a per-run rate cap (which could silently let
-/// the database grow under sustained load), the executor is *leashed*: it stops
-/// scheduling checkpoints while the pruner has fallen more than
-/// `PRUNING_LEASH_SLACK_MS` behind its retention target.
-pub struct PruningCoordinator {
     /// Executor -> pruner: latest executed checkpoint sequence number. Updating
-    /// it both records progress and wakes the pruner to drain.
+    /// it both records progress and wakes the pruner task to drain.
     executed: watch::Sender<CheckpointSequenceNumber>,
     /// Pruner -> executor: the executed-checkpoint timestamp the pruner has
     /// caught up to (the `highest_executed` it observed on its last completed
     /// drain). The leash throttles execution while it runs more than
-    /// `PRUNING_LEASH_SLACK_MS` of chain-time ahead of this, i.e. ahead of
-    /// the pruner's last completed drain. Initialized to `u64::MAX` so the
-    /// executor is never leashed before the pruner has published a real
-    /// value.
+    /// `PRUNING_LEASH_SLACK_MS` of chain-time ahead of this, i.e. ahead of the
+    /// pruner's last completed drain. Initialized to `u64::MAX` so the executor
+    /// is never leashed before the pruner has published a real value.
     frontier_ms: watch::Sender<CheckpointTimestamp>,
 }
 
-impl PruningCoordinator {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Self {
-            executed: watch::channel(0).0,
-            frontier_ms: watch::channel(u64::MAX).0,
-        })
-    }
-
+impl AuthorityStorePruner {
     /// Called by the executor after a checkpoint has been executed and made
     /// available (watermark bumped, subscribers notified). Wakes the pruner.
     pub fn nudge(&self, executed_seq: CheckpointSequenceNumber) {
@@ -153,16 +143,6 @@ impl PruningCoordinator {
             // borrowed for the duration of this call.
             let _ = rx.changed().await;
         }
-    }
-
-    /// Pruner-side: a receiver that wakes on each executor nudge.
-    fn subscribe_executed(&self) -> watch::Receiver<CheckpointSequenceNumber> {
-        self.executed.subscribe()
-    }
-
-    /// Pruner-side: publish the current pruning frontier for the leash.
-    fn set_frontier(&self, frontier_ms: CheckpointTimestamp) {
-        self.frontier_ms.send_replace(frontier_ms);
     }
 }
 
@@ -777,7 +757,8 @@ impl AuthorityStorePruner {
         metrics: Arc<AuthorityStorePruningMetrics>,
         archive_readers: ArchiveReaderBalancer,
         progress_tracker: Option<Arc<CheckpointProgressTracker>>,
-        coordinator: Arc<PruningCoordinator>,
+        mut executed_rx: watch::Receiver<CheckpointSequenceNumber>,
+        frontier_tx: watch::Sender<CheckpointTimestamp>,
     ) -> Sender<()> {
         let (sender, mut recv) = tokio::sync::oneshot::channel();
         debug!(
@@ -838,7 +819,6 @@ impl AuthorityStorePruner {
         // first nudge handles any startup backlog. The `watch` nudge coalesces
         // many executed checkpoints into a single drain.
         tokio::task::spawn(async move {
-            let mut executed_rx = coordinator.subscribe_executed();
             loop {
                 // The executed position this pass prunes up to. Published as the
                 // frontier once draining completes, so the leash measures how far
@@ -917,13 +897,13 @@ impl AuthorityStorePruner {
                 }
 
                 if leash_enabled {
-                    coordinator.set_frontier(caught_up_to);
+                    frontier_tx.send_replace(caught_up_to);
                 }
 
                 tokio::select! {
                     _ = &mut recv => break,
-                    // `changed()` cannot error: the sender lives in `coordinator`,
-                    // which is owned by this task.
+                    // `changed()` cannot error: the paired sender lives in the
+                    // `AuthorityStorePruner` returned to the caller.
                     _ = executed_rx.changed() => {}
                 }
 
@@ -953,7 +933,6 @@ impl AuthorityStorePruner {
         archive_readers: ArchiveReaderBalancer,
         pruner_db: Option<Arc<AuthorityPrunerTables>>,
         progress_tracker: Option<Arc<CheckpointProgressTracker>>,
-        coordinator: Arc<PruningCoordinator>,
     ) -> Self {
         if pruning_config.num_epochs_to_retain > 0 && pruning_config.num_epochs_to_retain < u64::MAX
         {
@@ -968,6 +947,12 @@ impl AuthorityStorePruner {
                 warn!("Consider using an aggressive pruner (num_epochs_to_retain = 0)");
             }
         }
+        // Coordination channels between the checkpoint executor and the pruner
+        // task. The pruner task receives nudges (`executed_rx`) and publishes the
+        // frontier (`frontier_tx`); the executor-facing ends are kept on the
+        // returned handle for `nudge` / `await_leash`.
+        let (executed, executed_rx) = watch::channel(0);
+        let (frontier_ms, _) = watch::channel(u64::MAX);
         AuthorityStorePruner {
             _objects_pruner_cancel_handle: Self::setup_pruning(
                 pruning_config,
@@ -980,8 +965,11 @@ impl AuthorityStorePruner {
                 AuthorityStorePruningMetrics::new(registry),
                 archive_readers,
                 progress_tracker,
-                coordinator,
+                executed_rx,
+                frontier_ms.clone(),
             ),
+            executed,
+            frontier_ms,
         }
     }
 
@@ -1083,13 +1071,14 @@ mod tests {
     };
     use more_asserts as ma;
     use prometheus_filtered::Registry;
+    use tokio::sync::{oneshot, watch};
     use tracing::info;
     use typed_store::{
         Map,
         rocks::{DBMap, MetricConf, ReadWriteOptions, default_db_options},
     };
 
-    use super::{AuthorityStorePruner, PRUNING_LEASH_SLACK_MS, PruningCoordinator, PruningMode};
+    use super::{AuthorityStorePruner, PRUNING_LEASH_SLACK_MS, PruningMode};
     use crate::{
         authority::{
             authority_store_pruner::AuthorityStorePruningMetrics,
@@ -1484,29 +1473,39 @@ mod tests {
         assert_eq!(pruned, None);
     }
 
+    // Builds a pruner handle with just the coordination channels (no pruning
+    // task), for exercising `nudge` / `await_leash` in isolation.
+    fn coordination_pruner() -> AuthorityStorePruner {
+        AuthorityStorePruner {
+            _objects_pruner_cancel_handle: oneshot::channel().0,
+            executed: watch::channel(0).0,
+            frontier_ms: watch::channel(u64::MAX).0,
+        }
+    }
+
     // The leash passes without blocking while the executed timestamp is within
     // the slack of the pruning frontier (and always before the pruner has run,
     // when the frontier is u64::MAX).
     #[tokio::test]
     async fn test_leash_passes_within_slack() {
-        let coordinator = PruningCoordinator::new();
+        let pruner = coordination_pruner();
         // Frontier starts at u64::MAX: never leashed before the pruner runs.
-        coordinator.await_leash(1_000_000).await;
+        pruner.await_leash(1_000_000).await;
 
-        coordinator.set_frontier(500);
+        pruner.frontier_ms.send_replace(500);
         // Gap exactly equals the slack -> still passes.
-        coordinator.await_leash(500 + PRUNING_LEASH_SLACK_MS).await;
+        pruner.await_leash(500 + PRUNING_LEASH_SLACK_MS).await;
     }
 
     // The leash blocks while the pruner is more than the slack behind, and
     // releases once the frontier advances.
     #[tokio::test]
     async fn test_leash_blocks_until_frontier_advances() {
-        let coordinator = PruningCoordinator::new();
-        coordinator.set_frontier(0);
+        let pruner = Arc::new(coordination_pruner());
+        pruner.frontier_ms.send_replace(0);
         let executed_ts = PRUNING_LEASH_SLACK_MS + 10_000;
 
-        let waiter = coordinator.clone();
+        let waiter = pruner.clone();
         let handle = tokio::spawn(async move { waiter.await_leash(executed_ts).await });
 
         // Let the spawned task run until it parks on the frontier watch.
@@ -1517,18 +1516,18 @@ mod tests {
         );
 
         // Once the pruner catches up, the leash releases.
-        coordinator.set_frontier(executed_ts);
+        pruner.frontier_ms.send_replace(executed_ts);
         handle
             .await
             .expect("leash should release after frontier advances");
     }
 
-    // A nudge wakes the pruner-side subscription.
+    // A nudge wakes the pruner task's subscription.
     #[tokio::test]
     async fn test_nudge_wakes_subscriber() {
-        let coordinator = PruningCoordinator::new();
-        let mut rx = coordinator.subscribe_executed();
-        coordinator.nudge(42);
+        let pruner = coordination_pruner();
+        let mut rx = pruner.executed.subscribe();
+        pruner.nudge(42);
         rx.changed().await.expect("nudge should notify subscriber");
         assert_eq!(*rx.borrow(), 42);
     }

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -272,7 +272,7 @@ impl CheckpointExecutor {
                 // pipeline) while pruning has fallen more than the slack behind
                 // its retention target; self-throttles execution under overload.
                 this.state
-                    .pruning_coordinator()
+                    .pruner()
                     .await_leash(checkpoint.timestamp_ms)
                     .await;
                 let pipeline_handle = pipeline_handle.await;
@@ -465,7 +465,7 @@ impl CheckpointExecutor {
         // Nudge the pruner now that this checkpoint is executed and available;
         // pruning of aged-out data runs off the propagation path.
         self.state
-            .pruning_coordinator()
+            .pruner()
             .nudge(ckpt_state.data.checkpoint.sequence_number());
 
         finish_stage!(pipeline_handle, BumpHighestExecutedCheckpoint);

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -267,6 +267,14 @@ impl CheckpointExecutor {
             let this = this.clone();
             let pipeline_handle = pipeline_stages.handle(checkpoint.sequence_number());
             async move {
+                // Leash: apply backpressure so the executed watermark cannot
+                // outrun the pruner unboundedly. Blocks here (before entering the
+                // pipeline) while pruning has fallen more than the slack behind
+                // its retention target; self-throttles execution under overload.
+                this.state
+                    .pruning_coordinator()
+                    .await_leash(checkpoint.timestamp_ms)
+                    .await;
                 let pipeline_handle = pipeline_handle.await;
                 tokio::spawn(this.execute_checkpoint(checkpoint, pipeline_handle))
                     .await
@@ -453,6 +461,12 @@ impl CheckpointExecutor {
         self.bump_highest_executed_checkpoint(&ckpt_state.data.checkpoint);
 
         self.broadcast_checkpoint(&ckpt_state.data, ckpt_state.full_data.as_ref());
+
+        // Nudge the pruner now that this checkpoint is executed and available;
+        // pruning of aged-out data runs off the propagation path.
+        self.state
+            .pruning_coordinator()
+            .nudge(ckpt_state.data.checkpoint.sequence_number());
 
         finish_stage!(pipeline_handle, BumpHighestExecutedCheckpoint);
 

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -271,10 +271,16 @@ impl CheckpointExecutor {
                 // outrun the pruner unboundedly. Blocks here (before entering the
                 // pipeline) while pruning has fallen more than the slack behind
                 // its retention target; self-throttles execution under overload.
-                this.state
-                    .pruner()
-                    .await_leash(checkpoint.timestamp_ms)
-                    .await;
+                let executed_timestamp_ms = this
+                    .checkpoint_store
+                    .get_highest_executed_checkpoint()
+                    .ok()
+                    .flatten()
+                    .map(|checkpoint| checkpoint.timestamp_ms)
+                    .unwrap_or(0);
+
+                this.state.pruner().await_leash(executed_timestamp_ms).await;
+
                 let pipeline_handle = pipeline_handle.await;
                 tokio::spawn(this.execute_checkpoint(checkpoint, pipeline_handle))
                     .await

--- a/crates/iota-e2e-tests/tests/full_node_migration_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_migration_tests.rs
@@ -77,6 +77,10 @@ async fn test_full_node_load_migration_data_with_address_swap() -> Result<(), an
 
     // A new test cluster can be spawn with the stardust object snapshot
     let test_cluster = TestClusterBuilder::new()
+        // The tx response requests full content (balance/object changes), which
+        // reads input objects at their pre-transaction versions; disable pruning
+        // so those versions are not pruned before the response is built.
+        .disable_fullnode_pruning()
         .with_migration_data(vec![snapshot_source])
         .with_delegator(Address::from_str(DELEGATOR).unwrap())
         .build()
@@ -122,6 +126,10 @@ async fn test_full_node_load_migration_data_with_address_swap_split() -> Result<
 
     // A new test cluster can be spawn with the stardust object snapshot
     let test_cluster = TestClusterBuilder::new()
+        // The tx response requests full content (balance/object changes), which
+        // reads input objects at their pre-transaction versions; disable pruning
+        // so those versions are not pruned before the response is built.
+        .disable_fullnode_pruning()
         .with_migration_data(vec![snapshot_source])
         .with_delegator(Address::from_str(DELEGATOR).unwrap())
         .build()

--- a/crates/iota-e2e-tests/tests/full_node_migration_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_migration_tests.rs
@@ -93,7 +93,7 @@ async fn test_full_node_load_migration_data_with_address_swap() -> Result<(), an
 
     // The transaction must be successful
     assert!(confirmed_local_execution.unwrap());
-    assert!(errors.is_empty());
+    assert!(errors.is_empty(), "unexpected tx errors: {errors:?}");
     Ok(())
 }
 

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -379,7 +379,6 @@ async fn test_staking() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
-#[ignore = "https://github.com/iotaledger/iota/issues/5085"]
 async fn test_unstaking() -> Result<(), anyhow::Error> {
     // disable pruning so that we can query the unstaked object after it is deleted
     let cluster = TestClusterBuilder::new()

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -381,7 +381,11 @@ async fn test_staking() -> Result<(), anyhow::Error> {
 #[sim_test]
 #[ignore = "https://github.com/iotaledger/iota/issues/5085"]
 async fn test_unstaking() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await;
+    // disable pruning so that we can query the unstaked object after it is deleted
+    let cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .build()
+        .await;
 
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
@@ -693,7 +697,9 @@ async fn test_timelocked_unstaking() -> Result<(), anyhow::Error> {
         storage_rebate: 0,
     };
 
+    // disable pruning so that we can query the unstaked object after it is deleted
     let cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
         .with_accounts(
             [AccountConfig {
                 address: Some(address),

--- a/crates/iota-proxy/README.md
+++ b/crates/iota-proxy/README.md
@@ -166,8 +166,6 @@ migration-tx-data-path: /opt/iota/config/migration.blob
 # Pruning configuration
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
-  max-checkpoints-in-batch: 10
-  max-transactions-in-batch: 1000
   num-epochs-to-retain: 0
   num-epochs-to-retain-for-checkpoints: 2
   periodic-compaction-threshold-days: 1

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -37,8 +37,6 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       num-epochs-to-retain: 0
-      max-checkpoints-in-batch: 10
-      max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 4
@@ -137,8 +135,6 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       num-epochs-to-retain: 0
-      max-checkpoints-in-batch: 10
-      max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 4
@@ -237,8 +233,6 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       num-epochs-to-retain: 0
-      max-checkpoints-in-batch: 10
-      max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 4
@@ -337,8 +331,6 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       num-epochs-to-retain: 0
-      max-checkpoints-in-batch: 10
-      max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 4
@@ -437,8 +429,6 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       num-epochs-to-retain: 0
-      max-checkpoints-in-batch: 10
-      max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 4
@@ -537,8 +527,6 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       num-epochs-to-retain: 0
-      max-checkpoints-in-batch: 10
-      max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 4
@@ -637,8 +625,6 @@ validator_configs:
     authority-store-pruning-config:
       num-latest-epoch-dbs-to-retain: 3
       num-epochs-to-retain: 0
-      max-checkpoints-in-batch: 10
-      max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
       checkpoint-execution-max-concurrency: 4

--- a/crates/iota-tool/src/db_tool/mod.rs
+++ b/crates/iota-tool/src/db_tool/mod.rs
@@ -341,25 +341,6 @@ pub async fn reset_db_to_genesis(path: &Path) -> anyhow::Result<()> {
     // genesis with: cargo run --package iota-tool -- db-tool --db-path
     // /opt/iota/db/authorities_db/live reset-db Start the iota full node: cargo
     // run --release --bin iota-node -- --config-path ~/db_checkpoints/fullnode.yaml
-    // A sample fullnode.yaml config would be:
-    // ---
-    // db-path:  /opt/iota/db/authorities_db
-    // network-address: /ip4/0.0.0.0/tcp/8080/http
-    // json-rpc-address: "0.0.0.0:9000"
-    // websocket-address: "0.0.0.0:9001"
-    // metrics-address: "0.0.0.0:9184"
-    // admin-interface-address: "127.0.0.1:1337"
-    // grpc-load-shed: ~
-    // grpc-concurrency-limit: ~
-    // p2p-config:
-    //   listen-address: "0.0.0.0:8084"
-    // genesis:
-    //   genesis-file-location:  <path to genesis blob for the network>
-    // authority-store-pruning-config:
-    //   num-latest-epoch-dbs-to-retain: 3
-    //   num-epochs-to-retain: 18446744073709551615
-    //   max-checkpoints-in-batch: 10
-    //   max-transactions-in-batch: 1000
     safe_drop_db(
         path.join("store").join("perpetual"),
         std::time::Duration::from_secs(60),

--- a/dev-tools/iota-network/genesis/static/fullnode.yaml
+++ b/dev-tools/iota-network/genesis/static/fullnode.yaml
@@ -13,9 +13,6 @@ genesis:
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
   num-epochs-to-retain: 18446744073709551615
-  max-checkpoints-in-batch: 5
-  max-transactions-in-batch: 1000
   use-range-deletion: true
-  pruning-run-delay-seconds: 60
 state-debug-dump-config:
   dump-file-directory: /opt/iota/state_debug_dump

--- a/dev-tools/iota-private-network/configs/fullnodes/backup.yaml
+++ b/dev-tools/iota-private-network/configs/fullnodes/backup.yaml
@@ -13,10 +13,7 @@ genesis:
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
   num-epochs-to-retain: 18446744073709551615
-  max-checkpoints-in-batch: 5
-  max-transactions-in-batch: 1000
   use-range-deletion: true
-  pruning-run-delay-seconds: 60
 state-debug-dump-config:
   dump-file-directory: /opt/iota/state_debug_dump
 enable-experimental-rest-api: true

--- a/dev-tools/iota-private-network/configs/fullnodes/fullnode.yaml
+++ b/dev-tools/iota-private-network/configs/fullnodes/fullnode.yaml
@@ -13,10 +13,7 @@ genesis:
 authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
   num-epochs-to-retain: 18446744073709551615
-  max-checkpoints-in-batch: 5
-  max-transactions-in-batch: 1000
   use-range-deletion: true
-  pruning-run-delay-seconds: 60
 state-debug-dump-config:
   dump-file-directory: /opt/iota/state_debug_dump
 enable-experimental-rest-api: true

--- a/docs/content/operator/common/pruning.mdx
+++ b/docs/content/operator/common/pruning.mdx
@@ -77,21 +77,15 @@ authority-store-pruning-config:
   # config). Set to "null" to disable periodic compaction entirely.
   periodic-compaction-threshold-days: 1
 
-  # Maximum checkpoints processed in a single pruning batch (advanced). Default: 10.
-  max-checkpoints-in-batch: 10
-
-  # Maximum transactions processed in a single pruning batch (advanced). Default: 1000.
-  max-transactions-in-batch: 1000
-
   # Use the RocksDB compaction filter for object-table pruning. When disabled,
   # a range-deletion approach is used. Do not toggle frequently — switching
   # back to range deletion may leave some old versions unpruned. Default: false.
   # enable-compaction-filter: false
-
-  # Delay (seconds) between consecutive pruner runs in aggressive mode
-  # (num-epochs-to-retain: 0). Optional. Default: unset.
-  # pruning-run-delay-seconds: null
 ```
+
+Pruning is driven by checkpoint execution: after each executed checkpoint the
+node prunes data that has aged past the retention window, pacing the work
+against on-chain checkpoint timestamps.
 
 ## Set an Archiving Watermark
 


### PR DESCRIPTION
# Description of change

Follow-up to the chain-time pruning cutoff (#12132, already on `develop`). That
change stopped the database from growing unbounded during catch-up sync, but
pruning still ran on a background timer that accumulated ~10s of backlog and then
flushed it in one burst. On a live node each burst saturates the shared RocksDB
instance (cold reads of old checkpoint data, tombstone writes, and the compaction
they trigger on the same column families execution reads), so checkpoint
execution drops to **0 tx/s** for the duration of the burst and resumes once it
ends — the node repeatedly falls behind the network.

This PR makes pruning **execution-driven** so the work is spread evenly instead of
bursting, and adds a backpressure **leash** so on-disk state stays bounded without
a per-run rate cap (which could silently let the database grow under sustained
load).

Key idea: with a chain-time retention window, ~one checkpoint's worth of data ages
out of the window per checkpoint executed — at tip *and* during catch-up. So
pruning a little after every executed checkpoint is naturally rate-matched and
fits within the per-checkpoint slack.

Changes:
- **`PruningCoordinator`** (`authority_store_pruner.rs`): a shared handle with two
  `watch` channels — the executor nudges it after each checkpoint, and the pruner
  publishes a *frontier* = the highest-executed checkpoint timestamp it has caught
  up to on its last completed drain.
- **Pruner**: replaced the timer/`select!` loop with a nudge-driven loop. On each
  nudge it drains objects/checkpoints/indexes **fully** to the chain-time cutoff
  (no per-run cap — full-drain is self-correcting and cannot fall behind), then
  publishes the frontier. The `watch` nudge coalesces many executed checkpoints
  into a single drain. Periodic background compaction is unchanged.
- **Executor** (`checkpoint_executor/mod.rs`): after a checkpoint is executed and
  broadcast, it nudges the pruner (off the propagation path); before scheduling a
  checkpoint it awaits the leash — throttling while execution has run more than
  **1h of chain-time** ahead of the pruner's last completed drain. Uniform for
  validators and full nodes.
- **Config**: removed the now-unused `pruning-run-delay-seconds`,
  `max-checkpoints-in-batch`, and `max-transactions-in-batch` (batch sizes are now
  internal constants; they only bounded `WriteBatch` memory, never total work).
  Deserialization ignores unknown fields, so existing `fullnode.yaml` files with
  these options still load.

### Why the frontier is the executed position, not `pruned + window`

The leash needs a signal for "how far behind is the pruner." An earlier revision
derived it from the pruned watermark (`pruned_ts + retention_window`), but that
**deadlocked** on far-behind nodes: the drain is also bounded by the epoch guard
(the last `num_epochs_to_retain` epochs are never pruned) and `window` uses the
*current* `epoch_duration_ms`, which doesn't match the actual durations of the
*historical* epochs a catching-up node replays. When historical epochs are longer
than the current epoch duration, `pruned_ts + window` sits permanently below
`executed − slack`; the leash never opens, execution stops nudging, the
nudge-driven pruner sleeps, and the whole pipeline freezes (only state-sync keeps
moving).

Publishing the executed timestamp the pruner has drained up to instead makes the
leash measure "how far execution has run ahead of the pruner's last completed
drain" — a real, monotonically advancing value, independent of epoch-duration
variance and the epoch guard. It cannot deadlock (each completed drain lifts the
frontier; nudges buffered during a drain trigger the next drain immediately) and
still bounds disk: the pruner drains to `executed − window` each pass and the
leash keeps `executed − frontier ≤ slack`, so the retained span stays
`≤ window + slack`.

### Behavioral note (throttles on slowness, fails open on errors)

If pruning is merely slow (IO-bound), the drain still completes fully each pass —
it just takes longer — and the leash holds execution within the slack of the
drain's start, so disk stays bounded and the node self-throttles. If pruning
*persistently errors* (a bug, a corrupt store), the frontier still advances (it
tracks the executed position, published regardless of drain success), so execution
keeps going and the DB grows — i.e. it **fails open**, with errors logged loudly.
This is deliberate: it avoids the deadlock above, and fail-open is the safer choice
for liveness. If bounded disk on prune failure is ever required, gate it explicitly
(e.g. halt only after N consecutive errors) rather than by coupling the frontier to
pruned-watermark progress.

## Links to any relevant issues

_No tracked issue. Follow-up to #12132._

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Unit tests cover the coordinator (leash passes within slack, leash blocks until
the frontier advances, nudge wakes the pruner subscription) and the chain-time
cutoff drain (stops at the timestamp cutoff, bounded by the hard ceiling, cutoff
below all, duplicate boundary timestamps, epoch-count guard takes precedence).
`cargo clippy` and `cargo +nightly fmt` are clean; `iota-core`, `iota-config`,
`iota-node`, and `iota-tool` compile.

Note: end-to-end behavior under real epoch progression is best validated by the
sim/e2e pruning suite in CI and a live-node run (verified on a testnet full node
that a far-behind node keeps executing instead of deadlocking).

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Database pruning is now driven by
  checkpoint execution rather than a background timer: after each executed
  checkpoint the node prunes data that has aged past the retention window, pacing
  the work against on-chain checkpoint timestamps so it no longer stalls execution
  in bursts. Execution is throttled if pruning falls behind, keeping on-disk size
  bounded. The `authority-store-pruning-config` options `pruning-run-delay-seconds`,
  `max-checkpoints-in-batch`, and `max-transactions-in-batch` have been removed and
  are safely ignored if still present.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
