### PR TITLE
upstream(iota-core): dedup in-flight transactions on the driver path

### DIFF
--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -7,7 +7,12 @@
 // finality, and proactively executes finalized transactions locally.
 
 use std::{
-    collections::BTreeMap, net::SocketAddr, ops::Deref, path::Path, sync::Arc, time::Duration,
+    collections::{BTreeMap, HashSet},
+    net::SocketAddr,
+    ops::Deref,
+    path::Path,
+    sync::Arc,
+    time::Duration,
 };
 
 use futures::{
@@ -39,6 +44,7 @@ use iota_types::{
     },
     transaction_executor::{SimulateTransactionResult, VmChecks},
 };
+use parking_lot::Mutex;
 use prometheus_filtered::{
     Histogram, Registry,
     core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge},
@@ -94,6 +100,12 @@ pub struct TransactionOrchestrator<A: Clone> {
     validator_state: Arc<AuthorityState>,
     _local_executor_handle: Option<JoinHandle<()>>,
     pending_tx_log: Arc<WritePathPendingTransactionLog>,
+    /// Digests currently being driven to finality by the TransactionDriver;
+    /// used to deduplicate concurrent submissions of the same transaction.
+    /// Kept in memory only: the driver path is best-effort, so there is
+    /// nothing to recover after a restart. The QuorumDriver path tracks its
+    /// submissions in `pending_tx_log` instead.
+    in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
     notifier: Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>,
     metrics: Arc<TransactionOrchestratorMetrics>,
 }
@@ -217,6 +229,7 @@ where
             validator_state,
             _local_executor_handle,
             pending_tx_log,
+            in_flight_transactions: Default::default(),
             notifier,
             metrics,
         }
@@ -262,25 +275,13 @@ where
 
         let (mut response, seq) = match (&self.driver, wait_for_local_execution) {
             (Driver::Transaction(td), true) => {
-                self.submit_with_checkpoint_race(
-                    td.clone(),
-                    &transaction,
-                    request,
-                    client_addr,
-                    tx_digest,
-                )
-                .await?
+                self.submit_with_checkpoint_race(td.clone(), request, client_addr, tx_digest)
+                    .await?
             }
             (Driver::Transaction(td), false) => (
                 Some(
-                    self.submit_with_transaction_driver(
-                        td.clone(),
-                        &transaction,
-                        request,
-                        client_addr,
-                        false,
-                    )
-                    .await?,
+                    self.submit_with_transaction_driver(td.clone(), request, client_addr, false)
+                        .await?,
                 ),
                 None,
             ),
@@ -521,12 +522,11 @@ where
                 // execution service) are responsible for their own
                 // `wait_for_checkpoint_inclusion` when they need it, and will
                 // reconcile the response from the cache there.
-                let transaction = epoch_store
+                epoch_store
                     .verify_transaction(request.transaction.clone())
                     .map_err(QuorumDriverError::InvalidUserSignature)?;
                 self.submit_with_transaction_driver(
                     td.clone(),
-                    &transaction,
                     request,
                     client_addr,
                     skip_certification,
@@ -563,7 +563,6 @@ where
     async fn submit_with_checkpoint_race(
         &self,
         td: Arc<TransactionDriver<A>>,
-        transaction: &VerifiedTransaction,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         tx_digest: TransactionDigest,
@@ -579,8 +578,7 @@ where
             .validator_state
             .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT);
         tokio::pin!(checkpoint_inclusion);
-        let driver =
-            self.submit_with_transaction_driver(td, transaction, request, client_addr, true);
+        let driver = self.submit_with_transaction_driver(td, request, client_addr, true);
 
         let seq_for_tx = |inclusion_map: BTreeMap<_, (CheckpointSequenceNumber, _)>| {
             inclusion_map.get(&tx_digest).map(|&(seq, _)| seq)
@@ -621,20 +619,18 @@ where
     async fn submit_with_transaction_driver(
         &self,
         td: Arc<TransactionDriver<A>>,
-        transaction: &VerifiedTransaction,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         skip_certification: bool,
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
-        let tx_digest = *transaction.digest();
+        let tx_digest = *request.transaction.digest();
 
         // Deduplicate concurrent submissions of the same digest: only the first
         // caller drives the committee-wide submission; the rest wait for its
-        // effects. The guard removes the pending-log entry on every exit path
-        // (success, error, timeout, or cancellation) when it is dropped.
-        let guard = TransactionSubmissionGuard::new(self.pending_tx_log.clone(), transaction)
-            .await
-            .map_err(QuorumDriverError::QuorumDriverInternal)?;
+        // effects. The guard removes the digest from the in-flight set on every
+        // exit path (success, error, timeout, or cancellation) when it is
+        // dropped.
+        let guard = TransactionSubmissionGuard::new(self.in_flight_transactions.clone(), tx_digest);
         if !guard.is_new_transaction() {
             debug!(
                 ?tx_digest,
@@ -1488,38 +1484,35 @@ fn read_cached_transaction_data(
 }
 
 /// Tracks a transaction that is being submitted to finality so that concurrent
-/// submissions of the same digest deduplicate, and guarantees the pending
-/// transaction log entry is removed once submission finishes.
+/// submissions of the same digest deduplicate.
 ///
 /// `is_new_transaction` is `false` when another submission of the same digest
 /// is already in flight; the caller should then wait for that submission's
-/// effects instead of starting a new one. The log entry is removed when the
-/// guard is dropped, covering success, error, timeout, and cancellation.
+/// effects instead of starting a new one. The driving submission's guard
+/// removes the digest from the in-flight set when dropped, covering success,
+/// error, timeout, and cancellation.
 struct TransactionSubmissionGuard {
-    pending_tx_log: Arc<WritePathPendingTransactionLog>,
+    in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
     tx_digest: TransactionDigest,
     is_new_transaction: bool,
 }
 
 impl TransactionSubmissionGuard {
-    async fn new(
-        pending_tx_log: Arc<WritePathPendingTransactionLog>,
-        transaction: &VerifiedTransaction,
-    ) -> IotaResult<Self> {
-        let tx_digest = *transaction.digest();
-        let is_new_transaction = pending_tx_log
-            .write_pending_transaction_maybe(transaction)
-            .await?;
+    fn new(
+        in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
+        tx_digest: TransactionDigest,
+    ) -> Self {
+        let is_new_transaction = in_flight_transactions.lock().insert(tx_digest);
         if is_new_transaction {
             debug!(?tx_digest, "added transaction to in-flight set");
         } else {
             debug!(?tx_digest, "transaction already being processed");
         }
-        Ok(Self {
-            pending_tx_log,
+        Self {
+            in_flight_transactions,
             tx_digest,
             is_new_transaction,
-        })
+        }
     }
 
     fn is_new_transaction(&self) -> bool {
@@ -1529,12 +1522,11 @@ impl TransactionSubmissionGuard {
 
 impl Drop for TransactionSubmissionGuard {
     fn drop(&mut self) {
-        match self.pending_tx_log.finish_transaction(&self.tx_digest) {
-            Ok(()) => debug!(tx_digest = ?self.tx_digest, "cleaned up transaction in pending log"),
-            Err(err) => warn!(
-                tx_digest = ?self.tx_digest,
-                "failed to clean up transaction in pending log: {err}"
-            ),
+        // Only the guard that inserted the digest owns the entry; a duplicate
+        // submission's guard must not remove it while the driving submission
+        // is still in flight.
+        if self.is_new_transaction {
+            self.in_flight_transactions.lock().remove(&self.tx_digest);
         }
     }
 }

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -262,14 +262,25 @@ where
 
         let (mut response, seq) = match (&self.driver, wait_for_local_execution) {
             (Driver::Transaction(td), true) => {
-                self.submit_with_checkpoint_race(td.clone(), request, client_addr, tx_digest)
-                    .await?
+                self.submit_with_checkpoint_race(
+                    td.clone(),
+                    &transaction,
+                    request,
+                    client_addr,
+                    tx_digest,
+                )
+                .await?
             }
             (Driver::Transaction(td), false) => (
                 Some(
-                    self.submit_with_transaction_driver(td.clone(), request, client_addr, false)
-                        .await
-                        .map_err(map_td_error_to_qd)?,
+                    self.submit_with_transaction_driver(
+                        td.clone(),
+                        &transaction,
+                        request,
+                        client_addr,
+                        false,
+                    )
+                    .await?,
                 ),
                 None,
             ),
@@ -510,17 +521,17 @@ where
                 // execution service) are responsible for their own
                 // `wait_for_checkpoint_inclusion` when they need it, and will
                 // reconcile the response from the cache there.
-                epoch_store
+                let transaction = epoch_store
                     .verify_transaction(request.transaction.clone())
                     .map_err(QuorumDriverError::InvalidUserSignature)?;
                 self.submit_with_transaction_driver(
                     td.clone(),
+                    &transaction,
                     request,
                     client_addr,
                     skip_certification,
                 )
                 .await
-                .map_err(map_td_error_to_qd)
             }
             Driver::Quorum(qd) => {
                 let qd_resp = self
@@ -552,6 +563,7 @@ where
     async fn submit_with_checkpoint_race(
         &self,
         td: Arc<TransactionDriver<A>>,
+        transaction: &VerifiedTransaction,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         tx_digest: TransactionDigest,
@@ -567,7 +579,8 @@ where
             .validator_state
             .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT);
         tokio::pin!(checkpoint_inclusion);
-        let driver = self.submit_with_transaction_driver(td, request, client_addr, true);
+        let driver =
+            self.submit_with_transaction_driver(td, transaction, request, client_addr, true);
 
         let seq_for_tx = |inclusion_map: BTreeMap<_, (CheckpointSequenceNumber, _)>| {
             inclusion_map.get(&tx_digest).map(|&(seq, _)| seq)
@@ -580,7 +593,7 @@ where
             // only returns here as `Ok`, `TimeoutWithLastRetriableError`, or
             // a non-retriable error like `RejectedByValidators`.
             driver_result = driver => {
-                let response = Some(driver_result.map_err(map_td_error_to_qd)?);
+                let response = Some(driver_result?);
                 let seq = (&mut checkpoint_inclusion).await.ok().and_then(seq_for_tx);
                 (response, seq)
             }
@@ -608,23 +621,28 @@ where
     async fn submit_with_transaction_driver(
         &self,
         td: Arc<TransactionDriver<A>>,
+        transaction: &VerifiedTransaction,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         skip_certification: bool,
-    ) -> Result<ExecuteTransactionResponseV1, TransactionDriverError> {
-        let tx_digest = *request.transaction.digest();
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
+        let tx_digest = *transaction.digest();
 
-        // TODO: add transaction to some struct to prevent sending the same transaction
-        // multiple times in case client sends it multiple times if self
-        //     .pending_tx_log
-        //     .write_pending_transaction_maybe(&transaction)
-        //     .await
-        //     .map_err(|e| QuorumDriverError::QuorumDriverInternal(e))?
-        // {
-        //     debug!(?tx_digest, "no pending request in flight, submitting to
-        // TransactionDriver."); } else {
-        //     debug!(?tx_digest, "transaction already in flight, skipping duplicate
-        // submission."); }
+        // Deduplicate concurrent submissions of the same digest: only the first
+        // caller drives the committee-wide submission; the rest wait for its
+        // effects. The guard removes the pending-log entry on every exit path
+        // (success, error, timeout, or cancellation) when it is dropped.
+        let guard = TransactionSubmissionGuard::new(self.pending_tx_log.clone(), transaction)
+            .await
+            .map_err(QuorumDriverError::QuorumDriverInternal)?;
+        if !guard.is_new_transaction() {
+            debug!(
+                ?tx_digest,
+                "transaction already in flight; awaiting its effects instead of driving a \
+                 duplicate submission"
+            );
+            return self.await_in_flight_transaction(tx_digest, &request).await;
+        }
 
         let td_response = td
             .drive_transaction(
@@ -636,7 +654,8 @@ where
                 Some(WAIT_FOR_FINALITY_TIMEOUT),
                 skip_certification,
             )
-            .await?;
+            .await
+            .map_err(map_td_error_to_qd)?;
 
         debug!(
             "TransactionOrchestrator: TransactionDriver submission succeeded for transaction {}",
@@ -671,6 +690,34 @@ where
                 None
             },
         })
+    }
+
+    /// Wait for an already in-flight submission of `tx_digest` to reach
+    /// finality and build the response from the authoritative local cache,
+    /// instead of starting a second committee-wide submission for the same
+    /// transaction. Times out with `TimeoutBeforeFinality` if the in-flight
+    /// submission does not get the transaction checkpointed in time.
+    async fn await_in_flight_transaction(
+        &self,
+        tx_digest: TransactionDigest,
+        request: &ExecuteTransactionRequestV1,
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
+        let digests = [tx_digest];
+        let seq = self
+            .validator_state
+            .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT)
+            .await
+            .ok()
+            .and_then(|inclusion| inclusion.get(&tx_digest).map(|&(seq, _)| seq))
+            .ok_or(QuorumDriverError::TimeoutBeforeFinality)?;
+        Self::build_response_from_cache(
+            &self.validator_state,
+            tx_digest,
+            seq,
+            request.include_events,
+            request.include_input_objects,
+            request.include_output_objects,
+        )
     }
 
     // TODO check if tx is already executed on this node.
@@ -1438,4 +1485,56 @@ fn read_cached_transaction_data(
             output_objects,
         },
     ))
+}
+
+/// Tracks a transaction that is being submitted to finality so that concurrent
+/// submissions of the same digest deduplicate, and guarantees the pending
+/// transaction log entry is removed once submission finishes.
+///
+/// `is_new_transaction` is `false` when another submission of the same digest
+/// is already in flight; the caller should then wait for that submission's
+/// effects instead of starting a new one. The log entry is removed when the
+/// guard is dropped, covering success, error, timeout, and cancellation.
+struct TransactionSubmissionGuard {
+    pending_tx_log: Arc<WritePathPendingTransactionLog>,
+    tx_digest: TransactionDigest,
+    is_new_transaction: bool,
+}
+
+impl TransactionSubmissionGuard {
+    async fn new(
+        pending_tx_log: Arc<WritePathPendingTransactionLog>,
+        transaction: &VerifiedTransaction,
+    ) -> IotaResult<Self> {
+        let tx_digest = *transaction.digest();
+        let is_new_transaction = pending_tx_log
+            .write_pending_transaction_maybe(transaction)
+            .await?;
+        if is_new_transaction {
+            debug!(?tx_digest, "added transaction to in-flight set");
+        } else {
+            debug!(?tx_digest, "transaction already being processed");
+        }
+        Ok(Self {
+            pending_tx_log,
+            tx_digest,
+            is_new_transaction,
+        })
+    }
+
+    fn is_new_transaction(&self) -> bool {
+        self.is_new_transaction
+    }
+}
+
+impl Drop for TransactionSubmissionGuard {
+    fn drop(&mut self) {
+        match self.pending_tx_log.finish_transaction(&self.tx_digest) {
+            Ok(()) => debug!(tx_digest = ?self.tx_digest, "cleaned up transaction in pending log"),
+            Err(err) => warn!(
+                tx_digest = ?self.tx_digest,
+                "failed to clean up transaction in pending log: {err}"
+            ),
+        }
+    }
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -534,7 +534,8 @@ async fn test_skip_effect_cert_respects_request_flags() -> Result<(), anyhow::Er
 /// transaction digest must not each drive an independent committee-wide
 /// submission: the second observes the first in flight and waits for its
 /// effects instead. Both callers must return the same finalized effects, and
-/// the pending-transaction log must be empty once both complete.
+/// the pending-transaction log must stay empty: the driver path tracks
+/// in-flight submissions in memory only.
 #[sim_test]
 async fn test_pcool_deduplicates_concurrent_submissions() -> Result<(), anyhow::Error> {
     let _env_guard = enable_pcool_env();
@@ -599,7 +600,7 @@ async fn test_pcool_deduplicates_concurrent_submissions() -> Result<(), anyhow::
     let pending = orchestrator.load_all_pending_transactions()?;
     assert!(
         pending.is_empty(),
-        "pending transaction log must be cleaned up after submissions complete, found {pending:?}"
+        "driver path must not write to the pending transaction log, found {pending:?}"
     );
 
     Ok(())

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -530,6 +530,81 @@ async fn test_skip_effect_cert_respects_request_flags() -> Result<(), anyhow::Er
     Ok(())
 }
 
+/// With the P-COOL flow enabled, two concurrent submissions of the same
+/// transaction digest must not each drive an independent committee-wide
+/// submission: the second observes the first in flight and waits for its
+/// effects instead. Both callers must return the same finalized effects, and
+/// the pending-transaction log must be empty once both complete.
+#[sim_test]
+async fn test_pcool_deduplicates_concurrent_submissions() -> Result<(), anyhow::Error> {
+    let _env_guard = enable_pcool_env();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.iota_node;
+    let orchestrator = handle.with(|n| n.transaction_orchestrator().as_ref().unwrap().clone());
+
+    let txn = batch_make_transfer_transactions(context, 1)
+        .await
+        .pop()
+        .expect("gas objects should produce at least one tx");
+    let digest = *txn.digest();
+
+    let request = |txn: Transaction| ExecuteTransactionRequestV1 {
+        transaction: txn,
+        include_events: false,
+        include_input_objects: false,
+        include_output_objects: false,
+        include_auxiliary_data: false,
+    };
+
+    let (first, second) = tokio::join!(
+        orchestrator.execute_transaction_block(
+            request(txn.clone()),
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(make_socket_addr()),
+        ),
+        orchestrator.execute_transaction_block(
+            request(txn.clone()),
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(make_socket_addr()),
+        ),
+    );
+
+    let (first_response, _) =
+        first.unwrap_or_else(|e| panic!("first submission failed for {digest:?}: {e:?}"));
+    let (second_response, _) =
+        second.unwrap_or_else(|e| panic!("second submission failed for {digest:?}: {e:?}"));
+
+    for response in [&first_response, &second_response] {
+        assert!(
+            matches!(
+                response.effects.finality_info,
+                EffectsFinalityInfo::Checkpointed(_, _)
+            ),
+            "concurrent submission should resolve to Checkpointed, got {:?}",
+            response.effects.finality_info
+        );
+    }
+    assert_eq!(
+        first_response.effects.effects.transaction_digest(),
+        second_response.effects.effects.transaction_digest(),
+        "both concurrent submissions must report the same finalized effects"
+    );
+
+    let pending = orchestrator.load_all_pending_transactions()?;
+    assert!(
+        pending.is_empty(),
+        "pending transaction log must be cleaned up after submissions complete, found {pending:?}"
+    );
+
+    Ok(())
+}
+
 /// Without consensus quorum, the skip-cert path can never observe checkpoint
 /// inclusion. The orchestrator must surface this as `TimeoutBeforeFinality`
 /// (a retriable transient), not `QuorumDriverInternal` — the latter would


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#24381](https://github.com/MystenLabs/sui/pull/24381)
- Description:

On the TransactionDriver path, concurrent submissions of the same transaction digest each drove an independent committee-wide submission. A submission guard now lets only the first caller drive the transaction; concurrent duplicates wait for checkpoint inclusion and rebuild the response from the authoritative local cache. The guard releases its entry on every exit path (success, error, timeout, cancellation).

Adapted to the fork:

- The in-flight set is an in-memory `Mutex<HashSet<TransactionDigest>>`; the driver path does not write to the pending transaction log at all. The driver flow is best-effort and nothing reads the log back in driver mode (startup recovery stays on the QuorumDriver path). Whether driver-path submissions should be persisted is tracked in iotaledger/iota-private#466.
- Only the guard that inserted the digest removes it on drop; upstream's duplicate guards remove the winner's log entry while it is still in flight.
- Duplicates wait via `wait_for_checkpoint_inclusion` + cache rebuild rather than upstream's local-effects notification, matching the P-COOL flow.
- The upstream storage-layer change (sync `write_pending_transaction_maybe`) is not ported: the fork's `MutexTable` version already closes the same check-then-insert race, and the driver path no longer uses the log.

## Links to any relevant issues

Related: iotaledger/iota-private#466

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
