### PR TITLE
fix(iota-core, iota-types): read coin deny list epoch-gated in pcool post-consensus validation

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -962,7 +962,22 @@ impl AuthorityState {
     /// before the current epoch, which is deterministic across validators
     /// regardless of each validator's execution progress - required
     /// post-consensus, where the verdict decides whether the transaction
-    /// stays in the committed set.
+    /// stays in the committed set. The two read modes intentionally disagree
+    /// about deny-list changes made in the current epoch, in both directions:
+    /// - An entry added this epoch is enforced at admission right away, while
+    ///   the epoch-gated layers enforce it only from the next epoch. Since
+    ///   execution and post-consensus must read epoch-gated to stay
+    ///   deterministic, admission is the only layer that can react to a new
+    ///   denial or global pause before the epoch boundary.
+    /// - An entry removed this epoch is admitted right away but still denied by
+    ///   the epoch-gated post-consensus read, so such transactions are
+    ///   sequenced by consensus and then deterministically dropped (no
+    ///   execution, no gas charged) until the removal settles at the next epoch
+    ///   boundary. The wasted consensus slot is accepted: post-consensus must
+    ///   handle deterministic drops regardless (owned-object double-spend
+    ///   losers, for example), and validators that skip admission can put such
+    ///   transactions into their blocks anyway, so no admission policy can
+    ///   limit how many deterministically-dropped transactions reach consensus.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
     pub(crate) async fn handle_transaction_validation_checks(
         &self,
@@ -1157,7 +1172,9 @@ impl AuthorityState {
                 &transaction,
                 epoch_store,
                 // Latest-value coin deny-list read: admission is validator-local,
-                // and denials should take effect immediately.
+                // and denials should take effect immediately. Unlike the P-COOL
+                // submission path, no post-consensus re-check follows - this is
+                // the only sender-side coin deny check in the certificate flow.
                 false,
             )
             .await?;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -955,11 +955,20 @@ impl AuthorityState {
     /// Runs deny list, input object validation, gas checks, coin deny list, and
     /// MoveAuthenticator checks. Returns the owned object refs for optional
     /// version validation. Does NOT acquire locks or sign the transaction.
+    ///
+    /// `epoch_gated_coin_deny_list` selects how the coin deny list is read:
+    /// `false` reads the latest value, so denials apply immediately - for
+    /// validator-local admission (signing); `true` reads the value settled
+    /// before the current epoch, which is deterministic across validators
+    /// regardless of each validator's execution progress - required
+    /// post-consensus, where the verdict decides whether the transaction
+    /// stays in the committed set.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
     pub(crate) async fn handle_transaction_validation_checks(
         &self,
         transaction: &VerifiedTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        epoch_gated_coin_deny_list: bool,
     ) -> IotaResult<Vec<ObjectReference>> {
         let protocol_config = epoch_store.protocol_config();
         let reference_gas_price = epoch_store.reference_gas_price();
@@ -1021,6 +1030,7 @@ impl AuthorityState {
             &tx_receiving_objects,
             &per_authenticator_checked_input_objects,
             &self.get_object_store(),
+            epoch_gated_coin_deny_list.then_some(epoch),
         )?;
 
         let (kind, signer, gas_data) = tx_data.execution_parts();
@@ -1143,7 +1153,13 @@ impl AuthorityState {
         let _execution_lock = self.execution_lock_for_signing()?;
 
         let owned_objects = self
-            .handle_transaction_validation_checks(&transaction, epoch_store)
+            .handle_transaction_validation_checks(
+                &transaction,
+                epoch_store,
+                // Latest-value coin deny-list read: admission is validator-local,
+                // and denials should take effect immediately.
+                false,
+            )
             .await?;
 
         let epoch = epoch_store.epoch();

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -221,7 +221,13 @@ impl ValidatorService {
 
         // Content validation: deny checks + owned object version validation.
         let owned_objects = match state
-            .handle_transaction_validation_checks(&verified_tx, epoch_store)
+            .handle_transaction_validation_checks(
+                &verified_tx,
+                epoch_store,
+                // Latest-value coin deny-list read: admission is validator-local,
+                // and denials should take effect immediately.
+                false,
+            )
             .await
         {
             Ok(objs) => objs,

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -225,7 +225,9 @@ impl ValidatorService {
                 &verified_tx,
                 epoch_store,
                 // Latest-value coin deny-list read: admission is validator-local,
-                // and denials should take effect immediately.
+                // and denials should take effect immediately. This deliberately
+                // differs from the epoch-gated post-consensus read; see the
+                // read-mode notes on `handle_transaction_validation_checks`.
                 false,
             )
             .await

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -262,7 +262,14 @@ pub async fn validate_and_resolve_conflicts(
         // diverging from other honest validators.
         let verified_tx = VerifiedTransaction::new_from_verified((*transaction).clone());
         if let Err(e) = authority_state
-            .handle_transaction_validation_checks(&verified_tx, epoch_store)
+            .handle_transaction_validation_checks(
+                &verified_tx,
+                epoch_store,
+                // Epoch-gated coin deny-list read: the verdict here decides whether
+                // the transaction stays in the committed set, so it must not depend
+                // on this validator's execution progress.
+                true,
+            )
             .await
         {
             if e.is_storage_or_epoch_error() {

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
-    Address, Identifier, ObjectId, ObjectReference, SharedObjectReference, StructTag, TypeTag,
+    Address, Identifier, ObjectId, ObjectReference, SharedObjectReference, StructTag,
+    TransactionDigest, TypeTag, Version,
 };
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
@@ -17,21 +18,21 @@ use iota_types::{
         get_per_type_coin_deny_list_v1,
     },
     effects::{TransactionEffects, TransactionEffectsAPI},
-    error::{IotaError, UserInputError},
+    error::{IotaError, IotaResult, UserInputError},
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     object::Object,
-    transaction::{CallArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH, VerifiedTransaction},
+    transaction::{CallArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH, Transaction, VerifiedTransaction},
 };
 
 use crate::{
     authority::{
-        AuthorityState, authority_tests::send_and_confirm_transaction_,
+        AuthorityState, authority_test_utils::send_and_confirm_transaction_with_execution_error,
+        authority_tests::send_and_confirm_transaction_,
         move_integration_tests::build_and_try_publish_test_package,
         test_authority_builder::TestAuthorityBuilder,
     },
     consensus_handler::VerifiedSequencedConsensusTransaction,
     post_consensus_validation,
-    test_utils::make_transfer_object_transaction,
 };
 
 // Test that a v1 regulated coin can be created and all the necessary objects
@@ -237,103 +238,103 @@ async fn test_regulated_coin_v1_types() {
 // authority) model those two execution frontiers.
 #[tokio::test]
 async fn test_coin_deny_list_read_modes_across_execution_progress() {
-    let env = new_authority_and_publish("coin_deny_list_v1_mintable").await;
-    let epoch_store = env.authority.epoch_store_for_testing();
-    assert_eq!(epoch_store.epoch(), 0);
-    let rgp = env.authority.reference_gas_price_for_testing().unwrap();
-
-    let (package_id, deny_cap_ref, coin_id) = find_published_objects(&env);
-    let regulated_coin_type = TypeTag::Struct(Box::new(StructTag::new(
-        package_id,
-        Identifier::from_static("regulated_coin"),
-        Identifier::from_static("REGULATED_COIN"),
-        vec![],
-    )));
-
-    // Give the transfer its own gas object so the deny-add below (which
-    // consumes the publisher's gas) does not invalidate the transfer's input
-    // references.
-    let transfer_gas_object = Object::with_owner_for_testing(env.sender);
-    env.authority
-        .insert_genesis_object(transfer_gas_object.clone());
-
-    let transfer_tx = VerifiedTransaction::new_unchecked(
-        TestTransactionBuilder::new(env.sender, transfer_gas_object.object_ref(), rgp)
-            .transfer(env.get_latest_object_ref(&coin_id).await, dbg_addr(2))
-            .build_and_sign(&env.keypair),
-    );
+    let env = RegulatedCoinEnv::new().await;
+    assert_eq!(env.epoch(), 0);
+    let transfer_tx = env.build_transfer().await;
 
     // Frontier 1 - the deny-add has not executed: no deny list config exists
     // for the coin type, both read modes pass the transaction.
     for epoch_gated in [false, true] {
-        env.authority
-            .handle_transaction_validation_checks(&transfer_tx, &epoch_store, epoch_gated)
+        env.validation_check(&transfer_tx, epoch_gated)
             .await
             .expect("no deny list entry executed yet");
     }
     assert!(
         get_per_type_coin_deny_list_v1(
-            &regulated_coin_type.to_canonical_string(false),
-            &env.authority.get_object_store(),
+            &env.regulated_coin_type.to_canonical_string(false),
+            &env.env.authority.get_object_store(),
         )
         .is_none()
     );
 
     // Execute `deny_list_v1_add(sender)` in the same epoch.
-    let deny_list_object_init_version = env
-        .get_latest_object_ref(&ObjectId::DENY_LIST)
-        .await
-        .version;
-    let deny_tx = TestTransactionBuilder::new(
-        env.sender,
-        env.get_latest_object_ref(&env.gas_object_id).await,
-        rgp,
-    )
-    .move_call(
-        ObjectId::FRAMEWORK,
-        "coin",
-        "deny_list_v1_add",
-        vec![
-            CallArg::Shared(SharedObjectReference::new(
-                ObjectId::DENY_LIST,
-                deny_list_object_init_version,
-                true,
-            )),
-            CallArg::ImmutableOrOwned(deny_cap_ref),
-            CallArg::pure(&env.sender),
-        ],
-    )
-    .with_type_args(vec![regulated_coin_type.clone()])
-    .build_and_sign(&env.keypair);
-    let (_, effects) = send_and_confirm_transaction_(&env.authority, None, deny_tx, true)
-        .await
-        .unwrap();
-    assert!(!effects.status().is_failure(), "{:?}", effects.status());
+    env.deny_sender().await;
 
     // Frontier 2, latest-value read - the very same transaction is now
     // rejected within the same epoch: the verdict followed the local
     // execution frontier.
-    let err = env
-        .authority
-        .handle_transaction_validation_checks(&transfer_tx, &epoch_store, false)
-        .await
-        .unwrap_err();
+    let err = env.validation_check(&transfer_tx, false).await.unwrap_err();
     assert!(
         matches!(
             &err,
             IotaError::UserInput {
                 error: UserInputError::AddressDeniedForCoin { address, .. }
-            } if *address == env.sender
+            } if *address == env.env.sender
         ),
         "unexpected error: {err:?}"
     );
 
     // Frontier 2, epoch-gated read - same verdict as frontier 1: the entry
     // written this epoch is not active yet, execution progress is irrelevant.
-    env.authority
-        .handle_transaction_validation_checks(&transfer_tx, &epoch_store, true)
+    env.validation_check(&transfer_tx, true)
         .await
         .expect("entry written this epoch must not be active for the epoch-gated read");
+}
+
+// Relaxation mirror of the test above: a denial settled in a previous epoch
+// is lifted in the current one. The latest-value read honors the removal
+// immediately, while the epoch-gated read still denies until the removal
+// settles at the next epoch boundary - the window in which admission accepts
+// transactions that post-consensus deterministically drops.
+#[tokio::test]
+async fn test_coin_deny_list_read_modes_after_denial_relaxed() {
+    let env = RegulatedCoinEnv::new().await;
+    env.deny_sender().await;
+
+    // Settle the denial: entries written in epoch 0 activate in epoch 1.
+    env.reconfigure().await;
+    assert_eq!(env.epoch(), 1);
+
+    let transfer_tx = env.build_transfer().await;
+
+    // Frontier 1 - the removal has not executed: the denial is settled, both
+    // read modes reject the transaction.
+    for epoch_gated in [false, true] {
+        let err = env
+            .validation_check(&transfer_tx, epoch_gated)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                IotaError::UserInput {
+                    error: UserInputError::AddressDeniedForCoin { .. }
+                }
+            ),
+            "a settled denial must be enforced by both read modes, got {err:?}"
+        );
+    }
+
+    // Execute `deny_list_v1_remove(sender)` in the same epoch.
+    env.undeny_sender().await;
+
+    // Frontier 2, latest-value read - the removal applies immediately.
+    env.validation_check(&transfer_tx, false)
+        .await
+        .expect("a removal must apply immediately for the latest-value read");
+
+    // Frontier 2, epoch-gated read - the removal is not settled yet, the
+    // denial still holds until the next epoch boundary.
+    let err = env.validation_check(&transfer_tx, true).await.unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            IotaError::UserInput {
+                error: UserInputError::AddressDeniedForCoin { .. }
+            }
+        ),
+        "a removal written this epoch must not be active for the epoch-gated read, got {err:?}"
+    );
 }
 
 // Runs the real post-consensus validation pipeline over a `UserTransactionV1`
@@ -352,99 +353,272 @@ async fn test_post_consensus_keeps_tx_spending_coin_paused_this_epoch() {
         config
     });
 
-    let env = new_authority_and_publish("coin_deny_list_v1_mintable").await;
-    let rgp = env.authority.reference_gas_price_for_testing().unwrap();
-
-    let (package_id, deny_cap_ref, coin_id) = find_published_objects(&env);
-    let regulated_coin_type = TypeTag::Struct(Box::new(StructTag::new(
-        package_id,
-        Identifier::from_static("regulated_coin"),
-        Identifier::from_static("REGULATED_COIN"),
-        vec![],
-    )));
+    let env = RegulatedCoinEnv::new().await;
 
     // Globally pause the regulated coin; executes in the current epoch.
-    let deny_list_object_init_version = env
-        .get_latest_object_ref(&ObjectId::DENY_LIST)
-        .await
-        .version;
-    let pause_tx = TestTransactionBuilder::new(
-        env.sender,
-        env.get_latest_object_ref(&env.gas_object_id).await,
-        rgp,
-    )
-    .move_call(
-        ObjectId::FRAMEWORK,
-        "coin",
-        "deny_list_v1_enable_global_pause",
-        vec![
-            CallArg::Shared(SharedObjectReference::new(
-                ObjectId::DENY_LIST,
-                deny_list_object_init_version,
-                true,
-            )),
-            CallArg::ImmutableOrOwned(deny_cap_ref),
-        ],
-    )
-    .with_type_args(vec![regulated_coin_type.clone()])
-    .build_and_sign(&env.keypair);
-    let (_, effects) = send_and_confirm_transaction_(&env.authority, None, pause_tx, true)
-        .await
-        .unwrap();
-    assert!(!effects.status().is_failure(), "{:?}", effects.status());
+    env.pause().await;
 
     // A transaction spending the paused coin, sequenced as `UserTransactionV1`.
-    let transfer_tx = make_transfer_object_transaction(
-        env.get_latest_object_ref(&coin_id).await,
-        env.get_latest_object_ref(&env.gas_object_id).await,
-        env.sender,
-        &env.keypair,
-        dbg_addr(9),
-        rgp,
-    );
-    let digest = *transfer_tx.digest();
-    let consensus_tx = ConsensusTransaction {
-        kind: ConsensusTransactionKind::UserTransactionV1(Box::new(transfer_tx)),
-        tracking_id: Default::default(),
-    };
-    let mut transactions = vec![VerifiedSequencedConsensusTransaction::new_test(
-        consensus_tx,
-    )];
+    let transfer_tx = env.build_transfer().await;
+    let (dropped, kept) = env.post_consensus_validate(transfer_tx).await;
+    assert!(dropped.is_empty(), "unexpected drops: {dropped:?}");
+    assert!(kept);
+}
 
-    let epoch_store = env.authority.epoch_store_for_testing();
-    let (dropped, _locks, user_tx_digests) =
-        post_consensus_validation::validate_and_resolve_conflicts(
-            &env.authority,
-            &epoch_store,
-            &mut transactions,
+// The admitted-then-dropped window end-to-end: a pause settled at the epoch
+// boundary is lifted mid-epoch. Admission (latest-value read) honors the
+// lifted pause immediately, while the epoch-gated post-consensus read still
+// sees the settled pause, so the admitted transaction is deterministically
+// dropped until the removal settles at the next epoch boundary.
+#[tokio::test]
+async fn test_post_consensus_drops_tx_spending_coin_unpaused_this_epoch() {
+    let guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let env = RegulatedCoinEnv::new().await;
+    env.pause().await;
+
+    // `reconfigure_for_testing` applies its own config override (carrying the
+    // current epoch store's config, including the flag set above, into the
+    // next epoch) and panics if another override is still installed.
+    drop(guard);
+
+    // Settle the pause: entries written in epoch 0 activate in epoch 1.
+    env.reconfigure().await;
+    assert_eq!(env.epoch(), 1);
+
+    // Lift the pause; executes in epoch 1, settles at epoch 2.
+    env.unpause().await;
+
+    let transfer_tx = env.build_transfer().await;
+
+    // Admission honors the lifted pause immediately.
+    env.validation_check(&transfer_tx, false)
+        .await
+        .expect("a lifted pause must apply immediately at admission");
+
+    // Post-consensus still sees the settled pause and drops.
+    let (dropped, kept) = env.post_consensus_validate(transfer_tx).await;
+    assert!(!kept);
+    assert_eq!(dropped.len(), 1);
+    assert!(
+        matches!(
+            &dropped[0].1,
+            IotaError::UserInput {
+                error: UserInputError::CoinTypeGlobalPause { .. }
+            }
+        ),
+        "unexpected drop reason: {:?}",
+        dropped[0].1
+    );
+}
+
+/// A published `coin_deny_list_v1_mintable` package - the regulated coin
+/// type, its deny cap, and one minted coin - with helpers for the deny-list
+/// operations the tests exercise.
+struct RegulatedCoinEnv {
+    env: TestEnv,
+    regulated_coin_type: TypeTag,
+    deny_cap_id: ObjectId,
+    coin_id: ObjectId,
+    /// Captured before any deny-list mutation: `CallArg::Shared` needs the
+    /// initial shared version, which later mutations do not change.
+    deny_list_initial_version: Version,
+}
+
+impl RegulatedCoinEnv {
+    async fn new() -> Self {
+        let env = new_authority_and_publish("coin_deny_list_v1_mintable").await;
+        let mut package_id = None;
+        let mut deny_cap_id = None;
+        let mut coin_id = None;
+
+        for (oref, _owner) in env.publish_effects.created() {
+            let object = env.authority.get_object(&oref.object_id).unwrap();
+            if object.is_package() {
+                package_id = Some(object.id());
+                continue;
+            }
+            if object.type_().unwrap().is_deny_cap_v1() {
+                deny_cap_id = Some(object.id());
+            } else if !object.is_gas_coin() && object.coin_type_opt().is_some() {
+                coin_id = Some(object.id());
+            }
+        }
+
+        let regulated_coin_type = TypeTag::Struct(Box::new(StructTag::new(
+            package_id.expect("package must be created"),
+            Identifier::from_static("regulated_coin"),
+            Identifier::from_static("REGULATED_COIN"),
+            vec![],
+        )));
+        let deny_list_initial_version = env
+            .get_latest_object_ref(&ObjectId::DENY_LIST)
+            .await
+            .version;
+
+        Self {
+            env,
+            regulated_coin_type,
+            deny_cap_id: deny_cap_id.expect("deny cap must be created"),
+            coin_id: coin_id.expect("minted regulated coin must be created"),
+            deny_list_initial_version,
+        }
+    }
+
+    fn rgp(&self) -> u64 {
+        self.env
+            .authority
+            .reference_gas_price_for_testing()
+            .unwrap()
+    }
+
+    fn epoch(&self) -> u64 {
+        self.env.authority.epoch_store_for_testing().epoch()
+    }
+
+    async fn reconfigure(&self) {
+        self.env.authority.reconfigure_for_testing().await;
+    }
+
+    /// Executes a `0x2::coin` deny-list function over the regulated coin
+    /// type; `deny_list_v1_add`/`deny_list_v1_remove` take a target address,
+    /// the global pause functions take none.
+    async fn call_deny_list(&self, function: &'static str, address: Option<Address>) {
+        let mut args = vec![
+            CallArg::Shared(SharedObjectReference::new(
+                ObjectId::DENY_LIST,
+                self.deny_list_initial_version,
+                true,
+            )),
+            // Re-fetched every call: the cap's version bumps on each one.
+            CallArg::ImmutableOrOwned(self.env.get_latest_object_ref(&self.deny_cap_id).await),
+        ];
+
+        if let Some(address) = address {
+            args.push(CallArg::pure(&address));
+        }
+
+        let tx = TestTransactionBuilder::new(
+            self.env.sender,
+            self.env
+                .get_latest_object_ref(&self.env.gas_object_id)
+                .await,
+            self.rgp(),
+        )
+        .move_call(ObjectId::FRAMEWORK, "coin", function, args)
+        .with_type_args(vec![self.regulated_coin_type.clone()])
+        .build_and_sign(&self.env.keypair);
+
+        // `fake_consensus = false`: assign the shared-object version directly
+        // instead of going through the consensus commit handler, which
+        // requires a randomness manager - the epoch store created by
+        // `reconfigure_for_testing` has none.
+        let (_, effects, _) = send_and_confirm_transaction_with_execution_error(
+            &self.env.authority,
+            None,
+            tx,
+            true,
+            false,
         )
         .await
         .unwrap();
 
-    assert!(dropped.is_empty(), "unexpected drops: {dropped:?}");
-    assert_eq!(transactions.len(), 1);
-    assert_eq!(user_tx_digests, vec![digest]);
-}
-
-/// Returns the package id, deny cap reference, and minted regulated coin id
-/// created by publishing `coin_deny_list_v1_mintable`.
-fn find_published_objects(env: &TestEnv) -> (ObjectId, ObjectReference, ObjectId) {
-    let mut package_id = None;
-    let mut deny_cap_ref = None;
-    let mut coin_id = None;
-    for (oref, _owner) in env.publish_effects.created() {
-        let object = env.authority.get_object(&oref.object_id).unwrap();
-        if object.is_package() {
-            package_id = Some(object.id());
-            continue;
-        }
-        if object.type_().unwrap().is_deny_cap_v1() {
-            deny_cap_ref = Some(object.object_ref());
-        } else if !object.is_gas_coin() && object.coin_type_opt().is_some() {
-            coin_id = Some(object.id());
-        }
+        assert!(
+            !effects.status().is_failure(),
+            "{function}: {:?}",
+            effects.status()
+        );
     }
-    (package_id.unwrap(), deny_cap_ref.unwrap(), coin_id.unwrap())
+
+    async fn deny_sender(&self) {
+        self.call_deny_list("deny_list_v1_add", Some(self.env.sender))
+            .await;
+    }
+
+    async fn undeny_sender(&self) {
+        self.call_deny_list("deny_list_v1_remove", Some(self.env.sender))
+            .await;
+    }
+
+    async fn pause(&self) {
+        self.call_deny_list("deny_list_v1_enable_global_pause", None)
+            .await;
+    }
+
+    async fn unpause(&self) {
+        self.call_deny_list("deny_list_v1_disable_global_pause", None)
+            .await;
+    }
+
+    /// A transfer of the regulated coin with its own freshly inserted gas
+    /// object, so the deny-list calls above (which spend the publisher's gas)
+    /// never invalidate its input references.
+    async fn build_transfer(&self) -> Transaction {
+        let gas_object = Object::with_owner_for_testing(self.env.sender);
+        self.env.authority.insert_genesis_object(gas_object.clone());
+
+        TestTransactionBuilder::new(self.env.sender, gas_object.object_ref(), self.rgp())
+            .transfer(
+                self.env.get_latest_object_ref(&self.coin_id).await,
+                dbg_addr(2),
+            )
+            .build_and_sign(&self.env.keypair)
+    }
+
+    /// Runs `handle_transaction_validation_checks` with the given coin
+    /// deny-list read mode. The epoch store is fetched per call, so the check
+    /// follows epoch changes made through [`Self::reconfigure`].
+    async fn validation_check(
+        &self,
+        transaction: &Transaction,
+        epoch_gated_coin_deny_list: bool,
+    ) -> IotaResult<Vec<ObjectReference>> {
+        let epoch_store = self.env.authority.epoch_store_for_testing();
+
+        self.env
+            .authority
+            .handle_transaction_validation_checks(
+                &VerifiedTransaction::new_unchecked(transaction.clone()),
+                &epoch_store,
+                epoch_gated_coin_deny_list,
+            )
+            .await
+    }
+
+    /// Runs post-consensus validation over the transaction sequenced as a
+    /// `UserTransactionV1`. Returns the drop list and whether the transaction
+    /// was kept in the sequence.
+    async fn post_consensus_validate(
+        &self,
+        transaction: Transaction,
+    ) -> (Vec<(TransactionDigest, IotaError)>, bool) {
+        let digest = *transaction.digest();
+        let consensus_tx = ConsensusTransaction {
+            kind: ConsensusTransactionKind::UserTransactionV1(Box::new(transaction)),
+            tracking_id: Default::default(),
+        };
+
+        let mut transactions = vec![VerifiedSequencedConsensusTransaction::new_test(
+            consensus_tx,
+        )];
+
+        let epoch_store = self.env.authority.epoch_store_for_testing();
+        let (dropped, _locks, user_tx_digests) =
+            post_consensus_validation::validate_and_resolve_conflicts(
+                &self.env.authority,
+                &epoch_store,
+                &mut transactions,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(user_tx_digests, vec![digest]);
+
+        (dropped, transactions.len() == 1)
+    }
 }
 
 struct TestEnv {

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -22,8 +22,6 @@ use iota_types::{
     object::Object,
     transaction::{CallArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH, VerifiedTransaction},
 };
-use prometheus_filtered::Registry;
-use typed_store::DBMetrics;
 
 use crate::{
     authority::{
@@ -464,15 +462,6 @@ impl TestEnv {
 }
 
 async fn new_authority_and_publish(path: &str) -> TestEnv {
-    // typed-store's `DBMetrics` registers rocksdb metrics into the global
-    // `default_registry()` on first initialization, and concurrent first-time
-    // initializers race with `AlreadyReg`. Pre-initialize with a throwaway
-    // registry up front: distinct registries can't collide, and once the init
-    // has run the authority build reuses the cached metrics. Without this,
-    // running several authority-building tests from this file concurrently
-    // flakes.
-    let _ = DBMetrics::init(&Registry::new());
-
     let (sender, keypair) = get_account_key_pair();
     let gas_object = Object::with_owner_for_testing(sender);
     let gas_object_id = gas_object.id();

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Address, Identifier, ObjectId, ObjectReference, SharedObjectReference, StructTag, TypeTag,
 };
@@ -16,14 +17,23 @@ use iota_types::{
         get_per_type_coin_deny_list_v1,
     },
     effects::{TransactionEffects, TransactionEffectsAPI},
+    error::{IotaError, UserInputError},
+    messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     object::Object,
-    transaction::{CallArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH},
+    transaction::{CallArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH, VerifiedTransaction},
 };
+use prometheus_filtered::Registry;
+use typed_store::DBMetrics;
 
-use crate::authority::{
-    AuthorityState, authority_tests::send_and_confirm_transaction_,
-    move_integration_tests::build_and_try_publish_test_package,
-    test_authority_builder::TestAuthorityBuilder,
+use crate::{
+    authority::{
+        AuthorityState, authority_tests::send_and_confirm_transaction_,
+        move_integration_tests::build_and_try_publish_test_package,
+        test_authority_builder::TestAuthorityBuilder,
+    },
+    consensus_handler::VerifiedSequencedConsensusTransaction,
+    post_consensus_validation,
+    test_utils::make_transfer_object_transaction,
 };
 
 // Test that a v1 regulated coin can be created and all the necessary objects
@@ -211,6 +221,234 @@ async fn test_regulated_coin_v1_types() {
     ));
 }
 
+// The coin deny-list read mode of `handle_transaction_validation_checks`
+// decides whether its verdict depends on the validator's execution progress.
+//
+// With the latest-value read (`epoch_gated_coin_deny_list = false`), the
+// verdict for one and the same transaction flips within an epoch once the
+// `deny_list_v1_add` transaction executes locally. That is intended for
+// admission at signing (denials apply immediately), but post-consensus it
+// would make two validators - one that has already executed the deny-add and
+// one that has not - reach opposite keep/drop decisions for the same
+// sequenced transaction, diverging the checkpoint. The epoch-gated read
+// (`epoch_gated_coin_deny_list = true`) returns the value settled before the
+// current epoch and is identical at both frontiers, which is why the
+// post-consensus caller uses it.
+//
+// The two calls below (before/after executing the deny-add on a single
+// authority) model those two execution frontiers.
+#[tokio::test]
+async fn test_coin_deny_list_read_modes_across_execution_progress() {
+    let env = new_authority_and_publish("coin_deny_list_v1_mintable").await;
+    let epoch_store = env.authority.epoch_store_for_testing();
+    assert_eq!(epoch_store.epoch(), 0);
+    let rgp = env.authority.reference_gas_price_for_testing().unwrap();
+
+    let (package_id, deny_cap_ref, coin_id) = find_published_objects(&env);
+    let regulated_coin_type = TypeTag::Struct(Box::new(StructTag::new(
+        package_id,
+        Identifier::from_static("regulated_coin"),
+        Identifier::from_static("REGULATED_COIN"),
+        vec![],
+    )));
+
+    // Give the transfer its own gas object so the deny-add below (which
+    // consumes the publisher's gas) does not invalidate the transfer's input
+    // references.
+    let transfer_gas_object = Object::with_owner_for_testing(env.sender);
+    env.authority
+        .insert_genesis_object(transfer_gas_object.clone());
+
+    let transfer_tx = VerifiedTransaction::new_unchecked(
+        TestTransactionBuilder::new(env.sender, transfer_gas_object.object_ref(), rgp)
+            .transfer(env.get_latest_object_ref(&coin_id).await, dbg_addr(2))
+            .build_and_sign(&env.keypair),
+    );
+
+    // Frontier 1 - the deny-add has not executed: no deny list config exists
+    // for the coin type, both read modes pass the transaction.
+    for epoch_gated in [false, true] {
+        env.authority
+            .handle_transaction_validation_checks(&transfer_tx, &epoch_store, epoch_gated)
+            .await
+            .expect("no deny list entry executed yet");
+    }
+    assert!(
+        get_per_type_coin_deny_list_v1(
+            &regulated_coin_type.to_canonical_string(false),
+            &env.authority.get_object_store(),
+        )
+        .is_none()
+    );
+
+    // Execute `deny_list_v1_add(sender)` in the same epoch.
+    let deny_list_object_init_version = env
+        .get_latest_object_ref(&ObjectId::DENY_LIST)
+        .await
+        .version;
+    let deny_tx = TestTransactionBuilder::new(
+        env.sender,
+        env.get_latest_object_ref(&env.gas_object_id).await,
+        rgp,
+    )
+    .move_call(
+        ObjectId::FRAMEWORK,
+        "coin",
+        "deny_list_v1_add",
+        vec![
+            CallArg::Shared(SharedObjectReference::new(
+                ObjectId::DENY_LIST,
+                deny_list_object_init_version,
+                true,
+            )),
+            CallArg::ImmutableOrOwned(deny_cap_ref),
+            CallArg::pure(&env.sender),
+        ],
+    )
+    .with_type_args(vec![regulated_coin_type.clone()])
+    .build_and_sign(&env.keypair);
+    let (_, effects) = send_and_confirm_transaction_(&env.authority, None, deny_tx, true)
+        .await
+        .unwrap();
+    assert!(!effects.status().is_failure(), "{:?}", effects.status());
+
+    // Frontier 2, latest-value read - the very same transaction is now
+    // rejected within the same epoch: the verdict followed the local
+    // execution frontier.
+    let err = env
+        .authority
+        .handle_transaction_validation_checks(&transfer_tx, &epoch_store, false)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            IotaError::UserInput {
+                error: UserInputError::AddressDeniedForCoin { address, .. }
+            } if *address == env.sender
+        ),
+        "unexpected error: {err:?}"
+    );
+
+    // Frontier 2, epoch-gated read - same verdict as frontier 1: the entry
+    // written this epoch is not active yet, execution progress is irrelevant.
+    env.authority
+        .handle_transaction_validation_checks(&transfer_tx, &epoch_store, true)
+        .await
+        .expect("entry written this epoch must not be active for the epoch-gated read");
+}
+
+// Runs the real post-consensus validation pipeline over a `UserTransactionV1`
+// spending a regulated coin whose type was globally paused earlier in the
+// same epoch. The pause has already executed locally, so the latest-value
+// read would report "paused" and drop the transaction - on this validator,
+// but not on one whose execution lags behind the pause. The epoch-gated read
+// used post-consensus keeps it on every validator: the pause activates next
+// epoch. (Recipient-side enforcement at execution,
+// `check_coin_deny_list_v1_during_execution`, has always been epoch-gated
+// the same way.)
+#[tokio::test]
+async fn test_post_consensus_keeps_tx_spending_coin_paused_this_epoch() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let env = new_authority_and_publish("coin_deny_list_v1_mintable").await;
+    let rgp = env.authority.reference_gas_price_for_testing().unwrap();
+
+    let (package_id, deny_cap_ref, coin_id) = find_published_objects(&env);
+    let regulated_coin_type = TypeTag::Struct(Box::new(StructTag::new(
+        package_id,
+        Identifier::from_static("regulated_coin"),
+        Identifier::from_static("REGULATED_COIN"),
+        vec![],
+    )));
+
+    // Globally pause the regulated coin; executes in the current epoch.
+    let deny_list_object_init_version = env
+        .get_latest_object_ref(&ObjectId::DENY_LIST)
+        .await
+        .version;
+    let pause_tx = TestTransactionBuilder::new(
+        env.sender,
+        env.get_latest_object_ref(&env.gas_object_id).await,
+        rgp,
+    )
+    .move_call(
+        ObjectId::FRAMEWORK,
+        "coin",
+        "deny_list_v1_enable_global_pause",
+        vec![
+            CallArg::Shared(SharedObjectReference::new(
+                ObjectId::DENY_LIST,
+                deny_list_object_init_version,
+                true,
+            )),
+            CallArg::ImmutableOrOwned(deny_cap_ref),
+        ],
+    )
+    .with_type_args(vec![regulated_coin_type.clone()])
+    .build_and_sign(&env.keypair);
+    let (_, effects) = send_and_confirm_transaction_(&env.authority, None, pause_tx, true)
+        .await
+        .unwrap();
+    assert!(!effects.status().is_failure(), "{:?}", effects.status());
+
+    // A transaction spending the paused coin, sequenced as `UserTransactionV1`.
+    let transfer_tx = make_transfer_object_transaction(
+        env.get_latest_object_ref(&coin_id).await,
+        env.get_latest_object_ref(&env.gas_object_id).await,
+        env.sender,
+        &env.keypair,
+        dbg_addr(9),
+        rgp,
+    );
+    let digest = *transfer_tx.digest();
+    let consensus_tx = ConsensusTransaction {
+        kind: ConsensusTransactionKind::UserTransactionV1(Box::new(transfer_tx)),
+        tracking_id: Default::default(),
+    };
+    let mut transactions = vec![VerifiedSequencedConsensusTransaction::new_test(
+        consensus_tx,
+    )];
+
+    let epoch_store = env.authority.epoch_store_for_testing();
+    let (dropped, _locks, user_tx_digests) =
+        post_consensus_validation::validate_and_resolve_conflicts(
+            &env.authority,
+            &epoch_store,
+            &mut transactions,
+        )
+        .await
+        .unwrap();
+
+    assert!(dropped.is_empty(), "unexpected drops: {dropped:?}");
+    assert_eq!(transactions.len(), 1);
+    assert_eq!(user_tx_digests, vec![digest]);
+}
+
+/// Returns the package id, deny cap reference, and minted regulated coin id
+/// created by publishing `coin_deny_list_v1_mintable`.
+fn find_published_objects(env: &TestEnv) -> (ObjectId, ObjectReference, ObjectId) {
+    let mut package_id = None;
+    let mut deny_cap_ref = None;
+    let mut coin_id = None;
+    for (oref, _owner) in env.publish_effects.created() {
+        let object = env.authority.get_object(&oref.object_id).unwrap();
+        if object.is_package() {
+            package_id = Some(object.id());
+            continue;
+        }
+        if object.type_().unwrap().is_deny_cap_v1() {
+            deny_cap_ref = Some(object.object_ref());
+        } else if !object.is_gas_coin() && object.coin_type_opt().is_some() {
+            coin_id = Some(object.id());
+        }
+    }
+    (package_id.unwrap(), deny_cap_ref.unwrap(), coin_id.unwrap())
+}
+
 struct TestEnv {
     authority: Arc<AuthorityState>,
     sender: Address,
@@ -226,6 +464,15 @@ impl TestEnv {
 }
 
 async fn new_authority_and_publish(path: &str) -> TestEnv {
+    // typed-store's `DBMetrics` registers rocksdb metrics into the global
+    // `default_registry()` on first initialization, and concurrent first-time
+    // initializers race with `AlreadyReg`. Pre-initialize with a throwaway
+    // registry up front: distinct registries can't collide, and once the init
+    // has run the authority build reuses the cached metrics. Without this,
+    // running several authority-building tests from this file concurrently
+    // flakes.
+    let _ = DBMetrics::init(&Registry::new());
+
     let (sender, keypair) = get_account_key_pair();
     let gas_object = Object::with_owner_for_testing(sender);
     let gas_object_id = gas_object.id();

--- a/crates/iota-core/src/unit_tests/data/coin_deny_list_v1_mintable/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/coin_deny_list_v1_mintable/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coin_deny_list_v1_mintable"
+version = "0.0.1"
+edition = "2024"
+
+[dependencies]
+Iota = { local = "../../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+coin_deny_list_v1_mintable = "0x0"

--- a/crates/iota-core/src/unit_tests/data/coin_deny_list_v1_mintable/sources/regulated_coin.move
+++ b/crates/iota-core/src/unit_tests/data/coin_deny_list_v1_mintable/sources/regulated_coin.move
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module coin_deny_list_v1_mintable::regulated_coin {
+    use iota::coin;
+
+    public struct REGULATED_COIN has drop {}
+
+    fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v1(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            true,
+            ctx
+        );
+
+        // Mint a spendable coin to the publisher so tests can transfer it.
+        let coin = coin::mint(&mut treasury_cap, 1_000_000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -85,6 +85,17 @@ impl MoveTypeTagTrait for GlobalPauseKey {
     }
 }
 
+/// Returns `Ok(())` if no input or receiving object's coin type is on a deny
+/// list for the given `address`.
+///
+/// With `cur_epoch = None`, the check reads the latest deny-list value, so
+/// denials take effect immediately; the result depends on how far the
+/// validator's execution has progressed, making it suitable only for
+/// validator-local decisions, such as pre-consensus admission. With
+/// `Some(epoch)`, the read is gated to the value settled before that epoch
+/// (entries written in epoch `E` activate in `E + 1`), making the result
+/// deterministic across validators; required where all validators must agree
+/// on the outcome, such as post-consensus validation.
 #[instrument(level = "trace", skip_all)]
 pub fn check_coin_deny_list_v1(
     address: Address,
@@ -92,6 +103,7 @@ pub fn check_coin_deny_list_v1(
     tx_receiving_objects: &ReceivingObjects,
     per_authenticator_input_objects: &Vec<&CheckedInputObjects>,
     object_store: &dyn ObjectStore,
+    cur_epoch: Option<EpochId>,
 ) -> UserInputResult {
     let coin_types = input_object_coin_types_for_denylist_check(
         tx_input_objects,
@@ -102,10 +114,10 @@ pub fn check_coin_deny_list_v1(
         let Some(deny_list) = get_per_type_coin_deny_list_v1(&coin_type, object_store) else {
             continue;
         };
-        if check_global_pause(&deny_list, object_store, None) {
+        if check_global_pause(&deny_list, object_store, cur_epoch) {
             return Err(UserInputError::CoinTypeGlobalPause { coin_type });
         }
-        if check_address_denied_by_config(&deny_list, address, object_store, None) {
+        if check_address_denied_by_config(&deny_list, address, object_store, cur_epoch) {
             return Err(UserInputError::AddressDeniedForCoin { address, coin_type });
         }
     }

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -570,6 +570,9 @@ fn run_coin_deny_list_check(
         receiving_objects,
         &per_authenticator_input_objects.to_vec(),
         store.as_object_store(),
+        // `None`: read the latest deny-list value. This offline check has no
+        // cross-validator determinism requirement.
+        None,
     )
     .map_err(|e| ValidationError::new("coin deny-list check", e).into())
 }


### PR DESCRIPTION
# Description of change

Post-consensus validation (`Check #5` in the P-COOL flow) drops transactions whose sender or coin type is on a coin deny list, but it reads the deny list at its latest executed value. That value depends on how far each validator's execution has progressed, so two honest validators could reach opposite keep/drop decisions for the same sequenced transaction: one that has already executed a `deny_list_v1_add` (or global pause) from an earlier commit drops it, and one that has not keeps it—divergent committed sets fork the checkpoint.

This PR modifies `check_coin_deny_list_v1` to take an extra argument, namely `cur_epoch: Option<EpochId>`: post-consensus validation uses the epoch-gated read; transaction signing and the V2 submission endpoint keep the immediate read, so admission behavior is unchanged.

No protocol version enables `enable_pcool_flow` yet, so no live network runs this path; the fix must land before the flag is ever activated.

> [!NOTE]
>  Why admission and post-consensus read the deny list differently in the P-COOL flow:
> - Execution and post-consensus must use the epoch-gated read to stay deterministic, so admission is the only layer that can enforce a new denial or global pause before the epoch boundary. Epoch-gating admission too would leave a fresh denial without effect anywhere for up to a full epoch.
> - The two reads therefore intentionally disagree for changes made mid-epoch:
>   - entry added: admission rejects within seconds, while post-consensus would keep the transaction until the next epoch—the deny list's fast path;
>   - entry removed: admission accepts, and the epoch-gated post-consensus check deterministically drops the transaction until the removal settles (no execution, no gas charged, client can retry).
> - The removal case wastes a consensus slot per attempt. This is known and accepted: post-consensus must handle deterministic drops regardless (owned-object double-spend losers, for example), and validators that skip admission can put such transactions into their blocks anyway, so no admission policy can limit how many deterministically-dropped transactions reach consensus.
>
> The same rationale is documented on `handle_transaction_validation_checks`.

## Links to any relevant issues

Fixes the V1-path half of the non-determinism discussed in https://github.com/iotaledger/iota-private/issues/438.

Note that `protocol-research/feat/transaction-attestation-feature` applies a similar fix, but unconditionally: it switches every caller of `check_coin_deny_list_v1`—including transaction signing—to the epoch-gated read, which silently changes the pre-consensus drop policy (denials and global pauses stop applying immediately at admission and only take effect the next epoch) in the certificate flow. After this PR is merged and that branch is rebased on top of it, the branch should be reduced to this PR's split in a separate PR: immediate read at admission, epoch-gated read in the post-consensus checks (including the attested-transaction re-check).

## How the change has been tested

```shell
IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib -E 'test(test_coin_deny_list_read_modes_across_execution_progress)'
IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib -E 'test(test_coin_deny_list_read_modes_after_denial_relaxed)'
IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib -E 'test(test_post_consensus_keeps_tx_spending_coin_paused_this_epoch)'
IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib -E 'test(test_post_consensus_drops_tx_spending_coin_unpaused_this_epoch)'
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes