### PR TITLE
refactor(`iota-kvstore`): add integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5663,8 +5663,8 @@ dependencies = [
 
 [[package]]
 name = "iota-bigtable"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?tag=v0.1.1#7fee772a2b124fe97b94826ca108d22d40b3de0a"
+version = "0.1.2"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=7a0328a6e9e536f1c52b4d46b1629aa1683bf45f#7a0328a6e9e536f1c52b4d46b1629aa1683bf45f"
 dependencies = [
  "backoff",
  "gcp_auth",
@@ -6745,8 +6745,10 @@ dependencies = [
  "async-trait",
  "bcs",
  "clap",
+ "futures",
  "iota-bigtable",
  "iota-data-ingestion-core",
+ "iota-kvstore",
  "iota-sdk-types",
  "iota-types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5664,7 +5664,7 @@ dependencies = [
 [[package]]
 name = "iota-bigtable"
 version = "0.1.2"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?rev=7a0328a6e9e536f1c52b4d46b1629aa1683bf45f#7a0328a6e9e536f1c52b4d46b1629aa1683bf45f"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?tag=v0.1.2#3c9c781e3db51206519992c0ed8ac94ce889095e"
 dependencies = [
  "backoff",
  "gcp_auth",

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -247,12 +247,12 @@ async fn main() -> Result<()> {
                 }
 
                 let client = if let Some(emulator_host) = kv_config.emulator_host {
-                    std::env::set_var("BIGTABLE_EMULATOR_HOST", &emulator_host);
                     BigTableClient::new_local(
+                        &emulator_host,
+                        "iota-data-ingestion",
                         kv_config.instance_id,
                         kv_config.column_family.clone(),
-                    )
-                    .await?
+                    )?
                 } else {
                     BigTableClient::new_remote(
                         kv_config.instance_id,

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -13,7 +13,7 @@ async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
 futures = { workspace = true, optional = true }
-iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "7a0328a6e9e536f1c52b4d46b1629aa1683bf45f" }
+iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", tag = "v0.1.2" }
 serde.workspace = true
 strum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -12,7 +12,8 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
-iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", tag = "v0.1.1" }
+futures = { workspace = true, optional = true }
+iota-bigtable = { git = "https://github.com/iotaledger/iota-bigtable.git", rev = "7a0328a6e9e536f1c52b4d46b1629aa1683bf45f" }
 serde.workspace = true
 strum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
@@ -23,6 +24,20 @@ iota-data-ingestion-core.workspace = true
 iota-sdk-types.workspace = true
 iota-types.workspace = true
 telemetry-subscribers.workspace = true
+
+[features]
+emulator = ["dep:futures", "tokio/process"]
+integration_tests = ["emulator"]
+
+[dev-dependencies]
+# Self-dependency that enables the `emulator` feature for all dev targets,
+# so the emulator helpers and the tests importing them compile under plain
+# `cargo test`, clippy, and IDE checks without extra flags.
+#
+# The helpers stay behind the feature gate so they are never compiled into
+# production binaries; the emulator-backed tests only run when the
+# `integration_tests` feature is explicitly enabled.
+iota-kvstore = { path = ".", features = ["emulator"] }
 
 [lints]
 workspace = true

--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -28,6 +28,9 @@ telemetry-subscribers.workspace = true
 [features]
 emulator = ["dep:futures", "tokio/process"]
 integration_tests = ["emulator"]
+# Keeps the emulator-backed tests ignored under `--all-features` (CI), which
+# would otherwise enable `integration_tests` on runners without the emulator.
+skip_integration_tests = []
 
 [dev-dependencies]
 # Self-dependency that enables the `emulator` feature for all dev targets,

--- a/crates/iota-kvstore/README.md
+++ b/crates/iota-kvstore/README.md
@@ -69,10 +69,10 @@ Never commit your credentials file to version control. Always keep it secure and
 
 - install `gcloud` CLI tool: https://cloud.google.com/sdk/docs/install
 
-- install the `cbt` CLI tool
+- install the `cbt` CLI tool and the Bigtable emulator
 
 ```sh
-gcloud components install cbt
+gcloud components install cbt bigtable
 ```
 
 - start the emulator
@@ -91,7 +91,9 @@ $(gcloud beta emulators bigtable env-init)
 
 ### Testing
 
-The integration tests require the `gcloud` and `cbt` CLI tools to be installed.
+The integration tests need the same tools as [local development](#local-development): `gcloud` (used to locate the SDK root), the Bigtable emulator binary (`cbtemulator`, resolved under the SDK root since it is not on `PATH`), and `cbt` (used to create the tables and column family).
+
+Unlike the local development flow, the tests are self-contained: each test spawns its own emulator on a random free port, creates the required tables, and kills the emulator when done. There is no need to start the emulator manually, set `BIGTABLE_EMULATOR_HOST`, or run `./init.sh`.
 
 ```shell
 cargo test --features integration_tests

--- a/crates/iota-kvstore/README.md
+++ b/crates/iota-kvstore/README.md
@@ -88,3 +88,17 @@ $(gcloud beta emulators bigtable env-init)
 ```
 
 - Run `./init.sh` to configure the emulator
+
+### Testing
+
+The integration tests require the `gcloud` and `cbt` CLI tools to be installed.
+
+```shell
+cargo test --features integration_tests
+```
+
+nextest is also available for running tests:
+
+```shell
+cargo nextest run --features integration_tests
+```

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -11,13 +11,16 @@ use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
 use iota_sdk_types::{Address, Owner};
 use iota_types::{
-    effects::TransactionEffectsExt, full_checkpoint_content::CheckpointData,
-    messages_checkpoint::CheckpointContentsExt, transaction::TransactionDataAPI,
+    digests::TransactionDigest, effects::TransactionEffectsExt,
+    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointContentsExt,
+    transaction::TransactionDataAPI,
 };
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
-use crate::{BigTableClient, KeyValueStoreWriter, TransactionData};
+use crate::{
+    BigTableClient, KeyValueStoreWriter, TransactionData, client::TransactionSequenceNumber,
+};
 
 /// Represents the BigTable tables used by the KvWorker.
 
@@ -71,17 +74,13 @@ impl KvWorker {
     /// ```rust
     /// # use iota_kvstore::KvWorker;
     /// # use iota_kvstore::{Table, BigTableClient};
-    ///
     /// # #[tokio::main]
     /// # async fn main() {
-    /// # std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost");
-    /// let client = BigTableClient::new_local("instance_id", "column_family")
-    ///     .await
-    ///     .unwrap();
+    /// let client =
+    ///     BigTableClient::new_local("localhost", "local", "instance_id", "column_family").unwrap();
     ///
-    /// /// Write all available tables to BigTable.
+    /// // Write all available tables to BigTable.
     /// let worker = KvWorker::new(client);
-    ///
     /// # drop(worker);
     /// # }
     /// ```
@@ -104,17 +103,13 @@ impl KvWorker {
     /// ```rust
     /// # use iota_kvstore::KvWorker;
     /// # use iota_kvstore::{Table, BigTableClient};
-    ///
     /// # #[tokio::main]
     /// # async fn main() {
-    /// # std::env::set_var("BIGTABLE_EMULATOR_HOST", "localhost");
-    /// let client = BigTableClient::new_local("instance_id", "column_family")
-    ///     .await
-    ///     .unwrap();
+    /// let client =
+    ///     BigTableClient::new_local("localhost", "local", "instance_id", "column_family").unwrap();
     ///
-    /// /// Write only the `Objects` table to BigTable.
+    /// // Write only the `Objects` table to BigTable.
     /// let worker = KvWorker::new_selective(client, [Table::Objects]);
-    ///
     /// # drop(worker);
     /// # }
     /// ```
@@ -155,29 +150,7 @@ impl Worker for KvWorker {
                     client.save_transactions(&transactions).await?;
                 }
                 Table::TransactionsByAddress => {
-                    let entries_by_address = checkpoint
-                        .checkpoint_contents
-                        .enumerate_transactions(&checkpoint.checkpoint_summary)
-                        .zip(&checkpoint.transactions)
-                        .flat_map(|((seq, exec_digest), tx)| {
-                            let digest = exec_digest.transaction;
-                            let tx_data = tx.transaction.transaction_data();
-
-                            let affected = std::iter::once(tx_data.sender())
-                                .chain(std::iter::once(tx_data.gas_owner()))
-                                .chain(tx.effects.all_changed_objects().into_iter().filter_map(
-                                    |(_object_ref, owner, _write_kind)| match owner {
-                                        Owner::Address(a) => Some(a),
-                                        _ => None,
-                                    },
-                                ))
-                                .collect::<HashSet<Address>>();
-
-                            affected
-                                .into_iter()
-                                .map(move |address| (address, seq, digest))
-                        });
-
+                    let entries_by_address = affected_addresses(&checkpoint);
                     client
                         .save_transactions_by_address(entries_by_address)
                         .await?;
@@ -192,4 +165,30 @@ impl Worker for KvWorker {
         }
         Ok(())
     }
+}
+
+/// Extracts the information related to an address involved in a transaction as
+/// sender, gas owner, or object owner, from a [`CheckpointData`].
+pub fn affected_addresses<'a>(
+    checkpoint: &'a CheckpointData,
+) -> impl Iterator<Item = (Address, TransactionSequenceNumber, TransactionDigest)> + 'a {
+    checkpoint
+        .checkpoint_contents
+        .enumerate_transactions(&checkpoint.checkpoint_summary)
+        .zip(&checkpoint.transactions)
+        .flat_map(|((seq, exec_digest), tx)| {
+            let tx_data = tx.transaction.transaction_data();
+            let affected: HashSet<Address> =
+                std::iter::once(tx_data.sender())
+                    .chain(std::iter::once(tx_data.gas_owner()))
+                    .chain(tx.effects.all_changed_objects().into_iter().filter_map(
+                        |(_, owner, _)| match owner {
+                            Owner::Address(a) => Some(a),
+                            _ => None,
+                        },
+                    ))
+                    .collect();
+            let digest = exec_digest.transaction;
+            affected.into_iter().map(move |addr| (addr, seq, digest))
+        })
 }

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -51,11 +51,15 @@ use crate::{
 #[strum(serialize_all = "snake_case")]
 #[non_exhaustive]
 pub enum Table {
-    /// Stores a mapping of [`ObjectKey`] to [`Object`] for every object.
+    /// Stores a mapping of [`ObjectKey`](iota_types::storage::ObjectKey) to
+    /// [`Object`](iota_types::object::Object) for every object.
     Objects,
-    /// Stores a mapping of [`TransactionDigest`] to
-    /// [`Transaction`], [`TransactionEffects`], [`TransactionEvents`] and
-    /// [`CheckpointSequenceNumber`] for every transaction.
+    /// Stores a mapping of
+    /// [`TransactionDigest`](iota_types::base_types::TransactionDigest) to
+    /// [`Transaction`](iota_types::transaction::Transaction),
+    /// [`TransactionEffects`](iota_types::effects::TransactionEffects),
+    /// [`TransactionEvents`](iota_types::effects::TransactionEvents) and
+    /// [`CheckpointSequenceNumber`](iota_types::messages_checkpoint::CheckpointSequenceNumber) for every transaction.
     Transactions,
     /// Stores a mapping of ( [`Address`], [`TransactionSequenceNumber`] ) to
     /// [`TransactionDigest`] for every affected address.
@@ -63,11 +67,14 @@ pub enum Table {
     /// An address is considered "affected" if it appears as the sender, a
     /// recipient, or the gas payer.
     TransactionsByAddress,
-    /// Stores a mapping of [`CheckpointSequenceNumber`] to
-    /// [`CheckpointContents`] and [`CertifiedCheckpointSummary`] for every
-    /// checkpoint.
+    /// Stores a mapping of
+    /// [`CheckpointSequenceNumber`](iota_types::messages_checkpoint::CheckpointSequenceNumber)
+    /// to [`CheckpointContents`](iota_types::messages_checkpoint::CheckpointContents) and [`CertifiedCheckpointSummary`](iota_types::messages_checkpoint::CertifiedCheckpointSummary) for
+    /// every checkpoint.
     Checkpoints,
-    /// Stores a mapping of [`CheckpointDigest`] to [`CheckpointSequenceNumber`]
+    /// Stores a mapping of
+    /// [`CheckpointDigest`](iota_types::digests::CheckpointDigest) to
+    /// [`CheckpointSequenceNumber`](iota_types::messages_checkpoint::CheckpointSequenceNumber)
     /// for every checkpoint.
     CheckpointsByDigest,
 }

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -184,8 +184,11 @@ impl Worker for KvWorker {
     }
 }
 
-/// Extracts the information related to an address involved in a transaction as
-/// sender, gas owner, or object owner, from a [`CheckpointData`].
+/// Uses [`CheckpointData`] to map addresses affected by a transaction to the
+/// respective transaction identifiers.
+///
+/// Affected addresses include the sender, and payer of the transaction,
+/// plus the owners of all changed objects.
 pub fn transactions_by_address<'a>(
     checkpoint: &'a CheckpointData,
 ) -> impl Iterator<Item = (Address, TransactionSequenceNumber, TransactionDigest)> + 'a {

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -15,14 +15,14 @@ use iota_types::{
     full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointContentsExt,
     transaction::TransactionDataAPI,
 };
-use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
 use crate::{
     BigTableClient, KeyValueStoreWriter, TransactionData, client::TransactionSequenceNumber,
 };
 
-/// Represents the BigTable tables used by the KvWorker.
+/// Represents the available BigTable tables the Client and the KvWorker can
+/// interact with.
 
 // Variants are declared in write order; the BTreeSet<Table> field
 // iterates by derived Ord, which follows declaration order.
@@ -41,17 +41,34 @@ use crate::{
     Hash,
     PartialOrd,
     Ord,
-    Serialize,
-    Deserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::Display,
+    strum::AsRefStr,
     strum::EnumIter,
 )]
 #[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "snake_case")]
 #[non_exhaustive]
 pub enum Table {
+    /// Stores a mapping of [`ObjectKey`] to [`Object`] for every object.
     Objects,
+    /// Stores a mapping of [`TransactionDigest`] to
+    /// [`Transaction`], [`TransactionEffects`], [`TransactionEvents`] and
+    /// [`CheckpointSequenceNumber`] for every transaction.
     Transactions,
+    /// Stores a mapping of ( [`Address`], [`TransactionSequenceNumber`] ) to
+    /// [`TransactionDigest`] for every affected address.
+    ///
+    /// An address is considered "affected" if it appears as the sender, a
+    /// recipient, or the gas payer.
     TransactionsByAddress,
+    /// Stores a mapping of [`CheckpointSequenceNumber`] to
+    /// [`CheckpointContents`] and [`CertifiedCheckpointSummary`] for every
+    /// checkpoint.
     Checkpoints,
+    /// Stores a mapping of [`CheckpointDigest`] to [`CheckpointSequenceNumber`]
+    /// for every checkpoint.
     CheckpointsByDigest,
 }
 
@@ -150,7 +167,7 @@ impl Worker for KvWorker {
                     client.save_transactions(&transactions).await?;
                 }
                 Table::TransactionsByAddress => {
-                    let entries_by_address = affected_addresses(&checkpoint);
+                    let entries_by_address = transactions_by_address(&checkpoint);
                     client
                         .save_transactions_by_address(entries_by_address)
                         .await?;
@@ -169,7 +186,7 @@ impl Worker for KvWorker {
 
 /// Extracts the information related to an address involved in a transaction as
 /// sender, gas owner, or object owner, from a [`CheckpointData`].
-pub fn affected_addresses<'a>(
+pub fn transactions_by_address<'a>(
     checkpoint: &'a CheckpointData,
 ) -> impl Iterator<Item = (Address, TransactionSequenceNumber, TransactionDigest)> + 'a {
     checkpoint

--- a/crates/iota-kvstore/src/emulator.rs
+++ b/crates/iota-kvstore/src/emulator.rs
@@ -2,28 +2,37 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Provides a `BigTableEmulator` that manages the emulator lifecycle (spawn,
-//! table creation, teardown) for use in integration tests across crates.
+//! Test-only lifecycle management for the Google Cloud Bigtable emulator.
 //!
-//! Requires `gcloud`, `cbt`, and the BigTable emulator on PATH.
+//! [`BigTableEmulator::start`] spawns a `cbtemulator` process on a random
+//! free port, creates every [`Table`] (with the `iota` column family) in it,
+//! and kills the process on drop. Integration tests in this and other crates
+//! use it to run against a real Bigtable API without a cloud instance.
+//!
+//! # Dependencies
+//!
+//! Three tools from the Google Cloud SDK are involved:
+//!
+//! - `gcloud`: must be on `PATH`. Only used to locate the SDK root. Install https://cloud.google.com/sdk/docs/install
+//! - `cbtemulator`: the emulator binary itself. It is shipped with the SDK but
+//!   *not* installed on `PATH`, so it is resolved relative to the SDK root
+//!   reported by `gcloud` (see [`cbtemulator_path`]). Install with `gcloud
+//!   components install bigtable`.
+//! - `cbt`: the Bigtable CLI, used to create tables and column families in the
+//!   emulator. Must be on `PATH`. Install with `gcloud components install cbt`.
 
 use std::{
-    net::{Ipv4Addr, SocketAddr},
+    net::Ipv4Addr,
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::OnceLock,
-    time::Duration,
 };
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use futures::future::try_join_all;
 use iota_bigtable::BigTableClient;
 use strum::IntoEnumIterator;
-use tokio::{
-    net::TcpStream,
-    process::Command as TokioCommand,
-    time::{interval, timeout},
-};
+use tokio::process::Command as TokioCommand;
 
 use crate::Table;
 
@@ -50,36 +59,12 @@ impl BigTableEmulator {
             .stderr(Stdio::null())
             .stdout(Stdio::null())
             .spawn()
-            .context("Failed to spawn BigTable emulator")?;
+            .context("failed to spawn BigTable emulator")?;
 
         let host = format!("localhost:{port}");
-        // Construct first so Drop kills the child if the readiness wait fails.
-        let mut emulator = Self { child, host };
-        emulator.wait_until_ready(port).await?;
+        let emulator = Self { child, host };
         create_tables(emulator.host(), INSTANCE_ID).await?;
         Ok(emulator)
-    }
-
-    /// Waits until the emulator accepts TCP connections on `port`.
-    ///
-    /// Fails if the process exits during startup or the timeout elapses.
-    async fn wait_until_ready(&mut self, port: u16) -> Result<()> {
-        const TIMEOUT: Duration = Duration::from_secs(10);
-        let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-        let mut poll = interval(Duration::from_millis(50));
-        timeout(TIMEOUT, async {
-            loop {
-                poll.tick().await;
-                if let Some(status) = self.child.try_wait()? {
-                    bail!("BigTable emulator exited during startup: {status}");
-                }
-                if TcpStream::connect(addr).await.is_ok() {
-                    return Ok(());
-                }
-            }
-        })
-        .await
-        .map_err(|_| anyhow!("BigTable emulator not ready on port {port} after {TIMEOUT:?}"))?
     }
 
     /// Returns the host string for the emulator, e.g. `localhost:12345`.
@@ -107,22 +92,23 @@ impl Drop for BigTableEmulator {
 /// the caller to reuse it with `SO_REUSEADDR`.
 fn get_available_port() -> Result<u16> {
     let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
-        .context("Failed to bind to ephemeral port")?;
+        .context("failed to bind to ephemeral port")?;
     let addr = listener
         .local_addr()
-        .context("Failed to get local address")?;
-    _ = std::net::TcpStream::connect(addr).context("Failed to connect to ephemeral port")?;
-    _ = listener.accept().context("Failed to accept connection")?;
+        .context("failed to get local address")?;
+    _ = std::net::TcpStream::connect(addr).context("failed to connect to ephemeral port")?;
+    _ = listener.accept().context("failed to accept connection")?;
     Ok(addr.port())
 }
 
-/// Resolve the path to `cbtemulator` relative to the gcloud SDK root.
+/// Resolves the path to the `cbtemulator` binary.
 ///
-/// Works regardless of whether gcloud was installed via apt, brew, or the
-/// standalone installer.
+/// `cbtemulator` is not on `PATH`, so it is located at a fixed path under
+/// the gcloud SDK root, which is queried from `gcloud` itself. This makes
+/// the lookup independent of how the SDK was installed (apt, brew,
+/// standalone installer).
 ///
-/// The lookup shells out to `gcloud`, so a successful result is cached for
-/// the lifetime of the process.
+/// A successful lookup is cached for the lifetime of the process.
 pub fn cbtemulator_path() -> Result<&'static Path> {
     static PATH: OnceLock<PathBuf> = OnceLock::new();
     if let Some(path) = PATH.get() {
@@ -152,10 +138,12 @@ pub fn cbtemulator_path() -> Result<&'static Path> {
     Ok(PATH.get_or_init(|| path))
 }
 
-/// Checks whether the BigTable emulator is available on the local machine.
+/// Checks that both `cbtemulator` and `cbt` are available on this machine,
+/// returning an error naming the missing component otherwise.
 ///
-/// The availability probe spawns a `cbt` subprocess, so its outcome is cached
-/// for the lifetime of the process.
+/// `cbtemulator` is checked via [`cbtemulator_path`]. The `cbt` CLI is probed
+/// by spawning `cbt version`, and that outcome is cached for the lifetime of
+/// the process.
 pub fn require_bigtable_emulator() -> Result<()> {
     static IS_CBT_AVAILABLE: OnceLock<bool> = OnceLock::new();
     cbtemulator_path()?;
@@ -181,7 +169,7 @@ pub async fn create_tables(host: &str, instance_id: &str) -> Result<()> {
             .env("BIGTABLE_EMULATOR_HOST", host)
             .output()
             .await
-            .with_context(|| format!("Failed to run cbt createtable {table}"))?;
+            .with_context(|| format!("failed to run cbt createtable {table}"))?;
         if !output.status.success() {
             bail!(
                 "cbt createtable {table} failed: {}",
@@ -195,7 +183,7 @@ pub async fn create_tables(host: &str, instance_id: &str) -> Result<()> {
             .env("BIGTABLE_EMULATOR_HOST", host)
             .output()
             .await
-            .with_context(|| format!("Failed to run cbt createfamily {table}"))?;
+            .with_context(|| format!("failed to run cbt createfamily {table}"))?;
         if !output.status.success() {
             bail!(
                 "cbt createfamily {table} failed: {}",

--- a/crates/iota-kvstore/src/emulator.rs
+++ b/crates/iota-kvstore/src/emulator.rs
@@ -8,30 +8,23 @@
 //! Requires `gcloud`, `cbt`, and the BigTable emulator on PATH.
 
 use std::{
-    net::Ipv4Addr,
+    net::{Ipv4Addr, SocketAddr, TcpStream},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::OnceLock,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, bail};
 use futures::future::try_join_all;
 use iota_bigtable::BigTableClient;
+use strum::IntoEnumIterator;
 use tokio::process::Command as TokioCommand;
 
-use crate::client;
+use crate::Table;
 
 pub const INSTANCE_ID: &str = "bigtable_test_instance";
 pub const COLUMN_FAMILY: &str = "iota";
-
-/// New tables must be added here when introduced.
-pub const TABLES: &[&str] = &[
-    client::OBJECTS_TABLE,
-    client::TRANSACTIONS_TABLE,
-    client::CHECKPOINTS_TABLE,
-    client::CHECKPOINTS_BY_DIGEST_TABLE,
-    client::TRANSACTIONS_BY_ADDRESS_TABLE,
-];
 
 /// A self-contained BigTable emulator process that is spawned on a random port.
 ///
@@ -55,7 +48,31 @@ impl BigTableEmulator {
             .context("Failed to spawn BigTable emulator")?;
 
         let host = format!("localhost:{port}");
-        Ok(Self { child, host })
+        // Construct first so Drop kills the child if the readiness wait fails.
+        let mut emulator = Self { child, host };
+        emulator.wait_until_ready(port)?;
+        Ok(emulator)
+    }
+
+    /// Waits until the emulator accepts TCP connections on `port`.
+    ///
+    /// Fails if the process exits during startup or the timeout elapses.
+    fn wait_until_ready(&mut self, port: u16) -> Result<()> {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            if let Some(status) = self.child.try_wait()? {
+                bail!("BigTable emulator exited during startup: {status}");
+            }
+            if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                bail!("BigTable emulator not ready on port {port} after {TIMEOUT:?}");
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
     }
 
     /// Spawns a new BigTable emulator as a child process on a random port and
@@ -143,8 +160,12 @@ pub fn cbtemulator_path() -> Result<&'static Path> {
 pub fn require_bigtable_emulator() -> Result<()> {
     static IS_CBT_AVAILABLE: OnceLock<bool> = OnceLock::new();
     cbtemulator_path()?;
-    let available =
-        *IS_CBT_AVAILABLE.get_or_init(|| Command::new("cbt").arg("-version").output().is_ok());
+    let available = *IS_CBT_AVAILABLE.get_or_init(|| {
+        Command::new("cbt")
+            .arg("version")
+            .output()
+            .is_ok_and(|output| output.status.success())
+    });
     if !available {
         bail!("cbt not found on PATH — run: gcloud components install cbt");
     }
@@ -153,11 +174,11 @@ pub fn require_bigtable_emulator() -> Result<()> {
 
 /// Creates all required BigTable tables in parallel using async subprocesses.
 pub async fn create_tables(host: &str, instance_id: &str) -> Result<()> {
-    try_join_all(TABLES.iter().map(|&table| async move {
+    try_join_all(Table::iter().map(|table| async move {
         let output = TokioCommand::new("cbt")
             .args(["-instance", instance_id, "-project", "emulator"])
             .arg("createtable")
-            .arg(table)
+            .arg(table.as_ref())
             .env("BIGTABLE_EMULATOR_HOST", host)
             .output()
             .await
@@ -171,7 +192,7 @@ pub async fn create_tables(host: &str, instance_id: &str) -> Result<()> {
 
         let output = TokioCommand::new("cbt")
             .args(["-instance", instance_id, "-project", "emulator"])
-            .args(["createfamily", table, COLUMN_FAMILY])
+            .args(["createfamily", table.as_ref(), COLUMN_FAMILY])
             .env("BIGTABLE_EMULATOR_HOST", host)
             .output()
             .await

--- a/crates/iota-kvstore/src/emulator.rs
+++ b/crates/iota-kvstore/src/emulator.rs
@@ -8,18 +8,22 @@
 //! Requires `gcloud`, `cbt`, and the BigTable emulator on PATH.
 
 use std::{
-    net::{Ipv4Addr, SocketAddr, TcpStream},
+    net::{Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::OnceLock,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use futures::future::try_join_all;
 use iota_bigtable::BigTableClient;
 use strum::IntoEnumIterator;
-use tokio::process::Command as TokioCommand;
+use tokio::{
+    net::TcpStream,
+    process::Command as TokioCommand,
+    time::{interval, timeout},
+};
 
 use crate::Table;
 
@@ -36,8 +40,9 @@ pub struct BigTableEmulator {
 }
 
 impl BigTableEmulator {
-    /// Spawns a new BigTable emulator as a child process on a random port.
-    pub fn start() -> Result<Self> {
+    /// Spawns a new BigTable emulator as a child process on a random port and
+    /// creates the necessary tables.
+    pub async fn start() -> Result<Self> {
         require_bigtable_emulator()?;
         let port = get_available_port()?;
         let child = Command::new(cbtemulator_path()?)
@@ -50,37 +55,31 @@ impl BigTableEmulator {
         let host = format!("localhost:{port}");
         // Construct first so Drop kills the child if the readiness wait fails.
         let mut emulator = Self { child, host };
-        emulator.wait_until_ready(port)?;
+        emulator.wait_until_ready(port).await?;
+        create_tables(emulator.host(), INSTANCE_ID).await?;
         Ok(emulator)
     }
 
     /// Waits until the emulator accepts TCP connections on `port`.
     ///
     /// Fails if the process exits during startup or the timeout elapses.
-    fn wait_until_ready(&mut self, port: u16) -> Result<()> {
+    async fn wait_until_ready(&mut self, port: u16) -> Result<()> {
         const TIMEOUT: Duration = Duration::from_secs(10);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-        let deadline = Instant::now() + TIMEOUT;
-        loop {
-            if let Some(status) = self.child.try_wait()? {
-                bail!("BigTable emulator exited during startup: {status}");
+        let mut poll = interval(Duration::from_millis(50));
+        timeout(TIMEOUT, async {
+            loop {
+                poll.tick().await;
+                if let Some(status) = self.child.try_wait()? {
+                    bail!("BigTable emulator exited during startup: {status}");
+                }
+                if TcpStream::connect(addr).await.is_ok() {
+                    return Ok(());
+                }
             }
-            if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
-                return Ok(());
-            }
-            if Instant::now() >= deadline {
-                bail!("BigTable emulator not ready on port {port} after {TIMEOUT:?}");
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-    }
-
-    /// Spawns a new BigTable emulator as a child process on a random port and
-    /// creates the necessary tables.
-    pub async fn start_and_create_tables() -> Result<Self> {
-        let emulator = Self::start()?;
-        create_tables(emulator.host(), INSTANCE_ID).await?;
-        Ok(emulator)
+        })
+        .await
+        .map_err(|_| anyhow!("BigTable emulator not ready on port {port} after {TIMEOUT:?}"))?
     }
 
     /// Returns the host string for the emulator, e.g. `localhost:12345`.

--- a/crates/iota-kvstore/src/emulator.rs
+++ b/crates/iota-kvstore/src/emulator.rs
@@ -13,7 +13,7 @@
 //!
 //! Three tools from the Google Cloud SDK are involved:
 //!
-//! - `gcloud`: must be on `PATH`. Only used to locate the SDK root. Install https://cloud.google.com/sdk/docs/install
+//! - `gcloud`: must be on `PATH`. Only used to locate the SDK root. Install <https://cloud.google.com/sdk/docs/install>
 //! - `cbtemulator`: the emulator binary itself. It is shipped with the SDK but
 //!   *not* installed on `PATH`, so it is resolved relative to the SDK root
 //!   reported by `gcloud` (see [`cbtemulator_path`]). Install with `gcloud

--- a/crates/iota-kvstore/src/emulator.rs
+++ b/crates/iota-kvstore/src/emulator.rs
@@ -1,0 +1,189 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides a `BigTableEmulator` that manages the emulator lifecycle (spawn,
+//! table creation, teardown) for use in integration tests across crates.
+//!
+//! Requires `gcloud`, `cbt`, and the BigTable emulator on PATH.
+
+use std::{
+    net::Ipv4Addr,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::OnceLock,
+};
+
+use anyhow::{Context, Result, bail};
+use futures::future::try_join_all;
+use iota_bigtable::BigTableClient;
+use tokio::process::Command as TokioCommand;
+
+use crate::client;
+
+pub const INSTANCE_ID: &str = "bigtable_test_instance";
+pub const COLUMN_FAMILY: &str = "iota";
+
+/// New tables must be added here when introduced.
+pub const TABLES: &[&str] = &[
+    client::OBJECTS_TABLE,
+    client::TRANSACTIONS_TABLE,
+    client::CHECKPOINTS_TABLE,
+    client::CHECKPOINTS_BY_DIGEST_TABLE,
+    client::TRANSACTIONS_BY_ADDRESS_TABLE,
+];
+
+/// A self-contained BigTable emulator process that is spawned on a random port.
+///
+/// # Note
+/// The emulator process is killed when this struct is dropped.
+pub struct BigTableEmulator {
+    child: Child,
+    host: String,
+}
+
+impl BigTableEmulator {
+    /// Spawns a new BigTable emulator as a child process on a random port.
+    pub fn start() -> Result<Self> {
+        require_bigtable_emulator()?;
+        let port = get_available_port()?;
+        let child = Command::new(cbtemulator_path()?)
+            .arg(format!("-port={port}"))
+            .stderr(Stdio::null())
+            .stdout(Stdio::null())
+            .spawn()
+            .context("Failed to spawn BigTable emulator")?;
+
+        let host = format!("localhost:{port}");
+        Ok(Self { child, host })
+    }
+
+    /// Spawns a new BigTable emulator as a child process on a random port and
+    /// creates the necessary tables.
+    pub async fn start_and_create_tables() -> Result<Self> {
+        let emulator = Self::start()?;
+        create_tables(emulator.host(), INSTANCE_ID).await?;
+        Ok(emulator)
+    }
+
+    /// Returns the host string for the emulator, e.g. `localhost:12345`.
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Creates a [`BigTableClient`] connected to this emulator.
+    pub fn client(&self) -> Result<BigTableClient> {
+        BigTableClient::new_local(&self.host, "testing", INSTANCE_ID, COLUMN_FAMILY)
+            .map_err(Into::into)
+    }
+}
+
+impl Drop for BigTableEmulator {
+    fn drop(&mut self) {
+        _ = self.child.kill();
+        _ = self.child.wait();
+    }
+}
+
+/// Binds to an ephemeral port and return it.
+///
+/// The port is moved into `TIME_WAIT` so the OS reserves it briefly, allowing
+/// the caller to reuse it with `SO_REUSEADDR`.
+fn get_available_port() -> Result<u16> {
+    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .context("Failed to bind to ephemeral port")?;
+    let addr = listener
+        .local_addr()
+        .context("Failed to get local address")?;
+    _ = std::net::TcpStream::connect(addr).context("Failed to connect to ephemeral port")?;
+    _ = listener.accept().context("Failed to accept connection")?;
+    Ok(addr.port())
+}
+
+/// Resolve the path to `cbtemulator` relative to the gcloud SDK root.
+///
+/// Works regardless of whether gcloud was installed via apt, brew, or the
+/// standalone installer.
+///
+/// The lookup shells out to `gcloud`, so a successful result is cached for
+/// the lifetime of the process.
+pub fn cbtemulator_path() -> Result<&'static Path> {
+    static PATH: OnceLock<PathBuf> = OnceLock::new();
+    if let Some(path) = PATH.get() {
+        return Ok(path);
+    }
+
+    let output = Command::new("gcloud")
+        .args(["info", "--format=value(installation.sdk_root)"])
+        .output()
+        .context("gcloud not found on PATH — install the Google Cloud SDK to run these tests")?;
+
+    if !output.status.success() {
+        bail!("failed to query gcloud sdk root");
+    }
+
+    let sdk_root = String::from_utf8(output.stdout)
+        .context("non-utf8 gcloud sdk root")?
+        .trim()
+        .to_string();
+
+    let path = PathBuf::from(sdk_root).join("platform/bigtable-emulator/cbtemulator");
+
+    if !path.exists() {
+        bail!("cbtemulator not found at {path:?} — run: gcloud components install bigtable");
+    }
+
+    Ok(PATH.get_or_init(|| path))
+}
+
+/// Checks whether the BigTable emulator is available on the local machine.
+///
+/// The availability probe spawns a `cbt` subprocess, so its outcome is cached
+/// for the lifetime of the process.
+pub fn require_bigtable_emulator() -> Result<()> {
+    static IS_CBT_AVAILABLE: OnceLock<bool> = OnceLock::new();
+    cbtemulator_path()?;
+    let available =
+        *IS_CBT_AVAILABLE.get_or_init(|| Command::new("cbt").arg("-version").output().is_ok());
+    if !available {
+        bail!("cbt not found on PATH — run: gcloud components install cbt");
+    }
+    Ok(())
+}
+
+/// Creates all required BigTable tables in parallel using async subprocesses.
+pub async fn create_tables(host: &str, instance_id: &str) -> Result<()> {
+    try_join_all(TABLES.iter().map(|&table| async move {
+        let output = TokioCommand::new("cbt")
+            .args(["-instance", instance_id, "-project", "emulator"])
+            .arg("createtable")
+            .arg(table)
+            .env("BIGTABLE_EMULATOR_HOST", host)
+            .output()
+            .await
+            .with_context(|| format!("Failed to run cbt createtable {table}"))?;
+        if !output.status.success() {
+            bail!(
+                "cbt createtable {table} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let output = TokioCommand::new("cbt")
+            .args(["-instance", instance_id, "-project", "emulator"])
+            .args(["createfamily", table, COLUMN_FAMILY])
+            .env("BIGTABLE_EMULATOR_HOST", host)
+            .output()
+            .await
+            .with_context(|| format!("Failed to run cbt createfamily {table}"))?;
+        if !output.status.success() {
+            bail!(
+                "cbt createfamily {table} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Ok(())
+    }))
+    .await?;
+    Ok(())
+}

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -23,9 +23,12 @@ use serde::{Deserialize, Serialize};
 /// BigTable Key Value store implementation.
 mod bigtable;
 
+#[cfg(feature = "emulator")]
+pub mod emulator;
+
 pub use bigtable::{
     client,
-    worker::{KvWorker, Table},
+    worker::{KvWorker, Table, affected_addresses},
 };
 pub use iota_bigtable::{BigTableClient, Cell, Row, proto};
 

--- a/crates/iota-kvstore/src/lib.rs
+++ b/crates/iota-kvstore/src/lib.rs
@@ -28,7 +28,7 @@ pub mod emulator;
 
 pub use bigtable::{
     client,
-    worker::{KvWorker, Table, affected_addresses},
+    worker::{KvWorker, Table, transactions_by_address},
 };
 pub use iota_bigtable::{BigTableClient, Cell, Row, proto};
 

--- a/crates/iota-kvstore/tests/kv_worker.rs
+++ b/crates/iota-kvstore/tests/kv_worker.rs
@@ -39,7 +39,7 @@ fn build_test_checkpoint() -> CheckpointData {
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn process_checkpoint_round_trips_objects_transactions_and_checkpoints() {
-    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let emulator = BigTableEmulator::start().await.unwrap();
     let mut client = emulator.client().unwrap();
 
     let checkpoint = build_test_checkpoint();
@@ -126,7 +126,7 @@ async fn process_checkpoint_round_trips_objects_transactions_and_checkpoints() {
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn readers_omit_not_found_keys() {
-    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let emulator = BigTableEmulator::start().await.unwrap();
     let mut client = emulator.client().unwrap();
 
     let checkpoint = build_test_checkpoint();

--- a/crates/iota-kvstore/tests/kv_worker.rs
+++ b/crates/iota-kvstore/tests/kv_worker.rs
@@ -35,7 +35,7 @@ fn build_test_checkpoint() -> CheckpointData {
 /// transactions, and checkpoints data.
 #[tokio::test]
 #[cfg_attr(
-    not(feature = "integration_tests"),
+    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn process_checkpoint_round_trips_objects_transactions_and_checkpoints() {
@@ -122,7 +122,7 @@ async fn process_checkpoint_round_trips_objects_transactions_and_checkpoints() {
 /// transactions.
 #[tokio::test]
 #[cfg_attr(
-    not(feature = "integration_tests"),
+    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn readers_omit_not_found_keys() {

--- a/crates/iota-kvstore/tests/kv_worker.rs
+++ b/crates/iota-kvstore/tests/kv_worker.rs
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use iota_data_ingestion_core::Worker;
+use iota_kvstore::{KeyValueStoreReader, KvWorker, TransactionData, emulator::BigTableEmulator};
+use iota_types::{
+    base_types::VersionNumber,
+    digests::{CheckpointDigest, TransactionDigest},
+    effects::TransactionEffectsAPI,
+    full_checkpoint_content::CheckpointData,
+    object::Object,
+    storage::ObjectKey,
+    test_checkpoint_data_builder::TestCheckpointDataBuilder,
+};
+
+/// Build a small checkpoint with a mix of object creations and transfers so
+/// every table receives more than one row.
+fn build_test_checkpoint() -> CheckpointData {
+    TestCheckpointDataBuilder::new(1)
+        .start_transaction(0)
+        .create_owned_object(0)
+        .finish_transaction()
+        .start_transaction(0)
+        .transfer_object(0, 1)
+        .finish_transaction()
+        .start_transaction(2)
+        .create_owned_object(1)
+        .finish_transaction()
+        .build_checkpoint()
+}
+
+/// Tests that a checkpoint is written to BigTable correctly, with objects,
+/// transactions, and checkpoints data.
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "integration_tests"),
+    ignore = "requires the BigTable emulator; run with --features integration_tests"
+)]
+async fn process_checkpoint_round_trips_objects_transactions_and_checkpoints() {
+    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let mut client = emulator.client().unwrap();
+
+    let checkpoint = build_test_checkpoint();
+    let checkpoint_seq = checkpoint.checkpoint_summary.sequence_number;
+    let checkpoint_digest = *checkpoint.checkpoint_summary.digest();
+
+    // capture the expected state before handing the checkpoint to the KvWorker.
+    let expected_objects = checkpoint
+        .transactions
+        .iter()
+        .flat_map(|t| &t.output_objects)
+        .map(|o| (ObjectKey(o.id(), o.version()), o.clone()))
+        .collect::<HashMap<ObjectKey, Object>>();
+
+    let expected_transactions = checkpoint
+        .transactions
+        .iter()
+        .map(|t| {
+            (
+                *t.transaction.digest(),
+                TransactionData::new(t, checkpoint_seq),
+            )
+        })
+        .collect::<HashMap<TransactionDigest, TransactionData>>();
+    let expected_contents = checkpoint.checkpoint_contents.clone();
+
+    // write to BigTable
+    let worker = KvWorker::new(client.clone());
+    worker.process_checkpoint(checkpoint.into()).await.unwrap();
+
+    // objects table: check that every output object comes back byte-identical.
+    let object_keys: Vec<ObjectKey> = expected_objects.keys().copied().collect();
+    let fetched = client.get_objects(&object_keys).await.unwrap();
+    assert_eq!(fetched.len(), expected_objects.len());
+    for object in &fetched {
+        let key = ObjectKey(object.id(), object.version());
+        assert_eq!(
+            Some(object),
+            expected_objects.get(&key),
+            "object stored under {key:?} does not match expected",
+        );
+    }
+
+    // transactions table: check that every transaction comes back byte-identical.
+    let tx_digests: Vec<TransactionDigest> = expected_transactions.keys().copied().collect();
+    let fetched = client.get_transactions(&tx_digests).await.unwrap();
+    assert_eq!(fetched.len(), expected_transactions.len());
+    for tx in &fetched {
+        let digest = *tx.transaction.digest();
+        let expected = &expected_transactions[&digest];
+        assert_eq!(tx.effects.transaction_digest(), &digest);
+        assert_eq!(tx.effects, expected.effects);
+        assert_eq!(tx.events, expected.events);
+        assert_eq!(tx.checkpoint_number, checkpoint_seq);
+    }
+
+    // checkpoints table: summary and contents round-trip by sequence number.
+    let fetched = client.get_checkpoints(&[checkpoint_seq]).await.unwrap();
+    assert_eq!(fetched.len(), 1);
+    assert_eq!(*fetched[0].summary.digest(), checkpoint_digest);
+    assert_eq!(fetched[0].summary.sequence_number, checkpoint_seq);
+    assert_eq!(fetched[0].contents.digest(), expected_contents.digest());
+
+    // checkpoints-by-digest index: digest resolves to the sequence number and,
+    // through it, to the full checkpoint.
+    let seqs = client
+        .get_checkpoint_sequence_numbers([checkpoint_digest])
+        .await
+        .unwrap();
+    assert_eq!(seqs, vec![checkpoint_seq]);
+    let fetched = client
+        .get_checkpoints_by_digest([checkpoint_digest])
+        .await
+        .unwrap();
+    assert_eq!(fetched.len(), 1);
+    assert_eq!(*fetched[0].summary.digest(), checkpoint_digest);
+}
+
+/// Tests that readers omit not-found keys when fetching objects and
+/// transactions.
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "integration_tests"),
+    ignore = "requires the BigTable emulator; run with --features integration_tests"
+)]
+async fn readers_omit_not_found_keys() {
+    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let mut client = emulator.client().unwrap();
+
+    let checkpoint = build_test_checkpoint();
+    let checkpoint_seq = checkpoint.checkpoint_summary.sequence_number;
+    let stored_object_id = checkpoint.transactions[0].output_objects[0].id();
+
+    let worker = KvWorker::new(client.clone());
+    worker.process_checkpoint(checkpoint.into()).await.unwrap();
+
+    let missing_key = ObjectKey(stored_object_id, VersionNumber::from_u64(999));
+    let fetched = client.get_objects(&[missing_key]).await.unwrap();
+    assert!(fetched.is_empty());
+
+    let fetched = client
+        .get_transactions(&[TransactionDigest::random()])
+        .await
+        .unwrap();
+    assert!(fetched.is_empty());
+
+    let fetched = client.get_checkpoints(&[checkpoint_seq + 1]).await.unwrap();
+    assert!(fetched.is_empty());
+
+    let fetched = client
+        .get_checkpoint_sequence_numbers([CheckpointDigest::random()])
+        .await
+        .unwrap();
+    assert!(fetched.is_empty());
+}

--- a/crates/iota-kvstore/tests/transactions_by_address.rs
+++ b/crates/iota-kvstore/tests/transactions_by_address.rs
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+
+use iota_data_ingestion_core::Worker;
+use iota_kvstore::{
+    KeyValueStoreReader, KeyValueStoreWriter, KvWorker, affected_addresses,
+    client::{TransactionSequenceNumber, TransactionsOrder},
+    emulator::BigTableEmulator,
+};
+use iota_sdk_types::Address;
+use iota_types::{
+    digests::TransactionDigest, full_checkpoint_content::CheckpointData,
+    test_checkpoint_data_builder::TestCheckpointDataBuilder,
+};
+
+/// Build a small checkpoint covering affected-address cases.
+fn build_test_checkpoint() -> CheckpointData {
+    TestCheckpointDataBuilder::new(1)
+        // tx 0: sender 0 creates object 0 (owned by sender 0)
+        //   → affected = {addr_0}
+        .start_transaction(0)
+        .create_owned_object(0)
+        .finish_transaction()
+        // tx 1: sender 0 transfers object 0 to addr 1
+        //   → affected = {addr_0, addr_1}
+        .start_transaction(0)
+        .transfer_object(0, 1)
+        .finish_transaction()
+        // tx 2: sender 2 creates object 1 (owned by sender 2)
+        //   → affected = {addr_2}
+        .start_transaction(2)
+        .create_owned_object(1)
+        .finish_transaction()
+        // tx 3: sender 2 transfers object 1 to addr 3
+        //   → affected = {addr_2, addr_3}
+        .start_transaction(2)
+        .transfer_object(1, 3)
+        .finish_transaction()
+        .build_checkpoint()
+}
+
+#[test]
+fn affected_addresses_per_transaction() {
+    let checkpoint = build_test_checkpoint();
+    let addr = TestCheckpointDataBuilder::derive_address;
+
+    let by_tx = affected_addresses(&checkpoint)
+        .map(|(a, seq, _)| (seq, a))
+        .collect::<HashSet<(u64, Address)>>();
+
+    let first_seq = affected_addresses(&checkpoint)
+        .map(|(_, s, _)| s)
+        .min()
+        .unwrap();
+    let s0 = first_seq;
+    let s1 = first_seq + 1;
+    let s2 = first_seq + 2;
+    let s3 = first_seq + 3;
+
+    // tx 0: only sender 0 (sender == payer == sole recipient)
+    assert!(by_tx.contains(&(s0, addr(0))));
+    assert_eq!(by_tx.iter().filter(|(s, _)| *s == s0).count(), 1);
+
+    // tx 1: sender 0 (also payer) + recipient 1
+    assert!(by_tx.contains(&(s1, addr(0))));
+    assert!(by_tx.contains(&(s1, addr(1))));
+    assert_eq!(by_tx.iter().filter(|(s, _)| *s == s1).count(), 2);
+
+    // tx 2: only sender 2
+    assert!(by_tx.contains(&(s2, addr(2))));
+    assert_eq!(by_tx.iter().filter(|(s, _)| *s == s2).count(), 1);
+
+    // tx 3: sender 2 (also payer) + recipient 3
+    assert!(by_tx.contains(&(s3, addr(2))));
+    assert!(by_tx.contains(&(s3, addr(3))));
+    assert_eq!(by_tx.iter().filter(|(s, _)| *s == s3).count(), 2);
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "integration_tests"),
+    ignore = "requires the BigTable emulator; run with --features integration_tests"
+)]
+async fn process_checkpoint() {
+    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let mut client = emulator.client().unwrap();
+    let checkpoint = build_test_checkpoint();
+
+    // capture expected (address -> set of digests) BEFORE the checkpoint is moved.
+    let expected_rows = affected_addresses(&checkpoint);
+    let mut expected_by_address: HashMap<
+        Address,
+        HashMap<TransactionSequenceNumber, TransactionDigest>,
+    > = HashMap::new();
+    for (address, seq, digest) in expected_rows {
+        expected_by_address
+            .entry(address)
+            .or_default()
+            .insert(seq, digest);
+    }
+
+    let kv_worker = KvWorker::new(client.clone());
+    // write to BigTable: run the worker on the checkpoint.
+    kv_worker
+        .process_checkpoint(checkpoint.into())
+        .await
+        .unwrap();
+
+    // read back from BigTable and compare per affected address.
+    for (address, expected_digests) in &expected_by_address {
+        let fetched = client
+            .get_transaction_digests_by_address(*address, None, 10, Default::default())
+            .await
+            .unwrap()
+            .into_iter()
+            .collect::<HashMap<TransactionSequenceNumber, TransactionDigest>>();
+
+        assert_eq!(
+            &fetched, expected_digests,
+            "digests stored for {address:?} do not match expected",
+        );
+    }
+
+    // addresses we never used should return nothing.
+    let unused = TestCheckpointDataBuilder::derive_address(99);
+    let fetched = client
+        .get_transaction_digests_by_address(unused, None, 10, Default::default())
+        .await
+        .unwrap();
+
+    assert!(
+        fetched.is_empty(),
+        "unrelated address {unused:?} unexpectedly has stored digests",
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "integration_tests"),
+    ignore = "requires the BigTable emulator; run with --features integration_tests"
+)]
+async fn paginates_newest_first() {
+    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let mut client = emulator.client().unwrap();
+
+    let address = Address::random();
+    let seqs = [10u64, 20, 30, 40, 50];
+    let digests = std::iter::repeat_n(TransactionDigest::random(), seqs.len())
+        .collect::<Vec<TransactionDigest>>();
+    let entries = seqs
+        .iter()
+        .zip(digests.iter())
+        .map(|(s, d)| (address, *s, *d))
+        .collect::<Vec<_>>();
+    client.save_transactions_by_address(entries).await.unwrap();
+
+    // page 1: 3 newest, in newest-first order.
+    let page1 = client
+        .get_transaction_digests_by_address(address, None, 3, TransactionsOrder::NewestFirst)
+        .await
+        .unwrap();
+    assert_eq!(
+        page1,
+        vec![(50, digests[4]), (40, digests[3]), (30, digests[2])]
+    );
+
+    // page 2: continue past seq 30, no overlap with page 1.
+    let page2 = client
+        .get_transaction_digests_by_address(address, Some(30), 10, TransactionsOrder::NewestFirst)
+        .await
+        .unwrap();
+    assert_eq!(page2, vec![(20, digests[1]), (10, digests[0])]);
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "integration_tests"),
+    ignore = "requires the BigTable emulator; run with --features integration_tests"
+)]
+async fn paginates_oldest_first() {
+    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let mut client = emulator.client().unwrap();
+
+    let address = Address::random();
+    let seqs = [10u64, 20, 30, 40, 50];
+    let digests = std::iter::repeat_n(TransactionDigest::random(), seqs.len())
+        .collect::<Vec<TransactionDigest>>();
+    let entries = seqs
+        .iter()
+        .zip(digests.iter())
+        .map(|(s, d)| (address, *s, *d))
+        .collect::<Vec<_>>();
+    client.save_transactions_by_address(entries).await.unwrap();
+
+    // page 1: 3 oldest, in oldest-first order.
+    let page1 = client
+        .get_transaction_digests_by_address(address, None, 3, TransactionsOrder::OldestFirst)
+        .await
+        .unwrap();
+    assert_eq!(
+        page1,
+        vec![(10, digests[0]), (20, digests[1]), (30, digests[2])]
+    );
+
+    // page 2: continue past seq 30, no overlap with page 1.
+    let page2 = client
+        .get_transaction_digests_by_address(address, Some(30), 10, TransactionsOrder::OldestFirst)
+        .await
+        .unwrap();
+    assert_eq!(page2, vec![(40, digests[3]), (50, digests[4])]);
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "integration_tests"),
+    ignore = "requires the BigTable emulator; run with --features integration_tests"
+)]
+async fn order_flip_is_exact_reverse() {
+    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let mut client = emulator.client().unwrap();
+
+    let address = Address::random();
+    let seqs = [10u64, 20, 30, 50];
+    let digests = std::iter::repeat_n(TransactionDigest::random(), seqs.len())
+        .collect::<Vec<TransactionDigest>>();
+    let entries = seqs
+        .iter()
+        .zip(digests.iter())
+        .map(|(s, d)| (address, *s, *d))
+        .collect::<Vec<_>>();
+    client.save_transactions_by_address(entries).await.unwrap();
+
+    let newest_first = client
+        .get_transaction_digests_by_address(address, None, 10, TransactionsOrder::NewestFirst)
+        .await
+        .unwrap();
+    let oldest_first = client
+        .get_transaction_digests_by_address(address, None, 10, TransactionsOrder::OldestFirst)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        newest_first,
+        vec![
+            (50, digests[3]),
+            (30, digests[2]),
+            (20, digests[1]),
+            (10, digests[0])
+        ]
+    );
+    assert_eq!(
+        oldest_first,
+        vec![
+            (10, digests[0]),
+            (20, digests[1]),
+            (30, digests[2]),
+            (50, digests[3])
+        ]
+    );
+    let mut reversed = oldest_first;
+    reversed.reverse();
+    assert_eq!(newest_first, reversed);
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "integration_tests"),
+    ignore = "requires the BigTable emulator; run with --features integration_tests"
+)]
+async fn empty_range_guards_return_ok_empty() {
+    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let mut client = emulator.client().unwrap();
+
+    // Address need not exist: the guards short-circuit before hitting BigTable.
+    let address = Address::random();
+
+    // NewestFirst with cursor = 0: nothing is older than seq 0.
+    // BigTable would reject the empty range; the guard must return Ok(vec![]).
+    let res = client
+        .get_transaction_digests_by_address(address, Some(0), 10, TransactionsOrder::NewestFirst)
+        .await
+        .unwrap();
+    assert!(res.is_empty());
+
+    // OldestFirst with cursor = u64::MAX: nothing is newer than u64::MAX.
+    let res = client
+        .get_transaction_digests_by_address(
+            address,
+            Some(u64::MAX),
+            10,
+            TransactionsOrder::OldestFirst,
+        )
+        .await
+        .unwrap();
+    assert!(res.is_empty());
+}

--- a/crates/iota-kvstore/tests/transactions_by_address.rs
+++ b/crates/iota-kvstore/tests/transactions_by_address.rs
@@ -13,6 +13,7 @@ use iota_kvstore::{
 use iota_sdk_types::Address;
 use iota_types::{
     digests::TransactionDigest, full_checkpoint_content::CheckpointData,
+    messages_checkpoint::CheckpointContentsExt,
     test_checkpoint_data_builder::TestCheckpointDataBuilder,
 };
 
@@ -142,7 +143,8 @@ async fn paginates_newest_first() {
 
     let address = Address::random();
     let seqs = [10u64, 20, 30, 40, 50];
-    let digests = std::iter::repeat_n(TransactionDigest::random(), seqs.len())
+    let digests = std::iter::repeat_with(TransactionDigest::random)
+        .take(seqs.len())
         .collect::<Vec<TransactionDigest>>();
     let entries = seqs
         .iter()
@@ -180,7 +182,8 @@ async fn paginates_oldest_first() {
 
     let address = Address::random();
     let seqs = [10u64, 20, 30, 40, 50];
-    let digests = std::iter::repeat_n(TransactionDigest::random(), seqs.len())
+    let digests = std::iter::repeat_with(TransactionDigest::random)
+        .take(seqs.len())
         .collect::<Vec<TransactionDigest>>();
     let entries = seqs
         .iter()
@@ -218,7 +221,8 @@ async fn order_flip_is_exact_reverse() {
 
     let address = Address::random();
     let seqs = [10u64, 20, 30, 50];
-    let digests = std::iter::repeat_n(TransactionDigest::random(), seqs.len())
+    let digests = std::iter::repeat_with(TransactionDigest::random)
+        .take(seqs.len())
         .collect::<Vec<TransactionDigest>>();
     let entries = seqs
         .iter()

--- a/crates/iota-kvstore/tests/transactions_by_address.rs
+++ b/crates/iota-kvstore/tests/transactions_by_address.rs
@@ -79,7 +79,7 @@ fn affected_addresses_per_transaction() {
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn process_checkpoint() {
-    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let emulator = BigTableEmulator::start().await.unwrap();
     let mut client = emulator.client().unwrap();
     let checkpoint = build_test_checkpoint();
 
@@ -137,7 +137,7 @@ async fn process_checkpoint() {
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn paginates_newest_first() {
-    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let emulator = BigTableEmulator::start().await.unwrap();
     let mut client = emulator.client().unwrap();
 
     let address = Address::random();
@@ -175,7 +175,7 @@ async fn paginates_newest_first() {
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn paginates_oldest_first() {
-    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let emulator = BigTableEmulator::start().await.unwrap();
     let mut client = emulator.client().unwrap();
 
     let address = Address::random();
@@ -213,7 +213,7 @@ async fn paginates_oldest_first() {
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn order_flip_is_exact_reverse() {
-    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let emulator = BigTableEmulator::start().await.unwrap();
     let mut client = emulator.client().unwrap();
 
     let address = Address::random();
@@ -265,7 +265,7 @@ async fn order_flip_is_exact_reverse() {
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn empty_range_guards_return_ok_empty() {
-    let emulator = BigTableEmulator::start_and_create_tables().await.unwrap();
+    let emulator = BigTableEmulator::start().await.unwrap();
     let mut client = emulator.client().unwrap();
 
     // Address need not exist: the guards short-circuit before hitting BigTable.

--- a/crates/iota-kvstore/tests/transactions_by_address.rs
+++ b/crates/iota-kvstore/tests/transactions_by_address.rs
@@ -5,9 +5,10 @@ use std::collections::{HashMap, HashSet};
 
 use iota_data_ingestion_core::Worker;
 use iota_kvstore::{
-    KeyValueStoreReader, KeyValueStoreWriter, KvWorker, affected_addresses,
+    KeyValueStoreReader, KeyValueStoreWriter, KvWorker,
     client::{TransactionSequenceNumber, TransactionsOrder},
     emulator::BigTableEmulator,
+    transactions_by_address,
 };
 use iota_sdk_types::Address;
 use iota_types::{
@@ -46,36 +47,30 @@ fn affected_addresses_per_transaction() {
     let checkpoint = build_test_checkpoint();
     let addr = TestCheckpointDataBuilder::derive_address;
 
-    let by_tx = affected_addresses(&checkpoint)
-        .map(|(a, seq, _)| (seq, a))
-        .collect::<HashSet<(u64, Address)>>();
+    let first_seq = checkpoint
+        .checkpoint_contents
+        .enumerate_transactions(&checkpoint.checkpoint_summary)
+        .next()
+        .unwrap()
+        .0;
+    let tx_seq_to_digest = |i: usize| *checkpoint.transactions[i].transaction.digest();
 
-    let first_seq = affected_addresses(&checkpoint)
-        .map(|(_, s, _)| s)
-        .min()
-        .unwrap();
-    let s0 = first_seq;
-    let s1 = first_seq + 1;
-    let s2 = first_seq + 2;
-    let s3 = first_seq + 3;
+    let expected = HashSet::from([
+        // tx 0: only sender 0 (sender == payer == sole recipient)
+        (addr(0), first_seq, tx_seq_to_digest(0)),
+        // tx 1: sender 0 (also payer) + recipient 1
+        (addr(0), first_seq + 1, tx_seq_to_digest(1)),
+        (addr(1), first_seq + 1, tx_seq_to_digest(1)),
+        // tx 2: only sender 2
+        (addr(2), first_seq + 2, tx_seq_to_digest(2)),
+        // tx 3: sender 2 (also payer) + recipient 3
+        (addr(2), first_seq + 3, tx_seq_to_digest(3)),
+        (addr(3), first_seq + 3, tx_seq_to_digest(3)),
+    ]);
 
-    // tx 0: only sender 0 (sender == payer == sole recipient)
-    assert!(by_tx.contains(&(s0, addr(0))));
-    assert_eq!(by_tx.iter().filter(|(s, _)| *s == s0).count(), 1);
-
-    // tx 1: sender 0 (also payer) + recipient 1
-    assert!(by_tx.contains(&(s1, addr(0))));
-    assert!(by_tx.contains(&(s1, addr(1))));
-    assert_eq!(by_tx.iter().filter(|(s, _)| *s == s1).count(), 2);
-
-    // tx 2: only sender 2
-    assert!(by_tx.contains(&(s2, addr(2))));
-    assert_eq!(by_tx.iter().filter(|(s, _)| *s == s2).count(), 1);
-
-    // tx 3: sender 2 (also payer) + recipient 3
-    assert!(by_tx.contains(&(s3, addr(2))));
-    assert!(by_tx.contains(&(s3, addr(3))));
-    assert_eq!(by_tx.iter().filter(|(s, _)| *s == s3).count(), 2);
+    let actual: HashSet<(Address, TransactionSequenceNumber, TransactionDigest)> =
+        transactions_by_address(&checkpoint).collect();
+    assert_eq!(actual, expected);
 }
 
 #[tokio::test]
@@ -89,7 +84,7 @@ async fn process_checkpoint() {
     let checkpoint = build_test_checkpoint();
 
     // capture expected (address -> set of digests) BEFORE the checkpoint is moved.
-    let expected_rows = affected_addresses(&checkpoint);
+    let expected_rows = transactions_by_address(&checkpoint);
     let mut expected_by_address: HashMap<
         Address,
         HashMap<TransactionSequenceNumber, TransactionDigest>,

--- a/crates/iota-kvstore/tests/transactions_by_address.rs
+++ b/crates/iota-kvstore/tests/transactions_by_address.rs
@@ -76,7 +76,7 @@ fn affected_addresses_per_transaction() {
 
 #[tokio::test]
 #[cfg_attr(
-    not(feature = "integration_tests"),
+    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn process_checkpoint() {
@@ -134,7 +134,7 @@ async fn process_checkpoint() {
 
 #[tokio::test]
 #[cfg_attr(
-    not(feature = "integration_tests"),
+    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn paginates_newest_first() {
@@ -173,7 +173,7 @@ async fn paginates_newest_first() {
 
 #[tokio::test]
 #[cfg_attr(
-    not(feature = "integration_tests"),
+    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn paginates_oldest_first() {
@@ -212,7 +212,7 @@ async fn paginates_oldest_first() {
 
 #[tokio::test]
 #[cfg_attr(
-    not(feature = "integration_tests"),
+    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn order_flip_is_exact_reverse() {
@@ -265,7 +265,7 @@ async fn order_flip_is_exact_reverse() {
 
 #[tokio::test]
 #[cfg_attr(
-    not(feature = "integration_tests"),
+    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn empty_range_guards_return_ok_empty() {

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -71,8 +71,12 @@ impl KvStoreClient {
     /// Internally it instantiates a BigTableDB client.
     pub async fn new(config: KvStoreConfig) -> Result<Self> {
         let bigtable_client = if let Some(emulator_host) = config.emulator_host {
-            std::env::set_var("BIGTABLE_EMULATOR_HOST", &emulator_host);
-            BigTableClient::new_local(config.instance_id, config.column_family).await?
+            BigTableClient::new_local(
+                &emulator_host,
+                "iota-rest-kv",
+                config.instance_id,
+                config.column_family,
+            )?
         } else {
             BigTableClient::new_remote(
                 config.instance_id,


### PR DESCRIPTION
# Description of change

This PR adds integration tests to the `iota-kvstore` crate, backed by the BigTable emulator.

- Bumped `iota-bigtable` to a revision where `BigTableClient::new_local` takes the emulator host directly instead of reading the `BIGTABLE_EMULATOR_HOST` env variable. Updated the callers in `iota-rest-kv` and `iota-data-ingestion` accordingly.
- Added a new emulator module (behind the `emulator` feature) with a `BigTableEmulator` helper that spawns the emulator on a random port, creates the required tables via `cbt`, and kills the process on drop. It requires `gcloud` and `cbt` on PATH.
- Added integration tests behind the `integration_tests` feature:
  - `kv_worker.rs`: round-trips objects, transactions, and checkpoints through `KvWorker::process_checkpoint` and verifies readers omit not-found keys.
  - `transactions_by_address.rs`: covers affected-address extraction, checkpoint processing, pagination in both directions, order flipping, and empty-range guards.
- Extracted the affected-address logic from `KvWorker::process_checkpoint` into a public `transactions_by_address ` function so tests can use it directly.
- Documented how to run the tests in the crate README: `cargo test --features integration_tests` (or `cargo nextest run -F integration_tests`).

> [!NOTE]
> The two features serve different purposes: `emulator` exposes the emulator helpers on their own, so other crates can reuse them to build their own BigTable-backed tests, while `integration_tests` (which enables `emulator`) is the single flag that gates running this crate's own emulator-backed test suite. The `emulator` feature is enabled through a dev self-dependency so the helpers and tests compile under plain cargo test, clippy, and IDE checks. Rust does not let integration tests reach non-exported test modules, so the helpers must live in the library behind a feature gate; the gate keeps them out of production builds, and the emulator-backed tests only run when `integration_tests` is explicitly enabled.


## Links to any relevant issues

fixes #11674 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

```shell
cargo test --features integration_tests
```
```shell
cargo nextest run -F integration_tests
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the iota-indexer, thus no further tests were conducted.