### PR TITLE
fix(indexer): fix failing tests by disabling fullnode pruning

### DIFF
--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -83,10 +83,12 @@ impl ApiTestSetup {
         GLOBAL_API_TEST_SETUP.get_or_init(|| {
             let runtime = tokio::runtime::Runtime::new().unwrap();
 
+            // disable full node pruning: tests read `balance_changes` / `object_changes` in
+            // which needs historical data.
             let (cluster, store, client) =
                 runtime.block_on(start_test_cluster_with_read_write_indexer(
                     Some("shared_test_indexer_db"),
-                    None,
+                    Some(Box::new(|builder| builder.disable_fullnode_pruning())),
                     None,
                 ));
 

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -599,9 +599,11 @@ fn indexer_get_total_supply_with_migrated_coin_manager_coins() {
 fn get_total_supply_with_native_coin_manager_coins() {
     let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
     runtime.block_on(async move {
+        // disable full node pruning: node needs historical object versions to assemble
+        // the checkpoint contents the indexer needs to ingest.
         let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
             Some("get_total_supply_with_native_coin_manager_coins"),
-            None,
+            Some(Box::new(|builder| builder.disable_fullnode_pruning())),
             None,
         )
         .await;


### PR DESCRIPTION
# Description of change

After merging #12186 , the pruning in the fullnodes is now deterministic. This exposed flaky tests that rely on historic data, but didn't preserve this data correctly. It was only available due to the fact that the pruner in the fullnode was triggered by a timer.

This PR disables the fullnode pruning in the indexer tests, which should fix the failing tests.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes