### PR TITLE
fix(core): keep host probes and rocksdb waits off the simulated schedule

### DIFF
--- a/crates/iota-metrics/src/hardware_metrics.rs
+++ b/crates/iota-metrics/src/hardware_metrics.rs
@@ -32,13 +32,24 @@ pub fn register_hardware_metrics(
     registry_service: &RegistryService,
     db_path: &Path,
 ) -> Result<(), HardwareMetricsErr> {
-    let registry = Registry::new_custom(Some("hw".to_string()), None)
-        .map_err(HardwareMetricsErr::ErrRegisterHardwareMetrics)?;
-    registry
-        .register(Box::new(HardwareMetrics::new(db_path)?))
-        .map_err(HardwareMetricsErr::ErrRegisterHardwareMetrics)?;
-    registry_service.add(registry);
-    Ok(())
+    // In the simulator these metrics would describe the host, not the simulated
+    // node, and sysinfo's refreshes run on the test thread where the intercepted
+    // clock and rng make them a source of non-determinism. Skip them entirely.
+    #[cfg(msim)]
+    {
+        let _ = (registry_service, db_path);
+        return Ok(());
+    }
+    #[cfg(not(msim))]
+    {
+        let registry = Registry::new_custom(Some("hw".to_string()), None)
+            .map_err(HardwareMetricsErr::ErrRegisterHardwareMetrics)?;
+        registry
+            .register(Box::new(HardwareMetrics::new(db_path)?))
+            .map_err(HardwareMetricsErr::ErrRegisterHardwareMetrics)?;
+        registry_service.add(registry);
+        Ok(())
+    }
 }
 
 pub struct HardwareMetrics {

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -12,7 +12,7 @@ use std::{
 
 use fastcrypto::hash::{Digest, HashFunction};
 use iota_common::debug_fatal;
-use iota_macros::fail_point;
+use iota_macros::{fail_point, nondeterministic};
 use prometheus_filtered::{Histogram, HistogramTimer};
 use rocksdb::{DBPinnableSlice, Error, LiveFile, ReadOptions, WriteBatch, checkpoint::Checkpoint};
 use serde::{Serialize, de::DeserializeOwned};
@@ -314,7 +314,11 @@ impl Database {
     /// Flush the memtable of a single column family to SST files on disk.
     pub(crate) fn flush_cf(&self, cf: &ColumnFamily) -> Result<(), TypedStoreError> {
         match &self.storage {
-            Storage::Rocks(rocks) => {
+            // A flush blocks on RocksDB background threads; under the simulator it
+            // must run off the test thread, like the opens in `rocks/mod.rs`, or
+            // real flush durations leak into the simulated schedule. No-op outside
+            // msim.
+            Storage::Rocks(rocks) => nondeterministic!({
                 let cf_name = cf.name();
                 if let Some(handle) = rocks.underlying.cf_handle(cf_name) {
                     rocks.underlying.flush_cf(&handle).map_err(|e| {
@@ -324,7 +328,7 @@ impl Database {
                     })?;
                 }
                 Ok(())
-            }
+            }),
             // InMemory databases don't need flushing.
             Storage::InMemory(_) => Ok(()),
         }
@@ -334,7 +338,9 @@ impl Database {
     /// family to SST files on disk.
     pub fn flush_all(&self) -> Result<(), TypedStoreError> {
         match &self.storage {
-            Storage::Rocks(rocks) => {
+            // See `flush_cf` for why the flushes run off the test thread under
+            // the simulator.
+            Storage::Rocks(rocks) => nondeterministic!({
                 for cf_name in &rocks.cf_names {
                     if let Some(cf) = rocks.underlying.cf_handle(cf_name) {
                         rocks.underlying.flush_cf(&cf).map_err(|e| {
@@ -345,7 +351,7 @@ impl Database {
                     }
                 }
                 Ok(())
-            }
+            }),
             // InMemory databases don't need flushing.
             Storage::InMemory(_) => Ok(()),
         }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -217,6 +217,31 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
 }
 
 // Drops a database if there is no other handle to it, with retries and timeout.
+#[cfg(msim)]
+pub async fn safe_drop_db(path: PathBuf, timeout: Duration) -> Result<(), rocksdb::Error> {
+    // The destroy fails until rocksdb's background threads release the file
+    // lock, which happens on the real clock. Retrying on the simulated clock
+    // would consume a machine-load-dependent amount of simulated time (and rng,
+    // through the backoff jitter), breaking simtest determinism, so retry on a
+    // real thread with real sleeps instead.
+    nondeterministic!({
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            match rocksdb::DB::destroy(&rocksdb::Options::default(), path.clone()) {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(err);
+                    }
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            }
+        }
+    })
+}
+
+// Drops a database if there is no other handle to it, with retries and timeout.
+#[cfg(not(msim))]
 pub async fn safe_drop_db(path: PathBuf, timeout: Duration) -> Result<(), rocksdb::Error> {
     let mut backoff = backoff::ExponentialBackoff {
         max_elapsed_time: Some(timeout),

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -4,6 +4,7 @@
 
 use std::{collections::BTreeMap, env};
 
+use iota_macros::nondeterministic;
 use rocksdb::{BlockBasedOptions, Cache, ReadOptions};
 use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 use tap::TapFallible;
@@ -157,27 +158,32 @@ pub fn bulk_ingestion_options() -> BulkIngestionOptions {
 /// Available memory in bytes, honoring cgroup limits in containerized
 /// environments and falling back to total system memory.
 fn available_memory_bytes() -> u64 {
-    // `RefreshKind::nothing().with_memory(..)` avoids collecting other, slower
-    // stats.
-    let mut sys = System::new_with_specifics(
-        RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
-    );
-    sys.refresh_memory();
+    // Under the simulator sysinfo must run off the test thread, where the
+    // intercepted clock and rng would make its probes a source of
+    // non-determinism. No-op outside msim.
+    nondeterministic!({
+        // `RefreshKind::nothing().with_memory(..)` avoids collecting other,
+        // slower stats.
+        let mut sys = System::new_with_specifics(
+            RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
+        );
+        sys.refresh_memory();
 
-    if let Some(cgroup_limits) = sys.cgroup_limits() {
-        // `total_memory` is 0 when there is no cgroup limit.
-        if cgroup_limits.total_memory > 0 {
-            debug!(
-                limit = cgroup_limits.total_memory,
-                "using cgroup memory limit"
-            );
-            return cgroup_limits.total_memory;
+        if let Some(cgroup_limits) = sys.cgroup_limits() {
+            // `total_memory` is 0 when there is no cgroup limit.
+            if cgroup_limits.total_memory > 0 {
+                debug!(
+                    limit = cgroup_limits.total_memory,
+                    "using cgroup memory limit"
+                );
+                return cgroup_limits.total_memory;
+            }
         }
-    }
 
-    let total = sys.total_memory();
-    debug!(total, "using total system memory");
-    total
+        let total = sys.total_memory();
+        debug!(total, "using total system memory");
+        total
+    })
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
# Description of change

Since the sysinfo 0.39 bump in #12001, the simtest determinism check (run nightly by the network-benchmark repo; the monorepo CI does not run it) has failed every night with mass `non-determinism detected` panics ~10 ms into simulated time. sysinfo 0.39 dropped its worker-thread refresh model, so hardware-metrics registration — which runs at every simulated node start — now probes the host on the simulator's test thread, where the intercepted clock and rng make the probe a machine-load-dependent schedule perturbation. The failure reproduces only under parallel test load, which is why it shows on CI runners but not on idle machines or macOS.

- Skip `register_hardware_metrics` under msim: the values would describe the host, not the simulated node, and the prometheus collector re-probes on every gather.
- Run typed-store's sysinfo memory probe, the rocksdb `flush_cf`/`flush_all`, and the `safe_drop_db` retry loop off the test thread via `nondeterministic!` — same class of hazard, following the existing pattern for rocksdb opens (#12062) and `tempdir()` (#10149).

Production (non-msim) behavior is unchanged: `nondeterministic!` is a no-op outside the simulator and the `cfg(not(msim))` paths are the original code.

Root cause was isolated by bisecting `4a46887e..eae81ed3` under a load-parallel determinism harness and then splitting #12001: its parent plus only the sysinfo bump reproduces the CI failure signature exactly (8 failed + 9 flaky of 23).

## Links to any relevant issues

Nightly simtest failures in network-benchmark since 2026-07-03.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

