### PR TITLE
feat(node): Add admin endpoint for Prometheus metrics filter

### DIFF
--- a/crates/iota-config/data/fullnode-template.yaml
+++ b/crates/iota-config/data/fullnode-template.yaml
@@ -40,6 +40,6 @@ authority-store-pruning-config:
 #     epoch: warn
 #     runtime: warn
 #     hardware: warn
-#     # free-form overrides for modules/metrics not covered by a group:
+#     # free-form overrides for modules/metrics:
 #     overrides:
 #       "iota_core::checkpoints": trace

--- a/crates/iota-config/data/fullnode-template.yaml
+++ b/crates/iota-config/data/fullnode-template.yaml
@@ -39,4 +39,7 @@ authority-store-pruning-config:
 #     rpc: warn
 #     epoch: warn
 #     runtime: warn
-#     hardware: warn # set to `off` to disable hardware metrics; takes effect at startup only
+#     hardware: warn
+#     # free-form overrides for modules/metrics not covered by a group:
+#     overrides:
+#       "iota_core::checkpoints": trace

--- a/crates/iota-metrics/src/hardware_metrics.rs
+++ b/crates/iota-metrics/src/hardware_metrics.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use prometheus_filtered::{
-    Filter, IntGauge, MetricLevel, Opts,
+    IntGauge, MetricLevel, Opts,
     core::{Collector, Desc, Number},
     proto::{LabelPair, Metric, MetricFamily, MetricType},
 };
@@ -24,16 +24,12 @@ pub enum HardwareMetricsErr {
     ErrRegisterHardwareMetrics(prometheus_filtered::Error),
 }
 
-/// Returns whether the hardware metrics should be registered under `filter`:
-/// any effective level for this module except `off` registers them.
-pub fn hardware_metrics_enabled(filter: &Filter) -> bool {
-    filter.is_exposed("hw", module_path!(), MetricLevel::Warn)
-}
-
 /// Register all hardware metrics: CPU specs, Memory specs/usage, Disk
 /// specs/usage
 /// These metrics are all named with a prefix "hw_"
 /// They are both pushed to iota-proxy and exposed on the /metrics endpoint.
+/// The whole group shares one level (`off` hides the collector, any
+/// other level exposes it), since it is a single collector.
 pub fn register_hardware_metrics(
     registry_service: &RegistryService,
     db_path: &Path,
@@ -52,13 +48,21 @@ pub fn register_hardware_metrics(
             .new_registry_custom(Some("hw".to_string()), None)
             .map_err(HardwareMetricsErr::ErrRegisterHardwareMetrics)?;
         registry
-            .register(Box::new(HardwareMetrics::new(db_path)?))
+            .register_filtered(
+                // Bookkeeping key for this collector, does not change the metric name:
+                // the exposed names come from the collector and the "hw" prefix.
+                "metrics",
+                module_path!(),
+                MetricLevel::Warn,
+                HardwareMetrics::new(db_path)?,
+            )
             .map_err(HardwareMetricsErr::ErrRegisterHardwareMetrics)?;
         registry_service.add(registry);
         Ok(())
     }
 }
 
+#[derive(Clone)]
 pub struct HardwareMetrics {
     system: Arc<Mutex<System>>,
     disks: Arc<Mutex<Disks>>,

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -582,6 +582,11 @@ impl RegistryService {
         self.default_registry.clone()
     }
 
+    /// Returns the metrics filter shared by the service's registries.
+    pub fn filter(&self) -> Arc<Filter> {
+        self.filter.clone()
+    }
+
     // Creates a new registry that shares the service's metric filter. Prefer
     // this over `Registry::new()`/`Registry::new_custom()` for registries added
     // via `add`, so that the configured filter applies to their metrics too.

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -560,8 +560,6 @@ pub struct RegistryService {
     default_registry: Registry,
     registries_by_id: Arc<DashMap<Uuid, Registry>>,
     filter: Arc<Filter>,
-    /// Serializes filter updates and the reconciles they trigger.
-    reconcile_lock: Arc<Mutex<()>>,
 }
 
 impl RegistryService {
@@ -572,7 +570,6 @@ impl RegistryService {
             filter: default_registry.filter(),
             default_registry,
             registries_by_id: Arc::new(DashMap::new()),
-            reconcile_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -605,18 +602,13 @@ impl RegistryService {
     // registry - we expected a removal to happen explicitly.
     pub fn add(&self, registry: Registry) -> RegistryID {
         let registry_id = Uuid::new_v4();
-        let _guard = self.reconcile_lock.lock();
         if self
             .registries_by_id
-            .insert(registry_id, registry.clone())
+            .insert(registry_id, registry)
             .is_some()
         {
             panic!("Other Registry already detected for the same id {registry_id}");
         }
-        // The registry may have been populated before a filter change whose
-        // reconcile pass could not see it yet; re-evaluate it now so its
-        // membership matches the filter currently in effect.
-        registry.reconcile();
 
         registry_id
     }
@@ -644,36 +636,26 @@ impl RegistryService {
         self.get_all().iter().flat_map(|r| r.gather()).collect()
     }
 
-    /// Sets the runtime override on the shared filter and reconciles every
-    /// registry. Rejects the whole update if any directive is invalid.
-    /// `directives` drive matching; `display` (e.g. the group-form input before
-    /// expansion) is what the admin endpoint echoes back.
+    /// Sets the runtime override on the shared filter; every registry's next
+    /// gather exposes metrics per the new directives. Rejects the whole
+    /// update if any directive is invalid. `directives` drive matching;
+    /// `display` (e.g. the group-form input before expansion) is what the
+    /// admin endpoint echoes back.
     pub fn set_runtime_filter(
         &self,
         directives: &str,
         display: &str,
     ) -> std::result::Result<(), String> {
-        let _guard = self.reconcile_lock.lock();
         self.filter
             .set_runtime_filter(prometheus_filtered::FilterSource::with_display(
                 directives, display,
-            ))?;
-        self.reconcile_all();
-        Ok(())
+            ))
     }
 
-    /// Drops the runtime override on the shared filter and reconciles every
-    /// registry back to its startup exposure.
+    /// Drops the runtime override on the shared filter, restoring every
+    /// registry to its startup exposure.
     pub fn reset_runtime_filter(&self) {
-        let _guard = self.reconcile_lock.lock();
         self.filter.reset_runtime_filter();
-        self.reconcile_all();
-    }
-
-    fn reconcile_all(&self) {
-        for registry in self.get_all() {
-            registry.reconcile();
-        }
     }
 }
 
@@ -874,7 +856,7 @@ mod tests {
     }
 
     #[test]
-    fn set_runtime_filter_reconciles_all_registries() {
+    fn set_runtime_filter_applies_to_all_registries() {
         use std::sync::Arc;
 
         use prometheus_filtered::{Filter, MetricLevel};
@@ -913,7 +895,8 @@ mod tests {
             ["default_g_warn", "second_g_warn"]
         );
 
-        // One runtime update reconciles every registry in the service.
+        // One runtime update changes the exposure of every registry in the
+        // service.
         registry_service
             .set_runtime_filter("iota_metrics=debug", "iota_metrics=debug")
             .unwrap();

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -637,18 +637,15 @@ impl RegistryService {
     }
 
     /// Sets the runtime override on the shared filter; every registry's next
-    /// gather exposes metrics per the new directives. Rejects the whole
-    /// update if any directive is invalid. `directives` drive matching;
-    /// `display` (e.g. the group-form input before expansion) is what the
-    /// admin endpoint echoes back.
-    pub fn set_runtime_filter(
-        &self,
-        directives: &str,
-        display: &str,
-    ) -> std::result::Result<(), String> {
+    /// gather exposes metrics per the new directives. `filter` may use
+    /// [`MetricGroups`] names, which are expanded for matching while the
+    /// string is echoed back as given. Rejects the whole update if any
+    /// directive is invalid.
+    pub fn set_runtime_filter(&self, filter: &str) -> std::result::Result<(), String> {
+        let expanded = MetricGroups::expand_directives(filter)?;
         self.filter
             .set_runtime_filter(prometheus_filtered::FilterSource::with_display(
-                directives, display,
+                &expanded, filter,
             ))
     }
 
@@ -898,7 +895,7 @@ mod tests {
         // One runtime update changes the exposure of every registry in the
         // service.
         registry_service
-            .set_runtime_filter("iota_metrics=debug", "iota_metrics=debug")
+            .set_runtime_filter("runtime=debug")
             .unwrap();
         assert_eq!(
             gathered_names(&registry_service),
@@ -909,13 +906,6 @@ mod tests {
                 "second_g_warn"
             ]
         );
-
-        // An invalid update is rejected without touching the current override.
-        let err = registry_service
-            .set_runtime_filter("bogus=nope", "bogus=nope")
-            .unwrap_err();
-        assert!(err.contains("bogus=nope"), "unexpected error: {err}");
-        assert_eq!(gathered_names(&registry_service).len(), 4);
 
         // Reset restores the startup exposure across all registries.
         registry_service.reset_runtime_filter();

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -857,4 +857,73 @@ mod tests {
         assert_eq!(metric_1.name(), "iota_counter_2");
         assert_eq!(metric_1.help(), "counter_2_desc");
     }
+
+    #[test]
+    fn set_runtime_filter_reconciles_all_registries() {
+        use std::sync::Arc;
+
+        use prometheus_filtered::{Filter, MetricLevel};
+
+        fn gathered_names(service: &RegistryService) -> Vec<String> {
+            let mut names: Vec<_> = service
+                .gather_all()
+                .iter()
+                .map(|f| f.name().to_owned())
+                .collect();
+            names.sort();
+            names
+        }
+
+        // Both registries share the service's filter, which starts at `warn`
+        // for this module, hiding the default-level (`debug`) gauges.
+        let filter = Arc::new(Filter::parse("iota_metrics=warn"));
+        let default_registry =
+            Registry::new_custom(Some("default".to_string()), None, Some(filter)).unwrap();
+        let registry_service = RegistryService::new(default_registry.clone());
+        let second_registry = registry_service
+            .new_registry_custom(Some("second".to_string()), None)
+            .unwrap();
+        registry_service.add(second_registry.clone());
+
+        for registry in [&default_registry, &second_registry] {
+            prometheus_filtered::register_int_gauge_with_registry!(
+                "g_warn", "h", registry; MetricLevel::Warn
+            )
+            .unwrap();
+            prometheus_filtered::register_int_gauge_with_registry!("g_debug", "h", registry)
+                .unwrap();
+        }
+        assert_eq!(
+            gathered_names(&registry_service),
+            ["default_g_warn", "second_g_warn"]
+        );
+
+        // One runtime update reconciles every registry in the service.
+        registry_service
+            .set_runtime_filter("iota_metrics=debug", "iota_metrics=debug")
+            .unwrap();
+        assert_eq!(
+            gathered_names(&registry_service),
+            [
+                "default_g_debug",
+                "default_g_warn",
+                "second_g_debug",
+                "second_g_warn"
+            ]
+        );
+
+        // An invalid update is rejected without touching the current override.
+        let err = registry_service
+            .set_runtime_filter("bogus=nope", "bogus=nope")
+            .unwrap_err();
+        assert!(err.contains("bogus=nope"), "unexpected error: {err}");
+        assert_eq!(gathered_names(&registry_service).len(), 4);
+
+        // Reset restores the startup exposure across all registries.
+        registry_service.reset_runtime_filter();
+        assert_eq!(
+            gathered_names(&registry_service),
+            ["default_g_warn", "second_g_warn"]
+        );
+    }
 }

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -560,6 +560,8 @@ pub struct RegistryService {
     default_registry: Registry,
     registries_by_id: Arc<DashMap<Uuid, Registry>>,
     filter: Arc<Filter>,
+    /// Serializes filter updates and the reconciles they trigger.
+    reconcile_lock: Arc<Mutex<()>>,
 }
 
 impl RegistryService {
@@ -570,6 +572,7 @@ impl RegistryService {
             filter: default_registry.filter(),
             default_registry,
             registries_by_id: Arc::new(DashMap::new()),
+            reconcile_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -597,13 +600,18 @@ impl RegistryService {
     // registry - we expected a removal to happen explicitly.
     pub fn add(&self, registry: Registry) -> RegistryID {
         let registry_id = Uuid::new_v4();
+        let _guard = self.reconcile_lock.lock();
         if self
             .registries_by_id
-            .insert(registry_id, registry)
+            .insert(registry_id, registry.clone())
             .is_some()
         {
             panic!("Other Registry already detected for the same id {registry_id}");
         }
+        // The registry may have been populated before a filter change whose
+        // reconcile pass could not see it yet; re-evaluate it now so its
+        // membership matches the filter currently in effect.
+        registry.reconcile();
 
         registry_id
     }
@@ -640,6 +648,7 @@ impl RegistryService {
         directives: &str,
         display: &str,
     ) -> std::result::Result<(), String> {
+        let _guard = self.reconcile_lock.lock();
         self.filter
             .set_runtime_filter(prometheus_filtered::FilterSource::with_display(
                 directives, display,
@@ -651,6 +660,7 @@ impl RegistryService {
     /// Drops the runtime override on the shared filter and reconciles every
     /// registry back to its startup exposure.
     pub fn reset_runtime_filter(&self) {
+        let _guard = self.reconcile_lock.lock();
         self.filter.reset_runtime_filter();
         self.reconcile_all();
     }

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -685,7 +685,7 @@ pub const METRICS_ROUTE: &str = "/metrics";
 // A RegistryService is returned that can be used to get access in prometheus
 // Registries.
 pub fn start_prometheus_server(addr: SocketAddr) -> RegistryService {
-    start_prometheus_server_with_filter(addr, Filter::resolve(None))
+    start_prometheus_server_with_filter(addr, Filter::from_env())
 }
 
 pub fn start_prometheus_server_with_filter(addr: SocketAddr, filter: Filter) -> RegistryService {

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -630,6 +630,27 @@ impl RegistryService {
     pub fn gather_all(&self) -> Vec<prometheus_filtered::proto::MetricFamily> {
         self.get_all().iter().flat_map(|r| r.gather()).collect()
     }
+
+    /// Sets the runtime override on the shared filter and reconciles every
+    /// registry. Rejects the whole update if any directive is invalid.
+    pub fn set_runtime_filter(&self, s: &str) -> std::result::Result<(), String> {
+        self.filter.set_runtime_filter(s)?;
+        self.reconcile_all();
+        Ok(())
+    }
+
+    /// Drops the runtime override on the shared filter and reconciles every
+    /// registry back to its startup exposure.
+    pub fn reset_runtime_filter(&self) {
+        self.filter.reset_runtime_filter();
+        self.reconcile_all();
+    }
+
+    fn reconcile_all(&self) {
+        for registry in self.get_all() {
+            registry.reconcile();
+        }
+    }
 }
 
 /// Create a metric that measures the uptime from when this metric was

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -633,8 +633,17 @@ impl RegistryService {
 
     /// Sets the runtime override on the shared filter and reconciles every
     /// registry. Rejects the whole update if any directive is invalid.
-    pub fn set_runtime_filter(&self, s: &str) -> std::result::Result<(), String> {
-        self.filter.set_runtime_filter(s)?;
+    /// `directives` drive matching; `display` (e.g. the group-form input before
+    /// expansion) is what the admin endpoint echoes back.
+    pub fn set_runtime_filter(
+        &self,
+        directives: &str,
+        display: &str,
+    ) -> std::result::Result<(), String> {
+        self.filter
+            .set_runtime_filter(prometheus_filtered::FilterSource::with_display(
+                directives, display,
+            ))?;
         self.reconcile_all();
         Ok(())
     }

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -142,7 +142,9 @@ pub struct MetricGroups {
     /// decides each metric (a metric-name match wins over a module match),
     /// so an override can raise or lower a single module or metric within a
     /// group. A `default` key is the same pattern as the `default` field and
-    /// replaces its level.
+    /// replaces its level; likewise a group-name key expands to the group's
+    /// patterns and replaces the group field's level, as the same directive
+    /// would in `METRICS_FILTER` or the admin endpoint.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub overrides: BTreeMap<String, MetricLevel>,
 }
@@ -277,7 +279,15 @@ impl MetricGroups {
                 directives.push(format!("{module}={}", level.as_str()));
             }
         }
-        directives.extend(self.override_directives());
+        for directive in self.override_directives() {
+            // Group-name keys expand exactly like env var and runtime
+            // directives; rendered after the group directives, the expansion
+            // replaces the group field's level.
+            directives.extend(
+                Self::expand_directive(&directive)
+                    .expect("override levels are typed, so the rendered directive is valid"),
+            );
+        }
         directives.join(",")
     }
 
@@ -681,7 +691,7 @@ mod tests {
         let groups: MetricGroups = serde_yaml::from_str(
             "consensus: off\n\
              overrides:\n  \"iota_core::authority::foo\": trace\n  bespoke_metric: off\n  \
-             certs_total: trace",
+             certs_total: trace\n  network: trace",
         )
         .unwrap();
         assert_eq!(groups.consensus, MetricLevel::Off);
@@ -689,6 +699,9 @@ mod tests {
         let filter_string = groups.to_filter_string();
         assert!(filter_string.contains("iota_core::authority::foo=trace"));
         assert!(filter_string.contains("bespoke_metric=off"));
+        // A group-name key expands to the group's module patterns, replacing
+        // the group field's level (`warn` here).
+        assert!(filter_string.contains("iota_network::discovery=trace"));
 
         let filter = Filter::parse(&filter_string);
         // The longer override pattern wins over the `authority` group directive.
@@ -704,5 +717,9 @@ mod tests {
         ));
         // Other metrics in the module keep the group's level.
         assert!(!filter.is_exposed("other", "iota_core::execution_cache", MetricLevel::Info));
+        // The expanded group-name override applies to the group's modules ...
+        assert!(filter.is_exposed("x", "iota_network::discovery", MetricLevel::Trace));
+        // ... and other groups keep their configured level.
+        assert!(!filter.is_exposed("x", "iota_storage::http_key_value_store", MetricLevel::Info));
     }
 }

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -40,6 +40,8 @@
 //! level exposes the collector (`off` hides it, any other level exposes it),
 //! and — like the other groups — it can be changed at runtime.
 
+use std::collections::BTreeMap;
+
 pub use prometheus_filtered::MetricLevel;
 use serde::{Deserialize, Serialize};
 
@@ -147,6 +149,10 @@ pub struct MetricGroups {
     /// Rendered as an `iota_metrics::hardware_metrics` directive, the module
     /// where the collector is registered.
     pub hardware: MetricLevel,
+    /// Free-form overrides for module paths or metric names not covered by the
+    /// named groups.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub overrides: BTreeMap<String, MetricLevel>,
 }
 
 impl Default for MetricGroups {
@@ -166,6 +172,7 @@ impl Default for MetricGroups {
             epoch: MetricLevel::Warn,
             runtime: MetricLevel::Warn,
             hardware: MetricLevel::Warn,
+            overrides: BTreeMap::new(),
         }
     }
 }
@@ -286,6 +293,7 @@ impl MetricGroups {
                 directives.push(format!("{module}={}", level_string(level)));
             }
         }
+        directives.extend(self.override_directives());
         directives.join(",")
     }
 
@@ -297,6 +305,7 @@ impl MetricGroups {
         for (group, level) in self.group_levels() {
             directives.push(format!("{group}={}", level_string(level)));
         }
+        directives.extend(self.override_directives());
         directives.join(",")
     }
 
@@ -342,10 +351,19 @@ impl MetricGroups {
             None => vec![part.to_owned()],
         })
     }
+
+    /// Renders the free-form overrides as `pattern=LEVEL` directives.
+    fn override_directives(&self) -> impl Iterator<Item = String> + '_ {
+        self.overrides
+            .iter()
+            .map(|(pattern, level)| format!("{pattern}={}", level_string(*level)))
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use prometheus_filtered::Filter;
 
     use super::{MetricGroups, MetricLevel};
@@ -366,6 +384,7 @@ mod tests {
             epoch: MetricLevel::Trace,
             runtime: MetricLevel::Trace,
             hardware: MetricLevel::Trace,
+            overrides: BTreeMap::new(),
         }
     }
 
@@ -642,5 +661,26 @@ mod tests {
         // leaving the intended group at its default.
         assert!(serde_yaml::from_str::<MetricGroups>("traffic_control: off").is_err());
         assert!(serde_yaml::from_str::<MetricGroups>("bogus: warn").is_err());
+    }
+
+    #[test]
+    fn metric_groups_config_allows_free_overrides() {
+        // Module- and metric-level directives that no named group covers go in
+        // the `overrides` map, keeping group-name typo protection intact.
+        let groups: MetricGroups = serde_yaml::from_str(
+            "consensus: off\n\
+             overrides:\n  \"iota_core::authority::foo\": trace\n  bespoke_metric: off",
+        )
+        .unwrap();
+        assert_eq!(groups.consensus, MetricLevel::Off);
+
+        let filter_string = groups.to_filter_string();
+        assert!(filter_string.contains("iota_core::authority::foo=trace"));
+        assert!(filter_string.contains("bespoke_metric=off"));
+
+        let filter = Filter::parse(&filter_string);
+        // The longer override pattern wins over the `authority` group directive.
+        assert!(filter.is_exposed("x", "iota_core::authority::foo", MetricLevel::Trace));
+        assert!(!filter.is_exposed("bespoke_metric_total", "somewhere", MetricLevel::Warn));
     }
 }

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -565,6 +565,43 @@ mod tests {
     }
 
     #[test]
+    fn runtime_group_override_keeps_other_groups_untouched() {
+        use prometheus_filtered::FilterSource;
+
+        // The `runtime` group's `iota_metrics` module prefix also covers the
+        // `p2p` and `hardware` groups' submodules; overriding `runtime` must
+        // not change those groups' exposure, matching the group definition.
+        let groups = MetricGroups {
+            hardware: MetricLevel::Off,
+            ..MetricGroups::default()
+        };
+        let filter = prometheus_filtered::Filter::from_sources(
+            FilterSource::with_display(&groups.to_filter_string(), &groups.to_display_string()),
+            None,
+        );
+        let expanded = MetricGroups::expand_directives("runtime=trace").unwrap();
+        filter
+            .set_runtime_filter(FilterSource::with_display(&expanded, "runtime=trace"))
+            .unwrap();
+
+        // The runtime group's own modules are raised ...
+        assert!(filter.is_exposed("x", "iota_metrics::monitored_mpsc", MetricLevel::Trace));
+        // ... while hardware stays off and p2p keeps its configured `warn`.
+        assert!(!filter.is_exposed(
+            "hw_metrics",
+            "iota_metrics::hardware_metrics",
+            MetricLevel::Warn
+        ));
+        assert!(!filter.is_exposed("x", "iota_metrics::metrics_network", MetricLevel::Info));
+        // The reported filter reflects that: only the runtime entry changed.
+        let display = filter.filter_string();
+        assert!(display.contains("runtime=trace"), "{display}");
+        assert!(display.contains("hardware=off"), "{display}");
+        assert!(display.contains("p2p=warn"), "{display}");
+        assert!(!display.contains("runtime=warn"), "{display}");
+    }
+
+    #[test]
     fn expand_startup_directives_drops_bad_directives() {
         // An invalid directive is dropped and reported; the rest still expand.
         let (expanded, errors) =

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -488,33 +488,6 @@ mod tests {
     }
 
     #[test]
-    fn metric_groups_renders_hardware_directive() {
-        let groups = MetricGroups {
-            hardware: MetricLevel::Off,
-            ..all_trace()
-        };
-        // The hardware group renders a directive for its collector's module,
-        // hiding it when `off`.
-        let filter_string = groups.to_filter_string();
-        assert!(filter_string.contains("iota_metrics::hardware_metrics=off"));
-        let filter = Filter::parse(&filter_string);
-        assert!(!filter.is_exposed(
-            "hw_cpu_core_count",
-            "iota_metrics::hardware_metrics",
-            MetricLevel::Warn
-        ));
-        // A later directive with the same pattern overrides the rendered one.
-        let overridden = Filter::parse(&format!(
-            "{filter_string},iota_metrics::hardware_metrics=warn"
-        ));
-        assert!(overridden.is_exposed(
-            "hw_cpu_core_count",
-            "iota_metrics::hardware_metrics",
-            MetricLevel::Warn
-        ));
-    }
-
-    #[test]
     fn modules_for_group_covers_every_group() {
         // Every group resolves to a non-empty module list; the rendered
         // filter contains exactly those modules.
@@ -565,6 +538,11 @@ mod tests {
             MetricGroups::expand_directives("default=info,traffic-control=off").unwrap(),
             "info,iota_core::traffic_controller=off,iota_config::node_config_metrics=off"
         );
+        // The single-collector hardware group expands like any other.
+        assert_eq!(
+            MetricGroups::expand_directives("hardware=off").unwrap(),
+            "iota_metrics::hardware_metrics=off"
+        );
     }
 
     #[test]
@@ -581,18 +559,6 @@ mod tests {
             errors[0].contains("consensus=bogus"),
             "unexpected error: {}",
             errors[0]
-        );
-    }
-
-    #[test]
-    fn expand_directives_expands_hardware_group() {
-        assert_eq!(
-            MetricGroups::expand_directives("hardware=off").unwrap(),
-            "iota_metrics::hardware_metrics=off"
-        );
-        assert_eq!(
-            MetricGroups::expand_directives("iota_metrics::hardware_metrics=warn").unwrap(),
-            "iota_metrics::hardware_metrics=warn"
         );
     }
 

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -6,7 +6,7 @@
 //! Most groups are filter-based: they key on the module path of the metrics
 //! (preferred over the metric name, because module paths are stable and names
 //! are not) and are rendered into a `METRICS_FILTER`-style string via
-//! [`MetricGroups::to_filter_string`].
+//! `MetricGroups::to_filter_string`.
 //!
 //! Each filter-based group is set to a [`MetricLevel`], a verbosity threshold.
 //! Individual metrics declare their own level where they are registered,
@@ -142,15 +142,16 @@ pub struct MetricGroups {
     /// Modules: `iota_metrics` (except the `hardware` and `p2p` group
     /// submodules), `telemetry_subscribers`.
     pub runtime: MetricLevel,
-    /// Host hardware metrics (CPU / memory / disk). One collector, so the level
-    /// applies to the whole group rather than individual metrics: `off` hides
-    /// it and every other level exposes it.
+    /// Host hardware metrics (CPU / memory / disk). Individual hardware metrics
+    /// cannot be given their own level.
     ///
     /// Rendered as an `iota_metrics::hardware_metrics` directive, the module
     /// where the collector is registered.
     pub hardware: MetricLevel,
-    /// Free-form overrides for module paths or metric names not covered by the
-    /// named groups.
+    /// Free-form overrides for module paths or metric names, including ones
+    /// already covered by a named group: the most specific matching pattern
+    /// decides each metric, so an override can raise or lower a single module
+    /// or metric within a group.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub overrides: BTreeMap<String, MetricLevel>,
 }
@@ -267,12 +268,8 @@ impl MetricGroups {
         ]
     }
 
-    /// Maps each group's configured level to the filter patterns it covers.
-    ///
-    /// Directive order does not matter: where one group's module prefix also
-    /// matches another group's submodules (e.g. `runtime`'s `iota_metrics`
-    /// covers the `p2p` and `hardware` groups'), the more specific pattern
-    /// wins.
+    /// List of metric level together with registered module paths
+    /// corresponding to all groups.
     fn group_modules(&self) -> [(MetricLevel, &'static [&'static str]); 13] {
         self.group_levels().map(|(group, level)| {
             (
@@ -283,7 +280,7 @@ impl MetricGroups {
     }
 
     /// Renders the levels into a `METRICS_FILTER`-style directive string.
-    pub fn to_filter_string(&self) -> String {
+    fn to_filter_string(&self) -> String {
         let mut directives = vec![format!("default={}", level_string(self.default))];
         for (level, modules) in self.group_modules() {
             for module in modules {
@@ -297,7 +294,7 @@ impl MetricGroups {
     /// Renders the levels into a group-form directive string.
     /// Keyed by group name rather than expanded
     /// to module paths, so the admin endpoint can echo the config compactly.
-    pub fn to_display_string(&self) -> String {
+    fn to_display_string(&self) -> String {
         let mut directives = vec![format!("default={}", level_string(self.default))];
         for (group, level) in self.group_levels() {
             directives.push(format!("{group}={}", level_string(level)));
@@ -322,7 +319,7 @@ impl MetricGroups {
     /// Like [`Self::expand_directives`], but for startup use: an invalid
     /// directive is dropped instead of rejecting the whole string, its error
     /// message returned alongside the expanded directives.
-    pub fn expand_startup_directives(filter: &str) -> (String, Vec<String>) {
+    fn expand_startup_directives(filter: &str) -> (String, Vec<String>) {
         let mut directives = Vec::new();
         let mut errors = Vec::new();
         for part in prometheus_filtered::directive_parts(filter) {
@@ -332,6 +329,34 @@ impl MetricGroups {
             }
         }
         (directives.join(","), errors)
+    }
+
+    /// Builds the startup metrics filter: these group levels with the `env`
+    /// directives merged over them.
+    /// Invalid env directives are dropped.
+    ///
+    /// Matching uses the expanded module directives; the admin endpoint
+    /// echoes the group-form strings, so each source keeps both.
+    pub fn startup_filter(&self, env: Option<&str>) -> (prometheus_filtered::Filter, Vec<String>) {
+        let mut errors = Vec::new();
+        let env_directives = env.map(|env| {
+            let (expanded, errs) = Self::expand_startup_directives(env);
+            errors = errs;
+            expanded
+        });
+        let filter = prometheus_filtered::Filter::from_sources(
+            prometheus_filtered::FilterSource::with_display(
+                &self.to_filter_string(),
+                &self.to_display_string(),
+            ),
+            env_directives
+                .as_deref()
+                .zip(env)
+                .map(|(directives, display)| {
+                    prometheus_filtered::FilterSource::with_display(directives, display)
+                }),
+        );
+        (filter, errors)
     }
 
     fn expand_directive(part: &str) -> Result<Vec<String>, String> {
@@ -552,7 +577,8 @@ mod tests {
         // place.
         assert_eq!(
             MetricGroups::expand_directives("default=info,traffic-control=off").unwrap(),
-            "info,iota_core::traffic_controller=off,iota_config::node_config_metrics=off"
+            "default=info,iota_core::traffic_controller=off,\
+             iota_config::node_config_metrics=off"
         );
         // The single-collector hardware group expands like any other.
         assert_eq!(

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -20,9 +20,9 @@
 //! - `debug` exposes everything except `trace`-tagged metrics;
 //! - `trace` exposes everything.
 //!
-//! Metrics whose module belongs to no group are covered by the `default`
-//! threshold (`info` unless configured), rendered as the leading catch-all
-//! directive.
+//! Metrics whose module belongs to no other group form the `default` group,
+//! covered by the `default` threshold (`info` unless configured), rendered
+//! as the leading `default=LEVEL` directive.
 //!
 //! The levels never affect collection: a filter-based group's metrics are
 //! registered and keep collecting regardless of the configured level.
@@ -282,12 +282,9 @@ impl MetricGroups {
         })
     }
 
-    /// Renders the levels into a `METRICS_FILTER`-style directive string: the
-    /// `default` threshold as the catch-all directive, then one directive per
-    /// group module (including the hardware group's). The group levels
-    /// override the catch-all for their modules, being more specific.
+    /// Renders the levels into a `METRICS_FILTER`-style directive string.
     pub fn to_filter_string(&self) -> String {
-        let mut directives = vec![level_string(self.default).to_owned()];
+        let mut directives = vec![format!("default={}", level_string(self.default))];
         for (level, modules) in self.group_modules() {
             for module in modules {
                 directives.push(format!("{module}={}", level_string(level)));
@@ -340,14 +337,12 @@ impl MetricGroups {
     fn expand_directive(part: &str) -> Result<Vec<String>, String> {
         prometheus_filtered::validate_directive(part)?;
         let (pattern, level) = prometheus_filtered::split_directive(part);
-        if pattern == "default" {
-            return Ok(vec![level.to_owned()]);
-        }
         Ok(match Self::modules_for_group(pattern) {
             Some(modules) => modules
                 .iter()
                 .map(|module| format!("{module}={level}"))
                 .collect(),
+            // A raw module path, metric-name prefix, or bare global level passes through unchanged.
             None => vec![part.to_owned()],
         })
     }
@@ -392,9 +387,9 @@ mod tests {
     fn metric_groups_default_trims_to_warn_tagged() {
         // The default (all groups `warn`) renders `{module}=warn` for every
         // group's modules, so only the `warn`-tagged metrics are exposed;
-        // non-grouped modules fall to the `info` catch-all.
+        // non-grouped modules fall to the `default` group's `info`.
         let filter_string = MetricGroups::default().to_filter_string();
-        assert!(filter_string.starts_with("info,"));
+        assert!(filter_string.starts_with("default=info,"));
         assert!(filter_string.contains("starfish_core=warn"));
         assert!(filter_string.contains("iota_core::execution_cache=warn"));
         assert!(filter_string.contains("iota_grpc_server=warn"));
@@ -435,7 +430,7 @@ mod tests {
             ..all_trace()
         };
         let filter_string = groups.to_filter_string();
-        assert!(filter_string.starts_with("trace,"));
+        assert!(filter_string.starts_with("default=trace,"));
         assert!(filter_string.contains("iota_core::execution_cache=warn"));
         assert!(filter_string.contains("iota_core::checkpoints=debug"));
         assert!(filter_string.contains("iota_core::epoch::epoch_metrics=off"));
@@ -447,9 +442,9 @@ mod tests {
         assert!(!filter.is_exposed("x", "iota_core::checkpoints", MetricLevel::Trace));
         assert!(!filter.is_exposed("x", "iota_core::epoch::epoch_metrics", MetricLevel::Warn));
         // `trace` groups expose everything — their directives are rendered,
-        // not skipped, so they are not clipped by the catch-all.
+        // not skipped, so they are not clipped by the `default` level.
         assert!(filter.is_exposed("x", "iota_core::quorum_driver", MetricLevel::Trace));
-        // Ungrouped modules follow the `default` catch-all (`trace` here).
+        // Ungrouped modules follow the `default` level (`trace` here).
         assert!(filter.is_exposed("x", "iota_node::some_module", MetricLevel::Trace));
     }
 
@@ -552,7 +547,9 @@ mod tests {
             "typed_store=warn,uptime=off,trace"
         );
         assert_eq!(MetricGroups::expand_directives("").unwrap(), "");
-        // The `default` group becomes the bare catch-all level.
+        // The reserved `default` pattern passes through unexpanded; it sets
+        // the `default` group's level and leaves the group directives in
+        // place.
         assert_eq!(
             MetricGroups::expand_directives("default=info,traffic-control=off").unwrap(),
             "info,iota_core::traffic_controller=off,iota_config::node_config_metrics=off"
@@ -599,6 +596,31 @@ mod tests {
         assert!(display.contains("hardware=off"), "{display}");
         assert!(display.contains("p2p=warn"), "{display}");
         assert!(!display.contains("runtime=warn"), "{display}");
+    }
+
+    #[test]
+    fn runtime_default_override_touches_only_ungrouped_modules() {
+        use prometheus_filtered::FilterSource;
+
+        // `default=LEVEL` raises the level of the ungrouped modules while
+        // every group keeps its configured level — the same meaning `default`
+        // has in the config's `metrics.groups` section.
+        let groups = MetricGroups::default();
+        let filter = prometheus_filtered::Filter::from_sources(
+            FilterSource::with_display(&groups.to_filter_string(), &groups.to_display_string()),
+            None,
+        );
+        let expanded = MetricGroups::expand_directives("default=trace").unwrap();
+        filter
+            .set_runtime_filter(FilterSource::with_display(&expanded, "default=trace"))
+            .unwrap();
+
+        assert!(filter.is_exposed("x", "iota_node::some_module", MetricLevel::Trace));
+        assert!(!filter.is_exposed("x", "starfish_core::metrics", MetricLevel::Info));
+        let display = filter.filter_string();
+        assert!(display.contains("default=trace"), "{display}");
+        assert!(display.contains("consensus=warn"), "{display}");
+        assert!(!display.contains("default=info"), "{display}");
     }
 
     #[test]

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -130,9 +130,9 @@ pub struct MetricGroups {
     /// Modules: `iota_metrics` (except the `hardware` and `p2p` group
     /// submodules), `telemetry_subscribers`.
     pub runtime: MetricLevel,
-    /// Host hardware metrics (CPU / memory / disk). Registered as a collector,
-    /// so individual metrics cannot be level-filtered: `off` skips the whole
-    /// group and every other level registers it, at startup only.
+    /// Host hardware metrics (CPU / memory / disk). One collector, so the level
+    /// applies to the whole group rather than individual metrics: `off` hides
+    /// it and every other level exposes it.
     ///
     /// Rendered as an `iota_metrics::hardware_metrics` directive, the module
     /// where the collector is registered.
@@ -286,26 +286,23 @@ impl MetricGroups {
 
     /// Expands group names in a `pattern=LEVEL` directive string into the
     /// groups' filter patterns; other directives pass through unchanged.
-    /// The first invalid directive rejects the whole string. The hardware
-    /// group is rejected too, since it is registered once at startup and
-    /// cannot be changed at runtime.
+    /// The first invalid directive rejects the whole string.
     pub fn expand_directives(filter: &str) -> Result<String, String> {
         let mut directives = Vec::new();
         for part in prometheus_filtered::directive_parts(filter) {
-            directives.extend(Self::expand_directive(part, true)?);
+            directives.extend(Self::expand_directive(part)?);
         }
         Ok(directives.join(","))
     }
 
-    /// Like [`Self::expand_directives`], but for startup use: the hardware
-    /// group is allowed, and an invalid
+    /// Like [`Self::expand_directives`], but for startup use: an invalid
     /// directive is dropped instead of rejecting the whole string, its error
     /// message returned alongside the expanded directives.
     pub fn expand_startup_directives(filter: &str) -> (String, Vec<String>) {
         let mut directives = Vec::new();
         let mut errors = Vec::new();
         for part in prometheus_filtered::directive_parts(filter) {
-            match Self::expand_directive(part, false) {
+            match Self::expand_directive(part) {
                 Ok(expanded) => directives.extend(expanded),
                 Err(err) => errors.push(err),
             }
@@ -313,17 +310,9 @@ impl MetricGroups {
         (directives.join(","), errors)
     }
 
-    fn expand_directive(part: &str, reject_hardware: bool) -> Result<Vec<String>, String> {
+    fn expand_directive(part: &str) -> Result<Vec<String>, String> {
         prometheus_filtered::validate_directive(part)?;
         let (pattern, level) = prometheus_filtered::split_directive(part);
-        if reject_hardware && (pattern == "hardware" || pattern == "iota_metrics::hardware_metrics")
-        {
-            return Err(
-                "the hardware group is registered once at startup and cannot be \
-                        changed at runtime"
-                    .into(),
-            );
-        }
         if pattern == "default" {
             return Ok(vec![level.to_owned()]);
         }
@@ -464,21 +453,29 @@ mod tests {
 
     #[test]
     fn metric_groups_renders_hardware_directive() {
-        use crate::hardware_metrics::hardware_metrics_enabled;
-
         let groups = MetricGroups {
             hardware: MetricLevel::Off,
             ..all_trace()
         };
-        // `hardware` is gated at registration, via the rendered directive.
+        // The hardware group renders a directive for its collector's module,
+        // hiding it when `off`.
         let filter_string = groups.to_filter_string();
         assert!(filter_string.contains("iota_metrics::hardware_metrics=off"));
-        assert!(!hardware_metrics_enabled(&Filter::parse(&filter_string)));
+        let filter = Filter::parse(&filter_string);
+        assert!(!filter.is_exposed(
+            "hw_cpu_core_count",
+            "iota_metrics::hardware_metrics",
+            MetricLevel::Warn
+        ));
         // A later directive with the same pattern overrides the rendered one.
         let overridden = Filter::parse(&format!(
             "{filter_string},iota_metrics::hardware_metrics=warn"
         ));
-        assert!(hardware_metrics_enabled(&overridden));
+        assert!(overridden.is_exposed(
+            "hw_cpu_core_count",
+            "iota_metrics::hardware_metrics",
+            MetricLevel::Warn
+        ));
     }
 
     #[test]
@@ -535,13 +532,7 @@ mod tests {
     }
 
     #[test]
-    fn expand_startup_directives_allows_hardware_and_drops_bad_directives() {
-        // At startup the hardware collector is not registered yet, so its
-        // group may be set — e.g. via the `METRICS_FILTER` env var.
-        assert_eq!(
-            MetricGroups::expand_startup_directives("hardware=off"),
-            ("iota_metrics::hardware_metrics=off".to_owned(), vec![])
-        );
+    fn expand_startup_directives_drops_bad_directives() {
         // An invalid directive is dropped and reported; the rest still expand.
         let (expanded, errors) =
             MetricGroups::expand_startup_directives("consensus=bogus,traffic-control=off");
@@ -555,18 +546,22 @@ mod tests {
             "unexpected error: {}",
             errors[0]
         );
-        // The runtime variant keeps rejecting the group: the registration
-        // decision cannot be revisited.
-        MetricGroups::expand_directives("hardware=off").unwrap_err();
+    }
+
+    #[test]
+    fn expand_directives_expands_hardware_group() {
+        assert_eq!(
+            MetricGroups::expand_directives("hardware=off").unwrap(),
+            "iota_metrics::hardware_metrics=off"
+        );
+        assert_eq!(
+            MetricGroups::expand_directives("iota_metrics::hardware_metrics=warn").unwrap(),
+            "iota_metrics::hardware_metrics=warn"
+        );
     }
 
     #[test]
     fn expand_directives_rejects_invalid_input() {
-        // The hardware group is rejected under both the group name and its
-        // module path: the collector is registered once at startup, so the
-        // directive would be a no-op.
-        MetricGroups::expand_directives("consensus=off,hardware=off").unwrap_err();
-        MetricGroups::expand_directives("iota_metrics::hardware_metrics=off").unwrap_err();
         // An invalid level fails up front, citing the directive as the
         // caller wrote it — not its expansion.
         let err = MetricGroups::expand_directives("consensus=bogus").unwrap_err();

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -286,42 +286,54 @@ impl MetricGroups {
 
     /// Expands group names in a `pattern=LEVEL` directive string into the
     /// groups' filter patterns; other directives pass through unchanged.
-    /// The hardware group is rejected, since it is registered once at startup
-    /// and cannot be changed at runtime.
+    /// The first invalid directive rejects the whole string. The hardware
+    /// group is rejected too, since it is registered once at startup and
+    /// cannot be changed at runtime.
     pub fn expand_directives(filter: &str) -> Result<String, String> {
-        Self::expand(filter, true)
-    }
-
-    pub fn expand_startup_directives(filter: &str) -> Result<String, String> {
-        Self::expand(filter, false)
-    }
-
-    fn expand(filter: &str, reject_hardware: bool) -> Result<String, String> {
-        let mut directives: Vec<String> = Vec::new();
+        let mut directives = Vec::new();
         for part in prometheus_filtered::directive_parts(filter) {
-            prometheus_filtered::validate_directive(part)?;
-            let (pattern, level) = prometheus_filtered::split_directive(part);
-            if reject_hardware
-                && (pattern == "hardware" || pattern == "iota_metrics::hardware_metrics")
-            {
-                return Err(
-                    "the hardware group is registered once at startup and cannot be \
-                            changed at runtime"
-                        .into(),
-                );
-            }
-            if pattern == "default" {
-                directives.push(level.to_owned());
-                continue;
-            }
-            match Self::modules_for_group(pattern) {
-                Some(modules) => {
-                    directives.extend(modules.iter().map(|module| format!("{module}={level}")));
-                }
-                None => directives.push(part.to_owned()),
-            }
+            directives.extend(Self::expand_directive(part, true)?);
         }
         Ok(directives.join(","))
+    }
+
+    /// Like [`Self::expand_directives`], but for startup use: the hardware
+    /// group is allowed, and an invalid
+    /// directive is dropped instead of rejecting the whole string, its error
+    /// message returned alongside the expanded directives.
+    pub fn expand_startup_directives(filter: &str) -> (String, Vec<String>) {
+        let mut directives = Vec::new();
+        let mut errors = Vec::new();
+        for part in prometheus_filtered::directive_parts(filter) {
+            match Self::expand_directive(part, false) {
+                Ok(expanded) => directives.extend(expanded),
+                Err(err) => errors.push(err),
+            }
+        }
+        (directives.join(","), errors)
+    }
+
+    fn expand_directive(part: &str, reject_hardware: bool) -> Result<Vec<String>, String> {
+        prometheus_filtered::validate_directive(part)?;
+        let (pattern, level) = prometheus_filtered::split_directive(part);
+        if reject_hardware && (pattern == "hardware" || pattern == "iota_metrics::hardware_metrics")
+        {
+            return Err(
+                "the hardware group is registered once at startup and cannot be \
+                        changed at runtime"
+                    .into(),
+            );
+        }
+        if pattern == "default" {
+            return Ok(vec![level.to_owned()]);
+        }
+        Ok(match Self::modules_for_group(pattern) {
+            Some(modules) => modules
+                .iter()
+                .map(|module| format!("{module}={level}"))
+                .collect(),
+            None => vec![part.to_owned()],
+        })
     }
 }
 
@@ -523,15 +535,26 @@ mod tests {
     }
 
     #[test]
-    fn expand_startup_directives_allows_hardware() {
+    fn expand_startup_directives_allows_hardware_and_drops_bad_directives() {
         // At startup the hardware collector is not registered yet, so its
         // group may be set — e.g. via the `METRICS_FILTER` env var.
         assert_eq!(
-            MetricGroups::expand_startup_directives("hardware=off").unwrap(),
-            "iota_metrics::hardware_metrics=off"
+            MetricGroups::expand_startup_directives("hardware=off"),
+            ("iota_metrics::hardware_metrics=off".to_owned(), vec![])
         );
-        // Invalid levels are still rejected.
-        MetricGroups::expand_startup_directives("consensus=bogus").unwrap_err();
+        // An invalid directive is dropped and reported; the rest still expand.
+        let (expanded, errors) =
+            MetricGroups::expand_startup_directives("consensus=bogus,traffic-control=off");
+        assert_eq!(
+            expanded,
+            "iota_core::traffic_controller=off,iota_config::node_config_metrics=off"
+        );
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains("consensus=bogus"),
+            "unexpected error: {}",
+            errors[0]
+        );
         // The runtime variant keeps rejecting the group: the registration
         // decision cannot be revisited.
         MetricGroups::expand_directives("hardware=off").unwrap_err();

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -283,6 +283,54 @@ impl MetricGroups {
         }
         directives.join(",")
     }
+
+    /// Expands group names in a `pattern=LEVEL` directive string into the
+    /// groups' filter patterns; other directives pass through unchanged.
+    pub fn expand_directives(filter: &str) -> Result<String, String> {
+        let mut directives: Vec<String> = Vec::new();
+        for part in prometheus_filtered::directive_parts(filter) {
+            prometheus_filtered::validate_directive(part)?;
+            let (pattern, level) = prometheus_filtered::split_directive(part);
+            if pattern == "hardware" || pattern == "iota_metrics::hardware_metrics" {
+                return Err(
+                    "the hardware group is registered once at startup and cannot be \
+                            changed at runtime"
+                        .into(),
+                );
+            }
+            if pattern == "default" {
+                directives.push(level.to_owned());
+                continue;
+            }
+            match Self::modules_for_group(pattern) {
+                Some(modules) => {
+                    directives.extend(modules.iter().map(|module| format!("{module}={level}")));
+                }
+                None => directives.push(part.to_owned()),
+            }
+        }
+        let rescued: Vec<String> = directives
+            .iter()
+            .enumerate()
+            .filter(|(i, directive)| {
+                let (pattern, _) = prometheus_filtered::split_directive(directive);
+                !pattern.is_empty()
+                    && directives[i + 1..].iter().any(|later| {
+                        let (later_pattern, _) = prometheus_filtered::split_directive(later);
+                        !later_pattern.is_empty()
+                            && pattern.len() > later_pattern.len()
+                            && pattern.starts_with(later_pattern)
+                    })
+                    // A later directive for the same pattern stays authoritative.
+                    && !directives[i + 1..].iter().any(|later| {
+                        prometheus_filtered::split_directive(later).0 == pattern
+                    })
+            })
+            .map(|(_, directive)| directive.clone())
+            .collect();
+        directives.extend(rescued);
+        Ok(directives.join(","))
+    }
 }
 
 #[cfg(test)]
@@ -459,6 +507,67 @@ mod tests {
         }
         // Unknown names resolve to nothing.
         assert_eq!(MetricGroups::modules_for_group("bogus"), None);
+    }
+
+    #[test]
+    fn expand_directives_expands_groups_and_passes_raw_patterns() {
+        assert_eq!(
+            MetricGroups::expand_directives("checkpoints=off,epoch=debug").unwrap(),
+            "iota_core::checkpoints=off,iota_core::epoch::epoch_metrics=debug,\
+             iota_current_protocol_version=debug,iota_binary_max_protocol_version=debug,\
+             iota_configured_max_protocol_version=debug"
+        );
+        // Raw module paths, metric-name prefixes, and bare global levels are
+        // kept verbatim; level validity is checked up front.
+        assert_eq!(
+            MetricGroups::expand_directives("typed_store=warn, uptime=off ,trace").unwrap(),
+            "typed_store=warn,uptime=off,trace"
+        );
+        assert_eq!(MetricGroups::expand_directives("").unwrap(), "");
+        // The `default` group becomes the bare catch-all level.
+        assert_eq!(
+            MetricGroups::expand_directives("default=info,traffic-control=off").unwrap(),
+            "info,iota_core::traffic_controller=off,iota_config::node_config_metrics=off"
+        );
+    }
+
+    #[test]
+    fn expand_directives_rejects_invalid_input() {
+        // The hardware group is rejected under both the group name and its
+        // module path: the collector is registered once at startup, so the
+        // directive would be a no-op.
+        MetricGroups::expand_directives("consensus=off,hardware=off").unwrap_err();
+        MetricGroups::expand_directives("iota_metrics::hardware_metrics=off").unwrap_err();
+        // An invalid level fails up front, citing the directive as the
+        // caller wrote it — not its expansion.
+        let err = MetricGroups::expand_directives("consensus=bogus").unwrap_err();
+        assert!(err.contains("consensus=bogus"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn expand_directives_keeps_specific_directives_effective() {
+        // `runtime` expands to the `iota_metrics` module prefix, which also
+        // matches the `transport` submodule; the more specific transport
+        // directive must win in either input order.
+        for input in [
+            "transport=warn,runtime=trace",
+            "runtime=trace,transport=warn",
+        ] {
+            let expanded = MetricGroups::expand_directives(input).unwrap();
+            let filter = Filter::parse(&expanded);
+            assert!(
+                filter.is_exposed("x", "iota_metrics", MetricLevel::Trace),
+                "{input} -> {expanded}"
+            );
+            assert!(
+                !filter.is_exposed("x", "iota_metrics::metrics_network", MetricLevel::Info),
+                "{input} -> {expanded}"
+            );
+        }
+        // A later directive for the same pattern still wins (last match).
+        let expanded = MetricGroups::expand_directives("iota_metrics=off,runtime=warn").unwrap();
+        let filter = Filter::parse(&expanded);
+        assert!(filter.is_exposed("x", "iota_metrics", MetricLevel::Warn));
     }
 
     #[test]

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -45,17 +45,6 @@ use std::collections::BTreeMap;
 pub use prometheus_filtered::MetricLevel;
 use serde::{Deserialize, Serialize};
 
-/// The `METRICS_FILTER` token for a level.
-fn level_string(level: MetricLevel) -> &'static str {
-    match level {
-        MetricLevel::Off => "off",
-        MetricLevel::Warn => "warn",
-        MetricLevel::Info => "info",
-        MetricLevel::Debug => "debug",
-        MetricLevel::Trace => "trace",
-    }
-}
-
 /// Per-group verbosity levels for the node's predefined Prometheus metric
 /// groups.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -281,10 +270,10 @@ impl MetricGroups {
 
     /// Renders the levels into a `METRICS_FILTER`-style directive string.
     fn to_filter_string(&self) -> String {
-        let mut directives = vec![format!("default={}", level_string(self.default))];
+        let mut directives = vec![format!("default={}", self.default.as_str())];
         for (level, modules) in self.group_modules() {
             for module in modules {
-                directives.push(format!("{module}={}", level_string(level)));
+                directives.push(format!("{module}={}", level.as_str()));
             }
         }
         directives.extend(self.override_directives());
@@ -295,9 +284,9 @@ impl MetricGroups {
     /// Keyed by group name rather than expanded
     /// to module paths, so the admin endpoint can echo the config compactly.
     fn to_display_string(&self) -> String {
-        let mut directives = vec![format!("default={}", level_string(self.default))];
+        let mut directives = vec![format!("default={}", self.default.as_str())];
         for (group, level) in self.group_levels() {
-            directives.push(format!("{group}={}", level_string(level)));
+            directives.push(format!("{group}={}", level.as_str()));
         }
         directives.extend(self.override_directives());
         directives.join(",")
@@ -307,7 +296,7 @@ impl MetricGroups {
     /// groups' filter patterns; other directives pass through unchanged.
     /// Any invalid directive rejects the whole string, with every offending
     /// directive reported.
-    pub fn expand_directives(filter: &str) -> Result<String, String> {
+    pub(crate) fn expand_directives(filter: &str) -> Result<String, String> {
         let (directives, errors) = Self::expand_startup_directives(filter);
         if errors.is_empty() {
             Ok(directives)
@@ -338,34 +327,33 @@ impl MetricGroups {
     /// Matching uses the expanded module directives; the admin endpoint
     /// echoes the group-form strings, so each source keeps both.
     pub fn startup_filter(&self, env: Option<&str>) -> (prometheus_filtered::Filter, Vec<String>) {
-        let mut errors = Vec::new();
-        let env_directives = env.map(|env| {
-            let (expanded, errs) = Self::expand_startup_directives(env);
-            errors = errs;
-            expanded
-        });
-        let filter = prometheus_filtered::Filter::from_sources(
-            prometheus_filtered::FilterSource::with_display(
-                &self.to_filter_string(),
-                &self.to_display_string(),
+        let directives = self.to_filter_string();
+        let display = self.to_display_string();
+        let config = prometheus_filtered::FilterSource::with_display(&directives, &display);
+        match env {
+            Some(env) => {
+                let (expanded, errors) = Self::expand_startup_directives(env);
+                let filter = prometheus_filtered::Filter::from_sources(
+                    config,
+                    Some(prometheus_filtered::FilterSource::with_display(
+                        &expanded, env,
+                    )),
+                );
+                (filter, errors)
+            }
+            None => (
+                prometheus_filtered::Filter::from_sources(config, None),
+                Vec::new(),
             ),
-            env_directives
-                .as_deref()
-                .zip(env)
-                .map(|(directives, display)| {
-                    prometheus_filtered::FilterSource::with_display(directives, display)
-                }),
-        );
-        (filter, errors)
+        }
     }
 
     fn expand_directive(part: &str) -> Result<Vec<String>, String> {
-        prometheus_filtered::validate_directive(part)?;
-        let (pattern, level) = prometheus_filtered::split_directive(part);
+        let (pattern, level) = prometheus_filtered::split_directive(part)?;
         Ok(match Self::modules_for_group(pattern) {
             Some(modules) => modules
                 .iter()
-                .map(|module| format!("{module}={level}"))
+                .map(|module| format!("{module}={}", level.as_str()))
                 .collect(),
             // A raw module path, metric-name prefix, or bare global level passes through unchanged.
             None => vec![part.to_owned()],
@@ -376,7 +364,7 @@ impl MetricGroups {
     fn override_directives(&self) -> impl Iterator<Item = String> + '_ {
         self.overrides
             .iter()
-            .map(|(pattern, level)| format!("{pattern}={}", level_string(*level)))
+            .map(|(pattern, level)| format!("{pattern}={}", level.as_str()))
     }
 }
 
@@ -585,6 +573,10 @@ mod tests {
             MetricGroups::expand_directives("hardware=off").unwrap(),
             "iota_metrics::hardware_metrics=off"
         );
+        assert_eq!(
+            MetricGroups::expand_directives("iota_metrics=off,runtime=warn").unwrap(),
+            "iota_metrics=off,iota_metrics=warn,telemetry_subscribers=warn"
+        );
     }
 
     #[test]
@@ -625,31 +617,6 @@ mod tests {
     }
 
     #[test]
-    fn runtime_default_override_touches_only_ungrouped_modules() {
-        use prometheus_filtered::FilterSource;
-
-        // `default=LEVEL` raises the level of the ungrouped modules while
-        // every group keeps its configured level — the same meaning `default`
-        // has in the config's `metrics.groups` section.
-        let groups = MetricGroups::default();
-        let filter = prometheus_filtered::Filter::from_sources(
-            FilterSource::with_display(&groups.to_filter_string(), &groups.to_display_string()),
-            None,
-        );
-        let expanded = MetricGroups::expand_directives("default=trace").unwrap();
-        filter
-            .set_runtime_filter(FilterSource::with_display(&expanded, "default=trace"))
-            .unwrap();
-
-        assert!(filter.is_exposed("x", "iota_node::some_module", MetricLevel::Trace));
-        assert!(!filter.is_exposed("x", "starfish_core::metrics", MetricLevel::Info));
-        let display = filter.filter_string();
-        assert!(display.contains("default=trace"), "{display}");
-        assert!(display.contains("consensus=warn"), "{display}");
-        assert!(!display.contains("default=info"), "{display}");
-    }
-
-    #[test]
     fn expand_startup_directives_drops_bad_directives() {
         // An invalid directive is dropped and reported; the rest still expand.
         let (expanded, errors) =
@@ -674,59 +641,6 @@ mod tests {
             MetricGroups::expand_directives("consensus=bogus,storage=warn,epoch=nah").unwrap_err();
         assert!(err.contains("consensus=bogus"), "unexpected error: {err}");
         assert!(err.contains("epoch=nah"), "unexpected error: {err}");
-    }
-
-    #[test]
-    fn expand_directives_is_order_independent() {
-        // A `default` level after a group directive does not cancel it.
-        for input in [
-            "traffic-control=off,default=info",
-            "default=info,traffic-control=off",
-        ] {
-            let expanded = MetricGroups::expand_directives(input).unwrap();
-            let filter = Filter::parse(&expanded);
-            assert!(
-                !filter.is_exposed("x", "iota_core::traffic_controller", MetricLevel::Warn),
-                "{input} -> {expanded}"
-            );
-            assert!(
-                filter.is_exposed("x", "iota_core::authority", MetricLevel::Info),
-                "{input} -> {expanded}"
-            );
-            assert!(
-                !filter.is_exposed("x", "iota_core::authority", MetricLevel::Debug),
-                "{input} -> {expanded}"
-            );
-        }
-        // With three nested module prefixes, each level applies to its own
-        // subtree: the most specific matching directive wins.
-        let expanded = MetricGroups::expand_directives(
-            "iota_metrics::metrics_network::inbound=off,transport=debug,runtime=trace",
-        )
-        .unwrap();
-        let filter = Filter::parse(&expanded);
-        assert!(
-            !filter.is_exposed(
-                "x",
-                "iota_metrics::metrics_network::inbound",
-                MetricLevel::Warn
-            ),
-            "{expanded}"
-        );
-        assert!(
-            filter.is_exposed("x", "iota_metrics::metrics_network", MetricLevel::Debug),
-            "{expanded}"
-        );
-        assert!(
-            filter.is_exposed("x", "iota_metrics", MetricLevel::Trace),
-            "{expanded}"
-        );
-        // A later directive for the same pattern still wins (last match):
-        // here `runtime` expands to the raw directive's `iota_metrics`
-        // pattern.
-        let expanded = MetricGroups::expand_directives("iota_metrics=off,runtime=warn").unwrap();
-        let filter = Filter::parse(&expanded);
-        assert!(filter.is_exposed("x", "iota_metrics", MetricLevel::Warn));
     }
 
     #[test]

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -44,6 +44,17 @@
 pub use prometheus_filtered::MetricLevel;
 use serde::{Deserialize, Serialize};
 
+/// The `METRICS_FILTER` token for a level.
+fn level_string(level: MetricLevel) -> &'static str {
+    match level {
+        MetricLevel::Off => "off",
+        MetricLevel::Warn => "warn",
+        MetricLevel::Info => "info",
+        MetricLevel::Debug => "debug",
+        MetricLevel::Trace => "trace",
+    }
+}
+
 /// Per-group verbosity levels for the node's predefined Prometheus metric
 /// groups.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -231,13 +242,8 @@ impl MetricGroups {
         })
     }
 
-    /// Maps each group's configured level to the filter patterns it covers.
-    ///
-    /// Directive order does not matter: where one group's module prefix also
-    /// matches another group's submodules (e.g. `runtime`'s `iota_metrics`
-    /// covers the `p2p` and `hardware` groups'), the more specific pattern
-    /// wins.
-    fn group_modules(&self) -> [(MetricLevel, &'static [&'static str]); 13] {
+    /// The predefined groups paired with their configured levels.
+    fn group_levels(&self) -> [(&'static str, MetricLevel); 13] {
         [
             ("runtime", self.runtime),
             ("consensus", self.consensus),
@@ -253,7 +259,16 @@ impl MetricGroups {
             ("epoch", self.epoch),
             ("hardware", self.hardware),
         ]
-        .map(|(group, level)| {
+    }
+
+    /// Maps each group's configured level to the filter patterns it covers.
+    ///
+    /// Directive order does not matter: where one group's module prefix also
+    /// matches another group's submodules (e.g. `runtime`'s `iota_metrics`
+    /// covers the `p2p` and `hardware` groups'), the more specific pattern
+    /// wins.
+    fn group_modules(&self) -> [(MetricLevel, &'static [&'static str]); 13] {
+        self.group_levels().map(|(group, level)| {
             (
                 level,
                 Self::modules_for_group(group).expect("group has modules"),
@@ -266,21 +281,24 @@ impl MetricGroups {
     /// group module (including the hardware group's). The group levels
     /// override the catch-all for their modules, being more specific.
     pub fn to_filter_string(&self) -> String {
-        fn token(level: MetricLevel) -> &'static str {
-            match level {
-                MetricLevel::Off => "off",
-                MetricLevel::Warn => "warn",
-                MetricLevel::Info => "info",
-                MetricLevel::Debug => "debug",
-                MetricLevel::Trace => "trace",
-            }
-        }
-        let mut directives = vec![token(self.default).to_owned()];
+        let mut directives = vec![level_string(self.default).to_owned()];
         for (level, modules) in self.group_modules() {
             for module in modules {
-                directives.push(format!("{module}={}", token(level)));
+                directives.push(format!("{module}={}", level_string(level)));
             }
         }
+        directives.join(",") 
+    }
+
+    /// Renders the levels into a group-form directive string.
+    /// Keyed by group name rather than expanded
+    /// to module paths, so the admin endpoint can echo the config compactly.
+    pub fn to_display_string(&self) -> String {
+        let mut directives = vec![format!("default={}", level_string(self.default))];
+        for (group, level) in self.group_levels() {
+            directives.push(format!("{group}={}", level_string(level)));
+        }
+        directives.extend(self.override_directives());
         directives.join(",")
     }
 
@@ -369,6 +387,24 @@ mod tests {
         assert!(!filter.is_exposed("x", "starfish_core::metrics", MetricLevel::Info));
         assert!(filter.is_exposed("x", "iota_node::some_module", MetricLevel::Info));
         assert!(!filter.is_exposed("x", "iota_node::some_module", MetricLevel::Debug));
+    }
+
+    #[test]
+    fn to_display_string_keys_by_group_name() {
+        // The display form keeps group names rather than expanding to modules.
+        let display = MetricGroups {
+            consensus: MetricLevel::Off,
+            storage: MetricLevel::Trace,
+            ..MetricGroups::default()
+        }
+        .to_display_string();
+        assert!(display.starts_with("default=info,"));
+        assert!(display.contains("consensus=off"));
+        assert!(display.contains("storage=trace"));
+        assert!(display.contains("hardware=warn"));
+        // No module paths leak into the display form.
+        assert!(!display.contains("::"));
+        assert!(!display.contains("starfish_core"));
     }
 
     #[test]

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -35,11 +35,10 @@
 //! `metrics.groups` entirely, so an omitted and an empty section behave the
 //! same.
 //!
-//! The `hw` hardware metrics are registered as a prometheus collector and
-//! so bypass the filtering macros entirely. They cannot be level-filtered
-//! individually: the `hardware` group's level is read once at registration
-//! time — [`MetricLevel::Off`] skips the whole group, any other level
-//! registers it.
+//! The `hw` hardware metrics are one collector rather than macro-registered
+//! metrics, so the whole group shares a single level: the `hardware` group's
+//! level exposes the collector (`off` hides it, any other level exposes it),
+//! and — like the other groups — it can be changed at runtime.
 
 pub use prometheus_filtered::MetricLevel;
 use serde::{Deserialize, Serialize};
@@ -287,7 +286,7 @@ impl MetricGroups {
                 directives.push(format!("{module}={}", level_string(level)));
             }
         }
-        directives.join(",") 
+        directives.join(",")
     }
 
     /// Renders the levels into a group-form directive string.
@@ -298,19 +297,20 @@ impl MetricGroups {
         for (group, level) in self.group_levels() {
             directives.push(format!("{group}={}", level_string(level)));
         }
-        directives.extend(self.override_directives());
         directives.join(",")
     }
 
     /// Expands group names in a `pattern=LEVEL` directive string into the
     /// groups' filter patterns; other directives pass through unchanged.
-    /// The first invalid directive rejects the whole string.
+    /// Any invalid directive rejects the whole string, with every offending
+    /// directive reported.
     pub fn expand_directives(filter: &str) -> Result<String, String> {
-        let mut directives = Vec::new();
-        for part in prometheus_filtered::directive_parts(filter) {
-            directives.extend(Self::expand_directive(part)?);
+        let (directives, errors) = Self::expand_startup_directives(filter);
+        if errors.is_empty() {
+            Ok(directives)
+        } else {
+            Err(errors.join("; "))
         }
-        Ok(directives.join(","))
     }
 
     /// Like [`Self::expand_directives`], but for startup use: an invalid
@@ -598,10 +598,12 @@ mod tests {
 
     #[test]
     fn expand_directives_rejects_invalid_input() {
-        // An invalid level fails up front, citing the directive as the
-        // caller wrote it — not its expansion.
-        let err = MetricGroups::expand_directives("consensus=bogus").unwrap_err();
+        // An invalid level fails the whole string, citing every offending
+        // directive as the caller wrote it — not its expansion.
+        let err =
+            MetricGroups::expand_directives("consensus=bogus,storage=warn,epoch=nah").unwrap_err();
         assert!(err.contains("consensus=bogus"), "unexpected error: {err}");
+        assert!(err.contains("epoch=nah"), "unexpected error: {err}");
     }
 
     #[test]

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -286,12 +286,24 @@ impl MetricGroups {
 
     /// Expands group names in a `pattern=LEVEL` directive string into the
     /// groups' filter patterns; other directives pass through unchanged.
+    /// The hardware group is rejected, since it is registered once at startup
+    /// and cannot be changed at runtime.
     pub fn expand_directives(filter: &str) -> Result<String, String> {
+        Self::expand(filter, true)
+    }
+
+    pub fn expand_startup_directives(filter: &str) -> Result<String, String> {
+        Self::expand(filter, false)
+    }
+
+    fn expand(filter: &str, reject_hardware: bool) -> Result<String, String> {
         let mut directives: Vec<String> = Vec::new();
         for part in prometheus_filtered::directive_parts(filter) {
             prometheus_filtered::validate_directive(part)?;
             let (pattern, level) = prometheus_filtered::split_directive(part);
-            if pattern == "hardware" || pattern == "iota_metrics::hardware_metrics" {
+            if reject_hardware
+                && (pattern == "hardware" || pattern == "iota_metrics::hardware_metrics")
+            {
                 return Err(
                     "the hardware group is registered once at startup and cannot be \
                             changed at runtime"
@@ -389,7 +401,7 @@ mod tests {
     fn metric_groups_runtime_prefix_is_overridden_by_submodule_groups() {
         // `runtime` covers the whole `iota_metrics` crate by module prefix,
         // but the `p2p` and `hardware` submodules belong to their own
-        // groups, whose directives render later and win.
+        // groups, whose more specific patterns win.
         let groups = MetricGroups {
             runtime: MetricLevel::Trace,
             p2p: MetricLevel::Warn,
@@ -508,6 +520,21 @@ mod tests {
             MetricGroups::expand_directives("default=info,traffic-control=off").unwrap(),
             "info,iota_core::traffic_controller=off,iota_config::node_config_metrics=off"
         );
+    }
+
+    #[test]
+    fn expand_startup_directives_allows_hardware() {
+        // At startup the hardware collector is not registered yet, so its
+        // group may be set — e.g. via the `METRICS_FILTER` env var.
+        assert_eq!(
+            MetricGroups::expand_startup_directives("hardware=off").unwrap(),
+            "iota_metrics::hardware_metrics=off"
+        );
+        // Invalid levels are still rejected.
+        MetricGroups::expand_startup_directives("consensus=bogus").unwrap_err();
+        // The runtime variant keeps rejecting the group: the registration
+        // decision cannot be revisited.
+        MetricGroups::expand_directives("hardware=off").unwrap_err();
     }
 
     #[test]

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -233,9 +233,10 @@ impl MetricGroups {
 
     /// Maps each group's configured level to the filter patterns it covers.
     ///
-    /// `runtime` must come first: its `iota_metrics` module prefix also
-    /// matches the `p2p` and `hardware` groups' submodules, and only a
-    /// later directive can override it (last match wins).
+    /// Directive order does not matter: where one group's module prefix also
+    /// matches another group's submodules (e.g. `runtime`'s `iota_metrics`
+    /// covers the `p2p` and `hardware` groups'), the more specific pattern
+    /// wins.
     fn group_modules(&self) -> [(MetricLevel, &'static [&'static str]); 13] {
         [
             ("runtime", self.runtime),
@@ -261,10 +262,9 @@ impl MetricGroups {
     }
 
     /// Renders the levels into a `METRICS_FILTER`-style directive string: the
-    /// `default` threshold as the leading catch-all directive, then one
-    /// directive per group module (including the hardware group's). Later
-    /// directives win, so the group levels override the catch-all for their
-    /// modules.
+    /// `default` threshold as the catch-all directive, then one directive per
+    /// group module (including the hardware group's). The group levels
+    /// override the catch-all for their modules, being more specific.
     pub fn to_filter_string(&self) -> String {
         fn token(level: MetricLevel) -> &'static str {
             match level {
@@ -309,26 +309,6 @@ impl MetricGroups {
                 None => directives.push(part.to_owned()),
             }
         }
-        let rescued: Vec<String> = directives
-            .iter()
-            .enumerate()
-            .filter(|(i, directive)| {
-                let (pattern, _) = prometheus_filtered::split_directive(directive);
-                !pattern.is_empty()
-                    && directives[i + 1..].iter().any(|later| {
-                        let (later_pattern, _) = prometheus_filtered::split_directive(later);
-                        !later_pattern.is_empty()
-                            && pattern.len() > later_pattern.len()
-                            && pattern.starts_with(later_pattern)
-                    })
-                    // A later directive for the same pattern stays authoritative.
-                    && !directives[i + 1..].iter().any(|later| {
-                        prometheus_filtered::split_directive(later).0 == pattern
-                    })
-            })
-            .map(|(_, directive)| directive.clone())
-            .collect();
-        directives.extend(rescued);
         Ok(directives.join(","))
     }
 }
@@ -470,8 +450,7 @@ mod tests {
         let filter_string = groups.to_filter_string();
         assert!(filter_string.contains("iota_metrics::hardware_metrics=off"));
         assert!(!hardware_metrics_enabled(&Filter::parse(&filter_string)));
-        // A `METRICS_FILTER` directive is appended after the config's and
-        // overrides it.
+        // A later directive with the same pattern overrides the rendered one.
         let overridden = Filter::parse(&format!(
             "{filter_string},iota_metrics::hardware_metrics=warn"
         ));
@@ -545,26 +524,53 @@ mod tests {
     }
 
     #[test]
-    fn expand_directives_keeps_specific_directives_effective() {
-        // `runtime` expands to the `iota_metrics` module prefix, which also
-        // matches the `transport` submodule; the more specific transport
-        // directive must win in either input order.
+    fn expand_directives_is_order_independent() {
+        // A `default` level after a group directive does not cancel it.
         for input in [
-            "transport=warn,runtime=trace",
-            "runtime=trace,transport=warn",
+            "traffic-control=off,default=info",
+            "default=info,traffic-control=off",
         ] {
             let expanded = MetricGroups::expand_directives(input).unwrap();
             let filter = Filter::parse(&expanded);
             assert!(
-                filter.is_exposed("x", "iota_metrics", MetricLevel::Trace),
+                !filter.is_exposed("x", "iota_core::traffic_controller", MetricLevel::Warn),
                 "{input} -> {expanded}"
             );
             assert!(
-                !filter.is_exposed("x", "iota_metrics::metrics_network", MetricLevel::Info),
+                filter.is_exposed("x", "iota_core::authority", MetricLevel::Info),
+                "{input} -> {expanded}"
+            );
+            assert!(
+                !filter.is_exposed("x", "iota_core::authority", MetricLevel::Debug),
                 "{input} -> {expanded}"
             );
         }
-        // A later directive for the same pattern still wins (last match).
+        // With three nested module prefixes, each level applies to its own
+        // subtree: the most specific matching directive wins.
+        let expanded = MetricGroups::expand_directives(
+            "iota_metrics::metrics_network::inbound=off,transport=debug,runtime=trace",
+        )
+        .unwrap();
+        let filter = Filter::parse(&expanded);
+        assert!(
+            !filter.is_exposed(
+                "x",
+                "iota_metrics::metrics_network::inbound",
+                MetricLevel::Warn
+            ),
+            "{expanded}"
+        );
+        assert!(
+            filter.is_exposed("x", "iota_metrics::metrics_network", MetricLevel::Debug),
+            "{expanded}"
+        );
+        assert!(
+            filter.is_exposed("x", "iota_metrics", MetricLevel::Trace),
+            "{expanded}"
+        );
+        // A later directive for the same pattern still wins (last match):
+        // here `runtime` expands to the raw directive's `iota_metrics`
+        // pattern.
         let expanded = MetricGroups::expand_directives("iota_metrics=off,runtime=warn").unwrap();
         let filter = Filter::parse(&expanded);
         assert!(filter.is_exposed("x", "iota_metrics", MetricLevel::Warn));

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -35,10 +35,8 @@
 //! `metrics.groups` entirely, so an omitted and an empty section behave the
 //! same.
 //!
-//! The `hw` hardware metrics are one collector rather than macro-registered
-//! metrics, so the whole group shares a single level: the `hardware` group's
-//! level exposes the collector (`off` hides it, any other level exposes it),
-//! and — like the other groups — it can be changed at runtime.
+//! The `hardware` metrics are grouped together as one collector and
+//! registered with `warn` level, so the whole group shares a single level.
 
 use std::collections::BTreeMap;
 
@@ -174,7 +172,7 @@ impl Default for MetricGroups {
 impl MetricGroups {
     /// Returns the filter patterns a group covers — keyed
     /// by the group's config key. `None` for unknown groups.
-    pub fn modules_for_group(group: &str) -> Option<&'static [&'static str]> {
+    fn modules_for_group(group: &str) -> Option<&'static [&'static str]> {
         Some(match group {
             "runtime" => &["iota_metrics", "telemetry_subscribers"],
             "consensus" => &[

--- a/crates/iota-metrics/src/metric_groups.rs
+++ b/crates/iota-metrics/src/metric_groups.rs
@@ -139,8 +139,10 @@ pub struct MetricGroups {
     pub hardware: MetricLevel,
     /// Free-form overrides for module paths or metric names, including ones
     /// already covered by a named group: the most specific matching pattern
-    /// decides each metric, so an override can raise or lower a single module
-    /// or metric within a group.
+    /// decides each metric (a metric-name match wins over a module match),
+    /// so an override can raise or lower a single module or metric within a
+    /// group. A `default` key is the same pattern as the `default` field and
+    /// replaces its level.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub overrides: BTreeMap<String, MetricLevel>,
 }
@@ -257,8 +259,7 @@ impl MetricGroups {
         ]
     }
 
-    /// List of metric level together with registered module paths
-    /// corresponding to all groups.
+    /// Each group's configured level paired with the module paths it covers.
     fn group_modules(&self) -> [(MetricLevel, &'static [&'static str]); 13] {
         self.group_levels().map(|(group, level)| {
             (
@@ -321,7 +322,9 @@ impl MetricGroups {
     }
 
     /// Builds the startup metrics filter: these group levels with the `env`
-    /// directives merged over them.
+    /// directives merged over them. An env bare level replaces the group
+    /// directives entirely instead of merging, so `METRICS_FILTER=trace`
+    /// exposes everything whatever the groups configure.
     /// Invalid env directives are dropped.
     ///
     /// Matching uses the expanded module directives; the admin endpoint
@@ -414,6 +417,15 @@ mod tests {
         assert!(!filter.is_exposed("x", "starfish_core::metrics", MetricLevel::Info));
         assert!(filter.is_exposed("x", "iota_node::some_module", MetricLevel::Info));
         assert!(!filter.is_exposed("x", "iota_node::some_module", MetricLevel::Debug));
+
+        // A bare env level replaces all group directives instead of merging
+        // over them, so `METRICS_FILTER=trace` (which the benchmark tooling
+        // exports to read gated metrics) exposes everything.
+        let (filter, errors) = MetricGroups::default().startup_filter(Some("trace"));
+        assert!(errors.is_empty());
+        assert!(filter.is_exposed("x", "iota_core::execution_cache", MetricLevel::Trace));
+        assert!(filter.is_exposed("x", "iota_node::some_module", MetricLevel::Trace));
+        assert_eq!(filter.startup_filter_string(), "trace");
     }
 
     #[test]
@@ -668,7 +680,8 @@ mod tests {
         // the `overrides` map, keeping group-name typo protection intact.
         let groups: MetricGroups = serde_yaml::from_str(
             "consensus: off\n\
-             overrides:\n  \"iota_core::authority::foo\": trace\n  bespoke_metric: off",
+             overrides:\n  \"iota_core::authority::foo\": trace\n  bespoke_metric: off\n  \
+             certs_total: trace",
         )
         .unwrap();
         assert_eq!(groups.consensus, MetricLevel::Off);
@@ -681,5 +694,15 @@ mod tests {
         // The longer override pattern wins over the `authority` group directive.
         assert!(filter.is_exposed("x", "iota_core::authority::foo", MetricLevel::Trace));
         assert!(!filter.is_exposed("bespoke_metric_total", "somewhere", MetricLevel::Warn));
+        // A metric-name override wins over its module's group directive
+        // (`iota_core::execution_cache=warn` here) even though the name is
+        // the shorter pattern.
+        assert!(filter.is_exposed(
+            "certs_total",
+            "iota_core::execution_cache",
+            MetricLevel::Trace
+        ));
+        // Other metrics in the module keep the group's level.
+        assert!(!filter.is_exposed("other", "iota_core::execution_cache", MetricLevel::Info));
     }
 }

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -94,7 +94,7 @@ use crate::IotaNode;
 // starts from the startup directives again rather than stacking on the
 // previous override.
 //
-//   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters' -d 'consensus=off,typed_store=warn'
+//   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters?filter=consensus=off,typed_store=warn'
 //
 // Drop the runtime override, restoring the startup configuration.
 //
@@ -628,11 +628,16 @@ async fn get_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, 
     )
 }
 
+#[derive(Deserialize)]
+struct MetricsFilterUpdate {
+    filter: String,
+}
+
 async fn set_metrics_filter(
     State(state): State<Arc<AppState>>,
-    new_filter: String,
+    Query(MetricsFilterUpdate { filter }): Query<MetricsFilterUpdate>,
 ) -> (StatusCode, String) {
-    let new_filter = new_filter.trim();
+    let new_filter = filter.trim();
     let expanded = match MetricGroups::expand_directives(new_filter) {
         Ok(expanded) => expanded,
         Err(err) => return (StatusCode::BAD_REQUEST, format!("{err}\n")),

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 use base64::Engine;
 use humantime::parse_duration;
+use iota_metrics::MetricGroups;
 use iota_sdk_types::RandomnessRound;
 use iota_types::{
     base_types::AuthorityName,
@@ -76,6 +77,22 @@ use crate::IotaNode;
 // Reconfigure traffic control policy
 //
 //  $ curl 'http://127.0.0.1:1337/traffic-control?error_threshold=100&spam_threshold=100&dry_run=true'
+//
+// View the current Prometheus metrics filter.
+//
+//   $ curl 'http://127.0.0.1:1337/metrics/filters'
+//
+// Change which metrics the /metrics endpoint exposes. Patterns may be group
+// names from the `metrics.groups` config section (`default` included) or raw
+// METRICS_FILTER-style patterns. The only
+// exception is the `hardware` group, whose collector is only registered at
+// startup and is therefore rejected.
+//
+//   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters' -d 'consensus=off,typed_store=warn'
+//
+// Reset the metrics filter to the startup configuration.
+//
+//   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters/reset'
 
 const LOGGING_ROUTE: &str = "/logging";
 const TRACING_ROUTE: &str = "/enable-tracing";
@@ -90,6 +107,8 @@ const RANDOMNESS_INJECT_PARTIAL_SIGS_ROUTE: &str = "/randomness-inject-partial-s
 const RANDOMNESS_INJECT_FULL_SIG_ROUTE: &str = "/randomness-inject-full-sig";
 const FLAMEGRAPH_ROUTE: &str = "/flamegraph";
 const TRAFFIC_CONTROL: &str = "/traffic-control";
+const METRICS_FILTER_ROUTE: &str = "/metrics/filters";
+const METRICS_FILTER_RESET_ROUTE: &str = "/metrics/filters/reset";
 
 struct AppState {
     node: Arc<IotaNode>,
@@ -135,6 +154,9 @@ pub async fn run_admin_server(
         )
         .route(FLAMEGRAPH_ROUTE, get(flamegraph))
         .route(TRAFFIC_CONTROL, post(traffic_control))
+        .route(METRICS_FILTER_ROUTE, get(get_metrics_filter))
+        .route(METRICS_FILTER_ROUTE, post(set_metrics_filter))
+        .route(METRICS_FILTER_RESET_ROUTE, post(reset_metrics_filter))
         .with_state(Arc::new(app_state));
 
     info!(
@@ -581,4 +603,40 @@ async fn traffic_control(
         ),
         Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }
+}
+
+async fn get_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
+    (
+        StatusCode::OK,
+        state.node.metrics_filter().runtime_filter_string(),
+    )
+}
+
+async fn set_metrics_filter(
+    State(state): State<Arc<AppState>>,
+    new_filter: String,
+) -> (StatusCode, String) {
+    let expanded = match MetricGroups::expand_directives(&new_filter) {
+        Ok(expanded) => expanded,
+        Err(err) => return (StatusCode::BAD_REQUEST, format!("{err}\n")),
+    };
+    match state.node.metrics_filter().set_runtime_filter(&expanded) {
+        Ok(()) => {
+            info!(filter =% expanded, "Metrics filter updated");
+            (
+                StatusCode::OK,
+                format!("metrics filter set to {expanded:?}\n"),
+            )
+        }
+        Err(err) => (StatusCode::BAD_REQUEST, format!("{err}\n")),
+    }
+}
+
+async fn reset_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
+    state.node.metrics_filter().reset_runtime_filter();
+    info!("Metrics filter reset to startup configuration");
+    (
+        StatusCode::OK,
+        "metrics filter reset to startup configuration\n".into(),
+    )
 }

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -608,16 +608,18 @@ async fn traffic_control(
 }
 
 async fn get_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
+    fn or_none(s: &str) -> &str {
+        if s.is_empty() { "(none)" } else { s }
+    }
     let filter = state.node.metrics_filter();
-    let runtime = filter
-        .runtime_filter_string()
-        .unwrap_or_else(|| "(none)".to_owned());
+    let runtime = filter.runtime_filter_string().unwrap_or_default();
     (
         StatusCode::OK,
         format!(
-            "runtime: {runtime}\nenv: {}\nconfig: {}\n",
-            filter.env_filter_string(),
-            filter.config_filter_string(),
+            "runtime: {}\nenv: {}\nconfig: {}\n",
+            or_none(&runtime),
+            or_none(filter.env_filter_string()),
+            or_none(filter.config_filter_string()),
         ),
     )
 }

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -89,7 +89,9 @@ use crate::IotaNode;
 // The override is merged over the startup directives: an override directive
 // replaces the startup directive with the same pattern, and otherwise the
 // most specific matching pattern decides each metric, whichever source it
-// came from. Each POST
+// came from. A bare level (e.g. `trace`) replaces the startup directives
+// entirely, exposing everything up to that level; `default=LEVEL` changes
+// only the level for the metrics no other directive matches. Each POST
 // starts from the startup directives again rather than stacking on the
 // previous override.
 //

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -84,9 +84,8 @@ use crate::IotaNode;
 //
 // Set the runtime override for the metrics the /metrics endpoint exposes.
 // Patterns may be group names from the `metrics.groups` config section
-// (`default` included) or raw METRICS_FILTER-style patterns; the `hardware`
-// group is rejected, its collector being only registered at startup. Where
-// an override directive matches a metric it takes precedence over the
+// (`default` and `hardware` included) or raw METRICS_FILTER-style patterns.
+// Where an override directive matches a metric it takes precedence over the
 // startup configuration; metrics matched by no override directive keep
 // their startup exposure. A bare level (e.g. `trace`) matches everything.
 //

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -632,7 +632,7 @@ async fn set_metrics_filter(
         Ok(expanded) => expanded,
         Err(err) => return (StatusCode::BAD_REQUEST, format!("{err}\n")),
     };
-    match state.node.metrics_filter().set_runtime_filter(&expanded) {
+    match state.node.set_metrics_runtime_filter(&expanded) {
         Ok(()) => {
             info!(filter =% expanded, "Metrics filter updated");
             (
@@ -645,7 +645,7 @@ async fn set_metrics_filter(
 }
 
 async fn reset_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
-    state.node.metrics_filter().reset_runtime_filter();
+    state.node.reset_metrics_runtime_filter();
     info!("Metrics filter reset to startup configuration");
     (
         StatusCode::OK,

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -78,19 +78,21 @@ use crate::IotaNode;
 //
 //  $ curl 'http://127.0.0.1:1337/traffic-control?error_threshold=100&spam_threshold=100&dry_run=true'
 //
-// View the current Prometheus metrics filter.
+// View the Prometheus metrics filter layers (runtime override, env, config).
 //
 //   $ curl 'http://127.0.0.1:1337/metrics/filters'
 //
-// Change which metrics the /metrics endpoint exposes. Patterns may be group
-// names from the `metrics.groups` config section (`default` included) or raw
-// METRICS_FILTER-style patterns. The only
-// exception is the `hardware` group, whose collector is only registered at
-// startup and is therefore rejected.
+// Set the runtime override for the metrics the /metrics endpoint exposes.
+// Patterns may be group names from the `metrics.groups` config section
+// (`default` included) or raw METRICS_FILTER-style patterns; the `hardware`
+// group is rejected, its collector being only registered at startup. Where
+// an override directive matches a metric it takes precedence over the
+// startup configuration; metrics matched by no override directive keep
+// their startup exposure. A bare level (e.g. `trace`) matches everything.
 //
 //   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters' -d 'consensus=off,typed_store=warn'
 //
-// Reset the metrics filter to the startup configuration.
+// Drop the runtime override, restoring the startup configuration.
 //
 //   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters/reset'
 
@@ -606,9 +608,17 @@ async fn traffic_control(
 }
 
 async fn get_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
+    let filter = state.node.metrics_filter();
+    let runtime = filter
+        .runtime_filter_string()
+        .unwrap_or_else(|| "(none)".to_owned());
     (
         StatusCode::OK,
-        state.node.metrics_filter().runtime_filter_string(),
+        format!(
+            "runtime: {runtime}\nenv: {}\nconfig: {}\n",
+            filter.env_filter_string(),
+            filter.config_filter_string(),
+        ),
     )
 }
 

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -13,7 +13,6 @@ use axum::{
 };
 use base64::Engine;
 use humantime::parse_duration;
-use iota_metrics::MetricGroups;
 use iota_sdk_types::RandomnessRound;
 use iota_types::{
     base_types::AuthorityName,
@@ -612,18 +611,15 @@ async fn traffic_control(
 }
 
 async fn get_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
-    fn or_none(s: String) -> String {
-        if s.is_empty() { "(none)".into() } else { s }
-    }
-    let filter = state.node.metrics_filter();
+    let filter = state.node.registry_service().filter();
     (
         StatusCode::OK,
         format!(
             "metrics exposure filter:\n\
-             current: {}\n\
-             startup: {}\n",
-            or_none(filter.filter_string()),
-            or_none(filter.startup_filter_string()),
+             current: {}\n\n\n\
+             (startup: {})\n",
+            filter.filter_string(),
+            filter.startup_filter_string(),
         ),
     )
 }
@@ -638,12 +634,7 @@ async fn set_metrics_filter(
     Query(MetricsFilterUpdate { filter }): Query<MetricsFilterUpdate>,
 ) -> (StatusCode, String) {
     let new_filter = filter.trim();
-    let expanded = match MetricGroups::expand_directives(new_filter) {
-        Ok(expanded) => expanded,
-        Err(err) => return (StatusCode::BAD_REQUEST, format!("{err}\n")),
-    };
-
-    match state.node.set_metrics_runtime_filter(&expanded, new_filter) {
+    match state.node.registry_service().set_runtime_filter(new_filter) {
         Ok(()) => {
             info!(filter =% new_filter, "Metrics filter updated");
             (
@@ -656,7 +647,7 @@ async fn set_metrics_filter(
 }
 
 async fn reset_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
-    state.node.reset_metrics_runtime_filter();
+    state.node.registry_service().reset_runtime_filter();
     info!("Metrics filter reset to startup configuration");
     (
         StatusCode::OK,

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -78,16 +78,20 @@ use crate::IotaNode;
 //
 //  $ curl 'http://127.0.0.1:1337/traffic-control?error_threshold=100&spam_threshold=100&dry_run=true'
 //
-// View the Prometheus metrics filter layers (runtime override, env, config).
+// View the Prometheus metrics filter: the directives currently in effect and
+// the startup directives (config with the METRICS_FILTER env var merged over
+// it) that a reset restores.
 //
 //   $ curl 'http://127.0.0.1:1337/metrics/filters'
 //
 // Set the runtime override for the metrics the /metrics endpoint exposes.
 // Patterns may be group names from the `metrics.groups` config section
 // (`default` and `hardware` included) or raw METRICS_FILTER-style patterns.
-// Where an override directive matches a metric it takes precedence over the
-// startup configuration; metrics matched by no override directive keep
-// their startup exposure. A bare level (e.g. `trace`) matches everything.
+// The override is merged over the startup directives: an override directive
+// replaces every startup directive whose pattern it prefixes, and metrics it
+// does not shadow keep their startup exposure. A bare level (e.g. `trace`)
+// replaces the whole filter. Each POST starts from the startup directives
+// again rather than stacking on the previous override.
 //
 //   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters' -d 'consensus=off,typed_store=warn'
 //
@@ -607,18 +611,16 @@ async fn traffic_control(
 }
 
 async fn get_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
-    fn or_none(s: &str) -> &str {
-        if s.is_empty() { "(none)" } else { s }
+    fn or_none(s: String) -> String {
+        if s.is_empty() { "(none)".into() } else { s }
     }
     let filter = state.node.metrics_filter();
-    let runtime = filter.runtime_filter_string().unwrap_or_default();
     (
         StatusCode::OK,
         format!(
-            "runtime: {}\nenv: {}\nconfig: {}\n",
-            or_none(&runtime),
-            or_none(filter.env_filter_string()),
-            or_none(filter.config_filter_string()),
+            "metrics exposure filter:\n\
+             {}\n",
+            or_none(filter.filter_string()),
         ),
     )
 }
@@ -627,16 +629,18 @@ async fn set_metrics_filter(
     State(state): State<Arc<AppState>>,
     new_filter: String,
 ) -> (StatusCode, String) {
-    let expanded = match MetricGroups::expand_directives(&new_filter) {
+    let new_filter = new_filter.trim();
+    let expanded = match MetricGroups::expand_directives(new_filter) {
         Ok(expanded) => expanded,
         Err(err) => return (StatusCode::BAD_REQUEST, format!("{err}\n")),
     };
-    match state.node.set_metrics_runtime_filter(&expanded) {
+
+    match state.node.set_metrics_runtime_filter(&expanded, new_filter) {
         Ok(()) => {
-            info!(filter =% expanded, "Metrics filter updated");
+            info!(filter =% new_filter, "Metrics filter updated");
             (
                 StatusCode::OK,
-                format!("metrics filter set to {expanded:?}\n"),
+                format!("metrics filter set to {new_filter:?}\n"),
             )
         }
         Err(err) => (StatusCode::BAD_REQUEST, format!("{err}\n")),

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -88,10 +88,11 @@ use crate::IotaNode;
 // Patterns may be group names from the `metrics.groups` config section
 // (`default` and `hardware` included) or raw METRICS_FILTER-style patterns.
 // The override is merged over the startup directives: an override directive
-// replaces every startup directive whose pattern it prefixes, and metrics it
-// does not shadow keep their startup exposure. A bare level (e.g. `trace`)
-// replaces the whole filter. Each POST starts from the startup directives
-// again rather than stacking on the previous override.
+// replaces the startup directive with the same pattern, and otherwise the
+// most specific matching pattern decides each metric, whichever source it
+// came from. A bare level (e.g. `trace`) replaces the whole filter. Each
+// POST starts from the startup directives again rather than stacking on the
+// previous override.
 //
 //   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters' -d 'consensus=off,typed_store=warn'
 //

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -90,8 +90,8 @@ use crate::IotaNode;
 // The override is merged over the startup directives: an override directive
 // replaces the startup directive with the same pattern, and otherwise the
 // most specific matching pattern decides each metric, whichever source it
-// came from. A bare level (e.g. `trace`) replaces the whole filter. Each
-// POST starts from the startup directives again rather than stacking on the
+// came from. Each POST
+// starts from the startup directives again rather than stacking on the
 // previous override.
 //
 //   $ curl -X POST 'http://127.0.0.1:1337/metrics/filters' -d 'consensus=off,typed_store=warn'
@@ -620,8 +620,10 @@ async fn get_metrics_filter(State(state): State<Arc<AppState>>) -> (StatusCode, 
         StatusCode::OK,
         format!(
             "metrics exposure filter:\n\
-             {}\n",
+             current: {}\n\
+             startup: {}\n",
             or_none(filter.filter_string()),
+            or_none(filter.startup_filter_string()),
         ),
     )
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2340,25 +2340,10 @@ impl IotaNode {
         self.randomness_handle.clone()
     }
 
-    /// Returns the metrics filter shared by the node's Prometheus registries.
-    pub fn metrics_filter(&self) -> Arc<prometheus_filtered::Filter> {
-        self.registry_service.filter()
-    }
-
-    /// Sets the runtime metrics filter. `directives` drive matching (groups
-    /// already expanded); `display` is the group-form input the admin endpoint
-    /// echoes back.
-    pub fn set_metrics_runtime_filter(
-        &self,
-        directives: &str,
-        display: &str,
-    ) -> std::result::Result<(), String> {
-        self.registry_service
-            .set_runtime_filter(directives, display)
-    }
-
-    pub fn reset_metrics_runtime_filter(&self) {
-        self.registry_service.reset_runtime_filter();
+    /// Returns the registry service holding the node's Prometheus registries
+    /// and their shared exposure filter.
+    pub(crate) fn registry_service(&self) -> &RegistryService {
+        &self.registry_service
     }
 
     /// Sends signed capability notification to committee validators for

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2342,7 +2342,7 @@ impl IotaNode {
 
     /// Returns the metrics filter shared by the node's Prometheus registries.
     pub fn metrics_filter(&self) -> Arc<prometheus_filtered::Filter> {
-        self.registry_service.default_registry().filter()
+        self.registry_service.filter()
     }
 
     /// Sets the runtime metrics filter. `directives` drive matching (groups

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2345,8 +2345,16 @@ impl IotaNode {
         self.registry_service.default_registry().filter()
     }
 
-    pub fn set_metrics_runtime_filter(&self, s: &str) -> std::result::Result<(), String> {
-        self.registry_service.set_runtime_filter(s)
+    /// Sets the runtime metrics filter. `directives` drive matching (groups
+    /// already expanded); `display` is the group-form input the admin endpoint
+    /// echoes back.
+    pub fn set_metrics_runtime_filter(
+        &self,
+        directives: &str,
+        display: &str,
+    ) -> std::result::Result<(), String> {
+        self.registry_service
+            .set_runtime_filter(directives, display)
     }
 
     pub fn reset_metrics_runtime_filter(&self) {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2345,6 +2345,14 @@ impl IotaNode {
         self.registry_service.default_registry().filter()
     }
 
+    pub fn set_metrics_runtime_filter(&self, s: &str) -> std::result::Result<(), String> {
+        self.registry_service.set_runtime_filter(s)
+    }
+
+    pub fn reset_metrics_runtime_filter(&self) {
+        self.registry_service.reset_runtime_filter();
+    }
+
     /// Sends signed capability notification to committee validators for
     /// non-committee validators. This method implements retry logic to handle
     /// failed attempts to send the notification. It will retry sending the

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2340,6 +2340,11 @@ impl IotaNode {
         self.randomness_handle.clone()
     }
 
+    /// Returns the metrics filter shared by the node's Prometheus registries.
+    pub fn metrics_filter(&self) -> Arc<prometheus_filtered::Filter> {
+        self.registry_service.default_registry().filter()
+    }
+
     /// Sends signed capability notification to committee validators for
     /// non-committee validators. This method implements retry logic to handle
     /// failed attempts to send the notification. It will retry sending the

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -74,36 +74,20 @@ fn main() {
         _ => config.run_with_range = None,
     };
 
-    // Apply the configured metric group levels from config and env variables.
-    // Matching uses the expanded module directives; the admin endpoint echoes
-    // the group-form strings, so each source keeps both.
+    // Apply the configured metric group levels, with the METRICS_FILTER env
+    // variable merged over them.
     let metric_groups = config
         .metrics
         .as_ref()
         .and_then(|m| m.groups.clone())
         .unwrap_or_default();
-    let env_raw = std::env::var("METRICS_FILTER").ok();
-    let env_directives = env_raw.as_ref().map(|env| {
-        let (expanded, errors) = iota_metrics::MetricGroups::expand_startup_directives(env);
-        // Logging is not initialized yet, so bad directives are reported on
-        // stderr; the remaining directives still apply.
-        for err in errors {
-            eprintln!("dropping METRICS_FILTER directive: {err}");
-        }
-        expanded
-    });
-    let metrics_filter = prometheus_filtered::Filter::from_sources(
-        prometheus_filtered::FilterSource::with_display(
-            &metric_groups.to_filter_string(),
-            &metric_groups.to_display_string(),
-        ),
-        env_directives
-            .as_deref()
-            .zip(env_raw.as_deref())
-            .map(|(directives, display)| {
-                prometheus_filtered::FilterSource::with_display(directives, display)
-            }),
-    );
+    let env_filter = std::env::var("METRICS_FILTER").ok();
+    let (metrics_filter, dropped_directives) = metric_groups.startup_filter(env_filter.as_deref());
+    // Logging is not initialized yet, so bad directives are reported on
+    // stderr; the remaining directives still apply.
+    for err in dropped_directives {
+        eprintln!("dropping METRICS_FILTER directive: {err}");
+    }
 
     let runtimes = IotaRuntimes::new(&config);
     let metrics_rt = runtimes.metrics.enter();

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -75,13 +75,16 @@ fn main() {
     };
 
     // Apply the configured metric group levels from config and env variables.
+    // Matching uses the expanded module directives; the admin endpoint echoes
+    // the group-form strings, so each source keeps both.
     let metric_groups = config
         .metrics
         .as_ref()
         .and_then(|m| m.groups.clone())
         .unwrap_or_default();
-    let env_filter = std::env::var("METRICS_FILTER").ok().map(|env| {
-        let (expanded, errors) = iota_metrics::MetricGroups::expand_startup_directives(&env);
+    let env_raw = std::env::var("METRICS_FILTER").ok();
+    let env_directives = env_raw.as_ref().map(|env| {
+        let (expanded, errors) = iota_metrics::MetricGroups::expand_startup_directives(env);
         // Logging is not initialized yet, so bad directives are reported on
         // stderr; the remaining directives still apply.
         for err in errors {
@@ -89,9 +92,17 @@ fn main() {
         }
         expanded
     });
-    let metrics_filter = prometheus_filtered::Filter::from_layers(
-        &metric_groups.to_filter_string(),
-        env_filter.as_deref(),
+    let metrics_filter = prometheus_filtered::Filter::from_sources(
+        prometheus_filtered::FilterSource::with_display(
+            &metric_groups.to_filter_string(),
+            &metric_groups.to_display_string(),
+        ),
+        env_directives
+            .as_deref()
+            .zip(env_raw.as_deref())
+            .map(|(directives, display)| {
+                prometheus_filtered::FilterSource::with_display(directives, display)
+            }),
     );
 
     let runtimes = IotaRuntimes::new(&config);

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -95,8 +95,9 @@ fn main() {
         iota_metrics::start_prometheus_server_with_filter(config.metrics_address, metrics_filter);
 
     // Register the host hardware collector.
-    register_hardware_metrics(&registry_service, &config.db_path)
-        .expect("Failed registering hardware metrics");
+    if let Err(err) = register_hardware_metrics(&registry_service, &config.db_path) {
+        eprintln!("failed to register hardware metrics: {err}");
+    }
 
     // Initialize logging
     let prometheus_registry = registry_service.default_registry();

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -8,7 +8,7 @@ use clap::{ArgGroup, Parser};
 use iota_common::sync::async_once_cell::AsyncOnceCell;
 use iota_config::{Config, NodeConfig, node::RunWithRange};
 use iota_core::runtime::IotaRuntimes;
-use iota_metrics::hardware_metrics::{hardware_metrics_enabled, register_hardware_metrics};
+use iota_metrics::hardware_metrics::register_hardware_metrics;
 use iota_node::{IotaNode, ServerVersion};
 use iota_types::{
     committee::EpochId, crypto::KeypairTraits, messages_checkpoint::CheckpointSequenceNumber,
@@ -99,13 +99,9 @@ fn main() {
     let registry_service =
         iota_metrics::start_prometheus_server_with_filter(config.metrics_address, metrics_filter);
 
-    // The hardware collector bypasses gather-time filtering, so its level is
-    // applied here, once at startup: `off` skips the group, any other level
-    // registers it.
-    if hardware_metrics_enabled(&registry_service.default_registry().filter()) {
-        register_hardware_metrics(&registry_service, &config.db_path)
-            .expect("Failed registering hardware metrics");
-    }
+    // Register the host hardware collector.
+    register_hardware_metrics(&registry_service, &config.db_path)
+        .expect("Failed registering hardware metrics");
 
     // Initialize logging
     let prometheus_registry = registry_service.default_registry();

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -74,15 +74,19 @@ fn main() {
         _ => config.run_with_range = None,
     };
 
-    // Apply the configured metric group levels; an omitted `metrics.groups`
-    // section behaves like the default config (dashboard metrics only).
+    // Apply the configured metric group levels from config and env variables.
     let metric_groups = config
         .metrics
         .as_ref()
         .and_then(|m| m.groups.clone())
         .unwrap_or_default();
-    let metrics_filter =
-        prometheus_filtered::Filter::resolve(Some(&metric_groups.to_filter_string()));
+    let env_filter = std::env::var("METRICS_FILTER")
+        .ok()
+        .map(|env| iota_metrics::MetricGroups::expand_startup_directives(&env).unwrap_or(env));
+    let metrics_filter = prometheus_filtered::Filter::from_layers(
+        &metric_groups.to_filter_string(),
+        env_filter.as_deref(),
+    );
 
     let runtimes = IotaRuntimes::new(&config);
     let metrics_rt = runtimes.metrics.enter();

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -80,9 +80,15 @@ fn main() {
         .as_ref()
         .and_then(|m| m.groups.clone())
         .unwrap_or_default();
-    let env_filter = std::env::var("METRICS_FILTER")
-        .ok()
-        .map(|env| iota_metrics::MetricGroups::expand_startup_directives(&env).unwrap_or(env));
+    let env_filter = std::env::var("METRICS_FILTER").ok().map(|env| {
+        let (expanded, errors) = iota_metrics::MetricGroups::expand_startup_directives(&env);
+        // Logging is not initialized yet, so bad directives are reported on
+        // stderr; the remaining directives still apply.
+        for err in errors {
+            eprintln!("dropping METRICS_FILTER directive: {err}");
+        }
+        expanded
+    });
     let metrics_filter = prometheus_filtered::Filter::from_layers(
         &metric_groups.to_filter_string(),
         env_filter.as_deref(),

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
         .as_ref()
         .and_then(|m| m.groups.clone())
         .unwrap_or_default();
-    let env_filter = std::env::var("METRICS_FILTER").ok();
+    let env_filter = std::env::var(prometheus_filtered::METRICS_FILTER_ENV).ok();
     let (metrics_filter, dropped_directives) = metric_groups.startup_filter(env_filter.as_deref());
     // Logging is not initialized yet, so bad directives are reported on
     // stderr; the remaining directives still apply.

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -35,10 +35,7 @@
 //! crate behaves exactly like plain `prometheus`; use a bare `LEVEL` directive
 //! to set a stricter global default.
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, OnceLock, RwLock},
-};
+use std::sync::{Arc, OnceLock, RwLock};
 
 /// Re-exported under a hidden alias so `$crate::prometheus::xxx!` works
 /// inside `#[macro_export]` macros without requiring callers to depend
@@ -49,9 +46,9 @@ pub use prometheus;
 // prometheus re-exports
 // ---------------------------------------------------------------------------
 
-// Filtering is enforced by registry membership (see `Registry::register_filtered`
-// and `Registry::reconcile`), so the metric types need no wrapping: re-export
-// prometheus's own types and generic primitives directly.
+// Filtering is enforced by a collector wrapper installed at registration (see
+// `Registry::register_filtered`), so the metric types need no wrapping:
+// re-export prometheus's own types and generic primitives directly.
 pub use prometheus::{
     Counter, CounterVec, Gauge, GaugeVec, Histogram, HistogramTimer, HistogramVec, IntCounter,
     IntCounterVec, IntGauge, IntGaugeVec, core,
@@ -103,6 +100,9 @@ struct FilterDirective {
     /// Empty string means the global default: it matches every metric but
     /// loses to any other matching directive.
     pattern: String,
+    /// `pattern` prefixed with `::`, precomputed so the per-gather module
+    /// component match allocates nothing.
+    component_pattern: String,
     /// Metrics matched by this directive are exposed iff their verbosity is
     /// `<= threshold`. `off=0`, `warn=1`, `info=2`, `debug=3`, `trace=4`.
     threshold: u8,
@@ -240,6 +240,7 @@ fn parse_directive(part: &str) -> std::result::Result<FilterDirective, String> {
         }
     };
     Ok(FilterDirective {
+        component_pattern: format!("::{pattern}"),
         pattern: pattern.to_owned(),
         threshold,
     })
@@ -288,7 +289,7 @@ fn threshold_for(directives: &[FilterDirective], name: &str, module: &str) -> Op
         let matches = dir.pattern.is_empty()
             || name.starts_with(dir.pattern.as_str())
             || module.starts_with(dir.pattern.as_str())
-            || module.contains(&format!("::{}", dir.pattern));
+            || module.contains(dir.component_pattern.as_str());
         if matches && best.is_none_or(|(len, _)| dir.pattern.len() >= len) {
             best = Some((dir.pattern.len(), dir.threshold));
         }
@@ -379,33 +380,39 @@ impl Filter {
 // Registry
 // ---------------------------------------------------------------------------
 
-/// A `prometheus::Collector` that can be boxed and cloned, so the registry can
-/// keep a handle to re-`register`/`unregister` it as the filter changes.
-pub trait CloneableCollector: prometheus::core::Collector {
-    fn clone_box(&self) -> Box<dyn CloneableCollector>;
-}
-
-impl<T: prometheus::core::Collector + Clone + 'static> CloneableCollector for T {
-    fn clone_box(&self) -> Box<dyn CloneableCollector> {
-        Box::new(self.clone())
-    }
-}
-
-/// A metric registered through the wrapper macros, retained so the filter can
-/// toggle its membership in the inner registry at runtime.
-struct RecordedMetric {
+/// A collector registered through the wrapper macros, wrapped so the filter
+/// decides its exposure at gather time: while the filter hides the metric,
+/// `collect` returns nothing, and the underlying metric keeps collecting.
+struct FilteredCollector<C> {
+    name: String,
     module: String,
     level: MetricLevel,
-    collector: Box<dyn CloneableCollector>,
+    filter: Arc<Filter>,
+    inner: C,
+}
+
+impl<C: prometheus::core::Collector> prometheus::core::Collector for FilteredCollector<C> {
+    fn desc(&self) -> Vec<&prometheus::core::Desc> {
+        self.inner.desc()
+    }
+
+    fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
+        if self.filter.is_exposed(&self.name, &self.module, self.level) {
+            self.inner.collect()
+        } else {
+            Vec::new()
+        }
+    }
 }
 
 /// Wraps `prometheus::Registry` with an embedded `Filter` so that
 /// `register_*_with_registry!` macros can decide whether a metric is exposed.
 ///
-/// Metrics registered through the wrapper macros are recorded with their module
-/// path, level, and a collector handle. Exposure is enforced by membership in
-/// the inner registry: a metric that the filter disables is `unregister`ed and
-/// re-`register`ed if the filter later enables it.
+/// Metrics registered through the wrapper macros join the inner registry
+/// wrapped in [`FilteredCollector`], which consults the filter on every
+/// `collect`.
+/// Exposure changes need no bookkeeping here: the next gather simply sees the
+/// new filter.
 #[derive(Clone)]
 pub struct Registry {
     inner: prometheus::Registry,
@@ -413,9 +420,6 @@ pub struct Registry {
     /// Name prefix passed to [`Registry::new_custom`]; gathered family names
     /// include it.
     prefix: Option<String>,
-    /// Gathered family name → recorded metric, for metrics registered via the
-    /// wrapper macros.
-    registered: Arc<RwLock<HashMap<String, RecordedMetric>>>,
 }
 
 impl Registry {
@@ -426,7 +430,6 @@ impl Registry {
             inner: prometheus::Registry::new(),
             filter: Arc::new(Filter::from_env()),
             prefix: None,
-            registered: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -440,7 +443,6 @@ impl Registry {
             inner: prometheus::Registry::new_custom(prefix.clone(), labels)?,
             filter: filter.unwrap_or_else(|| Arc::new(Filter::from_env())),
             prefix,
-            registered: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
@@ -458,9 +460,10 @@ impl Registry {
         }
     }
 
-    /// Used by the wrapper macros: Registers `collector` and records a
-    /// handle so the filter can toggle its exposure later. The collector joins
-    /// the inner registry only if the current filter exposes it.
+    /// Used by the wrapper macros: registers `collector` wrapped in
+    /// [`FilteredCollector`], so the filter in effect at each gather decides
+    /// whether the metric is exposed. Duplicate registrations are rejected by
+    /// the inner registry's descriptor check, hidden or not.
     #[inline]
     pub fn register_filtered<C>(
         &self,
@@ -472,47 +475,14 @@ impl Registry {
     where
         C: prometheus::core::Collector + Clone + 'static,
     {
-        let exposed_name = self.exposed_name(name);
-        let mut registered = self.registered.write().unwrap();
-        // Reject duplicate registration of the same metric name.
-        if registered.contains_key(&exposed_name) {
-            return Err(prometheus::Error::AlreadyReg);
-        }
-
-        let cloneable_collector: Box<dyn CloneableCollector> = Box::new(collector.clone());
-        if self.filter.is_exposed(&exposed_name, module, level) {
-            self.inner.register(cloneable_collector.clone_box())?;
-        }
-        registered.insert(
-            exposed_name,
-            RecordedMetric {
-                module: module.to_owned(),
-                level,
-                collector: cloneable_collector,
-            },
-        );
+        self.inner.register(Box::new(FilteredCollector {
+            name: self.exposed_name(name),
+            module: module.to_owned(),
+            level,
+            filter: self.filter.clone(),
+            inner: collector.clone(),
+        }))?;
         Ok(collector)
-    }
-
-    /// Re-evaluates every recorded metric against the current filter. Call
-    /// after changing the filter's runtime override.
-    pub fn reconcile(&self) {
-        // Snapshot the directives once so the whole pass sees a consistent
-        // filter and avoids re-locking them per metric.
-        let runtime = self.filter.runtime();
-        let registered = self.registered.read().unwrap();
-        for (name, recorded) in registered.iter() {
-            let want = threshold(&runtime.directives, name, &recorded.module)
-                >= recorded.level.verbosity();
-            if want {
-                match self.register(recorded.collector.clone_box()) {
-                    Ok(()) | Err(prometheus::Error::AlreadyReg) => {}
-                    Err(err) => warn!("failed to register metric {name}: {err}"),
-                }
-            } else {
-                let _ = self.unregister(recorded.collector.clone_box());
-            }
-        }
     }
 
     pub fn register(&self, c: Box<dyn prometheus::core::Collector>) -> prometheus::Result<()> {
@@ -558,7 +528,6 @@ pub fn default_registry() -> &'static Registry {
         inner: prometheus::default_registry().clone(),
         filter: default_filter().clone(),
         prefix: None,
-        registered: Arc::new(RwLock::new(HashMap::new())),
     })
 }
 
@@ -1126,14 +1095,11 @@ mod gather_filter_tests {
 
     #[test]
     fn duplicate_name_is_rejected_even_when_filtered_out() {
-        // The `off` directive unregisters the metric from the inner registry,
-        // but a second registration of the same name must still be rejected.
+        // The `off` directive hides the metric from gather, but its collector
+        // stays registered, so a second registration of the same name is
+        // still rejected by the inner registry's descriptor check.
         let reg = registry("g_dup=off");
-        // The first registration is registered then un-registered because `g_dup=off`.
         crate::register_int_gauge_with_registry!("g_dup", "h", &reg; MetricLevel::Warn).unwrap();
-        // The second registration is rejected because the metrics with the same name
-        // exists, it is just not in the registry map due to `g_dup=off`, so the
-        // second metric shouldn't exist.
         let err = crate::register_int_gauge_with_registry!("g_dup", "h", &reg; MetricLevel::Warn)
             .unwrap_err();
         assert!(
@@ -1198,19 +1164,17 @@ mod runtime_filter_tests {
         names
     }
 
-    // The node drives this via `RegistryService`; here we exercise the same
-    // two steps directly: set the runtime override, then reconcile membership.
+    // The node drives this via `RegistryService`; exposure follows the
+    // filter change on the next gather, with no extra step.
     fn set_runtime(registry: &Registry, s: &str) {
         registry
             .filter()
             .set_runtime_filter(FilterSource::new(s))
             .unwrap();
-        registry.reconcile();
     }
 
     fn reset_runtime(registry: &Registry) {
         registry.filter().reset_runtime_filter();
-        registry.reconcile();
     }
 
     #[test]

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -351,7 +351,7 @@ impl Filter {
     }
 
     /// Builds a filter whose startup directives are the env source merged
-    /// over the config source (see [`DirectiveSet::merged`]).
+    /// over the config source: env directives win on conflict.
     pub fn from_sources(config: FilterSource<'_>, env: Option<FilterSource<'_>>) -> Self {
         let startup = Arc::new(DirectiveSet::from_source(config).merged(
             &DirectiveSet::from_source(env.unwrap_or(FilterSource::new(""))),
@@ -382,7 +382,7 @@ impl Filter {
     }
 
     /// Replaces the directives in effect with the runtime override merged
-    /// over the startup directives (see [`DirectiveSet::merged`]) — each call
+    /// over the startup directives (the override wins on conflict) — each call
     /// starts from the startup directives again rather than stacking on the
     /// previous override; an override with a bare level replaces the startup
     /// directives entirely. Rejects the whole update if any directive is
@@ -439,7 +439,7 @@ impl<C: prometheus::core::Collector> prometheus::core::Collector for FilteredCol
 /// `register_*_with_registry!` macros can decide whether a metric is exposed.
 ///
 /// Metrics registered through the wrapper macros join the inner registry
-/// wrapped in [`FilteredCollector`], which consults the filter on every
+/// wrapped in a private collector type, which consults the filter on every
 /// `collect`.
 /// Exposure changes need no bookkeeping here: the next gather simply sees the
 /// new filter.
@@ -490,8 +490,8 @@ impl Registry {
         }
     }
 
-    /// Used by the wrapper macros: registers `collector` wrapped in
-    /// [`FilteredCollector`], so the filter in effect at each gather decides
+    /// Used by the wrapper macros: registers `collector` wrapped in a private
+    /// collector type, so the filter in effect at each gather decides
     /// whether the metric is exposed. Duplicate registrations are rejected by
     /// the inner registry's descriptor check, hidden or not.
     #[inline]

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -14,8 +14,9 @@
 //!
 //! Filter syntax: comma-separated `pattern=LEVEL` directives, where `LEVEL`
 //! is one of `off`, `warn`, `info`, `debug`, `trace`. A bare `LEVEL` token
-//! (no `pattern=`) matches every metric — as an env or runtime directive it
-//! replaces the whole filter. A pattern matches if it is a
+//! (no `pattern=`) and its reserved `default=LEVEL` spelling both set the
+//! global default: the level for the metrics no other directive matches. A
+//! pattern matches if it is a
 //! prefix of the metric name OR is a component/prefix of the calling module
 //! path (e.g. `traffic_controller` matches
 //! `iota_core::traffic_controller::metrics`). When several directives
@@ -99,7 +100,8 @@ const DEFAULT_THRESHOLD: u8 = MetricLevel::Trace.verbosity();
 
 #[derive(Clone)]
 struct FilterDirective {
-    /// Empty string means global catch-all.
+    /// Empty string means the global default: it matches every metric but
+    /// loses to any other matching directive.
     pattern: String,
     /// Metrics matched by this directive are exposed iff their verbosity is
     /// `<= threshold`. `off=0`, `warn=1`, `info=2`, `debug=3`, `trace=4`.
@@ -168,12 +170,6 @@ impl DirectiveSet {
     /// apply and the usual most-specific-pattern-wins matching decides each
     /// metric.
     fn merged(&self, over: &Self) -> Self {
-        if over.directives.iter().any(|dir| dir.pattern.is_empty()) {
-            return Self {
-                directives: over.directives.clone(),
-                display: over.display.clone(),
-            };
-        }
         Self {
             directives: merge_directives(&self.directives, &over.directives),
             display: merge_directives(&self.display, &over.display),
@@ -208,11 +204,15 @@ pub fn directive_parts(s: &str) -> impl Iterator<Item = &str> + '_ {
     s.split(',').map(str::trim).filter(|part| !part.is_empty())
 }
 
-/// Splits one directive into its `(pattern, level)` parts; a directive
-/// without `=` is a bare level with an empty (global catch-all) pattern.
+/// Splits one directive into its `(pattern, level)` parts. Two equivalent
+/// spellings yield the empty (global default) pattern: a bare level (no `=`)
+/// and the reserved `default` pattern, which normalizes to it here.
 pub fn split_directive(part: &str) -> (&str, &str) {
     match part.rfind('=') {
-        Some(eq) => (part[..eq].trim(), part[eq + 1..].trim()),
+        Some(eq) => match part[..eq].trim() {
+            "default" => ("", part[eq + 1..].trim()),
+            pattern => (pattern, part[eq + 1..].trim()),
+        },
         None => ("", part.trim()),
     }
 }
@@ -245,8 +245,8 @@ fn parse_directive(part: &str) -> std::result::Result<FilterDirective, String> {
     })
 }
 
-/// Renders directives back into their canonical `pattern=LEVEL` string, the
-/// inverse of [`parse_directive`].
+/// Renders directives back into their canonical `pattern=LEVEL` string. The
+/// empty pattern renders as `default=LEVEL`.
 fn render_directives(directives: &[FilterDirective]) -> String {
     fn token(threshold: u8) -> &'static str {
         match threshold {
@@ -261,7 +261,7 @@ fn render_directives(directives: &[FilterDirective]) -> String {
         .iter()
         .map(|dir| {
             if dir.pattern.is_empty() {
-                token(dir.threshold).to_owned()
+                format!("default={}", token(dir.threshold))
             } else {
                 format!("{}={}", dir.pattern, token(dir.threshold))
             }
@@ -274,7 +274,7 @@ fn render_directives(directives: &[FilterDirective]) -> String {
 /// directive's threshold, or `None` when no directive matches.
 ///
 /// A directive matches when its pattern is:
-/// 1. Empty — global default.
+/// 1. Empty (a bare level, or its `default=LEVEL` spelling) — global default.
 /// 2. A metric name prefix — `name.starts_with(pattern)`.
 /// 3. A module path prefix — `module.starts_with(pattern)`.
 /// 4. An exact module component — `module` contains `"::{pattern}"`.
@@ -505,7 +505,10 @@ impl Registry {
             let want = threshold(&runtime.directives, name, &recorded.module)
                 >= recorded.level.verbosity();
             if want {
-                let _ = self.register(recorded.collector.clone_box());
+                match self.register(recorded.collector.clone_box()) {
+                    Ok(()) | Err(prometheus::Error::AlreadyReg) => {}
+                    Err(err) => warn!("failed to register metric {name}: {err}"),
+                }
             } else {
                 let _ = self.unregister(recorded.collector.clone_box());
             }
@@ -967,15 +970,20 @@ mod tests {
             "iota_core::authority=off,iota_core=info,starfish=info"
         );
 
-        // A bare env level matches everything at its layer's highest
-        // precedence: a full override, replacing the config directives.
+        // A bare env level is the `default=LEVEL` spelling: it replaces the
+        // config's global default, while the config's more specific
+        // directives keep applying.
         let filter = super::Filter::from_sources(
             super::FilterSource::new("info,iota_core=warn"),
             Some(super::FilterSource::new("trace")),
         );
-        assert!(filter.is_exposed("x", "iota_core::authority", Trace));
+        assert!(filter.is_exposed("x", "iota_core::authority", Warn));
+        assert!(!filter.is_exposed("x", "iota_core::authority", Info));
         assert!(filter.is_exposed("x", "m", Trace));
-        assert_eq!(filter.startup_filter_string(), "trace");
+        assert_eq!(
+            filter.startup_filter_string(),
+            "iota_core=warn,default=trace"
+        );
 
         // A blank env var contributes no directives, so the config directives
         // still apply.
@@ -1256,9 +1264,11 @@ mod runtime_filter_tests {
         set_runtime(&reg, "");
         assert_eq!(gathered_names(&reg), ["g_b"]);
 
-        // A bare level replaces the whole filter: a full temporary override.
+        // A bare level is the `default=LEVEL` spelling: it raises the global
+        // default but never out-ranks a more specific startup directive, so
+        // `g_a=off` keeps hiding g_a.
         set_runtime(&reg, "trace");
-        assert_eq!(gathered_names(&reg), ["g_a", "g_b"]);
+        assert_eq!(gathered_names(&reg), ["g_b"]);
 
         reset_runtime(&reg);
         assert_eq!(gathered_names(&reg), ["g_b"]);
@@ -1294,33 +1304,71 @@ mod runtime_filter_tests {
             "iota_core=warn,iota_core::authority::sub=off,iota_core::authority=trace"
         );
 
-        // A bare level replaces the whole filter; more specific directives in
-        // the same override still apply on top of it.
+        // A bare level merges like `default=LEVEL`: the more specific
+        // startup directives keep applying beneath it, beside the override's
+        // other directives.
         let filter = Filter::parse("g_a=off,g_b=warn");
         filter
             .set_runtime_filter(FilterSource::new("trace,g_c=off"))
             .unwrap();
-        assert!(filter.is_exposed("g_a", "m", Trace));
-        assert!(filter.is_exposed("g_b", "m", Trace));
+        assert!(!filter.is_exposed("g_a", "m", Warn));
+        assert!(filter.is_exposed("g_b", "m", Warn));
+        assert!(!filter.is_exposed("g_b", "m", Debug));
         assert!(!filter.is_exposed("g_c", "m", Warn));
-        assert_eq!(filter.filter_string(), "trace,g_c=off");
+        assert!(filter.is_exposed("other", "m", Trace));
+        assert_eq!(
+            filter.filter_string(),
+            "g_a=off,g_b=warn,default=trace,g_c=off"
+        );
 
-        // A bare level in the override's directives replaces the display as
-        // a whole too (e.g. an expanded `default=LEVEL` group directive).
+        // The two spellings are interchangeable in the display too: a bare
+        // override level replaces the `default=LEVEL` display directive and
+        // renders back as `default=LEVEL`.
         let filter = Filter::from_sources(
             FilterSource::with_display("info,g_a=off", "default=info,g_a=off"),
             None,
         );
         filter
-            .set_runtime_filter(FilterSource::with_display("trace", "default=trace"))
+            .set_runtime_filter(FilterSource::new("trace"))
             .unwrap();
-        assert!(filter.is_exposed("g_a", "m", Trace));
-        assert_eq!(filter.filter_string(), "default=trace");
+        assert!(!filter.is_exposed("g_a", "m", Warn));
+        assert!(filter.is_exposed("x", "m", Trace));
+        assert_eq!(filter.filter_string(), "g_a=off,default=trace");
 
         // Reset restores the startup directives.
         filter.reset_runtime_filter();
         assert_eq!(filter.filter_string(), filter.startup_filter_string());
         assert!(!filter.is_exposed("g_a", "m", Warn));
+    }
+
+    #[test]
+    fn default_pattern_replaces_only_the_global_default() {
+        use MetricLevel::{Trace, Warn};
+
+        // `default=LEVEL` (equally, a bare `LEVEL`) replaces the startup
+        // global default and leaves the other startup directives in place.
+        let filter = Filter::parse("info,g_a=off");
+        filter
+            .set_runtime_filter(FilterSource::new("default=trace"))
+            .unwrap();
+        assert!(!filter.is_exposed("g_a", "m", Warn));
+        assert!(filter.is_exposed("x", "m", Trace));
+        assert_eq!(filter.filter_string(), "g_a=off,default=trace");
+
+        // The same holds for the env source over the config's directives.
+        let filter = Filter::from_sources(
+            FilterSource::new("info,g_a=off"),
+            Some(FilterSource::new("default=trace")),
+        );
+        assert!(!filter.is_exposed("g_a", "m", Warn));
+        assert!(filter.is_exposed("x", "m", Trace));
+        assert_eq!(filter.startup_filter_string(), "g_a=off,default=trace");
+
+        // `default` matches as the global default, not as a module named
+        // "default": any real pattern is more specific.
+        let filter = Filter::parse("default=off,p2p=warn");
+        assert!(filter.is_exposed("x", "p2p::discovery", Warn));
+        assert!(!filter.is_exposed("x", "other_module", Warn));
     }
 
     #[test]
@@ -1365,11 +1413,11 @@ mod runtime_filter_tests {
         // always be POSTed back through the strict runtime setter.
         let filter = Filter::parse("foo=bogus, typed_store=warn ,info");
         let startup = filter.startup_filter_string();
-        assert_eq!(startup, "typed_store=warn,info");
+        assert_eq!(startup, "typed_store=warn,default=info");
         filter
             .set_runtime_filter(FilterSource::new(&startup))
             .unwrap();
-        assert_eq!(filter.filter_string(), "typed_store=warn,info");
+        assert_eq!(filter.filter_string(), "typed_store=warn,default=info");
     }
 
     #[test]

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -5,16 +5,18 @@
 //! filtering.
 //!
 //! Replace `use prometheus::*` with `use prometheus_filtered::*` to control
-//! which metrics are exposed. The active filter combines the node config's
-//! directives with the `METRICS_FILTER` environment variable's; where both
-//! match the same metric, the env var wins.
+//! which metrics are exposed. The active filter comes from the node config's
+//! directives, unless the `METRICS_FILTER` environment variable is set, in
+//! which case it replaces the config's directives entirely.
 //!
-//! Filter syntax: comma-separated `pattern=LEVEL` directives, last-match
-//! wins, where `LEVEL` is one of `off`, `warn`, `info`, `debug`, `trace`.
-//! A bare `LEVEL` token (no `pattern=`) sets the global default. A pattern
-//! matches if it is a prefix of the metric name OR is a component/prefix of the
-//! calling module path (e.g. `traffic_controller` matches
-//! `iota_core::traffic_controller::metrics`).
+//! Filter syntax: comma-separated `pattern=LEVEL` directives, where `LEVEL`
+//! is one of `off`, `warn`, `info`, `debug`, `trace`. A bare `LEVEL` token
+//! (no `pattern=`) sets the global default. A pattern matches if it is a
+//! prefix of the metric name OR is a component/prefix of the calling module
+//! path (e.g. `traffic_controller` matches
+//! `iota_core::traffic_controller::metrics`). When several directives match
+//! the same metric, the most specific one (longest pattern) wins, regardless
+//! of order; among directives with the same pattern, the last one wins.
 //!
 //! Examples:
 //! - `METRICS_FILTER=off,authority=warn`
@@ -594,26 +596,30 @@ fn render_directives(directives: &[FilterDirective]) -> String {
         .join(",")
 }
 
-/// Evaluates `directives` for a metric, returning the last matching
+/// Evaluates `directives` for a metric, returning the most specific matching
 /// directive's threshold, or [`DEFAULT_THRESHOLD`] when none matches.
 ///
-/// Matching order (last wins):
-/// 1. Empty pattern — global default.
-/// 2. `name.starts_with(pattern)` — metric name prefix.
-/// 3. `module.starts_with(pattern)` — module path prefix.
-/// 4. `module` contains `"::{pattern}"` — exact module component.
+/// A directive matches when its pattern is:
+/// 1. Empty — global default.
+/// 2. A metric name prefix — `name.starts_with(pattern)`.
+/// 3. A module path prefix — `module.starts_with(pattern)`.
+/// 4. An exact module component — `module` contains `"::{pattern}"`.
+///
+/// Among matching directives, the longest pattern wins (so a directive for a
+/// submodule overrides one for its parent, and any pattern overrides the bare
+/// global level); among equal-length patterns, the last one wins.
 fn threshold_for(directives: &[FilterDirective], name: &str, module: &str) -> u8 {
-    let mut threshold = DEFAULT_THRESHOLD;
+    let mut best: Option<(usize, u8)> = None;
     for dir in directives {
-        if dir.pattern.is_empty()
+        let matches = dir.pattern.is_empty()
             || name.starts_with(dir.pattern.as_str())
             || module.starts_with(dir.pattern.as_str())
-            || module.contains(&format!("::{}", dir.pattern))
-        {
-            threshold = dir.threshold;
+            || module.contains(&format!("::{}", dir.pattern));
+        if matches && best.is_none_or(|(len, _)| dir.pattern.len() >= len) {
+            best = Some((dir.pattern.len(), dir.threshold));
         }
     }
-    threshold
+    best.map_or(DEFAULT_THRESHOLD, |(_, threshold)| threshold)
 }
 
 impl Filter {
@@ -677,16 +683,19 @@ impl Filter {
         *self.runtime.write().unwrap() = None;
     }
 
-    /// Resolves the metrics filter from `fallback` (the node config)
-    /// and the `METRICS_FILTER` env variables. If the same key exists in both,
-    /// the env var takes precedence.
+    /// Resolves the metrics filter from `fallback` (the node config) and the
+    /// `METRICS_FILTER` env variable. A non-blank env var replaces the
+    /// fallback entirely.
     pub fn resolve(fallback: Option<&str>) -> Self {
         let env = std::env::var("METRICS_FILTER").ok();
-        match (fallback, env.as_deref()) {
-            (Some(f), Some(e)) => Self::parse(&format!("{f},{e}")),
-            (Some(f), None) => Self::parse(f),
-            (None, Some(e)) => Self::parse(e),
-            (None, None) => Self::default(),
+        Self::resolve_from(fallback, env.as_deref())
+    }
+
+    fn resolve_from(fallback: Option<&str>, env: Option<&str>) -> Self {
+        let env = env.filter(|s| !s.trim().is_empty());
+        match env.or(fallback) {
+            Some(s) => Self::parse(s),
+            None => Self::default(),
         }
     }
 }
@@ -1183,7 +1192,7 @@ mod tests {
         assert!(!filter.is_exposed("certs_total", "iota_core::authority", Debug));
         assert!(!filter.is_exposed("certs_total", "iota_core::authority_aggregator", Debug));
 
-        // the last matching prefix shadows the previous ones
+        // the longer matching prefix shadows the shorter one
         let filter = super::Filter::parse("authority=off,authority_aggregator=trace");
         assert!(!filter.is_exposed("authority", "iota_core::checkpoints", Debug));
         assert!(filter.is_exposed("authority_aggregator", "iota_core::checkpoints", Debug));
@@ -1212,12 +1221,40 @@ mod tests {
         assert!(!filter.is_exposed("certs_total", "iota_core::authority", Debug));
         assert!(filter.is_exposed("certs_total", "starfish::core", Debug));
 
-        // last-match-wins applies to bare global directives too, and an
-        // explicit permissive default can carry a targeted `off` override.
+        // among directives with the same (here: empty) pattern the last one
+        // wins, and an explicit permissive default can carry a targeted
+        // `off` override.
         assert!(super::Filter::parse("off,trace").is_exposed("authority", "m", Debug));
         let filter = super::Filter::parse("trace,authority=off");
         assert!(filter.is_exposed("certs_total", "m", Debug));
         assert!(!filter.is_exposed("authority", "m", Debug));
+    }
+
+    #[test]
+    fn more_specific_pattern_wins_regardless_of_order() {
+        use super::MetricLevel::{Info, Warn};
+        // A blanket module directive does not shadow a more specific one,
+        // whichever is written first ...
+        for input in [
+            "iota_core::authority=warn,iota_core=off",
+            "iota_core=off,iota_core::authority=warn",
+        ] {
+            let filter = super::Filter::parse(input);
+            assert!(
+                filter.is_exposed("x", "iota_core::authority", Warn),
+                "{input}"
+            );
+            assert!(
+                !filter.is_exposed("x", "iota_core::checkpoints", Warn),
+                "{input}"
+            );
+        }
+        // ... and a trailing bare level does not cancel earlier specific
+        // directives.
+        let filter = super::Filter::parse("authority=off,info");
+        assert!(!filter.is_exposed("authority", "m", Warn));
+        assert!(filter.is_exposed("certs_total", "m", Info));
+        assert!(!filter.is_exposed("certs_total", "m", Debug));
     }
 
     #[test]
@@ -1271,8 +1308,8 @@ mod tests {
     fn resolve_applies_fallback() {
         use super::{Arc, Filter, MetricLevel, Registry};
 
-        // The env var's directives are merged after the fallback's, so the
-        // assertions below only hold when it is unset.
+        // A set env var replaces the fallback, so `Filter::resolve` is only
+        // exercised when it is unset; `resolve_from` covers the set case.
         if std::env::var_os("METRICS_FILTER").is_some() {
             return;
         }
@@ -1290,6 +1327,21 @@ mod tests {
         let registry = Registry::new_custom(None, None, Some(filter.clone())).unwrap();
         let shared = Registry::new_custom(None, None, Some(filter)).unwrap();
         assert!(std::sync::Arc::ptr_eq(&registry.filter(), &shared.filter()));
+    }
+
+    #[test]
+    fn env_replaces_fallback() {
+        use super::{Filter, MetricLevel};
+
+        // A set env var replaces the fallback entirely: the fallback's more
+        // specific directive does not survive the override.
+        let filter = Filter::resolve_from(Some("off,iota_core::authority=off"), Some("trace"));
+        assert!(filter.is_exposed("x", "iota_core::authority", MetricLevel::Trace));
+        assert!(filter.is_exposed("x", "iota_core::checkpoints", MetricLevel::Trace));
+
+        // A blank env var counts as unset: the fallback still applies.
+        let filter = Filter::resolve_from(Some("off"), Some(" "));
+        assert!(!filter.is_exposed("x", "m", MetricLevel::Warn));
     }
 
     #[test]

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -735,13 +735,33 @@ impl Filter {
 // Registry
 // ---------------------------------------------------------------------------
 
+/// A `prometheus::Collector` that can be boxed and cloned, so the registry can
+/// keep a handle to re-`register`/`unregister` it as the filter changes.
+pub trait CloneableCollector: prometheus::core::Collector {
+    fn clone_box(&self) -> Box<dyn CloneableCollector>;
+}
+
+impl<T: prometheus::core::Collector + Clone + 'static> CloneableCollector for T {
+    fn clone_box(&self) -> Box<dyn CloneableCollector> {
+        Box::new(self.clone())
+    }
+}
+
+/// A metric registered through the wrapper macros, retained so the filter can
+/// toggle its membership in the inner registry at runtime.
+struct RecordedMetric {
+    module: String,
+    level: MetricLevel,
+    collector: Box<dyn CloneableCollector>,
+}
+
 /// Wraps `prometheus::Registry` with an embedded `Filter` so that
-/// `register_*_with_registry!` macros can decide at construction time whether
-/// a metric should be active.
+/// `register_*_with_registry!` macros can decide whether a metric is exposed.
 ///
-/// Metrics registered through the wrapper macros are recorded with their
-/// module path and level, so [`Registry::gather`] can apply the filter's
-/// exposure directives to them.
+/// Metrics registered through the wrapper macros are recorded with their module
+/// path, level, and a collector handle. Exposure is enforced by membership in
+/// the inner registry: a metric that the filter disables is `unregister`ed and
+/// re-`register`ed if the filter later enables it.
 #[derive(Clone)]
 pub struct Registry {
     inner: prometheus::Registry,
@@ -749,9 +769,9 @@ pub struct Registry {
     /// Name prefix passed to [`Registry::new_custom`]; gathered family names
     /// include it.
     prefix: Option<String>,
-    /// Gathered family name → (module path, level) for metrics registered via
-    /// the wrapper macros; consulted by [`Registry::gather`].
-    registered: Arc<RwLock<HashMap<String, (String, MetricLevel)>>>,
+    /// Gathered family name → recorded metric, for metrics registered via the
+    /// wrapper macros.
+    registered: Arc<RwLock<HashMap<String, RecordedMetric>>>,
 }
 
 impl Registry {
@@ -787,19 +807,76 @@ impl Registry {
         self.filter.clone()
     }
 
-    /// Used by the wrapper macros: records a registering metric's module path
-    /// and level, so [`Registry::gather`] can apply the filter's exposure
-    /// directives to it.
-    #[inline]
-    pub fn record(&self, name: &str, module: &str, level: MetricLevel) {
-        let exposed_name = match &self.prefix {
+    fn exposed_name(&self, name: &str) -> String {
+        match &self.prefix {
             Some(prefix) => format!("{prefix}_{name}"),
             None => name.to_owned(),
+        }
+    }
+
+    /// Used by the wrapper macros: on a successful registration, retains a
+    /// handle to the metric with its module path and level, and immediately
+    /// `unregister`s it from the inner registry if the current filter disables
+    /// it.
+    #[inline]
+    pub fn record_collector<C>(
+        &self,
+        name: &str,
+        module: &str,
+        level: MetricLevel,
+        result: prometheus::Result<C>,
+    ) -> prometheus::Result<C>
+    where
+        C: prometheus::core::Collector + Clone + 'static,
+    {
+        let Ok(collector) = &result else {
+            return result;
         };
-        self.registered
-            .write()
-            .unwrap()
-            .insert(exposed_name, (module.to_owned(), level));
+        let collector: Box<dyn CloneableCollector> = Box::new(collector.clone());
+        let exposed_name = self.exposed_name(name);
+
+        let mut registered = self.registered.write().unwrap();
+        if registered.contains_key(&exposed_name) {
+            // The inner registry rejects a duplicate metric name, but only for names
+            // it still holds — a name the filter disabled has been `unregister`ed, so
+            // a second registration of it would slip through. This re-checks the
+            // recorded set to keep rejecting duplicates regardless of filter state.
+            // Check test `duplicate_name_is_rejected_even_when_filtered_out`
+            let _ = self.inner.unregister(collector);
+            return Err(prometheus::Error::AlreadyReg);
+        }
+        if !self.filter.is_exposed(&exposed_name, module, level) {
+            let _ = self.inner.unregister(collector.clone_box());
+        }
+        registered.insert(
+            exposed_name,
+            RecordedMetric {
+                module: module.to_owned(),
+                level,
+                collector,
+            },
+        );
+        result
+    }
+
+    /// Re-evaluates every recorded metric against the current filter. Call
+    /// after changing the filter's runtime override.
+    pub fn reconcile(&self) {
+        // Snapshot the runtime layer once so the whole pass sees a consistent
+        // filter and avoids re-locking it per metric.
+        let runtime = self.filter.runtime_layer();
+        let registered = self.registered.read().unwrap();
+        for (name, recorded) in registered.iter() {
+            let want = self
+                .filter
+                .threshold(runtime.as_deref(), name, &recorded.module)
+                >= recorded.level.verbosity();
+            if want {
+                let _ = self.register(recorded.collector.clone_box());
+            } else {
+                let _ = self.unregister(recorded.collector.clone_box());
+            }
+        }
     }
 
     /// Returns the underlying `prometheus::Registry` for use inside wrapper
@@ -817,25 +894,9 @@ impl Registry {
         self.inner.unregister(c)
     }
 
-    /// Gathers the registry's metric families, dropping those disabled by the
-    /// filter's exposure directives. Families not registered through the
-    /// wrapper macros (e.g. direct collectors) always pass through.
+    /// Gathers the registry's metric families.
     pub fn gather(&self) -> Vec<prometheus::proto::MetricFamily> {
-        // One runtime-layer snapshot for the whole pass, so a concurrent
-        // filter update cannot make a single scrape internally inconsistent.
-        let runtime = self.filter.runtime_layer();
-        let registered = self.registered.read().unwrap();
-        self.inner
-            .gather()
-            .into_iter()
-            .filter(|family| {
-                registered.get(family.name()).is_none_or(|(module, level)| {
-                    self.filter
-                        .threshold(runtime.as_deref(), family.name(), module)
-                        >= level.verbosity()
-                })
-            })
-            .collect()
+        self.inner.gather()
     }
 }
 
@@ -901,13 +962,18 @@ macro_rules! register_int_counter_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_int_counter_with_registry!(
-            name,
-            $help,
-            ($registry).inner()
-        )
-        .map($crate::core::GenericCounter::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_int_counter_with_registry!(
+                    name,
+                    $help,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::core::GenericCounter::new_some)
     }};
 }
 
@@ -923,14 +989,19 @@ macro_rules! register_int_counter_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_int_counter_vec_with_registry!(
-            name,
-            $help,
-            $labels,
-            ($registry).inner()
-        )
-        .map($crate::IntCounterVec::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_int_counter_vec_with_registry!(
+                    name,
+                    $help,
+                    $labels,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::IntCounterVec::new_some)
     }};
 }
 
@@ -946,8 +1017,17 @@ macro_rules! register_int_gauge_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_int_gauge_with_registry!(name, $help, ($registry).inner())
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_int_gauge_with_registry!(
+                    name,
+                    $help,
+                    ($registry).inner()
+                ),
+            )
             .map($crate::core::GenericGauge::new_some)
     }};
 }
@@ -964,14 +1044,19 @@ macro_rules! register_int_gauge_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_int_gauge_vec_with_registry!(
-            name,
-            $help,
-            $labels,
-            ($registry).inner()
-        )
-        .map($crate::IntGaugeVec::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_int_gauge_vec_with_registry!(
+                    name,
+                    $help,
+                    $labels,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::IntGaugeVec::new_some)
     }};
 }
 
@@ -991,22 +1076,36 @@ macro_rules! register_histogram_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_histogram_with_registry!(name, $help, ($registry).inner())
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_histogram_with_registry!(
+                    name,
+                    $help,
+                    ($registry).inner()
+                ),
+            )
             .map($crate::Histogram::new_some)
     }};
     ($name:expr, $help:expr, $buckets:expr, $registry:expr ; $level:expr $(,)?) => {{
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_histogram_with_registry!(
-            name,
-            $help,
-            $buckets,
-            ($registry).inner()
-        )
-        .map($crate::Histogram::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_histogram_with_registry!(
+                    name,
+                    $help,
+                    $buckets,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::Histogram::new_some)
     }};
 }
 
@@ -1028,28 +1127,38 @@ macro_rules! register_histogram_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_histogram_vec_with_registry!(
-            name,
-            $help,
-            $labels,
-            ($registry).inner()
-        )
-        .map($crate::HistogramVec::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_histogram_vec_with_registry!(
+                    name,
+                    $help,
+                    $labels,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::HistogramVec::new_some)
     }};
     ($name:expr, $help:expr, $labels:expr, $buckets:expr, $registry:expr ; $level:expr $(,)?) => {{
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_histogram_vec_with_registry!(
-            name,
-            $help,
-            $labels,
-            $buckets,
-            ($registry).inner()
-        )
-        .map($crate::HistogramVec::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_histogram_vec_with_registry!(
+                    name,
+                    $help,
+                    $labels,
+                    $buckets,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::HistogramVec::new_some)
     }};
 }
 
@@ -1065,14 +1174,19 @@ macro_rules! register_gauge_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_gauge_vec_with_registry!(
-            name,
-            $help,
-            $labels,
-            ($registry).inner()
-        )
-        .map($crate::core::GenericGaugeVec::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_gauge_vec_with_registry!(
+                    name,
+                    $help,
+                    $labels,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::core::GenericGaugeVec::new_some)
     }};
 }
 
@@ -1086,8 +1200,17 @@ macro_rules! register_gauge_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_gauge_with_registry!(name, $help, ($registry).inner())
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_gauge_with_registry!(
+                    name,
+                    $help,
+                    ($registry).inner()
+                ),
+            )
             .map($crate::core::GenericGauge::new_some)
     }};
 }
@@ -1102,8 +1225,13 @@ macro_rules! register_counter {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        $crate::default_registry().record(name, module, $level);
-        $crate::prometheus::register_counter!(name, $help)
+        $crate::default_registry()
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_counter!(name, $help),
+            )
             .map($crate::core::GenericCounter::new_some)
     }};
 }
@@ -1120,13 +1248,18 @@ macro_rules! register_counter_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_counter_with_registry!(
-            name,
-            $help,
-            ($registry).inner()
-        )
-        .map($crate::core::GenericCounter::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_counter_with_registry!(
+                    name,
+                    $help,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::core::GenericCounter::new_some)
     }};
 }
 
@@ -1142,14 +1275,19 @@ macro_rules! register_counter_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry).record(name, module, $level);
-        $crate::prometheus::register_counter_vec_with_registry!(
-            name,
-            $help,
-            $labels,
-            ($registry).inner()
-        )
-        .map($crate::core::GenericCounterVec::new_some)
+        ($registry)
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_counter_vec_with_registry!(
+                    name,
+                    $help,
+                    $labels,
+                    ($registry).inner()
+                ),
+            )
+            .map($crate::core::GenericCounterVec::new_some)
     }};
 }
 
@@ -1163,8 +1301,13 @@ macro_rules! register_counter_vec {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        $crate::default_registry().record(name, module, $level);
-        $crate::prometheus::register_counter_vec!(name, $help, $labels)
+        $crate::default_registry()
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_counter_vec!(name, $help, $labels),
+            )
             .map($crate::core::GenericCounterVec::new_some)
     }};
 }
@@ -1188,24 +1331,39 @@ macro_rules! register_histogram_vec {
         let opts = $opts;
         let name: &str = &opts.common_opts.name;
         let module: &str = module_path!();
-        $crate::default_registry().record(name, module, $level);
-        $crate::prometheus::register_histogram_vec!(opts, $labels)
+        $crate::default_registry()
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_histogram_vec!(opts, $labels),
+            )
             .map($crate::HistogramVec::new_some)
     }};
     ($name:expr, $help:expr, $labels:expr ; $level:expr $(,)?) => {{
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        $crate::default_registry().record(name, module, $level);
-        $crate::prometheus::register_histogram_vec!(name, $help, $labels)
+        $crate::default_registry()
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_histogram_vec!(name, $help, $labels),
+            )
             .map($crate::HistogramVec::new_some)
     }};
     ($name:expr, $help:expr, $labels:expr, $buckets:expr ; $level:expr $(,)?) => {{
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        $crate::default_registry().record(name, module, $level);
-        $crate::prometheus::register_histogram_vec!(name, $help, $labels, $buckets)
+        $crate::default_registry()
+            .record_collector(
+                name,
+                module,
+                $level,
+                $crate::prometheus::register_histogram_vec!(name, $help, $labels, $buckets),
+            )
             .map($crate::HistogramVec::new_some)
     }};
 }
@@ -1448,16 +1606,35 @@ mod gather_filter_tests {
     }
 
     #[test]
-    fn off_directive_hides_but_still_registers() {
+    fn off_directive_hides_but_metric_keeps_collecting() {
         let reg = registry("g_hidden=off");
         let g = crate::register_int_gauge_with_registry!("g_hidden", "h", &reg; MetricLevel::Warn)
             .unwrap();
-        // Registered (a disabled wrapper would print "(disabled)") and
-        // collecting, but absent from gather output.
+        // The metric handle is live and keeps collecting through the caller's
+        // copy, even though the filter unregistered it from the inner registry,
+        // so it is absent from gather output.
         assert_eq!(format!("{g:?}"), "GenericGauge");
         g.set(9);
         assert_eq!(g.get(), 9);
         assert_eq!(gathered_names(&reg), Vec::<String>::new());
+    }
+
+    #[test]
+    fn duplicate_name_is_rejected_even_when_filtered_out() {
+        // The `off` directive unregisters the metric from the inner registry,
+        // but a second registration of the same name must still be rejected.
+        let reg = registry("g_dup=off");
+        // The first registration is registered then un-registered because `g_dup=off`.
+        crate::register_int_gauge_with_registry!("g_dup", "h", &reg; MetricLevel::Warn).unwrap();
+        // The second registration is rejected because the metrics with the same name
+        // exists, it is just not in the registry map due to `g_dup=off`, so the
+        // second metric shouldn't exist.
+        let err = crate::register_int_gauge_with_registry!("g_dup", "h", &reg; MetricLevel::Warn)
+            .unwrap_err();
+        assert!(
+            matches!(err, prometheus::Error::AlreadyReg),
+            "unexpected error: {err:?}"
+        );
     }
 
     #[test]
@@ -1516,6 +1693,18 @@ mod runtime_filter_tests {
         names
     }
 
+    // The node drives this via `RegistryService`; here we exercise the same
+    // two steps directly: set the runtime override, then reconcile membership.
+    fn set_runtime(registry: &Registry, s: &str) {
+        registry.filter().set_runtime_filter(s).unwrap();
+        registry.reconcile();
+    }
+
+    fn reset_runtime(registry: &Registry) {
+        registry.filter().reset_runtime_filter();
+        registry.reconcile();
+    }
+
     #[test]
     fn raising_runtime_level_exposes_collected_metrics() {
         // A `warn` startup threshold hides the debug metric …
@@ -1527,9 +1716,7 @@ mod runtime_filter_tests {
 
         // … so raising the exposure level at runtime reveals it, with the
         // values it collected while hidden.
-        reg.filter()
-            .set_runtime_filter("runtime_filter_tests=debug")
-            .unwrap();
+        set_runtime(&reg, "runtime_filter_tests=debug");
         assert_eq!(gathered_names(&reg), ["g_debug", "g_warn"]);
         let family = reg
             .gather()
@@ -1545,7 +1732,7 @@ mod runtime_filter_tests {
             .unwrap();
         g.set(9);
         assert_eq!(gathered_names(&reg), Vec::<String>::new());
-        reg.filter().set_runtime_filter("g_hidden=warn").unwrap();
+        set_runtime(&reg, "g_hidden=warn");
         assert_eq!(gathered_names(&reg), ["g_hidden"]);
         let family = &reg.gather()[0];
         assert_eq!(family.get_metric()[0].get_gauge().value() as i64, 9);
@@ -1560,20 +1747,19 @@ mod runtime_filter_tests {
 
         // The override hides g_b; g_a is matched by no override directive
         // and keeps its startup exposure (hidden).
-        let filter = reg.filter();
-        filter.set_runtime_filter("g_b=off").unwrap();
+        set_runtime(&reg, "g_b=off");
         assert_eq!(gathered_names(&reg), Vec::<String>::new());
 
         // An empty override matches nothing, leaving the startup directives
         // fully in effect.
-        filter.set_runtime_filter("").unwrap();
+        set_runtime(&reg, "");
         assert_eq!(gathered_names(&reg), ["g_b"]);
 
         // A bare level matches everything: a full temporary override.
-        filter.set_runtime_filter("trace").unwrap();
+        set_runtime(&reg, "trace");
         assert_eq!(gathered_names(&reg), ["g_a", "g_b"]);
 
-        filter.reset_runtime_filter();
+        reset_runtime(&reg);
         assert_eq!(gathered_names(&reg), ["g_b"]);
     }
 

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -928,9 +928,16 @@ mod tests {
         assert!(!filter.is_exposed("authority", "m", Warn));
         assert!(filter.is_exposed("certs_total", "m", Info));
         assert!(!filter.is_exposed("certs_total", "m", Debug));
-        // Among directives with the same (here: empty) pattern the last one
-        // wins.
+        // Among directives with the same pattern the last one wins, whether
+        // the pattern is empty or not.
         assert!(super::Filter::parse("off,trace").is_exposed("authority", "m", Debug));
+        assert!(
+            super::Filter::parse("authority=off,authority=trace").is_exposed(
+                "authority",
+                "m",
+                Debug
+            )
+        );
     }
 
     #[test]
@@ -977,7 +984,7 @@ mod tests {
         use super::MetricLevel::{Info, Trace, Warn};
         // Filtering is opt-in: with no matching directive every metric is
         // exposed, matching plain `prometheus` behaviour.
-        for filter in [
+        let mut filters = vec![
             super::Filter::parse(""),
             super::Filter::default(),
             // empty segments are ignored rather than treated as directives.
@@ -1027,21 +1034,9 @@ mod tests {
     }
 
     #[test]
-    fn from_env_is_permissive_when_unset() {
+    fn registries_built_to_share_a_filter_see_the_same_decisions() {
         use super::{Arc, Filter, MetricLevel, Registry};
 
-        // A set env var would add an env layer, so `Filter::from_env` is
-        // only exercised when it is unset; `Filter::from_layers` covers the
-        // set case.
-        if std::env::var_os("METRICS_FILTER").is_some() {
-            return;
-        }
-
-        // No env, no config -> everything is exposed.
-        assert!(Filter::from_env().is_exposed("anything", "m", MetricLevel::Trace));
-        assert!(Filter::from_env().is_exposed("anything", "m", Debug));
-
-        // Registries built to share a filter see the same decisions.
         let filter = Arc::new(Filter::parse("off,authority=trace"));
         assert!(filter.is_exposed("authority", "m", MetricLevel::Debug));
         assert!(!filter.is_exposed("consensus", "m", MetricLevel::Debug));
@@ -1112,19 +1107,6 @@ mod gather_filter_tests {
         // and keeps collecting.
         assert_eq!(gathered_names(&reg), ["g_warn"]);
         assert_eq!(g_debug.get(), 7);
-    }
-
-    #[test]
-    fn off_directive_hides_but_metric_keeps_collecting() {
-        let reg = registry("g_hidden=off");
-        let g = crate::register_int_gauge_with_registry!("g_hidden", "h", &reg; MetricLevel::Warn)
-            .unwrap();
-        // The metric handle is live and keeps collecting through the caller's
-        // copy, even though the filter unregistered it from the inner registry,
-        // so it is absent from gather output.
-        g.set(9);
-        assert_eq!(g.get(), 9);
-        assert_eq!(gathered_names(&reg), Vec::<String>::new());
     }
 
     #[test]

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -35,7 +35,10 @@
 //! crate behaves exactly like plain `prometheus`; use a bare `LEVEL` directive
 //! to set a stricter global default.
 
-use std::sync::{Arc, OnceLock, RwLock};
+use std::{
+    result::Result as StdResult,
+    sync::{Arc, OnceLock, RwLock},
+};
 
 /// Re-exported under a hidden alias so `$crate::prometheus::xxx!` works
 /// inside `#[macro_export]` macros without requiring callers to depend
@@ -89,7 +92,21 @@ impl MetricLevel {
             Self::Trace => 4,
         }
     }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
 }
+
+/// Environment variable holding filter directives, read by
+/// [`Filter::from_env`].
+pub const METRICS_FILTER_ENV: &str = "METRICS_FILTER";
 
 /// Default threshold when no directive matches a metric: expose it. Filtering
 /// is opt-in, so an unfiltered registry behaves like plain `prometheus`.
@@ -104,8 +121,8 @@ struct FilterDirective {
     /// component match allocates nothing.
     component_pattern: String,
     /// Metrics matched by this directive are exposed iff their verbosity is
-    /// `<= threshold`. `off=0`, `warn=1`, `info=2`, `debug=3`, `trace=4`.
-    threshold: u8,
+    /// at most this level's.
+    level: MetricLevel,
 }
 
 /// Filter holds two directive sets: the immutable startup directives (the
@@ -187,15 +204,32 @@ fn merge_directives(base: &[FilterDirective], over: &[FilterDirective]) -> Vec<F
         .collect()
 }
 
+/// Parses a directive string, returning the valid directives and an error
+/// for each invalid one; the caller decides whether an error drops the
+/// directive or rejects the whole string.
+fn parse_directives(s: &str) -> (Vec<FilterDirective>, Vec<String>) {
+    let mut directives = Vec::new();
+    let mut errors = Vec::new();
+    for part in directive_parts(s) {
+        match split_directive(part) {
+            Ok((pattern, level)) => directives.push(FilterDirective {
+                component_pattern: format!("::{pattern}"),
+                pattern: pattern.to_owned(),
+                level,
+            }),
+            Err(err) => errors.push(err),
+        }
+    }
+    (directives, errors)
+}
+
 /// Parses a directive string, dropping invalid directives with a warning.
 fn parse_valid_directives(s: &str) -> Vec<FilterDirective> {
-    directive_parts(s)
-        .filter_map(|part| {
-            parse_directive(part)
-                .map_err(|err| warn!("dropping prometheus filter directive: {err}"))
-                .ok()
-        })
-        .collect()
+    let (directives, errors) = parse_directives(s);
+    for err in errors {
+        warn!("dropping prometheus filter directive: {err}");
+    }
+    directives
 }
 
 /// Splits a `METRICS_FILTER`-style string into its non-empty, trimmed
@@ -204,34 +238,25 @@ pub fn directive_parts(s: &str) -> impl Iterator<Item = &str> + '_ {
     s.split(',').map(str::trim).filter(|part| !part.is_empty())
 }
 
-/// Splits one directive into its `(pattern, level)` parts. Two equivalent
-/// spellings yield the empty (global default) pattern: a bare level (no `=`)
-/// and the reserved `default` pattern, which normalizes to it here.
-pub fn split_directive(part: &str) -> (&str, &str) {
-    match part.rfind('=') {
+/// Splits one directive into its `(pattern, level)` parts, rejecting an
+/// invalid level with an error describing the offending directive. Two
+/// equivalent spellings yield the empty (global default) pattern: a bare
+/// level (no `=`) and the reserved `default` pattern, which normalizes to it
+/// here.
+pub fn split_directive(part: &str) -> StdResult<(&str, MetricLevel), String> {
+    let (pattern, value) = match part.rfind('=') {
         Some(eq) => match part[..eq].trim() {
             "default" => ("", part[eq + 1..].trim()),
             pattern => (pattern, part[eq + 1..].trim()),
         },
         None => ("", part.trim()),
-    }
-}
-
-/// Returns an error describing the offending directive if `part` is not a
-/// valid `pattern=LEVEL` directive.
-pub fn validate_directive(part: &str) -> std::result::Result<(), String> {
-    parse_directive(part).map(|_| ())
-}
-
-/// Parses one `pattern=LEVEL` directive.
-fn parse_directive(part: &str) -> std::result::Result<FilterDirective, String> {
-    let (pattern, value) = split_directive(part);
-    let threshold = match value {
-        "off" => 0,
-        "warn" => 1,
-        "info" => 2,
-        "debug" => 3,
-        "trace" => 4,
+    };
+    let level = match value {
+        "off" => MetricLevel::Off,
+        "warn" => MetricLevel::Warn,
+        "info" => MetricLevel::Info,
+        "debug" => MetricLevel::Debug,
+        "trace" => MetricLevel::Trace,
         other => {
             return Err(format!(
                 "invalid level {other:?} in directive {part:?}: expected one of \
@@ -239,32 +264,19 @@ fn parse_directive(part: &str) -> std::result::Result<FilterDirective, String> {
             ));
         }
     };
-    Ok(FilterDirective {
-        component_pattern: format!("::{pattern}"),
-        pattern: pattern.to_owned(),
-        threshold,
-    })
+    Ok((pattern, level))
 }
 
 /// Renders directives back into their canonical `pattern=LEVEL` string. The
 /// empty pattern renders as `default=LEVEL`.
 fn render_directives(directives: &[FilterDirective]) -> String {
-    fn token(threshold: u8) -> &'static str {
-        match threshold {
-            0 => "off",
-            1 => "warn",
-            2 => "info",
-            3 => "debug",
-            _ => "trace",
-        }
-    }
     directives
         .iter()
         .map(|dir| {
             if dir.pattern.is_empty() {
-                format!("default={}", token(dir.threshold))
+                format!("default={}", dir.level.as_str())
             } else {
-                format!("{}={}", dir.pattern, token(dir.threshold))
+                format!("{}={}", dir.pattern, dir.level.as_str())
             }
         })
         .collect::<Vec<_>>()
@@ -272,7 +284,8 @@ fn render_directives(directives: &[FilterDirective]) -> String {
 }
 
 /// Evaluates `directives` for a metric, returning the most specific matching
-/// directive's threshold, or `None` when no directive matches.
+/// directive's threshold, or the permissive default when no directive
+/// matches.
 ///
 /// A directive matches when its pattern is:
 /// 1. Empty (a bare level, or its `default=LEVEL` spelling) — global default.
@@ -283,7 +296,7 @@ fn render_directives(directives: &[FilterDirective]) -> String {
 /// Among matching directives, the longest pattern wins (so a directive for a
 /// submodule overrides one for its parent, and any pattern overrides the bare
 /// global level); among equal-length patterns, the last one wins.
-fn threshold_for(directives: &[FilterDirective], name: &str, module: &str) -> Option<u8> {
+fn threshold(directives: &[FilterDirective], name: &str, module: &str) -> u8 {
     let mut best: Option<(usize, u8)> = None;
     for dir in directives {
         let matches = dir.pattern.is_empty()
@@ -291,16 +304,10 @@ fn threshold_for(directives: &[FilterDirective], name: &str, module: &str) -> Op
             || module.starts_with(dir.pattern.as_str())
             || module.contains(dir.component_pattern.as_str());
         if matches && best.is_none_or(|(len, _)| dir.pattern.len() >= len) {
-            best = Some((dir.pattern.len(), dir.threshold));
+            best = Some((dir.pattern.len(), dir.level.verbosity()));
         }
     }
-    best.map(|(_, threshold)| threshold)
-}
-
-/// Like [`threshold_for`], but falling back to the permissive default when no
-/// directive matches.
-fn threshold(directives: &[FilterDirective], name: &str, module: &str) -> u8 {
-    threshold_for(directives, name, module).unwrap_or(DEFAULT_THRESHOLD)
+    best.map_or(DEFAULT_THRESHOLD, |(_, threshold)| threshold)
 }
 
 impl Filter {
@@ -311,10 +318,10 @@ impl Filter {
         Self::from_sources(FilterSource::new(s), None)
     }
 
-    /// Builds a filter with an empty config source and the `METRICS_FILTER`
-    /// env variable's directives (permissive when unset).
+    /// Builds a filter with an empty config source and the
+    /// [`METRICS_FILTER_ENV`] variable's directives (permissive when unset).
     pub fn from_env() -> Self {
-        let env = std::env::var("METRICS_FILTER").ok();
+        let env = std::env::var(METRICS_FILTER_ENV).ok();
         Self::from_sources(FilterSource::new(""), env.as_deref().map(FilterSource::new))
     }
 
@@ -330,22 +337,18 @@ impl Filter {
         }
     }
 
-    /// Returns a snapshot of the directives currently in effect.
-    fn runtime(&self) -> Arc<DirectiveSet> {
-        self.runtime.read().unwrap().clone()
-    }
-
     /// Returns `true` if a registered metric named `name` in `module` at
     /// verbosity `level` should be exposed when gathering, per the directives
     /// currently in effect.
     #[inline]
     pub fn is_exposed(&self, name: &str, module: &str, level: MetricLevel) -> bool {
-        threshold(&self.runtime().directives, name, module) >= level.verbosity()
+        let runtime = self.runtime.read().unwrap();
+        threshold(&runtime.directives, name, module) >= level.verbosity()
     }
 
     /// Returns the display string of the directives currently in effect.
     pub fn filter_string(&self) -> String {
-        render_directives(&self.runtime().display)
+        render_directives(&self.runtime.read().unwrap().display)
     }
 
     /// Returns the startup directives' display string.
@@ -358,10 +361,11 @@ impl Filter {
     /// starts from the startup directives again rather than stacking on the
     /// previous override. Rejects the whole update if any directive is
     /// invalid.
-    pub fn set_runtime_filter(&self, source: FilterSource<'_>) -> std::result::Result<(), String> {
-        let directives = directive_parts(source.directives)
-            .map(parse_directive)
-            .collect::<std::result::Result<Vec<_>, String>>()?;
+    pub fn set_runtime_filter(&self, source: FilterSource<'_>) -> StdResult<(), String> {
+        let (directives, errors) = parse_directives(source.directives);
+        if !errors.is_empty() {
+            return Err(errors.join("; "));
+        }
         let over = DirectiveSet {
             directives,
             display: parse_valid_directives(source.display),
@@ -977,7 +981,7 @@ mod tests {
         // A set env var would add env directives, so `Filter::from_env` is
         // only exercised when it is unset; `Filter::from_sources` covers the
         // set case.
-        if std::env::var_os("METRICS_FILTER").is_none() {
+        if std::env::var_os(super::METRICS_FILTER_ENV).is_none() {
             filters.push(super::Filter::from_env());
         }
         for filter in filters {
@@ -1062,14 +1066,14 @@ mod tests {
 }
 
 #[cfg(test)]
-mod gather_filter_tests {
-    use super::{Filter, MetricLevel, Registry};
+mod test_helpers {
+    use super::{Filter, Registry};
 
-    fn registry(filter: &str) -> Registry {
+    pub fn registry(filter: &str) -> Registry {
         Registry::new_custom(None, None, Some(std::sync::Arc::new(Filter::parse(filter)))).unwrap()
     }
 
-    fn gathered_names(registry: &Registry) -> Vec<String> {
+    pub fn gathered_names(registry: &Registry) -> Vec<String> {
         let mut names: Vec<_> = registry
             .gather()
             .iter()
@@ -1078,6 +1082,14 @@ mod gather_filter_tests {
         names.sort();
         names
     }
+}
+
+#[cfg(test)]
+mod gather_filter_tests {
+    use super::{
+        Filter, MetricLevel, Registry,
+        test_helpers::{gathered_names, registry},
+    };
 
     #[test]
     fn gather_applies_level_thresholds_by_module() {
@@ -1148,21 +1160,10 @@ mod gather_filter_tests {
 
 #[cfg(test)]
 mod runtime_filter_tests {
-    use super::{Filter, FilterSource, MetricLevel, Registry};
-
-    fn registry(filter: &str) -> Registry {
-        Registry::new_custom(None, None, Some(std::sync::Arc::new(Filter::parse(filter)))).unwrap()
-    }
-
-    fn gathered_names(registry: &Registry) -> Vec<String> {
-        let mut names: Vec<_> = registry
-            .gather()
-            .iter()
-            .map(|f| f.name().to_owned())
-            .collect();
-        names.sort();
-        names
-    }
+    use super::{
+        Filter, FilterSource, MetricLevel, Registry,
+        test_helpers::{gathered_names, registry},
+    };
 
     // The node drives this via `RegistryService`; exposure follows the
     // filter change on the next gather, with no extra step.
@@ -1226,12 +1227,6 @@ mod runtime_filter_tests {
         // directives fully in effect — and replaces the previous override
         // rather than accumulating with it.
         set_runtime(&reg, "");
-        assert_eq!(gathered_names(&reg), ["g_b"]);
-
-        // A bare level is the `default=LEVEL` spelling: it raises the global
-        // default but never out-ranks a more specific startup directive, so
-        // `g_a=off` keeps hiding g_a.
-        set_runtime(&reg, "trace");
         assert_eq!(gathered_names(&reg), ["g_b"]);
 
         reset_runtime(&reg);
@@ -1306,27 +1301,8 @@ mod runtime_filter_tests {
     }
 
     #[test]
-    fn default_pattern_replaces_only_the_global_default() {
-        use MetricLevel::{Trace, Warn};
-
-        // `default=LEVEL` (equally, a bare `LEVEL`) replaces the startup
-        // global default and leaves the other startup directives in place.
-        let filter = Filter::parse("info,g_a=off");
-        filter
-            .set_runtime_filter(FilterSource::new("default=trace"))
-            .unwrap();
-        assert!(!filter.is_exposed("g_a", "m", Warn));
-        assert!(filter.is_exposed("x", "m", Trace));
-        assert_eq!(filter.filter_string(), "g_a=off,default=trace");
-
-        // The same holds for the env source over the config's directives.
-        let filter = Filter::from_sources(
-            FilterSource::new("info,g_a=off"),
-            Some(FilterSource::new("default=trace")),
-        );
-        assert!(!filter.is_exposed("g_a", "m", Warn));
-        assert!(filter.is_exposed("x", "m", Trace));
-        assert_eq!(filter.startup_filter_string(), "g_a=off,default=trace");
+    fn default_pattern_does_not_match_a_module_named_default() {
+        use MetricLevel::Warn;
 
         // `default` matches as the global default, not as a module named
         // "default": any real pattern is more specific.

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -5,18 +5,23 @@
 //! filtering.
 //!
 //! Replace `use prometheus::*` with `use prometheus_filtered::*` to control
-//! which metrics are exposed. The active filter comes from the node config's
-//! directives, unless the `METRICS_FILTER` environment variable is set, in
-//! which case it replaces the config's directives entirely.
+//! which metrics are exposed. The active filter is built from up to three
+//! directive layers: the node config's, the `METRICS_FILTER` environment
+//! variable's, and an optional runtime override set.
+//! A metric is decided by the highest-precedence layer (runtime > env >
+//! config); a layer's directives leave the metrics they do not match to the
+//! layers below.
 //!
 //! Filter syntax: comma-separated `pattern=LEVEL` directives, where `LEVEL`
 //! is one of `off`, `warn`, `info`, `debug`, `trace`. A bare `LEVEL` token
-//! (no `pattern=`) sets the global default. A pattern matches if it is a
+//! (no `pattern=`) matches every metric — as an env or runtime layer it is
+//! a full override of the layers below. A pattern matches if it is a
 //! prefix of the metric name OR is a component/prefix of the calling module
 //! path (e.g. `traffic_controller` matches
-//! `iota_core::traffic_controller::metrics`). When several directives match
-//! the same metric, the most specific one (longest pattern) wins, regardless
-//! of order; among directives with the same pattern, the last one wins.
+//! `iota_core::traffic_controller::metrics`). When several directives of one
+//! layer match the same metric, the most specific one (longest pattern) wins,
+//! regardless of order; among directives with the same pattern, the last one
+//! wins.
 //!
 //! Examples:
 //! - `METRICS_FILTER=off,authority=warn`
@@ -25,11 +30,9 @@
 //! The directives act as **exposure**
 //! thresholds deciding which metrics [`Registry::gather`] includes in its
 //! output (`off` exposes none of the matched metrics). Metrics matched by no
-//! directive are exposed unconditionally, so with no filter configured the
+//! layer are exposed unconditionally, so with no filter configured the
 //! crate behaves exactly like plain `prometheus`; use a bare `LEVEL` directive
-//! to set a stricter global default. The startup directives can be overridden
-//! while the process runs via [`Filter::set_runtime_filter`];
-//! [`Filter::reset_runtime_filter`] restores the startup set.
+//! to set a stricter global default.
 
 use std::{
     collections::HashMap,
@@ -511,21 +514,39 @@ struct FilterDirective {
     threshold: u8,
 }
 
-/// Parses and evaluates `METRICS_FILTER`-style directives.
+/// Filter holds the directives in three layers — the node config's, the
+/// `METRICS_FILTER` env var's, and an optional runtime override.
 #[derive(Default)]
 pub struct Filter {
-    /// The startup directives (config + env), immutable after construction.
-    directives: Arc<Vec<FilterDirective>>,
-    /// Canonical rendering of `directives`.
-    raw: String,
-    /// Override set via admin metrics endpoint; `None` means the
-    /// startup directives are in effect.
-    runtime: RwLock<Option<RuntimeDirectives>>,
+    /// The node config's directives, immutable after construction.
+    config: Layer,
+    /// The `METRICS_FILTER` env var's directives, immutable after
+    /// construction.
+    env: Layer,
+    /// Runtime override layer; consulted first while set.
+    runtime: RwLock<Option<Arc<Layer>>>,
 }
 
-struct RuntimeDirectives {
-    directives: Arc<Vec<FilterDirective>>,
+#[derive(Default)]
+struct Layer {
+    directives: Vec<FilterDirective>,
     raw: String,
+}
+
+impl Layer {
+    fn parse(s: &str) -> Self {
+        let directives: Vec<FilterDirective> = directive_parts(s)
+            .filter_map(|part| {
+                parse_directive(part)
+                    .map_err(|err| warn!("dropping prometheus filter directive: {err}"))
+                    .ok()
+            })
+            .collect();
+        Self {
+            raw: render_directives(&directives),
+            directives,
+        }
+    }
 }
 
 /// Splits a `METRICS_FILTER`-style string into its non-empty, trimmed
@@ -597,7 +618,7 @@ fn render_directives(directives: &[FilterDirective]) -> String {
 }
 
 /// Evaluates `directives` for a metric, returning the most specific matching
-/// directive's threshold, or [`DEFAULT_THRESHOLD`] when none matches.
+/// directive's threshold, or `None` when no directive matches.
 ///
 /// A directive matches when its pattern is:
 /// 1. Empty — global default.
@@ -608,7 +629,7 @@ fn render_directives(directives: &[FilterDirective]) -> String {
 /// Among matching directives, the longest pattern wins (so a directive for a
 /// submodule overrides one for its parent, and any pattern overrides the bare
 /// global level); among equal-length patterns, the last one wins.
-fn threshold_for(directives: &[FilterDirective], name: &str, module: &str) -> u8 {
+fn threshold_for(directives: &[FilterDirective], name: &str, module: &str) -> Option<u8> {
     let mut best: Option<(usize, u8)> = None;
     for dir in directives {
         let matches = dir.pattern.is_empty()
@@ -619,84 +640,94 @@ fn threshold_for(directives: &[FilterDirective], name: &str, module: &str) -> u8
             best = Some((dir.pattern.len(), dir.threshold));
         }
     }
-    best.map_or(DEFAULT_THRESHOLD, |(_, threshold)| threshold)
+    best.map(|(_, threshold)| threshold)
 }
 
 impl Filter {
-    /// Parses a directive string, ignoring the `METRICS_FILTER` env var; use
-    /// [`Filter::resolve`] to honour it.
+    /// Parses a config-layer directive string, ignoring the `METRICS_FILTER`
+    /// env var.
     pub fn parse(s: &str) -> Self {
-        let directives: Vec<FilterDirective> = directive_parts(s)
-            .filter_map(|part| {
-                parse_directive(part)
-                    .map_err(|err| warn!("dropping prometheus filter directive: {err}"))
-                    .ok()
-            })
-            .collect();
+        Self::from_layers(s, None)
+    }
+
+    /// Builds a filter with an empty config layer and the env layer read
+    /// from the `METRICS_FILTER` env variable (permissive when unset).
+    pub fn from_env() -> Self {
+        let env = std::env::var("METRICS_FILTER").ok();
+        Self::from_layers("", env.as_deref())
+    }
+
+    /// Builds a filter from the node config's directive string and the
+    /// `METRICS_FILTER` env var's.
+    pub fn from_layers(config: &str, env: Option<&str>) -> Self {
         Self {
-            raw: render_directives(&directives),
-            directives: Arc::new(directives),
+            config: Layer::parse(config),
+            env: Layer::parse(env.unwrap_or("")),
             runtime: RwLock::new(None),
         }
     }
 
-    /// Returns the directives currently in effect: the runtime override if
-    /// one is set, the startup directives otherwise.
-    fn current_filters(&self) -> Arc<Vec<FilterDirective>> {
-        match &*self.runtime.read().unwrap() {
-            Some(runtime) => runtime.directives.clone(),
-            None => self.directives.clone(),
-        }
+    /// Returns a snapshot of the runtime override layer, if one is set.
+    fn runtime_layer(&self) -> Option<Arc<Layer>> {
+        self.runtime.read().unwrap().clone()
+    }
+
+    /// Layered evaluation, starting from runtime -> env -> config. Returns the
+    /// threshold for a metric, or the default threshold if no layer has a
+    /// matching directive.
+    fn threshold(&self, runtime: Option<&Layer>, name: &str, module: &str) -> u8 {
+        runtime
+            .and_then(|layer| threshold_for(&layer.directives, name, module))
+            .or_else(|| threshold_for(&self.env.directives, name, module))
+            .or_else(|| threshold_for(&self.config.directives, name, module))
+            .unwrap_or(DEFAULT_THRESHOLD)
     }
 
     /// Returns `true` if a registered metric named `name` in `module` at
-    /// verbosity `level` should be exposed when gathering, per the directives
-    /// currently in effect.
+    /// verbosity `level` should be exposed when gathering, per the layered
+    /// directives currently in effect.
     #[inline]
     pub fn is_exposed(&self, name: &str, module: &str, level: MetricLevel) -> bool {
-        threshold_for(&self.current_filters(), name, module) >= level.verbosity()
+        self.threshold(self.runtime_layer().as_deref(), name, module) >= level.verbosity()
     }
 
-    /// Returns the canonical string of the directives currently in effect.
-    pub fn runtime_filter_string(&self) -> String {
-        match &*self.runtime.read().unwrap() {
-            Some(runtime) => runtime.raw.clone(),
-            None => self.raw.clone(),
-        }
+    /// Returns the canonical string of the config layer's directives.
+    pub fn config_filter_string(&self) -> &str {
+        &self.config.raw
     }
 
-    /// Replaces the runtime directives, which control the metrics exposed
-    /// when gathering. Rejects the whole update if any directive is invalid.
+    /// Returns the canonical string of the env (`METRICS_FILTER`) layer's
+    /// directives.
+    pub fn env_filter_string(&self) -> &str {
+        &self.env.raw
+    }
+
+    /// Returns the canonical string of the runtime override layer, or `None`
+    /// when no override is set.
+    pub fn runtime_filter_string(&self) -> Option<String> {
+        self.runtime
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|layer| layer.raw.clone())
+    }
+
+    /// Sets the runtime override layer. Rejects the whole update if
+    /// any directive is invalid.
     pub fn set_runtime_filter(&self, s: &str) -> std::result::Result<(), String> {
         let directives = directive_parts(s)
             .map(parse_directive)
             .collect::<std::result::Result<Vec<_>, _>>()?;
-        *self.runtime.write().unwrap() = Some(RuntimeDirectives {
+        *self.runtime.write().unwrap() = Some(Arc::new(Layer {
             raw: render_directives(&directives),
-            directives: Arc::new(directives),
-        });
+            directives,
+        }));
         Ok(())
     }
 
-    /// Restores the runtime directives to the startup (config + env) set.
+    /// Drops the runtime override layer.
     pub fn reset_runtime_filter(&self) {
         *self.runtime.write().unwrap() = None;
-    }
-
-    /// Resolves the metrics filter from `fallback` (the node config) and the
-    /// `METRICS_FILTER` env variable. A non-blank env var replaces the
-    /// fallback entirely.
-    pub fn resolve(fallback: Option<&str>) -> Self {
-        let env = std::env::var("METRICS_FILTER").ok();
-        Self::resolve_from(fallback, env.as_deref())
-    }
-
-    fn resolve_from(fallback: Option<&str>, env: Option<&str>) -> Self {
-        let env = env.filter(|s| !s.trim().is_empty());
-        match env.or(fallback) {
-            Some(s) => Self::parse(s),
-            None => Self::default(),
-        }
     }
 }
 
@@ -724,11 +755,12 @@ pub struct Registry {
 }
 
 impl Registry {
-    /// Creates a registry whose filter is resolved.
+    /// Creates a registry whose filter honours the `METRICS_FILTER` env var
+    /// (permissive when unset).
     pub fn new() -> Self {
         Self {
             inner: prometheus::Registry::new(),
-            filter: Arc::new(Filter::resolve(None)),
+            filter: Arc::new(Filter::from_env()),
             prefix: None,
             registered: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -742,7 +774,7 @@ impl Registry {
     ) -> prometheus::Result<Self> {
         Ok(Self {
             inner: prometheus::Registry::new_custom(prefix.clone(), labels)?,
-            filter: filter.unwrap_or_else(|| Arc::new(Filter::resolve(None))),
+            filter: filter.unwrap_or_else(|| Arc::new(Filter::from_env())),
             prefix,
             registered: Arc::new(RwLock::new(HashMap::new())),
         })
@@ -789,16 +821,18 @@ impl Registry {
     /// filter's exposure directives. Families not registered through the
     /// wrapper macros (e.g. direct collectors) always pass through.
     pub fn gather(&self) -> Vec<prometheus::proto::MetricFamily> {
-        // One directive snapshot for the whole pass, so a concurrent filter
-        // update cannot make a single scrape internally inconsistent.
-        let directives = self.filter.current_filters();
+        // One runtime-layer snapshot for the whole pass, so a concurrent
+        // filter update cannot make a single scrape internally inconsistent.
+        let runtime = self.filter.runtime_layer();
         let registered = self.registered.read().unwrap();
         self.inner
             .gather()
             .into_iter()
             .filter(|family| {
                 registered.get(family.name()).is_none_or(|(module, level)| {
-                    threshold_for(&directives, family.name(), module) >= level.verbosity()
+                    self.filter
+                        .threshold(runtime.as_deref(), family.name(), module)
+                        >= level.verbosity()
                 })
             })
             .collect()
@@ -821,7 +855,7 @@ impl std::fmt::Debug for Registry {
 /// once from `METRICS_FILTER`.
 fn default_filter() -> &'static Arc<Filter> {
     static INSTANCE: OnceLock<Arc<Filter>> = OnceLock::new();
-    INSTANCE.get_or_init(|| Arc::new(Filter::resolve(None)))
+    INSTANCE.get_or_init(|| Arc::new(Filter::from_env()))
 }
 
 /// Returns a reference to the global default `Registry`, wrapping the
@@ -1220,14 +1254,6 @@ mod tests {
         let filter = super::Filter::parse("iota_core=off");
         assert!(!filter.is_exposed("certs_total", "iota_core::authority", Debug));
         assert!(filter.is_exposed("certs_total", "starfish::core", Debug));
-
-        // among directives with the same (here: empty) pattern the last one
-        // wins, and an explicit permissive default can carry a targeted
-        // `off` override.
-        assert!(super::Filter::parse("off,trace").is_exposed("authority", "m", Debug));
-        let filter = super::Filter::parse("trace,authority=off");
-        assert!(filter.is_exposed("certs_total", "m", Debug));
-        assert!(!filter.is_exposed("authority", "m", Debug));
     }
 
     #[test]
@@ -1255,6 +1281,35 @@ mod tests {
         assert!(!filter.is_exposed("authority", "m", Warn));
         assert!(filter.is_exposed("certs_total", "m", Info));
         assert!(!filter.is_exposed("certs_total", "m", Debug));
+        // Among directives with the same (here: empty) pattern the last one
+        // wins.
+        assert!(super::Filter::parse("off,trace").is_exposed("authority", "m", Debug));
+    }
+
+    #[test]
+    fn env_layer_overrides_config_only_where_it_matches() {
+        use super::MetricLevel::{Info, Trace, Warn};
+        // Where an env directive matches, it beats the config layer even if
+        // the config directive is more specific ...
+        let filter = super::Filter::from_layers(
+            "iota_core::authority=off,starfish=warn",
+            Some("iota_core=info"),
+        );
+        assert!(filter.is_exposed("x", "iota_core::authority", Info));
+        assert!(!filter.is_exposed("x", "iota_core::authority", Debug));
+        // ... where it does not, the config layer still applies.
+        assert!(filter.is_exposed("x", "starfish::core", Warn));
+        assert!(!filter.is_exposed("x", "starfish::core", Info));
+
+        // A bare env level matches everything: a full override.
+        let filter = super::Filter::from_layers("info,iota_core=warn", Some("trace"));
+        assert!(filter.is_exposed("x", "iota_core::authority", Trace));
+        assert!(filter.is_exposed("x", "m", Trace));
+
+        // A blank env var contributes no directives, so the config layer
+        // still applies.
+        let filter = super::Filter::from_layers("off", Some(" "));
+        assert!(!filter.is_exposed("x", "m", Warn));
     }
 
     #[test]
@@ -1305,43 +1360,27 @@ mod tests {
     }
 
     #[test]
-    fn resolve_applies_fallback() {
+    fn from_env_is_permissive_when_unset() {
         use super::{Arc, Filter, MetricLevel, Registry};
 
-        // A set env var replaces the fallback, so `Filter::resolve` is only
-        // exercised when it is unset; `resolve_from` covers the set case.
+        // A set env var would add an env layer, so `Filter::from_env` is
+        // only exercised when it is unset; `Filter::from_layers` covers the
+        // set case.
         if std::env::var_os("METRICS_FILTER").is_some() {
             return;
         }
 
-        // No env, no fallback -> everything is exposed.
-        assert!(Filter::resolve(None).is_exposed("anything", "m", MetricLevel::Trace));
-        assert!(Filter::resolve(None).is_exposed("anything", "m", Debug));
+        // No env, no config -> everything is exposed.
+        assert!(Filter::from_env().is_exposed("anything", "m", MetricLevel::Trace));
+        assert!(Filter::from_env().is_exposed("anything", "m", Debug));
 
-        // No env -> the fallback directives apply.
-        let filter = Arc::new(Filter::resolve(Some("off,authority=trace")));
+        // Registries built to share a filter see the same decisions.
+        let filter = Arc::new(Filter::parse("off,authority=trace"));
         assert!(filter.is_exposed("authority", "m", MetricLevel::Debug));
         assert!(!filter.is_exposed("consensus", "m", MetricLevel::Debug));
-
-        // Registries built to share the filter see the same decisions.
         let registry = Registry::new_custom(None, None, Some(filter.clone())).unwrap();
         let shared = Registry::new_custom(None, None, Some(filter)).unwrap();
         assert!(std::sync::Arc::ptr_eq(&registry.filter(), &shared.filter()));
-    }
-
-    #[test]
-    fn env_replaces_fallback() {
-        use super::{Filter, MetricLevel};
-
-        // A set env var replaces the fallback entirely: the fallback's more
-        // specific directive does not survive the override.
-        let filter = Filter::resolve_from(Some("off,iota_core::authority=off"), Some("trace"));
-        assert!(filter.is_exposed("x", "iota_core::authority", MetricLevel::Trace));
-        assert!(filter.is_exposed("x", "iota_core::checkpoints", MetricLevel::Trace));
-
-        // A blank env var counts as unset: the fallback still applies.
-        let filter = Filter::resolve_from(Some("off"), Some(" "));
-        assert!(!filter.is_exposed("x", "m", MetricLevel::Warn));
     }
 
     #[test]
@@ -1478,26 +1517,6 @@ mod runtime_filter_tests {
     }
 
     #[test]
-    fn runtime_filter_hides_and_restores_registered_metrics() {
-        let reg = registry("");
-        crate::register_int_gauge_with_registry!(
-            "g_consensus", "h", &reg; MetricLevel::Warn
-        )
-        .unwrap();
-        crate::register_int_gauge_with_registry!("g_other", "h", &reg; MetricLevel::Warn).unwrap();
-        assert_eq!(gathered_names(&reg), ["g_consensus", "g_other"]);
-
-        // Hide by metric-name prefix at runtime; the metric stays registered.
-        let filter = reg.filter();
-        filter.set_runtime_filter("g_consensus=off").unwrap();
-        assert_eq!(gathered_names(&reg), ["g_other"]);
-
-        // Reset restores the startup (empty) directives.
-        filter.reset_runtime_filter();
-        assert_eq!(gathered_names(&reg), ["g_consensus", "g_other"]);
-    }
-
-    #[test]
     fn raising_runtime_level_exposes_collected_metrics() {
         // A `warn` startup threshold hides the debug metric …
         let reg = registry("runtime_filter_tests=warn");
@@ -1519,45 +1538,80 @@ mod runtime_filter_tests {
             .unwrap();
         assert_eq!(family.get_metric()[0].get_gauge().value() as i64, 7);
 
-        // The same holds for a startup `off` directive: an empty (permissive)
-        // runtime filter exposes the metric with its collected value.
+        // The same holds for a startup `off` directive: a runtime directive
+        // matching the metric exposes it with its collected value.
         let reg = registry("g_hidden=off");
         let g = crate::register_int_gauge_with_registry!("g_hidden", "h", &reg; MetricLevel::Warn)
             .unwrap();
         g.set(9);
         assert_eq!(gathered_names(&reg), Vec::<String>::new());
-        reg.filter().set_runtime_filter("").unwrap();
+        reg.filter().set_runtime_filter("g_hidden=warn").unwrap();
         assert_eq!(gathered_names(&reg), ["g_hidden"]);
         let family = &reg.gather()[0];
         assert_eq!(family.get_metric()[0].get_gauge().value() as i64, 9);
     }
 
     #[test]
-    fn runtime_filter_starts_as_startup_directives() {
-        let filter = Filter::parse("authority=off");
-        assert_eq!(filter.runtime_filter_string(), "authority=off");
+    fn runtime_layer_falls_back_to_startup_where_it_does_not_match() {
+        let reg = registry("g_a=off");
+        crate::register_int_gauge_with_registry!("g_a", "h", &reg; MetricLevel::Warn).unwrap();
+        crate::register_int_gauge_with_registry!("g_b", "h", &reg; MetricLevel::Warn).unwrap();
+        assert_eq!(gathered_names(&reg), ["g_b"]);
+
+        // The override hides g_b; g_a is matched by no override directive
+        // and keeps its startup exposure (hidden).
+        let filter = reg.filter();
+        filter.set_runtime_filter("g_b=off").unwrap();
+        assert_eq!(gathered_names(&reg), Vec::<String>::new());
+
+        // An empty override matches nothing, leaving the startup directives
+        // fully in effect.
+        filter.set_runtime_filter("").unwrap();
+        assert_eq!(gathered_names(&reg), ["g_b"]);
+
+        // A bare level matches everything: a full temporary override.
+        filter.set_runtime_filter("trace").unwrap();
+        assert_eq!(gathered_names(&reg), ["g_a", "g_b"]);
+
+        filter.reset_runtime_filter();
+        assert_eq!(gathered_names(&reg), ["g_b"]);
+    }
+
+    #[test]
+    fn filter_reports_its_layers() {
+        let filter = Filter::from_layers("authority=off", Some("checkpoints=warn"));
+        assert_eq!(filter.config_filter_string(), "authority=off");
+        assert_eq!(filter.env_filter_string(), "checkpoints=warn");
+        assert_eq!(filter.runtime_filter_string(), None);
         assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
 
         filter.set_runtime_filter("authority=warn").unwrap();
-        assert_eq!(filter.runtime_filter_string(), "authority=warn");
+        assert_eq!(
+            filter.runtime_filter_string().as_deref(),
+            Some("authority=warn")
+        );
         assert!(filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
         assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Debug));
 
         filter.reset_runtime_filter();
-        assert_eq!(filter.runtime_filter_string(), "authority=off");
+        assert_eq!(filter.runtime_filter_string(), None);
+        assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
     }
 
     #[test]
     fn filter_string_is_canonical_and_round_trips() {
-        // Invalid startup directives are dropped, and the reported string
-        // reflects the directives actually in effect — so it can always be
-        // POSTed back through the strict runtime setter.
+        // Invalid startup directives are dropped, and the reported config
+        // string reflects the directives actually in effect — so it can
+        // always be POSTed back through the strict runtime setter.
         let filter = Filter::parse("foo=bogus, typed_store=warn ,info");
-        assert_eq!(filter.runtime_filter_string(), "typed_store=warn,info");
+        assert_eq!(filter.config_filter_string(), "typed_store=warn,info");
         filter
-            .set_runtime_filter(&filter.runtime_filter_string())
+            .set_runtime_filter(filter.config_filter_string())
             .unwrap();
-        assert_eq!(filter.runtime_filter_string(), "typed_store=warn,info");
+        assert_eq!(
+            filter.runtime_filter_string().as_deref(),
+            Some("typed_store=warn,info")
+        );
     }
 
     #[test]
@@ -1567,8 +1621,8 @@ mod runtime_filter_tests {
             .set_runtime_filter("authority=warn,bogus=nope")
             .unwrap_err();
         assert!(err.contains("bogus=nope"), "unexpected error: {err}");
-        // The failed update leaves the runtime directives unchanged.
-        assert_eq!(filter.runtime_filter_string(), "authority=off");
+        // The failed update leaves the runtime layer unset.
+        assert_eq!(filter.runtime_filter_string(), None);
         assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
     }
 }

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -8,9 +8,9 @@
 //! which metrics are exposed. The active filter is one directive set, built
 //! by merging its inputs in precedence order — the node config's directives,
 //! the `METRICS_FILTER` environment variable's, and an optional runtime
-//! override: a higher-precedence directive replaces every directive whose
-//! pattern it prefixes, and the directives it does not shadow keep their
-//! effect (see [`Filter`]).
+//! override: a higher-precedence directive replaces the directive with the
+//! same pattern, and otherwise the sets' directives apply side by side (see
+//! [`Filter`]).
 //!
 //! Filter syntax: comma-separated `pattern=LEVEL` directives, where `LEVEL`
 //! is one of `off`, `warn`, `info`, `debug`, `trace`. A bare `LEVEL` token
@@ -163,12 +163,17 @@ impl DirectiveSet {
         }
     }
 
-    /// Merges `over` on top of `self`: an `over` directive replaces every
-    /// directive whose pattern it prefixes (a bare level replaces
-    /// everything), and directives it does not shadow keep their effect —
-    /// for overlapping unrelated patterns the usual longest-pattern-wins
-    /// matching applies.
+    /// Merges `over` on top of `self`: an `over` directive replaces the
+    /// directive with the same pattern; otherwise both sets' directives
+    /// apply and the usual most-specific-pattern-wins matching decides each
+    /// metric.
     fn merged(&self, over: &Self) -> Self {
+        if over.directives.iter().any(|dir| dir.pattern.is_empty()) {
+            return Self {
+                directives: over.directives.clone(),
+                display: over.display.clone(),
+            };
+        }
         Self {
             directives: merge_directives(&self.directives, &over.directives),
             display: merge_directives(&self.display, &over.display),
@@ -176,11 +181,11 @@ impl DirectiveSet {
     }
 }
 
-/// Appends `over` to `base`, dropping the `base` directives shadowed by an
-/// `over` directive's pattern prefix.
+/// Appends `over` to `base`, dropping the `base` directives that an `over`
+/// directive with the same pattern replaces.
 fn merge_directives(base: &[FilterDirective], over: &[FilterDirective]) -> Vec<FilterDirective> {
     base.iter()
-        .filter(|dir| !over.iter().any(|o| dir.pattern.starts_with(&o.pattern)))
+        .filter(|dir| !over.iter().any(|o| o.pattern == dir.pattern))
         .chain(over.iter())
         .cloned()
         .collect()
@@ -943,25 +948,27 @@ mod tests {
     #[test]
     fn env_directives_merge_over_config_into_one_startup_filter() {
         use super::MetricLevel::{Info, Trace, Warn};
-        // An env directive replaces every config directive whose pattern it
-        // prefixes, so it beats the config even where the config directive is
-        // more specific ...
+        // An env directive replaces the config directive with the same
+        // pattern; where the patterns differ, the most specific matching one
+        // decides each metric, whichever source it came from ...
         let filter = super::Filter::from_sources(
             super::FilterSource::new("iota_core::authority=off,starfish=warn"),
-            Some(super::FilterSource::new("iota_core=info")),
+            Some(super::FilterSource::new("iota_core=info,starfish=info")),
         );
-        assert!(filter.is_exposed("x", "iota_core::authority", Info));
-        assert!(!filter.is_exposed("x", "iota_core::authority", Debug));
-        // ... where it does not, the config directives still apply.
-        assert!(filter.is_exposed("x", "starfish::core", Warn));
-        assert!(!filter.is_exposed("x", "starfish::core", Info));
+        assert!(!filter.is_exposed("x", "iota_core::authority", Warn));
+        assert!(filter.is_exposed("x", "iota_core::checkpoints", Info));
+        assert!(!filter.is_exposed("x", "iota_core::checkpoints", Debug));
+        // ... same pattern: the env directive replaces the config's.
+        assert!(filter.is_exposed("x", "starfish::core", Info));
+        assert!(!filter.is_exposed("x", "starfish::core", Debug));
         // The two sources collapse into a single startup string.
         assert_eq!(
             filter.startup_filter_string(),
-            "starfish=warn,iota_core=info"
+            "iota_core::authority=off,iota_core=info,starfish=info"
         );
 
-        // A bare env level prefixes everything: a full override.
+        // A bare env level matches everything at its layer's highest
+        // precedence: a full override, replacing the config directives.
         let filter = super::Filter::from_sources(
             super::FilterSource::new("info,iota_core=warn"),
             Some(super::FilterSource::new("trace")),
@@ -1232,14 +1239,14 @@ mod runtime_filter_tests {
     }
 
     #[test]
-    fn runtime_override_keeps_startup_directives_it_does_not_shadow() {
+    fn runtime_override_keeps_startup_directives_for_other_patterns() {
         let reg = registry("g_a=off");
         crate::register_int_gauge_with_registry!("g_a", "h", &reg; MetricLevel::Warn).unwrap();
         crate::register_int_gauge_with_registry!("g_b", "h", &reg; MetricLevel::Warn).unwrap();
         assert_eq!(gathered_names(&reg), ["g_b"]);
 
-        // The override hides g_b; g_a is shadowed by no override directive
-        // and keeps its startup exposure (hidden).
+        // The override hides g_b; no override directive matches g_a, so it
+        // keeps its startup exposure (hidden).
         set_runtime(&reg, "g_b=off");
         assert_eq!(gathered_names(&reg), Vec::<String>::new());
 
@@ -1249,7 +1256,7 @@ mod runtime_filter_tests {
         set_runtime(&reg, "");
         assert_eq!(gathered_names(&reg), ["g_b"]);
 
-        // A bare level prefixes every pattern: a full temporary override.
+        // A bare level replaces the whole filter: a full temporary override.
         set_runtime(&reg, "trace");
         assert_eq!(gathered_names(&reg), ["g_a", "g_b"]);
 
@@ -1258,7 +1265,7 @@ mod runtime_filter_tests {
     }
 
     #[test]
-    fn runtime_directives_replace_the_startup_directives_they_shadow() {
+    fn runtime_directives_replace_same_pattern_startup_directives() {
         use MetricLevel::{Debug, Trace, Warn};
 
         // Same pattern: the override directive replaces the startup one.
@@ -1272,21 +1279,23 @@ mod runtime_filter_tests {
         // The startup filter is untouched, ready for reset.
         assert_eq!(filter.startup_filter_string(), "g_a=off,g_b=warn");
 
-        // Pattern prefix: an override directive claims its whole subtree, so
-        // a more specific startup directive cannot poke through it.
+        // Different patterns: the most specific matching one decides each
+        // metric, so a more specific startup directive survives a broader
+        // override and vice versa.
         let filter = Filter::parse("iota_core=warn,iota_core::authority::sub=off");
         filter
             .set_runtime_filter(FilterSource::new("iota_core::authority=trace"))
             .unwrap();
-        assert!(filter.is_exposed("x", "iota_core::authority::sub", Trace));
+        assert!(!filter.is_exposed("x", "iota_core::authority::sub", Warn));
+        assert!(filter.is_exposed("x", "iota_core::authority::other", Trace));
         assert!(!filter.is_exposed("x", "iota_core::checkpoints", Debug));
         assert_eq!(
             filter.filter_string(),
-            "iota_core=warn,iota_core::authority=trace"
+            "iota_core=warn,iota_core::authority::sub=off,iota_core::authority=trace"
         );
 
-        // A bare level shadows everything; more specific directives in the
-        // same override still apply on top of it.
+        // A bare level replaces the whole filter; more specific directives in
+        // the same override still apply on top of it.
         let filter = Filter::parse("g_a=off,g_b=warn");
         filter
             .set_runtime_filter(FilterSource::new("trace,g_c=off"))
@@ -1295,6 +1304,18 @@ mod runtime_filter_tests {
         assert!(filter.is_exposed("g_b", "m", Trace));
         assert!(!filter.is_exposed("g_c", "m", Warn));
         assert_eq!(filter.filter_string(), "trace,g_c=off");
+
+        // A bare level in the override's directives replaces the display as
+        // a whole too (e.g. an expanded `default=LEVEL` group directive).
+        let filter = Filter::from_sources(
+            FilterSource::with_display("info,g_a=off", "default=info,g_a=off"),
+            None,
+        );
+        filter
+            .set_runtime_filter(FilterSource::with_display("trace", "default=trace"))
+            .unwrap();
+        assert!(filter.is_exposed("g_a", "m", Trace));
+        assert_eq!(filter.filter_string(), "default=trace");
 
         // Reset restores the startup directives.
         filter.reset_runtime_filter();
@@ -1320,8 +1341,8 @@ mod runtime_filter_tests {
         assert_eq!(filter.filter_string(), filter.startup_filter_string());
         assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
 
-        // An override's display shadows the startup display the same way its
-        // directives shadow the startup directives.
+        // An override's display replaces the same-pattern startup display
+        // entry the same way its directives do.
         filter
             .set_runtime_filter(FilterSource::with_display(
                 "iota_core::authority=warn",

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -25,7 +25,9 @@
 //! output (`off` exposes none of the matched metrics). Metrics matched by no
 //! directive are exposed unconditionally, so with no filter configured the
 //! crate behaves exactly like plain `prometheus`; use a bare `LEVEL` directive
-//! to set a stricter global default.
+//! to set a stricter global default. The startup directives can be overridden
+//! while the process runs via [`Filter::set_runtime_filter`];
+//! [`Filter::reset_runtime_filter`] restores the startup set.
 
 use std::{
     collections::HashMap,
@@ -508,26 +510,46 @@ struct FilterDirective {
 }
 
 /// Parses and evaluates `METRICS_FILTER`-style directives.
-///
-/// Filter string: comma-separated `pattern=LEVEL` directives, last-match
-/// wins, a metric is exposed when its own level is at or below the threshold.
 #[derive(Default)]
 pub struct Filter {
-    directives: Vec<FilterDirective>,
+    /// The startup directives (config + env), immutable after construction.
+    directives: Arc<Vec<FilterDirective>>,
+    /// Canonical rendering of `directives`.
+    raw: String,
+    /// Override set via admin metrics endpoint; `None` means the
+    /// startup directives are in effect.
+    runtime: RwLock<Option<RuntimeDirectives>>,
 }
 
-/// Parses one `pattern=LEVEL` directive. `None` for an empty segment or an
-/// invalid level (dropped with a warning).
-fn parse_directive(part: &str) -> Option<FilterDirective> {
-    let part = part.trim();
-    if part.is_empty() {
-        return None;
+struct RuntimeDirectives {
+    directives: Arc<Vec<FilterDirective>>,
+    raw: String,
+}
+
+/// Splits a `METRICS_FILTER`-style string into its non-empty, trimmed
+/// directive segments.
+pub fn directive_parts(s: &str) -> impl Iterator<Item = &str> + '_ {
+    s.split(',').map(str::trim).filter(|part| !part.is_empty())
+}
+
+/// Splits one directive into its `(pattern, level)` parts; a directive
+/// without `=` is a bare level with an empty (global catch-all) pattern.
+pub fn split_directive(part: &str) -> (&str, &str) {
+    match part.rfind('=') {
+        Some(eq) => (part[..eq].trim(), part[eq + 1..].trim()),
+        None => ("", part.trim()),
     }
-    let (pattern, value) = if let Some(eq) = part.rfind('=') {
-        (part[..eq].trim().to_owned(), part[eq + 1..].trim())
-    } else {
-        (String::new(), part)
-    };
+}
+
+/// Returns an error describing the offending directive if `part` is not a
+/// valid `pattern=LEVEL` directive.
+pub fn validate_directive(part: &str) -> std::result::Result<(), String> {
+    parse_directive(part).map(|_| ())
+}
+
+/// Parses one `pattern=LEVEL` directive.
+fn parse_directive(part: &str) -> std::result::Result<FilterDirective, String> {
+    let (pattern, value) = split_directive(part);
     let threshold = match value {
         "off" => 0,
         "warn" => 1,
@@ -535,14 +557,41 @@ fn parse_directive(part: &str) -> Option<FilterDirective> {
         "debug" => 3,
         "trace" => 4,
         other => {
-            warn!(
-                "dropping prometheus filter directive {part:?}: invalid level {other:?}, \
-                 expected one of off/warn/info/debug/trace"
-            );
-            return None;
+            return Err(format!(
+                "invalid level {other:?} in directive {part:?}: expected one of \
+                 off/warn/info/debug/trace"
+            ));
         }
     };
-    Some(FilterDirective { pattern, threshold })
+    Ok(FilterDirective {
+        pattern: pattern.to_owned(),
+        threshold,
+    })
+}
+
+/// Renders directives back into their canonical `pattern=LEVEL` string, the
+/// inverse of [`parse_directive`].
+fn render_directives(directives: &[FilterDirective]) -> String {
+    fn token(threshold: u8) -> &'static str {
+        match threshold {
+            0 => "off",
+            1 => "warn",
+            2 => "info",
+            3 => "debug",
+            _ => "trace",
+        }
+    }
+    directives
+        .iter()
+        .map(|dir| {
+            if dir.pattern.is_empty() {
+                token(dir.threshold).to_owned()
+            } else {
+                format!("{}={}", dir.pattern, token(dir.threshold))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// Evaluates `directives` for a metric, returning the last matching
@@ -571,15 +620,61 @@ impl Filter {
     /// Parses a directive string, ignoring the `METRICS_FILTER` env var; use
     /// [`Filter::resolve`] to honour it.
     pub fn parse(s: &str) -> Self {
-        let directives = s.split(',').filter_map(parse_directive).collect();
-        Self { directives }
+        let directives: Vec<FilterDirective> = directive_parts(s)
+            .filter_map(|part| {
+                parse_directive(part)
+                    .map_err(|err| warn!("dropping prometheus filter directive: {err}"))
+                    .ok()
+            })
+            .collect();
+        Self {
+            raw: render_directives(&directives),
+            directives: Arc::new(directives),
+            runtime: RwLock::new(None),
+        }
+    }
+
+    /// Returns the directives currently in effect: the runtime override if
+    /// one is set, the startup directives otherwise.
+    fn current_filters(&self) -> Arc<Vec<FilterDirective>> {
+        match &*self.runtime.read().unwrap() {
+            Some(runtime) => runtime.directives.clone(),
+            None => self.directives.clone(),
+        }
     }
 
     /// Returns `true` if a registered metric named `name` in `module` at
-    /// verbosity `level` should be exposed when gathering.
+    /// verbosity `level` should be exposed when gathering, per the directives
+    /// currently in effect.
     #[inline]
     pub fn is_exposed(&self, name: &str, module: &str, level: MetricLevel) -> bool {
-        threshold_for(&self.directives, name, module) >= level.verbosity()
+        threshold_for(&self.current_filters(), name, module) >= level.verbosity()
+    }
+
+    /// Returns the canonical string of the directives currently in effect.
+    pub fn runtime_filter_string(&self) -> String {
+        match &*self.runtime.read().unwrap() {
+            Some(runtime) => runtime.raw.clone(),
+            None => self.raw.clone(),
+        }
+    }
+
+    /// Replaces the runtime directives, which control the metrics exposed
+    /// when gathering. Rejects the whole update if any directive is invalid.
+    pub fn set_runtime_filter(&self, s: &str) -> std::result::Result<(), String> {
+        let directives = directive_parts(s)
+            .map(parse_directive)
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        *self.runtime.write().unwrap() = Some(RuntimeDirectives {
+            raw: render_directives(&directives),
+            directives: Arc::new(directives),
+        });
+        Ok(())
+    }
+
+    /// Restores the runtime directives to the startup (config + env) set.
+    pub fn reset_runtime_filter(&self) {
+        *self.runtime.write().unwrap() = None;
     }
 
     /// Resolves the metrics filter from `fallback` (the node config)
@@ -620,8 +715,7 @@ pub struct Registry {
 }
 
 impl Registry {
-    /// Creates a registry whose filter is resolved from the `METRICS_FILTER`
-    /// env var (permissive when unset).
+    /// Creates a registry whose filter is resolved.
     pub fn new() -> Self {
         Self {
             inner: prometheus::Registry::new(),
@@ -686,13 +780,16 @@ impl Registry {
     /// filter's exposure directives. Families not registered through the
     /// wrapper macros (e.g. direct collectors) always pass through.
     pub fn gather(&self) -> Vec<prometheus::proto::MetricFamily> {
+        // One directive snapshot for the whole pass, so a concurrent filter
+        // update cannot make a single scrape internally inconsistent.
+        let directives = self.filter.current_filters();
         let registered = self.registered.read().unwrap();
         self.inner
             .gather()
             .into_iter()
             .filter(|family| {
                 registered.get(family.name()).is_none_or(|(module, level)| {
-                    self.filter.is_exposed(family.name(), module, *level)
+                    threshold_for(&directives, family.name(), module) >= level.verbosity()
                 })
             })
             .collect()
@@ -712,7 +809,7 @@ impl std::fmt::Debug for Registry {
 }
 
 /// Returns the process-wide `Filter` of the [`default_registry`], resolved
-/// once from `METRICS_FILTER` (permissive when unset).
+/// once from `METRICS_FILTER`.
 fn default_filter() -> &'static Arc<Filter> {
     static INSTANCE: OnceLock<Arc<Filter>> = OnceLock::new();
     INSTANCE.get_or_init(|| Arc::new(Filter::resolve(None)))
@@ -1108,6 +1205,19 @@ mod tests {
         assert!(!filter.is_exposed("authority_aggregator", "iota_core::checkpoints", Debug));
         assert!(filter.is_exposed("certs_total", "iota_core::authority", Debug));
         assert!(!filter.is_exposed("certs_total", "iota_core::authority_aggregator", Debug));
+
+        // a pattern that is a prefix of the full module path (not only a `::`
+        // component) matches.
+        let filter = super::Filter::parse("iota_core=off");
+        assert!(!filter.is_exposed("certs_total", "iota_core::authority", Debug));
+        assert!(filter.is_exposed("certs_total", "starfish::core", Debug));
+
+        // last-match-wins applies to bare global directives too, and an
+        // explicit permissive default can carry a targeted `off` override.
+        assert!(super::Filter::parse("off,trace").is_exposed("authority", "m", Debug));
+        let filter = super::Filter::parse("trace,authority=off");
+        assert!(filter.is_exposed("certs_total", "m", Debug));
+        assert!(!filter.is_exposed("authority", "m", Debug));
     }
 
     #[test]
@@ -1129,55 +1239,24 @@ mod tests {
     }
 
     #[test]
-    fn rejects_boolean_and_numeric_aliases() {
-        use super::MetricLevel::Trace;
-        // Only the RUST_LOG-style level names are accepted; the former
-        // `on`/`true`/`1` and `false`/`0` aliases are now invalid, so they are
-        // dropped and the directive falls back to the permissive default.
-        for alias in ["on", "true", "1", "false", "0"] {
-            let filter = super::Filter::parse(&format!("authority={alias}"));
-            assert!(
-                filter.is_exposed("authority", "m", Trace),
-                "{alias} should be dropped as invalid, leaving the default"
-            );
-        }
-        // `off` still disables.
-        assert!(
-            !super::Filter::parse("authority=off").is_exposed("authority", "m", Debug),
-            "off should disable"
-        );
-    }
-
-    #[test]
     fn invalid_directives_are_dropped() {
         use super::MetricLevel::Trace;
-        // an unrecognised value leaves the directive out, falling back to the
-        // permissive default.
-        assert!(super::Filter::parse("authority=maybe").is_exposed("authority", "m", Trace));
+        // An unrecognised value leaves the directive out, falling back to the
+        // permissive default. Only the RUST_LOG-style level names are
+        // accepted; the former `on`/`true`/`1` and `false`/`0` aliases are
+        // invalid too.
+        for level in ["maybe", "on", "true", "1", "false", "0"] {
+            let filter = super::Filter::parse(&format!("authority={level}"));
+            assert!(
+                filter.is_exposed("authority", "m", Trace),
+                "{level} should be dropped as invalid, leaving the default"
+            );
+        }
         // a bare token without `=LEVEL` is parsed as a global value and, being
         // invalid, dropped — it does NOT enable/disable the `authority` subsystem.
         assert!(super::Filter::parse("authority").is_exposed("authority", "m", Trace));
         // a valid directive alongside an invalid one still takes effect.
         let filter = super::Filter::parse("authority=off,bogus=nope");
-        assert!(!filter.is_exposed("authority", "m", Debug));
-    }
-
-    #[test]
-    fn matches_module_path_prefix() {
-        // a pattern that is a prefix of the full module path (not only a `::`
-        // component) matches.
-        let filter = super::Filter::parse("iota_core=off");
-        assert!(!filter.is_exposed("certs_total", "iota_core::authority", Debug));
-        assert!(filter.is_exposed("certs_total", "starfish::core", Debug));
-    }
-
-    #[test]
-    fn global_trace_default() {
-        // last-match-wins applies to bare global directives too.
-        assert!(super::Filter::parse("off,trace").is_exposed("authority", "m", Debug));
-        // an explicit permissive default with a targeted `off` override.
-        let filter = super::Filter::parse("trace,authority=off");
-        assert!(filter.is_exposed("certs_total", "m", Debug));
         assert!(!filter.is_exposed("authority", "m", Debug));
     }
 
@@ -1280,7 +1359,8 @@ mod gather_filter_tests {
     #[test]
     fn off_directive_hides_but_still_registers() {
         let reg = registry("g_hidden=off");
-        let g = crate::register_int_gauge_with_registry!("g_hidden", "h", &reg).unwrap();
+        let g = crate::register_int_gauge_with_registry!("g_hidden", "h", &reg; MetricLevel::Warn)
+            .unwrap();
         // Registered (a disabled wrapper would print "(disabled)") and
         // collecting, but absent from gather output.
         assert_eq!(format!("{g:?}"), "GenericGauge");
@@ -1328,38 +1408,115 @@ mod gather_filter_tests {
 }
 
 #[cfg(test)]
-mod level_macro_tests {
-    use super::{IntGauge, MetricLevel, Registry};
+mod runtime_filter_tests {
+    use super::{Filter, MetricLevel, Registry};
 
     fn registry(filter: &str) -> Registry {
-        Registry::new_custom(
-            None,
-            None,
-            Some(std::sync::Arc::new(super::Filter::parse(filter))),
-        )
-        .unwrap()
+        Registry::new_custom(None, None, Some(std::sync::Arc::new(Filter::parse(filter)))).unwrap()
+    }
+
+    fn gathered_names(registry: &Registry) -> Vec<String> {
+        let mut names: Vec<_> = registry
+            .gather()
+            .iter()
+            .map(|f| f.name().to_owned())
+            .collect();
+        names.sort();
+        names
     }
 
     #[test]
-    fn hidden_metrics_still_register_and_collect() {
-        // At a `warn` threshold, a default (`debug`) metric still registers
-        // and collects — it is only hidden from `gather` output.
-        let reg = registry("g_default=warn");
-        let g: IntGauge = crate::register_int_gauge_with_registry!("g_default", "h", &reg).unwrap();
-        // `IntGauge` is a type alias for `core::GenericGauge<AtomicI64>`; its
-        // `Debug` impl prints the underlying `GenericGauge` name, not the alias.
-        assert_eq!(format!("{g:?}"), "GenericGauge");
-        g.set(42);
-        assert_eq!(g.get(), 42);
-        assert!(reg.gather().is_empty());
-
-        // Even an `off` threshold registers the metric; it only hides it.
-        let reg = registry("g_off=off");
-        let g: IntGauge = crate::register_int_gauge_with_registry!(
-            "g_off", "h", &reg; MetricLevel::Warn
+    fn runtime_filter_hides_and_restores_registered_metrics() {
+        let reg = registry("");
+        crate::register_int_gauge_with_registry!(
+            "g_consensus", "h", &reg; MetricLevel::Warn
         )
         .unwrap();
-        assert_eq!(format!("{g:?}"), "GenericGauge");
-        assert!(reg.gather().is_empty());
+        crate::register_int_gauge_with_registry!("g_other", "h", &reg; MetricLevel::Warn).unwrap();
+        assert_eq!(gathered_names(&reg), ["g_consensus", "g_other"]);
+
+        // Hide by metric-name prefix at runtime; the metric stays registered.
+        let filter = reg.filter();
+        filter.set_runtime_filter("g_consensus=off").unwrap();
+        assert_eq!(gathered_names(&reg), ["g_other"]);
+
+        // Reset restores the startup (empty) directives.
+        filter.reset_runtime_filter();
+        assert_eq!(gathered_names(&reg), ["g_consensus", "g_other"]);
+    }
+
+    #[test]
+    fn raising_runtime_level_exposes_collected_metrics() {
+        // A `warn` startup threshold hides the debug metric …
+        let reg = registry("runtime_filter_tests=warn");
+        crate::register_int_gauge_with_registry!("g_warn", "h", &reg; MetricLevel::Warn).unwrap();
+        let g_debug = crate::register_int_gauge_with_registry!("g_debug", "h", &reg).unwrap();
+        g_debug.set(7);
+        assert_eq!(gathered_names(&reg), ["g_warn"]);
+
+        // … so raising the exposure level at runtime reveals it, with the
+        // values it collected while hidden.
+        reg.filter()
+            .set_runtime_filter("runtime_filter_tests=debug")
+            .unwrap();
+        assert_eq!(gathered_names(&reg), ["g_debug", "g_warn"]);
+        let family = reg
+            .gather()
+            .into_iter()
+            .find(|f| f.name() == "g_debug")
+            .unwrap();
+        assert_eq!(family.get_metric()[0].get_gauge().value() as i64, 7);
+
+        // The same holds for a startup `off` directive: an empty (permissive)
+        // runtime filter exposes the metric with its collected value.
+        let reg = registry("g_hidden=off");
+        let g = crate::register_int_gauge_with_registry!("g_hidden", "h", &reg; MetricLevel::Warn)
+            .unwrap();
+        g.set(9);
+        assert_eq!(gathered_names(&reg), Vec::<String>::new());
+        reg.filter().set_runtime_filter("").unwrap();
+        assert_eq!(gathered_names(&reg), ["g_hidden"]);
+        let family = &reg.gather()[0];
+        assert_eq!(family.get_metric()[0].get_gauge().value() as i64, 9);
+    }
+
+    #[test]
+    fn runtime_filter_starts_as_startup_directives() {
+        let filter = Filter::parse("authority=off");
+        assert_eq!(filter.runtime_filter_string(), "authority=off");
+        assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
+
+        filter.set_runtime_filter("authority=warn").unwrap();
+        assert_eq!(filter.runtime_filter_string(), "authority=warn");
+        assert!(filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
+        assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Debug));
+
+        filter.reset_runtime_filter();
+        assert_eq!(filter.runtime_filter_string(), "authority=off");
+    }
+
+    #[test]
+    fn filter_string_is_canonical_and_round_trips() {
+        // Invalid startup directives are dropped, and the reported string
+        // reflects the directives actually in effect — so it can always be
+        // POSTed back through the strict runtime setter.
+        let filter = Filter::parse("foo=bogus, typed_store=warn ,info");
+        assert_eq!(filter.runtime_filter_string(), "typed_store=warn,info");
+        filter
+            .set_runtime_filter(&filter.runtime_filter_string())
+            .unwrap();
+        assert_eq!(filter.runtime_filter_string(), "typed_store=warn,info");
+    }
+
+    #[test]
+    fn set_runtime_filter_rejects_invalid_directives() {
+        let filter = Filter::parse("authority=off");
+        let err = filter
+            .set_runtime_filter("authority=warn,bogus=nope")
+            .unwrap_err();
+        assert!(err.contains("bogus=nope"), "unexpected error: {err}");
+        // The failed update leaves the runtime directives unchanged.
+        assert_eq!(filter.runtime_filter_string(), "authority=off");
+        assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
     }
 }

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -5,21 +5,21 @@
 //! filtering.
 //!
 //! Replace `use prometheus::*` with `use prometheus_filtered::*` to control
-//! which metrics are exposed. The active filter is built from up to three
-//! directive layers: the node config's, the `METRICS_FILTER` environment
-//! variable's, and an optional runtime override set.
-//! A metric is decided by the highest-precedence layer (runtime > env >
-//! config); a layer's directives leave the metrics they do not match to the
-//! layers below.
+//! which metrics are exposed. The active filter is one directive set, built
+//! by merging its inputs in precedence order — the node config's directives,
+//! the `METRICS_FILTER` environment variable's, and an optional runtime
+//! override: a higher-precedence directive replaces every directive whose
+//! pattern it prefixes, and the directives it does not shadow keep their
+//! effect (see [`Filter`]).
 //!
 //! Filter syntax: comma-separated `pattern=LEVEL` directives, where `LEVEL`
 //! is one of `off`, `warn`, `info`, `debug`, `trace`. A bare `LEVEL` token
-//! (no `pattern=`) matches every metric — as an env or runtime layer it is
-//! a full override of the layers below. A pattern matches if it is a
+//! (no `pattern=`) matches every metric — as an env or runtime directive it
+//! replaces the whole filter. A pattern matches if it is a
 //! prefix of the metric name OR is a component/prefix of the calling module
 //! path (e.g. `traffic_controller` matches
-//! `iota_core::traffic_controller::metrics`). When several directives of one
-//! layer match the same metric, the most specific one (longest pattern) wins,
+//! `iota_core::traffic_controller::metrics`). When several directives
+//! match the same metric, the most specific one (longest pattern) wins,
 //! regardless of order; among directives with the same pattern, the last one
 //! wins.
 //!
@@ -30,7 +30,7 @@
 //! The directives act as **exposure**
 //! thresholds deciding which metrics [`Registry::gather`] includes in its
 //! output (`off` exposes none of the matched metrics). Metrics matched by no
-//! layer are exposed unconditionally, so with no filter configured the
+//! directive are exposed unconditionally, so with no filter configured the
 //! crate behaves exactly like plain `prometheus`; use a bare `LEVEL` directive
 //! to set a stricter global default.
 
@@ -106,39 +106,95 @@ struct FilterDirective {
     threshold: u8,
 }
 
-/// Filter holds the directives in three layers — the node config's, the
-/// `METRICS_FILTER` env var's, and an optional runtime override.
+/// Filter holds two directive sets: the immutable startup directives (the
+/// node config's with the `METRICS_FILTER` env var's merged over them) and
+/// the directives currently in effect — the startup directives, with the
+/// runtime override merged over them while one is set.
 #[derive(Default)]
 pub struct Filter {
-    /// The node config's directives, immutable after construction.
-    config: Layer,
-    /// The `METRICS_FILTER` env var's directives, immutable after
-    /// construction.
-    env: Layer,
-    /// Runtime override layer; consulted first while set.
-    runtime: RwLock<Option<Arc<Layer>>>,
+    /// The startup directives; what [`Filter::reset_runtime_filter`] restores.
+    startup: Arc<DirectiveSet>,
+    /// The directives consulted by [`Filter::is_exposed`].
+    runtime: RwLock<Arc<DirectiveSet>>,
 }
 
-#[derive(Default)]
-struct Layer {
-    directives: Vec<FilterDirective>,
-    raw: String,
+/// The source strings for one filter input. `directives` is parsed for
+/// matching; `display` is what [`Filter::filter_string`] and
+/// [`Filter::startup_filter_string`] echo back (e.g. the group-form string a
+/// caller expanded before building the filter). Use [`FilterSource::new`]
+/// when the two are the same string.
+#[derive(Clone, Copy)]
+pub struct FilterSource<'a> {
+    pub directives: &'a str,
+    pub display: &'a str,
 }
 
-impl Layer {
-    fn parse(s: &str) -> Self {
-        let directives: Vec<FilterDirective> = directive_parts(s)
-            .filter_map(|part| {
-                parse_directive(part)
-                    .map_err(|err| warn!("dropping prometheus filter directive: {err}"))
-                    .ok()
-            })
-            .collect();
+impl<'a> FilterSource<'a> {
+    pub fn new(s: &'a str) -> Self {
         Self {
-            raw: render_directives(&directives),
-            directives,
+            directives: s,
+            display: s,
         }
     }
+
+    /// `directives` drive matching; `display` is echoed by the admin
+    /// endpoint.
+    pub fn with_display(directives: &'a str, display: &'a str) -> Self {
+        Self {
+            directives,
+            display,
+        }
+    }
+}
+
+/// One parsed filter input: the matching directives plus the display
+/// directives they are reported as.
+#[derive(Default)]
+struct DirectiveSet {
+    directives: Vec<FilterDirective>,
+    display: Vec<FilterDirective>,
+}
+
+impl DirectiveSet {
+    fn from_source(source: FilterSource<'_>) -> Self {
+        Self {
+            directives: parse_valid_directives(source.directives),
+            display: parse_valid_directives(source.display),
+        }
+    }
+
+    /// Merges `over` on top of `self`: an `over` directive replaces every
+    /// directive whose pattern it prefixes (a bare level replaces
+    /// everything), and directives it does not shadow keep their effect —
+    /// for overlapping unrelated patterns the usual longest-pattern-wins
+    /// matching applies.
+    fn merged(&self, over: &Self) -> Self {
+        Self {
+            directives: merge_directives(&self.directives, &over.directives),
+            display: merge_directives(&self.display, &over.display),
+        }
+    }
+}
+
+/// Appends `over` to `base`, dropping the `base` directives shadowed by an
+/// `over` directive's pattern prefix.
+fn merge_directives(base: &[FilterDirective], over: &[FilterDirective]) -> Vec<FilterDirective> {
+    base.iter()
+        .filter(|dir| !over.iter().any(|o| dir.pattern.starts_with(&o.pattern)))
+        .chain(over.iter())
+        .cloned()
+        .collect()
+}
+
+/// Parses a directive string, dropping invalid directives with a warning.
+fn parse_valid_directives(s: &str) -> Vec<FilterDirective> {
+    directive_parts(s)
+        .filter_map(|part| {
+            parse_directive(part)
+                .map_err(|err| warn!("dropping prometheus filter directive: {err}"))
+                .ok()
+        })
+        .collect()
 }
 
 /// Splits a `METRICS_FILTER`-style string into its non-empty, trimmed
@@ -235,91 +291,82 @@ fn threshold_for(directives: &[FilterDirective], name: &str, module: &str) -> Op
     best.map(|(_, threshold)| threshold)
 }
 
+/// Like [`threshold_for`], but falling back to the permissive default when no
+/// directive matches.
+fn threshold(directives: &[FilterDirective], name: &str, module: &str) -> u8 {
+    threshold_for(directives, name, module).unwrap_or(DEFAULT_THRESHOLD)
+}
+
 impl Filter {
-    /// Parses a config-layer directive string, ignoring the `METRICS_FILTER`
-    /// env var.
+    // Parses a single directive string as the config source, ignoring the
+    // `METRICS_FILTER` env var. Convenience for
+    // `from_sources(FilterSource::new(s), None)`.
     pub fn parse(s: &str) -> Self {
-        Self::from_layers(s, None)
+        Self::from_sources(FilterSource::new(s), None)
     }
 
-    /// Builds a filter with an empty config layer and the env layer read
-    /// from the `METRICS_FILTER` env variable (permissive when unset).
+    /// Builds a filter with an empty config source and the `METRICS_FILTER`
+    /// env variable's directives (permissive when unset).
     pub fn from_env() -> Self {
         let env = std::env::var("METRICS_FILTER").ok();
-        Self::from_layers("", env.as_deref())
+        Self::from_sources(FilterSource::new(""), env.as_deref().map(FilterSource::new))
     }
 
-    /// Builds a filter from the node config's directive string and the
-    /// `METRICS_FILTER` env var's.
-    pub fn from_layers(config: &str, env: Option<&str>) -> Self {
+    /// Builds a filter whose startup directives are the env source merged
+    /// over the config source (see [`DirectiveSet::merged`]).
+    pub fn from_sources(config: FilterSource<'_>, env: Option<FilterSource<'_>>) -> Self {
+        let startup = Arc::new(DirectiveSet::from_source(config).merged(
+            &DirectiveSet::from_source(env.unwrap_or(FilterSource::new(""))),
+        ));
         Self {
-            config: Layer::parse(config),
-            env: Layer::parse(env.unwrap_or("")),
-            runtime: RwLock::new(None),
+            runtime: RwLock::new(startup.clone()),
+            startup,
         }
     }
 
-    /// Returns a snapshot of the runtime override layer, if one is set.
-    fn runtime_layer(&self) -> Option<Arc<Layer>> {
+    /// Returns a snapshot of the directives currently in effect.
+    fn runtime(&self) -> Arc<DirectiveSet> {
         self.runtime.read().unwrap().clone()
     }
 
-    /// Layered evaluation, starting from runtime -> env -> config. Returns the
-    /// threshold for a metric, or the default threshold if no layer has a
-    /// matching directive.
-    fn threshold(&self, runtime: Option<&Layer>, name: &str, module: &str) -> u8 {
-        runtime
-            .and_then(|layer| threshold_for(&layer.directives, name, module))
-            .or_else(|| threshold_for(&self.env.directives, name, module))
-            .or_else(|| threshold_for(&self.config.directives, name, module))
-            .unwrap_or(DEFAULT_THRESHOLD)
-    }
-
     /// Returns `true` if a registered metric named `name` in `module` at
-    /// verbosity `level` should be exposed when gathering, per the layered
-    /// directives currently in effect.
+    /// verbosity `level` should be exposed when gathering, per the directives
+    /// currently in effect.
     #[inline]
     pub fn is_exposed(&self, name: &str, module: &str, level: MetricLevel) -> bool {
-        self.threshold(self.runtime_layer().as_deref(), name, module) >= level.verbosity()
+        threshold(&self.runtime().directives, name, module) >= level.verbosity()
     }
 
-    /// Returns the canonical string of the config layer's directives.
-    pub fn config_filter_string(&self) -> &str {
-        &self.config.raw
+    /// Returns the display string of the directives currently in effect.
+    pub fn filter_string(&self) -> String {
+        render_directives(&self.runtime().display)
     }
 
-    /// Returns the canonical string of the env (`METRICS_FILTER`) layer's
-    /// directives.
-    pub fn env_filter_string(&self) -> &str {
-        &self.env.raw
+    /// Returns the startup directives' display string.
+    pub fn startup_filter_string(&self) -> String {
+        render_directives(&self.startup.display)
     }
 
-    /// Returns the canonical string of the runtime override layer, or `None`
-    /// when no override is set.
-    pub fn runtime_filter_string(&self) -> Option<String> {
-        self.runtime
-            .read()
-            .unwrap()
-            .as_ref()
-            .map(|layer| layer.raw.clone())
-    }
-
-    /// Sets the runtime override layer. Rejects the whole update if
-    /// any directive is invalid.
-    pub fn set_runtime_filter(&self, s: &str) -> std::result::Result<(), String> {
-        let directives = directive_parts(s)
+    /// Replaces the directives in effect with the runtime override merged
+    /// over the startup directives (see [`DirectiveSet::merged`]) — each call
+    /// starts from the startup directives again rather than stacking on the
+    /// previous override. Rejects the whole update if any directive is
+    /// invalid.
+    pub fn set_runtime_filter(&self, source: FilterSource<'_>) -> std::result::Result<(), String> {
+        let directives = directive_parts(source.directives)
             .map(parse_directive)
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        *self.runtime.write().unwrap() = Some(Arc::new(Layer {
-            raw: render_directives(&directives),
+            .collect::<std::result::Result<Vec<_>, String>>()?;
+        let over = DirectiveSet {
             directives,
-        }));
+            display: parse_valid_directives(source.display),
+        };
+        *self.runtime.write().unwrap() = Arc::new(self.startup.merged(&over));
         Ok(())
     }
 
-    /// Drops the runtime override layer.
+    /// Drops the runtime override, restoring the startup directives.
     pub fn reset_runtime_filter(&self) {
-        *self.runtime.write().unwrap() = None;
+        *self.runtime.write().unwrap() = self.startup.clone();
     }
 }
 
@@ -445,14 +492,12 @@ impl Registry {
     /// Re-evaluates every recorded metric against the current filter. Call
     /// after changing the filter's runtime override.
     pub fn reconcile(&self) {
-        // Snapshot the runtime layer once so the whole pass sees a consistent
-        // filter and avoids re-locking it per metric.
-        let runtime = self.filter.runtime_layer();
+        // Snapshot the directives once so the whole pass sees a consistent
+        // filter and avoids re-locking them per metric.
+        let runtime = self.filter.runtime();
         let registered = self.registered.read().unwrap();
         for (name, recorded) in registered.iter() {
-            let want = self
-                .filter
-                .threshold(runtime.as_deref(), name, &recorded.module)
+            let want = threshold(&runtime.directives, name, &recorded.module)
                 >= recorded.level.verbosity();
             if want {
                 let _ = self.register(recorded.collector.clone_box());
@@ -889,28 +934,41 @@ mod tests {
     }
 
     #[test]
-    fn env_layer_overrides_config_only_where_it_matches() {
+    fn env_directives_merge_over_config_into_one_startup_filter() {
         use super::MetricLevel::{Info, Trace, Warn};
-        // Where an env directive matches, it beats the config layer even if
-        // the config directive is more specific ...
-        let filter = super::Filter::from_layers(
-            "iota_core::authority=off,starfish=warn",
-            Some("iota_core=info"),
+        // An env directive replaces every config directive whose pattern it
+        // prefixes, so it beats the config even where the config directive is
+        // more specific ...
+        let filter = super::Filter::from_sources(
+            super::FilterSource::new("iota_core::authority=off,starfish=warn"),
+            Some(super::FilterSource::new("iota_core=info")),
         );
         assert!(filter.is_exposed("x", "iota_core::authority", Info));
         assert!(!filter.is_exposed("x", "iota_core::authority", Debug));
-        // ... where it does not, the config layer still applies.
+        // ... where it does not, the config directives still apply.
         assert!(filter.is_exposed("x", "starfish::core", Warn));
         assert!(!filter.is_exposed("x", "starfish::core", Info));
+        // The two sources collapse into a single startup string.
+        assert_eq!(
+            filter.startup_filter_string(),
+            "starfish=warn,iota_core=info"
+        );
 
-        // A bare env level matches everything: a full override.
-        let filter = super::Filter::from_layers("info,iota_core=warn", Some("trace"));
+        // A bare env level prefixes everything: a full override.
+        let filter = super::Filter::from_sources(
+            super::FilterSource::new("info,iota_core=warn"),
+            Some(super::FilterSource::new("trace")),
+        );
         assert!(filter.is_exposed("x", "iota_core::authority", Trace));
         assert!(filter.is_exposed("x", "m", Trace));
+        assert_eq!(filter.startup_filter_string(), "trace");
 
-        // A blank env var contributes no directives, so the config layer
-        // still applies.
-        let filter = super::Filter::from_layers("off", Some(" "));
+        // A blank env var contributes no directives, so the config directives
+        // still apply.
+        let filter = super::Filter::from_sources(
+            super::FilterSource::new("off"),
+            Some(super::FilterSource::new(" ")),
+        );
         assert!(!filter.is_exposed("x", "m", Warn));
     }
 
@@ -924,7 +982,14 @@ mod tests {
             super::Filter::default(),
             // empty segments are ignored rather than treated as directives.
             super::Filter::parse(",,"),
-        ] {
+        ];
+        // A set env var would add env directives, so `Filter::from_env` is
+        // only exercised when it is unset; `Filter::from_sources` covers the
+        // set case.
+        if std::env::var_os("METRICS_FILTER").is_none() {
+            filters.push(super::Filter::from_env());
+        }
+        for filter in filters {
             assert!(filter.is_exposed("anything", "any::module", Warn));
             assert!(filter.is_exposed("anything", "any::module", Info));
             assert!(filter.is_exposed("anything", "any::module", Debug));
@@ -1120,7 +1185,7 @@ mod gather_filter_tests {
 
 #[cfg(test)]
 mod runtime_filter_tests {
-    use super::{Filter, MetricLevel, Registry};
+    use super::{Filter, FilterSource, MetricLevel, Registry};
 
     fn registry(filter: &str) -> Registry {
         Registry::new_custom(None, None, Some(std::sync::Arc::new(Filter::parse(filter)))).unwrap()
@@ -1139,7 +1204,10 @@ mod runtime_filter_tests {
     // The node drives this via `RegistryService`; here we exercise the same
     // two steps directly: set the runtime override, then reconcile membership.
     fn set_runtime(registry: &Registry, s: &str) {
-        registry.filter().set_runtime_filter(s).unwrap();
+        registry
+            .filter()
+            .set_runtime_filter(FilterSource::new(s))
+            .unwrap();
         registry.reconcile();
     }
 
@@ -1182,23 +1250,24 @@ mod runtime_filter_tests {
     }
 
     #[test]
-    fn runtime_layer_falls_back_to_startup_where_it_does_not_match() {
+    fn runtime_override_keeps_startup_directives_it_does_not_shadow() {
         let reg = registry("g_a=off");
         crate::register_int_gauge_with_registry!("g_a", "h", &reg; MetricLevel::Warn).unwrap();
         crate::register_int_gauge_with_registry!("g_b", "h", &reg; MetricLevel::Warn).unwrap();
         assert_eq!(gathered_names(&reg), ["g_b"]);
 
-        // The override hides g_b; g_a is matched by no override directive
+        // The override hides g_b; g_a is shadowed by no override directive
         // and keeps its startup exposure (hidden).
         set_runtime(&reg, "g_b=off");
         assert_eq!(gathered_names(&reg), Vec::<String>::new());
 
-        // An empty override matches nothing, leaving the startup directives
-        // fully in effect.
+        // An empty override contributes nothing, leaving the startup
+        // directives fully in effect — and replaces the previous override
+        // rather than accumulating with it.
         set_runtime(&reg, "");
         assert_eq!(gathered_names(&reg), ["g_b"]);
 
-        // A bare level matches everything: a full temporary override.
+        // A bare level prefixes every pattern: a full temporary override.
         set_runtime(&reg, "trace");
         assert_eq!(gathered_names(&reg), ["g_a", "g_b"]);
 
@@ -1207,51 +1276,108 @@ mod runtime_filter_tests {
     }
 
     #[test]
-    fn filter_reports_its_layers() {
-        let filter = Filter::from_layers("authority=off", Some("checkpoints=warn"));
-        assert_eq!(filter.config_filter_string(), "authority=off");
-        assert_eq!(filter.env_filter_string(), "checkpoints=warn");
-        assert_eq!(filter.runtime_filter_string(), None);
+    fn runtime_directives_replace_the_startup_directives_they_shadow() {
+        use MetricLevel::{Debug, Trace, Warn};
+
+        // Same pattern: the override directive replaces the startup one.
+        let filter = Filter::parse("g_a=off,g_b=warn");
+        filter
+            .set_runtime_filter(FilterSource::new("g_b=trace"))
+            .unwrap();
+        assert!(!filter.is_exposed("g_a", "m", Warn));
+        assert!(filter.is_exposed("g_b", "m", Trace));
+        assert_eq!(filter.filter_string(), "g_a=off,g_b=trace");
+        // The startup filter is untouched, ready for reset.
+        assert_eq!(filter.startup_filter_string(), "g_a=off,g_b=warn");
+
+        // Pattern prefix: an override directive claims its whole subtree, so
+        // a more specific startup directive cannot poke through it.
+        let filter = Filter::parse("iota_core=warn,iota_core::authority::sub=off");
+        filter
+            .set_runtime_filter(FilterSource::new("iota_core::authority=trace"))
+            .unwrap();
+        assert!(filter.is_exposed("x", "iota_core::authority::sub", Trace));
+        assert!(!filter.is_exposed("x", "iota_core::checkpoints", Debug));
+        assert_eq!(
+            filter.filter_string(),
+            "iota_core=warn,iota_core::authority=trace"
+        );
+
+        // A bare level shadows everything; more specific directives in the
+        // same override still apply on top of it.
+        let filter = Filter::parse("g_a=off,g_b=warn");
+        filter
+            .set_runtime_filter(FilterSource::new("trace,g_c=off"))
+            .unwrap();
+        assert!(filter.is_exposed("g_a", "m", Trace));
+        assert!(filter.is_exposed("g_b", "m", Trace));
+        assert!(!filter.is_exposed("g_c", "m", Warn));
+        assert_eq!(filter.filter_string(), "trace,g_c=off");
+
+        // Reset restores the startup directives.
+        filter.reset_runtime_filter();
+        assert_eq!(filter.filter_string(), filter.startup_filter_string());
+        assert!(!filter.is_exposed("g_a", "m", Warn));
+    }
+
+    #[test]
+    fn filter_reports_startup_and_current_strings() {
+        // Both directive sets keep the group-form display the caller
+        // supplies, while matching uses the expanded directives.
+        let filter = Filter::from_sources(
+            FilterSource::with_display("iota_core::authority=off", "authority=off"),
+            Some(FilterSource::with_display(
+                "iota_core::checkpoints=warn",
+                "checkpoints=warn",
+            )),
+        );
+        assert_eq!(
+            filter.startup_filter_string(),
+            "authority=off,checkpoints=warn"
+        );
+        assert_eq!(filter.filter_string(), filter.startup_filter_string());
         assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
 
-        filter.set_runtime_filter("authority=warn").unwrap();
-        assert_eq!(
-            filter.runtime_filter_string().as_deref(),
-            Some("authority=warn")
-        );
+        // An override's display shadows the startup display the same way its
+        // directives shadow the startup directives.
+        filter
+            .set_runtime_filter(FilterSource::with_display(
+                "iota_core::authority=warn",
+                "authority=warn",
+            ))
+            .unwrap();
+        assert_eq!(filter.filter_string(), "checkpoints=warn,authority=warn");
         assert!(filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
         assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Debug));
 
         filter.reset_runtime_filter();
-        assert_eq!(filter.runtime_filter_string(), None);
+        assert_eq!(filter.filter_string(), filter.startup_filter_string());
         assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
     }
 
     #[test]
     fn filter_string_is_canonical_and_round_trips() {
-        // Invalid startup directives are dropped, and the reported config
+        // Invalid startup directives are dropped, and the reported startup
         // string reflects the directives actually in effect — so it can
         // always be POSTed back through the strict runtime setter.
         let filter = Filter::parse("foo=bogus, typed_store=warn ,info");
-        assert_eq!(filter.config_filter_string(), "typed_store=warn,info");
+        let startup = filter.startup_filter_string();
+        assert_eq!(startup, "typed_store=warn,info");
         filter
-            .set_runtime_filter(filter.config_filter_string())
+            .set_runtime_filter(FilterSource::new(&startup))
             .unwrap();
-        assert_eq!(
-            filter.runtime_filter_string().as_deref(),
-            Some("typed_store=warn,info")
-        );
+        assert_eq!(filter.filter_string(), "typed_store=warn,info");
     }
 
     #[test]
     fn set_runtime_filter_rejects_invalid_directives() {
         let filter = Filter::parse("authority=off");
         let err = filter
-            .set_runtime_filter("authority=warn,bogus=nope")
+            .set_runtime_filter(FilterSource::new("authority=warn,bogus=nope"))
             .unwrap_err();
         assert!(err.contains("bogus=nope"), "unexpected error: {err}");
-        // The failed update leaves the runtime layer unset.
-        assert_eq!(filter.runtime_filter_string(), None);
+        // The failed update leaves the startup directives in effect.
+        assert_eq!(filter.filter_string(), filter.startup_filter_string());
         assert!(!filter.is_exposed("x", "iota_core::authority", MetricLevel::Warn));
     }
 }

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -48,7 +48,7 @@ pub use prometheus;
 // prometheus re-exports
 // ---------------------------------------------------------------------------
 
-// Filtering is enforced by registry membership (see `Registry::record_collector`
+// Filtering is enforced by registry membership (see `Registry::register_filtered`
 // and `Registry::reconcile`), so the metric types need no wrapping: re-export
 // prometheus's own types and generic primitives directly.
 pub use prometheus::{
@@ -406,49 +406,40 @@ impl Registry {
         }
     }
 
-    /// Used by the wrapper macros: on a successful registration, retains a
-    /// handle to the metric with its module path and level, and immediately
-    /// `unregister`s it from the inner registry if the current filter disables
-    /// it.
+    /// Used by the wrapper macros: Registers `collector` and records a
+    /// handle so the filter can toggle its exposure later. The collector joins
+    /// the inner registry only if the current filter exposes it.
     #[inline]
-    pub fn record_collector<C>(
+    pub fn register_filtered<C>(
         &self,
         name: &str,
         module: &str,
         level: MetricLevel,
-        result: prometheus::Result<C>,
+        collector: C,
     ) -> prometheus::Result<C>
     where
         C: prometheus::core::Collector + Clone + 'static,
     {
-        let Ok(collector) = &result else {
-            return result;
-        };
-        let collector: Box<dyn CloneableCollector> = Box::new(collector.clone());
         let exposed_name = self.exposed_name(name);
-
         let mut registered = self.registered.write().unwrap();
+        // Reject duplicate registration of the same metric name.
         if registered.contains_key(&exposed_name) {
-            // The inner registry rejects a duplicate metric name, but only for names
-            // it still holds — a name the filter disabled has been `unregister`ed, so
-            // a second registration of it would slip through. This re-checks the
-            // recorded set to keep rejecting duplicates regardless of filter state.
-            // Check test `duplicate_name_is_rejected_even_when_filtered_out`
-            let _ = self.inner.unregister(collector);
             return Err(prometheus::Error::AlreadyReg);
         }
-        if !self.filter.is_exposed(&exposed_name, module, level) {
-            let _ = self.inner.unregister(collector.clone_box());
+
+        let cloneable_collector: Box<dyn CloneableCollector> = Box::new(collector.clone());
+        if self.filter.is_exposed(&exposed_name, module, level) {
+            self.inner.register(cloneable_collector.clone_box())?;
         }
         registered.insert(
             exposed_name,
             RecordedMetric {
                 module: module.to_owned(),
                 level,
-                collector,
+                collector: cloneable_collector,
             },
         );
-        result
+        Ok(collector)
     }
 
     /// Re-evaluates every recorded metric against the current filter. Call
@@ -469,13 +460,6 @@ impl Registry {
                 let _ = self.unregister(recorded.collector.clone_box());
             }
         }
-    }
-
-    /// Returns the underlying `prometheus::Registry` for use inside wrapper
-    /// macros.
-    #[inline]
-    pub fn inner(&self) -> &prometheus::Registry {
-        &self.inner
     }
 
     pub fn register(&self, c: Box<dyn prometheus::core::Collector>) -> prometheus::Result<()> {
@@ -532,12 +516,13 @@ pub fn default_registry() -> &'static Registry {
 // Each macro captures `module_path!()` at the call site so the filter can
 // match by subsystem in addition to metric name.
 //
-// The `$registry` must be a `prometheus_filtered::Registry`. Each macro returns
-// the prometheus metric type directly; the filter never turns a successful
-// registration into an `Err`.
+// The `$registry` must be a `prometheus_filtered::Registry`. Each macro builds
+// the prometheus metric unregistered, then hands it to
+// [`Registry::register_filtered`], which owns registration and returns the
+// metric. The filter never turns a successful construction into an `Err`.
 //
-// `$crate::prometheus::` is used for inner prometheus macro calls so that
-// callers don't need a direct `prometheus` crate dependency.
+// `$crate::prometheus::` names the metric constructors so callers don't need a
+// direct `prometheus` crate dependency.
 //
 // `let _n = $name; let name: &str = &*_n;` handles both `&str` literals and
 // `format!(...)` String expressions uniformly.
@@ -554,17 +539,8 @@ macro_rules! register_int_counter_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_int_counter_with_registry!(
-                    name,
-                    $help,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::IntCounter::new(name, $help)
+            .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -580,18 +556,8 @@ macro_rules! register_int_counter_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_int_counter_vec_with_registry!(
-                    name,
-                    $help,
-                    $labels,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::IntCounterVec::new($crate::prometheus::Opts::new(name, $help), $labels)
+            .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -607,17 +573,8 @@ macro_rules! register_int_gauge_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_int_gauge_with_registry!(
-                    name,
-                    $help,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::IntGauge::new(name, $help)
+            .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -633,18 +590,8 @@ macro_rules! register_int_gauge_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_int_gauge_vec_with_registry!(
-                    name,
-                    $help,
-                    $labels,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::IntGaugeVec::new($crate::prometheus::Opts::new(name, $help), $labels)
+            .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -664,34 +611,17 @@ macro_rules! register_histogram_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_histogram_with_registry!(
-                    name,
-                    $help,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::Histogram::with_opts($crate::prometheus::HistogramOpts::new(name, $help))
+            .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
     ($name:expr, $help:expr, $buckets:expr, $registry:expr ; $level:expr $(,)?) => {{
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_histogram_with_registry!(
-                    name,
-                    $help,
-                    $buckets,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::Histogram::with_opts(
+            $crate::prometheus::HistogramOpts::new(name, $help).buckets($buckets),
+        )
+        .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -713,36 +643,21 @@ macro_rules! register_histogram_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_histogram_vec_with_registry!(
-                    name,
-                    $help,
-                    $labels,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::HistogramVec::new(
+            $crate::prometheus::HistogramOpts::new(name, $help),
+            $labels,
+        )
+        .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
     ($name:expr, $help:expr, $labels:expr, $buckets:expr, $registry:expr ; $level:expr $(,)?) => {{
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_histogram_vec_with_registry!(
-                    name,
-                    $help,
-                    $labels,
-                    $buckets,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::HistogramVec::new(
+            $crate::prometheus::HistogramOpts::new(name, $help).buckets($buckets),
+            $labels,
+        )
+        .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -758,18 +673,8 @@ macro_rules! register_gauge_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_gauge_vec_with_registry!(
-                    name,
-                    $help,
-                    $labels,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::GaugeVec::new($crate::prometheus::Opts::new(name, $help), $labels)
+            .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -783,17 +688,8 @@ macro_rules! register_gauge_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_gauge_with_registry!(
-                    name,
-                    $help,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::Gauge::new(name, $help)
+            .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -807,13 +703,9 @@ macro_rules! register_counter {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        $crate::default_registry()
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_counter!(name, $help),
-            )
+        $crate::prometheus::Counter::new(name, $help).and_then(|metric| {
+            $crate::default_registry().register_filtered(name, module, $level, metric)
+        })
     }};
 }
 
@@ -829,17 +721,8 @@ macro_rules! register_counter_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_counter_with_registry!(
-                    name,
-                    $help,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::Counter::new(name, $help)
+            .and_then(|metric| ($registry).register_filtered(name, module, $level, metric))
     }};
 }
 
@@ -855,18 +738,10 @@ macro_rules! register_counter_vec_with_registry {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        ($registry)
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_counter_vec_with_registry!(
-                    name,
-                    $help,
-                    $labels,
-                    ($registry).inner()
-                ),
-            )
+        $crate::prometheus::CounterVec::new($crate::prometheus::Opts::new(name, $help), $labels)
+            .and_then(|metric| {
+                ($registry).register_filtered(name, module, $level, metric)
+            })
     }};
 }
 
@@ -880,13 +755,10 @@ macro_rules! register_counter_vec {
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        $crate::default_registry()
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_counter_vec!(name, $help, $labels),
-            )
+        $crate::prometheus::CounterVec::new($crate::prometheus::Opts::new(name, $help), $labels)
+            .and_then(|metric| {
+                $crate::default_registry().register_filtered(name, module, $level, metric)
+            })
     }};
 }
 
@@ -907,39 +779,36 @@ macro_rules! register_histogram_vec {
     };
     ($opts:expr, $labels:expr ; $level:expr $(,)?) => {{
         let opts = $opts;
-        let name: &str = &opts.common_opts.name;
+        let name = opts.common_opts.name.clone();
+        let name: &str = &name;
         let module: &str = module_path!();
-        $crate::default_registry()
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_histogram_vec!(opts, $labels),
-            )
+        $crate::prometheus::HistogramVec::new(opts, $labels).and_then(|metric| {
+            $crate::default_registry().register_filtered(name, module, $level, metric)
+        })
     }};
     ($name:expr, $help:expr, $labels:expr ; $level:expr $(,)?) => {{
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        $crate::default_registry()
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_histogram_vec!(name, $help, $labels),
-            )
+        $crate::prometheus::HistogramVec::new(
+            $crate::prometheus::HistogramOpts::new(name, $help),
+            $labels,
+        )
+        .and_then(|metric| {
+            $crate::default_registry().register_filtered(name, module, $level, metric)
+        })
     }};
     ($name:expr, $help:expr, $labels:expr, $buckets:expr ; $level:expr $(,)?) => {{
         let _n = $name;
         let name: &str = &*_n;
         let module: &str = module_path!();
-        $crate::default_registry()
-            .record_collector(
-                name,
-                module,
-                $level,
-                $crate::prometheus::register_histogram_vec!(name, $help, $labels, $buckets),
-            )
+        $crate::prometheus::HistogramVec::new(
+            $crate::prometheus::HistogramOpts::new(name, $help).buckets($buckets),
+            $labels,
+        )
+        .and_then(|metric| {
+            $crate::default_registry().register_filtered(name, module, $level, metric)
+        })
     }};
 }
 

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -15,14 +15,17 @@
 //! Filter syntax: comma-separated `pattern=LEVEL` directives, where `LEVEL`
 //! is one of `off`, `warn`, `info`, `debug`, `trace`. A bare `LEVEL` token
 //! (no `pattern=`) and its reserved `default=LEVEL` spelling both set the
-//! global default: the level for the metrics no other directive matches. A
+//! global default: the level for the metrics no other directive matches.
+//! The bare spelling additionally makes its source replace the
+//! lower-precedence sources' directives instead of merging over them —
+//! `METRICS_FILTER=trace` exposes everything, whatever the config sets. A
 //! pattern matches if it is a
 //! prefix of the metric name OR is a component/prefix of the calling module
 //! path (e.g. `traffic_controller` matches
 //! `iota_core::traffic_controller::metrics`). When several directives
-//! match the same metric, the most specific one (longest pattern) wins,
-//! regardless of order; among directives with the same pattern, the last one
-//! wins.
+//! match the same metric, the most specific one wins regardless of order: a
+//! metric-name match over a module match, then the longest pattern; among
+//! directives with the same pattern, the last one wins.
 //!
 //! Examples:
 //! - `METRICS_FILTER=off,authority=warn`
@@ -32,8 +35,8 @@
 //! thresholds deciding which metrics [`Registry::gather`] includes in its
 //! output (`off` exposes none of the matched metrics). Metrics matched by no
 //! directive are exposed unconditionally, so with no filter configured the
-//! crate behaves exactly like plain `prometheus`; use a bare `LEVEL` directive
-//! to set a stricter global default.
+//! crate behaves exactly like plain `prometheus`; use a `default=LEVEL`
+//! directive to set a stricter global default.
 
 use std::{
     result::Result as StdResult,
@@ -114,8 +117,9 @@ const DEFAULT_THRESHOLD: u8 = MetricLevel::Trace.verbosity();
 
 #[derive(Clone)]
 struct FilterDirective {
-    /// Empty string means the global default: it matches every metric but
-    /// loses to any other matching directive.
+    /// The empty string (a bare level) and the reserved `default` pattern
+    /// both mean the global default: they match every metric but lose to
+    /// any other matching directive.
     pattern: String,
     /// `pattern` prefixed with `::`, precomputed so the per-gather module
     /// component match allocates nothing.
@@ -168,7 +172,7 @@ impl<'a> FilterSource<'a> {
 
 /// One parsed filter input: the matching directives plus the display
 /// directives they are reported as.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct DirectiveSet {
     directives: Vec<FilterDirective>,
     display: Vec<FilterDirective>,
@@ -182,11 +186,22 @@ impl DirectiveSet {
         }
     }
 
+    /// Returns whether the set contains a bare-level directive.
+    fn replaces(&self) -> bool {
+        self.directives.iter().any(|dir| dir.pattern.is_empty())
+    }
+
     /// Merges `over` on top of `self`: an `over` directive replaces the
     /// directive with the same pattern; otherwise both sets' directives
     /// apply and the usual most-specific-pattern-wins matching decides each
-    /// metric.
+    /// metric. As the exception, an `over` set with a bare level replaces
+    /// `self` entirely — `METRICS_FILTER=trace` exposes everything no
+    /// matter what the config directives say, while `default=trace` raises
+    /// only the global default.
     fn merged(&self, over: &Self) -> Self {
+        if over.replaces() {
+            return over.clone();
+        }
         Self {
             directives: merge_directives(&self.directives, &over.directives),
             display: merge_directives(&self.display, &over.display),
@@ -239,16 +254,10 @@ pub fn directive_parts(s: &str) -> impl Iterator<Item = &str> + '_ {
 }
 
 /// Splits one directive into its `(pattern, level)` parts, rejecting an
-/// invalid level with an error describing the offending directive. Two
-/// equivalent spellings yield the empty (global default) pattern: a bare
-/// level (no `=`) and the reserved `default` pattern, which normalizes to it
-/// here.
+/// invalid level with an error describing the offending directive.
 pub fn split_directive(part: &str) -> StdResult<(&str, MetricLevel), String> {
     let (pattern, value) = match part.rfind('=') {
-        Some(eq) => match part[..eq].trim() {
-            "default" => ("", part[eq + 1..].trim()),
-            pattern => (pattern, part[eq + 1..].trim()),
-        },
+        Some(eq) => (part[..eq].trim(), part[eq + 1..].trim()),
         None => ("", part.trim()),
     };
     let level = match value {
@@ -267,14 +276,13 @@ pub fn split_directive(part: &str) -> StdResult<(&str, MetricLevel), String> {
     Ok((pattern, level))
 }
 
-/// Renders directives back into their canonical `pattern=LEVEL` string. The
-/// empty pattern renders as `default=LEVEL`.
+/// Renders directives back into their `pattern=LEVEL` string.
 fn render_directives(directives: &[FilterDirective]) -> String {
     directives
         .iter()
         .map(|dir| {
             if dir.pattern.is_empty() {
-                format!("default={}", dir.level.as_str())
+                dir.level.as_str().to_owned()
             } else {
                 format!("{}={}", dir.pattern, dir.level.as_str())
             }
@@ -288,23 +296,40 @@ fn render_directives(directives: &[FilterDirective]) -> String {
 /// matches.
 ///
 /// A directive matches when its pattern is:
-/// 1. Empty (a bare level, or its `default=LEVEL` spelling) — global default.
+/// 1. Empty (a bare level) or the reserved `default` — global default.
 /// 2. A metric name prefix — `name.starts_with(pattern)`.
 /// 3. A module path prefix — `module.starts_with(pattern)`.
 /// 4. An exact module component — `module` contains `"::{pattern}"`.
 ///
-/// Among matching directives, the longest pattern wins (so a directive for a
-/// submodule overrides one for its parent, and any pattern overrides the bare
-/// global level); among equal-length patterns, the last one wins.
+/// Among matching directives, a metric-name match wins over a module match:
+/// a name pattern targets the metric directly, and can never be longer than
+/// the name itself, so on length alone it would silently lose to any longer
+/// module directive covering the same metric. Within the same match kind,
+/// the longest pattern wins (so a directive for a submodule overrides one
+/// for its parent, and any pattern overrides the bare global level); among
+/// equal patterns, the last one wins.
 fn threshold(directives: &[FilterDirective], name: &str, module: &str) -> u8 {
-    let mut best: Option<(usize, u8)> = None;
+    // Ordered comparison of (matched-by-name, pattern length): name matches
+    // rank above module matches, longer patterns above shorter; the global
+    // default patterns rank below every other match.
+    let mut best: Option<((bool, usize), u8)> = None;
     for dir in directives {
-        let matches = dir.pattern.is_empty()
-            || name.starts_with(dir.pattern.as_str())
-            || module.starts_with(dir.pattern.as_str())
-            || module.contains(dir.component_pattern.as_str());
-        if matches && best.is_none_or(|(len, _)| dir.pattern.len() >= len) {
-            best = Some((dir.pattern.len(), dir.level.verbosity()));
+        let specificity = if dir.pattern.is_empty() || dir.pattern == "default" {
+            Some((false, 0))
+        } else if name.starts_with(dir.pattern.as_str()) {
+            Some((true, dir.pattern.len()))
+        } else if module.starts_with(dir.pattern.as_str())
+            || module.contains(dir.component_pattern.as_str())
+        {
+            Some((false, dir.pattern.len()))
+        } else {
+            None
+        };
+        match specificity {
+            Some(specificity) if best.is_none_or(|(prev, _)| specificity >= prev) => {
+                best = Some((specificity, dir.level.verbosity()));
+            }
+            _ => {}
         }
     }
     best.map_or(DEFAULT_THRESHOLD, |(_, threshold)| threshold)
@@ -359,7 +384,8 @@ impl Filter {
     /// Replaces the directives in effect with the runtime override merged
     /// over the startup directives (see [`DirectiveSet::merged`]) — each call
     /// starts from the startup directives again rather than stacking on the
-    /// previous override. Rejects the whole update if any directive is
+    /// previous override; an override with a bare level replaces the startup
+    /// directives entirely. Rejects the whole update if any directive is
     /// invalid.
     pub fn set_runtime_filter(&self, source: FilterSource<'_>) -> StdResult<(), String> {
         let (directives, errors) = parse_directives(source.directives);
@@ -886,7 +912,7 @@ mod tests {
 
     #[test]
     fn more_specific_pattern_wins_regardless_of_order() {
-        use super::MetricLevel::{Info, Warn};
+        use super::MetricLevel::{Info, Trace, Warn};
         // A blanket module directive does not shadow a more specific one,
         // whichever is written first ...
         for input in [
@@ -919,6 +945,27 @@ mod tests {
                 Debug
             )
         );
+        // A metric-name match beats a module match of any length (a name
+        // pattern can never be longer than the metric name), whichever is
+        // written first.
+        for input in [
+            "certs_total=trace,iota_core::execution_cache=warn",
+            "iota_core::execution_cache=warn,certs_total=trace",
+        ] {
+            let filter = super::Filter::parse(input);
+            assert!(
+                filter.is_exposed("certs_total", "iota_core::execution_cache", Trace),
+                "{input}"
+            );
+            // other metrics in the module keep the module directive's level.
+            assert!(
+                !filter.is_exposed("other_metric", "iota_core::execution_cache", Debug),
+                "{input}"
+            );
+        }
+        // The same holds when the name directive hides instead of exposes.
+        let filter = super::Filter::parse("iota_core::execution_cache=trace,certs_total=off");
+        assert!(!filter.is_exposed("certs_total", "iota_core::execution_cache", Warn));
     }
 
     #[test]
@@ -943,12 +990,12 @@ mod tests {
             "iota_core::authority=off,iota_core=info,starfish=info"
         );
 
-        // A bare env level is the `default=LEVEL` spelling: it replaces the
-        // config's global default, while the config's more specific
-        // directives keep applying.
+        // An env `default=LEVEL` directive replaces the config's global
+        // default, while the config's more specific directives keep
+        // applying.
         let filter = super::Filter::from_sources(
-            super::FilterSource::new("info,iota_core=warn"),
-            Some(super::FilterSource::new("trace")),
+            super::FilterSource::new("default=info,iota_core=warn"),
+            Some(super::FilterSource::new("default=trace")),
         );
         assert!(filter.is_exposed("x", "iota_core::authority", Warn));
         assert!(!filter.is_exposed("x", "iota_core::authority", Info));
@@ -957,6 +1004,18 @@ mod tests {
             filter.startup_filter_string(),
             "iota_core=warn,default=trace"
         );
+
+        // A bare env level replaces the config's directives entirely:
+        // `METRICS_FILTER=trace` exposes everything.
+        let filter = super::Filter::from_sources(
+            super::FilterSource::new("default=info,iota_core=warn"),
+            Some(super::FilterSource::new("trace")),
+        );
+        assert!(filter.is_exposed("x", "iota_core::authority", Trace));
+        assert!(filter.is_exposed("x", "m", Trace));
+        // The bare spelling is kept in the echo, so the reported string
+        // replays as a replacement, not a merge.
+        assert_eq!(filter.startup_filter_string(), "trace");
 
         // A blank env var contributes no directives, so the config directives
         // still apply.
@@ -1263,12 +1322,12 @@ mod runtime_filter_tests {
             "iota_core=warn,iota_core::authority::sub=off,iota_core::authority=trace"
         );
 
-        // A bare level merges like `default=LEVEL`: the more specific
-        // startup directives keep applying beneath it, beside the override's
-        // other directives.
+        // An override `default=LEVEL` directive raises only the global
+        // default: the more specific startup directives keep applying
+        // beneath it, beside the override's other directives.
         let filter = Filter::parse("g_a=off,g_b=warn");
         filter
-            .set_runtime_filter(FilterSource::new("trace,g_c=off"))
+            .set_runtime_filter(FilterSource::new("default=trace,g_c=off"))
             .unwrap();
         assert!(!filter.is_exposed("g_a", "m", Warn));
         assert!(filter.is_exposed("g_b", "m", Warn));
@@ -1280,19 +1339,16 @@ mod runtime_filter_tests {
             "g_a=off,g_b=warn,default=trace,g_c=off"
         );
 
-        // The two spellings are interchangeable in the display too: a bare
-        // override level replaces the `default=LEVEL` display directive and
-        // renders back as `default=LEVEL`.
-        let filter = Filter::from_sources(
-            FilterSource::with_display("info,g_a=off", "default=info,g_a=off"),
-            None,
-        );
+        // A bare override level instead replaces the startup directives
+        // entirely; only its sibling directives still apply.
+        let filter = Filter::parse("g_a=off,g_b=warn");
         filter
-            .set_runtime_filter(FilterSource::new("trace"))
+            .set_runtime_filter(FilterSource::new("trace,g_c=off"))
             .unwrap();
-        assert!(!filter.is_exposed("g_a", "m", Warn));
-        assert!(filter.is_exposed("x", "m", Trace));
-        assert_eq!(filter.filter_string(), "g_a=off,default=trace");
+        assert!(filter.is_exposed("g_a", "m", Trace));
+        assert!(filter.is_exposed("g_b", "m", Trace));
+        assert!(!filter.is_exposed("g_c", "m", Warn));
+        assert_eq!(filter.filter_string(), "trace,g_c=off");
 
         // Reset restores the startup directives.
         filter.reset_runtime_filter();
@@ -1351,13 +1407,28 @@ mod runtime_filter_tests {
         // Invalid startup directives are dropped, and the reported startup
         // string reflects the directives actually in effect — so it can
         // always be POSTed back through the strict runtime setter.
-        let filter = Filter::parse("foo=bogus, typed_store=warn ,info");
+        let filter = Filter::parse("foo=bogus, typed_store=warn ,default=info");
         let startup = filter.startup_filter_string();
         assert_eq!(startup, "typed_store=warn,default=info");
         filter
             .set_runtime_filter(FilterSource::new(&startup))
             .unwrap();
         assert_eq!(filter.filter_string(), "typed_store=warn,default=info");
+
+        // A bare level keeps its spelling in the echo, so replaying the
+        // string replaces the startup directives again instead of merging
+        // over them, reproducing the same filter.
+        let filter = Filter::parse("g_a=off");
+        filter
+            .set_runtime_filter(FilterSource::new("trace,g_c=off"))
+            .unwrap();
+        let current = filter.filter_string();
+        assert_eq!(current, "trace,g_c=off");
+        filter
+            .set_runtime_filter(FilterSource::new(&current))
+            .unwrap();
+        assert_eq!(filter.filter_string(), "trace,g_c=off");
+        assert!(filter.is_exposed("g_a", "m", MetricLevel::Trace));
     }
 
     #[test]

--- a/crates/prometheus-filtered/src/lib.rs
+++ b/crates/prometheus-filtered/src/lib.rs
@@ -44,431 +44,23 @@ use std::{
 /// directly on the `prometheus` crate.
 #[doc(hidden)]
 pub use prometheus;
-// Re-export prometheus primitives that require no wrapping.
+// ---------------------------------------------------------------------------
+// prometheus re-exports
+// ---------------------------------------------------------------------------
+
+// Filtering is enforced by registry membership (see `Registry::record_collector`
+// and `Registry::reconcile`), so the metric types need no wrapping: re-export
+// prometheus's own types and generic primitives directly.
+pub use prometheus::{
+    Counter, CounterVec, Gauge, GaugeVec, Histogram, HistogramTimer, HistogramVec, IntCounter,
+    IntCounterVec, IntGauge, IntGaugeVec, core,
+};
+// Re-export the prometheus items callers reach for through this crate.
 pub use prometheus::{
     DEFAULT_BUCKETS, Encoder, Error, HistogramOpts, Opts, PROTOBUF_FORMAT, ProtobufEncoder, Result,
     TextEncoder, exponential_buckets, gather, histogram_opts, linear_buckets, opts, proto,
 };
 use tracing::warn;
-
-// ---------------------------------------------------------------------------
-// core sub-module
-// ---------------------------------------------------------------------------
-
-/// Mirrors `prometheus::core` and provides `GenericGauge`/`GenericCounter`
-/// wrappers compatible with prometheus's own generic types.
-///
-/// `crate::IntGauge`, `crate::Gauge`, `crate::IntCounter`, and
-/// `crate::Counter` are type aliases for concrete instantiations of these
-/// types, so `Option<IntGauge>` and `Option<GenericGauge<AtomicI64>>` are
-/// the same type.
-pub mod core {
-    use std::mem::ManuallyDrop;
-
-    pub use prometheus::core::{
-        Atomic, AtomicF64, AtomicI64, AtomicU64, Collector, Desc, Describer, Metric,
-        MetricVecBuilder, Number,
-    };
-
-    macro_rules! impl_generic_metric_traits {
-        ($T:ident) => {
-            impl<P: Atomic> Clone for $T<P> {
-                fn clone(&self) -> Self {
-                    Self(self.0.clone())
-                }
-            }
-
-            impl<P: Atomic> std::fmt::Debug for $T<P> {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    write!(f, "{}", stringify!($T))?;
-                    if self.0.is_none() {
-                        write!(f, "(disabled)")?;
-                    }
-                    Ok(())
-                }
-            }
-
-            impl<P: Atomic> prometheus::core::Collector for $T<P> {
-                fn desc(&self) -> Vec<&Desc> {
-                    self.0
-                        .as_ref()
-                        .map(|inner| inner.desc())
-                        .unwrap_or_default()
-                }
-
-                fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
-                    self.0
-                        .as_ref()
-                        .map(|inner| inner.collect())
-                        .unwrap_or_default()
-                }
-            }
-        };
-    }
-
-    macro_rules! impl_metric_traits {
-        ($T:ident) => {
-            impl Clone for $T {
-                fn clone(&self) -> Self {
-                    Self(self.0.clone())
-                }
-            }
-
-            impl std::fmt::Debug for $T {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    write!(f, "{}", stringify!($T))?;
-                    if self.0.is_none() {
-                        write!(f, "(disabled)")?;
-                    }
-                    Ok(())
-                }
-            }
-
-            impl prometheus::core::Collector for $T {
-                fn desc(&self) -> Vec<&Desc> {
-                    self.0
-                        .as_ref()
-                        .map(|inner| inner.desc())
-                        .unwrap_or_default()
-                }
-
-                fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
-                    self.0
-                        .as_ref()
-                        .map(|inner| inner.collect())
-                        .unwrap_or_default()
-                }
-            }
-        };
-    }
-
-    macro_rules! impl_generic_metric_vec {
-        ($T:ident, $M:ident) => {
-            impl<P: Atomic> $T<P> {
-                pub fn new_some(inner: prometheus::core::$T<P>) -> Self {
-                    Self(Some(inner))
-                }
-
-                pub fn new_none() -> Self {
-                    Self(None)
-                }
-
-                #[inline]
-                pub fn with_label_values<V>(&self, vals: &[V]) -> $M<P>
-                where
-                    V: AsRef<str> + std::fmt::Debug,
-                {
-                    $M::<P>(self.0.as_ref().map(|inner| inner.with_label_values(vals)))
-                }
-
-                #[inline]
-                pub fn remove_label_values<V>(&self, vals: &[V]) -> super::Result<()>
-                where
-                    V: AsRef<str> + std::fmt::Debug,
-                {
-                    self.0
-                        .as_ref()
-                        .map(|inner| inner.remove_label_values(vals))
-                        .unwrap_or(Ok(()))
-                }
-
-                #[inline]
-                pub fn get_metric_with<V, S: std::hash::BuildHasher>(
-                    &self,
-                    labels: &std::collections::HashMap<&str, V, S>,
-                ) -> super::Result<$M<P>>
-                where
-                    V: AsRef<str> + std::fmt::Debug,
-                {
-                    self.0
-                        .as_ref()
-                        .map(|inner| inner.get_metric_with(labels).map($M::<P>::new_some))
-                        .unwrap_or(Ok($M::<P>::new_none()))
-                }
-
-                #[inline]
-                pub fn get_metric_with_label_values<V>(&self, vals: &[V]) -> super::Result<$M<P>>
-                where
-                    V: AsRef<str> + std::fmt::Debug,
-                {
-                    self.0
-                        .as_ref()
-                        .map(|inner| {
-                            inner
-                                .get_metric_with_label_values(vals)
-                                .map($M::<P>::new_some)
-                        })
-                        .unwrap_or(Ok($M::<P>::new_none()))
-                }
-
-                #[inline]
-                pub fn reset(&self) {
-                    if let Some(v) = &self.0 {
-                        v.reset();
-                    }
-                }
-            }
-        };
-    }
-
-    pub struct GenericCounter<P: Atomic>(Option<prometheus::core::GenericCounter<P>>);
-
-    impl<P: Atomic> GenericCounter<P> {
-        pub fn new_some(inner: prometheus::core::GenericCounter<P>) -> Self {
-            Self(Some(inner))
-        }
-
-        pub fn new_none() -> Self {
-            Self(None)
-        }
-
-        pub fn new(name: &str, help: &str) -> prometheus::Result<Self> {
-            prometheus::core::GenericCounter::new(name, help).map(Self::new_some)
-        }
-
-        pub fn with_opts(opts: super::Opts) -> super::Result<Self> {
-            prometheus::core::GenericCounter::with_opts(opts).map(Self::new_some)
-        }
-
-        #[inline]
-        pub fn get(&self) -> P::T {
-            self.0
-                .as_ref()
-                .map(|inner| inner.get())
-                .unwrap_or(<P::T>::from_i64(0))
-        }
-
-        #[inline]
-        pub fn inc(&self) {
-            if let Some(inner) = &self.0 {
-                inner.inc();
-            }
-        }
-
-        #[inline]
-        pub fn inc_by(&self, v: <P as Atomic>::T) {
-            if let Some(inner) = &self.0 {
-                inner.inc_by(v);
-            }
-        }
-
-        #[inline]
-        pub fn reset(&self) {
-            if let Some(inner) = &self.0 {
-                inner.reset();
-            }
-        }
-    }
-
-    impl_generic_metric_traits!(GenericCounter);
-
-    pub struct GenericGauge<P: Atomic>(Option<prometheus::core::GenericGauge<P>>);
-
-    impl<P: Atomic> GenericGauge<P> {
-        pub fn new_some(inner: prometheus::core::GenericGauge<P>) -> Self {
-            Self(Some(inner))
-        }
-
-        pub fn new_none() -> Self {
-            Self(None)
-        }
-
-        pub fn new(name: &str, help: &str) -> super::Result<Self> {
-            prometheus::core::GenericGauge::new(name, help).map(Self::new_some)
-        }
-
-        pub fn with_opts(opts: super::Opts) -> super::Result<Self> {
-            prometheus::core::GenericGauge::with_opts(opts).map(Self::new_some)
-        }
-
-        #[inline]
-        pub fn get(&self) -> P::T {
-            self.0
-                .as_ref()
-                .map(|inner| inner.get())
-                .unwrap_or(<P::T>::from_i64(0))
-        }
-
-        #[inline]
-        pub fn set(&self, v: P::T) {
-            if let Some(inner) = &self.0 {
-                inner.set(v);
-            }
-        }
-
-        #[inline]
-        pub fn inc(&self) {
-            if let Some(inner) = &self.0 {
-                inner.inc();
-            }
-        }
-
-        #[inline]
-        pub fn dec(&self) {
-            if let Some(inner) = &self.0 {
-                inner.dec();
-            }
-        }
-
-        #[inline]
-        pub fn add(&self, v: P::T) {
-            if let Some(inner) = &self.0 {
-                inner.add(v);
-            }
-        }
-
-        #[inline]
-        pub fn sub(&self, v: P::T) {
-            if let Some(inner) = &self.0 {
-                inner.sub(v);
-            }
-        }
-    }
-
-    impl_generic_metric_traits!(GenericGauge);
-
-    pub struct GenericCounterVec<P: Atomic>(Option<prometheus::core::GenericCounterVec<P>>);
-
-    impl_generic_metric_traits!(GenericCounterVec);
-    impl_generic_metric_vec!(GenericCounterVec, GenericCounter);
-
-    pub struct GenericGaugeVec<P: Atomic>(Option<prometheus::core::GenericGaugeVec<P>>);
-
-    impl_generic_metric_traits!(GenericGaugeVec);
-    impl_generic_metric_vec!(GenericGaugeVec, GenericGauge);
-
-    pub struct Histogram(Option<prometheus::Histogram>);
-
-    impl_metric_traits!(Histogram);
-
-    impl Histogram {
-        pub fn new_some(inner: prometheus::Histogram) -> Self {
-            Self(Some(inner))
-        }
-
-        pub fn new_none() -> Self {
-            Self(None)
-        }
-
-        pub fn with_opts(opts: prometheus::HistogramOpts) -> prometheus::Result<Self> {
-            prometheus::Histogram::with_opts(opts).map(|h| Self(Some(h)))
-        }
-
-        #[inline]
-        pub fn observe(&self, v: f64) {
-            if let Some(h) = &self.0 {
-                h.observe(v);
-            }
-        }
-
-        #[inline]
-        pub fn start_timer(&self) -> HistogramTimer {
-            HistogramTimer(self.0.as_ref().map(|h| h.start_timer()))
-        }
-
-        #[inline]
-        pub fn get_sample_count(&self) -> u64 {
-            self.0.as_ref().map_or(0, |h| h.get_sample_count())
-        }
-
-        #[inline]
-        pub fn get_sample_sum(&self) -> f64 {
-            self.0.as_ref().map_or(0.0, |h| h.get_sample_sum())
-        }
-    }
-
-    pub struct HistogramTimer(Option<prometheus::HistogramTimer>);
-
-    impl std::fmt::Debug for HistogramTimer {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "HistogramTimer")?;
-            if self.0.is_none() {
-                write!(f, "(disabled)")?;
-            }
-            Ok(())
-        }
-    }
-
-    impl Drop for HistogramTimer {
-        fn drop(&mut self) {
-            // Dropping the inner prometheus::HistogramTimer records the observation.
-            drop(self.0.take());
-        }
-    }
-
-    impl HistogramTimer {
-        /// Records the elapsed time and returns it; prevents the `Drop` impl
-        /// from recording a second time.
-        #[inline]
-        pub fn stop_and_record(self) -> f64 {
-            // ManuallyDrop prevents our Drop impl from running, so the inner timer
-            // can be consumed by its own stop_and_record without double-recording.
-            let mut wrapper = ManuallyDrop::new(self);
-            wrapper
-                .0
-                .take()
-                .map(|t| t.stop_and_record())
-                .unwrap_or_default()
-        }
-
-        /// Records the duration; provided for compatibility with older
-        /// prometheus APIs.
-        #[inline]
-        pub fn observe_duration(self) {
-            let _ = self.stop_and_record();
-        }
-
-        /// Discards the timer without recording; returns the elapsed seconds.
-        #[inline]
-        pub fn stop_and_discard(self) -> f64 {
-            let mut wrapper = ManuallyDrop::new(self);
-            wrapper
-                .0
-                .take()
-                .map(|t| t.stop_and_discard())
-                .unwrap_or_default()
-        }
-    }
-
-    pub struct HistogramVec(Option<prometheus::HistogramVec>);
-
-    impl_metric_traits!(HistogramVec);
-
-    impl HistogramVec {
-        pub fn new_some(inner: prometheus::HistogramVec) -> Self {
-            Self(Some(inner))
-        }
-
-        pub fn new_none() -> Self {
-            Self(None)
-        }
-
-        #[inline]
-        pub fn with_label_values(&self, vals: &[&str]) -> Histogram {
-            Histogram(self.0.as_ref().map(|v| v.with_label_values(vals)))
-        }
-
-        #[inline]
-        pub fn remove_label_values(&self, vals: &[&str]) -> prometheus::Result<()> {
-            match &self.0 {
-                Some(v) => v.remove_label_values(vals),
-                None => Ok(()),
-            }
-        }
-    }
-}
-
-pub type Counter = core::GenericCounter<prometheus::core::AtomicF64>;
-pub type IntCounter = core::GenericCounter<prometheus::core::AtomicU64>;
-pub type Gauge = core::GenericGauge<prometheus::core::AtomicF64>;
-pub type IntGauge = core::GenericGauge<prometheus::core::AtomicI64>;
-
-pub type CounterVec = core::GenericCounterVec<prometheus::core::AtomicF64>;
-pub type IntCounterVec = core::GenericCounterVec<prometheus::core::AtomicU64>;
-pub type GaugeVec = core::GenericGaugeVec<prometheus::core::AtomicF64>;
-pub type IntGaugeVec = core::GenericGaugeVec<prometheus::core::AtomicI64>;
-
-pub use core::{Histogram, HistogramTimer, HistogramVec};
 
 // ---------------------------------------------------------------------------
 // Filter
@@ -940,9 +532,9 @@ pub fn default_registry() -> &'static Registry {
 // Each macro captures `module_path!()` at the call site so the filter can
 // match by subsystem in addition to metric name.
 //
-// The `$registry` must be a `prometheus_filtered::Registry`. On success the
-// macro always returns `Ok(WrappedType(Some(...)))` or `Ok(WrappedType(None))`
-// — never `Err` from the filtering logic itself.
+// The `$registry` must be a `prometheus_filtered::Registry`. Each macro returns
+// the prometheus metric type directly; the filter never turns a successful
+// registration into an `Err`.
 //
 // `$crate::prometheus::` is used for inner prometheus macro calls so that
 // callers don't need a direct `prometheus` crate dependency.
@@ -973,7 +565,6 @@ macro_rules! register_int_counter_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::core::GenericCounter::new_some)
     }};
 }
 
@@ -1001,7 +592,6 @@ macro_rules! register_int_counter_vec_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::IntCounterVec::new_some)
     }};
 }
 
@@ -1028,7 +618,6 @@ macro_rules! register_int_gauge_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::core::GenericGauge::new_some)
     }};
 }
 
@@ -1056,7 +645,6 @@ macro_rules! register_int_gauge_vec_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::IntGaugeVec::new_some)
     }};
 }
 
@@ -1087,7 +675,6 @@ macro_rules! register_histogram_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::Histogram::new_some)
     }};
     ($name:expr, $help:expr, $buckets:expr, $registry:expr ; $level:expr $(,)?) => {{
         let _n = $name;
@@ -1105,7 +692,6 @@ macro_rules! register_histogram_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::Histogram::new_some)
     }};
 }
 
@@ -1139,7 +725,6 @@ macro_rules! register_histogram_vec_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::HistogramVec::new_some)
     }};
     ($name:expr, $help:expr, $labels:expr, $buckets:expr, $registry:expr ; $level:expr $(,)?) => {{
         let _n = $name;
@@ -1158,7 +743,6 @@ macro_rules! register_histogram_vec_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::HistogramVec::new_some)
     }};
 }
 
@@ -1186,7 +770,6 @@ macro_rules! register_gauge_vec_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::core::GenericGaugeVec::new_some)
     }};
 }
 
@@ -1211,7 +794,6 @@ macro_rules! register_gauge_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::core::GenericGauge::new_some)
     }};
 }
 
@@ -1232,7 +814,6 @@ macro_rules! register_counter {
                 $level,
                 $crate::prometheus::register_counter!(name, $help),
             )
-            .map($crate::core::GenericCounter::new_some)
     }};
 }
 
@@ -1259,7 +840,6 @@ macro_rules! register_counter_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::core::GenericCounter::new_some)
     }};
 }
 
@@ -1287,7 +867,6 @@ macro_rules! register_counter_vec_with_registry {
                     ($registry).inner()
                 ),
             )
-            .map($crate::core::GenericCounterVec::new_some)
     }};
 }
 
@@ -1308,7 +887,6 @@ macro_rules! register_counter_vec {
                 $level,
                 $crate::prometheus::register_counter_vec!(name, $help, $labels),
             )
-            .map($crate::core::GenericCounterVec::new_some)
     }};
 }
 
@@ -1338,7 +916,6 @@ macro_rules! register_histogram_vec {
                 $level,
                 $crate::prometheus::register_histogram_vec!(opts, $labels),
             )
-            .map($crate::HistogramVec::new_some)
     }};
     ($name:expr, $help:expr, $labels:expr ; $level:expr $(,)?) => {{
         let _n = $name;
@@ -1351,7 +928,6 @@ macro_rules! register_histogram_vec {
                 $level,
                 $crate::prometheus::register_histogram_vec!(name, $help, $labels),
             )
-            .map($crate::HistogramVec::new_some)
     }};
     ($name:expr, $help:expr, $labels:expr, $buckets:expr ; $level:expr $(,)?) => {{
         let _n = $name;
@@ -1364,7 +940,6 @@ macro_rules! register_histogram_vec {
                 $level,
                 $crate::prometheus::register_histogram_vec!(name, $help, $labels, $buckets),
             )
-            .map($crate::HistogramVec::new_some)
     }};
 }
 
@@ -1613,7 +1188,6 @@ mod gather_filter_tests {
         // The metric handle is live and keeps collecting through the caller's
         // copy, even though the filter unregistered it from the inner registry,
         // so it is absent from gather output.
-        assert_eq!(format!("{g:?}"), "GenericGauge");
         g.set(9);
         assert_eq!(g.get(), 9);
         assert_eq!(gathered_names(&reg), Vec::<String>::new());

--- a/crates/starfish/core/src/quantile_gauge.rs
+++ b/crates/starfish/core/src/quantile_gauge.rs
@@ -146,15 +146,13 @@ impl QuantileGauge {
     ) -> Self {
         let gauge =
             GaugeVec::new(Opts::new(name, help), &["quantile"]).expect("valid gauge options");
-        registry.record(name, module, level);
         let this = Self {
             gauge,
             window: Arc::new(Mutex::new(Window::new(Instant::now()))),
         };
         registry
-            .register(Box::new(this.clone()))
-            .expect("quantile gauge registers without collision");
-        this
+            .register_filtered(name, module, level, this)
+            .expect("quantile gauge registers without collision")
     }
 
     pub(crate) fn observe(&self, seconds: f64) {
@@ -204,15 +202,13 @@ impl QuantileGaugeVec {
     ) -> Self {
         let gauge = GaugeVec::new(Opts::new(name, help), &[label, "quantile"])
             .expect("valid gauge options");
-        registry.record(name, module, level);
         let this = Self {
             gauge,
             windows: Arc::new(Mutex::new(HashMap::new())),
         };
         registry
-            .register(Box::new(this.clone()))
-            .expect("quantile gauge registers without collision");
-        this
+            .register_filtered(name, module, level, this)
+            .expect("quantile gauge registers without collision")
     }
 
     pub(crate) fn observe(&self, label_value: &str, seconds: f64) {

--- a/crates/telemetry-subscribers/observability_guides.md
+++ b/crates/telemetry-subscribers/observability_guides.md
@@ -136,8 +136,8 @@ is set to `info`, so only spans with level `error` and `info` will be sent as me
    ```
 
    or via the `METRICS_FILTER` environment variable, whose directives override
-   the config's for the metrics they match (group names work here too; other
-   metrics keep their configured exposure):
+   the config's for the metrics they match (`iota-node` accepts group names
+   here too; other metrics keep their configured exposure):
 
    ```bash
    METRICS_FILTER=telemetry_subscribers=debug

--- a/crates/telemetry-subscribers/observability_guides.md
+++ b/crates/telemetry-subscribers/observability_guides.md
@@ -135,7 +135,8 @@ is set to `info`, so only spans with level `error` and `info` will be sent as me
        runtime: debug
    ```
 
-   or via the `METRICS_FILTER` environment variable, which overrides the config:
+   or via the `METRICS_FILTER` environment variable, which replaces the config's
+   directives entirely (other groups fall back to the permissive default):
 
    ```bash
    METRICS_FILTER=telemetry_subscribers=debug

--- a/crates/telemetry-subscribers/observability_guides.md
+++ b/crates/telemetry-subscribers/observability_guides.md
@@ -143,6 +143,9 @@ is set to `info`, so only spans with level `error` and `info` will be sent as me
    METRICS_FILTER=telemetry_subscribers=debug
    ```
 
+   A bare level replaces the configured filter entirely, so
+   `METRICS_FILTER=trace` exposes every metric.
+
    ```bash
    curl -X GET 'http://127.0.0.1:9184/metrics' | grep tracing_span_latencies_bucket
    ```

--- a/crates/telemetry-subscribers/observability_guides.md
+++ b/crates/telemetry-subscribers/observability_guides.md
@@ -135,8 +135,9 @@ is set to `info`, so only spans with level `error` and `info` will be sent as me
        runtime: debug
    ```
 
-   or via the `METRICS_FILTER` environment variable, which replaces the config's
-   directives entirely (other groups fall back to the permissive default):
+   or via the `METRICS_FILTER` environment variable, whose directives override
+   the config's for the metrics they match (group names work here too; other
+   metrics keep their configured exposure):
 
    ```bash
    METRICS_FILTER=telemetry_subscribers=debug

--- a/setups/fullnode/fullnode-devnet.yaml
+++ b/setups/fullnode/fullnode-devnet.yaml
@@ -51,4 +51,7 @@ checkpoint-archive-config:
 #     rpc: warn
 #     epoch: warn
 #     runtime: warn
-#     hardware: warn # set to `off` to disable hardware metrics; takes effect at startup only
+#     hardware: warn
+#     # free-form overrides for modules/metrics not covered by a group:
+#     overrides:
+#       "iota_core::checkpoints": trace

--- a/setups/fullnode/fullnode-devnet.yaml
+++ b/setups/fullnode/fullnode-devnet.yaml
@@ -52,6 +52,6 @@ checkpoint-archive-config:
 #     epoch: warn
 #     runtime: warn
 #     hardware: warn
-#     # free-form overrides for modules/metrics not covered by a group:
+#     # free-form overrides for modules/metrics:
 #     overrides:
 #       "iota_core::checkpoints": trace

--- a/setups/fullnode/fullnode-mainnet.yaml
+++ b/setups/fullnode/fullnode-mainnet.yaml
@@ -56,6 +56,6 @@ checkpoint-archive-config:
 #     epoch: warn
 #     runtime: warn
 #     hardware: warn
-#     # free-form overrides for modules/metrics not covered by a group:
+#     # free-form overrides for modules/metrics:
 #     overrides:
 #       "iota_core::checkpoints": trace

--- a/setups/fullnode/fullnode-mainnet.yaml
+++ b/setups/fullnode/fullnode-mainnet.yaml
@@ -55,4 +55,7 @@ checkpoint-archive-config:
 #     rpc: warn
 #     epoch: warn
 #     runtime: warn
-#     hardware: warn # set to `off` to disable hardware metrics; takes effect at startup only
+#     hardware: warn
+#     # free-form overrides for modules/metrics not covered by a group:
+#     overrides:
+#       "iota_core::checkpoints": trace

--- a/setups/fullnode/fullnode-testnet.yaml
+++ b/setups/fullnode/fullnode-testnet.yaml
@@ -51,6 +51,6 @@ checkpoint-archive-config:
 #     epoch: warn
 #     runtime: warn
 #     hardware: warn
-#     # free-form overrides for modules/metrics not covered by a group:
+#     # free-form overrides for modules/metrics:
 #     overrides:
 #       "iota_core::checkpoints": trace

--- a/setups/fullnode/fullnode-testnet.yaml
+++ b/setups/fullnode/fullnode-testnet.yaml
@@ -50,4 +50,7 @@ checkpoint-archive-config:
 #     rpc: warn
 #     epoch: warn
 #     runtime: warn
-#     hardware: warn # set to `off` to disable hardware metrics; takes effect at startup only
+#     hardware: warn
+#     # free-form overrides for modules/metrics not covered by a group:
+#     overrides:
+#       "iota_core::checkpoints": trace


### PR DESCRIPTION
# Description of change

Adds runtime control over which collected metrics the node exposes, via the admin server:

- `GET /metrics/filters` returns the filter currently in effect.
- `POST /metrics/filters` sets the runtime override from the `filter` query parameter; patterns may be group names from the `metrics.groups` config section (`default` and `hardware` included) or raw `METRICS_FILTER`-style patterns. An invalid directive rejects the whole update with a `400` naming every offending token. Each POST starts from the startup directives again rather than stacking on the previous override.
- `POST /metrics/filters/reset` drops the runtime override, restoring the startup behavior.

The directives from the three sources (config, `METRICS_FILTER` env var, runtime override) merge into one set: a higher-precedence directive replaces the lower source's directive with the same pattern, and otherwise the most specific matching pattern decides each metric (a metric-name match over a module match, then the longest pattern; among equal patterns the last one) — replacing the previous order-sensitive last-match-wins rule. A bare level (e.g. `trace`) makes its source replace the lower-precedence directives entirely — `METRICS_FILTER=trace` exposes everything regardless of the config, keeping the existing benchmarking/debugging escape hatch — while `default=LEVEL` is the surgical spelling that changes only the level for otherwise-unmatched metrics.

The `METRICS_FILTER` env var gets the same treatment: it now accepts group names and replaces same-pattern config directives instead of being concatenated onto the config string.

Config changes:

- `metrics.groups` gains a free-form `overrides` map for module paths, metric names, or group names, including ones already covered by a named group (e.g. `iota_core::checkpoints: trace`); the most specific pattern wins over the group directives, so a single module or metric can diverge from its group's level, and a group-name key expands like the same directive in `METRICS_FILTER` or the admin endpoint, replacing the group field's level. Group-name typo protection stays intact.
- The `hardware` group is now a regular group: its collector goes through the same gather-time filter as any other metric, so it can be toggled at runtime (previously decided once at startup). A hardware collector construction failure no longer prevents node startup.

Filtering is enforced at gather time: metrics registered through the wrapper macros are wrapped in a collector that consults the shared filter on every scrape, so exposure changes need no registration bookkeeping. Hidden metrics keep collecting and reappear with their up-to-date values.

```
$ curl 'http://127.0.0.1:1337/metrics/filters'
$ curl -X POST 'http://127.0.0.1:1337/metrics/filters?filter=consensus=debug,storage=trace'
$ curl -X POST 'http://127.0.0.1:1337/metrics/filters/reset'
```

## How our metrics level works
config, env, and runtime each contribute directives, and a higher source's directive replaces a lower one with the same pattern. Each metric is decided by its most specific matching directive — metric name beats module, longer beats shorter, later beats earlier. Exception: a bare level in a higher source discards the lower sources entirely. 

## Links to any relevant issues

Closes #12068

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes


### Release Notes

- [x] Nodes (Validators and Full nodes): the Prometheus metrics exposure filter can be inspected and overridden at runtime through the admin server; `metrics.groups` gains a free-form `overrides` map for per-module, per-metric, or per-group levels, and the `hardware` group is now toggleable at runtime (`hardware: off` hides the collector instead of skipping its registration at startup).

