### PR TITLE
fix(iota-e2e-tests): deflake traffic control blocked and delegated tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -39,7 +39,7 @@ threads-required = "num-test-threads"
 retries = 4
 filter = '''
 (package(iota) and (test(test_faucet_batch) or test(test_faucet_batch_concurrent_requests)))
-or (package(iota-e2e-tests) and (test(test_reconfig_with_committee_change_stress_determinism) or test(test_full_node_load_migration_data) or test(test_full_node_sync_flood_determinism) or test(test_passive_reconfig_determinism) or test(test_hash_collections) or test(test_net_determinism) or test(test_apy) or test(test_fullnode_traffic_control_spam_delegated)))
+or (package(iota-e2e-tests) and (test(test_reconfig_with_committee_change_stress_determinism) or test(test_full_node_load_migration_data) or test(test_full_node_sync_flood_determinism) or test(test_passive_reconfig_determinism) or test(test_hash_collections) or test(test_net_determinism) or test(test_apy) or test(test_fullnode_traffic_control_spam_delegated) or test(test_validator_traffic_control_error_blocked) or test(test_fullnode_traffic_control_spam_blocked) or test(test_fullnode_traffic_control_error_blocked) or test(test_validator_traffic_control_error_delegated)))
 or (package(iota-graphql-rpc) and test(test_epoch_data))
 or (package(iota-network-stack) and test(ip6))
 '''

--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -267,7 +267,12 @@ async fn test_validator_traffic_control_error_blocked() -> Result<(), anyhow::Er
     ));
 
     // it should take no more than 4 requests to be added to the blocklist
-    for _ in 0..n {
+    for i in 0..n {
+        // Give the background tally task time to apply the blocklist before
+        // the last request, which is expected to be rejected.
+        if i == n - 1 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
         let response = auth_client.handle_transaction(tx.clone(), None).await;
         if let Err(err) = response {
             if err.to_string().contains("Too many requests") {
@@ -405,7 +410,12 @@ async fn test_fullnode_traffic_control_spam_blocked() -> Result<(), anyhow::Erro
     assert!(confirmed_local_execution.unwrap());
 
     // it should take no more than 4 requests to be added to the blocklist
-    for _ in 0..txn_count {
+    for i in 0..txn_count {
+        // Give the background tally task time to apply the blocklist before
+        // the last request, which is expected to be rejected.
+        if i == txn_count - 1 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
         let response: Result<IotaTransactionBlockResponse, _> = jsonrpc_client
             .request("iota_getTransactionBlock", rpc_params![*tx_digest])
             .await;
@@ -454,7 +464,12 @@ async fn test_fullnode_traffic_control_error_blocked() -> Result<(), anyhow::Err
     );
 
     // it should take no more than 4 requests to be added to the blocklist
-    for _ in 0..txn_count {
+    for i in 0..txn_count {
+        // Give the background tally task time to apply the blocklist before
+        // the last request, which is expected to be rejected.
+        if i == txn_count - 1 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
         let txn = txns.swap_remove(0);
         let tx_digest = txn.digest();
         let (tx_bytes, _signatures) = txn.to_tx_bytes_and_signatures();


### PR DESCRIPTION
# Description of change

The traffic control tests expect the blocklist to be applied within a fixed number of requests, but it's applied asynchronously by the background tally task — on a loaded runner the final request can arrive before the block is visible (observed in https://github.com/iotaledger/iota/actions/runs/29322672652).

- Sleep 500 ms before the last request (the one expected to be rejected) in the blocked-variant tests, giving the tally task time to apply the blocklist
- Add the traffic control tests to the flaky-retries override in nextest.toml

## Links to any relevant issues

None — flake observed in CI for #12232.

## How the change has be

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes