### PR TITLE
chore(open-rpc): generate protocol config example from the max protocol version

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1287,7 +1287,7 @@
           "params": [
             {
               "name": "version",
-              "value": 6
+              "value": 31
             }
           ],
           "result": {
@@ -1295,62 +1295,62 @@
             "value": {
               "minSupportedProtocolVersion": "1",
               "maxSupportedProtocolVersion": "31",
-              "protocolVersion": "6",
+              "protocolVersion": "31",
               "featureFlags": {
-                "accept_passkey_in_multisig": false,
-                "additional_borrow_checks": false,
-                "additional_multisig_checks": false,
-                "adjust_rewards_by_score": false,
-                "always_advance_dkg_to_resolution": false,
-                "calculate_validator_scores": false,
-                "congestion_control_gas_price_feedback_mechanism": false,
-                "congestion_control_min_free_execution_slot": false,
-                "congestion_limit_overshoot_in_gas_price_feedback_mechanism": false,
-                "consensus_batched_block_sync": false,
-                "consensus_block_restrictions": false,
-                "consensus_commit_transactions_only_for_traversed_headers": false,
-                "consensus_distributed_vote_scoring_strategy": false,
-                "consensus_fast_commit_sync": false,
-                "consensus_linearize_subdag_v2": false,
-                "consensus_median_timestamp_with_checkpoint_enforcement": false,
-                "consensus_round_prober": false,
-                "consensus_round_prober_probe_accepted_rounds": false,
+                "accept_passkey_in_multisig": true,
+                "additional_borrow_checks": true,
+                "additional_multisig_checks": true,
+                "adjust_rewards_by_score": true,
+                "always_advance_dkg_to_resolution": true,
+                "calculate_validator_scores": true,
+                "congestion_control_gas_price_feedback_mechanism": true,
+                "congestion_control_min_free_execution_slot": true,
+                "congestion_limit_overshoot_in_gas_price_feedback_mechanism": true,
+                "consensus_batched_block_sync": true,
+                "consensus_block_restrictions": true,
+                "consensus_commit_transactions_only_for_traversed_headers": true,
+                "consensus_distributed_vote_scoring_strategy": true,
+                "consensus_fast_commit_sync": true,
+                "consensus_linearize_subdag_v2": true,
+                "consensus_median_timestamp_with_checkpoint_enforcement": true,
+                "consensus_round_prober": true,
+                "consensus_round_prober_probe_accepted_rounds": true,
                 "consensus_smart_ancestor_selection": false,
                 "consensus_starfish_speed": false,
-                "consensus_zstd_compression": false,
+                "consensus_zstd_compression": true,
                 "convert_type_argument_error": true,
-                "dependency_linkage_error": false,
+                "dependency_linkage_error": true,
                 "disable_invariant_violation_check_in_swap_loc": true,
                 "disallow_new_modules_in_deps_only_packages": true,
                 "enable_group_ops_native_function_msm": true,
-                "enable_move_authentication": false,
-                "enable_move_authentication_for_sponsor": false,
+                "enable_move_authentication": true,
+                "enable_move_authentication_for_sponsor": true,
                 "enable_pcool_flow": false,
                 "enable_poseidon": true,
                 "enable_vdf": true,
                 "hardened_otw_check": true,
-                "metadata_in_module_bytes": false,
-                "minimize_child_object_mutations": false,
-                "move_native_tx_context": false,
+                "metadata_in_module_bytes": true,
+                "minimize_child_object_mutations": true,
+                "move_native_tx_context": true,
                 "native_charging_v2": true,
                 "no_extraneous_module_bytes": true,
-                "normalize_ptb_arguments": false,
-                "pass_calculated_validator_scores_to_advance_epoch": false,
-                "pass_validator_scores_to_advance_epoch": false,
+                "normalize_ptb_arguments": true,
+                "pass_calculated_validator_scores_to_advance_epoch": true,
+                "pass_validator_scores_to_advance_epoch": true,
                 "passkey_auth": true,
-                "pre_consensus_sponsor_only_move_authentication": false,
+                "pre_consensus_sponsor_only_move_authentication": true,
                 "protocol_defined_base_fee": true,
-                "publish_package_metadata": false,
+                "publish_package_metadata": true,
                 "relocate_event_module": true,
                 "rethrow_serialization_type_layout_errors": true,
-                "select_committee_from_eligible_validators": false,
-                "select_committee_supporting_next_epoch_version": false,
-                "separate_gas_price_feedback_mechanism_for_randomness": false,
-                "track_non_committee_eligible_validators": false,
+                "select_committee_from_eligible_validators": true,
+                "select_committee_supporting_next_epoch_version": true,
+                "separate_gas_price_feedback_mechanism_for_randomness": true,
+                "track_non_committee_eligible_validators": true,
                 "uncompressed_g1_group_elements": true,
-                "validate_identifier_inputs": false,
-                "validator_metadata_verify_v2": false,
-                "variant_nodes": false
+                "validate_identifier_inputs": true,
+                "validator_metadata_verify_v2": true,
+                "variant_nodes": true
               },
               "attributes": {
                 "address_from_bytes_cost_base": {
@@ -1362,16 +1362,36 @@
                 "address_to_u256_cost_base": {
                   "u64": "52"
                 },
-                "auth_context_authenticator_function_info_v1_cost_base": null,
-                "auth_context_digest_cost_base": null,
-                "auth_context_replace_cost_base": null,
-                "auth_context_replace_cost_per_byte": null,
-                "auth_context_tx_commands_cost_base": null,
-                "auth_context_tx_commands_cost_per_byte": null,
-                "auth_context_tx_data_bytes_cost_base": null,
-                "auth_context_tx_data_bytes_cost_per_byte": null,
-                "auth_context_tx_inputs_cost_base": null,
-                "auth_context_tx_inputs_cost_per_byte": null,
+                "auth_context_authenticator_function_info_v1_cost_base": {
+                  "u64": "270"
+                },
+                "auth_context_digest_cost_base": {
+                  "u64": "30"
+                },
+                "auth_context_replace_cost_base": {
+                  "u64": "30"
+                },
+                "auth_context_replace_cost_per_byte": {
+                  "u64": "2"
+                },
+                "auth_context_tx_commands_cost_base": {
+                  "u64": "30"
+                },
+                "auth_context_tx_commands_cost_per_byte": {
+                  "u64": "2"
+                },
+                "auth_context_tx_data_bytes_cost_base": {
+                  "u64": "30"
+                },
+                "auth_context_tx_data_bytes_cost_per_byte": {
+                  "u64": "2"
+                },
+                "auth_context_tx_inputs_cost_base": {
+                  "u64": "30"
+                },
+                "auth_context_tx_inputs_cost_per_byte": {
+                  "u64": "2"
+                },
                 "base_gas_price": {
                   "u64": "1000"
                 },
@@ -1454,18 +1474,12 @@
                 "bls12381_bls12381_min_sig_verify_msg_cost_per_byte": {
                   "u64": "2"
                 },
-                "bridge_should_try_to_finalize_committee": {
-                  "bool": "true"
-                },
+                "bridge_should_try_to_finalize_committee": null,
                 "buffer_stake_for_protocol_upgrade_bps": {
                   "u64": "5000"
                 },
-                "check_zklogin_id_cost_base": {
-                  "u64": "200"
-                },
-                "check_zklogin_issuer_cost_base": {
-                  "u64": "200"
-                },
+                "check_zklogin_id_cost_base": null,
+                "check_zklogin_issuer_cost_base": null,
                 "checkpoint_summary_version_specific_data": {
                   "u64": "1"
                 },
@@ -1479,7 +1493,9 @@
                   "u64": "20"
                 },
                 "consensus_commits_per_schedule": null,
-                "consensus_gc_depth": null,
+                "consensus_gc_depth": {
+                  "u32": "60"
+                },
                 "consensus_max_acknowledgments_per_block": null,
                 "consensus_max_num_transactions_in_block": {
                   "u64": "512"
@@ -1841,13 +1857,13 @@
                 "max_accumulated_txn_cost_per_object_in_mysticeti_commit": {
                   "u64": "10"
                 },
-                "max_age_of_jwk_in_epochs": {
-                  "u64": "1"
-                },
+                "max_age_of_jwk_in_epochs": null,
                 "max_arguments": {
                   "u32": "512"
                 },
-                "max_auth_gas": null,
+                "max_auth_gas": {
+                  "u64": "250000"
+                },
                 "max_back_edges_per_function": {
                   "u64": "10000"
                 },
@@ -1861,9 +1877,11 @@
                   "u64": "31457280"
                 },
                 "max_committee_members_count": {
-                  "u64": "50"
+                  "u64": "100"
                 },
-                "max_congestion_limit_overshoot_per_commit": null,
+                "max_congestion_limit_overshoot_per_commit": {
+                  "u64": "100"
+                },
                 "max_deferral_rounds_for_congestion_control": {
                   "u64": "10"
                 },
@@ -1900,9 +1918,7 @@
                 "max_input_objects": {
                   "u64": "2048"
                 },
-                "max_jwk_votes_per_validator_per_epoch": {
-                  "u64": "240"
-                },
+                "max_jwk_votes_per_validator_per_epoch": null,
                 "max_loop_depth": {
                   "u64": "5"
                 },
@@ -2093,7 +2109,9 @@
                 "reward_slashing_rate": {
                   "u64": "10000"
                 },
-                "scorer_version": null,
+                "scorer_version": {
+                  "u16": "1"
+                },
                 "storage_gas_price": {
                   "u64": "76"
                 },
@@ -2128,7 +2146,7 @@
                   "u64": "52"
                 },
                 "transfer_receive_object_cost_base": {
-                  "u64": "52"
+                  "u64": "100"
                 },
                 "transfer_share_object_cost_base": {
                   "u64": "52"
@@ -2139,17 +2157,39 @@
                 "tx_context_derive_id_cost_base": {
                   "u64": "52"
                 },
-                "tx_context_digest_cost_base": null,
-                "tx_context_epoch_cost_base": null,
-                "tx_context_epoch_timestamp_ms_cost_base": null,
-                "tx_context_fresh_id_cost_base": null,
-                "tx_context_gas_budget_cost_base": null,
-                "tx_context_gas_price_cost_base": null,
-                "tx_context_ids_created_cost_base": null,
-                "tx_context_replace_cost_base": null,
-                "tx_context_rgp_cost_base": null,
-                "tx_context_sender_cost_base": null,
-                "tx_context_sponsor_cost_base": null,
+                "tx_context_digest_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_epoch_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_epoch_timestamp_ms_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_fresh_id_cost_base": {
+                  "u64": "52"
+                },
+                "tx_context_gas_budget_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_gas_price_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_ids_created_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_replace_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_rgp_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_sender_cost_base": {
+                  "u64": "30"
+                },
+                "tx_context_sponsor_cost_base": {
+                  "u64": "30"
+                },
                 "type_name_get_base_cost": {
                   "u64": "52"
                 },

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -25,7 +25,7 @@ use iota_json_rpc_types::{
     TransferObjectParams, ValidatorApy, ValidatorApys,
 };
 use iota_open_rpc::ExamplePairing;
-use iota_protocol_config::{Chain, ProtocolConfig};
+use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
     Address, Identifier, ObjectId, ObjectReference, Owner, StructTag, TypeTag, gas::GasCostSummary,
 };
@@ -638,7 +638,7 @@ impl RpcExampleProvider {
     }
 
     fn get_protocol_config(&mut self) -> Examples {
-        let version = Some(6);
+        let version = Some(ProtocolVersion::MAX.as_u64());
         Examples::new(
             "iota_getProtocolConfig",
             vec![ExamplePairing::new(


### PR DESCRIPTION
# Description of change

The `openrpc.json` was always generated for protocol version **6** instead of following the latest changes.
This changes the code so that it always generates the JSON file with `ProtocolVersion::MAX`

