### PR TITLE
fix(consensus): rebuild leader schedule from a recovered scoring backlog

### DIFF
--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -32,7 +32,7 @@ use crate::{
         VerifiedTransactions, genesis_blocks,
     },
     commit::{
-        CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRef, CommitVote,
+        CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRange, CommitRef, CommitVote,
         GENESIS_COMMIT_INDEX, SubDagBase, TrustedCommit, load_pending_subdag_from_store,
     },
     context::Context,
@@ -642,25 +642,17 @@ impl DagState {
         let Some(last_commit) = self.last_commit.as_ref() else {
             return;
         };
+        let last_commit_index = last_commit.index();
 
         let commit_recovery_start_index = self.last_commit_info_index().saturating_add(1);
 
-        if commit_recovery_start_index > last_commit.index() {
+        if commit_recovery_start_index > last_commit_index {
             return;
         }
 
-        let commits = self
-            .store
-            .scan_commits((commit_recovery_start_index..=last_commit.index()).into())
-            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"));
-
-        let mut unscored_subdags = Vec::with_capacity(commits.len());
-        for commit in commits {
-            let pending_subdag =
-                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![])
-                    .unwrap_or_else(|e| panic!("Failed to recover pending subdag: {e:?}"));
-            unscored_subdags.push(pending_subdag.base);
-        }
+        let unscored_subdags = self.load_scoring_subdags_from_store(
+            (commit_recovery_start_index..=last_commit_index).into(),
+        );
 
         if !unscored_subdags.is_empty() {
             self.scoring_subdag.add_subdags(unscored_subdags);
@@ -2843,6 +2835,22 @@ impl DagState {
             .adaptive_ack_excluded_authorities
             .set(mask.len() as i64);
         mask
+    }
+
+    /// Loads the committed subdags in `range` from stored commits, for
+    /// re-scoring. The commits and their block headers must exist in the
+    /// store.
+    pub(crate) fn load_scoring_subdags_from_store(&self, range: CommitRange) -> Vec<SubDagBase> {
+        self.store
+            .scan_commits(range)
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"))
+            .into_iter()
+            .map(|commit| {
+                load_pending_subdag_from_store(self.store.as_ref(), commit, vec![])
+                    .unwrap_or_else(|e| panic!("Failed to recover pending subdag: {e:?}"))
+                    .base
+            })
+            .collect()
     }
 }
 #[cfg(test)]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2618,12 +2618,11 @@ impl DagState {
         self.scoring_subdag.calculate_distributed_vote_scores()
     }
 
-    pub(crate) fn scoring_subdag_commit_range(&self) -> CommitIndex {
+    pub(crate) fn scoring_subdag_commit_range(&self) -> CommitRange {
         self.scoring_subdag
             .commit_range
-            .as_ref()
+            .clone()
             .expect("commit range should exist for scoring subdag")
-            .end()
     }
 
     /// The last round that should get evicted after a cache-clean-up operation.

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -122,10 +122,10 @@ impl LeaderSchedule {
         // online path buffers both at rotation, fast sync applies the scores
         // embedded in fetched commits before flushing the batch), so on disk
         // the last commit stays within one window of the last `CommitInfo`.
-        // A recovered backlog exceeding the window therefore indicates a store
-        // written by different code or modified externally. It is not treated
-        // as fatal: returning 0 forces an immediate schedule update, which
-        // rebuilds the schedule from the backlog's last full window.
+        // A recovered backlog exceeding the window should therefore never
+        // occur — but it is a recoverable state, so recovering is preferred
+        // over panicking: returning 0 forces an immediate schedule update,
+        // which rebuilds the schedule from the backlog's last full window.
         if subdag_count > self.num_commits_per_schedule {
             tracing::warn!(
                 "Recovered scoring backlog ({subdag_count} subdags) exceeds the schedule \
@@ -357,8 +357,8 @@ impl LeaderSchedule {
 
     /// Updates the leader schedule from a recovered scoring backlog spanning
     /// more than one rotation interval — a store state current persistence
-    /// never produces, tolerated in case the store was written by different
-    /// code or modified externally.
+    /// never produces, recovered from rather than panicked on should it ever
+    /// occur.
     ///
     /// Only the last full window of the backlog is scored: it alone determines
     /// the swap table a continuously running node had at that point, and

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -18,7 +18,7 @@ use crate::{
     context::Context,
     dag_state::DagState,
     error::ConsensusResult,
-    leader_scoring::ReputationScores,
+    leader_scoring::{ReputationScores, ScoringSubdag},
 };
 
 /// Calculates the seed index for leader swap table initialization.
@@ -255,9 +255,14 @@ impl LeaderSchedule {
             .scope_processing_time
             .with_label_values(&["LeaderSchedule::update_leader_schedule"])
             .start_timer();
+        if dag_state_write_lock.scoring_subdags_count() as u32 > self.num_commits_per_schedule {
+            self.update_leader_schedule_from_backlog(dag_state_write_lock);
+            return;
+        }
+
         let (reputation_scores, last_commit_index) = {
             let reputation_scores = dag_state_write_lock.calculate_scoring_subdag_scores();
-            let last_commit_index = dag_state_write_lock.scoring_subdag_commit_range();
+            let last_commit_index = dag_state_write_lock.scoring_subdag_commit_range().end();
             (reputation_scores, last_commit_index)
         };
         let table = LeaderSwapTable::new(
@@ -267,7 +272,7 @@ impl LeaderSchedule {
         );
         self.persist_scores(dag_state_write_lock, reputation_scores);
         {
-            self.range_validation(&table, &self.leader_swap_table.read());
+            self.range_validation_or_skip(&table, &self.leader_swap_table.read());
             self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
         }
     }
@@ -341,6 +346,75 @@ impl LeaderSchedule {
         self.persist_scores(dag_state_write_lock, reputation_scores);
         self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
         Ok(())
+    }
+
+    /// Updates the leader schedule from a recovered scoring backlog spanning
+    /// more than one rotation interval, possible after fast sync or recovery
+    /// from a store whose last persisted `CommitInfo` is missing or stale.
+    ///
+    /// The backlog is replayed window by window from the store, so every
+    /// rebuilt swap table matches the one a continuously running node computed
+    /// over the same commits, and rotations stay on the same commit boundaries.
+    /// The trailing partial window becomes the live scoring subdag.
+    fn update_leader_schedule_from_backlog(&self, dag_state_write_lock: &mut DagState) {
+        let backlog_range = dag_state_write_lock.scoring_subdag_commit_range();
+        let window_size = self.num_commits_per_schedule;
+        let full_windows = backlog_range.size() as u32 / window_size;
+
+        tracing::info!(
+            "Replaying recovered scoring backlog {backlog_range:?} as {full_windows} window(s) of {window_size} commits"
+        );
+
+        dag_state_write_lock.clear_scoring_subdag();
+
+        let mut last_window_scores = None;
+        for window in 0..full_windows {
+            let window_start = backlog_range.start() + window * window_size;
+            let window_end = window_start + (window_size - 1);
+            let mut scoring_subdag = ScoringSubdag::new(self.context.clone());
+            scoring_subdag.add_subdags(
+                dag_state_write_lock
+                    .load_scoring_subdags_from_store((window_start..=window_end).into()),
+            );
+            let reputation_scores = scoring_subdag.calculate_distributed_vote_scores();
+            let table =
+                LeaderSwapTable::new(self.context.clone(), window_end, reputation_scores.clone());
+            self.range_validation_or_skip(&table, &self.leader_swap_table.read());
+            self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
+            last_window_scores = Some(reputation_scores);
+        }
+
+        // Recovery resumes from the end of the last persisted commit range, so
+        // only the last completed window's scores need to be persisted.
+        let reputation_scores = last_window_scores
+            .expect("a backlog larger than one window contains at least one full window");
+        dag_state_write_lock.add_commit_info(reputation_scores);
+
+        let remainder_start = backlog_range.start() + full_windows * window_size;
+        if remainder_start <= backlog_range.end() {
+            let remainder_subdags = dag_state_write_lock
+                .load_scoring_subdags_from_store((remainder_start..=backlog_range.end()).into());
+            dag_state_write_lock.add_scoring_subdags(remainder_subdags);
+        }
+    }
+
+    /// Runs `range_validation` unless the old table's commit range doesn't
+    /// span one rotation interval — possible when the recovered state was
+    /// persisted under a different `commits_per_schedule` — in which case the
+    /// mismatch is expected: warn and apply the new table unvalidated.
+    fn range_validation_or_skip(&self, new_table: &LeaderSwapTable, old_table: &LeaderSwapTable) {
+        let old_commit_range = &old_table.reputation_scores.commit_range;
+        if *old_commit_range == CommitRange::default()
+            || old_commit_range.size() == self.num_commits_per_schedule as usize
+        {
+            self.range_validation(new_table, old_table);
+        } else {
+            tracing::warn!(
+                "Skipping commit range validation: old range {old_commit_range:?} does not span one rotation interval ({}), new range {:?}",
+                self.num_commits_per_schedule,
+                new_table.reputation_scores.commit_range,
+            );
+        }
     }
 
     #[cfg(test)]
@@ -1150,5 +1224,291 @@ mod tests {
 
         // Update leader from old swap table to new invalid swap table
         leader_schedule.update_leader_swap_table_strict_for_test(leader_swap_table);
+    }
+
+    // Recovers a schedule from a store whose last CommitInfo lags the last
+    // commit by more than one rotation interval, and checks that the backlog
+    // is replayed window by window onto the same rotation boundaries a
+    // continuously running node used.
+    async fn run_update_after_recovery_backlog(restart: bool) {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+
+        const INTERVAL: u32 = 3;
+
+        // Persist commits 1..=11 but only one CommitInfo, covering (1..=3):
+        // recovery rebuilds a backlog of 8 commits — two full windows (4..=6)
+        // and (7..=9) plus the partial window (10..=11).
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=12).build();
+        let first_window = dag_builder.get_sub_dag_and_commits(1..=INTERVAL);
+        let committed_rounds = dag_builder.last_committed_rounds.clone();
+        let rest = dag_builder.get_sub_dag_and_commits(INTERVAL + 1..=12);
+
+        let mut headers_to_write = vec![];
+        let mut commits_to_write = vec![];
+        for (sub_dag, commit) in first_window.iter().chain(&rest[..8]) {
+            headers_to_write.extend(sub_dag.headers.iter().cloned());
+            commits_to_write.push(commit.clone());
+        }
+        let commit_info = CommitInfo {
+            reputation_scores: ReputationScores::new((1..=INTERVAL).into(), vec![1, 2, 4, 3]),
+            committed_rounds,
+        };
+        let commit_ref = first_window.last().unwrap().1.reference();
+        store
+            .write(
+                WriteBatch::default()
+                    .commit_info(vec![(commit_ref, commit_info)])
+                    .block_headers(headers_to_write)
+                    .commits(commits_to_write),
+            )
+            .unwrap();
+
+        let mut dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        assert_eq!(dag_state.read().scoring_subdags_count(), 8);
+
+        let mut leader_schedule = LeaderSchedule::from_store(context.clone(), dag_state.clone())
+            .with_num_commits_per_schedule(INTERVAL);
+        assert_eq!(
+            leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range,
+            (1..=3).into()
+        );
+
+        // The backlog forces an immediate schedule update.
+        assert_eq!(
+            leader_schedule.commits_until_leader_schedule_update(dag_state.clone()),
+            0
+        );
+
+        // The full windows are replayed; the partial window stays live.
+        leader_schedule.update_leader_schedule(&mut dag_state.write());
+        {
+            let table = leader_schedule.leader_swap_table.read();
+            assert_eq!(table.reputation_scores.commit_range, (7..=9).into());
+            assert_eq!(table.good_nodes.len(), 1);
+            assert_eq!(table.bad_nodes.len(), 1);
+        }
+        assert_eq!(dag_state.read().scoring_subdags_count(), 2);
+
+        if restart {
+            dag_state.write().flush();
+            assert_eq!(dag_state.read().last_commit_info_index(), 9);
+            dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            assert_eq!(dag_state.read().scoring_subdags_count(), 2);
+            leader_schedule = LeaderSchedule::from_store(context, dag_state.clone())
+                .with_num_commits_per_schedule(INTERVAL);
+            assert_eq!(
+                leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .reputation_scores
+                    .commit_range,
+                (7..=9).into()
+            );
+        }
+
+        // The next rotation triggers after commit 12 and validates strictly:
+        // (10..=12) continues on the same window boundaries.
+        let (sub_dag, commit) = &rest[8];
+        {
+            let mut write = dag_state.write();
+            write.add_commit(commit.clone());
+            write.add_scoring_subdags(vec![sub_dag.base.clone()]);
+        }
+        assert_eq!(
+            leader_schedule.commits_until_leader_schedule_update(dag_state.clone()),
+            0
+        );
+        leader_schedule.update_leader_schedule(&mut dag_state.write());
+        assert_eq!(
+            leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range,
+            (10..=12).into()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_leader_schedule_update_after_recovery_backlog() {
+        run_update_after_recovery_backlog(false).await;
+    }
+
+    #[tokio::test]
+    async fn test_leader_schedule_update_after_recovery_backlog_with_restart() {
+        run_update_after_recovery_backlog(true).await;
+    }
+
+    /// Verifies that replaying an oversized recovered backlog window by window
+    /// produces the exact same per-window `ReputationScores` (and therefore the
+    /// same `LeaderSwapTable`) as a node that never crashed and updated its
+    /// schedule incrementally over the same commits.
+    #[tokio::test]
+    async fn test_update_leader_schedule_from_backlog_matches_live_schedule_per_window() {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
+        let context = Arc::new(context);
+
+        // Two full 5-commit windows, built once and shared by both scenarios so
+        // both operate on identical committed subdags.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=10).build();
+        let sub_dags_and_commits = dag_builder.get_sub_dag_and_commits(1..=10);
+
+        // Live scenario: commits are added one at a time and the schedule is
+        // updated as soon as each 5-commit window fills up.
+        let dag_state_live = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let leader_schedule_live = LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
+            .with_num_commits_per_schedule(5);
+        let mut live_scores_window_1 = None;
+        for (index, (sub_dag, commit)) in sub_dags_and_commits.iter().enumerate() {
+            let mut dag_state_write = dag_state_live.write();
+            dag_state_write.set_last_commit(commit.clone());
+            dag_state_write.add_scoring_subdags(vec![sub_dag.base.clone()]);
+            if (index + 1) % 5 == 0 {
+                leader_schedule_live.update_leader_schedule(&mut dag_state_write);
+                if index + 1 == 5 {
+                    live_scores_window_1 = Some(
+                        leader_schedule_live
+                            .leader_swap_table
+                            .read()
+                            .reputation_scores
+                            .clone(),
+                    );
+                }
+            }
+        }
+        let live_scores_window_1 = live_scores_window_1.expect("window 1 update should have run");
+        let live_table_window_2 = leader_schedule_live.leader_swap_table.read().clone();
+
+        // Recovered scenario: the same 10 commits are persisted with no
+        // CommitInfo at all, so DagState recovers them as a single 10-commit
+        // backlog exceeding the 5-commit schedule window.
+        let store = Arc::new(MemStore::new());
+        let mut headers_to_write = vec![];
+        let mut commits_to_write = vec![];
+        for (sub_dag, commit) in &sub_dags_and_commits {
+            headers_to_write.extend(sub_dag.headers.iter().cloned());
+            commits_to_write.push(commit.clone());
+        }
+        store
+            .write(
+                WriteBatch::default()
+                    .block_headers(headers_to_write)
+                    .commits(commits_to_write),
+            )
+            .unwrap();
+
+        let dag_state_recovered = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        assert_eq!(dag_state_recovered.read().scoring_subdags_count(), 10);
+
+        let leader_schedule_recovered =
+            LeaderSchedule::from_store(context.clone(), dag_state_recovered.clone())
+                .with_num_commits_per_schedule(5);
+        leader_schedule_recovered.update_leader_schedule(&mut dag_state_recovered.write());
+        let recovered_table = leader_schedule_recovered.leader_swap_table.read().clone();
+
+        // The final table produced by the backlog replay (window 2) must match
+        // the live node's window-2 table exactly.
+        assert_eq!(
+            recovered_table.reputation_scores,
+            live_table_window_2.reputation_scores
+        );
+        assert_eq!(recovered_table.good_nodes, live_table_window_2.good_nodes);
+        assert_eq!(recovered_table.bad_nodes, live_table_window_2.bad_nodes);
+
+        // Per-window check: recompute window 1's scores the same way the
+        // replay does internally (batch-load the window's commits into a fresh
+        // ScoringSubdag) and confirm they match what the live node computed
+        // incrementally for that same window.
+        let window_1_subdags = dag_state_recovered
+            .read()
+            .load_scoring_subdags_from_store((1..=5).into());
+        let mut window_1_scoring_subdag = ScoringSubdag::new(context);
+        window_1_scoring_subdag.add_subdags(window_1_subdags);
+        let window_1_scores = window_1_scoring_subdag.calculate_distributed_vote_scores();
+        assert_eq!(window_1_scores, live_scores_window_1);
+    }
+
+    // A recovered CommitInfo may span a different number of commits than the
+    // current `commits_per_schedule`. The first replayed window then can't
+    // match the old range's size: it must be applied with a warning instead of
+    // a panic, and subsequent windows validate strictly again.
+    #[tokio::test]
+    async fn test_update_leader_schedule_backlog_after_commits_per_schedule_change() {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+
+        // CommitInfo covers (1..=2) — a two-commit interval — while the
+        // schedule now rotates every three commits. The backlog (3..=8)
+        // replays as windows (3..=5) and (6..=8) with no remainder.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=8).build();
+        let first_window = dag_builder.get_sub_dag_and_commits(1..=2);
+        let committed_rounds = dag_builder.last_committed_rounds.clone();
+        let rest = dag_builder.get_sub_dag_and_commits(3..=8);
+
+        let mut headers_to_write = vec![];
+        let mut commits_to_write = vec![];
+        for (sub_dag, commit) in first_window.iter().chain(rest.iter()) {
+            headers_to_write.extend(sub_dag.headers.iter().cloned());
+            commits_to_write.push(commit.clone());
+        }
+        let commit_info = CommitInfo {
+            reputation_scores: ReputationScores::new((1..=2).into(), vec![1, 2, 4, 3]),
+            committed_rounds,
+        };
+        let commit_ref = first_window.last().unwrap().1.reference();
+        store
+            .write(
+                WriteBatch::default()
+                    .commit_info(vec![(commit_ref, commit_info)])
+                    .block_headers(headers_to_write)
+                    .commits(commits_to_write),
+            )
+            .unwrap();
+
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        assert_eq!(dag_state.read().scoring_subdags_count(), 6);
+
+        let leader_schedule =
+            LeaderSchedule::from_store(context, dag_state.clone()).with_num_commits_per_schedule(3);
+        assert_eq!(
+            leader_schedule.commits_until_leader_schedule_update(dag_state.clone()),
+            0
+        );
+
+        leader_schedule.update_leader_schedule(&mut dag_state.write());
+        assert_eq!(
+            leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range,
+            (6..=8).into()
+        );
+        assert_eq!(dag_state.read().scoring_subdags_count(), 0);
     }
 }

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -117,13 +117,20 @@ impl LeaderSchedule {
         // In the normal online flow, `scoring_subdag` is cleared every time we
         // update the schedule, so its size stays within `num_commits_per_schedule`.
         //
-        // After fast-sync or when recovering from older/stale DBs where CommitInfo
-        // wasn't persisted frequently, recovery may rebuild a backlog of scoring
-        // subdags that exceeds the window. In that case, we should trigger an
-        // immediate schedule update rather than panic.
+        // The same bound holds for recovered state: every writer persists
+        // `CommitInfo` in the same write batch as the commits it covers (the
+        // online path buffers both at rotation, fast sync applies the scores
+        // embedded in fetched commits before flushing the batch), so on disk
+        // the last commit stays within one window of the last `CommitInfo`.
+        // A recovered backlog exceeding the window therefore indicates a store
+        // written by different code or modified externally. It is not treated
+        // as fatal: returning 0 forces an immediate schedule update, which
+        // replays the backlog window by window.
         if subdag_count > self.num_commits_per_schedule {
             tracing::warn!(
-                "Committed subdags count ({subdag_count}) exceeds commits-per-schedule ({}) - forcing immediate leader schedule update. This can happen after fast sync / recovery if CommitInfo was missing or stale.",
+                "Recovered scoring backlog ({subdag_count} subdags) exceeds the schedule \
+                 window ({}): commits and CommitInfo are inconsistent on disk, which current \
+                 persistence never produces. Forcing an immediate schedule update.",
                 self.num_commits_per_schedule,
             );
             return 0;
@@ -349,8 +356,9 @@ impl LeaderSchedule {
     }
 
     /// Updates the leader schedule from a recovered scoring backlog spanning
-    /// more than one rotation interval, possible after fast sync or recovery
-    /// from a store whose last persisted `CommitInfo` is missing or stale.
+    /// more than one rotation interval — a store state current persistence
+    /// never produces, tolerated in case the store was written by different
+    /// code or modified externally.
     ///
     /// The backlog is replayed window by window from the store, so every
     /// rebuilt swap table matches the one a continuously running node computed
@@ -362,7 +370,8 @@ impl LeaderSchedule {
         let full_windows = backlog_range.size() as u32 / window_size;
 
         tracing::info!(
-            "Replaying recovered scoring backlog {backlog_range:?} as {full_windows} window(s) of {window_size} commits"
+            "Replaying recovered scoring backlog {backlog_range:?} as {full_windows} full \
+             window(s) of {window_size} commits"
         );
 
         dag_state_write_lock.clear_scoring_subdag();
@@ -410,7 +419,8 @@ impl LeaderSchedule {
             self.range_validation(new_table, old_table);
         } else {
             tracing::warn!(
-                "Skipping commit range validation: old range {old_commit_range:?} does not span one rotation interval ({}), new range {:?}",
+                "Skipping commit range validation: old range {old_commit_range:?} does not \
+                 span one rotation interval ({}), new range {:?}",
                 self.num_commits_per_schedule,
                 new_table.reputation_scores.commit_range,
             );

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -125,7 +125,7 @@ impl LeaderSchedule {
         // A recovered backlog exceeding the window therefore indicates a store
         // written by different code or modified externally. It is not treated
         // as fatal: returning 0 forces an immediate schedule update, which
-        // replays the backlog window by window.
+        // rebuilds the schedule from the backlog's last full window.
         if subdag_count > self.num_commits_per_schedule {
             tracing::warn!(
                 "Recovered scoring backlog ({subdag_count} subdags) exceeds the schedule \
@@ -360,46 +360,43 @@ impl LeaderSchedule {
     /// never produces, tolerated in case the store was written by different
     /// code or modified externally.
     ///
-    /// The backlog is replayed window by window from the store, so every
-    /// rebuilt swap table matches the one a continuously running node computed
-    /// over the same commits, and rotations stay on the same commit boundaries.
-    /// The trailing partial window becomes the live scoring subdag.
+    /// Only the last full window of the backlog is scored: it alone determines
+    /// the swap table a continuously running node had at that point, and
+    /// rotations stay on the same commit boundaries. The trailing partial
+    /// window becomes the live scoring subdag.
     fn update_leader_schedule_from_backlog(&self, dag_state_write_lock: &mut DagState) {
         let backlog_range = dag_state_write_lock.scoring_subdag_commit_range();
         let window_size = self.num_commits_per_schedule;
+        // The caller only routes here when the backlog exceeds one window, so
+        // there is at least one full window.
         let full_windows = backlog_range.size() as u32 / window_size;
+        let window_start = backlog_range.start() + (full_windows - 1) * window_size;
+        let window_end = window_start + (window_size - 1);
 
         tracing::info!(
-            "Replaying recovered scoring backlog {backlog_range:?} as {full_windows} full \
-             window(s) of {window_size} commits"
+            "Rebuilding leader schedule from the last full window \
+             ({window_start}..={window_end}) of the recovered scoring backlog {backlog_range:?}"
         );
 
         dag_state_write_lock.clear_scoring_subdag();
 
-        let mut last_window_scores = None;
-        for window in 0..full_windows {
-            let window_start = backlog_range.start() + window * window_size;
-            let window_end = window_start + (window_size - 1);
-            let mut scoring_subdag = ScoringSubdag::new(self.context.clone());
-            scoring_subdag.add_subdags(
-                dag_state_write_lock
-                    .load_scoring_subdags_from_store((window_start..=window_end).into()),
-            );
-            let reputation_scores = scoring_subdag.calculate_distributed_vote_scores();
-            let table =
-                LeaderSwapTable::new(self.context.clone(), window_end, reputation_scores.clone());
-            self.range_validation_or_skip(&table, &self.leader_swap_table.read());
-            self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
-            last_window_scores = Some(reputation_scores);
-        }
+        let mut scoring_subdag = ScoringSubdag::new(self.context.clone());
+        scoring_subdag.add_subdags(
+            dag_state_write_lock
+                .load_scoring_subdags_from_store((window_start..=window_end).into()),
+        );
+        let reputation_scores = scoring_subdag.calculate_distributed_vote_scores();
+        // The window is interval-wide and lands on the rotation boundaries by
+        // construction, so the steady-state range validation is not repeated.
+        let table =
+            LeaderSwapTable::new(self.context.clone(), window_end, reputation_scores.clone());
+        self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
 
         // Recovery resumes from the end of the last persisted commit range, so
-        // only the last completed window's scores need to be persisted.
-        let reputation_scores = last_window_scores
-            .expect("a backlog larger than one window contains at least one full window");
+        // these are the only scores that need to be persisted.
         dag_state_write_lock.add_commit_info(reputation_scores);
 
-        let remainder_start = backlog_range.start() + full_windows * window_size;
+        let remainder_start = window_end + 1;
         if remainder_start <= backlog_range.end() {
             let remainder_subdags = dag_state_write_lock
                 .load_scoring_subdags_from_store((remainder_start..=backlog_range.end()).into());
@@ -1237,9 +1234,9 @@ mod tests {
     }
 
     // Recovers a schedule from a store whose last CommitInfo lags the last
-    // commit by more than one rotation interval, and checks that the backlog
-    // is replayed window by window onto the same rotation boundaries a
-    // continuously running node used.
+    // commit by more than one rotation interval, and checks that the schedule
+    // is rebuilt onto the same rotation boundaries a continuously running
+    // node used.
     async fn run_update_after_recovery_backlog(restart: bool) {
         telemetry_subscribers::init_for_testing();
         let mut context = Context::new_for_test(4).0;
@@ -1300,7 +1297,8 @@ mod tests {
             0
         );
 
-        // The full windows are replayed; the partial window stays live.
+        // The last full window rebuilds the table; the partial window stays
+        // live.
         leader_schedule.update_leader_schedule(&mut dag_state.write());
         {
             let table = leader_schedule.leader_swap_table.read();
@@ -1360,12 +1358,11 @@ mod tests {
         run_update_after_recovery_backlog(true).await;
     }
 
-    /// Verifies that replaying an oversized recovered backlog window by window
-    /// produces the exact same per-window `ReputationScores` (and therefore the
-    /// same `LeaderSwapTable`) as a node that never crashed and updated its
-    /// schedule incrementally over the same commits.
+    /// Verifies that rebuilding the schedule from an oversized recovered
+    /// backlog produces the exact same `LeaderSwapTable` as a node that never
+    /// crashed and updated its schedule incrementally over the same commits.
     #[tokio::test]
-    async fn test_update_leader_schedule_from_backlog_matches_live_schedule_per_window() {
+    async fn test_update_leader_schedule_from_backlog_matches_live_schedule() {
         telemetry_subscribers::init_for_testing();
         let mut context = Context::new_for_test(4).0;
         context
@@ -1387,25 +1384,14 @@ mod tests {
         )));
         let leader_schedule_live = LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
             .with_num_commits_per_schedule(5);
-        let mut live_scores_window_1 = None;
         for (index, (sub_dag, commit)) in sub_dags_and_commits.iter().enumerate() {
             let mut dag_state_write = dag_state_live.write();
             dag_state_write.set_last_commit(commit.clone());
             dag_state_write.add_scoring_subdags(vec![sub_dag.base.clone()]);
             if (index + 1) % 5 == 0 {
                 leader_schedule_live.update_leader_schedule(&mut dag_state_write);
-                if index + 1 == 5 {
-                    live_scores_window_1 = Some(
-                        leader_schedule_live
-                            .leader_swap_table
-                            .read()
-                            .reputation_scores
-                            .clone(),
-                    );
-                }
             }
         }
-        let live_scores_window_1 = live_scores_window_1.expect("window 1 update should have run");
         let live_table_window_2 = leader_schedule_live.leader_swap_table.read().clone();
 
         // Recovered scenario: the same 10 commits are persisted with no
@@ -1430,95 +1416,18 @@ mod tests {
         assert_eq!(dag_state_recovered.read().scoring_subdags_count(), 10);
 
         let leader_schedule_recovered =
-            LeaderSchedule::from_store(context.clone(), dag_state_recovered.clone())
+            LeaderSchedule::from_store(context, dag_state_recovered.clone())
                 .with_num_commits_per_schedule(5);
         leader_schedule_recovered.update_leader_schedule(&mut dag_state_recovered.write());
         let recovered_table = leader_schedule_recovered.leader_swap_table.read().clone();
 
-        // The final table produced by the backlog replay (window 2) must match
-        // the live node's window-2 table exactly.
+        // The table rebuilt from the backlog (last full window) must match the
+        // live node's window-2 table exactly.
         assert_eq!(
             recovered_table.reputation_scores,
             live_table_window_2.reputation_scores
         );
         assert_eq!(recovered_table.good_nodes, live_table_window_2.good_nodes);
         assert_eq!(recovered_table.bad_nodes, live_table_window_2.bad_nodes);
-
-        // Per-window check: recompute window 1's scores the same way the
-        // replay does internally (batch-load the window's commits into a fresh
-        // ScoringSubdag) and confirm they match what the live node computed
-        // incrementally for that same window.
-        let window_1_subdags = dag_state_recovered
-            .read()
-            .load_scoring_subdags_from_store((1..=5).into());
-        let mut window_1_scoring_subdag = ScoringSubdag::new(context);
-        window_1_scoring_subdag.add_subdags(window_1_subdags);
-        let window_1_scores = window_1_scoring_subdag.calculate_distributed_vote_scores();
-        assert_eq!(window_1_scores, live_scores_window_1);
-    }
-
-    // A recovered CommitInfo may span a different number of commits than the
-    // current `commits_per_schedule`. The first replayed window then can't
-    // match the old range's size: it must be applied with a warning instead of
-    // a panic, and subsequent windows validate strictly again.
-    #[tokio::test]
-    async fn test_update_leader_schedule_backlog_after_commits_per_schedule_change() {
-        telemetry_subscribers::init_for_testing();
-        let mut context = Context::new_for_test(4).0;
-        context
-            .protocol_config
-            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-
-        // CommitInfo covers (1..=2) — a two-commit interval — while the
-        // schedule now rotates every three commits. The backlog (3..=8)
-        // replays as windows (3..=5) and (6..=8) with no remainder.
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder.layers(1..=8).build();
-        let first_window = dag_builder.get_sub_dag_and_commits(1..=2);
-        let committed_rounds = dag_builder.last_committed_rounds.clone();
-        let rest = dag_builder.get_sub_dag_and_commits(3..=8);
-
-        let mut headers_to_write = vec![];
-        let mut commits_to_write = vec![];
-        for (sub_dag, commit) in first_window.iter().chain(rest.iter()) {
-            headers_to_write.extend(sub_dag.headers.iter().cloned());
-            commits_to_write.push(commit.clone());
-        }
-        let commit_info = CommitInfo {
-            reputation_scores: ReputationScores::new((1..=2).into(), vec![1, 2, 4, 3]),
-            committed_rounds,
-        };
-        let commit_ref = first_window.last().unwrap().1.reference();
-        store
-            .write(
-                WriteBatch::default()
-                    .commit_info(vec![(commit_ref, commit_info)])
-                    .block_headers(headers_to_write)
-                    .commits(commits_to_write),
-            )
-            .unwrap();
-
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        assert_eq!(dag_state.read().scoring_subdags_count(), 6);
-
-        let leader_schedule =
-            LeaderSchedule::from_store(context, dag_state.clone()).with_num_commits_per_schedule(3);
-        assert_eq!(
-            leader_schedule.commits_until_leader_schedule_update(dag_state.clone()),
-            0
-        );
-
-        leader_schedule.update_leader_schedule(&mut dag_state.write());
-        assert_eq!(
-            leader_schedule
-                .leader_swap_table
-                .read()
-                .reputation_scores
-                .commit_range,
-            (6..=8).into()
-        );
-        assert_eq!(dag_state.read().scoring_subdags_count(), 0);
     }
 }

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -279,7 +279,7 @@ impl LeaderSchedule {
         );
         self.persist_scores(dag_state_write_lock, reputation_scores);
         {
-            self.range_validation_or_skip(&table, &self.leader_swap_table.read());
+            self.range_validation(&table, &self.leader_swap_table.read());
             self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
         }
     }
@@ -401,26 +401,6 @@ impl LeaderSchedule {
             let remainder_subdags = dag_state_write_lock
                 .load_scoring_subdags_from_store((remainder_start..=backlog_range.end()).into());
             dag_state_write_lock.add_scoring_subdags(remainder_subdags);
-        }
-    }
-
-    /// Runs `range_validation` unless the old table's commit range doesn't
-    /// span one rotation interval — possible when the recovered state was
-    /// persisted under a different `commits_per_schedule` — in which case the
-    /// mismatch is expected: warn and apply the new table unvalidated.
-    fn range_validation_or_skip(&self, new_table: &LeaderSwapTable, old_table: &LeaderSwapTable) {
-        let old_commit_range = &old_table.reputation_scores.commit_range;
-        if *old_commit_range == CommitRange::default()
-            || old_commit_range.size() == self.num_commits_per_schedule as usize
-        {
-            self.range_validation(new_table, old_table);
-        } else {
-            tracing::warn!(
-                "Skipping commit range validation: old range {old_commit_range:?} does not \
-                 span one rotation interval ({}), new range {:?}",
-                self.num_commits_per_schedule,
-                new_table.reputation_scores.commit_range,
-            );
         }
     }
 


### PR DESCRIPTION
# Description of change

`range_validation` asserts that each new swap table covers exactly the window after the previous one. A recovered scoring backlog spanning more than one schedule window would violate that: `update_leader_schedule` would build one oversized table and panic — and since the state is persisted, every restart would panic again.

Current code cannot produce such a backlog: every writer flushes `CommitInfo` in the same write batch as the commits it covers, so recovery never finds more than one window unscored (the invariant is now documented at the detection branch). Still, the state is recoverable, so should it ever occur, recovering is preferred over panicking.

The rebuild uses the backlog's last full window, which alone determines the swap table a continuously running node had, on the same rotation boundaries; the partial tail stays as the live scoring subdag. `range_validation` and the normal update path are unchanged. The sliding-window path on the unmerged feature branch needs its own treatment.

Supersedes #12246 with a simpler rebuild and restart regression coverage.

## Links to any relevant issues

Relates to iotaledger/iota-private#459 (not closed by this PR): classic-path half only.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
