### PR TITLE
upstream(iota-core): detach TransactionDriver submission from client cancellation

### DIFF
--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -241,11 +241,11 @@ where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
     #[instrument(name = "tx_orchestrator_execute_transaction_block", level = "trace", skip_all,
-    fields(
+        fields(
         tx_digest = ?request.transaction.digest(),
         tx_type = ?request_type,
-    ),
-    err)]
+        ),
+        err)]
     pub async fn execute_transaction_block(
         &self,
         request: ExecuteTransactionRequestV1,
@@ -302,16 +302,50 @@ where
         );
         let (mut response, seq) = match (&self.driver, wait_for_local_execution) {
             (Driver::Transaction(td), true) => {
-                self.submit_with_checkpoint_race(td.clone(), request, client_addr, tx_digest)
-                    .await?
+                let td = td.clone();
+                let in_flight_transactions = self.in_flight_transactions.clone();
+                let validator_state = self.validator_state.clone();
+                let metrics = self.metrics.clone();
+                // Detached so a client disconnect (this future dropped) does
+                // not cancel a submission that may already be in consensus;
+                // the task drives the transaction to finality on its own.
+                spawn_monitored_task!(Self::submit_with_checkpoint_race(
+                    td,
+                    in_flight_transactions,
+                    validator_state,
+                    metrics,
+                    request,
+                    client_addr,
+                    tx_digest,
+                ))
+                .await
+                .unwrap_or_else(|e| {
+                    Err(QuorumDriverError::QuorumDriverInternal(IotaError::Unknown(
+                        format!("transaction submission task panicked: {e}"),
+                    )))
+                })?
             }
-            (Driver::Transaction(td), false) => (
-                Some(
-                    self.submit_with_transaction_driver(td.clone(), request, client_addr, false)
-                        .await?,
-                ),
-                None,
-            ),
+            (Driver::Transaction(td), false) => {
+                let td = td.clone();
+                let in_flight_transactions = self.in_flight_transactions.clone();
+                let validator_state = self.validator_state.clone();
+                // Detached for the same reason as above.
+                let result = spawn_monitored_task!(Self::submit_with_transaction_driver(
+                    td,
+                    in_flight_transactions,
+                    validator_state,
+                    request,
+                    client_addr,
+                    false,
+                ))
+                .await
+                .unwrap_or_else(|e| {
+                    Err(QuorumDriverError::QuorumDriverInternal(IotaError::Unknown(
+                        format!("transaction submission task panicked: {e}"),
+                    )))
+                })?;
+                (Some(result), None)
+            }
             (Driver::Quorum(qd), _) => {
                 let qd_resp = self
                     .execute_transaction_impl(
@@ -584,7 +618,7 @@ where
     // Utilize the handle_certificate_v1 validator api to request input/output
     // objects
     #[instrument(name = "tx_orchestrator_execute_transaction_v1", level = "trace", skip_all,
-                 fields(tx_digest = ?request.transaction.digest()))]
+        fields(tx_digest = ?request.transaction.digest()))]
     pub async fn execute_transaction_v1(
         &self,
         request: ExecuteTransactionRequestV1,
@@ -631,13 +665,28 @@ where
                 // execution service) are responsible for their own
                 // `wait_for_checkpoint_inclusion` when they need it, and will
                 // reconcile the response from the cache there.
-                self.submit_with_transaction_driver(
-                    td.clone(),
+                epoch_store
+                    .verify_transaction(request.transaction.clone())
+                    .map_err(QuorumDriverError::InvalidUserSignature)?;
+                let td = td.clone();
+                let in_flight_transactions = self.in_flight_transactions.clone();
+                let validator_state = self.validator_state.clone();
+                // Detached so a client disconnect does not cancel a
+                // submission that may already be in consensus.
+                spawn_monitored_task!(Self::submit_with_transaction_driver(
+                    td,
+                    in_flight_transactions,
+                    validator_state,
                     request,
                     client_addr,
                     skip_certification,
-                )
+                ))
                 .await
+                .unwrap_or_else(|e| {
+                    Err(QuorumDriverError::QuorumDriverInternal(IotaError::Unknown(
+                        format!("transaction submission task panicked: {e}"),
+                    )))
+                })
             }
             Driver::Quorum(qd) => {
                 let qd_resp = self
@@ -663,11 +712,19 @@ where
     /// returned a result (which may carry `UncertifiedSingleValidator`
     /// finality requiring rebuild) and `seq` is the checkpoint sequence if
     /// either future yielded it.
+    ///
+    /// Takes `in_flight_transactions`, `validator_state`, and `metrics` by
+    /// `Arc` rather than `&self`: the caller runs this inside a detached task
+    /// so a client disconnect does not cancel the race before the
+    /// checkpoint-seq bookkeeping completes, and a detached task needs owned,
+    /// `'static` inputs.
     #[instrument(name = "tx_orchestrator_submit_with_checkpoint_race", level = "trace", skip_all,
-                 fields(tx_digest = ?tx_digest))]
+        fields(tx_digest = ?tx_digest))]
     async fn submit_with_checkpoint_race(
-        &self,
         td: Arc<TransactionDriver<A>>,
+        in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
+        validator_state: Arc<AuthorityState>,
+        metrics: Arc<TransactionOrchestratorMetrics>,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         tx_digest: TransactionDigest,
@@ -679,11 +736,17 @@ where
         QuorumDriverError,
     > {
         let digests = [tx_digest];
-        let checkpoint_inclusion = self
-            .validator_state
-            .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT);
+        let checkpoint_inclusion =
+            validator_state.wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT);
         tokio::pin!(checkpoint_inclusion);
-        let driver = self.submit_with_transaction_driver(td, request, client_addr, true);
+        let driver = Self::submit_with_transaction_driver(
+            td,
+            in_flight_transactions,
+            validator_state.clone(),
+            request,
+            client_addr,
+            true,
+        );
 
         let seq_for_tx = |inclusion_map: BTreeMap<_, (CheckpointSequenceNumber, _)>| {
             inclusion_map.get(&tx_digest).map(|&(seq, _)| seq)
@@ -701,7 +764,7 @@ where
                 (response, seq)
             }
             checkpoint_result = &mut checkpoint_inclusion => {
-                self.metrics.skip_effect_cert_checkpoint_overrode_driver.inc();
+                metrics.skip_effect_cert_checkpoint_overrode_driver.inc();
                 (None, checkpoint_result.ok().and_then(seq_for_tx))
             }
         };
@@ -719,11 +782,18 @@ where
     /// authoritative data — uncertified data must never reach the client.
     /// See `corroborate_single_validator_error` for the per-submission
     /// fetch-failure recovery flow inside the driver.
+    ///
+    /// Takes `td`, `in_flight_transactions`, and `validator_state` by `Arc`
+    /// rather than `&self`: the caller runs this inside a detached task so a
+    /// client disconnect does not cancel a `drive_transaction` call that may
+    /// already be in consensus, and a detached task needs owned, `'static`
+    /// inputs.
     #[instrument(name = "tx_orchestrator_submit_with_td", level = "trace", skip_all,
-                 fields(tx_digest = ?request.transaction.digest()))]
+        fields(tx_digest = ?request.transaction.digest()))]
     async fn submit_with_transaction_driver(
-        &self,
         td: Arc<TransactionDriver<A>>,
+        in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
+        validator_state: Arc<AuthorityState>,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         skip_certification: bool,
@@ -735,17 +805,21 @@ where
         // effects. The guard removes the digest from the in-flight set on every
         // exit path (success, error, timeout, or cancellation) when it is
         // dropped.
-        let guard = TransactionSubmissionGuard::new(self.in_flight_transactions.clone(), tx_digest);
+        let guard = TransactionSubmissionGuard::new(in_flight_transactions, tx_digest);
         if !guard.is_new_transaction() {
             debug!(
                 ?tx_digest,
                 "transaction already in flight; awaiting its effects instead of driving a \
                  duplicate submission"
             );
-            return self.await_in_flight_transaction(tx_digest, &request).await;
+            return Self::await_in_flight_transaction(&validator_state, tx_digest, &request).await;
         }
 
-        let td_response = td
+        // This call runs inside a task detached from the caller, so the
+        // outcome is logged here rather than left to the caller — a
+        // disconnected client's continuation never runs and would
+        // otherwise never observe it.
+        let td_response = match td
             .drive_transaction(
                 Some(request.transaction.clone()),
                 SubmitTransactionOptions {
@@ -756,12 +830,15 @@ where
                 skip_certification,
             )
             .await
-            .map_err(map_td_error_to_qd)?;
+        {
+            Ok(response) => response,
+            Err(e) => {
+                warn!(?tx_digest, "TransactionDriver submission failed: {e}");
+                return Err(map_td_error_to_qd(e));
+            }
+        };
 
-        debug!(
-            "TransactionOrchestrator: TransactionDriver submission succeeded for transaction {}",
-            tx_digest
-        );
+        debug!(?tx_digest, "TransactionDriver submission succeeded");
 
         let QuorumTransactionResponse {
             effects: td_effects,
@@ -799,20 +876,19 @@ where
     /// transaction. Times out with `TimeoutBeforeFinality` if the in-flight
     /// submission does not get the transaction checkpointed in time.
     async fn await_in_flight_transaction(
-        &self,
+        validator_state: &Arc<AuthorityState>,
         tx_digest: TransactionDigest,
         request: &ExecuteTransactionRequestV1,
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
         let digests = [tx_digest];
-        let seq = self
-            .validator_state
+        let seq = validator_state
             .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT)
             .await
             .ok()
             .and_then(|inclusion| inclusion.get(&tx_digest).map(|&(seq, _)| seq))
             .ok_or(QuorumDriverError::TimeoutBeforeFinality)?;
         Self::build_response_from_cache(
-            &self.validator_state,
+            validator_state,
             tx_digest,
             seq,
             request.include_events,
@@ -951,7 +1027,13 @@ where
         })
     }
 
-    #[instrument(name = "tx_orchestrator_wait_for_finalized_tx_executed_locally_with_timeout", level = "debug", skip_all, fields(tx_digest = ?transaction.digest()), err)]
+    #[instrument(
+        name = "tx_orchestrator_wait_for_finalized_tx_executed_locally_with_timeout",
+        level = "debug",
+        skip_all,
+        fields(tx_digest = ?transaction.digest()),
+        err
+    )]
     async fn wait_for_finalized_tx_executed_locally_with_timeout(
         validator_state: &Arc<AuthorityState>,
         transaction: &VerifiedTransaction,
@@ -1334,7 +1416,7 @@ impl TransactionOrchestratorMetrics {
             registry;
             MetricLevel::Warn,
         )
-        .unwrap();
+            .unwrap();
 
         let total_req_received_single_writer =
             total_req_received.with_label_values(&[TX_TYPE_SINGLE_WRITER_TX]);
@@ -1408,55 +1490,55 @@ impl TransactionOrchestratorMetrics {
                 registry;
                 MetricLevel::Warn,
             )
-            .unwrap(),
+                .unwrap(),
             wait_for_finality_finished: register_int_counter_with_registry!(
                 "tx_orchestrator_wait_for_finality_finished",
                 "Total number of txns Transaction Orchestrator gets responses from Quorum Driver before timeout, either success or failure",
                 registry;
                 MetricLevel::Warn,
             )
-            .unwrap(),
+                .unwrap(),
             wait_for_finality_timeout: register_int_counter_with_registry!(
                 "tx_orchestrator_wait_for_finality_timeout",
                 "Total number of txns timing out in waiting for finality Transaction Orchestrator handles",
                 registry;
                 MetricLevel::Warn,
             )
-            .unwrap(),
+                .unwrap(),
             local_execution_in_flight: register_int_gauge_with_registry!(
                 "tx_orchestrator_local_execution_in_flight",
                 "Number of local execution txns in flights Transaction Orchestrator handles",
                 registry;
                 MetricLevel::Warn,
             )
-            .unwrap(),
+                .unwrap(),
             local_execution_success: register_int_counter_with_registry!(
                 "tx_orchestrator_local_execution_success",
                 "Total number of successful local execution txns Transaction Orchestrator handles",
                 registry;
                 MetricLevel::Warn,
             )
-            .unwrap(),
+                .unwrap(),
             local_execution_timeout: register_int_counter_with_registry!(
                 "tx_orchestrator_local_execution_timeout",
                 "Total number of timed-out local execution txns Transaction Orchestrator handles",
                 registry;
                 MetricLevel::Warn,
             )
-            .unwrap(),
+                .unwrap(),
             local_execution_failure: register_int_counter_with_registry!(
                 "tx_orchestrator_local_execution_failure",
                 "Total number of failed local execution txns Transaction Orchestrator handles",
                 registry;
                 MetricLevel::Warn,
             )
-            .unwrap(),
+                .unwrap(),
             early_cached_response: register_int_counter_with_registry!(
                 "tx_orchestrator_early_cached_response",
                 "Total number of requests returning cached results for already-executed transactions",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             skip_effect_cert_events_cache_miss: register_int_counter_with_registry!(
                 "tx_orchestrator_skip_effect_cert_events_cache_miss",
                 "Number of skip-effect-certification responses rejected because the \
@@ -1464,7 +1546,7 @@ impl TransactionOrchestratorMetrics {
                  corroborate them",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             skip_effect_cert_checkpoint_overrode_driver: register_int_counter_with_registry!(
                 "tx_orchestrator_skip_effect_cert_checkpoint_overrode_driver",
                 "Number of skip-effect-certification requests where local checkpoint \
@@ -1472,7 +1554,7 @@ impl TransactionOrchestratorMetrics {
                  driver future was cancelled and the response was rebuilt from cache",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             request_latency_single_writer: request_latency
                 .with_label_values(&[TX_TYPE_SINGLE_WRITER_TX]),
             request_latency_shared_obj: request_latency.with_label_values(&[TX_TYPE_SHARED_OBJ_TX]),

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -309,7 +309,7 @@ where
                 // Detached so a client disconnect (this future dropped) does
                 // not cancel a submission that may already be in consensus;
                 // the task drives the transaction to finality on its own.
-                spawn_monitored_task!(Self::submit_with_checkpoint_race(
+                join_submission_task(spawn_monitored_task!(Self::submit_with_checkpoint_race(
                     td,
                     in_flight_transactions,
                     validator_state,
@@ -317,33 +317,25 @@ where
                     request,
                     client_addr,
                     tx_digest,
-                ))
-                .await
-                .unwrap_or_else(|e| {
-                    Err(QuorumDriverError::QuorumDriverInternal(IotaError::Unknown(
-                        format!("transaction submission task panicked: {e}"),
-                    )))
-                })?
+                )))
+                .await?
             }
             (Driver::Transaction(td), false) => {
                 let td = td.clone();
                 let in_flight_transactions = self.in_flight_transactions.clone();
                 let validator_state = self.validator_state.clone();
                 // Detached for the same reason as above.
-                let result = spawn_monitored_task!(Self::submit_with_transaction_driver(
-                    td,
-                    in_flight_transactions,
-                    validator_state,
-                    request,
-                    client_addr,
-                    false,
+                let result = join_submission_task(spawn_monitored_task!(
+                    Self::submit_with_transaction_driver(
+                        td,
+                        in_flight_transactions,
+                        validator_state,
+                        request,
+                        client_addr,
+                        false,
+                    )
                 ))
-                .await
-                .unwrap_or_else(|e| {
-                    Err(QuorumDriverError::QuorumDriverInternal(IotaError::Unknown(
-                        format!("transaction submission task panicked: {e}"),
-                    )))
-                })?;
+                .await?;
                 (Some(result), None)
             }
             (Driver::Quorum(qd), _) => {
@@ -661,32 +653,25 @@ where
 
         match &self.driver {
             Driver::Transaction(td) => {
+                let td = td.clone();
+                let in_flight_transactions = self.in_flight_transactions.clone();
+                let validator_state = self.validator_state.clone();
                 // v1 does not do an internal wait; callers (e.g. the gRPC
                 // execution service) are responsible for their own
                 // `wait_for_checkpoint_inclusion` when they need it, and will
                 // reconcile the response from the cache there.
-                epoch_store
-                    .verify_transaction(request.transaction.clone())
-                    .map_err(QuorumDriverError::InvalidUserSignature)?;
-                let td = td.clone();
-                let in_flight_transactions = self.in_flight_transactions.clone();
-                let validator_state = self.validator_state.clone();
-                // Detached so a client disconnect does not cancel a
-                // submission that may already be in consensus.
-                spawn_monitored_task!(Self::submit_with_transaction_driver(
+                //
+                // Detached so a client disconnect does not cancel a submission
+                // that may already be in consensus.
+                join_submission_task(spawn_monitored_task!(Self::submit_with_transaction_driver(
                     td,
                     in_flight_transactions,
                     validator_state,
                     request,
                     client_addr,
                     skip_certification,
-                ))
+                )))
                 .await
-                .unwrap_or_else(|e| {
-                    Err(QuorumDriverError::QuorumDriverInternal(IotaError::Unknown(
-                        format!("transaction submission task panicked: {e}"),
-                    )))
-                })
             }
             Driver::Quorum(qd) => {
                 let qd_resp = self
@@ -713,11 +698,8 @@ where
     /// finality requiring rebuild) and `seq` is the checkpoint sequence if
     /// either future yielded it.
     ///
-    /// Takes `in_flight_transactions`, `validator_state`, and `metrics` by
-    /// `Arc` rather than `&self`: the caller runs this inside a detached task
-    /// so a client disconnect does not cancel the race before the
-    /// checkpoint-seq bookkeeping completes, and a detached task needs owned,
-    /// `'static` inputs.
+    /// Run inside a detached task so a client disconnect cannot cancel the
+    /// race before the checkpoint-sequence bookkeeping completes.
     #[instrument(name = "tx_orchestrator_submit_with_checkpoint_race", level = "trace", skip_all,
         fields(tx_digest = ?tx_digest))]
     async fn submit_with_checkpoint_race(
@@ -783,11 +765,8 @@ where
     /// See `corroborate_single_validator_error` for the per-submission
     /// fetch-failure recovery flow inside the driver.
     ///
-    /// Takes `td`, `in_flight_transactions`, and `validator_state` by `Arc`
-    /// rather than `&self`: the caller runs this inside a detached task so a
-    /// client disconnect does not cancel a `drive_transaction` call that may
-    /// already be in consensus, and a detached task needs owned, `'static`
-    /// inputs.
+    /// Run inside a detached task so a client disconnect cannot cancel a
+    /// `drive_transaction` call that may already be in consensus.
     #[instrument(name = "tx_orchestrator_submit_with_td", level = "trace", skip_all,
         fields(tx_digest = ?request.transaction.digest()))]
     async fn submit_with_transaction_driver(
@@ -1358,6 +1337,18 @@ fn count_validator_attempts(errors: &AggregatedRequestErrors) -> u32 {
         .iter()
         .map(|(_, authorities, _, _)| authorities.len() as u32)
         .sum()
+}
+
+/// Await a detached submission task, surfacing a task panic as an internal
+/// error.
+async fn join_submission_task<T>(
+    handle: tokio::task::JoinHandle<Result<T, QuorumDriverError>>,
+) -> Result<T, QuorumDriverError> {
+    handle.await.unwrap_or_else(|e| {
+        Err(QuorumDriverError::QuorumDriverInternal(IotaError::Unknown(
+            format!("transaction submission task panicked: {e}"),
+        )))
+    })
 }
 
 /// Prometheus metrics which can be displayed in Grafana, queried and alerted on

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -979,3 +979,80 @@ async fn test_orchestrator_rejects_expired_transaction() {
         "expected InvalidTransaction(TransactionExpired), got {err:?}"
     );
 }
+
+/// Under the P-COOL flow, `WaitForLocalExecution` races the
+/// TransactionDriver submission against local checkpoint inclusion inside
+/// `submit_with_checkpoint_race`. That race — including the
+/// `drive_transaction` call it wraps — runs in a task detached from the
+/// caller, so a client that disconnects mid-call must not stop the
+/// transaction from being driven to finality.
+///
+/// Quorum is broken before submission so the caller can be aborted while the
+/// transaction is provably still stuck (no quorum can possibly have been
+/// reached yet); quorum is then restored and finality is confirmed
+/// independently of the aborted caller.
+#[sim_test]
+async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
+    let _env_guard = enable_pcool_env();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.iota_node;
+    let orchestrator = handle.with(|n| n.transaction_orchestrator().as_ref().unwrap().clone());
+
+    let txn = batch_make_transfer_transactions(context, 1)
+        .await
+        .pop()
+        .expect("gas objects should produce at least one tx");
+    let digest = *txn.digest();
+
+    // Break quorum so the submission cannot possibly finish yet, then submit
+    // and abort the caller while it is provably still stuck.
+    let validator_addresses = test_cluster.get_validator_pubkeys();
+    assert_eq!(validator_addresses.len(), 4);
+    test_cluster.stop_node(&validator_addresses[0]);
+    test_cluster.stop_node(&validator_addresses[1]);
+
+    let caller_orchestrator = orchestrator.clone();
+    let caller_task = tokio::spawn(async move {
+        caller_orchestrator
+            .execute_transaction_block(
+                ExecuteTransactionRequestV1::new(txn),
+                ExecuteTransactionRequestType::WaitForLocalExecution,
+                Some(make_socket_addr()),
+            )
+            .await
+    });
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    caller_task.abort();
+    assert!(
+        caller_task
+            .await
+            .expect_err("caller task should not have finished before quorum was restored")
+            .is_cancelled(),
+        "caller task should have been aborted, not have panicked"
+    );
+
+    // Restore quorum. The detached task inside the orchestrator — never
+    // aborted — should still be retrying submission on its own and drive the
+    // transaction to finality.
+    test_cluster.start_node(&validator_addresses[0]).await;
+    test_cluster.start_node(&validator_addresses[1]).await;
+
+    let inclusion = handle
+        .state()
+        .wait_for_checkpoint_inclusion(&[digest], Duration::from_secs(30))
+        .await
+        .expect("wait_for_checkpoint_inclusion should not error");
+    assert!(
+        inclusion.contains_key(&digest),
+        "transaction should reach finality via the detached task even though \
+         the caller was aborted"
+    );
+
+    Ok(())
+}

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -1017,9 +1017,8 @@ async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
     test_cluster.stop_node(&validator_addresses[0]);
     test_cluster.stop_node(&validator_addresses[1]);
 
-    let caller_orchestrator = orchestrator.clone();
     let caller_task = tokio::spawn(async move {
-        caller_orchestrator
+        orchestrator
             .execute_transaction_block(
                 ExecuteTransactionRequestV1::new(txn),
                 ExecuteTransactionRequestType::WaitForLocalExecution,
@@ -1040,8 +1039,10 @@ async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
     // Restore quorum. The detached task inside the orchestrator — never
     // aborted — should still be retrying submission on its own and drive the
     // transaction to finality.
-    test_cluster.start_node(&validator_addresses[0]).await;
-    test_cluster.start_node(&validator_addresses[1]).await;
+    tokio::join!(
+        test_cluster.start_node(&validator_addresses[0]),
+        test_cluster.start_node(&validator_addresses[1]),
+    );
 
     let inclusion = handle
         .state()


### PR DESCRIPTION
# Description of change

- Port of upstream PR: [MystenLabs/sui#24649](https://github.com/MystenLabs/sui/pull/24649) (partial)
- Description:

TransactionDriver submissions now run in a detached task, so a client disconnect no longer cancels a submission that may already be in consensus — the task drives the transaction to finality on its own and logs the outcome. Connected clients see identical behavior: the caller awaits the task handle and receives the same result as before.

Adapted to the fork:

- Deliberately partial: only the detached-execution half is ported. The background retry machinery (exponential backoff, retry metrics, `enforce_live_input_objects`) is skipped — the driver flow is best-effort and clients own retries; failures return to the caller immediately.
- On the `WaitForLocalExecution` path the whole checkpoint race is detached (submission + checkpoint-sequence bookkeeping), not just the driver call.
- The two TD helpers become associated functions taking `Arc` parameters, since a detached task needs owned `'static` inputs.

Notes for reviewers:

- The new e2e test pins the contract end-to-end (submission aborted client-side still reaches finality) but cannot fully isolate the orchestrator change from validator-side durability: with only part of the committee stopped, a validator that already accepted the transaction can carry it through consensus regardless. Stopping the whole committee instead starves the fixed 30s submission deadline, so that variant was discarded.

## Links to any relevant issues

Related: iotaledger/iota-private#467

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
