### PR TITLE
fix(cluster-test): disable fullnode pruning in local cluster

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -183,7 +183,10 @@ impl Cluster for LocalNewCluster {
 
         let mut cluster_builder = TestClusterBuilder::new()
             .enable_fullnode_events()
-            .with_data_ingestion_dir(data_ingestion_path.clone());
+            .with_data_ingestion_dir(data_ingestion_path.clone())
+            // disable full node pruning: tests read `balance_changes` /
+            // `object_changes` which needs historical data.
+            .disable_fullnode_pruning();
 
         // Check if we already have a config directory that is passed
         if let Some(config_dir) = options.config_dir.clone() {


### PR DESCRIPTION
# Description of change

`iota-cluster-test`'s `CoinIndexTest` intermittently panics on `balance_changes.unwrap()` (and would hit the same on `object_changes`). The fullnode computes those fields from the input objects at their pre-execution versions; pruning removes those historical versions, so against a freshly-started local cluster the fields occasionally come back empty and the test panics.

- Disable fullnode pruning on the local cluster (`LocalNewCluster`) so historical object versions stay available for the cluster's lifetime.

This mirrors the same fix already applied to the indexer test utils in #12217 / #12230.

## Links to any relevant issues

fixes #12228

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

[run-ci]