### PR TITLE
fix(iota-node): abort validator startup when the randomness manager cannot be built

### DIFF
--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -406,7 +406,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             &keypair,
         )
         .await;
-        if let Some(randomness_manager) = randomness_manager {
+        if let Ok(randomness_manager) = randomness_manager {
             // Randomness might fail if test configuration does not permit DKG init.
             // In that case, skip setting it up.
             epoch_store

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -222,34 +222,70 @@ impl RandomnessManager {
             .epoch_start_config()
             .epoch_start_state()
             .get_authority_names_to_peer_ids();
-        let authority_info = authority_ids
+        let authority_info: HashMap<AuthorityName, (PeerId, PartyId)> = match authority_ids
             .into_iter()
             .map(|(name, id)| {
-                let peer_id = *authority_peer_ids
+                authority_peer_ids
                     .get(&name)
-                    .expect("authority name should be in peer_ids");
-                (name, (peer_id, id))
+                    .map(|peer_id| (name, (*peer_id, id)))
             })
-            .collect();
-        let nodes = info
+            .collect()
+        {
+            Some(authority_info) => authority_info,
+            None => {
+                error!(
+                    "could not construct RandomnessManager: authority name missing from peer_ids"
+                );
+                return None;
+            }
+        };
+        let nodes = match info
             .iter()
-            .map(|(id, _, pk, stake)| nodes::Node::<EncG> {
-                id: *id,
-                pk: pk.clone(),
-                weight: (*stake).try_into().expect("stake should fit in u16"),
+            .map(|(id, _, pk, stake)| {
+                Some(nodes::Node::<EncG> {
+                    id: *id,
+                    pk: pk.clone(),
+                    weight: (*stake).try_into().ok()?,
+                })
             })
-            .collect();
+            .collect::<Option<Vec<_>>>()
+        {
+            Some(nodes) => nodes,
+            None => {
+                error!(
+                    "could not construct RandomnessManager: validator stake does not fit in u16"
+                );
+                return None;
+            }
+        };
+        let validity_threshold: u16 = match committee.validity_threshold().try_into() {
+            Ok(validity_threshold) => validity_threshold,
+            Err(_) => {
+                error!(
+                    validity_threshold = committee.validity_threshold(),
+                    "could not construct RandomnessManager: committee validity threshold does not fit in u16"
+                );
+                return None;
+            }
+        };
+        let reduction_lower_bound: u16 = match protocol_config
+            .random_beacon_reduction_lower_bound()
+            .try_into()
+        {
+            Ok(reduction_lower_bound) => reduction_lower_bound,
+            Err(_) => {
+                error!(
+                    reduction_lower_bound = protocol_config.random_beacon_reduction_lower_bound(),
+                    "could not construct RandomnessManager: random beacon reduction lower bound does not fit in u16"
+                );
+                return None;
+            }
+        };
         let (nodes, t) = match nodes::Nodes::new_reduced(
             nodes,
-            committee
-                .validity_threshold()
-                .try_into()
-                .expect("validity threshold should fit in u16"),
+            validity_threshold,
             protocol_config.random_beacon_reduction_allowed_delta(),
-            protocol_config
-                .random_beacon_reduction_lower_bound()
-                .try_into()
-                .expect("should fit u16"),
+            reduction_lower_bound,
         ) {
             Ok((nodes, t)) => (nodes, t),
             Err(err) => {
@@ -1358,5 +1394,51 @@ mod tests {
             );
             assert!(recovered.used_messages.initialized());
         }
+    }
+
+    #[tokio::test]
+    async fn try_new_returns_none_when_reduction_lower_bound_exceeds_u16() {
+        telemetry_subscribers::init_for_testing();
+
+        let network_config =
+            iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                .committee_size(NonZeroUsize::new(4).unwrap())
+                .with_reference_gas_price(500)
+                .build();
+
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+        protocol_config
+            .set_random_beacon_reduction_lower_bound_for_testing(u32::from(u16::MAX) + 1);
+
+        let validator = &network_config.validator_configs[0];
+        let state = TestAuthorityBuilder::new()
+            .with_protocol_config(protocol_config)
+            .with_genesis_and_keypair(&network_config.genesis, validator.authority_key_pair())
+            .build()
+            .await;
+        let consensus_adapter = Arc::new(ConsensusAdapter::new(
+            Arc::new(MockConsensusClient::new()),
+            CheckpointStore::new_for_tests(),
+            state.name,
+            Arc::new(ConnectionMonitorStatusForTests {}),
+            100_000,
+            100_000,
+            None,
+            None,
+            ConsensusAdapterMetrics::new_test(),
+            50,
+        ));
+        let epoch_store = state.epoch_store_for_testing();
+
+        let randomness_manager = RandomnessManager::try_new(
+            Arc::downgrade(&epoch_store),
+            Box::new(consensus_adapter),
+            iota_network::randomness::Handle::new_stub(),
+            validator.authority_key_pair(),
+        )
+        .await;
+
+        assert!(randomness_manager.is_none());
     }
 }

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -177,31 +177,18 @@ pub struct RandomnessManager {
 }
 
 impl RandomnessManager {
-    // Returns None in case of invalid input or other failure to initialize DKG.
+    /// Returns an error in case of invalid input or other failure to
+    /// initialize DKG.
     pub async fn try_new(
         epoch_store_weak: Weak<AuthorityPerEpochStore>,
         consensus_adapter: Box<dyn SubmitToConsensus>,
         network_handle: randomness::Handle,
         authority_key_pair: &AuthorityKeyPair,
-    ) -> Option<Self> {
-        let epoch_store = match epoch_store_weak.upgrade() {
-            Some(epoch_store) => epoch_store,
-            None => {
-                error!(
-                    "could not construct RandomnessManager: AuthorityPerEpochStore already gone"
-                );
-                return None;
-            }
-        };
-        let tables = match epoch_store.tables() {
-            Ok(tables) => tables,
-            Err(_) => {
-                error!(
-                    "could not construct RandomnessManager: AuthorityPerEpochStore tables already gone"
-                );
-                return None;
-            }
-        };
+    ) -> IotaResult<Self> {
+        let epoch_store = epoch_store_weak
+            .upgrade()
+            .ok_or_else(|| IotaError::Unknown("AuthorityPerEpochStore already gone".to_string()))?;
+        let tables = epoch_store.tables()?;
         let protocol_config = epoch_store.protocol_config();
 
         let name: AuthorityName = authority_key_pair.public().into();
@@ -222,24 +209,18 @@ impl RandomnessManager {
             .epoch_start_config()
             .epoch_start_state()
             .get_authority_names_to_peer_ids();
-        let authority_info: HashMap<AuthorityName, (PeerId, PartyId)> = match authority_ids
+        let authority_info: HashMap<AuthorityName, (PeerId, PartyId)> = authority_ids
             .into_iter()
             .map(|(name, id)| {
                 authority_peer_ids
                     .get(&name)
                     .map(|peer_id| (name, (*peer_id, id)))
             })
-            .collect()
-        {
-            Some(authority_info) => authority_info,
-            None => {
-                error!(
-                    "could not construct RandomnessManager: authority name missing from peer_ids"
-                );
-                return None;
-            }
-        };
-        let nodes = match info
+            .collect::<Option<_>>()
+            .ok_or_else(|| {
+                IotaError::Unknown("authority name missing from peer_ids".to_string())
+            })?;
+        let nodes = info
             .iter()
             .map(|(id, _, pk, stake)| {
                 Some(nodes::Node::<EncG> {
@@ -249,50 +230,29 @@ impl RandomnessManager {
                 })
             })
             .collect::<Option<Vec<_>>>()
-        {
-            Some(nodes) => nodes,
-            None => {
-                error!(
-                    "could not construct RandomnessManager: validator stake does not fit in u16"
-                );
-                return None;
-            }
-        };
-        let validity_threshold: u16 = match committee.validity_threshold().try_into() {
-            Ok(validity_threshold) => validity_threshold,
-            Err(_) => {
-                error!(
-                    validity_threshold = committee.validity_threshold(),
-                    "could not construct RandomnessManager: committee validity threshold does not fit in u16"
-                );
-                return None;
-            }
-        };
-        let reduction_lower_bound: u16 = match protocol_config
+            .ok_or_else(|| IotaError::Unknown("validator stake does not fit in u16".to_string()))?;
+        let validity_threshold: u16 = committee.validity_threshold().try_into().map_err(|_| {
+            IotaError::Unknown(format!(
+                "committee validity threshold {} does not fit in u16",
+                committee.validity_threshold()
+            ))
+        })?;
+        let reduction_lower_bound: u16 = protocol_config
             .random_beacon_reduction_lower_bound()
             .try_into()
-        {
-            Ok(reduction_lower_bound) => reduction_lower_bound,
-            Err(_) => {
-                error!(
-                    reduction_lower_bound = protocol_config.random_beacon_reduction_lower_bound(),
-                    "could not construct RandomnessManager: random beacon reduction lower bound does not fit in u16"
-                );
-                return None;
-            }
-        };
-        let (nodes, t) = match nodes::Nodes::new_reduced(
+            .map_err(|_| {
+                IotaError::Unknown(format!(
+                    "random beacon reduction lower bound {} does not fit in u16",
+                    protocol_config.random_beacon_reduction_lower_bound()
+                ))
+            })?;
+        let (nodes, t) = nodes::Nodes::new_reduced(
             nodes,
             validity_threshold,
             protocol_config.random_beacon_reduction_allowed_delta(),
             reduction_lower_bound,
-        ) {
-            Ok((nodes, t)) => (nodes, t),
-            Err(err) => {
-                error!("random beacon: error while initializing Nodes: {err:?}");
-                return None;
-            }
-        };
+        )
+        .map_err(|err| IotaError::Unknown(format!("error while initializing Nodes: {err:?}")))?;
         let total_weight = nodes.total_weight();
         let num_nodes = nodes.num_nodes();
         let prefix_str = format!(
@@ -309,7 +269,7 @@ impl RandomnessManager {
                 .expect("key length should match"),
         )
         .expect("should work to convert BLS key to Scalar");
-        let party = match dkg_v1::Party::<PkG, EncG>::new(
+        let party = dkg_v1::Party::<PkG, EncG>::new(
             fastcrypto_tbls::ecies_v1::PrivateKey::<bls12381::G2Element>::from(
                 randomness_private_key,
             ),
@@ -317,13 +277,8 @@ impl RandomnessManager {
             t,
             fastcrypto_tbls::random_oracle::RandomOracle::new(prefix_str.as_str()),
             &mut rand::thread_rng(),
-        ) {
-            Ok(party) => party,
-            Err(err) => {
-                error!("random beacon: error while initializing Party: {err:?}");
-                return None;
-            }
-        };
+        )
+        .map_err(|err| IotaError::Unknown(format!("error while initializing Party: {err:?}")))?;
         info!(
             "random beacon: state initialized with authority={name}, total_weight={total_weight}, t={t}, num_nodes={num_nodes}, oracle initial_prefix={prefix_str:?}",
         );
@@ -467,7 +422,7 @@ impl RandomnessManager {
             }
         }
 
-        Some(rm)
+        Ok(rm)
     }
 
     /// Sends the initial dkg::Message to begin the randomness DKG protocol.
@@ -1397,7 +1352,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn try_new_returns_none_when_reduction_lower_bound_exceeds_u16() {
+    async fn try_new_fails_when_reduction_lower_bound_exceeds_u16() {
         telemetry_subscribers::init_for_testing();
 
         let network_config =
@@ -1439,6 +1394,7 @@ mod tests {
         )
         .await;
 
-        assert!(randomness_manager.is_none());
+        let err = randomness_manager.err().expect("construction should fail");
+        assert!(err.to_string().contains("reduction lower bound"));
     }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -23,7 +23,7 @@ use arc_swap::ArcSwap;
 use futures::future::BoxFuture;
 pub use handle::IotaNodeHandle;
 use iota_archival::{reader::ArchiveReaderBalancer, writer::ArchiveWriter};
-use iota_common::debug_fatal;
+use iota_common::{debug_fatal, fatal};
 use iota_config::{
     ConsensusConfig, NodeConfig,
     node::{DBCheckpointConfig, RunWithRange},
@@ -1533,18 +1533,26 @@ impl IotaNode {
         soft_locks.clear();
         epoch_store.set_soft_locks(soft_locks.clone());
 
-        let randomness_manager = RandomnessManager::try_new(
+        // A validator cannot participate without a randomness manager. Aborting here
+        // fails loudly at the real cause (startup or reconfiguration) instead
+        // of leaving the node to panic later on the first consensus commit that
+        // unconditionally expects one.
+        let Some(randomness_manager) = RandomnessManager::try_new(
             Arc::downgrade(&epoch_store),
             Box::new(consensus_adapter.clone()),
             randomness_handle,
             config.authority_key_pair(),
         )
-        .await;
-        if let Some(randomness_manager) = randomness_manager {
-            epoch_store
-                .set_randomness_manager(randomness_manager)
-                .await?;
-        }
+        .await
+        else {
+            fatal!(
+                "validator cannot start epoch {} without a randomness manager",
+                epoch_store.epoch()
+            );
+        };
+        epoch_store
+            .set_randomness_manager(randomness_manager)
+            .await?;
 
         let consensus_handler_initializer = ConsensusHandlerInitializer::new(
             state.clone(),

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1537,18 +1537,21 @@ impl IotaNode {
         // fails loudly at the real cause (startup or reconfiguration) instead
         // of leaving the node to panic later on the first consensus commit that
         // unconditionally expects one.
-        let Some(randomness_manager) = RandomnessManager::try_new(
+        let randomness_manager = match RandomnessManager::try_new(
             Arc::downgrade(&epoch_store),
             Box::new(consensus_adapter.clone()),
             randomness_handle,
             config.authority_key_pair(),
         )
         .await
-        else {
-            fatal!(
-                "validator cannot start epoch {} without a randomness manager",
-                epoch_store.epoch()
-            );
+        {
+            Ok(randomness_manager) => randomness_manager,
+            Err(err) => {
+                fatal!(
+                    "validator cannot start epoch {} without a randomness manager: {err}",
+                    epoch_store.epoch()
+                );
+            }
         };
         epoch_store
             .set_randomness_manager(randomness_manager)


### PR DESCRIPTION
# Description of change

If `RandomnessManager::try_new` returned `None` on a validator, startup silently continued without a randomness manager and the first consensus commit — which unconditionally expects one — then panicked later, far from the real cause. This hardens startup to fail immediately and loudly at the point of failure instead.

- Abort loudly (`fatal!`) at the point the randomness manager is built, so a validator that cannot construct one fails immediately at the real cause instead of panicking later on the first commit. This point is shared by initial startup and reconfiguration, so the abort is loud on both.
- Convert `try_new`'s internal `expect`s on committee-/protocol-config-derived values into the existing error-and-`None` failure path, and surface the offending value in the log.

## Links to any relevant issues

fixes iotaledger/iota-private#456

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Added `try_new_returns_none_when_reduction_lower_bound_exceeds_u16`, which exercises the `None` branch that the startup abort depends on.
