### PR TITLE
refactor(indexer): revise API to accommodate package restore

### DIFF
--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -162,9 +162,9 @@ pub(crate) struct PackageCursor {
     pub checkpoint_viewed_at: u64,
 }
 
-/// `DataLoader` key for fetching the storage ID of the (user) package that
-/// shares an original (aka runtime) ID with the package stored at `package_id`,
-/// and whose version is `version`.
+/// `DataLoader` key for fetching the storage ID of the (user) package at
+/// `version` that shares an original (aka runtime) ID with the package version
+/// stored at `address`.
 ///
 /// Note that this is different from looking up the historical version of an
 /// object -- the query returns the ID of the package (each version of a user

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -633,16 +633,14 @@ impl PrimaryWorker {
                 data.transactions
                     .iter()
                     .flat_map(|tx| &tx.output_objects)
-                    .filter_map(|o| {
-                        if let iota_sdk_types::ObjectData::Package(p) = &o.data {
-                            Some(IndexedPackage {
-                                package_id: o.id(),
-                                move_package: p.clone(),
-                                checkpoint_sequence_number,
-                            })
-                        } else {
-                            None
-                        }
+                    .filter_map(|object| {
+                        let iota_sdk_types::ObjectData::Package(package) = object.data() else {
+                            return None;
+                        };
+                        Some(IndexedPackage::new(
+                            package.clone(),
+                            checkpoint_sequence_number,
+                        ))
                     })
                     .collect::<Vec<_>>()
             })

--- a/crates/iota-indexer/src/models/packages.rs
+++ b/crates/iota-indexer/src/models/packages.rs
@@ -20,7 +20,7 @@ pub struct StoredPackage {
 impl From<IndexedPackage> for StoredPackage {
     fn from(p: IndexedPackage) -> Self {
         Self {
-            package_id: p.package_id.as_bytes().to_vec(),
+            package_id: p.move_package.id().as_bytes().to_vec(),
             original_id: p.move_package.original_package_id().as_bytes().to_vec(),
             package_version: p.move_package.version().as_u64() as i64,
             move_package: bcs::to_bytes(&p.move_package).unwrap(),

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     pruning::pruner::PrunableTable,
     store::{IndexerStore, PgIndexerStore},
-    types::{IndexedCheckpoint, IndexedPackage},
+    types::IndexedCheckpoint,
 };
 
 /// Data derived from the live-object set included in the snapshot.
@@ -36,7 +36,7 @@ struct ObjectDerivedData {
 }
 
 impl ObjectDerivedData {
-    fn extend(&mut self, object: &Object, checkpoint_sequence_number: u64) {
+    fn extend(&mut self, object: &Object) {
         self.hasher.update(object.object_ref().digest.inner());
         if let Some(display) = StoredDisplay::try_from_object(object) {
             self.displays.insert(display.object_type.clone(), display);
@@ -61,7 +61,7 @@ impl Restore for PgIndexerStore {
                 } = snapshot_object;
                 let checkpoint_sequence_number =
                     previous_transaction_checkpoint.unwrap_or_default();
-                derived_data.extend(&object, checkpoint_sequence_number);
+                derived_data.extend(&object);
                 Some(LiveObject::new(checkpoint_sequence_number, object))
             },
         );

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -8,7 +8,9 @@ use fastcrypto::hash::{HashFunction, Sha3_256};
 use iota_core::authority::authority_store_tables::LiveObject as SnapshotObject;
 use iota_snapshot::{FileMetadata, VerifiedEpochInfo, reader::LiveObjectIter, restore::Restore};
 use iota_storage::SHA3_BYTES;
-use iota_types::{digests::ChainIdentifier, iota_system_state::IotaSystemStateTrait};
+use iota_types::{
+    digests::ChainIdentifier, iota_system_state::IotaSystemStateTrait, object::Object,
+};
 use itertools::Itertools;
 use strum::IntoEnumIterator;
 
@@ -23,8 +25,24 @@ use crate::{
     },
     pruning::pruner::PrunableTable,
     store::{IndexerStore, PgIndexerStore},
-    types::IndexedCheckpoint,
+    types::{IndexedCheckpoint, IndexedPackage},
 };
+
+/// Data derived from the live-object set included in the snapshot.
+#[derive(Default)]
+struct ObjectDerivedData {
+    hasher: Sha3_256,
+    displays: BTreeMap<String, StoredDisplay>,
+}
+
+impl ObjectDerivedData {
+    fn extend(&mut self, object: &Object, checkpoint_sequence_number: u64) {
+        self.hasher.update(object.object_ref().digest.inner());
+        if let Some(display) = StoredDisplay::try_from_object(object) {
+            self.displays.insert(display.object_type.clone(), display);
+        }
+    }
+}
 
 impl Restore for PgIndexerStore {
     async fn insert_partition(
@@ -33,26 +51,22 @@ impl Restore for PgIndexerStore {
         bytes: Bytes,
         expected_checksum: &[u8; SHA3_BYTES],
     ) -> anyhow::Result<()> {
-        let mut hasher = Sha3_256::default();
-        let mut displays = BTreeMap::new();
+        let mut derived_data = ObjectDerivedData::default();
         let partition = LiveObjectIter::new(&file_metadata, bytes)?.scan(
-            &mut hasher,
-            |hasher,
-             SnapshotObject {
-                 object,
-                 previous_transaction_checkpoint,
-             }| {
-                hasher.update(object.object_ref().digest.inner());
-                if let Some(display) = StoredDisplay::try_from_object(&object) {
-                    displays.insert(display.object_type.clone(), display);
-                }
+            &mut derived_data,
+            |derived_data, snapshot_object| {
+                let SnapshotObject {
+                    object,
+                    previous_transaction_checkpoint,
+                } = snapshot_object;
                 let checkpoint_sequence_number =
                     previous_transaction_checkpoint.unwrap_or_default();
+                derived_data.extend(&object, checkpoint_sequence_number);
                 Some(LiveObject::new(checkpoint_sequence_number, object))
             },
         );
         let chunks = chunk!(partition, self.config.parallel_objects_chunk_size);
-        let sha3_digest = hasher.finalize().digest;
+        let sha3_digest = derived_data.hasher.finalize().digest;
         if *expected_checksum != sha3_digest {
             tracing::error!(
                 "sha does not match! expected: {expected_checksum:?}, actual: {sha3_digest:?}",
@@ -82,7 +96,7 @@ impl Restore for PgIndexerStore {
                     "failed to persist all formal snapshot object chunks: {e:?}",
                 ))
             })?;
-        self.persist_displays(displays.into_values().collect())
+        self.persist_displays(derived_data.displays.into_values().collect())
             .await?;
         Ok(())
     }

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -393,9 +393,17 @@ impl IndexedDeletedObject {
 
 #[derive(Debug)]
 pub struct IndexedPackage {
-    pub package_id: ObjectId,
     pub move_package: MovePackage,
     pub checkpoint_sequence_number: u64,
+}
+
+impl IndexedPackage {
+    pub(crate) fn new(move_package: MovePackage, checkpoint_sequence_number: u64) -> Self {
+        Self {
+            move_package,
+            checkpoint_sequence_number
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -401,7 +401,7 @@ impl IndexedPackage {
     pub(crate) fn new(move_package: MovePackage, checkpoint_sequence_number: u64) -> Self {
         Self {
             move_package,
-            checkpoint_sequence_number
+            checkpoint_sequence_number,
         }
     }
 }


### PR DESCRIPTION
# Description of change

This patch prepares the ground for restoring the `packages` table through formal snapshots with a few revisions:

* `IndexedPackage` is simplified (`id` can be derived by `MovePackage`)
* A new `DerivedData` struct is introduced in the context of restore to handle data derived from the live object set in a more ergonomic way.
* A GraphQL doc is updated for the sake of clarity.

## Links to any relevant issues

Part of #12254 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
