### PR TITLE
feat(iota-core): use governance deny rules in post-consensus validation (#12220)

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -71,6 +71,7 @@ use iota_types::{
     committee::{Committee, EpochId, ProtocolVersion},
     crypto::{AuthorityPublicKey, AuthoritySignInfo, AuthoritySignature, Signer},
     deny_list_v1::check_coin_deny_list_v1,
+    deny_rule_governance::DenyRuleConfig,
     digests::ChainIdentifier,
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, visitor as DFV},
     effects::{
@@ -958,6 +959,12 @@ impl AuthorityState {
     /// MoveAuthenticator checks. Returns the owned object refs for optional
     /// version validation. Does NOT acquire locks or sign the transaction.
     ///
+    /// `deny_config` is the deny rule source to enforce, chosen per caller:
+    /// the local config alone, the local config combined with the governance
+    /// rules (admission), or the governance-derived active set alone
+    /// (post-consensus) — the latter two when `deny_rule_governance` is
+    /// enabled.
+    ///
     /// `epoch_gated_coin_deny_list` selects how the coin deny list is read:
     /// `false` reads the latest value, so denials apply immediately - for
     /// validator-local admission (signing); `true` reads the value settled
@@ -985,6 +992,7 @@ impl AuthorityState {
         &self,
         transaction: &VerifiedTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        deny_config: &dyn DenyRuleConfig,
         epoch_gated_coin_deny_list: bool,
     ) -> IotaResult<Vec<ObjectReference>> {
         let protocol_config = epoch_store.protocol_config();
@@ -1002,7 +1010,7 @@ impl AuthorityState {
             transaction.signatures(),
             &transaction.input_objects()?,
             &tx.receiving_objects(),
-            &self.config.transaction_deny_config,
+            deny_config,
             self.get_backing_package_store().as_ref(),
         )?;
 
@@ -1173,6 +1181,7 @@ impl AuthorityState {
             .handle_transaction_validation_checks(
                 &transaction,
                 epoch_store,
+                &self.config.transaction_deny_config,
                 // Latest-value coin deny-list read: admission is validator-local,
                 // and denials should take effect immediately. Unlike the P-COOL
                 // submission path, no post-consensus re-check follows - this is

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -8,8 +8,9 @@ use iota_network::api::{
     GetTxStatusRequest, HealthCheckRequest, HealthCheckResponse, NotifyCapabilitiesRequest,
     NotifyCapabilitiesResponse, SubmitTxRequest, TxStatus, ValidatorV2,
 };
-use iota_sdk_types::TransactionDigest;
+use iota_sdk_types::{Address, ObjectId, TransactionDigest};
 use iota_types::{
+    deny_rule_governance::DenyRuleConfig,
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::IotaError,
     fp_ensure,
@@ -37,6 +38,62 @@ const MAX_QUERIES_PER_GET_TX_STATUS: usize = 32;
 
 /// Timeout for waiting on transaction execution in `get_tx_status`.
 const GET_TX_STATUS_TIMEOUT_SECS: u64 = 30;
+
+/// The union of two deny rule sources: denies whatever either source denies.
+struct DenyRuleUnion<'a> {
+    first: &'a dyn DenyRuleConfig,
+    second: &'a dyn DenyRuleConfig,
+}
+
+impl DenyRuleConfig for DenyRuleUnion<'_> {
+    fn is_address_denied(&self, address: &Address) -> bool {
+        self.first.is_address_denied(address) || self.second.is_address_denied(address)
+    }
+
+    fn is_object_denied(&self, id: &ObjectId) -> bool {
+        self.first.is_object_denied(id) || self.second.is_object_denied(id)
+    }
+
+    fn is_package_denied(&self, id: &ObjectId) -> bool {
+        self.first.is_package_denied(id) || self.second.is_package_denied(id)
+    }
+
+    fn has_denied_addresses(&self) -> bool {
+        self.first.has_denied_addresses() || self.second.has_denied_addresses()
+    }
+
+    fn has_denied_objects(&self) -> bool {
+        self.first.has_denied_objects() || self.second.has_denied_objects()
+    }
+
+    fn has_denied_packages(&self) -> bool {
+        self.first.has_denied_packages() || self.second.has_denied_packages()
+    }
+
+    fn package_publish_disabled(&self) -> bool {
+        self.first.package_publish_disabled() || self.second.package_publish_disabled()
+    }
+
+    fn package_upgrade_disabled(&self) -> bool {
+        self.first.package_upgrade_disabled() || self.second.package_upgrade_disabled()
+    }
+
+    fn shared_object_disabled(&self) -> bool {
+        self.first.shared_object_disabled() || self.second.shared_object_disabled()
+    }
+
+    fn user_transaction_disabled(&self) -> bool {
+        self.first.user_transaction_disabled() || self.second.user_transaction_disabled()
+    }
+
+    fn receiving_objects_disabled(&self) -> bool {
+        self.first.receiving_objects_disabled() || self.second.receiving_objects_disabled()
+    }
+
+    fn move_authenticator_disabled(&self) -> bool {
+        self.first.move_authenticator_disabled() || self.second.move_authenticator_disabled()
+    }
+}
 
 /// Maximum number of `submit_single_tx` futures allowed to run concurrently
 /// per `submit_tx` request. Caps pre-consensus work (signature verification,
@@ -220,10 +277,29 @@ impl ValidatorService {
         }
 
         // Content validation: deny checks + owned object version validation.
+        // With governance enabled, admission checks the active governance
+        // rules on top of the local config, so transactions the network will
+        // deterministically drop post-consensus don't occupy consensus slots.
+        // The local config always applies.
+        let local_deny_config = &state.config.transaction_deny_config;
+        let governance_rules;
+        let combined_deny_config;
+        let deny_config: &dyn DenyRuleConfig =
+            if epoch_store.protocol_config().deny_rule_governance() {
+                governance_rules = epoch_store.get_active_transaction_deny_rules();
+                combined_deny_config = DenyRuleUnion {
+                    first: local_deny_config,
+                    second: governance_rules.as_ref(),
+                };
+                &combined_deny_config
+            } else {
+                local_deny_config
+            };
         let owned_objects = match state
             .handle_transaction_validation_checks(
                 &verified_tx,
                 epoch_store,
+                deny_config,
                 // Latest-value coin deny-list read: admission is validator-local,
                 // and denials should take effect immediately. This deliberately
                 // differs from the epoch-gated post-consensus read; see the
@@ -659,5 +735,41 @@ impl ValidatorV2 for ValidatorService {
     ) -> Result<tonic::Response<HealthCheckResponse>, tonic::Status> {
         let (req, ip) = self.pre_handle(request).await?;
         self.post_handle_unary(ip, self.health_check_impl(req))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_sdk_types::{Address, ObjectId};
+    use iota_types::deny_rule_governance::{DenyRuleConfig, DenyRuleSet};
+
+    use super::DenyRuleUnion;
+
+    /// The union denies whatever either source denies.
+    #[test]
+    fn deny_rule_union_denies_from_either_source() {
+        let first = DenyRuleSet {
+            denied_addresses: [Address::new([1u8; 32])].into(),
+            user_transaction_disabled: true,
+            ..Default::default()
+        };
+        let second = DenyRuleSet {
+            denied_objects: [ObjectId::new([2u8; 32])].into(),
+            shared_object_disabled: true,
+            ..Default::default()
+        };
+        let union = DenyRuleUnion {
+            first: &first,
+            second: &second,
+        };
+        assert!(union.is_address_denied(&Address::new([1u8; 32])));
+        assert!(union.is_object_denied(&ObjectId::new([2u8; 32])));
+        assert!(!union.is_package_denied(&ObjectId::new([3u8; 32])));
+        assert!(union.has_denied_addresses());
+        assert!(union.has_denied_objects());
+        assert!(!union.has_denied_packages());
+        assert!(union.user_transaction_disabled());
+        assert!(union.shared_object_disabled());
+        assert!(!union.package_publish_disabled());
     }
 }

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -41,6 +41,7 @@ use std::{
 use iota_common::fatal;
 use iota_sdk_types::{ObjectReference, TransactionDigest};
 use iota_types::{
+    deny_rule_governance::DenyRuleConfig,
     error::{IotaError, IotaResult},
     transaction::{InputObjectKind, SenderSignedTransactionAPI, VerifiedTransaction},
 };
@@ -108,6 +109,18 @@ pub async fn validate_and_resolve_conflicts(
     // All UserTransactionV1 digests seen in this commit (both kept and dropped),
     // used by the caller to release pre-consensus soft locks.
     let mut all_user_tx_digests = Vec::with_capacity(transactions.len());
+
+    // One deny-rule snapshot for the whole commit, so every transaction in it
+    // is judged by the same set. With governance enabled this must be the
+    // consensus-derived set — local config can differ between validators and
+    // would fork the post-consensus decisions.
+    let governance_deny_rules;
+    let deny_config: &dyn DenyRuleConfig = if epoch_store.protocol_config().deny_rule_governance() {
+        governance_deny_rules = epoch_store.get_active_transaction_deny_rules();
+        governance_deny_rules.as_ref()
+    } else {
+        &authority_state.config.transaction_deny_config
+    };
 
     for (i, tx) in transactions.iter().enumerate() {
         // Check #0: Dedup by ConsensusTransactionKey.
@@ -265,6 +278,7 @@ pub async fn validate_and_resolve_conflicts(
             .handle_transaction_validation_checks(
                 &verified_tx,
                 epoch_store,
+                deny_config,
                 // Epoch-gated coin deny-list read: the verdict here decides whether
                 // the transaction stays in the committed set, so it must not depend
                 // on this validator's execution progress.

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -583,6 +583,7 @@ impl RegulatedCoinEnv {
             .handle_transaction_validation_checks(
                 &VerifiedTransaction::new_unchecked(transaction.clone()),
                 &epoch_store,
+                &self.env.authority.config.transaction_deny_config,
                 epoch_gated_coin_deny_list,
             )
             .await

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -1737,3 +1737,262 @@ async fn already_executed_tx_locked_by_different_digest_is_fatal() {
     )
     .await;
 }
+
+// ---------------------------------------------------------------------------
+// Governance deny rule tests
+// ---------------------------------------------------------------------------
+
+/// Activates `rules` on the epoch store by recording a proposal from this
+/// (sole, full-stake) validator through the quarantine push path. A strictly
+/// higher `generation` supersedes a previously activated set.
+fn activate_deny_rules(
+    epoch_store: &Arc<crate::authority::authority_per_epoch_store::AuthorityPerEpochStore>,
+    rules: iota_types::deny_rule_governance::DenyRuleSet,
+    generation: u64,
+) {
+    let mut output = ConsensusCommitOutput::new(0);
+    output.record_deny_rule_proposal(
+        iota_types::messages_consensus::TransactionDenyRuleProposal {
+            authority: epoch_store.name,
+            generation,
+            proposed_rules: rules,
+        },
+    );
+    output.set_default_commit_stats_for_testing();
+    epoch_store.push_consensus_output_for_tests(output);
+}
+
+/// With `deny_rule_governance` enabled, post-consensus validation drops a
+/// transaction whose sender is denied by the consensus-governed active set.
+#[sim_test]
+async fn post_consensus_validation_uses_governance_rules_when_enabled() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config.set_deny_rule_governance_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (Address, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+    let epoch_store = authority.epoch_store_for_testing();
+
+    activate_deny_rules(
+        &epoch_store,
+        iota_types::deny_rule_governance::DenyRuleSet {
+            denied_addresses: [sender].into(),
+            ..Default::default()
+        },
+        1,
+    );
+
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    let tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let digest = *tx.digest();
+    let mut transactions = vec![make_user_tx_v1(tx)];
+
+    let (dropped, locks, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &authority,
+        &epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(dropped.len(), 1);
+    assert_eq!(dropped[0].0, digest);
+    assert!(matches!(
+        &dropped[0].1,
+        IotaError::UserInput {
+            error: UserInputError::TransactionDenied { .. }
+        }
+    ));
+    assert!(transactions.is_empty());
+    assert!(locks.is_empty(), "dropped transaction must not take locks");
+}
+
+/// With `deny_rule_governance` enabled and active rules denying an unrelated
+/// address, a non-denied sender's transaction is kept and takes its locks.
+#[sim_test]
+async fn post_consensus_validation_keeps_non_denied_transactions() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config.set_deny_rule_governance_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (Address, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+    let epoch_store = authority.epoch_store_for_testing();
+
+    activate_deny_rules(
+        &epoch_store,
+        iota_types::deny_rule_governance::DenyRuleSet {
+            denied_addresses: [get_key_pair::<AccountKeyPair>().0].into(),
+            ..Default::default()
+        },
+        1,
+    );
+
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    let tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let mut transactions = vec![make_user_tx_v1(tx)];
+
+    let (dropped, locks, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &authority,
+        &epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+
+    assert!(dropped.is_empty(), "{dropped:?}");
+    assert_eq!(transactions.len(), 1, "non-denied transaction must be kept");
+    assert_eq!(
+        locks.len(),
+        2,
+        "kept transaction must lock its owned inputs"
+    );
+}
+
+/// With `deny_rule_governance` disabled, the same active set is ignored and
+/// validation falls back to the (empty) local config.
+#[sim_test]
+async fn post_consensus_validation_uses_local_config_when_disabled() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (Address, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+    let epoch_store = authority.epoch_store_for_testing();
+
+    activate_deny_rules(
+        &epoch_store,
+        iota_types::deny_rule_governance::DenyRuleSet {
+            denied_addresses: [sender].into(),
+            ..Default::default()
+        },
+        1,
+    );
+
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    let tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let mut transactions = vec![make_user_tx_v1(tx)];
+
+    let (dropped, locks, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &authority,
+        &epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+
+    assert!(dropped.is_empty());
+    assert_eq!(transactions.len(), 1);
+    assert_eq!(locks.len(), 2);
+}
+
+/// A sender denied by the active set is dropped, and after a newer-generation
+/// proposal withdraws the rules the same sender's transaction is kept.
+#[sim_test]
+async fn post_consensus_validation_applies_relaxed_rules() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config.set_deny_rule_governance_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (Address, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+    let epoch_store = authority.epoch_store_for_testing();
+
+    activate_deny_rules(
+        &epoch_store,
+        iota_types::deny_rule_governance::DenyRuleSet {
+            denied_addresses: [sender].into(),
+            ..Default::default()
+        },
+        1,
+    );
+
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    let tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let mut transactions = vec![make_user_tx_v1(tx)];
+
+    let (dropped, locks, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &authority,
+        &epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+    assert_eq!(dropped.len(), 1, "denied sender must be dropped");
+    assert!(locks.is_empty());
+
+    // Withdraw the rules with a newer-generation empty proposal.
+    activate_deny_rules(&epoch_store, Default::default(), 2);
+
+    // The dropped transaction did not execute, so the same object refs are
+    // still current for a fresh transaction (distinct digest via a new
+    // recipient) from the no-longer-denied sender.
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+    let tx =
+        make_transfer_object_transaction(object_ref, gas_ref, sender, &sender_key, recipient, rgp);
+    let mut transactions = vec![make_user_tx_v1(tx)];
+
+    let (dropped, locks, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &authority,
+        &epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+    assert!(dropped.is_empty(), "{dropped:?}");
+    assert_eq!(
+        transactions.len(),
+        1,
+        "previously denied sender must be kept after withdrawal"
+    );
+    assert_eq!(locks.len(), 2);
+}

--- a/crates/iota-types/src/deny_rule_governance.rs
+++ b/crates/iota-types/src/deny_rule_governance.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// Implemented by both a validator's local `TransactionDenyConfig` and the
 /// consensus-governed [`DenyRuleSet`], so the deny checks can run against
 /// either source without knowing which one is in effect.
-pub trait DenyRuleConfig {
+pub trait DenyRuleConfig: Send + Sync {
     /// Whether `address` is denied as a transaction sender or gas sponsor.
     fn is_address_denied(&self, address: &Address) -> bool;
     /// Whether the object `id` is denied as an input or receiving object.


### PR DESCRIPTION
# Description of change

Part of #10749. Post-consensus validation now reads the consensus-governed active deny rule set (#12151) instead of node-local config when `deny_rule_governance` is enabled — the determinism-critical switch of the series.

- `handle_transaction_validation_checks` takes `deny_config: &dyn DenyRuleConfig`
- `validate_and_resolve_conflicts` selects one snapshot per commit: governance set when the flag is on, local config otherwise — every transaction in a commit is judged by the same set
- Pre-consensus, dry-run, simulate, dev-inspect paths keep local config
- `DenyRuleConfig` gains `Send + Sync` bounds (trait objects cross await points)

Stacked on the #12164 branch (PR #12219).

## Links to any relevant issues

Fixes #12220.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes