### PR TITLE
fix(starfish-core): verify shard-reconstructed and synced transactions before acknowledgment

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -238,8 +238,12 @@ impl ConsensusAuthority {
             context.clone(),
         );
 
-        let shard_reconstructor =
-            ShardReconstructor::start(context.clone(), dag_state.clone(), core_dispatcher.clone());
+        let shard_reconstructor = ShardReconstructor::start(
+            context.clone(),
+            dag_state.clone(),
+            core_dispatcher.clone(),
+            block_verifier.clone(),
+        );
 
         // `fast_sync_active` is a shared flag used by the fast syncer to
         // signal when it has any work in flight. The regular commit syncer

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -229,6 +229,7 @@ impl ConsensusAuthority {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let leader_timeout_handle = LeaderTimeoutTask::start(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1833,6 +1833,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -1925,6 +1926,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
         let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
@@ -2012,6 +2014,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -2129,6 +2132,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -2269,6 +2273,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -2354,6 +2359,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -2593,6 +2599,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -2760,6 +2767,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -2938,6 +2946,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -3271,6 +3280,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -3422,6 +3432,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -3592,6 +3603,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -3815,6 +3827,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(
@@ -4014,6 +4027,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let header_synchronizer = HeaderSynchronizer::start(

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1020,6 +1020,7 @@ mod tests {
                 context.clone(),
                 core_thread_dispatcher.clone(),
                 dag_state.clone(),
+                block_verifier.clone(),
             );
             let header_synchronizer = HeaderSynchronizer::start(
                 network_client.clone(),

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -829,6 +829,7 @@ mod tests {
                 context.clone(),
                 core_thread_dispatcher.clone(),
                 dag_state.clone(),
+                block_verifier.clone(),
             );
         let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
@@ -955,6 +956,7 @@ mod tests {
                     context.clone(),
                     core_thread_dispatcher.clone(),
                     dag_state.clone(),
+                    block_verifier.clone(),
                 );
             let header_synchronizer = HeaderSynchronizer::start(
                 network_client.clone(),

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2732,7 +2732,7 @@ impl DagState {
         self.pending_acknowledgments = acknowledgments.into_iter().collect::<BTreeSet<_>>();
     }
 
-    pub(crate) fn misbehavior_store(&self) -> &MisbehaviorStore {
+    pub(crate) fn misbehavior_store(&self) -> &Arc<MisbehaviorStore> {
         &self.misbehavior_store
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1204,7 +1204,6 @@ impl DagState {
     /// Checks if verified block headers exist for the given transaction refs.
     /// Checks in-memory data (genesis and recent_block_headers) first, then
     /// falls back to storage for blocks not found in memory.
-    #[cfg_attr(test, expect(dead_code))]
     pub(crate) fn contains_verified_block_headers_for_transaction_refs(
         &self,
         tx_refs: &[TransactionRef],

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -82,7 +82,7 @@ pub(crate) enum ConsensusError {
     )]
     TooManyFetchedTransactionsReturned(AuthorityIndex),
 
-    #[error("Transaction {transaction_ref} returned from authority {peer} was not requested")]
+    #[error("Transaction {transaction_ref} returned from peer {peer} was not requested")]
     UnrequestedTransactionFetched {
         peer: AuthorityIndex,
         transaction_ref: TransactionRef,

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -2174,6 +2174,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
@@ -2245,6 +2246,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
@@ -2330,6 +2332,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
         // Create some test block headers
         let expected_block_headers_1 = (0..10)
@@ -2444,6 +2447,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
         // AND stub some missing blocks. The highest accepted round is 0.
         // Create some blocks that are below and above the threshold sync.
@@ -2582,6 +2586,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
         // AND stub some missing blocks. The highest accepted round is 0. Create blocks
         // that are above the threshold sync.
@@ -2735,6 +2740,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
         // Create some test block headers
         let mut expected_block_headers = (8..=10)
@@ -3247,6 +3253,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
         // Create input test blocks:
         // - Authority 0 block at round 60.
@@ -3393,6 +3400,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            block_verifier.clone(),
         );
 
         // Frontier is genesis round 0; a header one past the ceiling can never

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -220,6 +220,7 @@ mod tests {
     use crate::{
         BlockRef, Round, TestBlockHeader,
         block_header::VerifiedBlock,
+        block_verifier::NoopBlockVerifier,
         commit::CommitRange,
         context::Context,
         core::{CoreSignals, ReasonToCreateBlock},
@@ -328,6 +329,7 @@ mod tests {
                 context.clone(),
                 Arc::new(MemStore::new()),
             ))),
+            Arc::new(NoopBlockVerifier),
         );
 
         // spawn the task
@@ -442,6 +444,7 @@ mod tests {
                 context.clone(),
                 Arc::new(MemStore::new()),
             ))),
+            Arc::new(NoopBlockVerifier),
         );
 
         let now = Instant::now();

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -232,6 +232,33 @@ impl MisbehaviorStore {
             FaultType::Untracked => {}
         }
     }
+
+    /// Attributes a transaction payload that failed verification.
+    ///
+    /// `author` is charged with a provable fault only when `authored` is true,
+    /// i.e. a verified, author-signed block header commits to this payload, so
+    /// the invalid transactions are provably the author's. Each peer in
+    /// `relayers` is charged an unprovable fault for handing us a payload it
+    /// should not have relayed; a relayer that is also the author is not
+    /// double-charged when the author is already charged provably.
+    pub(crate) fn record_faulty_transactions(
+        &self,
+        author: AuthorityIndex,
+        authored: bool,
+        relayers: impl IntoIterator<Item = AuthorityIndex>,
+    ) {
+        let committee_size = self.in_memory.authorities.len();
+        if authored && author.value() < committee_size {
+            self.in_memory.record_block_fault_provable(author.value());
+        }
+        for peer in relayers {
+            let idx = peer.value();
+            if idx >= committee_size || (authored && peer == author) {
+                continue;
+            }
+            self.in_memory.record_block_fault_unprovable(idx);
+        }
+    }
 }
 
 /// Whether a block header fault can be cryptographically proven.

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -25,12 +25,14 @@ use crate::{
         BlockHeaderDigest, GENESIS_ROUND, Shard, ShardWithProof, ShardWithProofAPI,
         TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
     },
+    block_verifier::BlockVerifier,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, DataSource},
     decoder::{ShardsDecoder, create_decoder},
     encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
+    misbehavior_store::MisbehaviorStore,
     transaction_ref::TransactionRef,
 };
 
@@ -236,9 +238,10 @@ impl<C: CoreThreadDispatcher + 'static> ShardReconstructor<C> {
         context: Arc<Context>,
         dag_state: Arc<RwLock<DagState>>,
         core_dispatcher: Arc<C>,
+        block_verifier: Arc<dyn BlockVerifier>,
     ) -> Arc<ShardReconstructorHandle> {
         let (mut reconstructor, transaction_message_sender) =
-            ShardReconstructor::new(context, dag_state, core_dispatcher);
+            ShardReconstructor::new(context, dag_state, core_dispatcher, block_verifier);
 
         let join_handle = tokio::spawn(async move {
             reconstructor.run().await;
@@ -282,6 +285,11 @@ pub struct ShardReconstructor<C: CoreThreadDispatcher> {
     transaction_message_receiver: Receiver<Vec<TransactionMessage>>,
     /// After full reconstruction and verification, send data to the core
     core_dispatcher: Arc<C>,
+    /// Applies the same transaction limit and batch verification checks to
+    /// reconstructed payloads as the direct block-bundle route
+    block_verifier: Arc<dyn BlockVerifier>,
+    /// Records the author of payloads that fail verification
+    misbehavior_store: Arc<MisbehaviorStore>,
     /// Queue is used to not reconstruct the same data twice
     reconstruction_queue: BTreeSet<TransactionRef>,
     /// Once enough shards are collected, they are sent to reconstructor workers
@@ -300,6 +308,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         context: Arc<Context>,
         dag_state: Arc<RwLock<DagState>>,
         core_dispatcher: Arc<C>,
+        block_verifier: Arc<dyn BlockVerifier>,
     ) -> (Self, Sender<Vec<TransactionMessage>>) {
         let info_length = context.committee.info_length();
         let total_length = context.committee.size();
@@ -308,12 +317,15 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         let (ready_sender, ready_receiver) = mpsc::channel(1000);
         let (result_sender, result_receiver) = mpsc::channel(1000);
 
+        let misbehavior_store = dag_state.read().misbehavior_store().clone();
         let reconstructor = Self {
             info_length,
             total_length,
             context,
             core_dispatcher,
             dag_state,
+            block_verifier,
+            misbehavior_store,
             transaction_gc_round: GENESIS_ROUND,
             reconstruction_queue: BTreeSet::new(),
             ready_to_reconstruct_sender: ready_sender,
@@ -334,8 +346,11 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             let mut codec = Codec::new(&self.context);
             let ready_rx = Arc::clone(&self.ready_to_reconstruct_receiver);
             let result_tx = self.reconstructed_transactions_sender.clone();
-            let metrics = Arc::clone(&self.context.metrics);
+            let context = self.context.clone();
+            let block_verifier = self.block_verifier.clone();
+            let misbehavior_store = self.misbehavior_store.clone();
             tokio::spawn(async move {
+                let metrics = &context.metrics;
                 loop {
                     // Receive a job from the ready to reconstruct channel
                     let job = {
@@ -348,14 +363,44 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                             metrics.node_metrics.reconstruction_jobs_started.inc();
                             match shard_accumulator.decode_by_codec(&mut codec) {
                                 Ok(verified_transactions) => {
-                                    debug!(
-                                        "Successfully reconstructed transactions for {:?}",
-                                        shard_accumulator.transaction_ref
-                                    );
-                                    if let Err(err) = result_tx.send(verified_transactions).await {
-                                        warn!(
-                                            "Failed to send the result to shard accumulator {err}"
-                                        );
+                                    match block_verifier.check_and_verify_transactions(
+                                        &verified_transactions.transactions(),
+                                    ) {
+                                        Ok(()) => {
+                                            debug!(
+                                                "Successfully reconstructed transactions for {:?}",
+                                                shard_accumulator.transaction_ref
+                                            );
+                                            if let Err(err) =
+                                                result_tx.send(verified_transactions).await
+                                            {
+                                                warn!(
+                                                    "Failed to send the result to shard accumulator {err}"
+                                                );
+                                            }
+                                        }
+                                        Err(err) => {
+                                            // The recomputed commitment matches the author-signed
+                                            // one, so the invalid payload is provably the author's.
+                                            // The shards came from relayers, so no sending peer is
+                                            // charged.
+                                            let author = shard_accumulator.transaction_ref.author;
+                                            metrics
+                                                .node_metrics
+                                                .invalid_transactions
+                                                .with_label_values(&[
+                                                    context.authority_hostname(author),
+                                                    "shard_reconstructor",
+                                                    err.name(),
+                                                ])
+                                                .inc();
+                                            misbehavior_store
+                                                .record_faulty_block_header(author, author, &err);
+                                            warn!(
+                                                "Reconstructed transactions for {:?} failed verification: {:?}",
+                                                shard_accumulator.transaction_ref, err
+                                            );
+                                        }
                                     }
                                 }
                                 Err(err) => {
@@ -633,12 +678,16 @@ mod tests {
             Shard, ShardWithProof, TransactionsCommitment, VerifiedBlock, VerifiedOwnShard,
             VerifiedTransactions,
         },
+        block_verifier::{
+            BlockVerifier, NoopBlockVerifier, SignedBlockVerifier, test::TxnSizeVerifier,
+        },
         commit::CertifiedCommits,
         context::Context,
         core::ReasonToCreateBlock,
         core_thread::{CoreError, CoreThreadDispatcher},
         dag_state::{DagState, DataSource},
         encoder::create_encoder,
+        misbehavior_store::MisbehaviorCounts,
         shard_reconstructor::{
             ShardMessage, ShardReconstructor, ShardReconstructorHandle, TransactionMessage,
         },
@@ -650,23 +699,40 @@ mod tests {
         context: Arc<Context>,
         core_dispatcher: Arc<MockCoreThreadDispatcher>,
         handle: Arc<ShardReconstructorHandle>,
+        dag_state: Arc<RwLock<DagState>>,
         tx: Sender<Vec<TransactionMessage>>,
     }
 
     impl TestHarness {
         fn new(committee_size: usize) -> Self {
             let (context, _) = Context::new_for_test(committee_size);
-            let context = Arc::new(context);
+            Self::new_with_block_verifier(Arc::new(context), Arc::new(NoopBlockVerifier))
+        }
+
+        /// Builds the harness with a caller-supplied `block_verifier`, so
+        /// tests can exercise the transaction-verification rejection path
+        /// with a verifier stricter than the default no-op. `context` is
+        /// taken from the caller so it can build a `block_verifier` bound to
+        /// the same committee and protocol config.
+        fn new_with_block_verifier(
+            context: Arc<Context>,
+            block_verifier: Arc<dyn BlockVerifier>,
+        ) -> Self {
             let store = Arc::new(MemStore::new());
             let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
             let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
-            let handle =
-                ShardReconstructor::start(context.clone(), dag_state, core_dispatcher.clone());
+            let handle = ShardReconstructor::start(
+                context.clone(),
+                dag_state.clone(),
+                core_dispatcher.clone(),
+                block_verifier,
+            );
             let tx = handle.transaction_message_sender();
             Self {
                 context,
                 core_dispatcher,
                 handle,
+                dag_state,
                 tx,
             }
         }
@@ -1199,5 +1265,83 @@ mod tests {
             "ShardMessage.transaction_ref.author must point to the shard-source block's author \
              (authority=1), not the carrier block's author (authority=0)"
         );
+    }
+
+    /// A reconstructed payload must pass the same per-transaction limit and
+    /// `verify_batch` checks the direct route enforces before it can reach
+    /// Core. Otherwise it could be acknowledged and become committable while
+    /// diverging from nodes that received the same payload directly.
+    #[tokio::test]
+    async fn test_reconstruction_rejects_transactions_failing_verification() {
+        telemetry_subscribers::init_for_testing();
+
+        // GIVEN a harness whose block_verifier rejects transactions shorter
+        // than 4 bytes.
+        let (context, _) = Context::new_for_test(10);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(SignedBlockVerifier::new(
+            context.clone(),
+            Arc::new(TxnSizeVerifier {}),
+        ));
+        let h = TestHarness::new_with_block_verifier(context.clone(), block_verifier);
+        let transaction_message_sender = h.tx.clone();
+
+        // A 2-byte transaction fails `TxnSizeVerifier::verify_batch` (< 4 bytes).
+        let txs = vec![Transaction::new(vec![0u8; 2])];
+        let serialized = Transaction::serialize(&txs).unwrap();
+
+        let mut encoder = create_encoder(&context);
+        let commitment = TransactionsCommitment::compute_transactions_commitment(
+            &serialized,
+            &context,
+            &mut encoder,
+        )
+        .unwrap();
+
+        let header = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build());
+        let block_ref = header.reference();
+        let author = block_ref.author;
+
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.parity_length();
+
+        let all_shards = encoder
+            .encode_serialized_data(&serialized, info_length, parity_length)
+            .unwrap();
+
+        let batch: Vec<_> = (0..info_length)
+            .map(|i| {
+                TransactionMessage::Shard(ShardMessage {
+                    transaction_ref: TransactionRef::new(block_ref, commitment),
+                    block_digest: Some(block_ref.digest),
+                    shard: all_shards[i].clone(),
+                    shard_index: i,
+                })
+            })
+            .collect();
+
+        // WHEN enough shards arrive to reconstruct the payload.
+        transaction_message_sender.send(batch).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(600)).await;
+
+        // THEN the payload is dropped instead of being handed to Core, so it
+        // can never be acknowledged.
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
+        assert!(
+            fetched.is_empty(),
+            "A reconstructed payload failing verification must never reach Core"
+        );
+
+        let counts = h.dag_state.read().misbehavior_store().snapshot_totals();
+        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        assert_eq!(
+            author_counts.faulty_blocks_provable, 1,
+            "The author should be charged for the provably invalid payload"
+        );
+
+        h.handle
+            .stop()
+            .await
+            .expect("We should expect graceful shutdown");
     }
 }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -220,16 +220,21 @@ fn record_reconstruction_verification_failure(
         .collected_shard_indices()
         .filter_map(|i| context.committee.to_authority_index(i))
         .collect();
-    context
-        .metrics
-        .node_metrics
-        .invalid_transactions
-        .with_label_values(&[
-            context.authority_hostname(author),
-            "shard_reconstructor",
-            err.name(),
-        ])
-        .inc();
+    // `invalid_transactions` counts payloads a block author provably produced,
+    // so only record it when a verified header ties this ref to the author;
+    // otherwise the ref may be fabricated by peers to frame an honest author.
+    if authored {
+        context
+            .metrics
+            .node_metrics
+            .invalid_transactions
+            .with_label_values(&[
+                context.authority_hostname(author),
+                "shard_reconstructor",
+                err.name(),
+            ])
+            .inc();
+    }
     misbehavior_store.record_faulty_transactions(author, authored, relayers);
     warn!(
         "Reconstructed transactions for {:?} failed verification: {:?}",
@@ -366,7 +371,9 @@ pub struct ShardReconstructor<C: CoreThreadDispatcher> {
     /// Applies the same transaction limit and batch verification checks to
     /// reconstructed payloads as the direct block-bundle route
     block_verifier: Arc<dyn BlockVerifier>,
-    /// Records the author of payloads that fail verification
+    /// Charges faults for payloads that fail verification: the author, when a
+    /// verified header proves the payload is theirs, and the peers that relayed
+    /// the shards.
     misbehavior_store: Arc<MisbehaviorStore>,
     /// Queue is used to not reconstruct the same data twice
     reconstruction_queue: BTreeSet<TransactionRef>,

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -145,6 +145,17 @@ impl ShardAccumulator {
         self.number_shards >= info_length
     }
 
+    /// Indices of the shards collected so far. A shard at index `i` is
+    /// authenticated as authority `i`'s (its Merkle proof is verified at
+    /// position `i`, which is the relaying peer's index), so a collected
+    /// shard identifies the peer that relayed it.
+    fn collected_shard_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        self.collected_shards
+            .iter()
+            .enumerate()
+            .filter_map(|(i, shard)| shard.as_ref().map(|_| i))
+    }
+
     /// We use Codec to decode the transaction data from collected shards. Once
     /// reconstructed, we encode and verify that the transaction commitment
     /// was computed correctly
@@ -347,6 +358,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             let ready_rx = Arc::clone(&self.ready_to_reconstruct_receiver);
             let result_tx = self.reconstructed_transactions_sender.clone();
             let context = self.context.clone();
+            let dag_state = self.dag_state.clone();
             let block_verifier = self.block_verifier.clone();
             let misbehavior_store = self.misbehavior_store.clone();
             tokio::spawn(async move {
@@ -380,11 +392,39 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                                             }
                                         }
                                         Err(err) => {
-                                            // The recomputed commitment matches the author-signed
-                                            // one, so the invalid payload is provably the author's.
-                                            // The shards came from relayers, so no sending peer is
-                                            // charged.
-                                            let author = shard_accumulator.transaction_ref.author;
+                                            // A peer must hold the full payload to erasure-code its
+                                            // shard, so every peer that contributed a shard could
+                                            // have verified the transactions and is charged an
+                                            // unprovable fault for relaying invalid bytes. The
+                                            // commitment here is peer-supplied, so without a
+                                            // verified author-signed header for this ref a
+                                            // coalition
+                                            // of peers could reconstruct invalid transactions under
+                                            // a
+                                            // fabricated commitment to frame the author; charge the
+                                            // author a provable fault only when such a header
+                                            // exists,
+                                            // as he then committed to the invalid transactions.
+                                            //
+                                            // Attribution is one-shot: a header arriving only after
+                                            // this failure does not retroactively charge the author
+                                            // (the failed ref stays in the reconstruction queue and
+                                            // is not revisited). Such an author is instead charged
+                                            // on the direct primary-block route, where the full
+                                            // payload is verified against the author.
+                                            let tx_ref = shard_accumulator.transaction_ref;
+                                            let author = tx_ref.author;
+                                            let authored = dag_state
+                                                .read()
+                                                .contains_verified_block_headers_for_transaction_refs(
+                                                    &[tx_ref],
+                                                )[0];
+                                            let relayers: Vec<_> = shard_accumulator
+                                                .collected_shard_indices()
+                                                .filter_map(|i| {
+                                                    context.committee.to_authority_index(i)
+                                                })
+                                                .collect();
                                             metrics
                                                 .node_metrics
                                                 .invalid_transactions
@@ -394,8 +434,9 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                                                     err.name(),
                                                 ])
                                                 .inc();
-                                            misbehavior_store
-                                                .record_faulty_block_header(author, author, &err);
+                                            misbehavior_store.record_faulty_transactions(
+                                                author, authored, relayers,
+                                            );
                                             warn!(
                                                 "Reconstructed transactions for {:?} failed verification: {:?}",
                                                 shard_accumulator.transaction_ref, err
@@ -1267,12 +1308,14 @@ mod tests {
         );
     }
 
-    /// A reconstructed payload must pass the same per-transaction limit and
-    /// `verify_batch` checks the direct route enforces before it can reach
-    /// Core. Otherwise it could be acknowledged and become committable while
-    /// diverging from nodes that received the same payload directly.
-    #[tokio::test]
-    async fn test_reconstruction_rejects_transactions_failing_verification() {
+    /// Reconstructs a payload that fails verification from a full set of shards
+    /// and returns the resulting misbehavior snapshot, the payload author, and
+    /// the info length. When `accept_header` is set, a verified block header
+    /// committing to the reconstructed payload is accepted into the dag state
+    /// first, so the invalid payload is provably the author's.
+    async fn reconstruct_failing_payload(
+        accept_header: bool,
+    ) -> (Vec<MisbehaviorCounts>, AuthorityIndex, usize) {
         telemetry_subscribers::init_for_testing();
 
         // GIVEN a harness whose block_verifier rejects transactions shorter
@@ -1298,9 +1341,21 @@ mod tests {
         )
         .unwrap();
 
-        let header = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build());
+        let header = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(5, 1)
+                .set_commitment(commitment)
+                .build(),
+        );
         let block_ref = header.reference();
         let author = block_ref.author;
+
+        // The author is charged only when a verified header ties the commitment
+        // to them; accept one for that case.
+        if accept_header {
+            h.dag_state
+                .write()
+                .accept_block_header(header, DataSource::BlockBundleStream);
+        }
 
         let info_length = context.committee.info_length();
         let parity_length = context.committee.parity_length();
@@ -1333,15 +1388,61 @@ mod tests {
         );
 
         let counts = h.dag_state.read().misbehavior_store().snapshot_totals();
-        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
-        assert_eq!(
-            author_counts.faulty_blocks_provable, 1,
-            "The author should be charged for the provably invalid payload"
-        );
-
         h.handle
             .stop()
             .await
             .expect("We should expect graceful shutdown");
+        (counts, author, info_length)
+    }
+
+    /// A reconstructed payload must pass the same per-transaction limit and
+    /// `verify_batch` checks the direct route enforces before it can reach
+    /// Core. Otherwise it could be acknowledged and become committable while
+    /// diverging from nodes that received the same payload directly.
+    ///
+    /// Without a verified header tying the peer-supplied commitment to the
+    /// author, the author must not be charged (a coalition of peers could
+    /// otherwise frame them); every peer that relayed a shard is charged an
+    /// unprovable fault.
+    #[tokio::test]
+    async fn test_reconstruction_rejects_transactions_failing_verification() {
+        let (counts, author, info_length) = reconstruct_failing_payload(false).await;
+
+        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        assert_eq!(
+            author_counts.faulty_blocks_provable, 0,
+            "The author must not be charged without a verified header tying the commitment to them"
+        );
+        for counts in counts.iter().take(info_length) {
+            let MisbehaviorCounts::V1(peer_counts) = counts;
+            assert_eq!(
+                peer_counts.faulty_blocks_unprovable, 1,
+                "Each peer that relayed a shard of the invalid payload must be charged unprovably"
+            );
+        }
+    }
+
+    /// When a verified header commits to the reconstructed payload, the invalid
+    /// transactions are provably the author's, so the author is charged a
+    /// provable fault while the relaying peers are still charged unprovably.
+    #[tokio::test]
+    async fn test_reconstruction_charges_author_when_header_present() {
+        let (counts, author, info_length) = reconstruct_failing_payload(true).await;
+
+        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        assert_eq!(
+            author_counts.faulty_blocks_provable, 1,
+            "The author must be charged provably when a verified header commits to the payload"
+        );
+        for (i, counts) in counts.iter().enumerate().take(info_length) {
+            if i == author.value() {
+                continue;
+            }
+            let MisbehaviorCounts::V1(peer_counts) = counts;
+            assert_eq!(
+                peer_counts.faulty_blocks_unprovable, 1,
+                "Each relaying peer other than the author must still be charged unprovably"
+            );
+        }
     }
 }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -190,6 +190,53 @@ impl ShardAccumulator {
     }
 }
 
+/// Attributes a reconstructed payload that failed verification.
+///
+/// A peer must hold the full payload to erasure-code its shard, so every peer
+/// that contributed a shard could have verified the transactions and is charged
+/// an unprovable fault for relaying invalid bytes. The commitment here is
+/// peer-supplied, so without a verified author-signed header for this ref a
+/// coalition of peers could reconstruct invalid transactions under a fabricated
+/// commitment to frame the author; charge the author a provable fault only when
+/// such a header exists, as he then committed to the invalid transactions.
+///
+/// Attribution is one-shot: a header arriving only after this failure does not
+/// retroactively charge the author (the failed ref stays in the reconstruction
+/// queue and is not revisited). Such an author is instead charged on the direct
+/// primary-block route, where the full payload is verified against the author.
+fn record_reconstruction_verification_failure(
+    context: &Context,
+    dag_state: &RwLock<DagState>,
+    misbehavior_store: &MisbehaviorStore,
+    shard_accumulator: &ShardAccumulator,
+    err: &ConsensusError,
+) {
+    let tx_ref = shard_accumulator.transaction_ref;
+    let author = tx_ref.author;
+    let authored = dag_state
+        .read()
+        .contains_verified_block_headers_for_transaction_refs(&[tx_ref])[0];
+    let relayers: Vec<_> = shard_accumulator
+        .collected_shard_indices()
+        .filter_map(|i| context.committee.to_authority_index(i))
+        .collect();
+    context
+        .metrics
+        .node_metrics
+        .invalid_transactions
+        .with_label_values(&[
+            context.authority_hostname(author),
+            "shard_reconstructor",
+            err.name(),
+        ])
+        .inc();
+    misbehavior_store.record_faulty_transactions(author, authored, relayers);
+    warn!(
+        "Reconstructed transactions for {:?} failed verification: {:?}",
+        tx_ref, err
+    );
+}
+
 /// Data structure containing both encoder and decoder
 pub struct Codec {
     pub encoder: Box<dyn ShardEncoder + Send + Sync>,
@@ -363,102 +410,43 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             let misbehavior_store = self.misbehavior_store.clone();
             tokio::spawn(async move {
                 let metrics = &context.metrics;
-                loop {
-                    // Receive a job from the ready to reconstruct channel
-                    let job = {
-                        let mut rx = ready_rx.lock().await;
-                        rx.recv().await
-                    };
-
-                    match job {
-                        Some(shard_accumulator) => {
-                            metrics.node_metrics.reconstruction_jobs_started.inc();
-                            match shard_accumulator.decode_by_codec(&mut codec) {
-                                Ok(verified_transactions) => {
-                                    match block_verifier.check_and_verify_transactions(
-                                        &verified_transactions.transactions(),
-                                    ) {
-                                        Ok(()) => {
-                                            debug!(
-                                                "Successfully reconstructed transactions for {:?}",
-                                                shard_accumulator.transaction_ref
-                                            );
-                                            if let Err(err) =
-                                                result_tx.send(verified_transactions).await
-                                            {
-                                                warn!(
-                                                    "Failed to send the result to shard accumulator {err}"
-                                                );
-                                            }
-                                        }
-                                        Err(err) => {
-                                            // A peer must hold the full payload to erasure-code its
-                                            // shard, so every peer that contributed a shard could
-                                            // have verified the transactions and is charged an
-                                            // unprovable fault for relaying invalid bytes. The
-                                            // commitment here is peer-supplied, so without a
-                                            // verified author-signed header for this ref a
-                                            // coalition
-                                            // of peers could reconstruct invalid transactions under
-                                            // a
-                                            // fabricated commitment to frame the author; charge the
-                                            // author a provable fault only when such a header
-                                            // exists,
-                                            // as he then committed to the invalid transactions.
-                                            //
-                                            // Attribution is one-shot: a header arriving only after
-                                            // this failure does not retroactively charge the author
-                                            // (the failed ref stays in the reconstruction queue and
-                                            // is not revisited). Such an author is instead charged
-                                            // on the direct primary-block route, where the full
-                                            // payload is verified against the author.
-                                            let tx_ref = shard_accumulator.transaction_ref;
-                                            let author = tx_ref.author;
-                                            let authored = dag_state
-                                                .read()
-                                                .contains_verified_block_headers_for_transaction_refs(
-                                                    &[tx_ref],
-                                                )[0];
-                                            let relayers: Vec<_> = shard_accumulator
-                                                .collected_shard_indices()
-                                                .filter_map(|i| {
-                                                    context.committee.to_authority_index(i)
-                                                })
-                                                .collect();
-                                            metrics
-                                                .node_metrics
-                                                .invalid_transactions
-                                                .with_label_values(&[
-                                                    context.authority_hostname(author),
-                                                    "shard_reconstructor",
-                                                    err.name(),
-                                                ])
-                                                .inc();
-                                            misbehavior_store.record_faulty_transactions(
-                                                author, authored, relayers,
-                                            );
-                                            warn!(
-                                                "Reconstructed transactions for {:?} failed verification: {:?}",
-                                                shard_accumulator.transaction_ref, err
-                                            );
-                                        }
-                                    }
-                                }
-                                Err(err) => {
-                                    warn!(
-                                        "Failed to reconstruct transactions for {:?}: {:?}",
-                                        shard_accumulator.transaction_ref, err
-                                    );
+                // Receive a job from the ready to reconstruct channel until it closes.
+                while let Some(shard_accumulator) = {
+                    let mut rx = ready_rx.lock().await;
+                    rx.recv().await
+                } {
+                    metrics.node_metrics.reconstruction_jobs_started.inc();
+                    match shard_accumulator.decode_by_codec(&mut codec) {
+                        Err(err) => {
+                            warn!(
+                                "Failed to reconstruct transactions for {:?}: {:?}",
+                                shard_accumulator.transaction_ref, err
+                            );
+                        }
+                        Ok(verified_transactions) => match block_verifier
+                            .check_and_verify_transactions(&verified_transactions.transactions())
+                        {
+                            Ok(()) => {
+                                debug!(
+                                    "Successfully reconstructed transactions for {:?}",
+                                    shard_accumulator.transaction_ref
+                                );
+                                if let Err(err) = result_tx.send(verified_transactions).await {
+                                    warn!("Failed to send the result to shard accumulator {err}");
                                 }
                             }
-                            metrics.node_metrics.reconstruction_jobs_finished.inc();
-                        }
-                        None => {
-                            debug!("Ready to reconstruct channel closed, workers exiting");
-                            break;
-                        }
+                            Err(err) => record_reconstruction_verification_failure(
+                                &context,
+                                &dag_state,
+                                &misbehavior_store,
+                                &shard_accumulator,
+                                &err,
+                            ),
+                        },
                     }
+                    metrics.node_metrics.reconstruction_jobs_finished.inc();
                 }
+                debug!("Ready to reconstruct channel closed, workers exiting");
             });
         }
     }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -237,6 +237,26 @@ fn record_reconstruction_verification_failure(
     );
 }
 
+/// Charges the peers that relayed shards for a reconstructed payload whose
+/// commitment doesn't match the one its ref commits to. The mismatch comes from
+/// the peer-supplied shards, not the author, so no author fault is recorded
+/// even when a verified header for the ref exists.
+fn record_reconstruction_commitment_mismatch(
+    context: &Context,
+    misbehavior_store: &MisbehaviorStore,
+    shard_accumulator: &ShardAccumulator,
+) {
+    let relayers: Vec<_> = shard_accumulator
+        .collected_shard_indices()
+        .filter_map(|i| context.committee.to_authority_index(i))
+        .collect();
+    misbehavior_store.record_faulty_transactions(
+        shard_accumulator.transaction_ref.author,
+        false,
+        relayers,
+    );
+}
+
 /// Data structure containing both encoder and decoder
 pub struct Codec {
     pub encoder: Box<dyn ShardEncoder + Send + Sync>,
@@ -422,6 +442,17 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                                 "Failed to reconstruct transactions for {:?}: {:?}",
                                 shard_accumulator.transaction_ref, err
                             );
+                            // A commitment mismatch means the reconstructed bytes
+                            // aren't the ones the author committed to; the shards,
+                            // and thus the mismatch, come from peers, so charge
+                            // only the peers that relayed shards, never the author.
+                            if matches!(err, ConsensusError::TransactionCommitmentMismatch { .. }) {
+                                record_reconstruction_commitment_mismatch(
+                                    &context,
+                                    &misbehavior_store,
+                                    &shard_accumulator,
+                                );
+                            }
                         }
                         Ok(verified_transactions) => match block_verifier
                             .check_and_verify_transactions(&verified_transactions.transactions())
@@ -1430,6 +1461,96 @@ mod tests {
             assert_eq!(
                 peer_counts.faulty_blocks_unprovable, 1,
                 "Each relaying peer other than the author must still be charged unprovably"
+            );
+        }
+    }
+
+    /// A reconstructed payload whose commitment doesn't match the ref's is not
+    /// provably the author's — the shards, and thus the mismatch, come from
+    /// peers — so only the relaying peers are charged, even when a verified
+    /// header for the ref exists.
+    #[tokio::test]
+    async fn test_reconstruction_charges_relayers_on_commitment_mismatch() {
+        telemetry_subscribers::init_for_testing();
+
+        let (context, _) = Context::new_for_test(10);
+        let context = Arc::new(context);
+        let h = TestHarness::new_with_block_verifier(context.clone(), Arc::new(NoopBlockVerifier));
+        let transaction_message_sender = h.tx.clone();
+
+        // Shards encode `txs`, but the ref commits to a different payload's
+        // commitment, so the reconstructed bytes won't match it.
+        let txs = vec![Transaction::new(vec![7u8; 8])];
+        let serialized = Transaction::serialize(&txs).unwrap();
+        let mut encoder = create_encoder(&context);
+        let other = Transaction::serialize(&[Transaction::new(vec![9u8; 8])]).unwrap();
+        let wrong_commitment =
+            TransactionsCommitment::compute_transactions_commitment(&other, &context, &mut encoder)
+                .unwrap();
+
+        // Accept a verified header committing to that (wrong) commitment, to
+        // prove the author is still not charged for a peer-produced mismatch.
+        let header = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(5, 1)
+                .set_commitment(wrong_commitment)
+                .build(),
+        );
+        let block_ref = header.reference();
+        let author = block_ref.author;
+        h.dag_state
+            .write()
+            .accept_block_header(header, DataSource::BlockBundleStream);
+
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.parity_length();
+        let all_shards = encoder
+            .encode_serialized_data(&serialized, info_length, parity_length)
+            .unwrap();
+
+        let batch: Vec<_> = (0..info_length)
+            .map(|i| {
+                TransactionMessage::Shard(ShardMessage {
+                    transaction_ref: TransactionRef::new(block_ref, wrong_commitment),
+                    block_digest: Some(block_ref.digest),
+                    shard: all_shards[i].clone(),
+                    shard_index: i,
+                })
+            })
+            .collect();
+
+        // WHEN enough shards arrive to reconstruct the payload.
+        transaction_message_sender.send(batch).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(600)).await;
+
+        // THEN the payload is dropped instead of being handed to Core.
+        assert!(
+            h.core_dispatcher
+                .get_and_drain_transactions()
+                .await
+                .is_empty(),
+            "A reconstructed payload failing commitment verification must never reach Core"
+        );
+
+        let counts = h.dag_state.read().misbehavior_store().snapshot_totals();
+        h.handle
+            .stop()
+            .await
+            .expect("We should expect graceful shutdown");
+
+        // The author is not charged provably, even though a verified header ties
+        // it to the (wrong) commitment.
+        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        assert_eq!(
+            author_counts.faulty_blocks_provable, 0,
+            "The author must not be charged for a peer-produced commitment mismatch"
+        );
+        // Every peer that relayed a shard — including the author, as a relayer —
+        // is charged an unprovable fault.
+        for counts in counts.iter().take(info_length) {
+            let MisbehaviorCounts::V1(peer_counts) = counts;
+            assert_eq!(
+                peer_counts.faulty_blocks_unprovable, 1,
+                "Each peer that relayed a shard must be charged unprovably"
             );
         }
     }

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -220,21 +220,6 @@ fn record_reconstruction_verification_failure(
         .collected_shard_indices()
         .filter_map(|i| context.committee.to_authority_index(i))
         .collect();
-    // `invalid_transactions` counts payloads a block author provably produced,
-    // so only record it when a verified header ties this ref to the author;
-    // otherwise the ref may be fabricated by peers to frame an honest author.
-    if authored {
-        context
-            .metrics
-            .node_metrics
-            .invalid_transactions
-            .with_label_values(&[
-                context.authority_hostname(author),
-                "shard_reconstructor",
-                err.name(),
-            ])
-            .inc();
-    }
     misbehavior_store.record_faulty_transactions(author, authored, relayers);
     warn!(
         "Reconstructed transactions for {:?} failed verification: {:?}",

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1061,8 +1061,6 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 peer_index,
             ));
         }
-        let requested_transaction_refs = requested_transactions_guard.transactions_refs.clone();
-
         let metrics = &context.metrics.node_metrics;
         let peer_hostname = &context.committee.authority(peer_index).hostname;
 
@@ -1083,7 +1081,15 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                     let committed_transaction_ref = GenericTransactionRef::TransactionRef(
                         serialized_transactions.transaction_ref,
                     );
-                    if !requested_transaction_refs.contains(&committed_transaction_ref) {
+                    // The commitment check below only proves each payload matches
+                    // its own claimed ref; it does not tie the ref to anything we
+                    // asked for. Reject a ref outside the requested set so a peer
+                    // cannot serve correctly-committed transactions we never
+                    // requested (which need not correspond to any real header).
+                    if !requested_transactions_guard
+                        .transactions_refs
+                        .contains(&committed_transaction_ref)
+                    {
                         return Err(ConsensusError::UnrequestedTransactionFetched {
                             peer: peer_index,
                             transaction_ref: serialized_transactions.transaction_ref,
@@ -1145,11 +1151,12 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                         err.name(),
                     ])
                     .inc();
-                // The recomputed commitment (checked above) already ties this
-                // payload to the author's signed transactions_commitment, so
-                // the invalid payload is provably the author's. `peer_index`
-                // only relayed it and is not charged.
-                misbehavior_store.record_faulty_block_header(author, author, &err);
+                // The recomputed commitment (checked above) ties this payload to
+                // the author's signed transactions_commitment, so the invalid
+                // payload is provably the author's. `peer_index` served a full
+                // payload it could have verified before relaying, so it is also
+                // charged an unprovable fault.
+                misbehavior_store.record_faulty_transactions(author, true, [peer_index]);
                 return Err(err);
             }
         }
@@ -1228,6 +1235,7 @@ mod tests {
         misbehavior_store::MisbehaviorCounts,
         network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
+        transaction_ref::TransactionRef,
     };
 
     #[tokio::test]
@@ -2047,6 +2055,104 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_syncing_rejects_unrequested_transactions() {
+        telemetry_subscribers::init_for_testing();
+        // GIVEN a synchronizer requesting transactions from a single peer.
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
+        let network_client = Arc::new(MockNetworkClient::new());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+
+        let handle = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
+        );
+        let mut encoder = create_encoder(&context);
+        let mut rng = thread_rng();
+
+        // The refs we actually request, backed by accepted headers.
+        let requested: Vec<(Round, u8)> = vec![(1, 0), (2, 1), (3, 2)];
+        let mut block_headers = Vec::new();
+        let mut missing_transactions = BTreeMap::new();
+        for (round, author) in requested {
+            let txs = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
+            let serialized = Bytes::from(bcs::to_bytes(&txs).unwrap());
+            let commitment = TransactionsCommitment::compute_transactions_commitment(
+                &serialized,
+                &context,
+                &mut encoder,
+            )
+            .unwrap();
+            let header = VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(round, author)
+                    .set_commitment(commitment)
+                    .build(),
+            );
+            let mut authorities = BTreeSet::new();
+            authorities.insert(AuthorityIndex::new_for_test(1));
+            missing_transactions.insert(
+                GenericTransactionRef::from(header.transaction_ref()),
+                authorities,
+            );
+            block_headers.push(header);
+        }
+
+        // The peer instead returns a self-consistent payload for a ref we never
+        // requested (round 9, author 3).
+        let unrequested_txs = vec![Transaction::new((0..32).map(|_| rng.gen()).collect())];
+        let unrequested_serialized = Bytes::from(bcs::to_bytes(&unrequested_txs).unwrap());
+        let unrequested_commitment = TransactionsCommitment::compute_transactions_commitment(
+            &unrequested_serialized,
+            &context,
+            &mut encoder,
+        )
+        .unwrap();
+        let unrequested_transaction = VerifiedTransactions::new(
+            unrequested_txs,
+            TransactionRef {
+                round: 9,
+                author: AuthorityIndex::new_for_test(3),
+                transactions_commitment: unrequested_commitment,
+            },
+            None,
+            unrequested_serialized,
+        );
+        network_client
+            .stub_unrequested_transactions(
+                vec![unrequested_transaction],
+                AuthorityIndex::new_for_test(1),
+            )
+            .await;
+
+        core_dispatcher
+            .stub_missing_transactions(missing_transactions.clone())
+            .await;
+        dag_state
+            .write()
+            .accept_block_headers(block_headers, DataSource::Test);
+
+        // WHEN the peer returns the unrequested payload.
+        let result = handle.fetch_transactions(missing_transactions).await;
+        assert!(result.is_ok());
+        sleep(Duration::from_millis(100)).await;
+
+        // THEN the payload is rejected and nothing reaches the core, even though
+        // it was internally self-consistent.
+        let fetched_transactions = core_dispatcher.get_and_drain_transactions().await;
+        assert!(
+            fetched_transactions.is_empty(),
+            "A self-consistent but unrequested transaction must not be added to the core"
+        );
+
+        handle.stop().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn live_syncing_with_unrequested_transactions_peer() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
@@ -2063,6 +2169,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 
@@ -2277,6 +2384,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1129,10 +1129,18 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         {
             Ok(transactions) => transactions,
             Err(err) => {
-                // A commitment/deserialization failure is unprovable against the
-                // author (the bytes don't match a committed payload), so charge
-                // only the serving peer. This is not an `invalid_transactions`
-                // event, which counts payloads a block author produced.
+                // The serving peer relayed a payload whose bytes don't match a
+                // committed payload; count it against that peer and charge it an
+                // unprovable fault. The mismatch can't be proven against the
+                // author, whose commitment the peer may have forged.
+                metrics
+                    .invalid_transactions
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        "transaction_synchronizer",
+                        err.name(),
+                    ])
+                    .inc();
                 misbehavior_store.record_faulty_transactions(peer_index, false, [peer_index]);
                 return Err(err);
             }
@@ -1156,7 +1164,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 metrics
                     .invalid_transactions
                     .with_label_values(&[
-                        context.authority_hostname(author),
+                        peer_hostname.as_str(),
                         "transaction_synchronizer",
                         err.name(),
                     ])

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -393,7 +393,8 @@ pub(crate) struct TransactionsSynchronizer<C: NetworkClient, D: CoreThreadDispat
     /// Applies the same transaction limit and batch verification checks to
     /// fetched payloads as the direct block-bundle route.
     block_verifier: Arc<dyn BlockVerifier>,
-    /// Records the author of fetched payloads that fail verification.
+    /// Charges faults for fetched payloads that fail verification: the author,
+    /// when the payload is provably theirs, and the peer that served it.
     misbehavior_store: Arc<MisbehaviorStore>,
 }
 

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1057,6 +1057,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         // allowed returned transactions
         if serialized_transactions_vec.len() > requested_transactions_guard.transactions_refs.len()
         {
+            misbehavior_store.record_faulty_transactions(peer_index, false, [peer_index]);
             return Err(ConsensusError::TooManyFetchedTransactionsReturned(
                 peer_index,
             ));
@@ -1077,6 +1078,13 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 for serialized_transaction_bytes in &serialized_transactions_vec {
                     let serialized_transactions: SerializedTransactionsV2 =
                         bcs::from_bytes(serialized_transaction_bytes)
+                            .inspect_err(|_| {
+                                misbehavior_store.record_faulty_transactions(
+                                    peer_index,
+                                    false,
+                                    [peer_index],
+                                )
+                            })
                             .map_err(ConsensusError::MalformedTransactions)?;
                     let committed_transaction_ref = GenericTransactionRef::TransactionRef(
                         serialized_transactions.transaction_ref,
@@ -1090,6 +1098,11 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                         .transactions_refs
                         .contains(&committed_transaction_ref)
                     {
+                        misbehavior_store.record_faulty_transactions(
+                            peer_index,
+                            false,
+                            [peer_index],
+                        );
                         return Err(ConsensusError::UnrequestedTransactionFetched {
                             peer: peer_index,
                             transaction_ref: serialized_transactions.transaction_ref,
@@ -1115,15 +1128,11 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         {
             Ok(transactions) => transactions,
             Err(err) => {
-                // Update metrics for invalid transactions.
-                metrics
-                    .invalid_transactions
-                    .with_label_values(&[
-                        peer_hostname.as_str(),
-                        "transaction_synchronizer",
-                        err.name(),
-                    ])
-                    .inc();
+                // A commitment/deserialization failure is unprovable against the
+                // author (the bytes don't match a committed payload), so charge
+                // only the serving peer. This is not an `invalid_transactions`
+                // event, which counts payloads a block author produced.
+                misbehavior_store.record_faulty_transactions(peer_index, false, [peer_index]);
                 return Err(err);
             }
         }
@@ -1441,9 +1450,81 @@ mod tests {
             author_counts.faulty_blocks_provable, 1,
             "The author should be charged for the provably invalid payload"
         );
+        assert_eq!(
+            author_counts.faulty_blocks_unprovable, 0,
+            "The peer must not be charged separately when it is also the author"
+        );
 
         // Clean up
         transaction_synchronizer.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn live_syncing_charges_serving_peer_for_too_many_transactions() {
+        telemetry_subscribers::init_for_testing();
+        // GIVEN a synchronizer requesting a single transaction from peer 1.
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
+        let network_client = Arc::new(MockNetworkClient::new());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+
+        let handle = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
+        );
+        // The payload is never deserialized: the wrong-length guard fires
+        // first, so the header only needs to mint a requested ref.
+        let header = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 2).build());
+        let peer = AuthorityIndex::new_for_test(1);
+
+        // The peer returns two payloads for the single requested ref.
+        network_client
+            .stub_oversized_transactions(
+                vec![Bytes::from(vec![0u8; 4]), Bytes::from(vec![0u8; 4])],
+                peer,
+            )
+            .await;
+
+        let mut missing_transactions = BTreeMap::new();
+        let mut authorities = BTreeSet::new();
+        authorities.insert(peer);
+        missing_transactions.insert(
+            GenericTransactionRef::from(header.transaction_ref()),
+            authorities,
+        );
+        core_dispatcher
+            .stub_missing_transactions(missing_transactions.clone())
+            .await;
+        dag_state
+            .write()
+            .accept_block_headers(vec![header], DataSource::Test);
+
+        // WHEN the peer returns more transactions than requested.
+        let result = handle.fetch_transactions(missing_transactions).await;
+        assert!(result.is_ok());
+        sleep(Duration::from_millis(100)).await;
+
+        // THEN nothing reaches the core and the serving peer is charged an
+        // unprovable fault.
+        assert!(
+            core_dispatcher
+                .get_and_drain_transactions()
+                .await
+                .is_empty()
+        );
+        let counts = dag_state.read().misbehavior_store().snapshot_totals();
+        let MisbehaviorCounts::V1(peer_counts) = &counts[peer.value()];
+        assert!(
+            peer_counts.faulty_blocks_unprovable >= 1,
+            "The serving peer must be charged for returning too many transactions"
+        );
+
+        handle.stop().await.unwrap();
     }
 
     #[tokio::test]
@@ -2050,6 +2131,16 @@ mod tests {
             );
         }
 
+        // AND the corrupted peer is charged an unprovable fault for serving
+        // undeserializable bytes. Peers are tried in a stable order in tests, so
+        // peer 1 is always reached before the fetch succeeds from peer 2.
+        let counts = dag_state.read().misbehavior_store().snapshot_totals();
+        let MisbehaviorCounts::V1(peer_counts) = &counts[AuthorityIndex::new_for_test(1).value()];
+        assert!(
+            peer_counts.faulty_blocks_unprovable >= 1,
+            "The corrupted peer must be charged for serving undeserializable bytes"
+        );
+
         // Clean up
         handle.stop().await.unwrap();
     }
@@ -2148,6 +2239,21 @@ mod tests {
             fetched_transactions.is_empty(),
             "A self-consistent but unrequested transaction must not be added to the core"
         );
+
+        // AND the serving peer is charged an unprovable fault for relaying the
+        // unrequested payload, while the author it named is not blamed.
+        let counts = dag_state.read().misbehavior_store().snapshot_totals();
+        let MisbehaviorCounts::V1(peer_counts) = &counts[AuthorityIndex::new_for_test(1).value()];
+        assert!(
+            peer_counts.faulty_blocks_unprovable >= 1,
+            "The serving peer must be charged for the unrequested payload"
+        );
+        let MisbehaviorCounts::V1(framed_author) = &counts[AuthorityIndex::new_for_test(3).value()];
+        assert_eq!(
+            framed_author.faulty_blocks_provable, 0,
+            "The author named by the peer must not be blamed"
+        );
+        assert_eq!(framed_author.faulty_blocks_unprovable, 0);
 
         handle.stop().await.unwrap();
     }
@@ -2633,6 +2739,9 @@ mod tests {
         empty_peers: Arc<Mutex<BTreeSet<AuthorityIndex>>>,
         corrupted_peers: Arc<Mutex<BTreeSet<AuthorityIndex>>>,
         unrequested_transactions: Arc<Mutex<HashMap<AuthorityIndex, Vec<Bytes>>>>,
+        // Peers that return a fixed list of payloads regardless of the request,
+        // used to return more transactions than were requested.
+        oversized_transactions: Arc<Mutex<HashMap<AuthorityIndex, Vec<Bytes>>>>,
     }
 
     impl MockNetworkClient {
@@ -2644,6 +2753,7 @@ mod tests {
                 empty_peers: Arc::new(Mutex::new(BTreeSet::new())),
                 corrupted_peers: Arc::new(Mutex::new(BTreeSet::new())),
                 unrequested_transactions: Arc::new(Mutex::new(HashMap::new())),
+                oversized_transactions: Arc::new(Mutex::new(HashMap::new())),
             }
         }
 
@@ -2706,6 +2816,13 @@ mod tests {
                 let serialized = bcs::to_bytes(&serialized_transactions).unwrap();
                 entry.push(serialized.into());
             }
+        }
+
+        // Set a peer to return a fixed list of payloads regardless of the
+        // request, used to exceed the requested transaction count.
+        async fn stub_oversized_transactions(&self, payloads: Vec<Bytes>, peer: AuthorityIndex) {
+            let mut oversized = self.oversized_transactions.lock().await;
+            oversized.insert(peer, payloads);
         }
     }
 
@@ -2921,6 +3038,12 @@ mod tests {
                     result.push(Bytes::from(vec![0, 1, 2, 3])); // Invalid serialized data
                 }
                 return Ok(result);
+            }
+
+            // Check if this peer is set to return more payloads than requested
+            let oversized = self.oversized_transactions.lock().await;
+            if let Some(payloads) = oversized.get(&peer) {
+                return Ok(payloads.clone());
             }
 
             // Normal case - return transactions from the map

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -28,11 +28,13 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::{
+    block_verifier::BlockVerifier,
     commit_syncer::verify_transactions_with_transactions_refs,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, DataSource},
     error::{ConsensusError, ConsensusResult},
+    misbehavior_store::MisbehaviorStore,
     network::{NetworkClient, SerializedTransactionsV2},
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
 };
@@ -388,6 +390,11 @@ pub(crate) struct TransactionsSynchronizer<C: NetworkClient, D: CoreThreadDispat
     inflight_transactions_map: Arc<InflightTransactionsMap>,
     commands_sender: Sender<Command>,
     last_failure_by_peer: Arc<LastFailureByPeer>,
+    /// Applies the same transaction limit and batch verification checks to
+    /// fetched payloads as the direct block-bundle route.
+    block_verifier: Arc<dyn BlockVerifier>,
+    /// Records the author of fetched payloads that fail verification.
+    misbehavior_store: Arc<MisbehaviorStore>,
 }
 
 impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
@@ -399,6 +406,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
         dag_state: Arc<RwLock<DagState>>,
+        block_verifier: Arc<dyn BlockVerifier>,
     ) -> Arc<TransactionsSynchronizerHandle> {
         let (commands_sender, commands_receiver) =
             channel("consensus_transactions_synchronizer_commands", 1_000);
@@ -413,6 +421,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         let mut tasks = JoinSet::new();
         let active_requests = InflightActiveRequests::new();
         let last_failure_by_peer = LastFailureByPeer::new(&context);
+        let misbehavior_store = dag_state.read().misbehavior_store().clone();
         // Spawn the live fetcher task
         let live_fetcher_async = Self::live_fetcher(
             active_requests.clone(),
@@ -422,6 +431,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
             live_fetch_receiver,
             inflight_transactions_map.clone(),
             last_failure_by_peer.clone(),
+            block_verifier.clone(),
+            misbehavior_store.clone(),
         );
         tasks.spawn(monitored_future!(live_fetcher_async));
 
@@ -441,6 +452,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 commands_sender: commands_sender_clone,
                 dag_state,
                 last_failure_by_peer,
+                block_verifier,
+                misbehavior_store,
             };
             s.run().await;
         }));
@@ -532,6 +545,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         mut receiver: Receiver<BTreeMap<GenericTransactionRef, BTreeSet<AuthorityIndex>>>,
         inflight_transactions_map: Arc<InflightTransactionsMap>,
         last_failure_by_peer: Arc<LastFailureByPeer>,
+        block_verifier: Arc<dyn BlockVerifier>,
+        misbehavior_store: Arc<MisbehaviorStore>,
     ) {
         let semaphore = Arc::new(Semaphore::new(LIVE_FETCH_TRANSACTIONS_CONCURRENCY));
 
@@ -551,6 +566,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                     let network_client = network_client.clone();
                     let core_dispatcher = core_dispatcher.clone();
                     let last_failure_by_peer = last_failure_by_peer.clone();
+                    let block_verifier = block_verifier.clone();
+                    let misbehavior_store = misbehavior_store.clone();
                     tokio::spawn(async move {
                         Self::fetch_and_process_transactions_from_authorities(
                             context,
@@ -561,6 +578,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                             core_dispatcher,
                             last_failure_by_peer,
                             SyncMethod::Live,
+                            block_verifier,
+                            misbehavior_store,
                         )
                         .await;
 
@@ -640,6 +659,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         let inflight_transactions_map = self.inflight_transactions_map.clone();
         let active_requests = self.active_requests.clone();
         let last_failure_by_peer = self.last_failure_by_peer.clone();
+        let block_verifier = self.block_verifier.clone();
+        let misbehavior_store = self.misbehavior_store.clone();
 
         self.fetch_transactions_scheduler_task
             .spawn(monitored_future!(async move {
@@ -660,6 +681,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                     core_dispatcher,
                     last_failure_by_peer,
                     SyncMethod::Periodic,
+                    block_verifier,
+                    misbehavior_store,
                 )
                 .await;
                 context
@@ -685,6 +708,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         core_dispatcher: Arc<D>,
         last_failure_by_peer: Arc<LastFailureByPeer>,
         sync_method: SyncMethod,
+        block_verifier: Arc<dyn BlockVerifier>,
+        misbehavior_store: Arc<MisbehaviorStore>,
     ) {
         // Build a mapping from authority -> set of BlockRefs it has acknowledged
         let mut blocks_by_authority: BTreeMap<AuthorityIndex, BTreeSet<GenericTransactionRef>> =
@@ -778,6 +803,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 let context = context.clone();
                 let network_client = network_client.clone();
                 let core_dispatcher = core_dispatcher.clone();
+                let block_verifier = block_verifier.clone();
+                let misbehavior_store = misbehavior_store.clone();
                 request_futures.push(async move {
                     let result = Self::fetch_and_process_transactions_from_authority(
                         authority,
@@ -787,6 +814,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                         core_dispatcher,
                         sync_method,
                         active_request_guard,
+                        block_verifier,
+                        misbehavior_store,
                     )
                     .await;
                     (authority, result)
@@ -857,6 +886,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         core_dispatcher: Arc<D>,
         sync_method: SyncMethod,
         _active_guard: ActiveRequestGuard,
+        block_verifier: Arc<dyn BlockVerifier>,
+        misbehavior_store: Arc<MisbehaviorStore>,
     ) -> ConsensusResult<FetchStats> {
         let peer_hostname = &context.committee.authority(peer).hostname;
         let total_requested = transactions_guard.transactions_refs.len();
@@ -893,6 +924,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
             core_dispatcher.clone(),
             context,
             sync_method,
+            block_verifier,
+            misbehavior_store,
         )
         .await?;
 
@@ -1011,6 +1044,8 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         core_dispatcher: Arc<D>,
         context: Arc<Context>,
         sync_method: SyncMethod,
+        block_verifier: Arc<dyn BlockVerifier>,
+        misbehavior_store: Arc<MisbehaviorStore>,
     ) -> ConsensusResult<usize> {
         let _s = context
             .metrics
@@ -1091,6 +1126,34 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         .cloned()
         .collect::<Vec<_>>();
 
+        // The commitment check above only proves the fetched bytes match what
+        // the author committed to; it does not enforce the per-transaction
+        // limits or the application-level `verify_batch` checks the direct
+        // block-bundle route applies before a payload can be acknowledged.
+        // Run the same checks here so a payload violating them can't be
+        // acknowledged and become committable via this route either.
+        for verified_transactions in &transactions {
+            if let Err(err) =
+                block_verifier.check_and_verify_transactions(&verified_transactions.transactions())
+            {
+                let author = verified_transactions.author();
+                metrics
+                    .invalid_transactions
+                    .with_label_values(&[
+                        context.authority_hostname(author),
+                        "transaction_synchronizer",
+                        err.name(),
+                    ])
+                    .inc();
+                // The recomputed commitment (checked above) already ties this
+                // payload to the author's signed transactions_commitment, so
+                // the invalid payload is provably the author's. `peer_index`
+                // only relayed it and is not charged.
+                misbehavior_store.record_faulty_block_header(author, author, &err);
+                return Err(err);
+            }
+        }
+
         metrics
             .transactions_synchronizer_fetched_transactions_by_peer
             .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string()])
@@ -1155,12 +1218,14 @@ mod tests {
             BlockHeaderDigest, BlockRef, TransactionsCommitment, VerifiedBlock,
             VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
         },
+        block_verifier::{NoopBlockVerifier, SignedBlockVerifier, test::TxnSizeVerifier},
         commit::{CertifiedCommits, CommitRange},
         context::Context,
         core::ReasonToCreateBlock,
         core_thread::CoreError,
         dag_state::{DagState, DataSource},
         encoder::create_encoder,
+        misbehavior_store::MisbehaviorCounts,
         network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
     };
@@ -1182,6 +1247,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 
@@ -1273,6 +1339,105 @@ mod tests {
         transaction_synchronizer.stop().await.unwrap();
     }
 
+    /// A fetched payload must pass the same per-transaction limit and
+    /// `verify_batch` checks the direct route enforces before it can reach
+    /// Core. Otherwise it could be acknowledged and become committable while
+    /// diverging from nodes that received the same payload directly.
+    #[tokio::test]
+    async fn live_syncing_rejects_transactions_failing_verification() {
+        telemetry_subscribers::init_for_testing();
+        // GIVEN a block_verifier that rejects transactions shorter than 4
+        // bytes.
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(SignedBlockVerifier::new(
+            context.clone(),
+            Arc::new(TxnSizeVerifier {}),
+        ));
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::new());
+        let network_client = Arc::new(MockNetworkClient::new());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+
+        // Start the transactions synchronizer
+        let transaction_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier,
+        );
+        let mut encoder = create_encoder(&context);
+
+        // A 2-byte transaction fails `TxnSizeVerifier::verify_batch` (< 4
+        // bytes).
+        let author = AuthorityIndex::new_for_test(1);
+        let transactions = vec![Transaction::new(vec![0u8; 2])];
+        let serialized = Bytes::from(bcs::to_bytes(&transactions).unwrap());
+        let commitment = TransactionsCommitment::compute_transactions_commitment(
+            &serialized,
+            &context,
+            &mut encoder,
+        )
+        .unwrap();
+
+        let header = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(1, author.value() as u8)
+                .set_commitment(commitment)
+                .build(),
+        );
+
+        let verified_transactions = VerifiedTransactions::new(
+            transactions,
+            header.transaction_ref(),
+            Some(header.digest()),
+            serialized,
+        );
+
+        let mut missing_transactions = BTreeMap::new();
+        let mut authorities = BTreeSet::new();
+        authorities.insert(author);
+        missing_transactions.insert(
+            GenericTransactionRef::from(header.transaction_ref()),
+            authorities,
+        );
+
+        network_client
+            .stub_fetch_transactions(vec![verified_transactions], author)
+            .await;
+
+        dag_state
+            .write()
+            .accept_block_headers(vec![header], DataSource::Test);
+
+        // WHEN
+        let result = transaction_synchronizer
+            .fetch_transactions(missing_transactions)
+            .await;
+        assert!(result.is_ok());
+
+        // Wait a bit for processing to complete
+        sleep(Duration::from_millis(1000)).await;
+
+        // THEN the payload never reaches Core, so it can never be
+        // acknowledged.
+        let fetched_transactions = core_dispatcher.get_and_drain_transactions().await;
+        assert!(
+            fetched_transactions.is_empty(),
+            "A fetched payload failing verification must never reach Core"
+        );
+
+        let counts = dag_state.read().misbehavior_store().snapshot_totals();
+        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        assert_eq!(
+            author_counts.faulty_blocks_provable, 1,
+            "The author should be charged for the provably invalid payload"
+        );
+
+        // Clean up
+        transaction_synchronizer.stop().await.unwrap();
+    }
+
     #[tokio::test]
     async fn live_syncing_with_saturated_tasks() {
         telemetry_subscribers::init_for_testing();
@@ -1290,6 +1455,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 
@@ -1412,6 +1578,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 
@@ -1539,6 +1706,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 
@@ -1655,6 +1823,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 
@@ -1773,6 +1942,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 
@@ -2006,6 +2176,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
         );
         let mut encoder = create_encoder(&context);
 


### PR DESCRIPTION
# Description of change

Transactions ingested via the direct block-bundle route run `check_and_verify_transactions` (per-transaction size/count limits plus `verify_batch`) before they can be acknowledged. The shard-reconstruction and transaction-synchronizer routes only recomputed the payload commitment and skipped those checks, yet both still produce acknowledgments — so a payload violating the limits could be acknowledged on nodes that received it via sync while being rejected on nodes that received it directly.

Both sync routes now run the same `check_and_verify_transactions` before the payload can reach `DagState` (the only path that records acknowledgments):

- Shard reconstruction gates the send to the accumulator on verification.
- The transaction synchronizer verifies each fetched group and drops the whole fetch on the first failure.

On failure the payload is dropped and the fault is charged to the transaction's committed author (not the relaying peer): the recomputed commitment already binds the bytes to the author's signature. This is deterministic, protocol-config-driven input validation identical to what the direct route already applies, so it needs no protocol-version change — it removes a divergence source rather than introducing one.

## Links to any relevant issues

fixes iotaledger/iota-private#462

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
