### PR TITLE
refactor(iota-core, iota-types): make `ConsensusTransactionKind` matches exhaustive

### DIFF
--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -1016,25 +1016,34 @@ impl ConsensusOutputQuarantine {
         let mut shared_input_object_ids: Vec<_> = transactions
             .iter()
             .filter_map(|tx| match &tx.0.transaction {
-                SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                    kind: ConsensusTransactionKind::CertifiedTransaction(tx),
-                    ..
-                }) => Some(
-                    tx.shared_input_objects()
-                        .into_iter()
-                        .map(|obj| obj.object_id)
-                        .collect::<Vec<_>>(),
-                ),
-                SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                    kind: ConsensusTransactionKind::UserTransactionV1(tx),
-                    ..
-                }) => Some(
-                    tx.shared_input_objects()
-                        .into_iter()
-                        .map(|obj| obj.object_id)
-                        .collect::<Vec<_>>(),
-                ),
-                _ => None,
+                // Listed exhaustively (no `_` arm) so a new user-transaction kind must be
+                // classified here rather than silently contributing no shared-object debt.
+                SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
+                    ConsensusTransactionKind::CertifiedTransaction(tx) => Some(
+                        tx.shared_input_objects()
+                            .into_iter()
+                            .map(|obj| obj.object_id)
+                            .collect::<Vec<_>>(),
+                    ),
+                    ConsensusTransactionKind::UserTransactionV1(tx) => Some(
+                        tx.shared_input_objects()
+                            .into_iter()
+                            .map(|obj| obj.object_id)
+                            .collect::<Vec<_>>(),
+                    ),
+                    // internal consensus messages have no shared input objects to preload
+                    ConsensusTransactionKind::CheckpointSignature(_)
+                    | ConsensusTransactionKind::EndOfPublish(_)
+                    | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                    | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+                    | ConsensusTransactionKind::RandomnessDkgMessage(..)
+                    | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+                    | ConsensusTransactionKind::MisbehaviorReport(_)
+                    | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
+                    #[allow(deprecated)]
+                    ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
+                },
+                SequencedConsensusTransactionKind::System(_) => None,
             })
             .flatten()
             .collect();

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -1015,37 +1015,20 @@ impl ConsensusOutputQuarantine {
         };
         let mut shared_input_object_ids: Vec<_> = transactions
             .iter()
+            // Only user transactions carry shared inputs to preload; which kinds
+            // those are lives in `as_sender_signed_data`. System transactions contribute
+            // none.
             .filter_map(|tx| match &tx.0.transaction {
-                // Listed exhaustively (no `_` arm) so a new user-transaction kind must be
-                // classified here rather than silently contributing no shared-object debt.
-                SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
-                    ConsensusTransactionKind::CertifiedTransaction(tx) => Some(
-                        tx.shared_input_objects()
-                            .into_iter()
-                            .map(|obj| obj.object_id)
-                            .collect::<Vec<_>>(),
-                    ),
-                    ConsensusTransactionKind::UserTransactionV1(tx) => Some(
-                        tx.shared_input_objects()
-                            .into_iter()
-                            .map(|obj| obj.object_id)
-                            .collect::<Vec<_>>(),
-                    ),
-                    // internal consensus messages have no shared input objects to preload
-                    ConsensusTransactionKind::CheckpointSignature(_)
-                    | ConsensusTransactionKind::EndOfPublish(_)
-                    | ConsensusTransactionKind::CapabilityNotificationV1(_)
-                    | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-                    | ConsensusTransactionKind::RandomnessDkgMessage(..)
-                    | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-                    | ConsensusTransactionKind::MisbehaviorReport(_)
-                    | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
-                    #[allow(deprecated)]
-                    ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
-                },
+                SequencedConsensusTransactionKind::External(ext) => {
+                    ext.kind.as_sender_signed_data()
+                }
                 SequencedConsensusTransactionKind::System(_) => None,
             })
-            .flatten()
+            .flat_map(|data| {
+                data.shared_input_objects()
+                    .into_iter()
+                    .map(|obj| obj.object_id)
+            })
             .collect();
         shared_input_object_ids.sort();
         shared_input_object_ids.dedup();

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -629,12 +629,12 @@ impl ConsensusAdapter {
             // UserTransactionV1 (P-COOL flow). submit_and_wait_inner
             // assumes a single transaction kind across the batch.
             for transaction in transactions {
+                // Routed through the shared user-transaction helpers rather than an
+                // inline match, so a new user-transaction kind is classified in one
+                // place (`ConsensusTransactionKind::is_user_transaction`) and becomes
+                // soft-bundle eligible automatically.
                 fp_ensure!(
-                    matches!(
-                        transaction.kind,
-                        ConsensusTransactionKind::CertifiedTransaction(_)
-                            | ConsensusTransactionKind::UserTransactionV1(_)
-                    ),
+                    transaction.is_user_certificate() || transaction.kind.is_user_transaction(),
                     IotaError::InvalidTxKindInSoftBundle
                 );
             }
@@ -936,18 +936,13 @@ impl ConsensusAdapter {
         let is_user_tx = is_soft_bundle
             || if epoch_store.protocol_config().enable_pcool_flow() {
                 // In the P-COOL flow, `UserTransactionV1` kind corresponds
-                // to user transactions.
-                matches!(
-                    transactions[0].kind,
-                    ConsensusTransactionKind::UserTransactionV1(_)
-                )
+                // to user transactions.  Routed through the shared predicate
+                // so a new user-transaction kind is classified in one place.
+                transactions[0].kind.is_user_transaction()
             } else {
                 // In the certificate mode, `CertifiedTransaction` kind corresponds
                 // to user transactions.
-                matches!(
-                    transactions[0].kind,
-                    ConsensusTransactionKind::CertifiedTransaction(_)
-                )
+                transactions[0].is_user_certificate()
             };
         let send_end_of_publish = if is_user_tx {
             if epoch_store.protocol_config().enable_pcool_flow() {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -335,11 +335,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         .consensus_handler_transaction_sizes
                         .with_label_values(&[kind])
                         .observe(serialized_len as f64);
-                    if matches!(
-                        &transaction.kind,
-                        ConsensusTransactionKind::CertifiedTransaction(_)
-                            | ConsensusTransactionKind::UserTransactionV1(_)
-                    ) {
+                    if transaction.is_user_certificate() || transaction.kind.is_user_transaction() {
                         self.last_consensus_stats
                             .stats
                             .inc_num_user_transactions(authority_index as usize);
@@ -729,12 +725,29 @@ impl SequencedConsensusTransactionKind {
         }
     }
 
+    /// Returns the digest for transactions that get executed -- user-originated
+    /// (`CertifiedTransaction` and `UserTransactionV1`) and system transactions
+    /// -- and `None` for internal consensus messages (checkpoint signatures,
+    /// capability notifications, randomness DKG, etc.). Used to build
+    /// checkpoint roots and to schedule transactions for execution.
     pub fn executable_transaction_digest(&self) -> Option<TransactionDigest> {
         match self {
+            // Listed exhaustively (no `_` arm) so a new user-transaction kind must
+            // be classified here rather than silently defaulting to non-executable.
             SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
                 ConsensusTransactionKind::CertifiedTransaction(txn) => Some(*txn.digest()),
                 ConsensusTransactionKind::UserTransactionV1(txn) => Some(*txn.digest()),
-                _ => None,
+                // internal consensus messages - not executable
+                ConsensusTransactionKind::CheckpointSignature(_)
+                | ConsensusTransactionKind::EndOfPublish(_)
+                | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+                | ConsensusTransactionKind::RandomnessDkgMessage(..)
+                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+                | ConsensusTransactionKind::MisbehaviorReport(_)
+                | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
+                #[allow(deprecated)]
+                ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
             },
             SequencedConsensusTransactionKind::System(txn) => Some(*txn.digest()),
         }
@@ -744,23 +757,35 @@ impl SequencedConsensusTransactionKind {
     /// (`CertifiedTransaction` and `UserTransactionV1`). Used by post-consensus
     /// load shedding to guarantee that no internal consensus messages
     /// (checkpoint signatures, capability notifications, randomness DKG, etc.)
-    /// are eligible to be dropped.
+    /// and system transactions are eligible to be dropped.
     pub fn user_transaction_digest(&self) -> Option<TransactionDigest> {
         match self {
+            // Listed exhaustively (no `_` arm) so a new user-transaction kind must
+            // be classified here rather than silently defaulting to non-sheddable.
             SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
                 ConsensusTransactionKind::CertifiedTransaction(txn) => Some(*txn.digest()),
                 ConsensusTransactionKind::UserTransactionV1(txn) => Some(*txn.digest()),
-                _ => None,
+                // internal consensus messages - never shed
+                ConsensusTransactionKind::CheckpointSignature(_)
+                | ConsensusTransactionKind::EndOfPublish(_)
+                | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+                | ConsensusTransactionKind::RandomnessDkgMessage(..)
+                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+                | ConsensusTransactionKind::MisbehaviorReport(_)
+                | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
+                #[allow(deprecated)]
+                ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
             },
-            _ => None,
+            SequencedConsensusTransactionKind::System(_) => None,
         }
     }
 
     pub fn is_end_of_publish(&self) -> bool {
         match self {
-            SequencedConsensusTransactionKind::External(ext) => {
-                matches!(ext.kind, ConsensusTransactionKind::EndOfPublish(..))
-            }
+            // Delegate to the `ConsensusTransaction` helper so the kind check
+            // stays in one place.
+            SequencedConsensusTransactionKind::External(ext) => ext.is_end_of_publish(),
             SequencedConsensusTransactionKind::System(_) => false,
         }
     }
@@ -776,10 +801,11 @@ impl SequencedConsensusTransaction {
     }
 
     pub fn is_end_of_publish(&self) -> bool {
-        if let SequencedConsensusTransactionKind::External(ref transaction) = self.transaction {
-            matches!(transaction.kind, ConsensusTransactionKind::EndOfPublish(..))
-        } else {
-            false
+        // Delegate to the `ConsensusTransaction` helper so the kind check
+        // stays in one place.
+        match &self.transaction {
+            SequencedConsensusTransactionKind::External(ext) => ext.is_end_of_publish(),
+            SequencedConsensusTransactionKind::System(_) => false,
         }
     }
 
@@ -790,45 +816,78 @@ impl SequencedConsensusTransaction {
         )
     }
 
+    /// Returns `true` if this is a user-originated transaction
+    /// (`CertifiedTransaction` or `UserTransactionV1`) that uses randomness.
+    /// Non-user kinds (internal consensus messages, system transactions) are
+    /// always `false`, since only user transactions can request randomness.
     pub fn is_user_tx_with_randomness(&self) -> bool {
         match &self.transaction {
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::CertifiedTransaction(certificate),
-                ..
-            }) => certificate.uses_randomness(),
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV1(transaction),
-                ..
-            }) => transaction.uses_randomness(),
-            _ => false,
+            // Listed exhaustively (no `_` arm) so a new user-transaction kind that
+            // may use randomness must be classified here rather than silently treated
+            // as non-randomness and misrouted.
+            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
+                ConsensusTransactionKind::CertifiedTransaction(cert) => cert.uses_randomness(),
+                ConsensusTransactionKind::UserTransactionV1(txn) => txn.uses_randomness(),
+                // internal consensus messages - not user transactions
+                ConsensusTransactionKind::CheckpointSignature(_)
+                | ConsensusTransactionKind::EndOfPublish(_)
+                | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+                | ConsensusTransactionKind::RandomnessDkgMessage(..)
+                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+                | ConsensusTransactionKind::MisbehaviorReport(_)
+                | ConsensusTransactionKind::OverloadNotificationV1(..) => false,
+                #[allow(deprecated)]
+                ConsensusTransactionKind::NewJWKFetchedDeprecated => false,
+            },
+            SequencedConsensusTransactionKind::System(_) => false,
         }
     }
 
+    /// Returns the transaction data if this is a user-originated
+    /// (`CertifiedTransaction` or `UserTransactionV1`) or system transaction
+    /// that touches at least one shared object, and `None` otherwise (internal
+    /// consensus messages, or a transaction with only owned objects).
     pub fn as_shared_object_txn(&self) -> Option<&SenderSignedData> {
         match &self.transaction {
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::CertifiedTransaction(certificate),
-                ..
-            }) if certificate.contains_shared_object() => Some(certificate.data()),
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV1(transaction),
-                ..
-            }) if transaction.contains_shared_object() => Some(transaction.data()),
-            SequencedConsensusTransactionKind::System(txn) if txn.contains_shared_object() => {
-                Some(txn.data())
+            // Listed exhaustively (no `_` arm) so a new user-transaction kind must
+            // be classified here rather than silently treated as having no shared
+            // objects.
+            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
+                ConsensusTransactionKind::CertifiedTransaction(cert) => {
+                    cert.contains_shared_object().then(|| cert.data())
+                }
+                ConsensusTransactionKind::UserTransactionV1(txn) => {
+                    txn.contains_shared_object().then(|| txn.data())
+                }
+                // internal consensus messages - not shared-object transactions
+                ConsensusTransactionKind::CheckpointSignature(_)
+                | ConsensusTransactionKind::EndOfPublish(_)
+                | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+                | ConsensusTransactionKind::RandomnessDkgMessage(..)
+                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+                | ConsensusTransactionKind::MisbehaviorReport(_)
+                | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
+                #[allow(deprecated)]
+                ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
+            },
+            SequencedConsensusTransactionKind::System(txn) => {
+                txn.contains_shared_object().then(|| txn.data())
             }
-            _ => None,
         }
     }
 
+    /// Returns `true` only for a raw, uncertified user transaction
+    /// (`UserTransactionV1`). Certified user transactions and system
+    /// transactions are not included.
     pub fn is_user_transaction(&self) -> bool {
-        matches!(
-            &self.transaction,
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV1(_),
-                ..
-            })
-        )
+        match &self.transaction {
+            // Classification of user-transaction kinds lives on the enum helper,
+            // so a new kind only has to be handled in one place there.
+            SequencedConsensusTransactionKind::External(ext) => ext.kind.is_user_transaction(),
+            SequencedConsensusTransactionKind::System(_) => false,
+        }
     }
 }
 

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -732,23 +732,7 @@ impl SequencedConsensusTransactionKind {
     /// checkpoint roots and to schedule transactions for execution.
     pub fn executable_transaction_digest(&self) -> Option<TransactionDigest> {
         match self {
-            // Listed exhaustively (no `_` arm) so a new user-transaction kind must
-            // be classified here rather than silently defaulting to non-executable.
-            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
-                ConsensusTransactionKind::CertifiedTransaction(txn) => Some(*txn.digest()),
-                ConsensusTransactionKind::UserTransactionV1(txn) => Some(*txn.digest()),
-                // internal consensus messages - not executable
-                ConsensusTransactionKind::CheckpointSignature(_)
-                | ConsensusTransactionKind::EndOfPublish(_)
-                | ConsensusTransactionKind::CapabilityNotificationV1(_)
-                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-                | ConsensusTransactionKind::RandomnessDkgMessage(..)
-                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-                | ConsensusTransactionKind::MisbehaviorReport(_)
-                | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
-                #[allow(deprecated)]
-                ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
-            },
+            SequencedConsensusTransactionKind::External(ext) => ext.kind.transaction_digest(),
             SequencedConsensusTransactionKind::System(txn) => Some(*txn.digest()),
         }
     }
@@ -760,23 +744,7 @@ impl SequencedConsensusTransactionKind {
     /// and system transactions are eligible to be dropped.
     pub fn user_transaction_digest(&self) -> Option<TransactionDigest> {
         match self {
-            // Listed exhaustively (no `_` arm) so a new user-transaction kind must
-            // be classified here rather than silently defaulting to non-sheddable.
-            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
-                ConsensusTransactionKind::CertifiedTransaction(txn) => Some(*txn.digest()),
-                ConsensusTransactionKind::UserTransactionV1(txn) => Some(*txn.digest()),
-                // internal consensus messages - never shed
-                ConsensusTransactionKind::CheckpointSignature(_)
-                | ConsensusTransactionKind::EndOfPublish(_)
-                | ConsensusTransactionKind::CapabilityNotificationV1(_)
-                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-                | ConsensusTransactionKind::RandomnessDkgMessage(..)
-                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-                | ConsensusTransactionKind::MisbehaviorReport(_)
-                | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
-                #[allow(deprecated)]
-                ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
-            },
+            SequencedConsensusTransactionKind::External(ext) => ext.kind.transaction_digest(),
             SequencedConsensusTransactionKind::System(_) => None,
         }
     }
@@ -822,26 +790,10 @@ impl SequencedConsensusTransaction {
     /// always `false`, since only user transactions can request randomness.
     pub fn is_user_tx_with_randomness(&self) -> bool {
         match &self.transaction {
-            // Listed exhaustively (no `_` arm) so a new user-transaction kind that
-            // may use randomness must be classified here rather than silently treated
-            // as non-randomness and misrouted.
-            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
-                ConsensusTransactionKind::CertifiedTransaction(cert) => cert.uses_randomness(),
-                ConsensusTransactionKind::UserTransactionV1(txn) => txn.uses_randomness(),
-                // internal consensus messages - not user transactions
-                ConsensusTransactionKind::CheckpointSignature(_)
-                | ConsensusTransactionKind::EndOfPublish(_)
-                | ConsensusTransactionKind::CapabilityNotificationV1(_)
-                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-                | ConsensusTransactionKind::RandomnessDkgMessage(..)
-                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-                | ConsensusTransactionKind::MisbehaviorReport(_)
-                | ConsensusTransactionKind::OverloadNotificationV1(..) => false,
-                #[allow(deprecated)]
-                ConsensusTransactionKind::NewJWKFetchedDeprecated => false,
-            },
-            SequencedConsensusTransactionKind::System(_) => false,
+            SequencedConsensusTransactionKind::External(ext) => ext.kind.as_sender_signed_data(),
+            SequencedConsensusTransactionKind::System(_) => None,
         }
+        .is_some_and(|data| data.uses_randomness())
     }
 
     /// Returns the transaction data if this is a user-originated
@@ -850,28 +802,10 @@ impl SequencedConsensusTransaction {
     /// consensus messages, or a transaction with only owned objects).
     pub fn as_shared_object_txn(&self) -> Option<&SenderSignedData> {
         match &self.transaction {
-            // Listed exhaustively (no `_` arm) so a new user-transaction kind must
-            // be classified here rather than silently treated as having no shared
-            // objects.
-            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
-                ConsensusTransactionKind::CertifiedTransaction(cert) => {
-                    cert.contains_shared_object().then(|| cert.data())
-                }
-                ConsensusTransactionKind::UserTransactionV1(txn) => {
-                    txn.contains_shared_object().then(|| txn.data())
-                }
-                // internal consensus messages - not shared-object transactions
-                ConsensusTransactionKind::CheckpointSignature(_)
-                | ConsensusTransactionKind::EndOfPublish(_)
-                | ConsensusTransactionKind::CapabilityNotificationV1(_)
-                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-                | ConsensusTransactionKind::RandomnessDkgMessage(..)
-                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-                | ConsensusTransactionKind::MisbehaviorReport(_)
-                | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
-                #[allow(deprecated)]
-                ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
-            },
+            SequencedConsensusTransactionKind::External(ext) => ext
+                .kind
+                .as_sender_signed_data()
+                .filter(|data| data.contains_shared_object()),
             SequencedConsensusTransactionKind::System(txn) => {
                 txn.contains_shared_object().then(|| txn.data())
             }

--- a/crates/iota-core/src/post_consensus_tx_reorder.rs
+++ b/crates/iota-core/src/post_consensus_tx_reorder.rs
@@ -4,7 +4,7 @@
 
 use iota_metrics::monitored_scope;
 use iota_protocol_config::ConsensusTransactionOrdering;
-use iota_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
+use iota_types::messages_consensus::ConsensusTransactionKind;
 
 use crate::consensus_handler::{
     SequencedConsensusTransactionKind, VerifiedSequencedConsensusTransaction,
@@ -34,17 +34,25 @@ impl PostConsensusTxReorder {
             // beginning.
             std::cmp::Reverse({
                 match &txn.0.transaction {
-                    SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                        tracking_id: _,
-                        kind: ConsensusTransactionKind::CertifiedTransaction(cert),
-                    }) => cert.gas_price(),
-                    SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                        kind: ConsensusTransactionKind::UserTransactionV1(tx),
-                        ..
-                    }) => tx.gas_price(),
-                    // Non-user transactions are considered to have gas price of MAX u64 and are
-                    // put to the beginning.
-                    _ => u64::MAX,
+                    // Listed exhaustively (no `_` arm) so a new user-transaction kind must
+                    // be classified here rather than silently sorting to the front.
+                    SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
+                        ConsensusTransactionKind::CertifiedTransaction(cert) => cert.gas_price(),
+                        ConsensusTransactionKind::UserTransactionV1(tx) => tx.gas_price(),
+                        // Non-user messages carry no gas price and sort to the front.
+                        ConsensusTransactionKind::CheckpointSignature(_)
+                        | ConsensusTransactionKind::EndOfPublish(_)
+                        | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                        | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+                        | ConsensusTransactionKind::RandomnessDkgMessage(..)
+                        | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+                        | ConsensusTransactionKind::MisbehaviorReport(_)
+                        | ConsensusTransactionKind::OverloadNotificationV1(..) => u64::MAX,
+                        #[allow(deprecated)]
+                        ConsensusTransactionKind::NewJWKFetchedDeprecated => u64::MAX,
+                    },
+                    // System transactions carry no gas price and sort to the front.
+                    SequencedConsensusTransactionKind::System(_) => u64::MAX,
                 }
             })
         })

--- a/crates/iota-core/src/post_consensus_tx_reorder.rs
+++ b/crates/iota-core/src/post_consensus_tx_reorder.rs
@@ -4,7 +4,7 @@
 
 use iota_metrics::monitored_scope;
 use iota_protocol_config::ConsensusTransactionOrdering;
-use iota_types::messages_consensus::ConsensusTransactionKind;
+use iota_types::transaction::TransactionDataAPI;
 
 use crate::consensus_handler::{
     SequencedConsensusTransactionKind, VerifiedSequencedConsensusTransaction,
@@ -30,31 +30,19 @@ impl PostConsensusTxReorder {
     fn order_by_gas_price(transactions: &mut [VerifiedSequencedConsensusTransaction]) {
         let _scope = monitored_scope("HandleConsensusOutput::order_by_gas_price");
         transactions.sort_by_key(|txn| {
-            // Reverse order, so that transactions with higher gas price are put to the
-            // beginning.
-            std::cmp::Reverse({
-                match &txn.0.transaction {
-                    // Listed exhaustively (no `_` arm) so a new user-transaction kind must
-                    // be classified here rather than silently sorting to the front.
-                    SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
-                        ConsensusTransactionKind::CertifiedTransaction(cert) => cert.gas_price(),
-                        ConsensusTransactionKind::UserTransactionV1(tx) => tx.gas_price(),
-                        // Non-user messages carry no gas price and sort to the front.
-                        ConsensusTransactionKind::CheckpointSignature(_)
-                        | ConsensusTransactionKind::EndOfPublish(_)
-                        | ConsensusTransactionKind::CapabilityNotificationV1(_)
-                        | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-                        | ConsensusTransactionKind::RandomnessDkgMessage(..)
-                        | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-                        | ConsensusTransactionKind::MisbehaviorReport(_)
-                        | ConsensusTransactionKind::OverloadNotificationV1(..) => u64::MAX,
-                        #[allow(deprecated)]
-                        ConsensusTransactionKind::NewJWKFetchedDeprecated => u64::MAX,
-                    },
-                    // System transactions carry no gas price and sort to the front.
-                    SequencedConsensusTransactionKind::System(_) => u64::MAX,
+            // Reverse order, so transactions with higher gas price sort to the front.
+            // Internal messages and system transactions carry no gas price and sort
+            // to the front via `u64::MAX`.
+            let gas_price = match &txn.0.transaction {
+                SequencedConsensusTransactionKind::External(ext) => {
+                    ext.kind.as_sender_signed_data()
                 }
-            })
+                SequencedConsensusTransactionKind::System(_) => None,
+            }
+            .map(|data| data.transaction_data().gas_price())
+            .unwrap_or(u64::MAX);
+
+            std::cmp::Reverse(gas_price)
         })
     }
 }

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -42,7 +42,6 @@ use iota_common::fatal;
 use iota_sdk_types::{ObjectReference, TransactionDigest};
 use iota_types::{
     error::{IotaError, IotaResult},
-    messages_consensus::ConsensusTransactionKind,
     transaction::{InputObjectKind, VerifiedTransaction},
 };
 use tracing::{debug, warn};
@@ -120,28 +119,12 @@ pub async fn validate_and_resolve_conflicts(
             continue;
         }
 
-        // Only validate UserTransactionV1; pass everything else through
-        // unchanged.
-        let transaction = match &tx.0.transaction {
-            // Listed exhaustively (no `_` arm) so a new user-transaction kind must
-            // be classified here rather than silently skipping validation.
-            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
-                ConsensusTransactionKind::UserTransactionV1(t) => t,
-                // Certified transactions, system transactions, and internal consensus
-                // messages pass through unchanged.
-                ConsensusTransactionKind::CertifiedTransaction(_)
-                | ConsensusTransactionKind::CheckpointSignature(_)
-                | ConsensusTransactionKind::EndOfPublish(_)
-                | ConsensusTransactionKind::CapabilityNotificationV1(_)
-                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-                | ConsensusTransactionKind::RandomnessDkgMessage(..)
-                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-                | ConsensusTransactionKind::MisbehaviorReport(_)
-                | ConsensusTransactionKind::OverloadNotificationV1(..) => continue,
-                #[allow(deprecated)]
-                ConsensusTransactionKind::NewJWKFetchedDeprecated => continue,
-            },
-            SequencedConsensusTransactionKind::System(_) => continue,
+        // Only validate UserTransactionV1; pass everything else through unchanged.
+        let Some(transaction) = (match &tx.0.transaction {
+            SequencedConsensusTransactionKind::External(ext) => ext.kind.as_user_transaction(),
+            SequencedConsensusTransactionKind::System(_) => None,
+        }) else {
+            continue;
         };
 
         let digest = *transaction.digest();
@@ -277,7 +260,7 @@ pub async fn validate_and_resolve_conflicts(
         // (2f+1 Byzantine/buggy validators), not something we can recover from
         // by rejecting the transaction post-consensus. Doing so would also risk
         // diverging from other honest validators.
-        let verified_tx = VerifiedTransaction::new_from_verified((**transaction).clone());
+        let verified_tx = VerifiedTransaction::new_from_verified((*transaction).clone());
         if let Err(e) = authority_state
             .handle_transaction_validation_checks(&verified_tx, epoch_store)
             .await
@@ -363,23 +346,9 @@ fn extract_owned_input_objects(
     tx: &VerifiedSequencedConsensusTransaction,
 ) -> IotaResult<Vec<ObjectReference>> {
     let Some(transaction_data) = (match &tx.0.transaction {
-        // Listed exhaustively (no `_` arm) so a new user-transaction kind must
-        // be classified here rather than silently returning the error below.
-        SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
-            ConsensusTransactionKind::UserTransactionV1(transaction) => Some(transaction.data()),
-            // Not a raw user transaction - no owned inputs to extract here.
-            ConsensusTransactionKind::CertifiedTransaction(_)
-            | ConsensusTransactionKind::CheckpointSignature(_)
-            | ConsensusTransactionKind::EndOfPublish(_)
-            | ConsensusTransactionKind::CapabilityNotificationV1(_)
-            | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-            | ConsensusTransactionKind::RandomnessDkgMessage(..)
-            | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-            | ConsensusTransactionKind::MisbehaviorReport(_)
-            | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
-            #[allow(deprecated)]
-            ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
-        },
+        SequencedConsensusTransactionKind::External(ext) => {
+            ext.kind.as_user_transaction().map(|t| t.data())
+        }
         SequencedConsensusTransactionKind::System(_) => None,
     }) else {
         return Err(IotaError::GenericAuthority {

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -128,7 +128,7 @@ pub async fn validate_and_resolve_conflicts(
             SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
                 ConsensusTransactionKind::UserTransactionV1(t) => t,
                 // Certified transactions, system transactions, and internal consensus
-                // message pass through unchanged.
+                // messages pass through unchanged.
                 ConsensusTransactionKind::CertifiedTransaction(_)
                 | ConsensusTransactionKind::CheckpointSignature(_)
                 | ConsensusTransactionKind::EndOfPublish(_)
@@ -362,7 +362,7 @@ fn find_existing_lock(
 fn extract_owned_input_objects(
     tx: &VerifiedSequencedConsensusTransaction,
 ) -> IotaResult<Vec<ObjectReference>> {
-    let transaction_data_opt = match &tx.0.transaction {
+    let Some(transaction_data) = (match &tx.0.transaction {
         // Listed exhaustively (no `_` arm) so a new user-transaction kind must
         // be classified here rather than silently returning the error below.
         SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
@@ -381,10 +381,7 @@ fn extract_owned_input_objects(
             ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
         },
         SequencedConsensusTransactionKind::System(_) => None,
-    };
-    let transaction_data = if let Some(transaction_data) = transaction_data_opt {
-        transaction_data
-    } else {
+    }) else {
         return Err(IotaError::GenericAuthority {
             error: "Expected UserTransactionV1 in extract_owned_input_objects".to_string(),
         });

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -42,7 +42,7 @@ use iota_common::fatal;
 use iota_sdk_types::{ObjectReference, TransactionDigest};
 use iota_types::{
     error::{IotaError, IotaResult},
-    messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
+    messages_consensus::ConsensusTransactionKind,
     transaction::{InputObjectKind, VerifiedTransaction},
 };
 use tracing::{debug, warn};
@@ -123,11 +123,25 @@ pub async fn validate_and_resolve_conflicts(
         // Only validate UserTransactionV1; pass everything else through
         // unchanged.
         let transaction = match &tx.0.transaction {
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV1(t),
-                ..
-            }) => t,
-            _ => continue,
+            // Listed exhaustively (no `_` arm) so a new user-transaction kind must
+            // be classified here rather than silently skipping validation.
+            SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
+                ConsensusTransactionKind::UserTransactionV1(t) => t,
+                // Certified transactions, system transactions, and internal consensus
+                // message pass through unchanged.
+                ConsensusTransactionKind::CertifiedTransaction(_)
+                | ConsensusTransactionKind::CheckpointSignature(_)
+                | ConsensusTransactionKind::EndOfPublish(_)
+                | ConsensusTransactionKind::CapabilityNotificationV1(_)
+                | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+                | ConsensusTransactionKind::RandomnessDkgMessage(..)
+                | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+                | ConsensusTransactionKind::MisbehaviorReport(_)
+                | ConsensusTransactionKind::OverloadNotificationV1(..) => continue,
+                #[allow(deprecated)]
+                ConsensusTransactionKind::NewJWKFetchedDeprecated => continue,
+            },
+            SequencedConsensusTransactionKind::System(_) => continue,
         };
 
         let digest = *transaction.digest();
@@ -348,16 +362,32 @@ fn find_existing_lock(
 fn extract_owned_input_objects(
     tx: &VerifiedSequencedConsensusTransaction,
 ) -> IotaResult<Vec<ObjectReference>> {
-    let transaction_data = match &tx.0.transaction {
-        SequencedConsensusTransactionKind::External(ConsensusTransaction {
-            kind: ConsensusTransactionKind::UserTransactionV1(transaction),
-            ..
-        }) => transaction.data(),
-        _ => {
-            return Err(IotaError::GenericAuthority {
-                error: "Expected UserTransactionV1 in extract_owned_input_objects".to_string(),
-            });
-        }
+    let transaction_data_opt = match &tx.0.transaction {
+        // Listed exhaustively (no `_` arm) so a new user-transaction kind must
+        // be classified here rather than silently returning the error below.
+        SequencedConsensusTransactionKind::External(ext) => match &ext.kind {
+            ConsensusTransactionKind::UserTransactionV1(transaction) => Some(transaction.data()),
+            // Not a raw user transaction - no owned inputs to extract here.
+            ConsensusTransactionKind::CertifiedTransaction(_)
+            | ConsensusTransactionKind::CheckpointSignature(_)
+            | ConsensusTransactionKind::EndOfPublish(_)
+            | ConsensusTransactionKind::CapabilityNotificationV1(_)
+            | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+            | ConsensusTransactionKind::RandomnessDkgMessage(..)
+            | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+            | ConsensusTransactionKind::MisbehaviorReport(_)
+            | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
+            #[allow(deprecated)]
+            ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
+        },
+        SequencedConsensusTransactionKind::System(_) => None,
+    };
+    let transaction_data = if let Some(transaction_data) = transaction_data_opt {
+        transaction_data
+    } else {
+        return Err(IotaError::GenericAuthority {
+            error: "Expected UserTransactionV1 in extract_owned_input_objects".to_string(),
+        });
     };
 
     // Use SenderSignedData::input_objects() rather than

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -28,7 +28,7 @@ use crate::{
     supported_protocol_versions::{
         Chain, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
-    transaction::{CertifiedTransaction, Transaction},
+    transaction::{CertifiedTransaction, SenderSignedData, Transaction},
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -258,6 +258,29 @@ pub enum ConsensusTransactionKind {
 }
 
 impl ConsensusTransactionKind {
+    /// The signed data of the underlying user transaction (certified or raw),
+    /// or `None` for internal consensus messages.
+    pub fn as_sender_signed_data(&self) -> Option<&SenderSignedData> {
+        // Listed exhaustively (no `_` arm) so a new user-transaction kind must be
+        // classified here. This is the single place the consensus-handling sites
+        // rely on to decide whether a transaction carries user-signed data, so a
+        // new variant is caught once here rather than silently missed at each site.
+        match self {
+            Self::CertifiedTransaction(c) => Some(c.data()),
+            Self::UserTransactionV1(t) => Some(t.data()),
+            Self::CheckpointSignature(_)
+            | Self::EndOfPublish(_)
+            | Self::CapabilityNotificationV1(_)
+            | Self::SignedCapabilityNotificationV1(_)
+            | Self::RandomnessDkgMessage(..)
+            | Self::RandomnessDkgConfirmation(..)
+            | Self::MisbehaviorReport(_)
+            | Self::OverloadNotificationV1(..) => None,
+            #[allow(deprecated)]
+            Self::NewJWKFetchedDeprecated => None,
+        }
+    }
+
     pub fn is_dkg(&self) -> bool {
         matches!(
             self,

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -258,83 +258,88 @@ pub enum ConsensusTransactionKind {
 }
 
 impl ConsensusTransactionKind {
-    /// The signed data of the underlying user transaction (certified or raw),
+    // NOTE: Keep every match in this impl exhaustive (no `_` arm) so a new
+    // `ConsensusTransactionKind` variant must be classified here rather
+    // than being silently mishandled.
+
+    /// Helper that applies the matching projection to the underlying certified
+    /// or raw user transaction, or `None` for internal consensus messages.
+    fn map_cert_or_raw_user_tx<'a, R>(
+        &'a self,
+        certified: impl FnOnce(&'a CertifiedTransaction) -> R,
+        raw: impl FnOnce(&'a Transaction) -> R,
+    ) -> Option<R> {
+        match self {
+            Self::CertifiedTransaction(c) => Some(certified(c)),
+            Self::UserTransactionV1(t) => Some(raw(t)),
+            Self::CheckpointSignature(_)
+            | Self::EndOfPublish(_)
+            | Self::CapabilityNotificationV1(_)
+            | Self::SignedCapabilityNotificationV1(_)
+            | Self::RandomnessDkgMessage(..)
+            | Self::RandomnessDkgConfirmation(..)
+            | Self::MisbehaviorReport(_)
+            | Self::OverloadNotificationV1(..) => None,
+            #[allow(deprecated)]
+            Self::NewJWKFetchedDeprecated => None,
+        }
+    }
+
+    /// The signed data of the underlying certified or raw user transaction,
     /// or `None` for internal consensus messages.
     pub fn as_sender_signed_data(&self) -> Option<&SenderSignedData> {
-        // Listed exhaustively (no `_` arm) so a new user-transaction kind must be
-        // classified here. This is the single place the consensus-handling sites
-        // rely on to decide whether a transaction carries user-signed data, so a
-        // new variant is caught once here rather than silently missed at each site.
-        match self {
-            Self::CertifiedTransaction(c) => Some(c.data()),
-            Self::UserTransactionV1(t) => Some(t.data()),
-            Self::CheckpointSignature(_)
-            | Self::EndOfPublish(_)
-            | Self::CapabilityNotificationV1(_)
-            | Self::SignedCapabilityNotificationV1(_)
-            | Self::RandomnessDkgMessage(..)
-            | Self::RandomnessDkgConfirmation(..)
-            | Self::MisbehaviorReport(_)
-            | Self::OverloadNotificationV1(..) => None,
-            #[allow(deprecated)]
-            Self::NewJWKFetchedDeprecated => None,
-        }
+        self.map_cert_or_raw_user_tx(|c| c.data(), |t| t.data())
     }
 
-    /// The (cached) transaction digest if this is a user transaction or
-    /// certificate, else `None`.
+    /// The (cached) transaction digest of the underlying certified or raw
+    /// user transaction, or `None` for internal consensus messages.
     pub fn transaction_digest(&self) -> Option<TransactionDigest> {
-        match self {
-            Self::CertifiedTransaction(c) => Some(*c.digest()),
-            Self::UserTransactionV1(t) => Some(*t.digest()),
-            Self::CheckpointSignature(_)
-            | Self::EndOfPublish(_)
-            | Self::CapabilityNotificationV1(_)
-            | Self::SignedCapabilityNotificationV1(_)
-            | Self::RandomnessDkgMessage(..)
-            | Self::RandomnessDkgConfirmation(..)
-            | Self::MisbehaviorReport(_)
-            | Self::OverloadNotificationV1(..) => None,
-            #[allow(deprecated)]
-            Self::NewJWKFetchedDeprecated => None,
-        }
-    }
-
-    pub fn is_dkg(&self) -> bool {
-        matches!(
-            self,
-            ConsensusTransactionKind::RandomnessDkgMessage(_, _)
-                | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
-        )
+        self.map_cert_or_raw_user_tx(|c| *c.digest(), |t| *t.digest())
     }
 
     /// Returns the raw, uncertified user transaction (`UserTransactionV1`)
     /// submitted directly to consensus, or `None` for any other kind. Certified
-    /// user transactions are not included.
+    /// user transactions are not included here.
     pub fn as_user_transaction(&self) -> Option<&Transaction> {
-        // Listed exhaustively (no `_` arm) so a new user-transaction kind must be
-        // classified here rather than silently treated as a non-user transaction.
         match self {
-            ConsensusTransactionKind::UserTransactionV1(tx) => Some(tx),
-            ConsensusTransactionKind::CertifiedTransaction(_)
-            | ConsensusTransactionKind::CheckpointSignature(_)
-            | ConsensusTransactionKind::EndOfPublish(_)
-            | ConsensusTransactionKind::CapabilityNotificationV1(_)
-            | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
-            | ConsensusTransactionKind::RandomnessDkgMessage(..)
-            | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
-            | ConsensusTransactionKind::MisbehaviorReport(_)
-            | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
+            Self::UserTransactionV1(tx) => Some(tx),
+            Self::CertifiedTransaction(_)
+            | Self::CheckpointSignature(_)
+            | Self::EndOfPublish(_)
+            | Self::CapabilityNotificationV1(_)
+            | Self::SignedCapabilityNotificationV1(_)
+            | Self::RandomnessDkgMessage(..)
+            | Self::RandomnessDkgConfirmation(..)
+            | Self::MisbehaviorReport(_)
+            | Self::OverloadNotificationV1(..) => None,
             #[allow(deprecated)]
-            ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
+            Self::NewJWKFetchedDeprecated => None,
         }
     }
 
     /// Returns `true` only for a raw, uncertified user transaction
     /// (`UserTransactionV1`) submitted directly to consensus. Certified user
-    /// transactions are not included - check those with `is_user_certificate`.
+    /// transactions are not included here.
     pub fn is_user_transaction(&self) -> bool {
         self.as_user_transaction().is_some()
+    }
+
+    /// Returns `true` for the randomness DKG messages
+    /// (`RandomnessDkgMessage` and `RandomnessDkgConfirmation`).
+    pub fn is_dkg(&self) -> bool {
+        match self {
+            Self::RandomnessDkgMessage(_, _) | Self::RandomnessDkgConfirmation(_, _) => true,
+            Self::UserTransactionV1(_)
+            | Self::CertifiedTransaction(_)
+            | Self::CheckpointSignature(_)
+            | Self::EndOfPublish(_)
+            | Self::CapabilityNotificationV1(_)
+            | Self::SignedCapabilityNotificationV1(_)
+            | Self::MisbehaviorReport(_)
+            | Self::OverloadNotificationV1(..) => false,
+            #[allow(deprecated)]
+            Self::NewJWKFetchedDeprecated => false,
+        }
     }
 }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -266,8 +266,26 @@ impl ConsensusTransactionKind {
         )
     }
 
+    /// Returns `true` only for a raw, uncertified user transaction
+    /// (`UserTransactionV1`) submitted directly to consensus. Certified user
+    /// transactions are not included - check those with `is_user_certificate`.
     pub fn is_user_transaction(&self) -> bool {
-        matches!(self, ConsensusTransactionKind::UserTransactionV1(_))
+        // Listed exhaustively (no `_` arm) so a new user-transaction kind must be
+        // classified here rather than silently treated as a non-user transaction.
+        match self {
+            ConsensusTransactionKind::UserTransactionV1(_) => true,
+            ConsensusTransactionKind::CertifiedTransaction(_)
+            | ConsensusTransactionKind::CheckpointSignature(_)
+            | ConsensusTransactionKind::EndOfPublish(_)
+            | ConsensusTransactionKind::CapabilityNotificationV1(_)
+            | ConsensusTransactionKind::SignedCapabilityNotificationV1(_)
+            | ConsensusTransactionKind::RandomnessDkgMessage(..)
+            | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
+            | ConsensusTransactionKind::MisbehaviorReport(_)
+            | ConsensusTransactionKind::OverloadNotificationV1(..) => false,
+            #[allow(deprecated)]
+            ConsensusTransactionKind::NewJWKFetchedDeprecated => false,
+        }
     }
 }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -308,14 +308,14 @@ impl ConsensusTransactionKind {
         )
     }
 
-    /// Returns `true` only for a raw, uncertified user transaction
-    /// (`UserTransactionV1`) submitted directly to consensus. Certified user
-    /// transactions are not included - check those with `is_user_certificate`.
-    pub fn is_user_transaction(&self) -> bool {
+    /// Returns the raw, uncertified user transaction (`UserTransactionV1`)
+    /// submitted directly to consensus, or `None` for any other kind. Certified
+    /// user transactions are not included.
+    pub fn as_user_transaction(&self) -> Option<&Transaction> {
         // Listed exhaustively (no `_` arm) so a new user-transaction kind must be
         // classified here rather than silently treated as a non-user transaction.
         match self {
-            ConsensusTransactionKind::UserTransactionV1(_) => true,
+            ConsensusTransactionKind::UserTransactionV1(tx) => Some(tx),
             ConsensusTransactionKind::CertifiedTransaction(_)
             | ConsensusTransactionKind::CheckpointSignature(_)
             | ConsensusTransactionKind::EndOfPublish(_)
@@ -324,10 +324,17 @@ impl ConsensusTransactionKind {
             | ConsensusTransactionKind::RandomnessDkgMessage(..)
             | ConsensusTransactionKind::RandomnessDkgConfirmation(..)
             | ConsensusTransactionKind::MisbehaviorReport(_)
-            | ConsensusTransactionKind::OverloadNotificationV1(..) => false,
+            | ConsensusTransactionKind::OverloadNotificationV1(..) => None,
             #[allow(deprecated)]
-            ConsensusTransactionKind::NewJWKFetchedDeprecated => false,
+            ConsensusTransactionKind::NewJWKFetchedDeprecated => None,
         }
+    }
+
+    /// Returns `true` only for a raw, uncertified user transaction
+    /// (`UserTransactionV1`) submitted directly to consensus. Certified user
+    /// transactions are not included - check those with `is_user_certificate`.
+    pub fn is_user_transaction(&self) -> bool {
+        self.as_user_transaction().is_some()
     }
 }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -281,6 +281,25 @@ impl ConsensusTransactionKind {
         }
     }
 
+    /// The (cached) transaction digest if this is a user transaction or
+    /// certificate, else `None`.
+    pub fn transaction_digest(&self) -> Option<TransactionDigest> {
+        match self {
+            Self::CertifiedTransaction(c) => Some(*c.digest()),
+            Self::UserTransactionV1(t) => Some(*t.digest()),
+            Self::CheckpointSignature(_)
+            | Self::EndOfPublish(_)
+            | Self::CapabilityNotificationV1(_)
+            | Self::SignedCapabilityNotificationV1(_)
+            | Self::RandomnessDkgMessage(..)
+            | Self::RandomnessDkgConfirmation(..)
+            | Self::MisbehaviorReport(_)
+            | Self::OverloadNotificationV1(..) => None,
+            #[allow(deprecated)]
+            Self::NewJWKFetchedDeprecated => None,
+        }
+    }
+
     pub fn is_dkg(&self) -> bool {
         matches!(
             self,


### PR DESCRIPTION
# Description of change

This PR replaces wildcard (`_ =>`) arms in the consensus transaction-handling code with explicit per-variant arms, so every site that classifies a `ConsensusTransactionKind` is either an exhaustive match or delegates to a shared exhaustive helper. No behavior change.

**Rationale:** A new user-transaction variant (e.g., `UserTransactionV2`) added to the enum would today fall into an existing wildcard `_` arm and be silently misclassified. During attestation stress tests, one such case caused zero `UserTransactionV2` transactions to be dropped by post-consensus load-shedding despite a non-zero quorum shedding percentage. Making the matches exhaustive turns each of these into a compile error, forcing whoever adds the variant to decide its behavior at every site.

Sites hardened: `consensus_handler.rs`, `consensus_adapter.rs`, `consensus_quarantine.rs`, `post_consensus_tx_reorder.rs`, `post_consensus_validation.rs`, `messages_consensus.rs`.

`await_submit_delay` and `reexecute_pending_consensus_certs` are intentionally left unchanged: `UserTransactionV1` already sits in the default arm, so a new variant inherits the correct behavior there; only `CertifiedTransaction` gets special handling, and there is no plan for a "certified V2".

## Links to any relevant issues

Related PR https://github.com/iotaledger/iota/pull/12205.

This PR targets `develop`; after the merge, `protocol-research/feat/transaction-attestation-feature` will be rebased to pick up the changes.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
