### PR TITLE
chore(node): remove the one-time epoch_info backfill

### DIFF
--- a/crates/iota-core/src/checkpoints/epoch_info.rs
+++ b/crates/iota-core/src/checkpoints/epoch_info.rs
@@ -15,15 +15,10 @@ use iota_types::{
     committee::EpochId,
     full_checkpoint_content::CheckpointData,
     iota_system_state::IotaSystemStateTrait,
-    messages_checkpoint::{
-        CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, VerifiedCheckpoint,
-    },
-    storage::{
-        EpochInfoV1Entry, EpochInfoV2,
-        error::{Error as StorageError, Kind as StorageErrorKind},
-    },
+    messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary},
+    storage::{EpochInfoV1Entry, EpochInfoV2, error::Error as StorageError},
 };
-use tracing::{info, warn};
+use tracing::warn;
 use typed_store::{Map, TypedStoreError, rocks::DBBatch};
 
 use crate::{authority::AuthorityStore, checkpoints::CheckpointStore};
@@ -87,7 +82,7 @@ impl CheckpointStore {
             return Ok(None); // still in the genesis epoch; no closed epoch
         };
         let highest_indexed = self.highest_indexed_epoch()?;
-        // `<`, not `!=`: a backfill seeded past local execution is a superset.
+        // `<`, not `!=`: rows seeded past local execution are a superset.
         Ok((highest_indexed < Some(last_executed)).then_some((highest_indexed, last_executed)))
     }
 
@@ -112,12 +107,12 @@ impl CheckpointStore {
         }
 
         let Some(start_checkpoint) = self.current_epoch_start_checkpoint(current_epoch)? else {
-            // Skip rather than fail startup; re-seeded once the backfill lands
-            // the previous epoch's row.
+            // Skip rather than fail startup; re-seeded once the previous
+            // epoch's row lands (e.g. from a formal-snapshot restore).
             warn!(
                 epoch = current_epoch,
                 "skipping current-epoch seed: previous epoch's last checkpoint is \
-                 unknown locally; deferring to the snapshot backfill"
+                 unknown locally"
             );
             return Ok(());
         };
@@ -138,136 +133,6 @@ impl CheckpointStore {
             .insert(&epoch_info.epoch, &epoch_info)?;
 
         Ok(())
-    }
-
-    /// Rebuild the closed-epoch `epoch_info` chain from local checkpoints,
-    /// replaying each missing epoch's closing checkpoint above the finalized
-    /// prefix. With no finalized prefix it starts from genesis, seeding epoch
-    /// 0's row from the genesis checkpoint first (the only place epoch 0's
-    /// start state exists).
-    ///
-    /// Called once at startup, after any formal-snapshot restore: on a
-    /// recognized chain it closes the residual tail the published snapshot
-    /// lagged; on an unrecognized network (no snapshot) it rebuilds the whole
-    /// chain from genesis.
-    ///
-    /// Best-effort: stops at the first epoch (or genesis) whose checkpoint data
-    /// is already pruned, leaving the rest unfilled (the caller decides whether
-    /// an unfilled gap is fatal). Must not run concurrently with live indexing,
-    /// like [`Self::insert_epoch_info`].
-    ///
-    /// TODO: <https://github.com/iotaledger/iota/issues/12028> — one-time
-    /// migration aid (with its `try_seed_genesis_epoch` / `assemble_*`
-    /// helpers); remove once every node has backfilled the chain, after
-    /// which it is maintained live and seeded by V2 formal-snapshot
-    /// restore.
-    pub fn backfill_epoch_info_from_local_history(
-        &self,
-        authority_store: &AuthorityStore,
-    ) -> Result<(), StorageError> {
-        let Some(last_executed) = self
-            .first_open_epoch()?
-            .and_then(|open| open.checked_sub(1))
-        else {
-            return Ok(()); // no closed epoch yet
-        };
-        let highest_indexed = self.highest_indexed_epoch()?;
-        if highest_indexed.is_some_and(|highest| highest >= last_executed) {
-            return Ok(()); // chain already complete
-        }
-
-        // Where the replay starts. With a finalized prefix, resume at the
-        // watermark (its row exists). Otherwise start at genesis, which first
-        // needs epoch 0's row seeded from the genesis checkpoint before its
-        // close can be finalized; if genesis data is pruned, nothing local can
-        // seed the prefix and only a snapshot backfill can fill the chain.
-        let start_epoch = match highest_indexed {
-            Some(highest) => highest,
-            None => {
-                if !self.try_seed_genesis_epoch(authority_store)? {
-                    return Ok(());
-                }
-                0
-            }
-        };
-
-        // Replay the closing checkpoints of epochs `[start_epoch,
-        // last_executed]` in order: the first re-finalizes the prefix end (or,
-        // from genesis, finalizes the just-seeded epoch 0) and creates the next
-        // epoch's row (an epoch's start state only exists in the previous
-        // epoch's closing checkpoint), each subsequent one finalizes a missing
-        // row and creates the next.
-        for epoch in start_epoch..=last_executed {
-            let Some(checkpoint_data) = self.assemble_closing_checkpoint(authority_store, epoch)?
-            else {
-                warn!(
-                    epoch,
-                    "cannot index epoch locally (its closing checkpoint's data is pruned); \
-                     stopping the local rebuild here, the remaining epochs stay unfilled"
-                );
-                return Ok(());
-            };
-
-            self.index_epoch_boundary(&checkpoint_data)?;
-        }
-        info!("rebuilt the local epoch_info chain through epoch {last_executed}");
-        Ok(())
-    }
-
-    /// Assemble `epoch`'s closing checkpoint (its boundary tx only) from local
-    /// stores, or `None` when any of it (the summary, contents, or the boundary
-    /// tx's effects/objects) has been pruned.
-    fn assemble_closing_checkpoint(
-        &self,
-        authority_store: &AuthorityStore,
-        epoch: EpochId,
-    ) -> Result<Option<CheckpointData>, StorageError> {
-        // The map is never pruned, but the checkpoint data it points to may be.
-        let Some(seq) = self.get_epoch_last_checkpoint_seq_number(epoch)? else {
-            return Ok(None);
-        };
-        let Some(summary) = self.get_checkpoint_by_sequence_number(seq)? else {
-            return Ok(None);
-        };
-        let Some(contents) = self.get_checkpoint_contents(&summary.content_digest)? else {
-            return Ok(None);
-        };
-        match assemble_boundary_checkpoint_data(authority_store, summary, contents) {
-            Ok(data) => Ok(Some(data)),
-            // A pruned-away boundary transaction/effects/objects is the expected
-            // end of what can be rebuilt locally; anything else is a real
-            // storage failure and must propagate.
-            Err(e) if e.kind() == StorageErrorKind::Missing => Ok(None),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Seed epoch 0's row by replaying the genesis checkpoint. Returns whether
-    /// the row is present afterwards (false only when the genesis checkpoint's
-    /// data is unavailable, e.g. pruned).
-    fn try_seed_genesis_epoch(
-        &self,
-        authority_store: &AuthorityStore,
-    ) -> Result<bool, StorageError> {
-        if self.tables.epoch_info.get(&0)?.is_some() {
-            return Ok(true);
-        }
-        let Some(summary) = self.get_checkpoint_by_sequence_number(0)? else {
-            return Ok(false);
-        };
-        let Some(contents) = self.get_checkpoint_contents(&summary.content_digest)? else {
-            return Ok(false);
-        };
-        match assemble_boundary_checkpoint_data(authority_store, summary, contents) {
-            Ok(genesis_data) => {
-                self.index_epoch_boundary(&genesis_data)?;
-                Ok(true)
-            }
-            // Pruned genesis data is the expected "nothing to rebuild locally"
-            // case; anything else is a real storage failure and must propagate.
-            Err(e) if e.kind() == StorageErrorKind::Missing => Ok(false),
-            Err(e) => Err(e),
-        }
     }
 
     /// The current epoch's start checkpoint, or `None` when it can't be derived
@@ -322,8 +187,7 @@ impl CheckpointStore {
             // If no row exists for `prev_epoch`, this node didn't see its
             // start (e.g. bootstrapped mid-epoch). Skip the upsert; the row
             // stays absent and the watermark stays behind, so the snapshot
-            // writer correctly refuses to publish until an external backfill
-            // fills the gap.
+            // writer correctly refuses to publish the incomplete chain.
             if let Some(mut previous_epoch) = self.tables.epoch_info.get(&prev_epoch)? {
                 // The closing checkpoint's last tx is `prev_epoch`'s
                 // epoch-change tx; its effects and the system-state objects it
@@ -408,7 +272,7 @@ impl CheckpointStore {
     ///
     /// Unlike [`Self::try_advance_epoch_info_watermark`] (the live +1 step),
     /// this can jump the watermark across a whole seeded prefix, which is what
-    /// a snapshot backfill needs.
+    /// a snapshot restore needs.
     fn reconcile_epoch_info_watermark(&self) -> Result<(), TypedStoreError> {
         // `[0, watermark]` is already known complete, so resume the scan from
         // `watermark + 1` rather than re-scanning the whole table.
@@ -451,70 +315,6 @@ fn open_epoch_of(checkpoint: &CheckpointSummary) -> EpochId {
     }
 }
 
-/// Assemble a `CheckpointData` carrying only the checkpoint's *boundary*
-/// transaction — the epoch-change tx (last in `contents`), or the genesis tx
-/// for checkpoint 0. The result is deliberately sparse: `transactions` holds a
-/// single entry while `checkpoint_contents` keeps the full digest list (the
-/// close-of-epoch proof bundle is anchored to it). It is valid only for
-/// epoch-boundary indexing, which reads `transactions.last()` and the boundary
-/// tx's effects/output objects/events.
-///
-/// A pruned boundary transaction, effects, output objects, or events surfaces
-/// as a `Missing` error. The boundary tx's *input* objects are never loaded:
-/// boundary indexing does not read them, and skipping them avoids a spurious
-/// `Missing` when only old input-object versions have been pruned.
-fn assemble_boundary_checkpoint_data(
-    authority_store: &AuthorityStore,
-    summary: VerifiedCheckpoint,
-    contents: CheckpointContents,
-) -> Result<CheckpointData, StorageError> {
-    use iota_types::{
-        effects::TransactionEffectsAPI, full_checkpoint_content::CheckpointTransaction,
-    };
-
-    let inner = contents.transactions();
-    let Some(boundary_digests) = inner.last() else {
-        return Err(StorageError::custom("empty checkpoint contents"));
-    };
-    let tx_digest = boundary_digests.transaction;
-
-    let transaction = authority_store
-        .get_transaction_block(&tx_digest)?
-        .ok_or_else(|| StorageError::missing("missing boundary transaction"))?;
-    let effects = authority_store
-        .get_executed_effects(&tx_digest)?
-        .ok_or_else(|| StorageError::missing("missing boundary transaction effects"))?;
-    let output_objects =
-        iota_types::storage::get_transaction_output_objects(authority_store, &effects)?;
-
-    let events = if effects.events_digest().is_some() {
-        Some(
-            authority_store
-                .get_events(effects.transaction_digest())
-                .map_err(|e| StorageError::custom(format!("loading events: {e}")))?
-                .ok_or_else(|| {
-                    StorageError::missing("missing events for the boundary transaction")
-                })?,
-        )
-    } else {
-        None
-    };
-
-    let boundary_transaction = CheckpointTransaction {
-        transaction: transaction.into(),
-        effects,
-        events,
-        input_objects: Vec::new(),
-        output_objects,
-    };
-
-    Ok(CheckpointData {
-        checkpoint_summary: summary.into(),
-        checkpoint_contents: contents,
-        transactions: vec![boundary_transaction],
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use iota_sdk_types::GasCostSummary;
@@ -525,7 +325,8 @@ mod tests {
         iota_system_state::IotaSystemState,
         message_envelope::Envelope,
         messages_checkpoint::{
-            CertifiedCheckpointSummary, CheckpointContentsExt, CheckpointSummary, EndOfEpochData,
+            CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt,
+            CheckpointSummary, EndOfEpochData, VerifiedCheckpoint,
         },
     };
     use typed_store::Map;
@@ -727,8 +528,8 @@ mod tests {
     }
 
     /// `epoch_info_gap` flags a contiguous prefix that falls short of the last
-    /// executed closed epoch — and nothing else: no closed epoch yet and a
-    /// backfill seeded past local execution both count as complete.
+    /// executed closed epoch — and nothing else: no closed epoch yet and rows
+    /// seeded past local execution both count as complete.
     #[tokio::test]
     async fn epoch_info_gap_flags_short_prefix_not_overshoot() {
         let store = CheckpointStore::new_for_tests();
@@ -761,7 +562,7 @@ mod tests {
             .unwrap();
         assert_eq!(store.epoch_info_gap().unwrap(), None);
 
-        // A backfill seeded beyond local execution is a superset, not a gap.
+        // Rows seeded beyond local execution are a superset, not a gap.
         store
             .insert_epoch_info(vec![complete_epoch_info(2), complete_epoch_info(3)])
             .unwrap();

--- a/crates/iota-core/src/checkpoints/epoch_info.rs
+++ b/crates/iota-core/src/checkpoints/epoch_info.rs
@@ -11,8 +11,10 @@
 //! and never pruned; the `epoch_info_watermark` tracks the highest
 //! epoch whose contiguous prefix is finalized.
 
+use iota_protocol_config::Chain;
 use iota_types::{
     committee::EpochId,
+    digests::ChainIdentifier,
     full_checkpoint_content::CheckpointData,
     iota_system_state::IotaSystemStateTrait,
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary},
@@ -84,6 +86,47 @@ impl CheckpointStore {
         let highest_indexed = self.highest_indexed_epoch()?;
         // `<`, not `!=`: rows seeded past local execution are a superset.
         Ok((highest_indexed < Some(last_executed)).then_some((highest_indexed, last_executed)))
+    }
+
+    /// Seeds the open epoch's `epoch_info` row and guards the chain's
+    /// completeness; called once at node startup, before live execution
+    /// resumes. Every node maintains the chain live at its executed epoch
+    /// boundaries, and new nodes obtain the history through genesis sync or a
+    /// formal-snapshot restore, so a gap can only mean this node's store
+    /// predates the `epoch_info` table. A gap is a fatal error on
+    /// mainnet/testnet — every node must hold the verified chain since
+    /// genesis — and only a warning on other networks, where the missing
+    /// epochs are left unfilled: such a node cannot produce snapshots or
+    /// serve the epoch gRPC API for those epochs.
+    pub fn seed_epoch_info(
+        &self,
+        authority_store: &AuthorityStore,
+        chain_identifier: ChainIdentifier,
+    ) -> Result<(), StorageError> {
+        // Seed the open epoch's row (no-op if already present). Without it the
+        // next executed boundary can't finalize it and the watermark wedges.
+        self.ensure_current_epoch_info(authority_store)?;
+
+        if let Some((highest_indexed, last_executed)) = self.epoch_info_gap()? {
+            let detail = format!(
+                "the epoch_info chain is incomplete (finalized through {highest_indexed:?}, \
+                 executed through epoch {last_executed})"
+            );
+            match chain_identifier.chain() {
+                Chain::Mainnet | Chain::Testnet => {
+                    return Err(StorageError::custom(format!(
+                        "{detail}; restore this node from a formal snapshot or resync it from \
+                         genesis to obtain the verified chain"
+                    )));
+                }
+                Chain::Unknown => warn!(
+                    "{detail}; the missing epochs are left unfilled (live indexing only \
+                     extends the chain forward), so this node cannot produce snapshots or \
+                     serve the epoch gRPC API for those epochs"
+                ),
+            }
+        }
+        Ok(())
     }
 
     /// Seed the current (open) epoch's `epoch_info` row if still missing. No-op

--- a/crates/iota-e2e-tests/tests/epoch_info_tests.rs
+++ b/crates/iota-e2e-tests/tests/epoch_info_tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::Path, sync::Arc};
-
 use iota_core::checkpoints::CheckpointStore;
 use iota_macros::sim_test;
 use iota_snapshot::{EpochInfo, EpochInfoV1};
@@ -114,7 +112,7 @@ async fn epoch_info_chain_is_populated_live() {
 /// chain-id mismatch or a non-genesis trust root yields no verified witness, so
 /// nothing is written.
 #[sim_test]
-async fn epoch_info_backfill_verifies_chain_before_seeding() {
+async fn epoch_info_restore_verifies_chain_before_seeding() {
     // Long epoch duration so the epoch only advances when forced, keeping the
     // closed-epoch set stable across the assertions. Pruning disabled so the
     // live store keeps every closed epoch's finalized row.
@@ -176,7 +174,7 @@ async fn epoch_info_backfill_verifies_chain_before_seeding() {
     for epoch in 0..current_epoch {
         assert!(
             ok_store.get_epoch_info(epoch).unwrap().is_some(),
-            "epoch {epoch} must be seeded after a verified backfill"
+            "epoch {epoch} must be seeded after a verified restore"
         );
     }
 
@@ -491,79 +489,6 @@ async fn epoch_info_verifies_safe_mode_boundary() {
     }
 }
 
-/// When a snapshot backfill seeds a prefix that ends below the locally executed
-/// epochs (the published snapshot lags by more than one epoch),
-/// `backfill_epoch_info_from_local_history` closes the residual gap from the
-/// missing epochs' own closing checkpoints — and creates the open epoch's row
-/// along the way.
-#[sim_test]
-async fn missing_epochs_above_snapshot_prefix_are_indexed_locally() {
-    // Pruning disabled so the closing checkpoints' data is still available
-    // locally — the precondition for the local replay.
-    let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(600_000)
-        .disable_fullnode_pruning()
-        .build()
-        .await;
-    test_cluster.force_new_epoch().await;
-    test_cluster.force_new_epoch().await;
-
-    let state = test_cluster
-        .fullnode_handle
-        .iota_node
-        .with(|node| node.state());
-    let authority_store = state.database_for_testing();
-    let node_checkpoint_store = state.get_checkpoint_store().clone();
-    let current_epoch = state.current_epoch_for_testing();
-    assert!(current_epoch >= 2, "need at least two closed epochs");
-    wait_until_executed_open_epoch(&node_checkpoint_store, current_epoch).await;
-
-    let expected_chain_id = state.get_chain_identifier();
-    let genesis = &test_cluster.swarm.config().genesis;
-    let genesis_committee = genesis.committee().expect("genesis committee");
-    let genesis_system_state = genesis.iota_system_object();
-
-    // Staging store with only the closing checkpoints (what the replay reads)
-    // and no `epoch_info` rows — the state a lagging-snapshot backfill leaves.
-    let staging_tmp = tempfile::tempdir().unwrap();
-    let staged =
-        stage_closing_checkpoints(staging_tmp.path(), &node_checkpoint_store, current_epoch);
-
-    // Mimic a backfill from a lagging snapshot: seed only epoch 0, leaving the
-    // later closed epochs missing.
-    iota_snapshot::verify_epoch_info_chain(
-        real_epoch_info(&node_checkpoint_store, 1),
-        genesis_committee,
-        genesis_system_state,
-        expected_chain_id,
-        expected_chain_id,
-    )
-    .expect("the lagging snapshot's prefix must verify")
-    .restore_epoch_info(&*staged)
-    .await
-    .expect("seeding the lagging snapshot's prefix must succeed");
-    assert_eq!(staged.highest_indexed_epoch().unwrap(), Some(0));
-    assert!(
-        staged.epoch_info_gap().unwrap().is_some(),
-        "the lagging prefix must leave a gap"
-    );
-
-    staged
-        .backfill_epoch_info_from_local_history(&authority_store)
-        .unwrap();
-
-    assert_eq!(
-        staged.epoch_info_gap().unwrap(),
-        None,
-        "the local replay must close the residual gap"
-    );
-    // The last replayed closing checkpoint also creates the open epoch's row.
-    assert!(
-        staged.get_epoch_info(current_epoch).unwrap().is_some(),
-        "the local replay must create the open epoch's row"
-    );
-}
-
 /// Build a real `EpochInfo` for closed epochs `[0, current_epoch)` from each
 /// `epoch_info` row's close-of-epoch proof. Panics unless `source` has a
 /// finalized row for every closed epoch.
@@ -580,143 +505,4 @@ fn real_epoch_info(source: &CheckpointStore, current_epoch: EpochId) -> EpochInf
         })
         .collect();
     EpochInfo::V1(EpochInfoV1 { entries })
-}
-
-/// Copy the closing checkpoints of closed epochs `[0, current_epoch)` from
-/// `node` into a fresh store, with its highest-executed watermark set to the
-/// last one so its first open epoch is `current_epoch`. Writes no `epoch_info`
-/// rows: the caller seeds a partial prefix and runs the local replay over this.
-fn stage_closing_checkpoints(
-    dir: &Path,
-    node: &CheckpointStore,
-    current_epoch: EpochId,
-) -> Arc<CheckpointStore> {
-    let staged = CheckpointStore::new(&dir.join("checkpoints"));
-    let mut last_closing = None;
-    for epoch in 0..current_epoch {
-        let closing = node
-            .get_epoch_last_checkpoint(epoch)
-            .unwrap()
-            .unwrap_or_else(|| panic!("node missing closing checkpoint for epoch {epoch}"));
-        let contents = node
-            .get_checkpoint_contents(&closing.content_digest)
-            .unwrap()
-            .expect("node missing closing checkpoint contents");
-        staged.insert_checkpoint_contents(contents).unwrap();
-        // Writes the certified checkpoint and (since closing checkpoints carry
-        // `next_epoch_committee`) the `epoch_last_checkpoint_map` entry the
-        // replay reads.
-        staged.insert_verified_checkpoint(&closing).unwrap();
-        last_closing = Some(closing);
-    }
-    let last_closing = last_closing.expect("current_epoch >= 1");
-    staged
-        .update_highest_executed_checkpoint(&last_closing)
-        .unwrap();
-    staged
-}
-
-/// The from-genesis local rebuild (the upgrade path): a checkpoint store with
-/// the executed history but no `epoch_info` rows rebuilds the whole chain by
-/// replaying genesis and each closed epoch's closing checkpoint from local
-/// data, closing the gap entirely. Unlike
-/// `missing_epochs_above_snapshot_prefix_are_indexed_locally`, no prefix is
-/// seeded first, so this exercises the genesis-seeding branch. Each rebuilt row
-/// is asserted byte-identical to the node's live-indexed row, proving the
-/// boundary transaction alone reconstructs the same proof bundle.
-#[sim_test]
-async fn epoch_info_rebuilds_from_local_history() {
-    // Pruning disabled so the closing checkpoints' data is still available
-    // locally — the precondition for the local replay.
-    let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(600_000)
-        .disable_fullnode_pruning()
-        .build()
-        .await;
-    test_cluster.force_new_epoch().await;
-    test_cluster.force_new_epoch().await;
-
-    let state = test_cluster
-        .fullnode_handle
-        .iota_node
-        .with(|node| node.state());
-    let authority_store = state.database_for_testing();
-    let node_checkpoint_store = state.get_checkpoint_store().clone();
-    let current_epoch = state.current_epoch_for_testing();
-    assert!(current_epoch >= 2, "need at least two closed epochs");
-    wait_until_executed_open_epoch(&node_checkpoint_store, current_epoch).await;
-
-    // Build a fresh store holding only the checkpoint history the rebuild reads
-    // — genesis, each closed epoch's closing checkpoint, and the current
-    // highest-executed checkpoint — but no `epoch_info` rows. This is the state
-    // an existing node lands in the first time it upgrades to this feature.
-    // Genesis (sequence 0) must be staged: the rebuild seeds epoch 0's row from
-    // it before any close can be finalized.
-    let tmp = tempfile::tempdir().unwrap();
-    let target = CheckpointStore::new(&tmp.path().join("checkpoints"));
-    let highest = node_checkpoint_store
-        .get_highest_executed_checkpoint()
-        .unwrap()
-        .unwrap();
-
-    let mut seqs = vec![0u64, highest.sequence_number()];
-    for epoch in 0..current_epoch {
-        let closing = node_checkpoint_store
-            .get_epoch_last_checkpoint(epoch)
-            .unwrap()
-            .unwrap_or_else(|| panic!("missing closing checkpoint for closed epoch {epoch}"));
-        target
-            .insert_epoch_last_checkpoint(epoch, &closing)
-            .unwrap();
-        seqs.push(closing.sequence_number());
-    }
-    for seq in seqs {
-        let summary = node_checkpoint_store
-            .get_checkpoint_by_sequence_number(seq)
-            .unwrap()
-            .unwrap();
-        let contents = node_checkpoint_store
-            .get_checkpoint_contents(&summary.content_digest)
-            .unwrap()
-            .unwrap();
-        target.insert_verified_checkpoint(&summary).unwrap();
-        target.insert_checkpoint_contents(contents).unwrap();
-    }
-    target.update_highest_executed_checkpoint(&highest).unwrap();
-
-    // No rows yet → a gap past genesis.
-    assert!(
-        target.epoch_info_gap().unwrap().is_some(),
-        "an empty epoch_info table past genesis must report a gap"
-    );
-
-    // The transactions/effects/objects of the closing checkpoints come from the
-    // (unpruned) live authority store.
-    target
-        .backfill_epoch_info_from_local_history(&authority_store)
-        .unwrap();
-
-    assert_eq!(
-        target.epoch_info_gap().unwrap(),
-        None,
-        "the from-genesis local rebuild must close the gap"
-    );
-    // Each rebuilt row is byte-identical to the node's live-indexed row: the
-    // boundary tx alone reconstructs the same proof bundle the full checkpoint
-    // produced live.
-    for epoch in 0..current_epoch {
-        let rebuilt = target
-            .get_epoch_info(epoch)
-            .unwrap()
-            .unwrap_or_else(|| panic!("epoch {epoch} must be rebuilt from local history"));
-        let live = node_checkpoint_store
-            .get_epoch_info(epoch)
-            .unwrap()
-            .unwrap_or_else(|| panic!("missing live row for epoch {epoch}"));
-        assert_eq!(
-            bcs::to_bytes(&rebuilt).unwrap(),
-            bcs::to_bytes(&live).unwrap(),
-            "rebuilt row for epoch {epoch} must match the live-indexed row"
-        );
-    }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -103,7 +103,7 @@ use iota_network::{
     randomness, state_sync,
 };
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
-use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
     RandomnessRound,
     crypto::{Intent, IntentMessage, IntentScope},
@@ -597,7 +597,8 @@ impl IotaNode {
         };
 
         // Seed the open epoch's `epoch_info` row before services start.
-        Self::seed_epoch_info(&checkpoint_store, &store, chain_identifier)
+        checkpoint_store
+            .seed_epoch_info(&store, chain_identifier)
             .expect("failed to seed the epoch_info chain");
 
         info!("creating archive reader");
@@ -906,49 +907,6 @@ impl IotaNode {
             .spawn_logging_task(node.checkpoint_store.clone(), perpetual_tables_for_progress);
 
         Ok(node)
-    }
-
-    /// Seeds the open epoch's `epoch_info` row and guards the chain's
-    /// completeness before live execution resumes. Every node maintains the
-    /// chain live at its executed epoch boundaries, and new nodes obtain the
-    /// history through genesis sync or a formal-snapshot restore, so a gap can
-    /// only mean this node's store predates the `epoch_info` table. A gap is a
-    /// fatal startup error on mainnet/testnet — every node must hold the
-    /// verified chain since genesis — and only a warning on other networks,
-    /// where the missing epochs are left unfilled: such a node cannot produce
-    /// snapshots or serve the epoch gRPC API for those epochs.
-    fn seed_epoch_info(
-        checkpoint_store: &CheckpointStore,
-        authority_store: &AuthorityStore,
-        chain_identifier: ChainIdentifier,
-    ) -> anyhow::Result<()> {
-        // Seed the open epoch's row (no-op if already present). Without it the
-        // next executed boundary can't finalize it and the watermark wedges.
-        checkpoint_store
-            .ensure_current_epoch_info(authority_store)
-            .map_err(|e| anyhow::anyhow!("seeding the current epoch_info row: {e}"))?;
-
-        if let Some((highest_indexed, last_executed)) = checkpoint_store
-            .epoch_info_gap()
-            .map_err(|e| anyhow::anyhow!("checking epoch_info completeness: {e}"))?
-        {
-            let detail = format!(
-                "the epoch_info chain is incomplete (finalized through {highest_indexed:?}, \
-                 executed through epoch {last_executed})"
-            );
-            match chain_identifier.chain() {
-                Chain::Mainnet | Chain::Testnet => anyhow::bail!(
-                    "{detail}; restore this node from a formal snapshot or resync it from \
-                     genesis to obtain the verified chain"
-                ),
-                Chain::Unknown => warn!(
-                    "{detail}; the missing epochs are left unfilled (live indexing only \
-                     extends the chain forward), so this node cannot produce snapshots or \
-                     serve the epoch gRPC API for those epochs"
-                ),
-            }
-        }
-        Ok(())
     }
 
     pub fn subscribe_to_epoch_change(&self) -> broadcast::Receiver<IotaSystemState> {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -108,10 +108,7 @@ use iota_sdk_types::{
     RandomnessRound,
     crypto::{Intent, IntentMessage, IntentScope},
 };
-use iota_snapshot::{
-    reader::{StateSnapshotReaderV1, latest_available_epoch},
-    uploader::StateSnapshotUploader,
-};
+use iota_snapshot::uploader::StateSnapshotUploader;
 use iota_storage::{
     FileCompression, StorageFormat,
     http_key_value_store::HttpKVStore,
@@ -122,7 +119,7 @@ use iota_types::{
     base_types::{AuthorityName, ConciseableName, EpochId},
     committee::Committee,
     crypto::{AuthoritySignature, IotaAuthoritySignature, KeypairTraits},
-    digests::{ChainIdentifier, get_devnet_chain_identifier},
+    digests::ChainIdentifier,
     error::{IotaError, IotaResult},
     executable_transaction::VerifiedExecutableTransaction,
     execution_config_utils::to_binary_config,
@@ -599,11 +596,8 @@ impl IotaNode {
             None
         };
 
-        // Seed and backfill the `epoch_info` chain before services start. Done
-        // here, not in the store, because the EPOCH_INFO reader lives in
-        // `iota-snapshot`, which depends on `iota-core`.
-        Self::seed_epoch_info(&checkpoint_store, &store, &genesis, chain_identifier)
-            .await
+        // Seed the open epoch's `epoch_info` row before services start.
+        Self::seed_epoch_info(&checkpoint_store, &store, chain_identifier)
             .expect("failed to seed the epoch_info chain");
 
         info!("creating archive reader");
@@ -914,123 +908,47 @@ impl IotaNode {
         Ok(node)
     }
 
-    /// Seeds the open epoch's `epoch_info` row and backfills any historical gap
-    /// before live execution resumes. A recognized chain (mainnet, testnet, or
-    /// the current devnet) fills from its formal-snapshot `EPOCH_INFO` first —
-    /// cheap and bulk — then replays local checkpoints for whatever the
-    /// snapshot still lags; an unfillable gap there is a fatal startup
-    /// error, since every node must hold the verified chain since genesis.
-    /// An unrecognized network (no published snapshot) rebuilds from local
-    /// state alone; a residual gap there is only a warning and is left
-    /// unfilled — acceptable since such a node is not expected to produce
+    /// Seeds the open epoch's `epoch_info` row and guards the chain's
+    /// completeness before live execution resumes. Every node maintains the
+    /// chain live at its executed epoch boundaries, and new nodes obtain the
+    /// history through genesis sync or a formal-snapshot restore, so a gap can
+    /// only mean this node's store predates the `epoch_info` table. A gap is a
+    /// fatal startup error on mainnet/testnet — every node must hold the
+    /// verified chain since genesis — and only a warning on other networks,
+    /// where the missing epochs are left unfilled: such a node cannot produce
     /// snapshots or serve the epoch gRPC API for those epochs.
-    ///
-    /// TODO: <https://github.com/iotaledger/iota/issues/12028> — once every node
-    /// holds the chain this startup backfill is no longer needed; it reduces to
-    /// seeding the open epoch, or is removed entirely.
-    async fn seed_epoch_info(
+    fn seed_epoch_info(
         checkpoint_store: &CheckpointStore,
         authority_store: &AuthorityStore,
-        genesis: &iota_config::genesis::Genesis,
-        expected_chain_id: ChainIdentifier,
+        chain_identifier: ChainIdentifier,
     ) -> anyhow::Result<()> {
-        let chain = expected_chain_id.chain();
-        let recognized_source = formal_snapshot_read_config(expected_chain_id);
-
-        // Fill any historical gap before live execution resumes; skip the work
-        // entirely when the chain is already complete (the common restart).
-        if checkpoint_store
-            .epoch_info_gap()
-            .map_err(|e| anyhow::anyhow!("checking epoch_info completeness: {e}"))?
-            .is_some()
-        {
-            // snapshot pull (recognized chains only)
-            if let Some(remote_store_config) = &recognized_source {
-                if let Err(e) = Self::backfill_epoch_info_from_snapshot(
-                    checkpoint_store,
-                    remote_store_config,
-                    genesis.committee()?,
-                    genesis.iota_system_object(),
-                    expected_chain_id,
-                )
-                .await
-                {
-                    warn!(
-                        "epoch_info snapshot backfill failed ({e:#}); falling back to \
-                         rebuilding from local checkpoint history"
-                    );
-                }
-            }
-
-            // local replay
-            checkpoint_store
-                .backfill_epoch_info_from_local_history(authority_store)
-                .map_err(|e| anyhow::anyhow!("rebuilding epoch_info from local history: {e}"))?;
-        }
-
         // Seed the open epoch's row (no-op if already present). Without it the
         // next executed boundary can't finalize it and the watermark wedges.
         checkpoint_store
             .ensure_current_epoch_info(authority_store)
             .map_err(|e| anyhow::anyhow!("seeding the current epoch_info row: {e}"))?;
 
-        // A residual gap is fatal on a recognized chain — every node must hold
-        // the verified chain since genesis — and only a warning elsewhere.
         if let Some((highest_indexed, last_executed)) = checkpoint_store
             .epoch_info_gap()
-            .map_err(|e| anyhow::anyhow!("re-checking epoch_info completeness: {e}"))?
+            .map_err(|e| anyhow::anyhow!("checking epoch_info completeness: {e}"))?
         {
             let detail = format!(
-                "the epoch_info chain is incomplete after backfilling (finalized through \
-                 {highest_indexed:?}, executed through epoch {last_executed})"
+                "the epoch_info chain is incomplete (finalized through {highest_indexed:?}, \
+                 executed through epoch {last_executed})"
             );
-            if recognized_source.is_some() {
-                anyhow::bail!(
-                    "{detail}: the latest published snapshot is older than this node's history \
-                     and the missing epochs' checkpoint data is already pruned locally; retry \
-                     once a newer snapshot is available"
-                );
+            match chain_identifier.chain() {
+                Chain::Mainnet | Chain::Testnet => anyhow::bail!(
+                    "{detail}; restore this node from a formal snapshot or resync it from \
+                     genesis to obtain the verified chain"
+                ),
+                Chain::Unknown => warn!(
+                    "{detail}; the missing epochs are left unfilled (live indexing only \
+                     extends the chain forward), so this node cannot produce snapshots or \
+                     serve the epoch gRPC API for those epochs"
+                ),
             }
-            warn!(
-                "{detail} and {chain:?} has no public formal-snapshot source to backfill from; \
-                 the missing epochs are left unfilled (live indexing only extends the chain \
-                 forward), so this node cannot produce snapshots or serve the epoch gRPC API for \
-                 those epochs"
-            );
         }
         Ok(())
-    }
-
-    /// Restores the CheckpointStore's `epoch_info` rows from the given
-    /// formal-snapshot bucket's EPOCH_INFO, verifying the chain against this
-    /// node's trust roots. A wrong-network snapshot is rejected before any
-    /// write. Only seeds what the snapshot covers — the published snapshot can
-    /// lag this node's executed history, so the caller replays local
-    /// checkpoints for the residual tail.
-    ///
-    /// TODO: <https://github.com/iotaledger/iota/issues/12028> — one-time
-    /// migration aid; remove once every node has backfilled the chain.
-    async fn backfill_epoch_info_from_snapshot(
-        checkpoint_store: &CheckpointStore,
-        remote_store_config: &ObjectStoreConfig,
-        genesis_committee: Committee,
-        genesis_system_state: IotaSystemState,
-        expected_chain_id: ChainIdentifier,
-    ) -> anyhow::Result<u64> {
-        let epoch = latest_available_epoch(remote_store_config).await?;
-        info!("restoring epoch_info from snapshot EPOCH_INFO up to epoch {epoch}");
-        let (snapshot_chain_id, epoch_info) =
-            StateSnapshotReaderV1::read_epoch_info_only(epoch, remote_store_config).await?;
-        let verified = iota_snapshot::verify_epoch_info_chain(
-            epoch_info,
-            genesis_committee,
-            genesis_system_state,
-            snapshot_chain_id,
-            expected_chain_id,
-        )?;
-        verified.restore_epoch_info(checkpoint_store).await?;
-        info!("restored epoch_info from snapshot up to epoch {epoch}");
-        Ok(epoch)
     }
 
     pub fn subscribe_to_epoch_change(&self) -> broadcast::Receiver<IotaSystemState> {
@@ -2521,51 +2439,6 @@ impl SpawnOnce {
             handle.trigger_shutdown();
         }
     }
-}
-
-/// The public formal-snapshot source for a recognized chain, used to backfill a
-/// pruned node's `epoch_info` chain from the bucket's `EPOCH_INFO`. `None` for
-/// networks without a published bucket (custom/local), where a residual gap is
-/// left to extend forward instead.
-///
-/// Hardcoded deliberately: this is a one-time migration aid. Remove it together
-/// with `backfill_epoch_info_from_snapshot` (and `get_devnet_chain_identifier`)
-/// one release after this ships, once every node holds the chain and new nodes
-/// get it from genesis sync or a V2 formal-snapshot restore. Anything fetched
-/// is verified against the genesis committee, so the URL is only a source hint,
-/// not a trust root.
-///
-/// TODO: <https://github.com/iotaledger/iota/issues/12028>
-fn formal_snapshot_read_config(chain_id: ChainIdentifier) -> Option<ObjectStoreConfig> {
-    let (bucket, endpoint) = match chain_id.chain() {
-        Chain::Mainnet => (
-            "iota-mainnet-formal",
-            "https://formal-snapshot.mainnet.iota.cafe",
-        ),
-        Chain::Testnet => (
-            "iota-testnet-formal",
-            "https://formal-snapshot.testnet.iota.cafe",
-        ),
-        // Devnet has no stable identity (`Chain::Unknown`), so match the current
-        // devnet genesis explicitly. After a reset the new genesis no longer
-        // matches and this falls through to `None`. Devnet backfill is
-        // best-effort (see `seed_epoch_info`), so a stale id or absent bucket is
-        // never fatal.
-        Chain::Unknown if chain_id == get_devnet_chain_identifier() => (
-            "iota-devnet-formal",
-            "https://formal-snapshot.devnet.iota.cafe",
-        ),
-        Chain::Unknown => return None,
-    };
-    Some(ObjectStoreConfig {
-        object_store: Some(ObjectStoreType::S3),
-        bucket: Some(bucket.to_owned()),
-        aws_endpoint: Some(endpoint.to_owned()),
-        aws_virtual_hosted_style_request: true,
-        object_store_connection_limit: 200,
-        no_sign_request: true,
-        ..Default::default()
-    })
 }
 
 /// Notify [`DiscoveryEventLoop`] that a new list of trusted peers are now

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -356,7 +356,7 @@ async fn snapshot_round_trip(
 /// Writes the EPOCH_INFO file for `[0, snapshot_epoch]`, reads it back, and
 /// asserts every entry round-trips well-formed (one per epoch, in order, with a
 /// populated proof bundle) — the writer/reader half of the restore path.
-async fn epoch_info_backfill_round_trip(
+async fn epoch_info_round_trip(
     tmp_dir: &std::path::Path,
     snapshot_epoch: EpochId,
 ) -> Result<(), anyhow::Error> {
@@ -390,8 +390,9 @@ async fn epoch_info_backfill_round_trip(
         .write_internal(snapshot_epoch, perpetual_db, root_accumulator)
         .await?;
 
-    // 2. LOAD via `read_epoch_info_only` (the running-node background backfill
-    //    path): downloads only MANIFEST + EPOCH_INFO, verifies sha3 + magic.
+    // 2. LOAD via `read_epoch_info_only` (the formal-snapshot restore's
+    //    EPOCH_INFO-first step): downloads only MANIFEST + EPOCH_INFO, verifies
+    //    sha3 + magic.
     let (chain_id, epoch_info) =
         StateSnapshotReaderV1::read_epoch_info_only(snapshot_epoch, &remote_store_config).await?;
     assert_eq!(
@@ -474,9 +475,9 @@ async fn snapshot_round_trip_populated_zstd() -> Result<(), anyhow::Error> {
 
 /// EPOCH_INFO write → read entry round-trip across two epochs.
 #[tokio::test]
-async fn snapshot_epoch_info_backfill_round_trip() -> Result<(), anyhow::Error> {
+async fn snapshot_epoch_info_round_trip() -> Result<(), anyhow::Error> {
     let dir = iota_common::tempdir();
-    epoch_info_backfill_round_trip(dir.path(), 2).await
+    epoch_info_round_trip(dir.path(), 2).await
 }
 
 /// Restoring through [`RestoreWithGrpcIndexes`] must build the gRPC

--- a/crates/iota-snapshot/src/writer.rs
+++ b/crates/iota-snapshot/src/writer.rs
@@ -507,14 +507,14 @@ impl StateSnapshotWriterV1 {
             None => Err(anyhow!(
                 "Snapshot V2 writer: the epoch_info completeness watermark is \
                  absent — no epoch_info rows have been finalized on this node \
-                 yet. Run the epoch_info backfill before publishing the first \
-                 V2 snapshot, or wait until at least epoch 0 closes under live \
-                 indexing."
+                 yet. Wait until at least epoch 0 closes under live indexing, \
+                 or restore this node from a formal snapshot."
             )),
             Some(h) if h < epoch => Err(anyhow!(
                 "Snapshot V2 writer: the epoch_info completeness watermark is at \
-                 epoch {h}, but snapshot_epoch is {epoch}. Run the epoch_info \
-                 backfill on this node before publishing."
+                 epoch {h}, but snapshot_epoch is {epoch}. The chain is \
+                 incomplete; restore this node from a formal snapshot or resync \
+                 it from genesis before publishing."
             )),
             Some(_) => Ok(()),
         }

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -125,31 +125,6 @@ pub fn get_testnet_chain_identifier() -> ChainIdentifier {
     *digest
 }
 
-/// Genesis chain identifier of the **current** devnet. Unlike mainnet/testnet,
-/// devnet has no stable identity — it is wiped and re-genesised periodically —
-/// so this literal is only valid until the next reset. It exists solely as a
-/// one-time aid for backfilling the `epoch_info` chain from the devnet formal
-/// snapshot and should be removed (together with that backfill) one release
-/// after it ships. A stale value simply stops matching, degrading to
-/// best-effort rather than causing any error.
-///
-/// TODO: <https://github.com/iotaledger/iota/issues/12028>
-const DEVNET_CHAIN_IDENTIFIER_BASE58: &str = "Fjn7QQx49eH2kafFSfD1dPehZ89ps36wZpMPeALrByay";
-static DEVNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
-
-pub fn get_devnet_chain_identifier() -> ChainIdentifier {
-    let digest = DEVNET_CHAIN_IDENTIFIER.get_or_init(|| {
-        let digest = CheckpointDigest::new(
-            Base58::decode(DEVNET_CHAIN_IDENTIFIER_BASE58)
-                .expect("devnet genesis checkpoint digest literal is invalid")
-                .try_into()
-                .expect("devnet genesis checkpoint digest literal has incorrect length"),
-        );
-        ChainIdentifier::from(digest)
-    });
-    *digest
-}
-
 impl fmt::Display for ChainIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.0.as_bytes()[0..4].iter() {


### PR DESCRIPTION
# Description of change

The `epoch_info backfill` shipped previously as a one-time migration aid; every node now holds the chain, maintained live at epoch boundaries and seeded by genesis sync or a formal-snapshot restore. This removes the backfill code, as its TODOs instructed.

## Links to any relevant issues

fixes #12028 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes