### PR TITLE
feat(indexer): Change `total_epoch_committed` into `last_committed_epoch`

### DIFF
--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -80,6 +80,10 @@ impl Indexer {
             store.persist_protocol_configs_and_feature_flags(chain_id)?;
         }
 
+        // Restore metric from the DB so it doesn't stay as 0 until next epoch change.
+        let (_, latest_epoch) = IndexerStore::get_available_epoch_range(&store).await?;
+        metrics.last_committed_epoch.set(latest_epoch as i64);
+
         let primary_pipeline = PrimaryPipeline::setup(
             store.clone(),
             metrics.clone(),

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -218,6 +218,7 @@ impl PrimaryWriter {
         // On epoch boundary, we need to modify the existing partitions' upper bound,
         // and introduce a new partition for incoming data for the upcoming epoch.
         if let Some(epoch_data) = epoch {
+            let new_epoch_id = epoch_data.new_epoch.epoch;
             self.state
                 .advance_epoch(epoch_data)
                 .await
@@ -225,7 +226,7 @@ impl PrimaryWriter {
                     error!("failed to advance epoch with error: {}", e.to_string());
                 })
                 .expect("advancing epochs in DB should not fail.");
-            self.metrics.total_epoch_committed.inc();
+            self.metrics.last_committed_epoch.set(new_epoch_id);
 
             // Refresh participation metrics after advancing epoch
             self.state

--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -73,7 +73,7 @@ pub struct IndexerMetrics {
     pub total_object_change_committed: IntCounter, // not used
     pub total_transaction_chunk_committed: IntCounter, // not used
     pub total_object_change_chunk_committed: IntCounter, // not used
-    pub total_epoch_committed: IntCounter,
+    pub last_committed_epoch: IntGauge,
     pub latest_fullnode_checkpoint_sequence_number: IntGauge,
     pub latest_tx_checkpoint_sequence_number: IntGauge,
     pub latest_indexer_object_checkpoint_sequence_number: IntGauge, // not used
@@ -235,9 +235,9 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
-            total_epoch_committed: register_int_counter_with_registry!(
-                "total_epoch_committed",
-                "Total number of epoch committed",
+            last_committed_epoch: register_int_gauge_with_registry!(
+                "last_committed_epoch",
+                "Latest epoch committed to the DB",
                 registry,
             )
             .unwrap(),

--- a/dev-tools/grafana-local/dashboards/indexer-dashboard.json
+++ b/dev-tools/grafana-local/dashboards/indexer-dashboard.json
@@ -1402,7 +1402,7 @@
               }
             ]
           },
-          "unit": "ops"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -1431,12 +1431,12 @@
       },
       "targets": [
         {
-          "expr": "rate(indexer_total_epoch_committed[$__rate_interval])",
+          "expr": "indexer_last_committed_epoch",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],
-      "title": "Epochs Committed/s",
+      "title": "Last Committed Epoch",
       "type": "timeseries"
     },
     {

--- a/dev-tools/iota-indexer-monitoring/dashboards/indexer_metrics_dashboard.json
+++ b/dev-tools/iota-indexer-monitoring/dashboards/indexer_metrics_dashboard.json
@@ -197,7 +197,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "indexer_total_epoch_committed",
+          "expr": "indexer_last_committed_epoch",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -206,7 +206,7 @@
           "useBackend": false
         }
       ],
-      "title": "Total Epochs Committed",
+      "title": "Last Committed Epoch",
       "type": "stat"
     },
     {


### PR DESCRIPTION
# Description of change

Changed `total_epoch_committed` into `last_committed_epoch`, now it always points at the last committed epoch and doesn't start from 0 on every restart

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/9211

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: `total_epoch_committed` metric renamed to `last_committed_epoch`, now it always points at the last committed epoch and doesn't start from 0 on every restart

#### Breaking Changes Rollout

Affected Crates:

- iota-indexer

Required User Actions:

Change monitoring dashboards to use `last_committed_epoch` instead of `total_epoch_committed`

