### PR TITLE
feat(starfish): enable consensus gRPC protective limits by default

### DIFF
--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -130,16 +130,18 @@ impl ConsensusManagerTrait for StarfishManager {
             .find(|(_, a)| a.protocol_key == own_protocol_key)
             .expect("Own authority should be among the consensus authorities!");
 
-        // Opt into the protective consensus gRPC resource limits via an
-        // environment variable, for gradual rollout on a subset of validators
-        // without changing the default (inert) behaviour.
+        // Apply the protective consensus gRPC resource limits by default. A node
+        // can opt out via the environment variable without a redeploy; these are
+        // local operational parameters, so heterogeneous values across validators
+        // are safe.
         let parameters = {
             let mut p = parameters;
             if matches!(
                 std::env::var("CONSENSUS_GRPC_PROTECTIVE_LIMITS").as_deref(),
-                Ok("1") | Ok("true")
+                Ok("0") | Ok("false")
             ) {
-                info!("Applying protective consensus gRPC limits for validator {own_index}");
+                info!("Consensus gRPC protective limits disabled for validator {own_index}");
+            } else {
                 p.tonic.apply_protective();
             }
             p

--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -130,10 +130,11 @@ impl ConsensusManagerTrait for StarfishManager {
             .find(|(_, a)| a.protocol_key == own_protocol_key)
             .expect("Own authority should be among the consensus authorities!");
 
-        // Apply the protective consensus gRPC resource limits by default. A node
-        // can opt out via the environment variable without a redeploy; these are
-        // local operational parameters, so heterogeneous values across validators
-        // are safe.
+        // Apply the protective consensus gRPC resource limits by default,
+        // filling only the bounds left unconfigured so explicit node config is
+        // respected. A node can opt out via the environment variable without a
+        // redeploy; these are local operational parameters, so heterogeneous
+        // values across validators are safe.
         let parameters = {
             let mut p = parameters;
             if matches!(

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -535,16 +535,26 @@ impl TonicParameters {
         64 << 20
     }
 
-    /// Overrides only the inbound resource bounds with the protective preset
-    /// (sized for ~100-validator committees), preserving any
-    /// operator-configured transport settings (keepalive, buffers,
-    /// `message_size_limit`). `default()` stays inert, so the bounds never
-    /// change behaviour unless explicitly enabled.
+    /// Fills the inbound resource bounds that are still at their inert
+    /// defaults with the protective preset (sized for ~100-validator
+    /// committees). Bounds an operator configured explicitly are kept, as are
+    /// the transport settings the preset does not cover (keepalive, buffers,
+    /// `message_size_limit`). A bound explicitly configured to its inert value
+    /// still receives the preset; running without a bound requires disabling
+    /// the preset itself (`CONSENSUS_GRPC_PROTECTIVE_LIMITS=0`).
     pub fn apply_protective(&mut self) {
-        self.max_concurrent_streams = 64;
-        self.request_timeout = Duration::from_secs(120);
-        self.max_inbound_message_size = 1 << 20;
-        self.admission = AdmissionParameters::protective();
+        if self.max_concurrent_streams == 0 {
+            self.max_concurrent_streams = 64;
+        }
+        if self.request_timeout.is_zero() {
+            self.request_timeout = Duration::from_secs(120);
+        }
+        if self.max_inbound_message_size == 0 {
+            self.max_inbound_message_size = 1 << 20;
+        }
+        if self.admission.is_inert() {
+            self.admission = AdmissionParameters::protective();
+        }
     }
 
     /// The inert defaults with the protective bounds applied.
@@ -578,11 +588,13 @@ impl Default for TonicParameters {
 /// non-protocol parameters — heterogeneous values across authorities are safe,
 /// so they can be rolled out and tuned per node.
 ///
-/// `0` (the default for every cap) disables admission for that group, leaving
-/// the mechanism inert until an operator opts in. Recommended values for the
-/// opt-in protective preset, sized for ~100-validator committees and the local
-/// synchronizer fan-out toward one server: subscriptions 2, header fetches 32,
-/// transaction fetches 16, commit fetches `commit_sync_parallel_fetches` (8).
+/// `0` (the default for every cap) disables admission for that group. At node
+/// start the protective preset fills the caps when all of them are left at
+/// `0`; a caps block with any explicitly configured value is kept as-is, and
+/// `CONSENSUS_GRPC_PROTECTIVE_LIMITS=0` disables the preset entirely. Preset
+/// values, sized for ~100-validator committees and the local synchronizer
+/// fan-out toward one server: subscriptions 2, header fetches 32, transaction
+/// fetches 16, commit fetches `commit_sync_parallel_fetches` (8).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AdmissionParameters {
     /// Max concurrent block-subscription streams per peer.
@@ -605,8 +617,8 @@ pub struct AdmissionParameters {
 }
 
 impl AdmissionParameters {
-    /// Opt-in preset sized for ~100-validator committees and the local
-    /// synchronizer fan-out toward one server.
+    /// Preset sized for ~100-validator committees and the local synchronizer
+    /// fan-out toward one server.
     pub fn protective() -> Self {
         Self {
             max_subscriptions_per_peer: 2,
@@ -614,5 +626,13 @@ impl AdmissionParameters {
             max_transaction_fetches_per_peer: 16,
             max_commit_fetches_per_peer: Parameters::default_commit_sync_parallel_fetches() as u32,
         }
+    }
+
+    /// True when every cap is `0`, i.e. admission control is disabled.
+    pub fn is_inert(&self) -> bool {
+        self.max_subscriptions_per_peer == 0
+            && self.max_header_fetches_per_peer == 0
+            && self.max_transaction_fetches_per_peer == 0
+            && self.max_commit_fetches_per_peer == 0
     }
 }

--- a/crates/starfish/config/tests/parameters_test.rs
+++ b/crates/starfish/config/tests/parameters_test.rs
@@ -23,7 +23,7 @@ fn protective_preset_enables_bounds_and_default_stays_inert() {
     assert_eq!(protective.admission.max_transaction_fetches_per_peer, 16);
     assert!(protective.admission.max_commit_fetches_per_peer > 0);
 
-    // The default must stay inert so behaviour is unchanged unless opted in.
+    // The config defaults stay inert; the preset is applied at node start.
     let inert = starfish_config::TonicParameters::default();
     assert_eq!(inert.max_concurrent_streams, 0);
     assert!(inert.request_timeout.is_zero());
@@ -33,7 +33,7 @@ fn protective_preset_enables_bounds_and_default_stays_inert() {
 
 #[test]
 fn apply_protective_preserves_operator_transport_fields() {
-    // Operator-customised transport settings that must survive opting in.
+    // Operator-customised transport settings that must survive the preset.
     let mut tonic = starfish_config::TonicParameters {
         keepalive_interval: std::time::Duration::from_secs(11),
         connection_buffer_size: 9 << 20,
@@ -53,6 +53,31 @@ fn apply_protective_preserves_operator_transport_fields() {
     assert_eq!(tonic.connection_buffer_size, 9 << 20);
     assert_eq!(tonic.excessive_message_size, 5 << 20);
     assert_eq!(tonic.message_size_limit, 7 << 20);
+}
+
+#[test]
+fn apply_protective_preserves_operator_set_bounds() {
+    let mut tonic = starfish_config::TonicParameters {
+        max_concurrent_streams: 128,
+        request_timeout: std::time::Duration::from_secs(30),
+        max_inbound_message_size: 4 << 20,
+        admission: starfish_config::AdmissionParameters {
+            max_header_fetches_per_peer: 5,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    tonic.apply_protective();
+
+    // Explicitly configured bounds win over the preset.
+    assert_eq!(tonic.max_concurrent_streams, 128);
+    assert_eq!(tonic.request_timeout, std::time::Duration::from_secs(30));
+    assert_eq!(tonic.max_inbound_message_size, 4 << 20);
+    // An admission block with any explicitly configured cap is kept as-is,
+    // not mixed with preset values.
+    assert_eq!(tonic.admission.max_header_fetches_per_peer, 5);
+    assert_eq!(tonic.admission.max_subscriptions_per_peer, 0);
 }
 
 #[test]


### PR DESCRIPTION
# Description of change

After testing on the Testnet, we promote the consensus gRPC per-peer admission control and inbound resource bounds (added in #11970) from opt-in to on-by-default.

- The protective preset is now applied by default in the consensus manager.
- `CONSENSUS_GRPC_PROTECTIVE_LIMITS` becomes an opt-out: setting it to `0`/`false` disables the bounds so a node can roll back in the field without a redeploy.
- Local operational parameters only — no protocol version bump, and heterogeneous values across validators remain safe. The type-level default and the parameters snapshot are unchanged.

## Links to any relevant issues

Fixes #12198

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Validators now apply the consensus gRPC per-peer admission control and inbound resource bounds by default (full nodes are unaffected — they run no consensus server). Set `CONSENSUS_GRPC_PROTECTIVE_LIMITS=0` (or `false`) to opt out.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:


