### PR TITLE
feat(iota-core,iota-types): add DenyRuleProposal consensus message and pipeline wiring (#12164)

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -39,7 +39,7 @@ use iota_types::{
     base_types::{AuthorityName, CommitRound, ConciseableName, EpochId},
     committee::{Committee, CommitteeTrait, StakeUnit},
     crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo},
-    deny_rule_governance::{DenyRuleProposal, DenyRuleSet},
+    deny_rule_governance::DenyRuleSet,
     digests::ChainIdentifier,
     effects::TransactionEffects,
     error::{IotaError, IotaResult},
@@ -57,8 +57,8 @@ use iota_types::{
     },
     messages_consensus::{
         AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKey,
-        ConsensusTransactionKind, SignedAuthorityCapabilitiesV1, VerifiedAuthorityCapabilitiesV1,
-        VersionedDkgConfirmation,
+        ConsensusTransactionKind, SignedAuthorityCapabilitiesV1, TransactionDenyRuleProposal,
+        VerifiedAuthorityCapabilitiesV1, VersionedDkgConfirmation,
     },
     signature::UserSignature,
     storage::{BackingPackageStore, InputKey},
@@ -701,7 +701,8 @@ pub struct AuthorityPerEpochStore {
 
     /// The active deny rule set: the stake-weighted aggregate of the recorded
     /// deny rule proposals. Recomputed via
-    /// `update_active_transaction_deny_rules` and seeded from the
+    /// `store_active_transaction_deny_rules` in
+    /// `ConsensusOutputQuarantine::push_consensus_output` and seeded from the
     /// `deny_rule_proposals` table on construction.
     active_transaction_deny_rules: ArcSwap<DenyRuleSet>,
 
@@ -882,9 +883,9 @@ pub struct AuthorityEpochTables {
     authority_overload_notifications: DBMap<AuthorityName, u8>,
 
     /// Record of the latest deny rule proposal from each authority, received
-    /// via DenyRuleProposal consensus transactions. A newer generation
-    /// overwrites an older one from the same authority.
-    deny_rule_proposals: DBMap<AuthorityName, DenyRuleProposal>,
+    /// via TransactionDenyRuleProposal consensus transactions. A newer
+    /// generation overwrites an older one from the same authority.
+    deny_rule_proposals: DBMap<AuthorityName, TransactionDenyRuleProposal>,
 
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
@@ -1236,11 +1237,12 @@ impl AuthorityPerEpochStore {
         // table and derive the active rule set. A mid-epoch restart resumes
         // with the rules from all flushed commits; proposals from unflushed
         // commits are re-recorded by consensus replay.
-        let cached_deny_rule_proposals: BTreeMap<AuthorityName, DenyRuleProposal> = tables
-            .deny_rule_proposals
-            .safe_iter()
-            .collect::<Result<BTreeMap<_, _>, _>>()
-            .expect("AuthorityEpochTables should contain valid deny rule proposals");
+        let cached_deny_rule_proposals: BTreeMap<AuthorityName, TransactionDenyRuleProposal> =
+            tables
+                .deny_rule_proposals
+                .safe_iter()
+                .collect::<Result<BTreeMap<_, _>, _>>()
+                .expect("AuthorityEpochTables should contain valid deny rule proposals");
         let active_transaction_deny_rules = ArcSwap::from_pointee(
             Self::compute_active_transaction_deny_rules(&cached_deny_rule_proposals, &committee),
         );
@@ -2974,9 +2976,10 @@ impl AuthorityPerEpochStore {
     /// quarantine's in-memory cache of the persisted `deny_rule_proposals`
     /// table with every queued (processed-but-not-yet-flushed) commit's
     /// proposals overlaid on top.
+    #[cfg(test)]
     pub(crate) fn load_deny_rule_proposals(
         &self,
-    ) -> IotaResult<BTreeMap<AuthorityName, DenyRuleProposal>> {
+    ) -> IotaResult<BTreeMap<AuthorityName, TransactionDenyRuleProposal>> {
         Ok(self
             .consensus_quarantine
             .read()
@@ -2985,7 +2988,7 @@ impl AuthorityPerEpochStore {
 
     /// Whether `proposal` is newer than the recorded proposal (if any) from
     /// the same authority and should therefore be recorded.
-    pub fn should_record_deny_rule_proposal(&self, proposal: &DenyRuleProposal) -> bool {
+    pub fn should_record_deny_rule_proposal(&self, proposal: &TransactionDenyRuleProposal) -> bool {
         !self
             .consensus_quarantine
             .read()
@@ -2999,16 +3002,40 @@ impl AuthorityPerEpochStore {
     }
 
     /// Recomputes the active deny rule set from the current proposals and
-    /// swaps it in. Returns true when the active set changed.
+    /// swaps it in. Returns true when the active set changed. Production
+    /// recomputes through `ConsensusOutputQuarantine::push_consensus_output`;
+    /// this is a test shortcut.
+    #[cfg(test)]
     pub fn update_active_transaction_deny_rules(&self) -> IotaResult<bool> {
         let proposals = self.load_deny_rule_proposals()?;
-        let rules = Self::compute_active_transaction_deny_rules(&proposals, self.committee());
-        if *self.active_transaction_deny_rules.load_full() == rules {
-            return Ok(false);
+        Ok(self.store_active_transaction_deny_rules(&proposals))
+    }
+
+    /// Derives the active set from `proposals` and swaps it in when changed.
+    /// Called from `ConsensusOutputQuarantine::push_consensus_output` for
+    /// every commit that records proposals.
+    fn store_active_transaction_deny_rules(
+        &self,
+        proposals: &BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
+    ) -> bool {
+        let rules = Self::compute_active_transaction_deny_rules(proposals, self.committee());
+        if **self.active_transaction_deny_rules.load() == rules {
+            return false;
         }
-        info!(?rules, "active deny rules changed");
+        info!(
+            denied_addresses = rules.denied_addresses.len(),
+            denied_objects = rules.denied_objects.len(),
+            denied_packages = rules.denied_packages.len(),
+            package_publish_disabled = rules.package_publish_disabled,
+            package_upgrade_disabled = rules.package_upgrade_disabled,
+            shared_object_disabled = rules.shared_object_disabled,
+            user_transaction_disabled = rules.user_transaction_disabled,
+            receiving_objects_disabled = rules.receiving_objects_disabled,
+            move_authenticator_disabled = rules.move_authenticator_disabled,
+            "active transaction deny rules changed"
+        );
         self.active_transaction_deny_rules.store(Arc::new(rules));
-        Ok(true)
+        true
     }
 
     /// Computes the stake-weighted aggregate of the given deny rule proposals:
@@ -3016,7 +3043,7 @@ impl AuthorityPerEpochStore {
     /// with 2f+1. Pure function of the proposals and committee, so every
     /// validator derives the same set from the same consensus state.
     pub(crate) fn compute_active_transaction_deny_rules(
-        proposals: &BTreeMap<AuthorityName, DenyRuleProposal>,
+        proposals: &BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
         committee: &Committee,
     ) -> DenyRuleSet {
         let mut address_stakes: BTreeMap<Address, StakeUnit> = BTreeMap::new();
@@ -3145,7 +3172,10 @@ impl AuthorityPerEpochStore {
     /// commit flush loop does for a real commit. See
     /// `apply_overload_notification_to_cache_for_test`.
     #[cfg(test)]
-    pub(crate) fn apply_deny_rule_proposal_to_cache_for_test(&self, proposal: DenyRuleProposal) {
+    pub(crate) fn apply_deny_rule_proposal_to_cache_for_test(
+        &self,
+        proposal: TransactionDenyRuleProposal,
+    ) {
         self.consensus_quarantine
             .write()
             .apply_cached_deny_rule_proposal_for_test(proposal);
@@ -3438,6 +3468,25 @@ impl AuthorityPerEpochStore {
                         "OverloadNotificationV1 from {:?} has invalid percentage {}",
                         authority.concise(),
                         percentage
+                    );
+                    return None;
+                }
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::TransactionDenyRuleProposal(proposal),
+                ..
+            }) => {
+                if !self.protocol_config().deny_rule_governance() {
+                    debug!(
+                        "Ignoring TransactionDenyRuleProposal from {:?}: deny rule governance is disabled",
+                        proposal.authority.concise()
+                    );
+                    return None;
+                }
+                if transaction.sender_authority() != proposal.authority {
+                    warn!(
+                        "TransactionDenyRuleProposal authority {} does not match its author from consensus {}",
+                        proposal.authority, transaction.certificate_author_index
                     );
                     return None;
                 }
@@ -5010,6 +5059,37 @@ impl AuthorityPerEpochStore {
                     debug!(
                         "Ignoring OverloadNotificationV1 from {:?} because of end of epoch",
                         authority.concise()
+                    );
+                }
+                Ok(ConsensusTransactionResult::ConsensusMessage)
+            }
+            SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                kind: ConsensusTransactionKind::TransactionDenyRuleProposal(proposal),
+                ..
+            }) => {
+                // The `deny_rule_governance` feature gate is enforced in
+                // `verify_consensus_transaction`, which filters every
+                // sequenced transaction before it reaches this point.
+                if !self
+                    .get_reconfig_state_read_lock_guard()
+                    .should_accept_consensus_certs()
+                {
+                    debug!(
+                        "Ignoring TransactionDenyRuleProposal from {:?} because of end of epoch",
+                        proposal.authority.concise()
+                    );
+                } else if self.should_record_deny_rule_proposal(proposal) {
+                    debug!(
+                        "Received TransactionDenyRuleProposal from {:?} with generation {}",
+                        proposal.authority.concise(),
+                        proposal.generation
+                    );
+                    output.record_deny_rule_proposal(proposal.clone());
+                } else {
+                    debug!(
+                        "Ignoring TransactionDenyRuleProposal from {:?} with stale generation {}",
+                        proposal.authority.concise(),
+                        proposal.generation
                     );
                 }
                 Ok(ConsensusTransactionResult::ConsensusMessage)

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -12,10 +12,9 @@ use iota_sdk_types::{
 };
 use iota_types::{
     base_types::AuthorityName,
-    deny_rule_governance::DenyRuleProposal,
     error::IotaResult,
     messages_checkpoint::{CheckpointContents, CheckpointContentsExt, CheckpointSequenceNumber},
-    messages_consensus::VersionedDkgConfirmation,
+    messages_consensus::{TransactionDenyRuleProposal, VersionedDkgConfirmation},
     signature::UserSignature,
     transaction::SenderSignedTransactionAPI,
 };
@@ -101,7 +100,7 @@ pub(crate) struct ConsensusCommitOutput {
     // Newest deny rule proposal from each authority received during this
     // commit. Flushed to `deny_rule_proposals` atomically with
     // `last_consensus_stats`.
-    deny_rule_proposals: BTreeMap<AuthorityName, DenyRuleProposal>,
+    deny_rule_proposals: BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
 }
 
 impl ConsensusCommitOutput {
@@ -247,10 +246,7 @@ impl ConsensusCommitOutput {
     }
 
     /// Records `proposal`, keeping the newest generation per authority.
-    // TODO(#10749): remove cfg(test) once the consensus handler records
-    // proposals.
-    #[cfg(test)]
-    pub fn record_deny_rule_proposal(&mut self, proposal: DenyRuleProposal) {
+    pub fn record_deny_rule_proposal(&mut self, proposal: TransactionDenyRuleProposal) {
         if self
             .deny_rule_proposals
             .get(&proposal.authority)
@@ -603,7 +599,7 @@ pub(crate) struct ConsensusOutputQuarantine {
     // like `cached_overload_notifications`: seeded at construction, advanced
     // as commits are flushed, overlaid with queued commits by
     // `current_deny_rule_proposals`.
-    cached_deny_rule_proposals: BTreeMap<AuthorityName, DenyRuleProposal>,
+    cached_deny_rule_proposals: BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
 
     metrics: Arc<EpochMetrics>,
 }
@@ -612,7 +608,7 @@ impl ConsensusOutputQuarantine {
     pub(super) fn new(
         highest_executed_checkpoint: CheckpointSequenceNumber,
         cached_overload_notifications: HashMap<AuthorityName, u8>,
-        cached_deny_rule_proposals: BTreeMap<AuthorityName, DenyRuleProposal>,
+        cached_deny_rule_proposals: BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
         authority_metrics: Arc<EpochMetrics>,
     ) -> Self {
         Self {
@@ -646,7 +642,16 @@ impl ConsensusOutputQuarantine {
         self.insert_congestion_control_debts(&output);
         self.insert_processed_consensus_messages(&output);
         self.insert_owned_object_locks(&output);
+        let has_deny_rule_proposals = !output.deny_rule_proposals.is_empty();
         self.output_queue.push_back(output);
+
+        // Recompute the active deny rules whenever a commit recorded
+        // proposals, so the set applies from the next commit on. Computed
+        // inline: `epoch_store` methods that take the quarantine lock would
+        // self-deadlock here.
+        if has_deny_rule_proposals {
+            epoch_store.store_active_transaction_deny_rules(&self.current_deny_rule_proposals());
+        }
 
         self.metrics
             .consensus_quarantine_queue_size
@@ -1017,7 +1022,9 @@ impl ConsensusOutputQuarantine {
     /// Returns the current deny rule proposals keyed by authority: the
     /// in-memory cache of the persisted table with every queued
     /// (processed-but-not-yet-flushed) commit's proposals layered on top.
-    pub(super) fn current_deny_rule_proposals(&self) -> BTreeMap<AuthorityName, DenyRuleProposal> {
+    pub(super) fn current_deny_rule_proposals(
+        &self,
+    ) -> BTreeMap<AuthorityName, TransactionDenyRuleProposal> {
         let mut proposals = self.cached_deny_rule_proposals.clone();
         for output in &self.output_queue {
             for (authority, proposal) in &output.deny_rule_proposals {
@@ -1040,7 +1047,10 @@ impl ConsensusOutputQuarantine {
     }
 
     #[cfg(test)]
-    pub(super) fn apply_cached_deny_rule_proposal_for_test(&mut self, proposal: DenyRuleProposal) {
+    pub(super) fn apply_cached_deny_rule_proposal_for_test(
+        &mut self,
+        proposal: TransactionDenyRuleProposal,
+    ) {
         self.cached_deny_rule_proposals
             .insert(proposal.authority, proposal);
     }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -822,6 +822,7 @@ impl ConsensusAdapter {
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
                     | ConsensusTransactionKind::OverloadNotificationV1(_, _, _)
+                    | ConsensusTransactionKind::TransactionDenyRuleProposal(_)
             ) {
             let transaction_keys = transaction_keys.clone();
             Some(CancelOnDrop(spawn_monitored_task!(async {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -622,6 +622,9 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::RandomnessDkgMessage(_, _) => "randomness_dkg_message",
         ConsensusTransactionKind::RandomnessDkgConfirmation(_, _) => "randomness_dkg_confirmation",
         ConsensusTransactionKind::OverloadNotificationV1(_, _, _) => "overload_notification_v1",
+        ConsensusTransactionKind::TransactionDenyRuleProposal(_) => {
+            "transaction_deny_rule_proposal"
+        }
     }
 }
 

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -140,6 +140,18 @@ impl IotaTxValidator {
                         )));
                     }
                 }
+
+                // No explicit size cap on the proposed rules: the proposal is
+                // bounded by `max_transaction_size_bytes` (256 KiB), enforced
+                // on every received block by starfish's block verifier.
+                ConsensusTransactionKind::TransactionDenyRuleProposal(_) => {
+                    if !self.epoch_store.protocol_config().deny_rule_governance() {
+                        return Err(IotaError::UnsupportedFeature {
+                            error: "TransactionDenyRuleProposal not supported at current protocol version"
+                                .into(),
+                        });
+                    }
+                }
             }
         }
 
@@ -431,6 +443,11 @@ mod tests {
                 ConsensusTransactionKind::OverloadNotificationV1(_, _, _) => {
                     Some(config.enable_pcool_flow())
                 }
+
+                // Gated behind `deny_rule_governance`.
+                ConsensusTransactionKind::TransactionDenyRuleProposal(_) => {
+                    Some(config.deny_rule_governance())
+                }
             }
         }
 
@@ -489,6 +506,16 @@ mod tests {
             (
                 "OverloadNotificationV1",
                 ConsensusTransactionKind::OverloadNotificationV1(authority, 0, 50),
+            ),
+            (
+                "TransactionDenyRuleProposal",
+                ConsensusTransactionKind::TransactionDenyRuleProposal(
+                    iota_types::messages_consensus::TransactionDenyRuleProposal {
+                        authority,
+                        generation: 0,
+                        proposed_rules: Default::default(),
+                    },
+                ),
             ),
         ];
 

--- a/crates/iota-core/src/starfish_adapter.rs
+++ b/crates/iota-core/src/starfish_adapter.rs
@@ -128,6 +128,7 @@ impl ConsensusClient for LazyStarfishClient {
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
                     | ConsensusTransactionKind::OverloadNotificationV1(_, _, _)
+                    | ConsensusTransactionKind::TransactionDenyRuleProposal(_)
             )
         {
             let transaction_key = SequencedConsensusTransactionKey::External(transactions[0].key());

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -10,10 +10,8 @@ use std::{
 use iota_config::node::ExpensiveSafetyCheckConfig;
 use iota_sdk_types::{Address, ObjectId, TransactionDigest};
 use iota_types::{
-    base_types::AuthorityName,
-    committee::Committee,
-    crypto::KeypairTraits,
-    deny_rule_governance::{DenyRuleProposal, DenyRuleSet},
+    base_types::AuthorityName, committee::Committee, crypto::KeypairTraits,
+    deny_rule_governance::DenyRuleSet, messages_consensus::TransactionDenyRuleProposal,
 };
 use tokio::time::timeout;
 use typed_store::rocks::DBBatch;
@@ -344,8 +342,8 @@ fn deny_proposal(
     authority: AuthorityName,
     generation: u64,
     proposed_rules: DenyRuleSet,
-) -> DenyRuleProposal {
-    DenyRuleProposal {
+) -> TransactionDenyRuleProposal {
+    TransactionDenyRuleProposal {
         authority,
         generation,
         proposed_rules,
@@ -363,7 +361,7 @@ fn rules_denying_address(address: Address) -> DenyRuleSet {
 /// `process_consensus_transaction` will use: buffer it in
 /// `ConsensusCommitOutput` and flush via `write_to_batch`. See
 /// `flush_overload_notification`.
-fn flush_deny_rule_proposal(store: &AuthorityPerEpochStore, proposal: DenyRuleProposal) {
+fn flush_deny_rule_proposal(store: &AuthorityPerEpochStore, proposal: TransactionDenyRuleProposal) {
     let mut output = ConsensusCommitOutput::new(0);
     output.record_deny_rule_proposal(proposal.clone());
     output.set_default_commit_stats_for_testing();
@@ -389,7 +387,7 @@ fn compute_active_transaction_deny_rules_applies_stake_thresholds() {
     let active_package = ObjectId::new([6u8; 32]);
     let minority_package = ObjectId::new([7u8; 32]);
 
-    let mut proposals: BTreeMap<AuthorityName, DenyRuleProposal> = BTreeMap::new();
+    let mut proposals: BTreeMap<AuthorityName, TransactionDenyRuleProposal> = BTreeMap::new();
     // Two members support the `active_*` entries; switch support ranges from
     // 3 members (receiving/move authenticator) through 2 (shared object,
     // package publish) and 1 (user transaction) to 0 (package upgrade).

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -7296,3 +7296,162 @@ async fn test_consensus_queue_graduated_load_shedding() {
         "in certificate mode, no graduated shedding expected below/at hard limit",
     );
 }
+
+/// Builds an authority with the deny-rule-governance protocol flag toggled.
+async fn authority_with_deny_rule_governance(enabled: bool) -> Arc<AuthorityState> {
+    let mut protocol_config =
+        ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    if enabled {
+        protocol_config.set_deny_rule_governance_for_testing(true);
+    }
+    TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config)
+        .build()
+        .await
+}
+
+/// A `TransactionDenyRuleProposal` whose declared authority matches `author` is
+/// recorded through the consensus pipeline and its rules become active for the
+/// next commit; a proposal whose author does not match the consensus block
+/// author is dropped by `verify_consensus_transaction`.
+#[tokio::test]
+async fn deny_rule_proposal_through_consensus_updates_active_set() {
+    use iota_sdk_types::Address;
+    use iota_types::{
+        deny_rule_governance::{DenyRuleConfig, DenyRuleSet},
+        messages_consensus::TransactionDenyRuleProposal,
+    };
+
+    let authority = authority_with_deny_rule_governance(true).await;
+    let epoch_store = authority.epoch_store_for_testing();
+    // Single-validator test committee: this authority holds all stake and
+    // clears both the f+1 and 2f+1 thresholds alone.
+    let me = epoch_store.name;
+    let checkpoint_service = Arc::new(CheckpointServiceNoop {});
+
+    // Drive a proposal through consensus, authored by this validator.
+    let denied = Address::new([9u8; 32]);
+    let proposal = TransactionDenyRuleProposal {
+        authority: me,
+        generation: 1,
+        proposed_rules: DenyRuleSet {
+            denied_addresses: [denied].into(),
+            user_transaction_disabled: true,
+            ..Default::default()
+        },
+    };
+    let sequenced = SequencedConsensusTransaction {
+        certificate_author_index: 0,
+        certificate_author: me,
+        consensus_index: Default::default(),
+        transaction: crate::consensus_handler::SequencedConsensusTransactionKind::External(
+            ConsensusTransaction::new_transaction_deny_rule_proposal(proposal),
+        ),
+    };
+    epoch_store
+        .process_consensus_transactions_for_tests(
+            vec![sequenced],
+            &checkpoint_service,
+            authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
+            &authority.metrics,
+            true,
+            authority.as_ref(),
+        )
+        .await
+        .unwrap();
+
+    // Recorded and aggregated: the rules are active for subsequent commits.
+    let active = epoch_store.get_active_transaction_deny_rules();
+    assert!(active.is_address_denied(&denied));
+    assert!(active.user_transaction_disabled());
+
+    // A proposal whose declared authority does not match the consensus block
+    // author is dropped before recording, leaving the active set unchanged.
+    let other = AuthorityName::ZERO;
+    let forged = TransactionDenyRuleProposal {
+        authority: other,
+        generation: 2,
+        proposed_rules: rules_denying(Address::new([1u8; 32])),
+    };
+    let sequenced = SequencedConsensusTransaction {
+        certificate_author_index: 0,
+        certificate_author: me, // author != forged.authority
+        consensus_index: Default::default(),
+        transaction: crate::consensus_handler::SequencedConsensusTransactionKind::External(
+            ConsensusTransaction::new_transaction_deny_rule_proposal(forged),
+        ),
+    };
+    epoch_store
+        .process_consensus_transactions_for_tests(
+            vec![sequenced],
+            &checkpoint_service,
+            authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
+            &authority.metrics,
+            true,
+            authority.as_ref(),
+        )
+        .await
+        .unwrap();
+
+    let active = epoch_store.get_active_transaction_deny_rules();
+    assert!(!active.is_address_denied(&Address::new([1u8; 32])));
+    assert!(active.is_address_denied(&denied)); // original still in force
+}
+
+/// With the feature flag disabled, a well-formed proposal is ignored by the
+/// consensus handler and never affects the active set.
+#[tokio::test]
+async fn deny_rule_proposal_ignored_when_flag_disabled() {
+    use iota_sdk_types::Address;
+    use iota_types::{
+        deny_rule_governance::DenyRuleConfig, messages_consensus::TransactionDenyRuleProposal,
+    };
+
+    let authority = authority_with_deny_rule_governance(false).await;
+    let epoch_store = authority.epoch_store_for_testing();
+    let me = epoch_store.name;
+
+    let denied = Address::new([9u8; 32]);
+    let proposal = TransactionDenyRuleProposal {
+        authority: me,
+        generation: 1,
+        proposed_rules: rules_denying(denied),
+    };
+    let sequenced = SequencedConsensusTransaction {
+        certificate_author_index: 0,
+        certificate_author: me,
+        consensus_index: Default::default(),
+        transaction: crate::consensus_handler::SequencedConsensusTransactionKind::External(
+            ConsensusTransaction::new_transaction_deny_rule_proposal(proposal),
+        ),
+    };
+    epoch_store
+        .process_consensus_transactions_for_tests(
+            vec![sequenced],
+            &Arc::new(CheckpointServiceNoop {}),
+            authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
+            &authority.metrics,
+            true,
+            authority.as_ref(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !epoch_store
+            .get_active_transaction_deny_rules()
+            .is_address_denied(&denied)
+    );
+}
+
+fn rules_denying(
+    address: iota_sdk_types::Address,
+) -> iota_types::deny_rule_governance::DenyRuleSet {
+    iota_types::deny_rule_governance::DenyRuleSet {
+        denied_addresses: [address].into(),
+        ..Default::default()
+    }
+}

--- a/crates/iota-types/src/deny_rule_governance.rs
+++ b/crates/iota-types/src/deny_rule_governance.rs
@@ -6,8 +6,6 @@ use std::collections::BTreeSet;
 use iota_sdk_types::{Address, ObjectId};
 use serde::{Deserialize, Serialize};
 
-use crate::base_types::AuthorityName;
-
 /// Read access to a set of transaction deny rules.
 ///
 /// Implemented by both a validator's local `TransactionDenyConfig` and the
@@ -115,31 +113,11 @@ impl DenyRuleConfig for DenyRuleSet {
     }
 }
 
-/// A validator's full-state proposal for the network deny rules, announced
-/// through consensus.
-///
-/// Each proposal carries the authority's complete proposed rule set; the latest
-/// generation per authority supersedes earlier ones. The active rule set the
-/// network enforces is the stake-weighted aggregate of all current proposals.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct DenyRuleProposal {
-    /// The authority announcing this proposal.
-    pub authority: AuthorityName,
-    /// Per-authority counter used to deduplicate proposals; a higher generation
-    /// supersedes earlier proposals from the same authority.
-    pub generation: u64,
-    /// The complete set of rules this authority proposes.
-    pub proposed_rules: DenyRuleSet,
-}
-
 #[cfg(test)]
 mod tests {
     use iota_sdk_types::{Address, ObjectId};
 
-    use crate::{
-        crypto::AuthorityPublicKeyBytes,
-        deny_rule_governance::{DenyRuleConfig, DenyRuleProposal, DenyRuleSet},
-    };
+    use crate::deny_rule_governance::{DenyRuleConfig, DenyRuleSet};
 
     fn sample_rule_set() -> DenyRuleSet {
         DenyRuleSet {
@@ -162,17 +140,6 @@ mod tests {
         let rules = sample_rule_set();
         let bytes = bcs::to_bytes(&rules).unwrap();
         assert_eq!(rules, bcs::from_bytes(&bytes).unwrap());
-    }
-
-    #[test]
-    fn deny_rule_proposal_bcs_round_trip() {
-        let proposal = DenyRuleProposal {
-            authority: AuthorityPublicKeyBytes::ZERO,
-            generation: 42,
-            proposed_rules: sample_rule_set(),
-        };
-        let bytes = bcs::to_bytes(&proposal).unwrap();
-        assert_eq!(proposal, bcs::from_bytes(&bytes).unwrap());
     }
 
     #[test]

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -23,6 +23,7 @@ use tracing::warn;
 use crate::{
     base_types::{AuthorityName, ConciseableName},
     crypto::{AuthoritySignature, DefaultHash, default_hash},
+    deny_rule_governance::DenyRuleSet,
     message_envelope::{Envelope, Message, VerifiedEnvelope},
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
     supported_protocol_versions::{
@@ -58,6 +59,7 @@ pub enum ConsensusTransactionKey {
     /// P-COOL user transaction key (by transaction digest).
     UserTransaction(TransactionDigest),
     OverloadNotificationV1(AuthorityName, u64 /* generation */),
+    TransactionDenyRuleProposal(AuthorityName, u64 /* generation */),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -103,6 +105,13 @@ impl Debug for ConsensusTransactionKey {
                 write!(
                     f,
                     "OverloadNotificationV1({:?}, gen={generation:?})",
+                    name.concise()
+                )
+            }
+            Self::TransactionDenyRuleProposal(name, generation) => {
+                write!(
+                    f,
+                    "TransactionDenyRuleProposal({:?}, gen={generation:?})",
                     name.concise()
                 )
             }
@@ -223,6 +232,23 @@ impl SignedAuthorityCapabilitiesV1 {
     }
 }
 
+/// A validator's full-state proposal for the network transaction deny rules,
+/// announced through consensus.
+///
+/// Each proposal carries the authority's complete proposed rule set; the latest
+/// generation per authority supersedes earlier ones. The active rule set the
+/// network enforces is the stake-weighted aggregate of all current proposals.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TransactionDenyRuleProposal {
+    /// The authority announcing this proposal.
+    pub authority: AuthorityName,
+    /// Per-authority counter used to deduplicate proposals; a higher generation
+    /// supersedes earlier proposals from the same authority.
+    pub generation: u64,
+    /// The complete set of rules this authority proposes.
+    pub proposed_rules: DenyRuleSet,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ConsensusTransactionKind {
     CertifiedTransaction(Box<CertifiedTransaction>),
@@ -253,6 +279,10 @@ pub enum ConsensusTransactionKind {
         u64, // generation
         u8,  // percentage
     ),
+    /// A validator's full-state deny rule proposal. Unsigned: the sender is
+    /// authenticated as the consensus block author and must match
+    /// `TransactionDenyRuleProposal::authority`.
+    TransactionDenyRuleProposal(TransactionDenyRuleProposal),
     // New entries should be added at the end to preserve serialization compatibility. DO NOT
     // CHANGE THE ORDER OF EXISTING ENTRIES!
 }
@@ -279,7 +309,8 @@ impl ConsensusTransactionKind {
             | Self::RandomnessDkgMessage(..)
             | Self::RandomnessDkgConfirmation(..)
             | Self::MisbehaviorReport(_)
-            | Self::OverloadNotificationV1(..) => None,
+            | Self::OverloadNotificationV1(..)
+            | Self::TransactionDenyRuleProposal(_) => None,
             #[allow(deprecated)]
             Self::NewJWKFetchedDeprecated => None,
         }
@@ -311,7 +342,8 @@ impl ConsensusTransactionKind {
             | Self::RandomnessDkgMessage(..)
             | Self::RandomnessDkgConfirmation(..)
             | Self::MisbehaviorReport(_)
-            | Self::OverloadNotificationV1(..) => None,
+            | Self::OverloadNotificationV1(..)
+            | Self::TransactionDenyRuleProposal(_) => None,
             #[allow(deprecated)]
             Self::NewJWKFetchedDeprecated => None,
         }
@@ -336,7 +368,8 @@ impl ConsensusTransactionKind {
             | Self::CapabilityNotificationV1(_)
             | Self::SignedCapabilityNotificationV1(_)
             | Self::MisbehaviorReport(_)
-            | Self::OverloadNotificationV1(..) => false,
+            | Self::OverloadNotificationV1(..)
+            | Self::TransactionDenyRuleProposal(_) => false,
             #[allow(deprecated)]
             Self::NewJWKFetchedDeprecated => false,
         }
@@ -669,6 +702,16 @@ impl ConsensusTransaction {
         }
     }
 
+    pub fn new_transaction_deny_rule_proposal(proposal: TransactionDenyRuleProposal) -> Self {
+        let mut hasher = DefaultHasher::new();
+        proposal.hash(&mut hasher);
+        let tracking_id = hasher.finish().to_le_bytes();
+        Self {
+            tracking_id,
+            kind: ConsensusTransactionKind::TransactionDenyRuleProposal(proposal),
+        }
+    }
+
     pub fn get_tracking_id(&self) -> u64 {
         (&self.tracking_id[..])
             .read_u64::<BigEndian>()
@@ -721,6 +764,12 @@ impl ConsensusTransaction {
             }
             ConsensusTransactionKind::OverloadNotificationV1(authority, generation, _) => {
                 ConsensusTransactionKey::OverloadNotificationV1(*authority, *generation)
+            }
+            ConsensusTransactionKind::TransactionDenyRuleProposal(proposal) => {
+                ConsensusTransactionKey::TransactionDenyRuleProposal(
+                    proposal.authority,
+                    proposal.generation,
+                )
             }
         }
     }
@@ -825,5 +874,99 @@ mod tests {
             legacy_bytes, new_bytes,
             "ConsensusTransactionKind::MisbehaviorReport wire format must not change — testnet is live"
         );
+    }
+
+    /// Pins `ConsensusTransactionKind::TransactionDenyRuleProposal`'s variant
+    /// tag (11) and body layout: `(authority, generation, DenyRuleSet)`
+    /// with the rule set's fields in declaration order. Reordering enum
+    /// variants or `DenyRuleSet` fields breaks nodes on the old build.
+    #[test]
+    fn deny_rule_proposal_consensus_kind_wire_format_unchanged() {
+        use std::collections::BTreeSet;
+
+        use iota_sdk_types::{Address, ObjectId};
+
+        use crate::deny_rule_governance::DenyRuleSet;
+
+        let authority = AuthorityName::default();
+        let address = Address::new([7u8; 32]);
+        let object = ObjectId::new([8u8; 32]);
+        let package = ObjectId::new([9u8; 32]);
+
+        // Six one-hot switch patterns: a single sample can't pin the order of
+        // equal-valued booleans, so pin each switch position separately. The
+        // deny lists get distinct contents for the same reason.
+        for hot in 0..6usize {
+            let switch = |i: usize| i == hot;
+            let proposal = TransactionDenyRuleProposal {
+                authority,
+                generation: 42,
+                proposed_rules: DenyRuleSet {
+                    denied_addresses: [address].into(),
+                    denied_objects: [object].into(),
+                    denied_packages: [package].into(),
+                    package_publish_disabled: switch(0),
+                    package_upgrade_disabled: switch(1),
+                    shared_object_disabled: switch(2),
+                    user_transaction_disabled: switch(3),
+                    receiving_objects_disabled: switch(4),
+                    move_authenticator_disabled: switch(5),
+                },
+            };
+            let new_bytes = bcs::to_bytes(&ConsensusTransactionKind::TransactionDenyRuleProposal(
+                proposal,
+            ))
+            .unwrap();
+
+            let mut legacy_bytes = vec![11u8];
+            legacy_bytes.extend(
+                bcs::to_bytes(&(
+                    authority,
+                    42u64,
+                    (
+                        BTreeSet::from([address]),
+                        BTreeSet::from([object]),
+                        BTreeSet::from([package]),
+                        switch(0), // package_publish_disabled
+                        switch(1), // package_upgrade_disabled
+                        switch(2), // shared_object_disabled
+                        switch(3), // user_transaction_disabled
+                        switch(4), // receiving_objects_disabled
+                        switch(5), // move_authenticator_disabled
+                    ),
+                ))
+                .unwrap(),
+            );
+
+            assert_eq!(
+                legacy_bytes, new_bytes,
+                "ConsensusTransactionKind::TransactionDenyRuleProposal wire format must not \
+                 change (switch {hot})"
+            );
+        }
+    }
+
+    /// The proposal round-trips through BCS unchanged.
+    #[test]
+    fn deny_rule_proposal_bcs_round_trip() {
+        use iota_sdk_types::{Address, ObjectId};
+
+        use crate::deny_rule_governance::DenyRuleSet;
+
+        let proposal = TransactionDenyRuleProposal {
+            authority: AuthorityName::default(),
+            generation: 42,
+            proposed_rules: DenyRuleSet {
+                denied_addresses: [Address::new([1u8; 32])].into(),
+                denied_objects: [ObjectId::new([2u8; 32])].into(),
+                denied_packages: [ObjectId::new([3u8; 32])].into(),
+                package_publish_disabled: true,
+                shared_object_disabled: true,
+                receiving_objects_disabled: true,
+                ..Default::default()
+            },
+        };
+        let bytes = bcs::to_bytes(&proposal).unwrap();
+        assert_eq!(proposal, bcs::from_bytes(&bytes).unwrap());
     }
 }


### PR DESCRIPTION
# Description of change

Part of #10749. Adds the `DenyRuleProposal` consensus message and wires it through the pipeline: proposals delivered by consensus now deterministically update the in-memory active deny rule set (#12151). Nothing consumes the set yet — post-consensus validation switches to it in the next PR.

- `ConsensusTransactionKind`/`ConsensusTransactionKey` variants (appended), constructor, wire-format pin test (tag 11)
- `consensus_validator.rs`: rejected when `deny_rule_governance` is off; unsigned, committee-only
- `verify_consensus_transaction`: dropped unless `sender_authority() == proposal.authority`
- `process_consensus_transaction`: flag gate → reconfig gate → generation guard → record (`#[cfg(test)]` removed)
- `push_consensus_output`: recomputes the active set for commits that recorded proposals (next-commit activation)

Stacked on the #12151 branch (PR #12153).

## Links to any relevant issues

Fixes #12164.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes