### PR TITLE
upstream(iota-core,iota-types): do not abort the node when executed effects are missing

### DIFF
--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1282,9 +1282,9 @@ impl CheckpointBuilder {
                 .await?;
             let root_effects = self
                 .effects_store
-                .try_notify_read_executed_effects(&root_digests)
+                .notify_read_executed_effects(&root_digests)
                 .in_monitored_scope("CheckpointNotifyRead")
-                .await?;
+                .await;
 
             let consensus_commit_prologue = {
                 // If the roots contains consensus commit prologue transaction, we want to

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1282,9 +1282,9 @@ impl CheckpointBuilder {
                 .await?;
             let root_effects = self
                 .effects_store
-                .notify_read_executed_effects(&root_digests)
+                .try_notify_read_executed_effects(&root_digests)
                 .in_monitored_scope("CheckpointNotifyRead")
-                .await;
+                .await?;
 
             let consensus_commit_prologue = {
                 // If the roots contains consensus commit prologue transaction, we want to

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -1034,7 +1034,7 @@ pub trait TransactionCacheRead: Send + Sync {
     ///
     /// Panics if any of the requested effects are not found. For paths where
     /// effects may have been pruned, use `try_notify_read_executed_effects`.
-    fn notify_read_executed_effects<'a>(
+    fn notify_read_executed_effects_for_testing<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, Vec<TransactionEffects>> {

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -1010,9 +1010,7 @@ pub trait TransactionCacheRead: Send + Sync {
     /// reconfiguration from ever occurring!
     ///
     /// Returns an error if any of the requested effects have been pruned from
-    /// the database. Use this in paths where effects may not exist. For
-    /// critical paths where effects must exist (e.g. checkpoint building),
-    /// use `notify_read_executed_effects`.
+    /// the database.
     fn try_notify_read_executed_effects<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
@@ -1034,10 +1032,8 @@ pub trait TransactionCacheRead: Send + Sync {
 
     /// Non-fallible version of `try_notify_read_executed_effects`.
     ///
-    /// Panics if any of the requested effects are not found. Use this in
-    /// critical paths where effects are expected to exist (e.g. checkpoint
-    /// building). For paths where effects may have been pruned, use
-    /// `try_notify_read_executed_effects`.
+    /// Panics if any of the requested effects are not found. For paths where
+    /// effects may have been pruned, use `try_notify_read_executed_effects`.
     fn notify_read_executed_effects<'a>(
         &'a self,
         digests: &'a [TransactionDigest],

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashSet, path::Path, sync::Arc};
 
 use futures::{FutureExt, future::BoxFuture};
-use iota_common::{fatal, sync::notify_read::NotifyRead};
+use iota_common::sync::notify_read::NotifyRead;
 use iota_config::ExecutionCacheConfig;
 use iota_sdk_types::{ObjectId, ObjectReference, Version};
 use iota_types::{
@@ -1008,26 +1008,36 @@ pub trait TransactionCacheRead: Send + Sync {
     /// ExecutionLockReadGuard would also prevent reconfig from happening while
     /// waiting, but this is very dangerous, as it could prevent
     /// reconfiguration from ever occurring!
+    ///
+    /// Returns an error if any of the requested effects have been pruned from
+    /// the database. Use this in paths where effects may not exist. For
+    /// critical paths where effects must exist (e.g. checkpoint building),
+    /// use `notify_read_executed_effects`.
     fn try_notify_read_executed_effects<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffects>>> {
         async move {
-            let digests = self
+            let effects_digests = self
                 .try_notify_read_executed_effects_digests(digests)
                 .await?;
-            // once digests are available, effects must be present as well
-            self.try_multi_get_effects(&digests).map(|effects| {
-                effects
-                    .into_iter()
-                    .map(|e| e.unwrap_or_else(|| fatal!("digests must exist")))
-                    .collect()
-            })
+            self.try_multi_get_effects(&effects_digests)?
+                .into_iter()
+                .zip(digests)
+                .map(|(effects, digest)| {
+                    effects.ok_or(IotaError::TransactionEffectsNotFound { digest: *digest })
+                })
+                .collect()
         }
         .boxed()
     }
 
     /// Non-fallible version of `try_notify_read_executed_effects`.
+    ///
+    /// Panics if any of the requested effects are not found. Use this in
+    /// critical paths where effects are expected to exist (e.g. checkpoint
+    /// building). For paths where effects may have been pruned, use
+    /// `try_notify_read_executed_effects`.
     fn notify_read_executed_effects<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
@@ -1035,7 +1045,7 @@ pub trait TransactionCacheRead: Send + Sync {
         Box::pin(async move {
             self.try_notify_read_executed_effects(digests)
                 .await
-                .expect("storage access failed")
+                .unwrap_or_else(|e| panic!("effects must exist: {e}"))
         })
     }
 }

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -104,7 +104,8 @@ pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>) 
     )
     .await
     {
-        Ok(_) => info!(?digest, "digest found"),
+        Ok(Ok(_)) => info!(?digest, "digest found"),
+        Ok(Err(e)) => panic!("failed to read effects of digest! {e}"),
         Err(e) => {
             warn!(?digest, "digest not found!");
             panic!("timed out waiting for effects of digest! {e}");
@@ -121,7 +122,8 @@ pub async fn wait_for_all_txes(digests: Vec<TransactionDigest>, state: Arc<Autho
     )
     .await
     {
-        Ok(_) => info!(?digests, "all digests found"),
+        Ok(Ok(_)) => info!(?digests, "all digests found"),
+        Ok(Err(e)) => panic!("failed to read effects of digests! {e}"),
         Err(e) => {
             warn!(?digests, "some digests not found!");
             panic!("timed out waiting for effects of digests! {e}");

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -268,7 +268,7 @@ pub async fn do_cert_with_shared_objects(
     send_consensus(authority, cert).await;
     authority
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[*cert.digest()])
+        .notify_read_executed_effects_for_testing(&[*cert.digest()])
         .await
         .pop()
         .unwrap()
@@ -445,7 +445,7 @@ async fn test_execution_with_dependencies() {
         .collect();
     authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .notify_read_executed_effects_for_testing(&digests)
         .await;
 }
 
@@ -508,7 +508,7 @@ async fn test_per_object_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(&[*create_counter_cert.digest()])
+            .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
             .await
             .pop()
             .unwrap();
@@ -522,7 +522,7 @@ async fn test_per_object_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[*create_counter_cert.digest()])
+        .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
         .await
         .pop()
         .unwrap();
@@ -633,7 +633,7 @@ async fn test_txn_age_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(&[*create_counter_cert.digest()])
+            .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
             .await
             .pop()
             .unwrap();
@@ -647,7 +647,7 @@ async fn test_txn_age_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[*create_counter_cert.digest()])
+        .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
         .await
         .pop()
         .unwrap();

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -274,7 +274,7 @@ impl GasPriceFeedbackTester {
 
         self.authority_state
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(&transaction_digests)
+            .notify_read_executed_effects_for_testing(&transaction_digests)
             .await
     }
 

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -69,7 +69,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .notify_read_executed_effects_for_testing(&[digest])
         .await;
 
     // A small delay is needed for post processing operations following the
@@ -115,7 +115,7 @@ async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
         .iota_node
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .notify_read_executed_effects_for_testing(&[digest])
         .await;
 
     Ok(())
@@ -488,7 +488,7 @@ async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .notify_read_executed_effects_for_testing(&[digest])
         .await;
 
     let info = fullnode
@@ -598,7 +598,7 @@ async fn do_test_full_node_sync_flood() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .notify_read_executed_effects_for_testing(&digests)
         .await;
 }
 
@@ -784,7 +784,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .notify_read_executed_effects_for_testing(&[digest])
         .await;
     fullnode.state().get_executed_transaction_and_effects(digest, kv_store).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {digest:?} that was executed with WaitForEffectsCert: {e:?}"));
@@ -1087,7 +1087,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
 
     node.state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .notify_read_executed_effects_for_testing(&[digest])
         .await;
 
     loop {
@@ -1106,7 +1106,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
         transfer_coin(&test_cluster.wallet).await?;
     node.state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest_after_restore])
+        .notify_read_executed_effects_for_testing(&[digest_after_restore])
         .await;
     Ok(())
 }

--- a/crates/iota-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/iota-e2e-tests/tests/shared_objects_tests.rs
@@ -140,7 +140,7 @@ async fn shared_object_deletion_multiple_times() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .notify_read_executed_effects_for_testing(&digests)
         .await;
 }
 
@@ -196,7 +196,7 @@ async fn shared_object_deletion_multiple_times_cert_racing() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .notify_read_executed_effects_for_testing(&digests)
         .await;
 }
 
@@ -311,7 +311,7 @@ async fn shared_object_deletion_multi_certs() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[inc_tx_a_digest, inc_tx_b_digest])
+        .notify_read_executed_effects_for_testing(&[inc_tx_a_digest, inc_tx_b_digest])
         .await;
 }
 

--- a/crates/iota-e2e-tests/tests/simulator_tests.rs
+++ b/crates/iota-e2e-tests/tests/simulator_tests.rs
@@ -139,6 +139,6 @@ async fn test_net_determinism() {
         .iota_node
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .notify_read_executed_effects_for_testing(&[digest])
         .await;
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -71,7 +71,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     handle
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .notify_read_executed_effects_for_testing(&[digest])
         .await;
 
     // Transaction Orchestrator proactivcely executes txn locally

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -685,6 +685,9 @@ pub enum IotaError {
 
     #[error("Invalid admin request: {0}")]
     InvalidAdminRequest(String),
+
+    #[error("Could not find the referenced transaction effects [{digest}]")]
+    TransactionEffectsNotFound { digest: TransactionDigest },
 }
 
 #[repr(u64)]


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#25200](https://github.com/MystenLabs/sui/pull/25200)
- Description:

When executed effects disappear between the digest notification and the effects fetch (a pruner batch can land in that window), `try_notify_read_executed_effects` aborted the whole node via `fatal!`. It now returns a `TransactionEffectsNotFound` error that propagates to the caller as a retriable failure.

Adapted to the fork:

- No `_may_fail` name introduced: the existing `try_` / non-fallible split already expresses the distinction, so the fallible behavior lives in `try_notify_read_executed_effects`.
- Deliberate divergence from upstream: the checkpoint builder stays on the fallible `try_notify_read_executed_effects` instead of the panicking wrapper upstream uses. Any error there (missing effects included) flows into the builder's existing retry loop (1s backoff, `checkpoint_errors` metric), keeping the node alive instead of aborting.
- With that, the panicking wrapper has no production callers left, so it is renamed to `notify_read_executed_effects_for_testing`.
- Upstream's demotion of `notify_read_effects` / `wait_for_transaction_execution` to `_for_testing` is not ported: on this fork `handle_certificate_v1` / `submit_certificate` are still production endpoints (only rejected when the P-COOL flow is enabled) and call `wait_for_certificate_execution` → `AuthorityState::notify_read_effects`, so those methods and their metrics stay. `AuthorityState::notify_read_effects` calls the fallible `try_notify_read_executed_effects` and propagates the error, so this production path gets the retriable-error behavior, not a panic.

## Links to any relevant issues

Related: iotaledger/iota-private#467

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
