### PR TITLE
upstream(iota-core): return cached results for already-executed transactions

### DIFF
--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -1566,8 +1566,8 @@ fn read_cached_transaction_data(
         return Ok(None);
     };
 
-    let events = if include_events {
-        cache.try_get_events(digest)?
+    let events = if include_events && effects.events_digest().is_some() {
+        Some(validator_state.get_transaction_events(digest)?)
     } else {
         None
     };

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -273,6 +273,24 @@ where
         );
         let tx_digest = *transaction.digest();
 
+        // A resubmission of an already-executed transaction is answered from
+        // the local cache instead of being driven through the validators
+        // again.
+        if let Some(response) = Self::build_response_from_local_effects(
+            &self.validator_state,
+            &tx_digest,
+            include_events,
+            include_input_objects,
+            include_output_objects,
+        )? {
+            self.metrics.early_cached_response.inc();
+            debug!(
+                ?tx_digest,
+                "Returning cached results for already-executed transaction"
+            );
+            return Ok((response, true));
+        }
+
         let (mut response, seq) = match (&self.driver, wait_for_local_execution) {
             (Driver::Transaction(td), true) => {
                 self.submit_with_checkpoint_race(td.clone(), request, client_addr, tx_digest)
@@ -504,6 +522,50 @@ where
         })
     }
 
+    /// Build a response from the local cache for a transaction that has
+    /// already been executed on this node. Returns `Ok(None)` when the
+    /// transaction has not been executed locally. Unlike
+    /// `build_response_from_cache`, no checkpoint sequence is required: local
+    /// effects only exist for finalized transactions, so the response is
+    /// tagged `QuorumExecuted`.
+    fn build_response_from_local_effects(
+        validator_state: &Arc<AuthorityState>,
+        tx_digest: &TransactionDigest,
+        include_events: bool,
+        include_input_objects: bool,
+        include_output_objects: bool,
+    ) -> Result<Option<ExecuteTransactionResponseV1>, QuorumDriverError> {
+        let Some(cached) = read_cached_transaction_data(
+            validator_state,
+            tx_digest,
+            include_events,
+            include_input_objects,
+            include_output_objects,
+        )
+        .map_err(QuorumDriverError::QuorumDriverInternal)?
+        else {
+            return Ok(None);
+        };
+        let iota_types::transaction_executor::CachedTransactionData {
+            effects,
+            events,
+            input_objects,
+            output_objects,
+        } = cached;
+
+        let epoch = effects.epoch();
+        Ok(Some(ExecuteTransactionResponseV1 {
+            effects: FinalizedEffects {
+                effects,
+                finality_info: EffectsFinalityInfo::QuorumExecuted(epoch),
+            },
+            events,
+            input_objects,
+            output_objects,
+            auxiliary_data: None,
+        }))
+    }
+
     // Utilize the handle_certificate_v1 validator api to request input/output
     // objects
     #[instrument(name = "tx_orchestrator_execute_transaction_v1", level = "trace", skip_all,
@@ -516,15 +578,35 @@ where
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
         let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
 
+        epoch_store
+            .verify_transaction(request.transaction.clone())
+            .map_err(QuorumDriverError::InvalidUserSignature)?;
+        let tx_digest = *request.transaction.digest();
+
+        // A resubmission of an already-executed transaction is answered from
+        // the local cache instead of being driven through the validators
+        // again.
+        if let Some(response) = Self::build_response_from_local_effects(
+            &self.validator_state,
+            &tx_digest,
+            request.include_events,
+            request.include_input_objects,
+            request.include_output_objects,
+        )? {
+            self.metrics.early_cached_response.inc();
+            debug!(
+                ?tx_digest,
+                "Returning cached results for already-executed transaction"
+            );
+            return Ok(response);
+        }
+
         match &self.driver {
             Driver::Transaction(td) => {
                 // v1 does not do an internal wait; callers (e.g. the gRPC
                 // execution service) are responsible for their own
                 // `wait_for_checkpoint_inclusion` when they need it, and will
                 // reconcile the response from the cache there.
-                epoch_store
-                    .verify_transaction(request.transaction.clone())
-                    .map_err(QuorumDriverError::InvalidUserSignature)?;
                 self.submit_with_transaction_driver(
                     td.clone(),
                     request,
@@ -716,9 +798,6 @@ where
         )
     }
 
-    // TODO check if tx is already executed on this node.
-    // Note: since EffectsCert is not stored today, we need to gather that from
-    // validators (and maybe store it for caching purposes)
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.transaction.digest()))]
     async fn execute_transaction_impl(
         &self,
@@ -1202,6 +1281,8 @@ pub struct TransactionOrchestratorMetrics {
     local_execution_timeout: GenericCounter<AtomicU64>,
     local_execution_failure: GenericCounter<AtomicU64>,
 
+    early_cached_response: GenericCounter<AtomicU64>,
+
     // Bumped when the skip-effect-certification path reconciles against the
     // local cache but the cache has no events for a tx the single submitter
     // claimed had events. Uncertified events are rejected and the request
@@ -1350,6 +1431,12 @@ impl TransactionOrchestratorMetrics {
                 "Total number of failed local execution txns Transaction Orchestrator handles",
                 registry;
                 MetricLevel::Warn,
+            )
+            .unwrap(),
+            early_cached_response: register_int_counter_with_registry!(
+                "tx_orchestrator_early_cached_response",
+                "Total number of requests returning cached results for already-executed transactions",
+                registry,
             )
             .unwrap(),
             skip_effect_cert_events_cache_miss: register_int_counter_with_registry!(

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -255,6 +255,10 @@ where
     {
         let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
 
+        let transaction = epoch_store
+            .verify_transaction(request.transaction.clone())
+            .map_err(QuorumDriverError::InvalidUserSignature)?;
+
         // Captured before `request` moves so the skip-cert reconcile reads
         // caller intent, not whatever the submitter happened to return — a
         // Byzantine submitter could otherwise censor a field by returning
@@ -263,14 +267,6 @@ where
         let include_input_objects = request.include_input_objects;
         let include_output_objects = request.include_output_objects;
 
-        let transaction = epoch_store
-            .verify_transaction(request.transaction.clone())
-            .map_err(QuorumDriverError::InvalidUserSignature)?;
-
-        let wait_for_local_execution = matches!(
-            request_type,
-            ExecuteTransactionRequestType::WaitForLocalExecution
-        );
         let tx_digest = *transaction.digest();
 
         // A resubmission of an already-executed transaction is answered from
@@ -291,6 +287,19 @@ where
             return Ok((response, true));
         }
 
+        // Reject malformed transactions before either driver inspects shared
+        // inputs or `MoveAuthenticator`. Runs after the cache lookup so that,
+        // as on the upstream flow, a resubmission of an executed transaction
+        // gets its cached results even if it no longer passes the current
+        // epoch's checks (e.g. its expiration epoch has passed).
+        transaction
+            .validity_check(&epoch_store.tx_validity_check_context())
+            .map_err(QuorumDriverError::InvalidTransaction)?;
+
+        let wait_for_local_execution = matches!(
+            request_type,
+            ExecuteTransactionRequestType::WaitForLocalExecution
+        );
         let (mut response, seq) = match (&self.driver, wait_for_local_execution) {
             (Driver::Transaction(td), true) => {
                 self.submit_with_checkpoint_race(td.clone(), request, client_addr, tx_digest)
@@ -304,8 +313,14 @@ where
                 None,
             ),
             (Driver::Quorum(qd), _) => {
-                let (_, qd_resp) = self
-                    .execute_transaction_impl(qd, &epoch_store, request, client_addr)
+                let qd_resp = self
+                    .execute_transaction_impl(
+                        qd,
+                        &epoch_store,
+                        request,
+                        transaction.clone(),
+                        client_addr,
+                    )
                     .await?;
                 (Some(quorum_driver_response_to_v1(qd_resp)), None)
             }
@@ -578,10 +593,10 @@ where
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
         let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
 
-        epoch_store
+        let transaction = epoch_store
             .verify_transaction(request.transaction.clone())
             .map_err(QuorumDriverError::InvalidUserSignature)?;
-        let tx_digest = *request.transaction.digest();
+        let tx_digest = *transaction.digest();
 
         // A resubmission of an already-executed transaction is answered from
         // the local cache instead of being driven through the validators
@@ -601,6 +616,15 @@ where
             return Ok(response);
         }
 
+        // Reject malformed transactions before either driver inspects shared
+        // inputs or `MoveAuthenticator`. Runs after the cache lookup so that,
+        // as on the upstream flow, a resubmission of an executed transaction
+        // gets its cached results even if it no longer passes the current
+        // epoch's checks (e.g. its expiration epoch has passed).
+        transaction
+            .validity_check(&epoch_store.tx_validity_check_context())
+            .map_err(QuorumDriverError::InvalidTransaction)?;
+
         match &self.driver {
             Driver::Transaction(td) => {
                 // v1 does not do an internal wait; callers (e.g. the gRPC
@@ -617,9 +641,8 @@ where
             }
             Driver::Quorum(qd) => {
                 let qd_resp = self
-                    .execute_transaction_impl(qd, &epoch_store, request, client_addr)
-                    .await
-                    .map(|(_, r)| r)?;
+                    .execute_transaction_impl(qd, &epoch_store, request, transaction, client_addr)
+                    .await?;
                 Ok(quorum_driver_response_to_v1(qd_resp))
             }
         }
@@ -798,23 +821,18 @@ where
         )
     }
 
+    /// Submit a transaction via the QuorumDriver. `transaction` must be the
+    /// signature-verified form of `request.transaction`, and the caller must
+    /// have run `validity_check` on it beforehand.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.transaction.digest()))]
     async fn execute_transaction_impl(
         &self,
         quorum_driver: &Arc<QuorumDriverHandler<A>>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         request: ExecuteTransactionRequestV1,
+        transaction: VerifiedTransaction,
         client_addr: Option<SocketAddr>,
-    ) -> Result<(VerifiedTransaction, QuorumDriverResponse), QuorumDriverError> {
-        // Reject malformed transactions before any code path inspects shared
-        // inputs or `MoveAuthenticator`
-        request
-            .transaction
-            .validity_check(&epoch_store.tx_validity_check_context())
-            .map_err(QuorumDriverError::InvalidTransaction)?;
-        let transaction = epoch_store
-            .verify_transaction(request.transaction.clone())
-            .map_err(QuorumDriverError::InvalidUserSignature)?;
+    ) -> Result<QuorumDriverResponse, QuorumDriverError> {
         let (_in_flight_metrics_guards, good_response_metrics) = self.update_metrics(&transaction);
         let tx_digest = *transaction.digest();
         debug!(?tx_digest, "TO Received transaction execution request.");
@@ -875,7 +893,7 @@ where
             Ok(Err(err)) => Err(err),
             Ok(Ok(response)) => {
                 good_response_metrics.inc();
-                Ok((transaction, response))
+                Ok(response)
             }
         }
     }

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -894,6 +894,33 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
         .unwrap();
 
     // Test request with ExecuteTransactionRequestType::WaitForEffectsCert
+    // Use the same txn which should return local finalized effects
+    let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
+    let params = rpc_params![
+        tx_bytes,
+        signatures,
+        IotaTransactionBlockResponseOptions::new().with_effects(),
+        ExecuteTransactionRequestType::WaitForEffectsCert
+    ];
+    let response: IotaTransactionBlockResponse = jsonrpc_client
+        .request("iota_executeTransactionBlock", params)
+        .await
+        .unwrap();
+
+    let IotaTransactionBlockResponse {
+        effects,
+        confirmed_local_execution,
+        ..
+    } = response;
+    assert_eq!(effects.unwrap().transaction_digest(), tx_digest);
+    assert!(confirmed_local_execution.unwrap());
+
+    // Test request with ExecuteTransactionRequestType::WaitForEffectsCert
+    // Use a different txn to avoid the case where the txn effects are already
+    // cached locally
+    let txn = txns.swap_remove(0);
+    let tx_digest = txn.digest();
+
     let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
     let params = rpc_params![
         tx_bytes,

--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -123,9 +123,9 @@ async fn test_fullnode_traffic_control_ok() -> Result<(), anyhow::Error> {
         // 2 x rpc.discover - those are not sent by the test scenario
         // 5 x iotax_getOwnedObjects
         // 1 x iotax_getReferenceGasPrice
-        // 2 x iota_executeTransactionBlock
+        // 3 x iota_executeTransactionBlock
         // 1 x iota_getTransactionBlock
-        spam_policy_type: PolicyType::TestNConnIP(11),
+        spam_policy_type: PolicyType::TestNConnIP(12),
         // This should never be invoked when set as an error policy
         // as we are not sending requests that error
         error_policy_type: PolicyType::TestPanicOnInvocation,
@@ -939,6 +939,33 @@ async fn assert_traffic_control_ok(mut test_cluster: TestCluster) -> Result<(), 
         .unwrap();
 
     // Test request with ExecuteTransactionRequestType::WaitForEffectsCert
+    // Use the same txn which should return local finalized effects
+    let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
+    let params = rpc_params![
+        tx_bytes,
+        signatures,
+        IotaTransactionBlockResponseOptions::new().with_effects(),
+        ExecuteTransactionRequestType::WaitForEffectsCert
+    ];
+    let response: IotaTransactionBlockResponse = jsonrpc_client
+        .request("iota_executeTransactionBlock", params)
+        .await
+        .unwrap();
+
+    let IotaTransactionBlockResponse {
+        effects,
+        confirmed_local_execution,
+        ..
+    } = response;
+    assert_eq!(effects.unwrap().transaction_digest(), tx_digest);
+    assert!(confirmed_local_execution.unwrap());
+
+    // Test request with ExecuteTransactionRequestType::WaitForEffectsCert
+    // Use a different txn to avoid the case where the txn effects are already
+    // cached locally
+    let txn = txns.swap_remove(0);
+    let tx_digest = txn.digest();
+
     let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
     let params = rpc_params![
         tx_bytes,

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -314,6 +314,96 @@ async fn execute_with_orchestrator(
         .await
 }
 
+/// A resubmission of an already-executed transaction must be answered from
+/// the local cache (finality `QuorumExecuted`) instead of being driven
+/// through the validators again — on every entry point.
+#[sim_test]
+async fn test_cached_response_for_executed_transaction() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.iota_node;
+    let orchestrator = handle.with(|n| n.transaction_orchestrator().as_ref().unwrap().clone());
+
+    let txn = batch_make_transfer_transactions(context, 1)
+        .await
+        .pop()
+        .expect("gas objects should produce at least one tx");
+    let digest = *txn.digest();
+
+    let (first, _) = execute_with_orchestrator(
+        &orchestrator,
+        txn.clone(),
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await?;
+    assert!(
+        matches!(
+            first.effects.finality_info,
+            EffectsFinalityInfo::Certified(_)
+        ),
+        "first execution should be driven to a certificate, got {:?}",
+        first.effects.finality_info
+    );
+
+    // Make sure the effects have landed in the local cache before
+    // resubmitting.
+    handle
+        .state()
+        .get_transaction_cache_reader()
+        .notify_read_executed_effects(&[digest])
+        .await;
+
+    let (second, executed_locally) = execute_with_orchestrator(
+        &orchestrator,
+        txn.clone(),
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await?;
+    assert!(executed_locally);
+    assert!(
+        matches!(
+            second.effects.finality_info,
+            EffectsFinalityInfo::QuorumExecuted(_)
+        ),
+        "resubmission should be answered from the local cache, got {:?}",
+        second.effects.finality_info
+    );
+    assert_eq!(
+        first.effects.effects.digest(),
+        second.effects.effects.digest()
+    );
+
+    let (third, _) = execute_with_orchestrator(
+        &orchestrator,
+        txn.clone(),
+        ExecuteTransactionRequestType::WaitForEffectsCert,
+    )
+    .await?;
+    assert!(
+        matches!(
+            third.effects.finality_info,
+            EffectsFinalityInfo::QuorumExecuted(_)
+        ),
+        "resubmission without local-execution wait should also be answered \
+         from the local cache, got {:?}",
+        third.effects.finality_info
+    );
+
+    let response = orchestrator
+        .execute_transaction_v1(ExecuteTransactionRequestV1::new(txn), false, None)
+        .await?;
+    assert!(
+        matches!(
+            response.effects.finality_info,
+            EffectsFinalityInfo::QuorumExecuted(_)
+        ),
+        "v1 resubmission should be answered from the local cache, got {:?}",
+        response.effects.finality_info
+    );
+
+    Ok(())
+}
+
 #[sim_test]
 async fn execute_transaction_v1() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await;
@@ -468,6 +558,69 @@ async fn test_skip_effect_cert_reconciles_to_checkpointed() -> Result<(), anyhow
     // `test_skip_effect_cert_respects_request_flags`.)
     assert!(response.input_objects.is_some());
     assert!(response.output_objects.is_some());
+
+    Ok(())
+}
+
+/// Under the P-COOL flow, a resubmission of an already-executed transaction
+/// must be answered from the local cache (finality `QuorumExecuted`) before
+/// reaching the skip-effect-certification path, and must not be routed
+/// through the cache-rebuild reconciliation (which would tag it
+/// `Checkpointed`).
+#[sim_test]
+async fn test_cached_response_for_executed_transaction_under_pcool() -> Result<(), anyhow::Error> {
+    let _env_guard = enable_pcool_env();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.iota_node;
+    let orchestrator = handle.with(|n| n.transaction_orchestrator().as_ref().unwrap().clone());
+
+    let txn = batch_make_transfer_transactions(context, 1)
+        .await
+        .pop()
+        .expect("gas objects should produce at least one tx");
+
+    // The first execution reconciles from the local cache after checkpoint
+    // inclusion, so the effects are guaranteed to be cached afterwards.
+    let (first, _) = execute_with_orchestrator(
+        &orchestrator,
+        txn.clone(),
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await?;
+    assert!(
+        matches!(
+            first.effects.finality_info,
+            EffectsFinalityInfo::Checkpointed(_, _)
+        ),
+        "first skip-cert execution should reconcile to Checkpointed, got {:?}",
+        first.effects.finality_info
+    );
+
+    let (second, executed_locally) = execute_with_orchestrator(
+        &orchestrator,
+        txn,
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await?;
+    assert!(executed_locally);
+    assert!(
+        matches!(
+            second.effects.finality_info,
+            EffectsFinalityInfo::QuorumExecuted(_)
+        ),
+        "resubmission should be answered from the local cache, got {:?}",
+        second.effects.finality_info
+    );
+    assert_eq!(
+        first.effects.effects.digest(),
+        second.effects.effects.digest()
+    );
 
     Ok(())
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -350,7 +350,7 @@ async fn test_cached_response_for_executed_transaction() -> Result<(), anyhow::E
     handle
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .notify_read_executed_effects_for_testing(&[digest])
         .await;
 
     let (second, executed_locally) = execute_with_orchestrator(


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#25348](https://github.com/MystenLabs/sui/pull/25348) (partial)
- Description:

Resubmissions of already-executed transactions are answered from the local cache in both orchestrator entry points, instead of being driven through the validators again. The response carries `QuorumExecuted` finality (local effects only exist for finalized transactions). This also removes the long-standing TODO on `execute_transaction_impl`.

Behavior note: on the QuorumDriver path a resubmitted already-executed transaction now returns `QuorumExecuted` instead of a fresh `Certified` response — the same variant the TransactionDriver path already emits.

Adapted to the fork:

- Upstream hosts the early check in its single effects-waiting entry point; here it is placed at the top of `execute_transaction_block` and `execute_transaction_v1`, before driver dispatch, so it covers both driver flows and exits before the skip-effect-certification cache-rebuild logic is computed.
- The cache read reuses the existing `read_cached_transaction_data` helper instead of duplicating response assembly.
- The upstream commit's backup-submission part (start a second submission after 1s of silence) is deliberately left out: with soft-lock submission dedup a backup would have to wait a full lock interval (~12s) rather than 1s, so it needs separate design. The validator-side `wait_for_effects` changes and the reconfig-observer module shuffle are also not ported (different server code / module layout).

## Links to any relevant issues

Related: iotaledger/iota-private#467

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
