### PR TITLE
chore(indexer): Remove `--epochs-to-keep` CLI arg

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -6,7 +6,7 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use iota_graphql_rpc_client::simple_client::SimpleClient;
 use iota_indexer::{
-    config::PruningOptions,
+    config::RetentionConfig,
     errors::IndexerError,
     store::PgIndexerStore,
     test_utils::{IndexerTypeConfig, force_delete_database, start_test_indexer_impl},
@@ -137,10 +137,9 @@ pub async fn serve_executor(
         true,
         None,
         format!("http://{executor_server_url}"),
-        IndexerTypeConfig::writer_mode(Some(PruningOptions {
-            epochs_to_keep,
-            ..Default::default()
-        })),
+        IndexerTypeConfig::writer_mode_with_retention(
+            epochs_to_keep.map(|epochs| RetentionConfig::new(epochs, Default::default())),
+        ),
         Some(data_ingestion_path),
         cancellation_token.clone(),
     )

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -116,8 +116,6 @@ tx_senders = 3
 > [!NOTE]
 > All retention values must be greater than 0.
 
-The legacy `--epochs-to-keep` CLI argument is still supported but deprecated, and will be removed in v1.28.0. If both `--pruning-config-path` and `--epochs-to-keep` are provided, the config file takes precedence.
-
 #### Default behavior
 
 - If no pruning configuration is provided, pruning is disabled.

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -10,7 +10,6 @@ use iota_names::config::IotaNamesConfig;
 use iota_sdk_types::{Address, ObjectId};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
-use tracing::warn;
 use url::Url;
 
 use crate::{
@@ -304,10 +303,6 @@ pub const DEFAULT_PRUNING_BATCH_SIZE: u64 = 1000;
 
 #[derive(Args, Debug, Clone)]
 pub struct PruningOptions {
-    /// DEPRECATED: will be removed in v1.28.0. Use `--pruning-config-path`
-    /// pointing at a TOML retention config instead.
-    #[arg(long, env = "EPOCHS_TO_KEEP")]
-    pub epochs_to_keep: Option<u64>,
     /// Path to TOML file containing configuration for retention policies.
     #[arg(long)]
     pub pruning_config_path: Option<PathBuf>,
@@ -335,7 +330,6 @@ pub struct PruningOptions {
 impl Default for PruningOptions {
     fn default() -> Self {
         Self {
-            epochs_to_keep: None,
             pruning_config_path: None,
             pruning_delay_ms: DEFAULT_PRUNING_DELAY_MS,
             pruning_batch_size: DEFAULT_PRUNING_BATCH_SIZE,
@@ -361,25 +355,7 @@ impl PruningOptions {
     /// Loads default retention policy and overrides from file.
     pub fn load_from_file(&self) -> IndexerResult<Option<RetentionConfig>> {
         let Some(config_path) = self.pruning_config_path.as_ref() else {
-            let Some(epochs_to_keep) = self.epochs_to_keep else {
-                return Ok(None);
-            };
-            warn!(
-                "using the deprecated --epochs-to-keep argument for pruning configuration. \
-                 This argument will be removed in v1.28.0. \
-                 Please use --pruning-config-path to specify a TOML configuration file instead."
-            );
-            return Ok(Some(RetentionConfig::new(
-                epochs_to_keep,
-                Default::default(),
-            )));
-        };
-
-        if self.epochs_to_keep.is_some() {
-            warn!(
-                "the --epochs-to-keep argument will be ignored since --pruning-config-path is also provided. \
-                 Note that --epochs-to-keep is deprecated and will be removed in v1.28.0."
-            );
+            return Ok(None);
         };
 
         let contents = std::fs::read_to_string(config_path)

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -13,7 +13,10 @@ use url::Url;
 
 use crate::{
     IndexerMetrics,
-    config::{IngestionConfig, IotaNamesOptions, PruningOptions, RetentionConfig},
+    config::{
+        DEFAULT_PRUNING_BATCH_SIZE, IngestionConfig, IotaNamesOptions, PruningOptions,
+        RetentionConfig,
+    },
     db::{ConnectionPool, ConnectionPoolConfig, PoolConnection, new_connection_pool},
     errors::IndexerError,
     indexer::Indexer,
@@ -88,6 +91,16 @@ impl IndexerTypeConfig {
                 .expect("failed to load the indexer retention configuration"),
             pruning_delay_ms: TEST_PRUNING_DELAY_MS,
             pruning_batch_size: opts.pruning_batch_size,
+        }
+    }
+
+    /// Writer mode with the retention config given directly, instead of loaded
+    /// from a TOML file via [`PruningOptions`].
+    pub fn writer_mode_with_retention(retention_config: Option<RetentionConfig>) -> Self {
+        Self::Writer {
+            retention_config,
+            pruning_delay_ms: TEST_PRUNING_DELAY_MS,
+            pruning_batch_size: DEFAULT_PRUNING_BATCH_SIZE,
         }
     }
 }

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -20,7 +20,7 @@ use fastcrypto::traits::Signer;
 use iota_config::local_ip_utils::{get_available_port, new_local_tcp_socket_for_testing};
 use iota_grpc_server::GrpcServerHandle;
 use iota_indexer::{
-    config::{IotaNamesOptions, JsonRpcConfig, PruningOptions},
+    config::{IotaNamesOptions, JsonRpcConfig, RetentionConfig},
     db::{ConnectionPoolConfig, new_connection_pool},
     errors::IndexerError,
     indexer::Indexer,
@@ -140,11 +140,11 @@ impl SimulacrumTestSetup {
 }
 
 /// Start a [`TestCluster`][`test_cluster::TestCluster`] with a `Read` &
-/// `Write` indexer. Set `epochs_to_keep` (> 0) to enable indexer pruning.
+/// `Write` indexer. Pass a `retention_config` to enable indexer pruning.
 pub async fn start_test_cluster_with_read_write_indexer(
     database_name: impl Into<Option<&str>>,
     builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
-    pruning_options: Option<PruningOptions>,
+    retention_config: Option<RetentionConfig>,
 ) -> (TestCluster, PgIndexerStore, HttpClient) {
     let database_name = database_name.into();
     let mut builder = TestClusterBuilder::new().with_fullnode_enable_grpc_api(true);
@@ -162,7 +162,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
         true,
         None,
         cluster.grpc_url(),
-        IndexerTypeConfig::writer_mode(pruning_options),
+        IndexerTypeConfig::writer_mode_with_retention(retention_config),
         None,
     )
     .await;

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -5,7 +5,7 @@ use std::{fs::File, path::Path, str::FromStr, sync::Arc};
 
 use hex::FromHex;
 use iota_indexer::{
-    config::PruningOptions,
+    config::RetentionConfig,
     models::transactions::StoredTransaction,
     store::{PgIndexerStore, package_resolver::IndexerStorePackageResolver},
     test_utils::{TestDatabase, db_url},
@@ -1975,10 +1975,7 @@ fn get_chain_identifier_with_pruning_enabled() {
         let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
             Some("test_get_chain_identifier_with_pruning_enabled"),
             None,
-            Some(PruningOptions {
-                epochs_to_keep: Some(1),
-                ..Default::default()
-            }),
+            Some(RetentionConfig::new(1, Default::default())),
         )
         .await;
 

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -7,7 +7,7 @@ use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl};
 use fastcrypto::encoding::Base64;
 use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
 use iota_indexer::{
-    config::PruningOptions, errors::IndexerError, read_only_blocking, schema::objects,
+    config::RetentionConfig, errors::IndexerError, read_only_blocking, schema::objects,
     store::indexer_store::IndexerStore, types::IndexerResult,
 };
 use iota_json::{call_arg, call_args, type_args};
@@ -999,10 +999,7 @@ async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
     let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
         Some("test_optimistic_tables_pruning"),
         None,
-        Some(PruningOptions {
-            epochs_to_keep: Some(1),
-            ..Default::default()
-        }),
+        Some(RetentionConfig::new(1, Default::default())),
     )
     .await;
     indexer_wait_for_checkpoint(store, 1).await;


### PR DESCRIPTION
# Description of change

Remove `--epochs-to-keep` CLI arg

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11693

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: the deprecated `--epochs-to-keep` CLI arg and `EPOCHS_TO_KEEP` env var were removed. Use `--pruning-config-path` with `epochs_to_keep` set in the TOML config file instead.

#### Breaking Changes Rollout

Affected Crates:

- iota-indexer
- iota-localnet 
- 
Required User Actions: Switch from using `--epochs-to-keep` CLI arg to the `--pruning-config-path`.

