### PR TITLE
fix(ci): stop release-notes job from clearing the pre-release flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,6 @@ jobs:
   generate-release-notes:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PRERELEASE: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'release' }}
     needs: generate-tag
@@ -266,7 +265,6 @@ jobs:
         with:
           tag_name: ${{ needs.generate-tag.outputs.iota_ref }}
           body_path: ${{ env.RELEASE_NOTES_FILE }}
-          prerelease: ${{ env.PRERELEASE }}
 
   update-homebrew-formula:
     name: Update the homebrew-tap formula


### PR DESCRIPTION
## Description of change

- The `generate-release-notes` job passed an explicit `prerelease` input to `action-gh-release`, computed only from `-alpha`/`-beta` tag suffixes.
- For `-rc` releases this evaluated to `false`, so the release-notes update flipped the existing release from pre-release to full release (confirmed in the logs of the v1.27.0-rc run).
- Remove the input so the action preserves the flag set when the release was created; the workflow only runs on `release: created`, so the release always exists with the correct flag.

## Links to any relevant issues

Closes #12185

🤖 Generated with [Claude Code](https://claude.com/claude-code)