### PR TITLE
feat(graphql): Add possibility to read txs affected by address in graphql

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.move
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests the `affectedAddress` filter: a transaction affects an address when
+// the address is the sender or a recipient. Also tests the AFFECTED relation
+// on `Address.transactionBlocks` and combining the filter with other filters.
+
+//# init --protocol-version 15 --addresses Test=0x0 --accounts A B C --simulator
+
+//# programmable --sender A --inputs 1000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender B --inputs 2000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender B --inputs 3000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+query {
+  affectedAsSender: transactionBlocks(filter: { affectedAddress: "@{A}" }) {
+    nodes { digest }
+  }
+  affectedAsRecipient: transactionBlocks(filter: { affectedAddress: "@{C}" }) {
+    nodes { digest }
+  }
+  affectedBoth: transactionBlocks(filter: { affectedAddress: "@{B}" }) {
+    nodes { digest }
+  }
+  combinedWithKind: transactionBlocks(filter: { affectedAddress: "@{B}", kind: PROGRAMMABLE_TX }, scanLimit: 10) {
+    nodes { digest }
+  }
+  combinedWithSent: transactionBlocks(filter: { affectedAddress: "@{B}", sentAddress: "@{B}" }) {
+    nodes { digest }
+  }
+  combinedWithOtherSent: transactionBlocks(filter: { affectedAddress: "@{C}", sentAddress: "@{B}" }) {
+    nodes { digest }
+  }
+  affectedViaAddress: address(address: "@{B}") {
+    transactionBlocks(relation: AFFECTED) {
+      nodes { digest }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.snap
@@ -1,0 +1,126 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 10-12:
+//# programmable --sender A --inputs 1000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 14-16:
+//# programmable --sender B --inputs 2000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 18-20:
+//# programmable --sender B --inputs 3000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 4, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 24-49:
+//# run-graphql
+Response: {
+  "data": {
+    "affectedAsRecipient": {
+      "nodes": [
+        {
+          "digest": "6JMNrTEhpNEP9r9XGcHJxU8SNZidgXgx27KKmVGnT4gw"
+        },
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        }
+      ]
+    },
+    "affectedAsSender": {
+      "nodes": [
+        {
+          "digest": "6JMNrTEhpNEP9r9XGcHJxU8SNZidgXgx27KKmVGnT4gw"
+        },
+        {
+          "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
+        }
+      ]
+    },
+    "affectedBoth": {
+      "nodes": [
+        {
+          "digest": "6JMNrTEhpNEP9r9XGcHJxU8SNZidgXgx27KKmVGnT4gw"
+        },
+        {
+          "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
+        },
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        },
+        {
+          "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
+        }
+      ]
+    },
+    "affectedViaAddress": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "6JMNrTEhpNEP9r9XGcHJxU8SNZidgXgx27KKmVGnT4gw"
+          },
+          {
+            "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
+          },
+          {
+            "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+          },
+          {
+            "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
+          }
+        ]
+      }
+    },
+    "combinedWithKind": {
+      "nodes": [
+        {
+          "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
+        },
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        },
+        {
+          "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
+        }
+      ]
+    },
+    "combinedWithOtherSent": {
+      "nodes": [
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        }
+      ]
+    },
+    "combinedWithSent": {
+      "nodes": [
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        },
+        {
+          "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
+        }
+      ]
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -110,7 +110,8 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sent or received.
+The possible relationship types for a transaction block: sent, received,
+or affected.
 """
 enum AddressTransactionBlockRelationship {
 	"""
@@ -121,6 +122,11 @@ enum AddressTransactionBlockRelationship {
 	Transactions that sent objects to this address.
 	"""
 	RECV
+	"""
+	Transactions that affected this address (the address is the sender or
+	a recipient).
+	"""
+	AFFECTED
 }
 
 """
@@ -4555,6 +4561,11 @@ input TransactionBlockFilter {
 	Limit to transactions that sent an object to the given address.
 	"""
 	recvAddress: IotaAddress
+	"""
+	Limit to transactions that affected the given address (the address is
+	the sender or a recipient).
+	"""
+	affectedAddress: IotaAddress
 	"""
 	Limit to transactions that accepted the given object as an input.
 	"""

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -123,8 +123,8 @@ enum AddressTransactionBlockRelationship {
 	"""
 	RECV
 	"""
-	Transactions that affected this address (the address is the sender or
-	a recipient).
+	Transactions that affected this address (the address is the sender,
+	a recipient, or the owner of the gas payment).
 	"""
 	AFFECTED
 }
@@ -4563,7 +4563,7 @@ input TransactionBlockFilter {
 	recvAddress: IotaAddress
 	"""
 	Limit to transactions that affected the given address (the address is
-	the sender or a recipient).
+	the sender, a recipient, or the owner of the gas payment).
 	"""
 	affectedAddress: IotaAddress
 	"""

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -29,13 +29,17 @@ pub(crate) struct Address {
     pub checkpoint_viewed_at: u64,
 }
 
-/// The possible relationship types for a transaction block: sent or received.
+/// The possible relationship types for a transaction block: sent, received,
+/// or affected.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum AddressTransactionBlockRelationship {
     /// Transactions this address has sent.
     Sent,
     /// Transactions that sent objects to this address.
     Recv,
+    /// Transactions that affected this address (the address is the sender or
+    /// a recipient).
+    Affected,
 }
 
 /// The 32-byte address that is an account address (corresponding to a public
@@ -197,6 +201,11 @@ impl Address {
 
             Some(R::Recv) => TransactionBlockFilter {
                 recv_address: Some(self.address),
+                ..Default::default()
+            },
+
+            Some(R::Affected) => TransactionBlockFilter {
+                affected_address: Some(self.address),
                 ..Default::default()
             },
         }) else {

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -37,8 +37,8 @@ pub(crate) enum AddressTransactionBlockRelationship {
     Sent,
     /// Transactions that sent objects to this address.
     Recv,
-    /// Transactions that affected this address (the address is the sender or
-    /// a recipient).
+    /// Transactions that affected this address (the address is the sender,
+    /// a recipient, or the owner of the gas payment).
     Affected,
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -34,6 +34,9 @@ pub(crate) struct TransactionBlockFilter {
     pub sent_address: Option<IotaAddress>,
     /// Limit to transactions that sent an object to the given address.
     pub recv_address: Option<IotaAddress>,
+    /// Limit to transactions that affected the given address (the address is
+    /// the sender or a recipient).
+    pub affected_address: Option<IotaAddress>,
     /// Limit to transactions that accepted the given object as an input.
     pub input_object: Option<IotaAddress>,
     /// Limit to transactions that output a version of this object.
@@ -67,6 +70,7 @@ impl TransactionBlockFilter {
 
             sent_address: intersect!(sent_address, intersect::by_eq)?,
             recv_address: intersect!(recv_address, intersect::by_eq)?,
+            affected_address: intersect!(affected_address, intersect::by_eq)?,
             input_object: intersect!(input_object, intersect::by_eq)?,
             changed_object: intersect!(changed_object, intersect::by_eq)?,
             wrapped_or_deleted_object: intersect!(wrapped_or_deleted_object, intersect::by_eq)?,
@@ -88,6 +92,7 @@ impl TransactionBlockFilter {
             self.function.is_some(),
             self.kind.is_some(),
             self.recv_address.is_some(),
+            self.affected_address.is_some(),
             self.input_object.is_some(),
             self.changed_object.is_some(),
             self.wrapped_or_deleted_object.is_some(),
@@ -107,6 +112,7 @@ impl TransactionBlockFilter {
         if self.function.is_none()
             && self.kind.is_none()
             && self.recv_address.is_none()
+            && self.affected_address.is_none()
             && self.input_object.is_none()
             && self.changed_object.is_none()
             && self.wrapped_or_deleted_object.is_none()
@@ -124,6 +130,7 @@ impl TransactionBlockFilter {
             || self.kind.is_some()
             || self.sent_address.is_some()
             || self.recv_address.is_some()
+            || self.affected_address.is_some()
             || self.input_object.is_some()
             || self.changed_object.is_some()
             || self.wrapped_or_deleted_object.is_some()

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -35,7 +35,7 @@ pub(crate) struct TransactionBlockFilter {
     /// Limit to transactions that sent an object to the given address.
     pub recv_address: Option<IotaAddress>,
     /// Limit to transactions that affected the given address (the address is
-    /// the sender or a recipient).
+    /// the sender, a recipient, or the owner of the gas payment).
     pub affected_address: Option<IotaAddress>,
     /// Limit to transactions that accepted the given object as an input.
     pub input_object: Option<IotaAddress>,

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -460,7 +460,7 @@ impl TransactionBlock {
 
                     (prev, next, iter.collect())
                 } else {
-                    let subquery = subqueries(&filter, tx_bounds).unwrap();
+                    let subquery = subqueries(&filter, tx_bounds, &page).unwrap();
                     let (prev, next, results) =
                         page.paginate_raw_query::<TxLookup>(conn, checkpoint_viewed_at, subquery)?;
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -349,6 +349,9 @@ pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -
     if let Some(recv) = &filter.recv_address {
         subqueries.push(("tx_recipients", select_recipient(recv, sender, tx_bounds)));
     }
+    if let Some(affected) = &filter.affected_address {
+        subqueries.push(("tx_affected", select_affected(affected, sender, tx_bounds)));
+    }
     if let Some(input) = &filter.input_object {
         subqueries.push(("tx_input_objects", select_input(input, sender, tx_bounds)));
     }
@@ -480,6 +483,26 @@ fn select_recipient(recv: &IotaAddress, sender: Option<IotaAddress>, bound: TxBo
     filter!(
         select_tx(sender, bound, "tx_recipients"),
         format!("recipient = {}", bytea_literal(recv.as_slice()))
+    )
+}
+
+fn select_affected(
+    affected: &IotaAddress,
+    sender: Option<IotaAddress>,
+    bound: TxBounds,
+) -> RawQuery {
+    let recipients = select_recipient(affected, sender, bound);
+    // A `sender` filter different from `affected` can only match transactions
+    // where `affected` is the recipient.
+    if sender.is_some_and(|sender| sender != *affected) {
+        return recipients;
+    }
+    // The UNION is wrapped in a select so that later filters and ordering
+    // apply to the whole result, not just the second select.
+    query!(
+        "SELECT tx_sequence_number FROM ({} UNION {}) AS affected",
+        select_sender(affected, bound),
+        recipients
     )
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -323,8 +323,13 @@ fn min_option<T: Ord>(xs: impl IntoIterator<Item = Option<T>>) -> Option<T> {
 
 /// Constructs a `RawQuery` as a join over all relevant side tables, filtered on
 /// their own filter condition, plus optionally a sender, plus optionally tx/cp
-/// bounds.
-pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -> Option<RawQuery> {
+/// bounds. An `affected_address` filter without a `sender` filter is a special
+/// case, handled by `select_affected`.
+pub(crate) fn subqueries(
+    filter: &TransactionBlockFilter,
+    tx_bounds: TxBounds,
+    page: &Page<Cursor>,
+) -> Option<RawQuery> {
     let sender = filter.sent_address;
 
     let mut subqueries = vec![];
@@ -349,9 +354,6 @@ pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -
     if let Some(recv) = &filter.recv_address {
         subqueries.push(("tx_recipients", select_recipient(recv, sender, tx_bounds)));
     }
-    if let Some(affected) = &filter.affected_address {
-        subqueries.push(("tx_affected", select_affected(affected, sender, tx_bounds)));
-    }
     if let Some(input) = &filter.input_object {
         subqueries.push(("tx_input_objects", select_input(input, sender, tx_bounds)));
     }
@@ -374,6 +376,30 @@ pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -
         subqueries.push(("tx_digests", select_ids(txs, tx_bounds)));
     }
 
+    if let Some(affected) = &filter.affected_address {
+        match sender {
+            // A `sender` filter equal to `affected` can only match transactions
+            // where `affected` is the sender.
+            Some(sender) if sender == *affected => {
+                subqueries.push(("tx_affected", select_sender(affected, tx_bounds)));
+            }
+            // A `sender` filter different from `affected` can only match
+            // transactions where `affected` is the recipient.
+            Some(_) => {
+                subqueries.push(("tx_affected", select_recipient(affected, sender, tx_bounds)));
+            }
+            // Otherwise `affected` can be either the sender or a recipient,
+            // so we query both.
+            None => return Some(select_affected(affected, subqueries, tx_bounds, page)),
+        }
+    }
+
+    join_subqueries(subqueries)
+}
+
+/// Joins `subqueries` on `tx_sequence_number` into a single query, or `None` if
+/// there are no subqueries.
+fn join_subqueries(mut subqueries: Vec<(&str, RawQuery)>) -> Option<RawQuery> {
     let (_, mut subquery) = subqueries.pop()?;
 
     if !subqueries.is_empty() {
@@ -486,23 +512,37 @@ fn select_recipient(recv: &IotaAddress, sender: Option<IotaAddress>, bound: TxBo
     )
 }
 
+/// Selects transactions where `affected` is the sender or a recipient, as a
+/// `UNION` of the `tx_senders` and `tx_recipients` tables.
+///
+/// To avoid full table scans on `UNION` we apply order and limit on the
+/// subqueries before `UNION`. For the result to be correct we need to apply all
+/// other filters on the subquery level, by joining each subquery with all
+/// `other_subqueries`.
 fn select_affected(
     affected: &IotaAddress,
-    sender: Option<IotaAddress>,
+    other_subqueries: Vec<(&str, RawQuery)>,
     bound: TxBounds,
+    page: &Page<Cursor>,
 ) -> RawQuery {
-    let recipients = select_recipient(affected, sender, bound);
-    // A `sender` filter different from `affected` can only match transactions
-    // where `affected` is the recipient.
-    if sender.is_some_and(|sender| sender != *affected) {
-        return recipients;
-    }
-    // The UNION is wrapped in a select so that later filters and ordering
-    // apply to the whole result, not just the second select.
+    let bounded_subquery = |from: RawQuery, other_subqueries: Vec<(&str, RawQuery)>| {
+        let mut all = vec![("tx_affected", from)];
+        all.extend(other_subqueries);
+        join_subqueries(all)
+            .expect("subqueries list is not empty")
+            .order_by(format!(
+                "tx_sequence_number {}",
+                if page.is_from_front() { "ASC" } else { "DESC" }
+            ))
+            // The same limit that `Page::apply` puts on the overall query: the
+            // page size plus the two rows pointed at by the page's cursors.
+            .limit(page.limit() as i64 + 2)
+    };
+
     query!(
-        "SELECT tx_sequence_number FROM ({} UNION {}) AS affected",
-        select_sender(affected, bound),
-        recipients
+        "SELECT tx_sequence_number FROM (({}) UNION ({})) AS affected",
+        bounded_subquery(select_sender(affected, bound), other_subqueries.clone()),
+        bounded_subquery(select_recipient(affected, None, bound), other_subqueries)
     )
 }
 

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -114,7 +114,8 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sent or received.
+The possible relationship types for a transaction block: sent, received,
+or affected.
 """
 enum AddressTransactionBlockRelationship {
 	"""
@@ -125,6 +126,11 @@ enum AddressTransactionBlockRelationship {
 	Transactions that sent objects to this address.
 	"""
 	RECV
+	"""
+	Transactions that affected this address (the address is the sender or
+	a recipient).
+	"""
+	AFFECTED
 }
 
 """
@@ -4559,6 +4565,11 @@ input TransactionBlockFilter {
 	Limit to transactions that sent an object to the given address.
 	"""
 	recvAddress: IotaAddress
+	"""
+	Limit to transactions that affected the given address (the address is
+	the sender or a recipient).
+	"""
+	affectedAddress: IotaAddress
 	"""
 	Limit to transactions that accepted the given object as an input.
 	"""

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -127,8 +127,8 @@ enum AddressTransactionBlockRelationship {
 	"""
 	RECV
 	"""
-	Transactions that affected this address (the address is the sender or
-	a recipient).
+	Transactions that affected this address (the address is the sender,
+	a recipient, or the owner of the gas payment).
 	"""
 	AFFECTED
 }
@@ -4567,7 +4567,7 @@ input TransactionBlockFilter {
 	recvAddress: IotaAddress
 	"""
 	Limit to transactions that affected the given address (the address is
-	the sender or a recipient).
+	the sender, a recipient, or the owner of the gas payment).
 	"""
 	affectedAddress: IotaAddress
 	"""


### PR DESCRIPTION
# Description of change

Add possibility to read txs affected by address in graphql.

This is to match the same ability in JSON RPC, and in the followup issue to enable serving such queries from the KV fallback.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/12213

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: Added the `affectedAddress` filter on `transactionBlocks` and the `AFFECTED` relation on `Address.transactionBlocks`. They list transactions where the address is the sender or a recipient, providing the same functionality as `FromOrToAddress` filter in the JSON-RPC.