### PR TITLE
feat(iota-node,iota-swarm-config): submit deny rule proposals on startup and epoch change (#12221)

### DIFF
--- a/crates/iota-config/src/transaction_deny_config.rs
+++ b/crates/iota-config/src/transaction_deny_config.rs
@@ -5,7 +5,7 @@
 use std::collections::HashSet;
 
 use iota_sdk_types::{Address, ObjectId};
-use iota_types::deny_rule_governance::DenyRuleConfig;
+use iota_types::deny_rule_governance::{DenyRuleConfig, DenyRuleSet};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
@@ -117,6 +117,22 @@ impl TransactionDenyConfig {
 
     pub fn move_authenticator_disabled(&self) -> bool {
         self.move_authenticator_disabled
+    }
+
+    /// The full-state [`DenyRuleSet`] equivalent of this config, for
+    /// announcing it as a deny rule proposal.
+    pub fn to_deny_rule_set(&self) -> DenyRuleSet {
+        DenyRuleSet {
+            denied_addresses: self.address_deny_list.iter().copied().collect(),
+            denied_objects: self.object_deny_list.iter().copied().collect(),
+            denied_packages: self.package_deny_list.iter().copied().collect(),
+            package_publish_disabled: self.package_publish_disabled,
+            package_upgrade_disabled: self.package_upgrade_disabled,
+            shared_object_disabled: self.shared_object_disabled,
+            user_transaction_disabled: self.user_transaction_disabled,
+            receiving_objects_disabled: self.receiving_objects_disabled,
+            move_authenticator_disabled: self.move_authenticator_disabled,
+        }
     }
 }
 
@@ -233,6 +249,7 @@ impl DenyRuleConfig for TransactionDenyConfig {
 #[cfg(test)]
 mod tests {
     use iota_sdk_types::{Address, ObjectId};
+    use iota_types::deny_rule_governance::DenyRuleSet;
 
     use super::{DenyRuleConfig, TransactionDenyConfig, TransactionDenyConfigBuilder};
 
@@ -271,5 +288,73 @@ mod tests {
         assert!(!empty.has_denied_addresses());
         assert!(!empty.has_denied_objects());
         assert!(!empty.has_denied_packages());
+    }
+
+    #[test]
+    fn to_deny_rule_set_round_trips_lists_and_switches() {
+        let addr = Address::new([1u8; 32]);
+        let obj = ObjectId::new([2u8; 32]);
+        let pkg = ObjectId::new([3u8; 32]);
+        let rules = TransactionDenyConfigBuilder::new()
+            .add_denied_address(addr)
+            .add_denied_object(obj)
+            .add_denied_package(pkg)
+            .build()
+            .to_deny_rule_set();
+        assert_eq!(rules.denied_addresses, [addr].into());
+        assert_eq!(rules.denied_objects, [obj].into());
+        assert_eq!(rules.denied_packages, [pkg].into());
+
+        // One switch per config: a single sample can't distinguish the six
+        // boolean mappings, so pin each switch position separately.
+        type Setter = fn(TransactionDenyConfigBuilder) -> TransactionDenyConfigBuilder;
+        type Getter = fn(&DenyRuleSet) -> bool;
+        let switches: [(&str, Setter, Getter); 6] = [
+            (
+                "package_publish_disabled",
+                TransactionDenyConfigBuilder::disable_package_publish,
+                |r| r.package_publish_disabled,
+            ),
+            (
+                "package_upgrade_disabled",
+                TransactionDenyConfigBuilder::disable_package_upgrade,
+                |r| r.package_upgrade_disabled,
+            ),
+            (
+                "shared_object_disabled",
+                TransactionDenyConfigBuilder::disable_shared_object_transaction,
+                |r| r.shared_object_disabled,
+            ),
+            (
+                "user_transaction_disabled",
+                TransactionDenyConfigBuilder::disable_user_transaction,
+                |r| r.user_transaction_disabled,
+            ),
+            (
+                "receiving_objects_disabled",
+                TransactionDenyConfigBuilder::disable_receiving_objects,
+                |r| r.receiving_objects_disabled,
+            ),
+            (
+                "move_authenticator_disabled",
+                TransactionDenyConfigBuilder::disable_move_authenticator,
+                |r| r.move_authenticator_disabled,
+            ),
+        ];
+        for (hot, (hot_name, set, _)) in switches.iter().enumerate() {
+            let rules = set(TransactionDenyConfigBuilder::new())
+                .build()
+                .to_deny_rule_set();
+            for (i, (name, _, get)) in switches.iter().enumerate() {
+                assert_eq!(get(&rules), i == hot, "set {hot_name}, checked {name}");
+            }
+        }
+
+        // An empty config produces the default (nothing denied) set — the node
+        // uses this to decide whether to submit a proposal at all.
+        assert_eq!(
+            TransactionDenyConfig::default().to_deny_rule_set(),
+            DenyRuleSet::default()
+        );
     }
 }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2986,6 +2986,17 @@ impl AuthorityPerEpochStore {
             .current_deny_rule_proposals())
     }
 
+    /// The proposal recorded from `authority` this epoch, if any.
+    pub fn recorded_deny_rule_proposal(
+        &self,
+        authority: &AuthorityName,
+    ) -> Option<TransactionDenyRuleProposal> {
+        self.consensus_quarantine
+            .read()
+            .current_deny_rule_proposals()
+            .remove(authority)
+    }
+
     /// Whether `proposal` is newer than the recorded proposal (if any) from
     /// the same authority and should therefore be recorded.
     pub fn should_record_deny_rule_proposal(&self, proposal: &TransactionDenyRuleProposal) -> bool {

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -75,7 +75,8 @@ use crate::{
 /// # Arguments
 ///
 /// * `authority_state` — Used for cache reads and deny checks.
-/// * `epoch_store` — Current epoch store (protocol config, lock storage).
+/// * `epoch_store` — Current epoch store (protocol config, lock storage,
+///   governance deny rules).
 /// * `transactions` — All sequenced transactions for this consensus commit;
 ///   modified in-place.
 ///

--- a/crates/iota-e2e-tests/tests/deny_rule_governance_tests.rs
+++ b/crates/iota-e2e-tests/tests/deny_rule_governance_tests.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// The protocol config override used to enable the feature flags is
+// thread-local, so these tests only work under the simulator, where all nodes
+// share one thread.
+#[cfg(msim)]
+mod simtests {
+    use std::time::Duration;
+
+    use iota_config::transaction_deny_config::TransactionDenyConfigBuilder;
+    use iota_macros::sim_test;
+    use iota_protocol_config::ProtocolConfig;
+    use iota_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
+    use iota_test_transaction_builder::TestTransactionBuilder;
+    use iota_types::crypto::get_account_key_pair;
+    use test_cluster::TestClusterBuilder;
+
+    /// Validators announce their local deny config through consensus on
+    /// startup; the stake-weighted aggregate must become active on every
+    /// validator, admit non-denied transactions, and reject denied senders.
+    #[sim_test]
+    async fn deny_rule_proposals_converge_across_validators() {
+        telemetry_subscribers::init_for_testing();
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_enable_pcool_flow_for_testing(true);
+            config.set_deny_rule_governance_for_testing(true);
+            config
+        });
+
+        // A funded account whose address every validator's local config
+        // denies, and a funded non-denied account for the positive path.
+        let (denied, denied_key) = get_account_key_pair();
+        let deny_config = TransactionDenyConfigBuilder::new()
+            .add_denied_address(denied)
+            .build();
+
+        let test_cluster = TestClusterBuilder::new()
+            .with_transaction_deny_config(deny_config)
+            .with_accounts(vec![
+                AccountConfig {
+                    address: Some(denied),
+                    gas_amounts: vec![DEFAULT_GAS_AMOUNT],
+                },
+                AccountConfig {
+                    address: None,
+                    gas_amounts: vec![DEFAULT_GAS_AMOUNT; 2],
+                },
+            ])
+            .build()
+            .await;
+
+        // Proposals are submitted on startup and aggregated at commit
+        // boundaries; poll until the rule is active on every validator.
+        let mut converged = false;
+        for _ in 0..120 {
+            converged = test_cluster
+                .swarm
+                .validator_node_handles()
+                .iter()
+                .all(|handle| {
+                    handle.with(|node| {
+                        node.state()
+                            .epoch_store_for_testing()
+                            .get_active_transaction_deny_rules()
+                            .denied_addresses
+                            .contains(&denied)
+                    })
+                });
+            if converged {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        assert!(
+            converged,
+            "governance deny rules did not become active on all validators"
+        );
+
+        let rgp = test_cluster.get_reference_gas_price().await;
+
+        // A non-denied sender's transaction executes normally.
+        let sender = test_cluster.get_address_0();
+        let gas = test_cluster
+            .wallet
+            .get_one_gas_object_owned_by_address(sender)
+            .await
+            .unwrap()
+            .expect("sender should own gas");
+        let tx_data = TestTransactionBuilder::new(sender, gas, rgp)
+            .transfer_iota(Some(1_000), sender)
+            .build();
+        test_cluster.sign_and_execute_transaction(&tx_data).await;
+
+        // The denied sender is rejected at submission: admission checks the
+        // local config and the governance rules (both deny here, since every
+        // validator runs the same local config), so the transaction never
+        // occupies a consensus slot. Governance propagation itself is proven
+        // by the convergence poll above.
+        let denied_gas = test_cluster
+            .wallet
+            .get_one_gas_object_owned_by_address(denied)
+            .await
+            .unwrap()
+            .expect("denied account should own gas");
+        let denied_tx = TestTransactionBuilder::new(denied, denied_gas, rgp)
+            .transfer_iota(Some(1_000), sender)
+            .build_and_sign(&denied_key);
+        let result = test_cluster
+            .wallet
+            .execute_transaction_may_fail(denied_tx)
+            .await;
+        let error = result
+            .expect_err("denied sender must be rejected")
+            .to_string();
+        assert!(
+            error.contains("temporarily disabled"),
+            "unexpected rejection reason: {error}"
+        );
+    }
+}

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -118,6 +118,7 @@ use iota_types::{
     base_types::{AuthorityName, ConciseableName, EpochId},
     committee::Committee,
     crypto::{AuthoritySignature, IotaAuthoritySignature, KeypairTraits},
+    deny_rule_governance::DenyRuleSet,
     digests::ChainIdentifier,
     error::{IotaError, IotaResult},
     executable_transaction::VerifiedExecutableTransaction,
@@ -130,7 +131,7 @@ use iota_types::{
     messages_checkpoint::CheckpointSummaryExt,
     messages_consensus::{
         AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKind,
-        SignedAuthorityCapabilitiesV1,
+        SignedAuthorityCapabilitiesV1, TransactionDenyRuleProposal,
     },
     messages_grpc::HandleCapabilityNotificationRequestV1,
     quorum_driver_types::QuorumDriverEffectsQueueResult,
@@ -1798,8 +1799,8 @@ impl IotaNode {
     /// This function awaits the completion of checkpoint execution of the
     /// current epoch, after which it initiates reconfiguration of the
     /// entire system. This function also handles role changes for the node when
-    /// epoch changes and advertises capabilities to the committee if the node
-    /// is a validator.
+    /// epoch changes and, if the node is a validator, advertises capabilities
+    /// and submits the local deny rule proposal to consensus.
     pub async fn monitor_reconfiguration(
         self: Arc<Self>,
         mut epoch_store: Arc<AuthorityPerEpochStore>,
@@ -1873,6 +1874,37 @@ impl IotaNode {
                 components
                     .consensus_adapter
                     .submit(transaction, None, &cur_epoch_store)?;
+
+                // Announce the local deny rules. Recorded proposals are
+                // epoch-scoped, so this re-announces on every epoch change.
+                // An empty set is still submitted when a non-empty proposal
+                // is recorded this epoch: in the full-state model that
+                // withdraws the earlier rules after an operator cleared the
+                // local config and restarted.
+                if config.deny_rule_governance() {
+                    let proposed_rules = self.config.transaction_deny_config.to_deny_rule_set();
+                    let recorded = cur_epoch_store.recorded_deny_rule_proposal(&self.state.name);
+                    let should_submit = proposed_rules != DenyRuleSet::default()
+                        || recorded
+                            .as_ref()
+                            .is_some_and(|p| p.proposed_rules != DenyRuleSet::default());
+                    if should_submit {
+                        let transaction = ConsensusTransaction::new_transaction_deny_rule_proposal(
+                            TransactionDenyRuleProposal::new(
+                                self.state.name,
+                                proposed_rules,
+                                recorded.map(|p| p.generation),
+                            ),
+                        );
+                        info!(
+                            tracking_id = ?transaction.get_tracking_id(),
+                            "submitting deny rule proposal to consensus"
+                        );
+                        components
+                            .consensus_adapter
+                            .submit(transaction, None, &cur_epoch_store)?;
+                    }
+                }
             } else if self.state.is_active_validator(&cur_epoch_store)
                 && cur_epoch_store
                     .protocol_config()

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -14,6 +14,7 @@ use iota_config::{
     ExecutionCacheConfig, IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
     genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
     node::AuthorityOverloadConfig,
+    transaction_deny_config::TransactionDenyConfig,
 };
 use iota_genesis_builder::genesis_build_effects::GenesisBuildEffects;
 use iota_protocol_config::Chain;
@@ -87,6 +88,7 @@ pub struct ConfigBuilder<R = OsRng> {
     additional_objects: Vec<Object>,
     num_unpruned_validators: Option<usize>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    transaction_deny_config: Option<TransactionDenyConfig>,
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     policy_config: Option<PolicyConfig>,
@@ -113,6 +115,7 @@ impl ConfigBuilder {
             additional_objects: vec![],
             num_unpruned_validators: None,
             authority_overload_config: None,
+            transaction_deny_config: None,
             execution_cache_config: None,
             data_ingestion_dir: None,
             policy_config: None,
@@ -262,6 +265,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_transaction_deny_config(mut self, c: TransactionDenyConfig) -> Self {
+        self.transaction_deny_config = Some(c);
+        self
+    }
+
     pub fn with_execution_cache_config(mut self, c: ExecutionCacheConfig) -> Self {
         self.execution_cache_config = Some(c);
         self
@@ -307,6 +315,7 @@ impl<R> ConfigBuilder<R> {
             additional_objects: self.additional_objects,
             num_unpruned_validators: self.num_unpruned_validators,
             authority_overload_config: self.authority_overload_config,
+            transaction_deny_config: self.transaction_deny_config,
             execution_cache_config: self.execution_cache_config,
             data_ingestion_dir: self.data_ingestion_dir,
             policy_config: self.policy_config,
@@ -510,6 +519,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 if let Some(authority_overload_config) = &self.authority_overload_config {
                     builder =
                         builder.with_authority_overload_config(authority_overload_config.clone());
+                }
+
+                if let Some(transaction_deny_config) = &self.transaction_deny_config {
+                    builder = builder.with_transaction_deny_config(transaction_deny_config.clone());
                 }
 
                 if let Some(execution_cache_config) = &self.execution_cache_config {

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -20,6 +20,7 @@ use iota_config::{
         default_full_checkpoint_contents_cache_size_mb,
     },
     p2p::{DiscoveryConfig, P2pConfig, SeedPeer, StateSyncConfig},
+    transaction_deny_config::TransactionDenyConfig,
     verifier_signing_config::VerifierSigningConfig,
 };
 use iota_names::config::IotaNamesConfig;
@@ -45,6 +46,7 @@ pub struct ValidatorConfigBuilder {
     supported_protocol_versions: Option<SupportedProtocolVersions>,
     force_unpruned_checkpoints: bool,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    transaction_deny_config: Option<TransactionDenyConfig>,
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     policy_config: Option<PolicyConfig>,
@@ -90,6 +92,11 @@ impl ValidatorConfigBuilder {
 
     pub fn with_authority_overload_config(mut self, config: AuthorityOverloadConfig) -> Self {
         self.authority_overload_config = Some(config);
+        self
+    }
+
+    pub fn with_transaction_deny_config(mut self, config: TransactionDenyConfig) -> Self {
+        self.transaction_deny_config = Some(config);
         self
     }
 
@@ -217,7 +224,7 @@ impl ValidatorConfigBuilder {
             // By default, expensive checks will be enabled in debug build, but not in release
             // build.
             expensive_safety_check_config: ExpensiveSafetyCheckConfig::default(),
-            transaction_deny_config: Default::default(),
+            transaction_deny_config: self.transaction_deny_config.unwrap_or_default(),
             certificate_deny_config: Default::default(),
             state_debug_dump_config: Default::default(),
             state_archive_write_config: StateArchiveConfig::default(),

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -16,6 +16,7 @@ use iota_config::{
     ExecutionCacheConfig, IOTA_GENESIS_FILENAME, NodeConfig,
     node::{AuthorityOverloadConfig, DBCheckpointConfig, GrpcApiConfig, RunWithRange},
     p2p::DiscoveryConfig,
+    transaction_deny_config::TransactionDenyConfig,
 };
 use iota_macros::nondeterministic;
 use iota_names::config::IotaNamesConfig;
@@ -61,6 +62,7 @@ pub struct SwarmBuilder<R = OsRng> {
     db_checkpoint_config: DBCheckpointConfig,
     num_unpruned_validators: Option<usize>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    transaction_deny_config: Option<TransactionDenyConfig>,
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
@@ -96,6 +98,7 @@ impl SwarmBuilder {
             db_checkpoint_config: DBCheckpointConfig::default(),
             num_unpruned_validators: None,
             authority_overload_config: None,
+            transaction_deny_config: None,
             execution_cache_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
@@ -133,6 +136,7 @@ impl<R> SwarmBuilder<R> {
             db_checkpoint_config: self.db_checkpoint_config,
             num_unpruned_validators: self.num_unpruned_validators,
             authority_overload_config: self.authority_overload_config,
+            transaction_deny_config: self.transaction_deny_config,
             execution_cache_config: self.execution_cache_config,
             data_ingestion_dir: self.data_ingestion_dir,
             fullnode_run_with_range: self.fullnode_run_with_range,
@@ -292,6 +296,15 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    pub fn with_transaction_deny_config(
+        mut self,
+        transaction_deny_config: TransactionDenyConfig,
+    ) -> Self {
+        assert!(self.network_config.is_none());
+        self.transaction_deny_config = Some(transaction_deny_config);
+        self
+    }
+
     pub fn with_execution_cache_config(
         mut self,
         execution_cache_config: ExecutionCacheConfig,
@@ -402,6 +415,11 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             if let Some(authority_overload_config) = self.authority_overload_config {
                 config_builder =
                     config_builder.with_authority_overload_config(authority_overload_config);
+            }
+
+            if let Some(transaction_deny_config) = self.transaction_deny_config {
+                config_builder =
+                    config_builder.with_transaction_deny_config(transaction_deny_config);
             }
 
             if let Some(execution_cache_config) = self.execution_cache_config {

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -249,6 +249,30 @@ pub struct TransactionDenyRuleProposal {
     pub proposed_rules: DenyRuleSet,
 }
 
+impl TransactionDenyRuleProposal {
+    /// Creates a proposal with a wall-clock generation, so a resubmission
+    /// supersedes this authority's earlier proposals. Pass the generation of
+    /// this authority's currently recorded proposal (if any) so the new one
+    /// stays newer even after a backward wall-clock step.
+    pub fn new(
+        authority: AuthorityName,
+        proposed_rules: DenyRuleSet,
+        last_generation: Option<u64>,
+    ) -> Self {
+        let now: u64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("IOTA did not exist prior to 1970")
+            .as_millis()
+            .try_into()
+            .expect("This build of iota is not supported in the year 500,000,000");
+        Self {
+            authority,
+            generation: now.max(last_generation.map_or(0, |g| g.saturating_add(1))),
+            proposed_rules,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ConsensusTransactionKind {
     CertifiedTransaction(Box<CertifiedTransaction>),
@@ -968,5 +992,21 @@ mod tests {
         };
         let bytes = bcs::to_bytes(&proposal).unwrap();
         assert_eq!(proposal, bcs::from_bytes(&bytes).unwrap());
+    }
+
+    /// The generation is wall-clock time, but never regresses below a
+    /// recorded proposal's generation even if the clock stepped backward.
+    #[test]
+    fn proposal_generation_supersedes_last_generation() {
+        use crate::deny_rule_governance::DenyRuleSet;
+
+        let authority = AuthorityName::default();
+        let fresh = TransactionDenyRuleProposal::new(authority, DenyRuleSet::default(), None);
+        assert!(fresh.generation > 0);
+
+        let far_future = fresh.generation + 1_000_000_000;
+        let successor =
+            TransactionDenyRuleProposal::new(authority, DenyRuleSet::default(), Some(far_future));
+        assert_eq!(successor.generation, far_future + 1);
     }
 }

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -18,6 +18,7 @@ use iota_config::{
     NodeConfig, PersistedConfig,
     genesis::Genesis,
     node::{AuthorityOverloadConfig, DBCheckpointConfig, GrpcApiConfig, RunWithRange},
+    transaction_deny_config::TransactionDenyConfig,
 };
 use iota_core::{
     authority_aggregator::AuthorityAggregator, authority_client::NetworkAuthorityClient,
@@ -1008,6 +1009,7 @@ pub struct TestClusterBuilder {
     num_unpruned_validators: Option<usize>,
     config_dir: Option<PathBuf>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    transaction_deny_config: Option<TransactionDenyConfig>,
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
@@ -1041,6 +1043,7 @@ impl TestClusterBuilder {
             num_unpruned_validators: None,
             config_dir: None,
             authority_overload_config: None,
+            transaction_deny_config: None,
             execution_cache_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
@@ -1249,6 +1252,12 @@ impl TestClusterBuilder {
         self
     }
 
+    pub fn with_transaction_deny_config(mut self, config: TransactionDenyConfig) -> Self {
+        assert!(self.network_config.is_none());
+        self.transaction_deny_config = Some(config);
+        self
+    }
+
     pub fn with_execution_cache_config(mut self, config: ExecutionCacheConfig) -> Self {
         assert!(self.network_config.is_none());
         self.execution_cache_config = Some(config);
@@ -1384,6 +1393,10 @@ impl TestClusterBuilder {
 
         if let Some(authority_overload_config) = self.authority_overload_config.take() {
             builder = builder.with_authority_overload_config(authority_overload_config);
+        }
+
+        if let Some(transaction_deny_config) = self.transaction_deny_config.take() {
+            builder = builder.with_transaction_deny_config(transaction_deny_config);
         }
 
         if let Some(execution_cache_config) = self.execution_cache_config.take() {


### PR DESCRIPTION
# Description of change

Part of #10749. Validators now announce their local `TransactionDenyConfig` as a `DenyRuleProposal` through consensus, on startup and on every epoch change (vote tracking is epoch-scoped).

- Submission hook in `IotaNode` next to the capabilities submit, gated on `deny_rule_governance`; empty configs are not announced
- `DenyRuleProposal::new` stamps a wall-clock generation so a resubmission supersedes earlier proposals (mirrors `AuthorityCapabilitiesV1::new`)
- `TransactionDenyConfig::to_deny_rule_set()` converts the local config to the full-state proposal payload
- `with_transaction_deny_config` knob through the validator config/swarm/test-cluster builders (test infra)
- E2e simtest verifying proposals converge and become active on all validators
- Doc fix in `post_consensus_validation.rs` left over from #12231

Stacked on the #12220 branch (PR #12231).

## Links to any relevant issues

Fixes #12221.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes