### PR TITLE
fix(starfish-core): record misbehavior at all bundle-ingest rejection sites

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -172,7 +172,11 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         let SerializedHeaderAndTransactions {
             serialized_block_header,
             serialized_transactions,
-        } = SerializedHeaderAndTransactions::try_from(SerializedBlock { serialized_block })?;
+        } = SerializedHeaderAndTransactions::try_from(SerializedBlock { serialized_block })
+            .inspect_err(|e| {
+                self.misbehavior_store
+                    .record_faulty_block_header(peer, peer, e);
+            })?;
 
         let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
             .map_err(ConsensusError::MalformedHeader)
@@ -318,22 +322,20 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 
             let header_round = signed_block_header.round();
             if header_round >= block_round {
-                let e = Err(ConsensusError::TooBigHeaderRoundInABundle {
+                let e = ConsensusError::TooBigHeaderRoundInABundle {
                     header_round,
                     block_round,
-                });
+                };
                 self.context
                     .metrics
                     .node_metrics
                     .bundles_with_invalid_parts
                     .with_label_values(&[peer_hostname, "header", "invalid round in header"])
                     .inc();
-                info!(
-                    "Invalid additional block header from {}: {}",
-                    peer,
-                    e.as_ref().unwrap_err()
-                );
-                return e;
+                self.misbehavior_store
+                    .record_faulty_block_header(peer, peer, &e);
+                info!("Invalid additional block header from {}: {}", peer, e);
+                return Err(e);
             }
 
             if let Err(e) = self.block_verifier.verify(&signed_block_header) {
@@ -387,8 +389,12 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 
         let mut verified_shards: Vec<ShardWithProof> = vec![];
         for serialized_shard in &serialized_shards {
-            let shard: ShardWithProof =
-                bcs::from_bytes(serialized_shard).map_err(ConsensusError::MalformedShard)?;
+            let shard: ShardWithProof = bcs::from_bytes(serialized_shard)
+                .map_err(ConsensusError::MalformedShard)
+                .inspect_err(|e| {
+                    self.misbehavior_store
+                        .record_faulty_block_header(peer, peer, e);
+                })?;
 
             if let Err(e) = check_shard_version(&shard) {
                 self.context
@@ -423,6 +429,8 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .bundles_with_invalid_parts
                     .with_label_values(&[peer_hostname, "shard", e.name()])
                     .inc();
+                self.misbehavior_store
+                    .record_faulty_block_header(peer, peer, &e);
                 info!("Invalid shard from {}: {}", peer, e);
                 return Err(e);
             }
@@ -445,6 +453,8 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .bundles_with_invalid_parts
                     .with_label_values(&[peer_hostname, "shard", e.name()])
                     .inc();
+                self.misbehavior_store
+                    .record_faulty_block_header(peer, peer, &e);
                 info!("Invalid shard from {}: {}", peer, e);
                 return Err(e);
             }
@@ -717,7 +727,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         let peer_hostname = &self.context.committee.authority(peer).hostname;
         let mut serialized_block_bundle_parts =
-            SerializedBlockBundleParts::try_from(serialized_block_bundle)?;
+            SerializedBlockBundleParts::try_from(serialized_block_bundle).inspect_err(|e| {
+                self.misbehavior_store
+                    .record_faulty_block_header(peer, peer, e);
+            })?;
         if let Err(e) =
             serialized_block_bundle_parts.validate_useful_authorities(&self.context.committee)
         {
@@ -727,6 +740,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .bundles_with_invalid_parts
                 .with_label_values(&[peer_hostname.as_str(), "metadata", e.name()])
                 .inc();
+            self.misbehavior_store
+                .record_faulty_block_header(peer, peer, &e);
             warn!("Invalid bundle metadata from {}: {}", peer, e);
             return Err(e);
         }
@@ -2148,6 +2163,7 @@ mod tests {
             Arc::new(MisbehaviorStore::new(&context)),
         );
 
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
@@ -2158,7 +2174,7 @@ mod tests {
             rx_block_broadcast,
             dag_state,
             store,
-            Arc::new(MisbehaviorStore::new(&context)),
+            misbehavior_store.clone(),
             tx_message_sender,
             cordial_knowledge,
         ));
@@ -2209,6 +2225,10 @@ mod tests {
         } else {
             panic!("Expected TooBigHeaderRoundInABundle error, got {result:?}",);
         }
+
+        // The relaying peer (authority 0) is charged for the invalid header.
+        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[0];
+        assert_eq!(counts.faulty_blocks_unprovable, 1);
 
         // Create a block with a big round
         let input_block = VerifiedBlock::new_for_test(
@@ -2289,6 +2309,7 @@ mod tests {
             Arc::new(MisbehaviorStore::new(&context)),
         );
 
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
@@ -2299,7 +2320,7 @@ mod tests {
             rx_block_broadcast,
             dag_state,
             store,
-            Arc::new(MisbehaviorStore::new(&context)),
+            misbehavior_store.clone(),
             tx_message_sender,
             cordial_knowledge,
         ));
@@ -2337,6 +2358,10 @@ mod tests {
         assert!(core_dispatcher.get_blocks().is_empty());
         assert!(core_dispatcher.get_block_headers().is_empty());
         assert_eq!(authority_service.received_block_headers.size(), 0);
+
+        // The relaying peer (authority 0) is charged for the invalid metadata.
+        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[0];
+        assert_eq!(counts.faulty_blocks_unprovable, 1);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -174,15 +174,13 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             serialized_transactions,
         } = SerializedHeaderAndTransactions::try_from(SerializedBlock { serialized_block })
             .inspect_err(|e| {
-                self.misbehavior_store
-                    .record_faulty_block_header(peer, peer, e);
+                self.misbehavior_store.record_faulty_block(peer, peer, e);
             })?;
 
         let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
             .map_err(ConsensusError::MalformedHeader)
             .inspect_err(|e| {
-                self.misbehavior_store
-                    .record_faulty_block_header(peer, peer, e);
+                self.misbehavior_store.record_faulty_block(peer, peer, e);
             })?;
 
         // Reject blocks not produced by the peer.
@@ -194,8 +192,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 .bundles_with_invalid_parts
                 .with_label_values(&[peer_hostname, "header", e.name()])
                 .inc();
-            self.misbehavior_store
-                .record_faulty_block_header(peer, peer, &e);
+            self.misbehavior_store.record_faulty_block(peer, peer, &e);
             info!("Block with wrong authority from {}: {}", peer, e);
             return Err(e);
         }
@@ -207,13 +204,10 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 .with_label_values(&[peer_hostname, "header", e.name()])
                 .inc();
             // peer == author is guaranteed by the UnexpectedAuthority check above.
-            // Pass both so record_faulty_block_header can attribute correctly:
+            // Pass both so record_faulty_block can attribute correctly:
             // provable errors → author, unprovable (bad signature) → peer.
-            self.misbehavior_store.record_faulty_block_header(
-                peer,
-                signed_block_header.author(),
-                &e,
-            );
+            self.misbehavior_store
+                .record_faulty_block(peer, signed_block_header.author(), &e);
             info!("Invalid block header from {}: {}", peer, e);
             return Err(e);
         }
@@ -283,7 +277,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             .with_label_values(&[peer_hostname, "transactions", error.name()])
             .inc();
         self.misbehavior_store
-            .record_faulty_block_header(peer, peer, error);
+            .record_faulty_block(peer, peer, error);
     }
 
     fn extract_additional_block_headers_from_bundle(
@@ -316,8 +310,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 .map_err(ConsensusError::MalformedHeader)
                 .inspect_err(|e| {
                     // Author is unknown when deserialization fails — blame the peer.
-                    self.misbehavior_store
-                        .record_faulty_block_header(peer, peer, e);
+                    self.misbehavior_store.record_faulty_block(peer, peer, e);
                 })?;
 
             let header_round = signed_block_header.round();
@@ -332,8 +325,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .bundles_with_invalid_parts
                     .with_label_values(&[peer_hostname, "header", "invalid round in header"])
                     .inc();
-                self.misbehavior_store
-                    .record_faulty_block_header(peer, peer, &e);
+                self.misbehavior_store.record_faulty_block(peer, peer, &e);
                 info!("Invalid additional block header from {}: {}", peer, e);
                 return Err(e);
             }
@@ -349,11 +341,8 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 // (the sender) and author separately so provable errors (valid
                 // signature, protocol violation) are charged to the block author
                 // while unprovable errors (bad signature) are charged to the peer.
-                self.misbehavior_store.record_faulty_block_header(
-                    peer,
-                    signed_block_header.author(),
-                    &e,
-                );
+                self.misbehavior_store
+                    .record_faulty_block(peer, signed_block_header.author(), &e);
                 info!("Invalid additional block header from {}: {}", peer, e);
                 return Err(e);
             }
@@ -392,8 +381,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             let shard: ShardWithProof = bcs::from_bytes(serialized_shard)
                 .map_err(ConsensusError::MalformedShard)
                 .inspect_err(|e| {
-                    self.misbehavior_store
-                        .record_faulty_block_header(peer, peer, e);
+                    self.misbehavior_store.record_faulty_block(peer, peer, e);
                 })?;
 
             if let Err(e) = check_shard_version(&shard) {
@@ -429,8 +417,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .bundles_with_invalid_parts
                     .with_label_values(&[peer_hostname, "shard", e.name()])
                     .inc();
-                self.misbehavior_store
-                    .record_faulty_block_header(peer, peer, &e);
+                self.misbehavior_store.record_faulty_block(peer, peer, &e);
                 info!("Invalid shard from {}: {}", peer, e);
                 return Err(e);
             }
@@ -453,8 +440,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .bundles_with_invalid_parts
                     .with_label_values(&[peer_hostname, "shard", e.name()])
                     .inc();
-                self.misbehavior_store
-                    .record_faulty_block_header(peer, peer, &e);
+                self.misbehavior_store.record_faulty_block(peer, peer, &e);
                 info!("Invalid shard from {}: {}", peer, e);
                 return Err(e);
             }
@@ -728,8 +714,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let peer_hostname = &self.context.committee.authority(peer).hostname;
         let mut serialized_block_bundle_parts =
             SerializedBlockBundleParts::try_from(serialized_block_bundle).inspect_err(|e| {
-                self.misbehavior_store
-                    .record_faulty_block_header(peer, peer, e);
+                self.misbehavior_store.record_faulty_block(peer, peer, e);
             })?;
         if let Err(e) =
             serialized_block_bundle_parts.validate_useful_authorities(&self.context.committee)
@@ -740,8 +725,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .bundles_with_invalid_parts
                 .with_label_values(&[peer_hostname.as_str(), "metadata", e.name()])
                 .inc();
-            self.misbehavior_store
-                .record_faulty_block_header(peer, peer, &e);
+            self.misbehavior_store.record_faulty_block(peer, peer, &e);
             warn!("Invalid bundle metadata from {}: {}", peer, e);
             return Err(e);
         }

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -800,7 +800,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                                 // fetch-shape errors (wrong count/ref) which classify
                                 // as Untracked. When per-header faults become observable
                                 // here, record them as peer misbehavior via
-                                // `inner.misbehavior_store.record_faulty_block_header`.
+                                // `inner.misbehavior_store.record_faulty_block`.
                                 warn!(
                                     "[{}] Failed to verify headers from {}: {}",
                                     inner.sync_type.as_str(),

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -366,11 +366,11 @@ pub(crate) fn verify_commits(
             .map_err(ConsensusError::MalformedHeader)
             .inspect_err(|e| {
                 // Author is unknown when deserialization fails — blame the peer.
-                misbehavior_store.record_faulty_block_header(peer, peer, e);
+                misbehavior_store.record_faulty_block(peer, peer, e);
             })?;
         // The block signature needs to be verified.
         if let Err(e) = block_verifier.verify(&signed_block_header) {
-            misbehavior_store.record_faulty_block_header(peer, signed_block_header.author(), &e);
+            misbehavior_store.record_faulty_block(peer, signed_block_header.author(), &e);
             return Err(e);
         }
         for vote in signed_block_header.commit_votes() {

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -585,7 +585,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                     // errors (wrong count/ref) which classify as Untracked. When
                     // per-header faults become observable here, record them as peer
                     // misbehavior via
-                    // `inner.misbehavior_store.record_faulty_block_header`.
+                    // `inner.misbehavior_store.record_faulty_block`.
                     verify_fetched_headers(
                         target_authority,
                         request_block_refs,

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -863,7 +863,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 .map_err(ConsensusError::MalformedHeader)
                 .inspect_err(|e| {
                     // Author is unknown when deserialization fails — blame the peer.
-                    misbehavior_store.record_faulty_block_header(peer_index, peer_index, e);
+                    misbehavior_store.record_faulty_block(peer_index, peer_index, e);
                 })?;
 
             if let Err(e) = block_verifier.verify(&signed_block_header) {
@@ -877,11 +877,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                     .synchronizer_invalid_block_headers
                     .with_label_values(&[hostname.as_str(), "synchronizer", e.name()])
                     .inc();
-                misbehavior_store.record_faulty_block_header(
-                    peer_index,
-                    signed_block_header.author(),
-                    &e,
-                );
+                misbehavior_store.record_faulty_block(peer_index, signed_block_header.author(), &e);
                 warn!("Invalid block received from {}: {}", peer_index, e);
                 return Err(e);
             }
@@ -1008,7 +1004,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                                             .map_err(ConsensusError::MalformedHeader)
                                             .inspect_err(|e| {
                                                 // Author unknown when deserialization fails — blame the peer.
-                                                misbehavior_store.record_faulty_block_header(
+                                                misbehavior_store.record_faulty_block(
                                                     authority_index,
                                                     authority_index,
                                                     e,
@@ -1022,7 +1018,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                                                 .synchronizer_invalid_block_headers
                                                 .with_label_values(&[hostname.as_str(), "synchronizer_own_block_header", err.clone().name()])
                                                 .inc();
-                                            misbehavior_store.record_faulty_block_header(
+                                            misbehavior_store.record_faulty_block(
                                                 authority_index,
                                                 signed_block_header.author(),
                                                 err,

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -340,6 +340,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::UnexpectedNumberOfHeadersFetched { .. }
         | ConsensusError::UnexpectedLastOwnHeader { .. }
         | ConsensusError::TooManyFetchedTransactionsReturned(_)
+        | ConsensusError::UnrequestedTransactionFetched { .. }
         | ConsensusError::TooManyAuthoritiesProvided(_)
         | ConsensusError::InvalidSizeOfHighestAcceptedRounds(..)
         | ConsensusError::InvalidAuthorityIndexRequested { .. }

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -276,6 +276,8 @@ enum FaultType {
 }
 
 fn classify_block_header_error(error: &ConsensusError) -> FaultType {
+    // Exhaustive on purpose: a new `ConsensusError` variant must be assigned a
+    // fault type here rather than silently falling through to `Untracked`.
     match error {
         // Pre-signature / parsing errors — the header's author field can't
         // be trusted, so charge the sender, not the claimed author.
@@ -292,20 +294,84 @@ fn classify_block_header_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::SerializedTransactionsTooLarge { .. }
         | ConsensusError::TransactionCommitmentFailure { .. } => FaultType::Unprovable,
 
-        // Signed block header verification — provably the author's fault
+        // Checks that run only after the author's signature is verified, so the
+        // signed header itself proves the author produced a block that violates
+        // protocol rules.
         ConsensusError::TooManyAncestors(..)
         | ConsensusError::InsufficientParentStakes { .. }
         | ConsensusError::InvalidAncestorPosition { .. }
         | ConsensusError::InvalidAncestorRound { .. }
+        | ConsensusError::AncestorRoundTooOld { .. }
+        | ConsensusError::AcknowledgmentRoundTooOld { .. }
         | ConsensusError::InvalidGenesisAncestor(_)
         | ConsensusError::DuplicatedAncestorsAuthority(_)
         | ConsensusError::InvalidOverlapIndices { .. }
+        | ConsensusError::TooManyAcknowledgments { .. }
+        | ConsensusError::TooManyCommitVotes { .. }
+        | ConsensusError::InvalidAcknowledgmentRound { .. }
+        | ConsensusError::InvalidStrongVoteAuthority { .. }
+        | ConsensusError::StrongVoteLeaderNotInAncestors { .. }
         | ConsensusError::TransactionTooLarge { .. }
         | ConsensusError::TooManyTransactions { .. }
         | ConsensusError::TooManyTransactionBytes { .. }
         | ConsensusError::InvalidTransaction(_) => FaultType::Provable,
 
-        _ => FaultType::Untracked,
+        // Not attributable to a block author from a signed block alone:
+        // subjective rejections, commit-chain and commit-sync inconsistencies,
+        // fetch-shape mismatches, relayed shard / bundle parts, reconstruction
+        // and encoder failures, storage, network transport, request-shape
+        // checks, and local lifecycle signals.
+        ConsensusError::MalformedShard(_)
+        | ConsensusError::MalformedCommit(_)
+        | ConsensusError::UnexpectedGenesisRequested { .. }
+        | ConsensusError::UnexpectedNumberOfHeadersFetched { .. }
+        | ConsensusError::UnexpectedLastOwnHeader { .. }
+        | ConsensusError::TooManyFetchedTransactionsReturned(_)
+        | ConsensusError::TooManyAuthoritiesProvided(_)
+        | ConsensusError::InvalidSizeOfHighestAcceptedRounds(..)
+        | ConsensusError::InvalidAuthorityIndexRequested { .. }
+        | ConsensusError::TransactionCommitmentMismatch { .. }
+        | ConsensusError::SynchronizerSaturated(_)
+        | ConsensusError::TransactionSynchronizerSaturated
+        | ConsensusError::BlockRejected { .. }
+        | ConsensusError::EmptyMerkleTree
+        | ConsensusError::MissingBlockHeader { .. }
+        | ConsensusError::CommitRangeExceededAfterScanning { .. }
+        | ConsensusError::TooManyCommitsFromPeer { .. }
+        | ConsensusError::NoCommitReceived { .. }
+        | ConsensusError::UnexpectedStartCommit { .. }
+        | ConsensusError::UnexpectedCommitSequence { .. }
+        | ConsensusError::NotEnoughCommitVotes { .. }
+        | ConsensusError::TooManyCommitVoteHeaders { .. }
+        | ConsensusError::SerializedCommitTooLarge { .. }
+        | ConsensusError::SerializedBlockHeaderTooLarge { .. }
+        | ConsensusError::InvalidCommitRange { .. }
+        | ConsensusError::UnexpectedBlockHeaderForCommit { .. }
+        | ConsensusError::UnexpectedTransactionForCommit { .. }
+        | ConsensusError::FetchedTransactionsMismatch { .. }
+        | ConsensusError::RocksDBFailure(_)
+        | ConsensusError::NetworkConfig(_)
+        | ConsensusError::NetworkClientConnection(_)
+        | ConsensusError::NetworkRequest(_)
+        | ConsensusError::NetworkRequestTimeout(_)
+        | ConsensusError::AccumulatorSenderClosed
+        | ConsensusError::Shutdown
+        | ConsensusError::EncoderResetFailed(_)
+        | ConsensusError::AddShardFailed(_)
+        | ConsensusError::ShardsEncodingFailed(_)
+        | ConsensusError::ShardsDecodingFailed(_)
+        | ConsensusError::InsufficientShardsInDecoder(..)
+        | ConsensusError::ShardsVecIsTooSmall(..)
+        | ConsensusError::TooBigHeaderRoundInABundle { .. }
+        | ConsensusError::IncorrectShardProof { .. }
+        | ConsensusError::TooBigShardRoundInABundle { .. }
+        | ConsensusError::InconsistentTransactionRefVariants
+        | ConsensusError::TransactionRefVariantMismatch { .. }
+        | ConsensusError::FailedToFetchBlockHeaders { .. }
+        | ConsensusError::MissingVotingBlockHeaderInStorage { .. }
+        | ConsensusError::WrongShardVersion { .. }
+        | ConsensusError::WrongCommitVersionForFlags { .. }
+        | ConsensusError::WrongBlockHeaderVersionForFlag { .. } => FaultType::Untracked,
     }
 }
 
@@ -844,6 +910,39 @@ mod tests {
                 limit: 50,
             },
             ConsensusError::InvalidTransaction("bad tx".to_string()),
+            // Bounds and structure checks that run only after the signature is
+            // verified, so the signed header proves the author's fault.
+            ConsensusError::TooManyAcknowledgments {
+                count: 100,
+                max: 50,
+            },
+            ConsensusError::TooManyCommitVotes {
+                count: 100,
+                max: 50,
+            },
+            ConsensusError::InvalidAcknowledgmentRound {
+                acknowledgment: 5,
+                block: 5,
+            },
+            ConsensusError::AcknowledgmentRoundTooOld {
+                acknowledgment: 1,
+                block: 10,
+                gc_depth: 3,
+            },
+            ConsensusError::AncestorRoundTooOld {
+                ancestor: 1,
+                block: 10,
+                gc_depth: 3,
+            },
+            ConsensusError::InvalidStrongVoteAuthority {
+                index: AuthorityIndex::new_for_test(3),
+                max: 4,
+            },
+            ConsensusError::StrongVoteLeaderNotInAncestors {
+                block_round: 5,
+                leader_round: 4,
+                leader_authority: AuthorityIndex::new_for_test(1),
+            },
         ];
         for e in cases {
             let (prov, unprov) = classify_via_record(e);

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -111,8 +111,8 @@ impl MisbehaviorStore {
         }
         let idx = authority_index.value();
 
-        // Move buffered faulty block header counts to persisted.
-        let had_faulty = self.flush_faulty_block_header_buffer(idx);
+        // Move buffered faulty block counts to persisted.
+        let had_faulty = self.flush_faulty_block_buffer(idx);
 
         // Recompute in-memory window from blocks still in cache.
         let in_memory_block_rounds: Vec<Round> = recent_refs
@@ -152,9 +152,9 @@ impl MisbehaviorStore {
         }
     }
 
-    /// Flush buffered faulty block header counts from in_memory to persisted
+    /// Flush buffered faulty block counts from in_memory to persisted
     /// for one authority. Returns true if any counts were moved.
-    fn flush_faulty_block_header_buffer(&self, idx: usize) -> bool {
+    fn flush_faulty_block_buffer(&self, idx: usize) -> bool {
         let (prov, unprov) = self.in_memory.drain_block_faults(idx);
         if prov == 0 && unprov == 0 {
             return false;
@@ -185,9 +185,10 @@ impl MisbehaviorStore {
             .collect()
     }
 
-    /// Records a faulty block header event detected during block header
-    /// validation. Events are buffered in the in_memory bucket and moved
-    /// to persisted on the next flush.
+    /// Records a faulty block event detected during ingest validation — a
+    /// rejected block header, or a corrupt part of a relayed bundle (framing,
+    /// metadata, or shard). Events are buffered in the in_memory bucket and
+    /// moved to persisted on the next flush.
     ///
     /// `peer` is the authority that sent us the block (always known from the
     /// network connection). `author` is the claimed block author (from the
@@ -200,7 +201,7 @@ impl MisbehaviorStore {
     ///   distributing a block they could have verified themselves.
     /// - Unprovable faults (bad/missing signature): charged to `peer` only — we
     ///   can't verify the author field, but we know who sent it to us.
-    pub(crate) fn record_faulty_block_header(
+    pub(crate) fn record_faulty_block(
         &self,
         peer: AuthorityIndex,
         author: AuthorityIndex,
@@ -214,7 +215,7 @@ impl MisbehaviorStore {
         if peer_idx >= committee_size {
             return;
         }
-        match classify_block_header_error(error) {
+        match classify_block_error(error) {
             FaultType::Provable => {
                 if author_idx >= committee_size {
                     // Can't credit a bogus author; charge the serving peer instead.
@@ -261,7 +262,7 @@ impl MisbehaviorStore {
     }
 }
 
-/// Whether a block header fault can be cryptographically proven.
+/// Whether a block fault can be cryptographically proven.
 enum FaultType {
     /// Block has a valid author signature but violates protocol rules.
     /// The signed block header itself is proof of misbehavior.
@@ -277,7 +278,7 @@ enum FaultType {
     Untracked,
 }
 
-fn classify_block_header_error(error: &ConsensusError) -> FaultType {
+fn classify_block_error(error: &ConsensusError) -> FaultType {
     // Exhaustive on purpose: a new `ConsensusError` variant must be assigned a
     // fault type here rather than silently falling through to `Untracked`.
     match error {
@@ -298,6 +299,9 @@ fn classify_block_header_error(error: &ConsensusError) -> FaultType {
         // Corrupt or invalid relayed bundle parts (framing, additional-header
         // round, and shard structure/proof). We know which peer relayed them
         // but can't tie them to a verified author.
+        // TODO(iotaledger/iota-private#470): count these under a dedicated
+        // bundle-part counter instead of folding them into the unprovable
+        // block-fault bucket.
         | ConsensusError::MalformedShard(_)
         | ConsensusError::TooBigHeaderRoundInABundle { .. }
         | ConsensusError::TooBigShardRoundInABundle { .. }
@@ -899,7 +903,7 @@ mod tests {
         let context = Arc::new(Context::new_for_test(4).0);
         let store = MisbehaviorStore::new(&context);
         let authority = AuthorityIndex::new_for_test(0);
-        store.record_faulty_block_header(authority, authority, error);
+        store.record_faulty_block(authority, authority, error);
         let counts = store.in_memory.snapshot(0);
         (
             counts.faulty_blocks_provable,
@@ -1043,9 +1047,9 @@ mod tests {
         let provable = ConsensusError::TooManyAncestors(10, 5);
 
         // Seed in_memory provable counts for authority 0 (2) and 1 (1).
-        store.record_faulty_block_header(a0, a0, &provable);
-        store.record_faulty_block_header(a0, a0, &provable);
-        store.record_faulty_block_header(a1, a1, &provable);
+        store.record_faulty_block(a0, a0, &provable);
+        store.record_faulty_block(a0, a0, &provable);
+        store.record_faulty_block(a1, a1, &provable);
 
         // Flush faulty buffer for authority 0 into persisted; leave authority 1
         // unflushed so the snapshot must sum across both buckets.
@@ -1054,7 +1058,7 @@ mod tests {
 
         // Record 3 more provable faults on authority 0 — these stay in_memory.
         for _ in 0..3 {
-            store.record_faulty_block_header(a0, a0, &provable);
+            store.record_faulty_block(a0, a0, &provable);
         }
 
         let snapshot = store.snapshot_totals();
@@ -1081,7 +1085,7 @@ mod tests {
         let store = MisbehaviorStore::new(&context);
         let author = AuthorityIndex::new_for_test(0);
         let peer = AuthorityIndex::new_for_test(1);
-        store.record_faulty_block_header(peer, author, &e);
+        store.record_faulty_block(peer, author, &e);
         let author_counts = store.in_memory.snapshot(0);
         let peer_counts = store.in_memory.snapshot(1);
         assert_eq!(author_counts.faulty_blocks_provable, 1);
@@ -1101,13 +1105,13 @@ mod tests {
         let bogus_author = AuthorityIndex::new_for_test(99);
 
         let provable = ConsensusError::TooManyAncestors(10, 5);
-        store.record_faulty_block_header(peer, bogus_author, &provable);
+        store.record_faulty_block(peer, bogus_author, &provable);
 
         let unprovable = ConsensusError::InvalidAuthorityIndex {
             index: bogus_author,
             max: 3,
         };
-        store.record_faulty_block_header(peer, bogus_author, &unprovable);
+        store.record_faulty_block(peer, bogus_author, &unprovable);
 
         let peer_counts = store.in_memory.snapshot(1);
         assert_eq!(peer_counts.faulty_blocks_provable, 0);

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -267,9 +267,11 @@ enum FaultType {
     /// The signed block header itself is proof of misbehavior.
     Provable,
     /// Can't prove authorship — either because the signature is bad or
-    /// missing, or because the header is rejected by a pre-signature check
+    /// missing, because the header is rejected by a pre-signature check
     /// (epoch / genesis / author-vs-peer mismatch) so its `author` field
-    /// can't be trusted. Charged to the sending peer, not the claimed author.
+    /// can't be trusted, or because the fault is in a relayed bundle part
+    /// (framing, metadata, or shard) that isn't tied to a verified author.
+    /// Charged to the sending peer, not the claimed author.
     Unprovable,
     /// Not counted as misbehavior.
     Untracked,
@@ -292,7 +294,14 @@ fn classify_block_header_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::SerializationFailure(_)
         | ConsensusError::DeserializationFailure(_)
         | ConsensusError::SerializedTransactionsTooLarge { .. }
-        | ConsensusError::TransactionCommitmentFailure { .. } => FaultType::Unprovable,
+        | ConsensusError::TransactionCommitmentFailure { .. }
+        // Corrupt or invalid relayed bundle parts (framing, additional-header
+        // round, and shard structure/proof). We know which peer relayed them
+        // but can't tie them to a verified author.
+        | ConsensusError::MalformedShard(_)
+        | ConsensusError::TooBigHeaderRoundInABundle { .. }
+        | ConsensusError::TooBigShardRoundInABundle { .. }
+        | ConsensusError::IncorrectShardProof { .. } => FaultType::Unprovable,
 
         // Checks that run only after the author's signature is verified, so the
         // signed header itself proves the author produced a block that violates
@@ -316,13 +325,13 @@ fn classify_block_header_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::TooManyTransactionBytes { .. }
         | ConsensusError::InvalidTransaction(_) => FaultType::Provable,
 
-        // Not attributable to a block author from a signed block alone:
-        // subjective rejections, commit-chain and commit-sync inconsistencies,
-        // fetch-shape mismatches, relayed shard / bundle parts, reconstruction
-        // and encoder failures, storage, network transport, request-shape
-        // checks, and local lifecycle signals.
-        ConsensusError::MalformedShard(_)
-        | ConsensusError::MalformedCommit(_)
+        // Not attributable as misbehavior from a signed block alone: subjective
+        // rejections, commit-chain and commit-sync inconsistencies, fetch-shape
+        // mismatches, reconstruction and encoder failures, storage, network
+        // transport, request-shape checks, local lifecycle signals, and version
+        // mismatches that may stem from a benign upgrade misconfiguration rather
+        // than a faulty peer.
+        ConsensusError::MalformedCommit(_)
         | ConsensusError::UnexpectedGenesisRequested { .. }
         | ConsensusError::UnexpectedNumberOfHeadersFetched { .. }
         | ConsensusError::UnexpectedLastOwnHeader { .. }
@@ -362,9 +371,6 @@ fn classify_block_header_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::ShardsDecodingFailed(_)
         | ConsensusError::InsufficientShardsInDecoder(..)
         | ConsensusError::ShardsVecIsTooSmall(..)
-        | ConsensusError::TooBigHeaderRoundInABundle { .. }
-        | ConsensusError::IncorrectShardProof { .. }
-        | ConsensusError::TooBigShardRoundInABundle { .. }
         | ConsensusError::InconsistentTransactionRefVariants
         | ConsensusError::TransactionRefVariantMismatch { .. }
         | ConsensusError::FailedToFetchBlockHeaders { .. }
@@ -963,6 +969,21 @@ mod tests {
                 AuthorityIndex::new_for_test(0),
                 AuthorityIndex::new_for_test(1),
             ),
+            // Corrupt or invalid relayed bundle parts: charged to the relaying
+            // peer, not to a verified author.
+            ConsensusError::MalformedShard(bcs::Error::Custom("bad".to_string())),
+            ConsensusError::TooBigHeaderRoundInABundle {
+                header_round: 5,
+                block_round: 5,
+            },
+            ConsensusError::TooBigShardRoundInABundle {
+                shard_round: 5,
+                block_round: 5,
+            },
+            ConsensusError::IncorrectShardProof {
+                peer: AuthorityIndex::new_for_test(0),
+                round: 3,
+            },
         ];
         for e in cases {
             let (prov, unprov) = classify_via_record(e);
@@ -1001,6 +1022,9 @@ mod tests {
                 expected: 3,
                 received: 1,
             },
+            // Version mismatch may be a benign upgrade misconfiguration, so it
+            // is not charged as misbehavior.
+            ConsensusError::WrongShardVersion { actual: "V1" },
         ];
         for e in cases {
             let (prov, unprov) = classify_via_record(e);


### PR DESCRIPTION
# Description of change

Improves misbehavior accounting on the bundle-ingest path so honest validators converge on the same per-peer counts:

- `authority_service.rs`: rejection sites that previously only returned an error (outer framing deserialization, envelope deserialization, invalid authority bitmask, the invalid-shard conditions, and the additional-header round check) now also record the fault against the sending peer, reusing the existing `record_faulty_block` helper. No new fault types or counters are introduced — this only counts existing rejections that were previously dropped.
- `misbehavior_store.rs`: `classify_block_error` (renamed from `classify_block_header_error`) is now exhaustive (no catch-all), so every future error variant forces an explicit classification decision. Post-signature `verify()` variants move to `Provable`; structural bundle/shard corruption variants move to `Unprovable` so they land in the existing `faulty_blocks_unprovable` bucket. `WrongShardVersion` and `WrongBlockHeaderVersionForFlag` stay untracked as benign version skew during upgrades.

Bundle tests extended to assert the unprovable count is recorded at the newly covered sites.

## Links to any relevant issues

fixes iotaledger/iota-private#463

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

