### PR TITLE
fix(ci): report fail-fast-cancelled develop runs to Slack

### DIFF
--- a/.github/workflows/develop_ci_slack_report.yml
+++ b/.github/workflows/develop_ci_slack_report.yml
@@ -9,9 +9,22 @@ on:
 jobs:
   on-failure:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+    if: contains(fromJSON('["failure", "timed_out", "cancelled"]'), github.event.workflow_run.conclusion)
+    permissions:
+      actions: read
     steps:
+      - name: Check for failed jobs
+        id: failed-jobs
+        # A cancelled run only indicates a broken develop if one of its jobs actually
+        # failed (the *-cancel fail-fast jobs cancel the whole run on failure); cancellations
+        # from the concurrency group or a manual cancel have no failed jobs and are not reported.
+        run: |
+          FAILED=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs?per_page=100" --paginate --jq '.jobs[] | select(.conclusion == "failure") | .id' | wc -l | tr -d '[:space:]')
+          echo "count=$FAILED" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        if: github.event.workflow_run.conclusion != 'cancelled' || steps.failed-jobs.outputs.count != '0'
         with:
           webhook: ${{ (github.event.workflow_run.name == 'Nightly checks' || github.event.workflow_run.name == 'Turborepo Nightly checks') && secrets.NIGHTLY_BROKEN_CI_SLACK_WEBHOOK || secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
# Description of change

Failures on `develop` were not reported to Slack: when a job fails, the `*-cancel` fail-fast jobs cancel the whole run, flipping its conclusion from `failure` to `cancelled`, which the Slack report workflow ignored. This happened for both `Hierarchy` failures on `develop` on 2026-07-13 (e.g. [29231470485](https://github.com/iotaledger/iota/actions/runs/29231470485)).

- Also trigger the Slack report on `cancelled` runs.
- Only alert if the cancelled run contains an actually failed job, so cancellations from the concurrency group (superseded by a newer push) or manual cancellations stay silent.
- `failure` / `timed_out` runs are reported unconditionally, as before.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Ran the failed-job check against real runs:

- [29231470485](https://github.com/iotaledger/iota/actions/runs/29231470485) (fail-fast cancelled, real test failure) → 1 failed job → would alert
- [29231513366](https://github.com/iotaledger/iota/actions/runs/29231513366) (cancelled by concurrency group, nothing broken) → 0 failed jobs → stays silent
