### PR TITLE
fix(iota): publish move-authenticator test packages from isolated copies

### DIFF
--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -6632,9 +6632,6 @@ async fn setup_move_authenticator_account(
         .parent()
         .unwrap()
         .join(package_relative_path);
-    // Publish from an isolated copy: the publish flow rewrites the package's
-    // `Move.lock`, and concurrent tests publishing the same in-tree package
-    // race on it.
     let (_temp_dir, package_path) = isolate_test_package(&src_pkg);
     let mut build_config = BuildConfig::new_for_testing().config;
     build_config.lock_file = Some(package_path.join("Move.lock"));

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -264,10 +264,10 @@ fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> 
     Ok(())
 }
 
-/// Copy a `tests/data/<pkg>/` Move package into a fresh `TempDir` so
-/// parallel PTB `--publish` / `--upgrade` tests don't race on the
-/// shared on-disk `build/` and `Move.lock`. The caller must keep the
-/// returned `TempDir` alive (drop deletes it).
+/// Copy an in-tree Move package into a fresh `TempDir` so parallel
+/// tests publishing the same package don't race on the shared on-disk
+/// `build/` and `Move.lock`. The caller must keep the returned
+/// `TempDir` alive (drop deletes it).
 fn isolate_test_package(src_pkg: &Path) -> (TempDir, PathBuf) {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let dst_pkg = temp_dir.path().join(src_pkg.file_name().unwrap());
@@ -6626,12 +6626,16 @@ async fn setup_move_authenticator_account(
         .unwrap()
         .coin_object_id;
 
-    let package_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+    let src_pkg = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
         .parent()
         .unwrap()
         .parent()
         .unwrap()
         .join(package_relative_path);
+    // Publish from an isolated copy: the publish flow rewrites the package's
+    // `Move.lock`, and concurrent tests publishing the same in-tree package
+    // race on it.
+    let (_temp_dir, package_path) = isolate_test_package(&src_pkg);
     let mut build_config = BuildConfig::new_for_testing().config;
     build_config.lock_file = Some(package_path.join("Move.lock"));
 


### PR DESCRIPTION
# Description of change

- The move-authenticator cli_tests publish the same in-tree example packages (`examples/move/account`, `examples/move/abstract_iota_accounts/account_multi_auth`) directly from the source tree.
- `iota client publish` rewrites the package's `Move.lock` (it zeroes `original-published-id` around the compile and records the published id afterwards), so concurrent test processes race on that shared file.
- Under `cargo simtest` the fixed seed makes genesis deterministic, so all test clusters share the same chain id; a lock entry written by one test then matches another test's chain id and its publish fails with `Modules must all have 0x0 as their addresses`. Under plain `cargo nextest` chain ids are random, which is why the race only surfaces in the simtest CI job.
- Fix: `setup_move_authenticator_account` now publishes from an isolated per-test copy via the existing `isolate_test_package` helper, so no test touches the in-tree `Move.lock`.

## Links to any relevant issues

fixes #12262

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes