### PR TITLE
fix(indexer): disable fullnode pruning in common test utils

### DIFF
--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -149,7 +149,9 @@ pub async fn start_test_cluster_with_read_write_indexer(
     pruning_options: Option<PruningOptions>,
 ) -> (TestCluster, PgIndexerStore, HttpClient) {
     let database_name = database_name.into();
-    let mut builder = TestClusterBuilder::new().with_fullnode_enable_grpc_api(true);
+    let mut builder = TestClusterBuilder::new()
+        .with_fullnode_enable_grpc_api(true)
+        .disable_fullnode_pruning();
 
     if let Some(builder_modifier) = builder_modifier {
         builder = builder_modifier(builder);


### PR DESCRIPTION
# Description of change

This is a hotfix disabling fullnode pruning in Indexer tests, following #12217

## Links to any relevant issues

Closes #12216

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
