### PR TITLE
feat(iota-core): resolve duplicate submissions from the in-flight submission's outcome

### DIFF
--- a/crates/iota-core/src/transaction_driver/mod.rs
+++ b/crates/iota-core/src/transaction_driver/mod.rs
@@ -273,9 +273,11 @@ where
     /// already submitted to consensus (e.g. by a concurrent submission of the
     /// same digest): collect the 2f+1 effects-acknowledgment quorum and
     /// return the certified finalized effects, without submitting the
-    /// transaction again. Unlike `drive_transaction` there is no retry loop
-    /// to bound, so no timeout is taken: the certifier's per-request
-    /// timeouts already bound the call.
+    /// transaction again. Unlike `drive_transaction` there is no
+    /// resubmission retry loop, but the certifier retries the full-effects
+    /// fetch across validators, so in the worst case the call is bounded
+    /// only by committee size times the per-request timeout — callers
+    /// needing a tighter bound must wrap the call in their own timeout.
     ///
     /// # Panics
     ///

--- a/crates/iota-core/src/transaction_driver/mod.rs
+++ b/crates/iota-core/src/transaction_driver/mod.rs
@@ -276,6 +276,10 @@ where
     /// transaction again. Unlike `drive_transaction` there is no retry loop
     /// to bound, so no timeout is taken: the certifier's per-request
     /// timeouts already bound the call.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the current committee is empty.
     #[instrument(level = "error", skip_all, err(level = "debug"), fields(tx_digest = ?tx_digest))]
     pub async fn certify_transaction(
         &self,

--- a/crates/iota-core/src/transaction_driver/mod.rs
+++ b/crates/iota-core/src/transaction_driver/mod.rs
@@ -20,6 +20,7 @@ use effects_certifier::*;
 pub use error::{AggregatedRequestErrors, TransactionDriverError};
 use iota_common::{backoff::ExponentialBackoff, debug_fatal};
 use iota_metrics::{monitored_future, spawn_logged_monitored_task};
+use iota_sdk_types::TransactionDigest;
 use iota_types::{committee::EpochId, messages_grpc::TxStatusUpdate, transaction::Transaction};
 pub use metrics::*;
 use parking_lot::Mutex;
@@ -266,6 +267,43 @@ where
             }
             None => retry_loop.await,
         }
+    }
+
+    /// Run only the effects-certification step for a transaction that is
+    /// already submitted to consensus (e.g. by a concurrent submission of the
+    /// same digest): collect the 2f+1 effects-acknowledgment quorum and
+    /// return the certified finalized effects, without submitting the
+    /// transaction again. Unlike `drive_transaction` there is no retry loop
+    /// to bound, so no timeout is taken: the certifier's per-request
+    /// timeouts already bound the call.
+    #[instrument(level = "error", skip_all, err(level = "debug"), fields(tx_digest = ?tx_digest))]
+    pub async fn certify_transaction(
+        &self,
+        tx_digest: TransactionDigest,
+        options: SubmitTransactionOptions,
+    ) -> Result<QuorumTransactionResponse, TransactionDriverError> {
+        let auth_agg = self.authority_aggregator.load();
+
+        // `get_certified_finalized_effects` reads the initial target only
+        // when full effects are pre-supplied; on this path it selects the
+        // fetch targets internally, so any committee member serves as the
+        // placeholder.
+        let target = *auth_agg
+            .committee
+            .names()
+            .next()
+            .expect("committee has at least one member");
+
+        self.certifier
+            .get_certified_finalized_effects(
+                &auth_agg,
+                &self.client_monitor,
+                Some(tx_digest),
+                target,
+                TxStatusUpdate::Submitted,
+                &options,
+            )
+            .await
     }
 
     #[instrument(level = "error", skip_all, err(level = "debug"))]

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -1873,11 +1873,12 @@ impl TransactionSubmissionGuard {
     }
 
     /// Publish the submission outcome to concurrent duplicate submissions.
-    /// A send into a channel without subscribers just means there is no
-    /// duplicate to notify.
+    /// The outcome is stored in the channel even when nobody is subscribed
+    /// yet, so a duplicate that subscribes after this call but before the
+    /// entry is removed still reads it instead of a closed channel.
     fn publish(&self, result: InFlightSubmissionResult) {
         if let Some(sender) = self.in_flight_transactions.lock().get(&self.tx_digest) {
-            let _ = sender.send(Some(result));
+            sender.send_replace(Some(result));
         }
     }
 }
@@ -1943,6 +1944,32 @@ mod tests {
             in_flight.lock().is_empty(),
             "guard drop must remove the in-flight entry"
         );
+    }
+
+    #[tokio::test]
+    async fn duplicate_subscribing_after_publish_receives_outcome() {
+        let in_flight = InFlightTransactions::default();
+        let tx_digest = TransactionDigest::random();
+
+        let guard = acquire_driving(&in_flight, tx_digest);
+        guard.publish(Err(QuorumDriverError::TimeoutBeforeFinality));
+
+        // Subscribing between the publish and the entry removal must still
+        // resolve to the outcome; falling back to checkpoint inclusion here
+        // would cost the duplicate a full finality timeout.
+        let mut receiver = acquire_duplicate(&in_flight, tx_digest);
+        drop(guard);
+
+        let outcome = receiver
+            .wait_for(|outcome| outcome.is_some())
+            .await
+            .expect("the outcome is stored in the channel regardless of subscribers")
+            .clone()
+            .expect("wait_for only returns once the outcome is Some");
+        assert!(matches!(
+            outcome,
+            Err(QuorumDriverError::TimeoutBeforeFinality)
+        ));
     }
 
     #[tokio::test]

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -328,13 +328,11 @@ where
             (Driver::Transaction(td), false) => {
                 let td = td.clone();
                 let in_flight_transactions = self.in_flight_transactions.clone();
-                let validator_state = self.validator_state.clone();
                 // Detached for the same reason as above.
                 let result = join_submission_task(spawn_monitored_task!(
                     Self::submit_with_transaction_driver(
                         td,
                         in_flight_transactions,
-                        validator_state,
                         request,
                         client_addr,
                         false,
@@ -358,9 +356,11 @@ where
         };
 
         // `needs_cache_rebuild` is derived from finality, not caller intent:
-        // the QD fallback path returns `Certified` (no rebuild needed) even
-        // when the caller asked for `WaitForLocalExecution`, while only the
-        // TD skip-cert engine produces `UncertifiedSingleValidator`. The
+        // the QD fallback path — and a duplicate submission inheriting the
+        // outcome of an in-flight certifying submission — returns `Certified`
+        // (no rebuild needed) even when the caller asked for
+        // `WaitForLocalExecution`, while only the TD skip-cert engine
+        // produces `UncertifiedSingleValidator`. The
         // checkpoint sequence comes from `submit_with_checkpoint_race`, which
         // relies on `executed_transactions_to_checkpoint` being written
         // strictly after every tx's effects — so a `Some(seq)` here implies
@@ -405,9 +405,10 @@ where
             }
             true
         } else {
-            // QD path: response is already 2f+1 certified, just confirm local
-            // execution finished. Removable once QD is dropped from the
-            // fullnode.
+            // The response is already 2f+1 certified — from the QuorumDriver,
+            // or inherited by a duplicate submission from an in-flight
+            // certifying submission — so just confirm local execution
+            // finished.
             let ok = Self::wait_for_finalized_tx_executed_locally_with_timeout(
                 &self.validator_state,
                 &transaction,
@@ -660,7 +661,6 @@ where
             Driver::Transaction(td) => {
                 let td = td.clone();
                 let in_flight_transactions = self.in_flight_transactions.clone();
-                let validator_state = self.validator_state.clone();
                 // v1 does not do an internal wait; callers (e.g. the gRPC
                 // execution service) are responsible for their own
                 // `wait_for_checkpoint_inclusion` when they need it, and will
@@ -671,7 +671,6 @@ where
                 join_submission_task(spawn_monitored_task!(Self::submit_with_transaction_driver(
                     td,
                     in_flight_transactions,
-                    validator_state,
                     request,
                     client_addr,
                     skip_certification,
@@ -729,7 +728,6 @@ where
         let driver = Self::submit_with_transaction_driver(
             td,
             in_flight_transactions,
-            validator_state.clone(),
             request,
             client_addr,
             true,
@@ -777,7 +775,6 @@ where
     async fn submit_with_transaction_driver(
         td: Arc<TransactionDriver<A>>,
         in_flight_transactions: InFlightTransactions,
-        validator_state: Arc<AuthorityState>,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         skip_certification: bool,
@@ -799,9 +796,10 @@ where
                 );
                 return Self::await_in_flight_transaction(
                     receiver,
-                    &validator_state,
+                    &td,
                     tx_digest,
                     &request,
+                    client_addr,
                     skip_certification,
                 )
                 .await;
@@ -837,38 +835,44 @@ where
 
         let td_response = Arc::new(td_response);
         guard.publish(Ok(td_response.clone()));
+        // Dropping the guard closes the channel, releasing its copy of the
+        // response unless a duplicate submission still holds a receiver — in
+        // the common no-duplicate case the response is then moved into the
+        // reply instead of cloned.
+        drop(guard);
+        let td_response = Arc::try_unwrap(td_response).unwrap_or_else(|shared| (*shared).clone());
 
-        Ok(Self::response_from_driver_response(&td_response, &request))
+        Ok(Self::response_from_driver_response(td_response, &request))
     }
 
     /// Build a caller-specific response from a driver response, honoring the
     /// caller's include flags.
     fn response_from_driver_response(
-        td_response: &QuorumTransactionResponse,
+        td_response: QuorumTransactionResponse,
         request: &ExecuteTransactionRequestV1,
     ) -> ExecuteTransactionResponseV1 {
+        let QuorumTransactionResponse {
+            effects,
+            events,
+            input_objects,
+            output_objects,
+            auxiliary_data,
+        } = td_response;
         ExecuteTransactionResponseV1 {
-            effects: convert_td_to_qd_effects(td_response.effects.clone()),
-            events: if request.include_events {
-                td_response.events.clone()
-            } else {
-                None
-            },
-            input_objects: if request.include_input_objects {
-                td_response.input_objects.clone()
-            } else {
-                None
-            },
-            output_objects: if request.include_output_objects {
-                td_response.output_objects.clone()
-            } else {
-                None
-            },
-            auxiliary_data: if request.include_auxiliary_data {
-                td_response.auxiliary_data.clone()
-            } else {
-                None
-            },
+            effects: convert_td_to_qd_effects(effects),
+            events: request.include_events.then_some(events).flatten(),
+            input_objects: request
+                .include_input_objects
+                .then_some(input_objects)
+                .flatten(),
+            output_objects: request
+                .include_output_objects
+                .then_some(output_objects)
+                .flatten(),
+            auxiliary_data: request
+                .include_auxiliary_data
+                .then_some(auxiliary_data)
+                .flatten(),
         }
     }
 
@@ -881,60 +885,60 @@ where
     ///   from the shared driver response with this caller's include flags.
     /// - It succeeded with `UncertifiedSingleValidator` effects but this caller
     ///   did not opt into skip-certification (so nothing downstream reconciles
-    ///   them against the cache): wait for checkpoint inclusion and rebuild
-    ///   from the authoritative local cache instead — uncertified data must
-    ///   never reach a caller that expects certified effects.
+    ///   them against the cache): run the effects-certification step for the
+    ///   digest — the transaction is already in consensus, only the 2f+1
+    ///   certification is missing — and respond from its certified result.
     /// - Nothing was published within `WAIT_FOR_FINALITY_TIMEOUT`, or the
     ///   in-flight submission's task died without publishing (panic or
     ///   shutdown): `TimeoutBeforeFinality`, so the client retries.
     async fn await_in_flight_transaction(
         mut receiver: watch::Receiver<Option<InFlightSubmissionResult>>,
-        validator_state: &Arc<AuthorityState>,
+        td: &Arc<TransactionDriver<A>>,
         tx_digest: TransactionDigest,
         request: &ExecuteTransactionRequestV1,
+        client_addr: Option<SocketAddr>,
         skip_certification: bool,
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
-        let outcome = {
-            let outcome_ref = tokio::time::timeout(
-                WAIT_FOR_FINALITY_TIMEOUT,
-                receiver.wait_for(|outcome| outcome.is_some()),
-            )
-            .await
-            .map_err(|_elapsed| QuorumDriverError::TimeoutBeforeFinality)?
-            .map_err(|_closed| QuorumDriverError::TimeoutBeforeFinality)?;
-            // `wait_for` only returns a value matching its predicate, so the
-            // `None` arm is unreachable; mapped to a retriable error instead
-            // of panicking.
-            (*outcome_ref)
-                .clone()
-                .ok_or(QuorumDriverError::TimeoutBeforeFinality)?
-        };
-
-        let td_response = outcome?;
+        // Timeout elapsed, channel closed (the driving task died without
+        // publishing), and the not-yet-published `None` (unreachable past
+        // `wait_for`) all surface as the same retriable timeout.
+        let td_response = tokio::time::timeout(
+            WAIT_FOR_FINALITY_TIMEOUT,
+            receiver.wait_for(|outcome| outcome.is_some()),
+        )
+        .await
+        .ok()
+        .and_then(|received| received.ok())
+        .and_then(|outcome| outcome.clone())
+        .ok_or(QuorumDriverError::TimeoutBeforeFinality)??;
 
         let uncertified = matches!(
             td_response.effects.finality_info,
             TdEffectsFinalityInfo::UncertifiedSingleValidator(_)
         );
         if uncertified && !skip_certification {
-            let digests = [tx_digest];
-            let seq = validator_state
-                .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT)
+            // The in-flight submission already drove the transaction into
+            // consensus; only the 2f+1 effects certification is missing for
+            // this caller. Certify the effects directly instead of starting
+            // a second committee-wide submission or waiting for a checkpoint
+            // inclusion the caller never asked for.
+            let certified = td
+                .certify_transaction(
+                    tx_digest,
+                    SubmitTransactionOptions {
+                        forwarded_client_addr: client_addr,
+                        ..Default::default()
+                    },
+                )
                 .await
-                .ok()
-                .and_then(|inclusion| inclusion.get(&tx_digest).map(|&(seq, _)| seq))
-                .ok_or(QuorumDriverError::TimeoutBeforeFinality)?;
-            return Self::build_response_from_cache(
-                validator_state,
-                tx_digest,
-                seq,
-                request.include_events,
-                request.include_input_objects,
-                request.include_output_objects,
-            );
+                .map_err(map_td_error_to_qd)?;
+            return Ok(Self::response_from_driver_response(certified, request));
         }
 
-        Ok(Self::response_from_driver_response(&td_response, request))
+        Ok(Self::response_from_driver_response(
+            (*td_response).clone(),
+            request,
+        ))
     }
 
     /// Submit a transaction via the QuorumDriver. `transaction` must be the
@@ -1779,7 +1783,6 @@ impl TransactionSubmissionGuard {
             let mut in_flight = in_flight_transactions.lock();
             match in_flight.entry(tx_digest) {
                 Entry::Occupied(entry) => {
-                    debug!(?tx_digest, "transaction already being processed");
                     return TransactionSubmission::AlreadyInFlight(entry.get().clone());
                 }
                 Entry::Vacant(entry) => {

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -896,7 +896,8 @@ where
     /// driving submission went away without publishing one (checkpoint-race
     /// cancellation, panic, or shutdown), and returns
     /// `TimeoutBeforeFinality` if nothing is published within
-    /// `WAIT_FOR_FINALITY_TIMEOUT`.
+    /// `WAIT_FOR_FINALITY_TIMEOUT` or the follow-up effects certification
+    /// does not complete within another `WAIT_FOR_FINALITY_TIMEOUT`.
     async fn await_in_flight_transaction(
         mut receiver: watch::Receiver<Option<InFlightSubmissionResult>>,
         td: &Arc<TransactionDriver<A>>,
@@ -939,17 +940,23 @@ where
             // consensus; only the 2f+1 effects certification is missing for
             // this caller. Certify the effects directly instead of starting
             // a second committee-wide submission or waiting for a checkpoint
-            // inclusion the caller never asked for.
-            let certified = td
-                .certify_transaction(
+            // inclusion the caller never asked for. `certify_transaction` is
+            // internally bounded only by committee size times its per-request
+            // timeout, so cap it to the same client-facing budget the driving
+            // submission gets for its whole `drive_transaction` call.
+            let certified = tokio::time::timeout(
+                WAIT_FOR_FINALITY_TIMEOUT,
+                td.certify_transaction(
                     tx_digest,
                     SubmitTransactionOptions {
                         forwarded_client_addr: client_addr,
                         ..Default::default()
                     },
-                )
-                .await
-                .map_err(map_td_error_to_qd)?;
+                ),
+            )
+            .await
+            .map_err(|_elapsed| QuorumDriverError::TimeoutBeforeFinality)?
+            .map_err(map_td_error_to_qd)?;
             return Ok(Self::response_from_driver_response(certified, request));
         }
 

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -1340,6 +1340,16 @@ where
     pub fn load_all_pending_transactions(&self) -> IotaResult<Vec<VerifiedTransaction>> {
         self.pending_tx_log.load_all_pending_transactions()
     }
+
+    /// Reports whether a driver submission of `tx_digest` is in flight, and
+    /// if so how many duplicate submissions are awaiting its outcome.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn in_flight_duplicates_for_testing(&self, tx_digest: &TransactionDigest) -> Option<usize> {
+        self.in_flight_transactions
+            .lock()
+            .get(tx_digest)
+            .map(|sender| sender.receiver_count())
+    }
 }
 
 /// Convert a `QuorumDriverResponse` (contains

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -358,11 +358,11 @@ where
         };
 
         // `needs_cache_rebuild` is derived from finality, not caller intent:
-        // the QD fallback path — and a duplicate submission inheriting the
-        // outcome of an in-flight certifying submission — returns `Certified`
-        // (no rebuild needed) even when the caller asked for
-        // `WaitForLocalExecution`, while only the TD skip-cert engine
-        // produces `UncertifiedSingleValidator`. The
+        // the QD fallback path returns `Certified` and a duplicate
+        // submission inheriting the outcome of an in-flight certifying
+        // submission returns `QuorumExecuted` — neither needs a rebuild —
+        // even when the caller asked for `WaitForLocalExecution`, while only
+        // the TD skip-cert engine produces `UncertifiedSingleValidator`. The
         // checkpoint sequence comes from `submit_with_checkpoint_race`, which
         // relies on `executed_transactions_to_checkpoint` being written
         // strictly after every tx's effects — so a `Some(seq)` here implies

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -328,11 +328,13 @@ where
             (Driver::Transaction(td), false) => {
                 let td = td.clone();
                 let in_flight_transactions = self.in_flight_transactions.clone();
+                let validator_state = self.validator_state.clone();
                 // Detached for the same reason as above.
                 let result = join_submission_task(spawn_monitored_task!(
                     Self::submit_with_transaction_driver(
                         td,
                         in_flight_transactions,
+                        validator_state,
                         request,
                         client_addr,
                         false,
@@ -661,6 +663,7 @@ where
             Driver::Transaction(td) => {
                 let td = td.clone();
                 let in_flight_transactions = self.in_flight_transactions.clone();
+                let validator_state = self.validator_state.clone();
                 // v1 does not do an internal wait; callers (e.g. the gRPC
                 // execution service) are responsible for their own
                 // `wait_for_checkpoint_inclusion` when they need it, and will
@@ -671,6 +674,7 @@ where
                 join_submission_task(spawn_monitored_task!(Self::submit_with_transaction_driver(
                     td,
                     in_flight_transactions,
+                    validator_state,
                     request,
                     client_addr,
                     skip_certification,
@@ -727,7 +731,8 @@ where
         tokio::pin!(checkpoint_inclusion);
         let driver = Self::submit_with_transaction_driver(
             td,
-            in_flight_transactions,
+            in_flight_transactions.clone(),
+            validator_state.clone(),
             request,
             client_addr,
             true,
@@ -750,7 +755,17 @@ where
             }
             checkpoint_result = &mut checkpoint_inclusion => {
                 metrics.skip_effect_cert_checkpoint_overrode_driver.inc();
-                (None, checkpoint_result.ok().and_then(seq_for_tx))
+                let seq = checkpoint_result.ok().and_then(seq_for_tx);
+                // The driver future is dropped without publishing; hand the
+                // checkpoint outcome to any duplicate submissions instead.
+                if let Some(seq) = seq {
+                    publish_in_flight_outcome(
+                        &in_flight_transactions,
+                        tx_digest,
+                        Ok(InFlightOutcome::Checkpointed(seq)),
+                    );
+                }
+                (None, seq)
             }
         };
         add_server_timing("local_execution");
@@ -775,6 +790,7 @@ where
     async fn submit_with_transaction_driver(
         td: Arc<TransactionDriver<A>>,
         in_flight_transactions: InFlightTransactions,
+        validator_state: Arc<AuthorityState>,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         skip_certification: bool,
@@ -797,6 +813,7 @@ where
                 return Self::await_in_flight_transaction(
                     receiver,
                     &td,
+                    &validator_state,
                     tx_digest,
                     &request,
                     client_addr,
@@ -834,7 +851,7 @@ where
         debug!(?tx_digest, "TransactionDriver submission succeeded");
 
         let td_response = Arc::new(td_response);
-        guard.publish(Ok(td_response.clone()));
+        guard.publish(Ok(InFlightOutcome::Response(td_response.clone())));
         // Dropping the guard closes the channel, releasing its copy of the
         // response unless a duplicate submission still holds a receiver — in
         // the common no-duplicate case the response is then moved into the
@@ -888,29 +905,60 @@ where
     ///   them against the cache): run the effects-certification step for the
     ///   digest — the transaction is already in consensus, only the 2f+1
     ///   certification is missing — and respond from its certified result.
-    /// - Nothing was published within `WAIT_FOR_FINALITY_TIMEOUT`, or the
-    ///   in-flight submission's task died without publishing (panic or
-    ///   shutdown): `TimeoutBeforeFinality`, so the client retries.
+    /// - Its checkpoint race observed the transaction in a local checkpoint and
+    ///   cancelled the driver, publishing the checkpoint sequence: the response
+    ///   is built from the authoritative local cache.
+    /// - It went away without publishing (panic or shutdown): fall back to
+    ///   waiting for checkpoint inclusion and answer from the cache, as if no
+    ///   in-flight submission had been found.
+    /// - Nothing was published within `WAIT_FOR_FINALITY_TIMEOUT`:
+    ///   `TimeoutBeforeFinality`, so the client retries.
     async fn await_in_flight_transaction(
         mut receiver: watch::Receiver<Option<InFlightSubmissionResult>>,
         td: &Arc<TransactionDriver<A>>,
+        validator_state: &Arc<AuthorityState>,
         tx_digest: TransactionDigest,
         request: &ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
         skip_certification: bool,
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
-        // Timeout elapsed, channel closed (the driving task died without
-        // publishing), and the not-yet-published `None` (unreachable past
-        // `wait_for`) all surface as the same retriable timeout.
-        let td_response = tokio::time::timeout(
+        // The `Ref` returned by `wait_for` is a read guard and must not be
+        // held across an await, so the outcome is cloned out before
+        // branching. `wait_for` only returns a value matching its predicate,
+        // so `Some` is guaranteed on success; a closed channel yields `None`.
+        let published = tokio::time::timeout(
             WAIT_FOR_FINALITY_TIMEOUT,
             receiver.wait_for(|outcome| outcome.is_some()),
         )
         .await
+        .map_err(|_elapsed| QuorumDriverError::TimeoutBeforeFinality)?
         .ok()
-        .and_then(|received| received.ok())
-        .and_then(|outcome| outcome.clone())
-        .ok_or(QuorumDriverError::TimeoutBeforeFinality)??;
+        .and_then(|outcome_ref| outcome_ref.clone());
+
+        let Some(outcome) = published else {
+            // Channel closed without an outcome: the driving submission's
+            // task died without publishing (panic or shutdown). Checkpoint
+            // inclusion is the only remaining signal of the outcome.
+            return Self::response_from_checkpoint_inclusion(validator_state, tx_digest, request)
+                .await;
+        };
+        let td_response = match outcome? {
+            // The checkpoint race cancelled the driver after observing the
+            // transaction in a local checkpoint; the cache is authoritative
+            // and the response it yields carries certified (`Checkpointed`)
+            // finality, satisfying every caller.
+            InFlightOutcome::Checkpointed(seq) => {
+                return Self::build_response_from_cache(
+                    validator_state,
+                    tx_digest,
+                    seq,
+                    request.include_events,
+                    request.include_input_objects,
+                    request.include_output_objects,
+                );
+            }
+            InFlightOutcome::Response(td_response) => td_response,
+        };
 
         let uncertified = matches!(
             td_response.effects.finality_info,
@@ -939,6 +987,42 @@ where
             (*td_response).clone(),
             request,
         ))
+    }
+
+    /// Wait for `tx_digest` to reach a local checkpoint and build the
+    /// response from the authoritative cache. The fallback outcome signal
+    /// for a duplicate whose driving submission went away without
+    /// publishing; the result carries `Checkpointed` finality, so it
+    /// satisfies every caller. Times out with `TimeoutBeforeFinality` if
+    /// the transaction does not get checkpointed in time.
+    async fn response_from_checkpoint_inclusion(
+        validator_state: &Arc<AuthorityState>,
+        tx_digest: TransactionDigest,
+        request: &ExecuteTransactionRequestV1,
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
+        let digests = [tx_digest];
+        // The caller has typically already waited a full timeout on the
+        // outcome channel, but this wait is still required: it is what
+        // yields the checkpoint sequence and guarantees the checkpoint
+        // mapping write has landed (see `reconcile_effects_from_cache`).
+        // When the transaction is already checkpointed — the routine reason
+        // the fallback fires — it resolves immediately; only after a
+        // driving-task death does it actually wait, as the last remaining
+        // signal of the outcome.
+        let seq = validator_state
+            .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT)
+            .await
+            .ok()
+            .and_then(|inclusion| inclusion.get(&tx_digest).map(|&(seq, _)| seq))
+            .ok_or(QuorumDriverError::TimeoutBeforeFinality)?;
+        Self::build_response_from_cache(
+            validator_state,
+            tx_digest,
+            seq,
+            request.include_events,
+            request.include_input_objects,
+            request.include_output_objects,
+        )
     }
 
     /// Submit a transaction via the QuorumDriver. `transaction` must be the
@@ -1739,16 +1823,39 @@ fn read_cached_transaction_data(
     ))
 }
 
+/// Successful outcome of an in-flight driver submission: the unfiltered
+/// driver response, or the local checkpoint the transaction was observed in
+/// when the checkpoint race cancelled the driver (the cache is then the
+/// authoritative source of the effects).
+#[derive(Clone, Debug)]
+enum InFlightOutcome {
+    Response(Arc<QuorumTransactionResponse>),
+    Checkpointed(CheckpointSequenceNumber),
+}
+
 /// Outcome of an in-flight driver submission, shared with concurrent
-/// submissions of the same digest: the unfiltered driver response, or the
-/// error the submission failed with.
-type InFlightSubmissionResult = Result<Arc<QuorumTransactionResponse>, QuorumDriverError>;
+/// submissions of the same digest.
+type InFlightSubmissionResult = Result<InFlightOutcome, QuorumDriverError>;
 
 /// Digests currently being driven to finality by the TransactionDriver,
-/// each with a channel carrying the submission outcome (`None` until the
-/// driving submission resolves).
+/// each with a channel through which the driving submission (or the
+/// checkpoint race that cancels it) publishes its outcome to concurrent
+/// duplicates.
 type InFlightTransactions =
-    Arc<Mutex<HashMap<TransactionDigest, watch::Receiver<Option<InFlightSubmissionResult>>>>>;
+    Arc<Mutex<HashMap<TransactionDigest, watch::Sender<Option<InFlightSubmissionResult>>>>>;
+
+/// Publish `result` to duplicate submissions of `tx_digest`, if its
+/// in-flight entry still exists. A send into a channel without subscribers
+/// just means there is no duplicate to notify.
+fn publish_in_flight_outcome(
+    in_flight_transactions: &InFlightTransactions,
+    tx_digest: TransactionDigest,
+    result: InFlightSubmissionResult,
+) {
+    if let Some(sender) = in_flight_transactions.lock().get(&tx_digest) {
+        let _ = sender.send(Some(result));
+    }
+}
 
 /// Result of trying to register a submission of a digest in the in-flight
 /// map: either this caller drives the committee-wide submission, or another
@@ -1763,15 +1870,17 @@ enum TransactionSubmission {
 /// concurrent submissions of the same digest deduplicate.
 ///
 /// Held only by the driving submission, which must `publish` its outcome so
-/// concurrent duplicates can return it. Dropping the guard removes the digest
-/// from the in-flight map on every exit path (success, error, timeout, and
-/// cancellation); receivers subscribed before removal still observe a
-/// published outcome, and if the guard is dropped without publishing (panic
-/// or shutdown) the closed channel tells them the submission died.
+/// concurrent duplicates can return it. The outcome channel's sender lives
+/// in the in-flight map itself, so the checkpoint race can publish a
+/// `Checkpointed` outcome when it cancels the driver without owning the
+/// guard. Dropping the guard removes the digest from the in-flight map on
+/// every exit path (success, error, timeout, and cancellation); receivers
+/// subscribed before removal still observe a published outcome, and if the
+/// entry is removed without any outcome (panic or shutdown) the closed
+/// channel tells duplicates to fall back to checkpoint inclusion.
 struct TransactionSubmissionGuard {
     in_flight_transactions: InFlightTransactions,
     tx_digest: TransactionDigest,
-    sender: watch::Sender<Option<InFlightSubmissionResult>>,
 }
 
 impl TransactionSubmissionGuard {
@@ -1779,32 +1888,28 @@ impl TransactionSubmissionGuard {
         in_flight_transactions: InFlightTransactions,
         tx_digest: TransactionDigest,
     ) -> TransactionSubmission {
-        let sender = {
+        {
             let mut in_flight = in_flight_transactions.lock();
             match in_flight.entry(tx_digest) {
                 Entry::Occupied(entry) => {
-                    return TransactionSubmission::AlreadyInFlight(entry.get().clone());
+                    return TransactionSubmission::AlreadyInFlight(entry.get().subscribe());
                 }
                 Entry::Vacant(entry) => {
-                    let (sender, receiver) = watch::channel(None);
-                    entry.insert(receiver);
+                    let (sender, _initial_receiver) = watch::channel(None);
+                    entry.insert(sender);
                     debug!(?tx_digest, "added transaction to in-flight map");
-                    sender
                 }
             }
-        };
+        }
         TransactionSubmission::Driving(Self {
             in_flight_transactions,
             tx_digest,
-            sender,
         })
     }
 
     /// Publish the submission outcome to concurrent duplicate submissions.
     fn publish(&self, result: InFlightSubmissionResult) {
-        // Send fails only when every receiver is dropped, which just means
-        // there is no duplicate submission to notify.
-        let _ = self.sender.send(Some(result));
+        publish_in_flight_outcome(&self.in_flight_transactions, self.tx_digest, result);
     }
 }
 
@@ -1888,5 +1993,27 @@ mod tests {
 
         // The digest can be driven again once the entry is gone.
         let _guard = acquire_driving(&in_flight, tx_digest);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_outcome_reaches_duplicate_without_the_guard() {
+        let in_flight = InFlightTransactions::default();
+        let tx_digest = TransactionDigest::random();
+
+        let guard = acquire_driving(&in_flight, tx_digest);
+        let mut receiver = acquire_duplicate(&in_flight, tx_digest);
+
+        // The checkpoint race publishes through the map after cancelling the
+        // driver, without owning the guard.
+        publish_in_flight_outcome(&in_flight, tx_digest, Ok(InFlightOutcome::Checkpointed(42)));
+        drop(guard);
+
+        let outcome = receiver
+            .wait_for(|outcome| outcome.is_some())
+            .await
+            .expect("outcome was published before the sender dropped")
+            .clone()
+            .expect("wait_for only returns once the outcome is Some");
+        assert!(matches!(outcome, Ok(InFlightOutcome::Checkpointed(42))));
     }
 }

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -731,7 +731,7 @@ where
         tokio::pin!(checkpoint_inclusion);
         let driver = Self::submit_with_transaction_driver(
             td,
-            in_flight_transactions.clone(),
+            in_flight_transactions,
             validator_state.clone(),
             request,
             client_addr,
@@ -755,16 +755,11 @@ where
             }
             checkpoint_result = &mut checkpoint_inclusion => {
                 metrics.skip_effect_cert_checkpoint_overrode_driver.inc();
+                // Dropping the cancelled driver closes the in-flight outcome
+                // channel; duplicate submissions fall back to waiting for
+                // checkpoint inclusion, which this race winning guarantees
+                // resolves immediately.
                 let seq = checkpoint_result.ok().and_then(seq_for_tx);
-                // The driver future is dropped without publishing; hand the
-                // checkpoint outcome to any duplicate submissions instead.
-                if let Some(seq) = seq {
-                    publish_in_flight_outcome(
-                        &in_flight_transactions,
-                        tx_digest,
-                        Ok(InFlightOutcome::Checkpointed(seq)),
-                    );
-                }
                 (None, seq)
             }
         };
@@ -851,7 +846,7 @@ where
         debug!(?tx_digest, "TransactionDriver submission succeeded");
 
         let td_response = Arc::new(td_response);
-        guard.publish(Ok(InFlightOutcome::Response(td_response.clone())));
+        guard.publish(Ok(td_response.clone()));
         // Dropping the guard closes the channel, releasing its copy of the
         // response unless a duplicate submission still holds a receiver — in
         // the common no-duplicate case the response is then moved into the
@@ -895,24 +890,13 @@ where
 
     /// Await the outcome of an already in-flight submission of `tx_digest`
     /// instead of starting a second committee-wide submission for the same
-    /// transaction:
-    ///
-    /// - The in-flight submission failed: its error is returned as-is.
-    /// - It succeeded with effects this caller can use: the response is rebuilt
-    ///   from the shared driver response with this caller's include flags.
-    /// - It succeeded with `UncertifiedSingleValidator` effects but this caller
-    ///   did not opt into skip-certification (so nothing downstream reconciles
-    ///   them against the cache): run the effects-certification step for the
-    ///   digest — the transaction is already in consensus, only the 2f+1
-    ///   certification is missing — and respond from its certified result.
-    /// - Its checkpoint race observed the transaction in a local checkpoint and
-    ///   cancelled the driver, publishing the checkpoint sequence: the response
-    ///   is built from the authoritative local cache.
-    /// - It went away without publishing (panic or shutdown): fall back to
-    ///   waiting for checkpoint inclusion and answer from the cache, as if no
-    ///   in-flight submission had been found.
-    /// - Nothing was published within `WAIT_FOR_FINALITY_TIMEOUT`:
-    ///   `TimeoutBeforeFinality`, so the client retries.
+    /// transaction. Resolves to that submission's outcome — running the
+    /// effects-certification step first if the outcome does not satisfy this
+    /// caller — falls back to waiting for checkpoint inclusion if the
+    /// driving submission went away without publishing one (checkpoint-race
+    /// cancellation, panic, or shutdown), and returns
+    /// `TimeoutBeforeFinality` if nothing is published within
+    /// `WAIT_FOR_FINALITY_TIMEOUT`.
     async fn await_in_flight_transaction(
         mut receiver: watch::Receiver<Option<InFlightSubmissionResult>>,
         td: &Arc<TransactionDriver<A>>,
@@ -936,29 +920,15 @@ where
         .and_then(|outcome_ref| outcome_ref.clone());
 
         let Some(outcome) = published else {
-            // Channel closed without an outcome: the driving submission's
-            // task died without publishing (panic or shutdown). Checkpoint
-            // inclusion is the only remaining signal of the outcome.
+            // Channel closed without an outcome: the driving submission went
+            // away without publishing — routinely because its checkpoint
+            // race observed the transaction in a local checkpoint and
+            // cancelled it, exceptionally on panic or shutdown. Checkpoint
+            // inclusion is the remaining signal of the outcome.
             return Self::response_from_checkpoint_inclusion(validator_state, tx_digest, request)
                 .await;
         };
-        let td_response = match outcome? {
-            // The checkpoint race cancelled the driver after observing the
-            // transaction in a local checkpoint; the cache is authoritative
-            // and the response it yields carries certified (`Checkpointed`)
-            // finality, satisfying every caller.
-            InFlightOutcome::Checkpointed(seq) => {
-                return Self::build_response_from_cache(
-                    validator_state,
-                    tx_digest,
-                    seq,
-                    request.include_events,
-                    request.include_input_objects,
-                    request.include_output_objects,
-                );
-            }
-            InFlightOutcome::Response(td_response) => td_response,
-        };
+        let td_response = outcome?;
 
         let uncertified = matches!(
             td_response.effects.finality_info,
@@ -1827,35 +1797,15 @@ fn read_cached_transaction_data(
 /// driver response, or the local checkpoint the transaction was observed in
 /// when the checkpoint race cancelled the driver (the cache is then the
 /// authoritative source of the effects).
-#[derive(Clone, Debug)]
-enum InFlightOutcome {
-    Response(Arc<QuorumTransactionResponse>),
-    Checkpointed(CheckpointSequenceNumber),
-}
-
 /// Outcome of an in-flight driver submission, shared with concurrent
 /// submissions of the same digest.
-type InFlightSubmissionResult = Result<InFlightOutcome, QuorumDriverError>;
+type InFlightSubmissionResult = Result<Arc<QuorumTransactionResponse>, QuorumDriverError>;
 
 /// Digests currently being driven to finality by the TransactionDriver,
-/// each with a channel through which the driving submission (or the
-/// checkpoint race that cancels it) publishes its outcome to concurrent
-/// duplicates.
+/// each with a channel through which the driving submission publishes its
+/// outcome to concurrent duplicates.
 type InFlightTransactions =
     Arc<Mutex<HashMap<TransactionDigest, watch::Sender<Option<InFlightSubmissionResult>>>>>;
-
-/// Publish `result` to duplicate submissions of `tx_digest`, if its
-/// in-flight entry still exists. A send into a channel without subscribers
-/// just means there is no duplicate to notify.
-fn publish_in_flight_outcome(
-    in_flight_transactions: &InFlightTransactions,
-    tx_digest: TransactionDigest,
-    result: InFlightSubmissionResult,
-) {
-    if let Some(sender) = in_flight_transactions.lock().get(&tx_digest) {
-        let _ = sender.send(Some(result));
-    }
-}
 
 /// Result of trying to register a submission of a digest in the in-flight
 /// map: either this caller drives the committee-wide submission, or another
@@ -1870,13 +1820,11 @@ enum TransactionSubmission {
 /// concurrent submissions of the same digest deduplicate.
 ///
 /// Held only by the driving submission, which must `publish` its outcome so
-/// concurrent duplicates can return it. The outcome channel's sender lives
-/// in the in-flight map itself, so the checkpoint race can publish a
-/// `Checkpointed` outcome when it cancels the driver without owning the
-/// guard. Dropping the guard removes the digest from the in-flight map on
-/// every exit path (success, error, timeout, and cancellation); receivers
-/// subscribed before removal still observe a published outcome, and if the
-/// entry is removed without any outcome (panic or shutdown) the closed
+/// concurrent duplicates can return it. Dropping the guard removes the
+/// digest from the in-flight map on every exit path (success, error,
+/// timeout, and cancellation); receivers subscribed before removal still
+/// observe a published outcome, and if the entry is removed without any
+/// outcome (checkpoint-race cancellation, panic, or shutdown) the closed
 /// channel tells duplicates to fall back to checkpoint inclusion.
 struct TransactionSubmissionGuard {
     in_flight_transactions: InFlightTransactions,
@@ -1908,8 +1856,12 @@ impl TransactionSubmissionGuard {
     }
 
     /// Publish the submission outcome to concurrent duplicate submissions.
+    /// A send into a channel without subscribers just means there is no
+    /// duplicate to notify.
     fn publish(&self, result: InFlightSubmissionResult) {
-        publish_in_flight_outcome(&self.in_flight_transactions, self.tx_digest, result);
+        if let Some(sender) = self.in_flight_transactions.lock().get(&self.tx_digest) {
+            let _ = sender.send(Some(result));
+        }
     }
 }
 
@@ -1993,27 +1945,5 @@ mod tests {
 
         // The digest can be driven again once the entry is gone.
         let _guard = acquire_driving(&in_flight, tx_digest);
-    }
-
-    #[tokio::test]
-    async fn checkpoint_outcome_reaches_duplicate_without_the_guard() {
-        let in_flight = InFlightTransactions::default();
-        let tx_digest = TransactionDigest::random();
-
-        let guard = acquire_driving(&in_flight, tx_digest);
-        let mut receiver = acquire_duplicate(&in_flight, tx_digest);
-
-        // The checkpoint race publishes through the map after cancelling the
-        // driver, without owning the guard.
-        publish_in_flight_outcome(&in_flight, tx_digest, Ok(InFlightOutcome::Checkpointed(42)));
-        drop(guard);
-
-        let outcome = receiver
-            .wait_for(|outcome| outcome.is_some())
-            .await
-            .expect("outcome was published before the sender dropped")
-            .clone()
-            .expect("wait_for only returns once the outcome is Some");
-        assert!(matches!(outcome, Ok(InFlightOutcome::Checkpointed(42))));
     }
 }

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -7,7 +7,7 @@
 // finality, and proactively executes finalized transactions locally.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, hash_map::Entry},
     net::SocketAddr,
     ops::Deref,
     path::Path,
@@ -53,7 +53,10 @@ use prometheus_filtered::{
     register_int_gauge_with_registry,
 };
 use tokio::{
-    sync::broadcast::{Receiver, error::RecvError},
+    sync::{
+        broadcast::{Receiver, error::RecvError},
+        watch,
+    },
     task::JoinHandle,
     time::timeout,
 };
@@ -101,11 +104,13 @@ pub struct TransactionOrchestrator<A: Clone> {
     _local_executor_handle: Option<JoinHandle<()>>,
     pending_tx_log: Arc<WritePathPendingTransactionLog>,
     /// Digests currently being driven to finality by the TransactionDriver;
-    /// used to deduplicate concurrent submissions of the same transaction.
-    /// Kept in memory only: the driver path is best-effort, so there is
-    /// nothing to recover after a restart. The QuorumDriver path tracks its
-    /// submissions in `pending_tx_log` instead.
-    in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
+    /// used to deduplicate concurrent submissions of the same transaction,
+    /// with a channel per digest through which the driving submission
+    /// publishes its outcome to concurrent duplicates. Kept in memory only:
+    /// the driver path is best-effort, so there is nothing to recover after
+    /// a restart. The QuorumDriver path tracks its submissions in
+    /// `pending_tx_log` instead.
+    in_flight_transactions: InFlightTransactions,
     notifier: Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>,
     metrics: Arc<TransactionOrchestratorMetrics>,
 }
@@ -704,7 +709,7 @@ where
         fields(tx_digest = ?tx_digest))]
     async fn submit_with_checkpoint_race(
         td: Arc<TransactionDriver<A>>,
-        in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
+        in_flight_transactions: InFlightTransactions,
         validator_state: Arc<AuthorityState>,
         metrics: Arc<TransactionOrchestratorMetrics>,
         request: ExecuteTransactionRequestV1,
@@ -771,7 +776,7 @@ where
         fields(tx_digest = ?request.transaction.digest()))]
     async fn submit_with_transaction_driver(
         td: Arc<TransactionDriver<A>>,
-        in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
+        in_flight_transactions: InFlightTransactions,
         validator_state: Arc<AuthorityState>,
         request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
@@ -779,20 +784,29 @@ where
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
         let tx_digest = *request.transaction.digest();
 
-        // Deduplicate concurrent submissions of the same digest: only the first
-        // caller drives the committee-wide submission; the rest wait for its
-        // effects. The guard removes the digest from the in-flight set on every
-        // exit path (success, error, timeout, or cancellation) when it is
-        // dropped.
-        let guard = TransactionSubmissionGuard::new(in_flight_transactions, tx_digest);
-        if !guard.is_new_transaction() {
-            debug!(
-                ?tx_digest,
-                "transaction already in flight; awaiting its effects instead of driving a \
-                 duplicate submission"
-            );
-            return Self::await_in_flight_transaction(&validator_state, tx_digest, &request).await;
-        }
+        // Deduplicate concurrent submissions of the same digest: only the
+        // first caller drives the committee-wide submission and publishes its
+        // outcome; the rest await that outcome. The guard removes the digest
+        // from the in-flight map on every exit path (success, error, timeout,
+        // or cancellation) when it is dropped.
+        let guard = match TransactionSubmissionGuard::acquire(in_flight_transactions, tx_digest) {
+            TransactionSubmission::Driving(guard) => guard,
+            TransactionSubmission::AlreadyInFlight(receiver) => {
+                debug!(
+                    ?tx_digest,
+                    "transaction already in flight; awaiting its outcome instead of driving a \
+                     duplicate submission"
+                );
+                return Self::await_in_flight_transaction(
+                    receiver,
+                    &validator_state,
+                    tx_digest,
+                    &request,
+                    skip_certification,
+                )
+                .await;
+            }
+        };
 
         // This call runs inside a task detached from the caller, so the
         // outcome is logged here rather than left to the caller — a
@@ -813,67 +827,114 @@ where
             Ok(response) => response,
             Err(e) => {
                 warn!(?tx_digest, "TransactionDriver submission failed: {e}");
-                return Err(map_td_error_to_qd(e));
+                let error = map_td_error_to_qd(e);
+                guard.publish(Err(error.clone()));
+                return Err(error);
             }
         };
 
         debug!(?tx_digest, "TransactionDriver submission succeeded");
 
-        let QuorumTransactionResponse {
-            effects: td_effects,
-            events,
-            input_objects,
-            output_objects,
-            auxiliary_data,
-        } = td_response;
+        let td_response = Arc::new(td_response);
+        guard.publish(Ok(td_response.clone()));
 
-        let effects = convert_td_to_qd_effects(td_effects);
-        Ok(ExecuteTransactionResponseV1 {
-            effects,
-            events: if request.include_events { events } else { None },
+        Ok(Self::response_from_driver_response(&td_response, &request))
+    }
+
+    /// Build a caller-specific response from a driver response, honoring the
+    /// caller's include flags.
+    fn response_from_driver_response(
+        td_response: &QuorumTransactionResponse,
+        request: &ExecuteTransactionRequestV1,
+    ) -> ExecuteTransactionResponseV1 {
+        ExecuteTransactionResponseV1 {
+            effects: convert_td_to_qd_effects(td_response.effects.clone()),
+            events: if request.include_events {
+                td_response.events.clone()
+            } else {
+                None
+            },
             input_objects: if request.include_input_objects {
-                input_objects
+                td_response.input_objects.clone()
             } else {
                 None
             },
             output_objects: if request.include_output_objects {
-                output_objects
+                td_response.output_objects.clone()
             } else {
                 None
             },
             auxiliary_data: if request.include_auxiliary_data {
-                auxiliary_data
+                td_response.auxiliary_data.clone()
             } else {
                 None
             },
-        })
+        }
     }
 
-    /// Wait for an already in-flight submission of `tx_digest` to reach
-    /// finality and build the response from the authoritative local cache,
+    /// Await the outcome of an already in-flight submission of `tx_digest`
     /// instead of starting a second committee-wide submission for the same
-    /// transaction. Times out with `TimeoutBeforeFinality` if the in-flight
-    /// submission does not get the transaction checkpointed in time.
+    /// transaction:
+    ///
+    /// - The in-flight submission failed: its error is returned as-is.
+    /// - It succeeded with effects this caller can use: the response is rebuilt
+    ///   from the shared driver response with this caller's include flags.
+    /// - It succeeded with `UncertifiedSingleValidator` effects but this caller
+    ///   did not opt into skip-certification (so nothing downstream reconciles
+    ///   them against the cache): wait for checkpoint inclusion and rebuild
+    ///   from the authoritative local cache instead — uncertified data must
+    ///   never reach a caller that expects certified effects.
+    /// - Nothing was published within `WAIT_FOR_FINALITY_TIMEOUT`, or the
+    ///   in-flight submission's task died without publishing (panic or
+    ///   shutdown): `TimeoutBeforeFinality`, so the client retries.
     async fn await_in_flight_transaction(
+        mut receiver: watch::Receiver<Option<InFlightSubmissionResult>>,
         validator_state: &Arc<AuthorityState>,
         tx_digest: TransactionDigest,
         request: &ExecuteTransactionRequestV1,
+        skip_certification: bool,
     ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
-        let digests = [tx_digest];
-        let seq = validator_state
-            .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT)
+        let outcome = {
+            let outcome_ref = tokio::time::timeout(
+                WAIT_FOR_FINALITY_TIMEOUT,
+                receiver.wait_for(|outcome| outcome.is_some()),
+            )
             .await
-            .ok()
-            .and_then(|inclusion| inclusion.get(&tx_digest).map(|&(seq, _)| seq))
-            .ok_or(QuorumDriverError::TimeoutBeforeFinality)?;
-        Self::build_response_from_cache(
-            validator_state,
-            tx_digest,
-            seq,
-            request.include_events,
-            request.include_input_objects,
-            request.include_output_objects,
-        )
+            .map_err(|_elapsed| QuorumDriverError::TimeoutBeforeFinality)?
+            .map_err(|_closed| QuorumDriverError::TimeoutBeforeFinality)?;
+            // `wait_for` only returns a value matching its predicate, so the
+            // `None` arm is unreachable; mapped to a retriable error instead
+            // of panicking.
+            (*outcome_ref)
+                .clone()
+                .ok_or(QuorumDriverError::TimeoutBeforeFinality)?
+        };
+
+        let td_response = outcome?;
+
+        let uncertified = matches!(
+            td_response.effects.finality_info,
+            TdEffectsFinalityInfo::UncertifiedSingleValidator(_)
+        );
+        if uncertified && !skip_certification {
+            let digests = [tx_digest];
+            let seq = validator_state
+                .wait_for_checkpoint_inclusion(&digests, WAIT_FOR_FINALITY_TIMEOUT)
+                .await
+                .ok()
+                .and_then(|inclusion| inclusion.get(&tx_digest).map(|&(seq, _)| seq))
+                .ok_or(QuorumDriverError::TimeoutBeforeFinality)?;
+            return Self::build_response_from_cache(
+                validator_state,
+                tx_digest,
+                seq,
+                request.include_events,
+                request.include_input_objects,
+                request.include_output_objects,
+            );
+        }
+
+        Ok(Self::response_from_driver_response(&td_response, request))
     }
 
     /// Submit a transaction via the QuorumDriver. `transaction` must be the
@@ -1674,50 +1735,155 @@ fn read_cached_transaction_data(
     ))
 }
 
-/// Tracks a transaction that is being submitted to finality so that concurrent
-/// submissions of the same digest deduplicate.
+/// Outcome of an in-flight driver submission, shared with concurrent
+/// submissions of the same digest: the unfiltered driver response, or the
+/// error the submission failed with.
+type InFlightSubmissionResult = Result<Arc<QuorumTransactionResponse>, QuorumDriverError>;
+
+/// Digests currently being driven to finality by the TransactionDriver,
+/// each with a channel carrying the submission outcome (`None` until the
+/// driving submission resolves).
+type InFlightTransactions =
+    Arc<Mutex<HashMap<TransactionDigest, watch::Receiver<Option<InFlightSubmissionResult>>>>>;
+
+/// Result of trying to register a submission of a digest in the in-flight
+/// map: either this caller drives the committee-wide submission, or another
+/// submission of the same digest is already in flight and this caller should
+/// await its published outcome instead.
+enum TransactionSubmission {
+    Driving(TransactionSubmissionGuard),
+    AlreadyInFlight(watch::Receiver<Option<InFlightSubmissionResult>>),
+}
+
+/// Tracks a transaction that is being submitted to finality so that
+/// concurrent submissions of the same digest deduplicate.
 ///
-/// `is_new_transaction` is `false` when another submission of the same digest
-/// is already in flight; the caller should then wait for that submission's
-/// effects instead of starting a new one. The driving submission's guard
-/// removes the digest from the in-flight set when dropped, covering success,
-/// error, timeout, and cancellation.
+/// Held only by the driving submission, which must `publish` its outcome so
+/// concurrent duplicates can return it. Dropping the guard removes the digest
+/// from the in-flight map on every exit path (success, error, timeout, and
+/// cancellation); receivers subscribed before removal still observe a
+/// published outcome, and if the guard is dropped without publishing (panic
+/// or shutdown) the closed channel tells them the submission died.
 struct TransactionSubmissionGuard {
-    in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
+    in_flight_transactions: InFlightTransactions,
     tx_digest: TransactionDigest,
-    is_new_transaction: bool,
+    sender: watch::Sender<Option<InFlightSubmissionResult>>,
 }
 
 impl TransactionSubmissionGuard {
-    fn new(
-        in_flight_transactions: Arc<Mutex<HashSet<TransactionDigest>>>,
+    fn acquire(
+        in_flight_transactions: InFlightTransactions,
         tx_digest: TransactionDigest,
-    ) -> Self {
-        let is_new_transaction = in_flight_transactions.lock().insert(tx_digest);
-        if is_new_transaction {
-            debug!(?tx_digest, "added transaction to in-flight set");
-        } else {
-            debug!(?tx_digest, "transaction already being processed");
-        }
-        Self {
+    ) -> TransactionSubmission {
+        let sender = {
+            let mut in_flight = in_flight_transactions.lock();
+            match in_flight.entry(tx_digest) {
+                Entry::Occupied(entry) => {
+                    debug!(?tx_digest, "transaction already being processed");
+                    return TransactionSubmission::AlreadyInFlight(entry.get().clone());
+                }
+                Entry::Vacant(entry) => {
+                    let (sender, receiver) = watch::channel(None);
+                    entry.insert(receiver);
+                    debug!(?tx_digest, "added transaction to in-flight map");
+                    sender
+                }
+            }
+        };
+        TransactionSubmission::Driving(Self {
             in_flight_transactions,
             tx_digest,
-            is_new_transaction,
-        }
+            sender,
+        })
     }
 
-    fn is_new_transaction(&self) -> bool {
-        self.is_new_transaction
+    /// Publish the submission outcome to concurrent duplicate submissions.
+    fn publish(&self, result: InFlightSubmissionResult) {
+        // Send fails only when every receiver is dropped, which just means
+        // there is no duplicate submission to notify.
+        let _ = self.sender.send(Some(result));
     }
 }
 
 impl Drop for TransactionSubmissionGuard {
     fn drop(&mut self) {
-        // Only the guard that inserted the digest owns the entry; a duplicate
-        // submission's guard must not remove it while the driving submission
-        // is still in flight.
-        if self.is_new_transaction {
-            self.in_flight_transactions.lock().remove(&self.tx_digest);
+        self.in_flight_transactions.lock().remove(&self.tx_digest);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acquire_driving(
+        in_flight: &InFlightTransactions,
+        tx_digest: TransactionDigest,
+    ) -> TransactionSubmissionGuard {
+        match TransactionSubmissionGuard::acquire(in_flight.clone(), tx_digest) {
+            TransactionSubmission::Driving(guard) => guard,
+            TransactionSubmission::AlreadyInFlight(_) => {
+                panic!("expected to acquire the driving submission")
+            }
         }
+    }
+
+    fn acquire_duplicate(
+        in_flight: &InFlightTransactions,
+        tx_digest: TransactionDigest,
+    ) -> watch::Receiver<Option<InFlightSubmissionResult>> {
+        match TransactionSubmissionGuard::acquire(in_flight.clone(), tx_digest) {
+            TransactionSubmission::Driving(_) => {
+                panic!("expected the digest to already be in flight")
+            }
+            TransactionSubmission::AlreadyInFlight(receiver) => receiver,
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_submission_receives_published_outcome() {
+        let in_flight = InFlightTransactions::default();
+        let tx_digest = TransactionDigest::random();
+
+        let guard = acquire_driving(&in_flight, tx_digest);
+        let mut receiver = acquire_duplicate(&in_flight, tx_digest);
+
+        guard.publish(Err(QuorumDriverError::TimeoutBeforeFinality));
+        drop(guard);
+
+        // The published outcome must survive the guard drop for receivers
+        // subscribed before the entry was removed.
+        let outcome = receiver
+            .wait_for(|outcome| outcome.is_some())
+            .await
+            .expect("outcome was published before the sender dropped")
+            .clone()
+            .expect("wait_for only returns once the outcome is Some");
+        assert!(matches!(
+            outcome,
+            Err(QuorumDriverError::TimeoutBeforeFinality)
+        ));
+        assert!(
+            in_flight.lock().is_empty(),
+            "guard drop must remove the in-flight entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn dropped_guard_without_outcome_closes_channel() {
+        let in_flight = InFlightTransactions::default();
+        let tx_digest = TransactionDigest::random();
+
+        let guard = acquire_driving(&in_flight, tx_digest);
+        let mut receiver = acquire_duplicate(&in_flight, tx_digest);
+        drop(guard);
+
+        receiver
+            .wait_for(|outcome| outcome.is_some())
+            .await
+            .expect_err("dropping the guard without publishing must close the channel");
+        assert!(in_flight.lock().is_empty());
+
+        // The digest can be driven again once the entry is gone.
+        let _guard = acquire_driving(&in_flight, tx_digest);
     }
 }

--- a/crates/iota-e2e-tests/Cargo.toml
+++ b/crates/iota-e2e-tests/Cargo.toml
@@ -42,7 +42,7 @@ url.workspace = true
 # internal dependencies
 iota-common.workspace = true
 iota-config.workspace = true
-iota-core.workspace = true
+iota-core = { workspace = true, features = ["test-utils"] }
 iota-framework.workspace = true
 iota-genesis-builder.workspace = true
 iota-grpc-client.workspace = true

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -1129,6 +1129,15 @@ async fn test_orchestrator_rejects_expired_transaction() {
 /// transaction is provably still stuck (no quorum can possibly have been
 /// reached yet); quorum is then restored and finality is confirmed
 /// independently of the aborted caller.
+///
+/// Checkpoint inclusion alone cannot isolate the detached task: the
+/// submission typically reaches a live validator's consensus adapter before
+/// the abort, and the validator carries it to finality once quorum is
+/// restored even if the fullnode-side task died. The in-flight map is the
+/// fullnode-side signal — a cancelled submission drops its guard and removes
+/// the entry — so the test asserts the digest stays in flight across the
+/// abort and that a duplicate submitted while quorum is still broken joins
+/// the surviving submission instead of driving its own.
 #[sim_test]
 async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
     let _env_guard = enable_pcool_env();
@@ -1155,14 +1164,18 @@ async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
     test_cluster.stop_node(&validator_addresses[0]);
     test_cluster.stop_node(&validator_addresses[1]);
 
-    let caller_task = tokio::spawn(async move {
-        orchestrator
-            .execute_transaction_block(
-                ExecuteTransactionRequestV1::new(txn),
-                ExecuteTransactionRequestType::WaitForLocalExecution,
-                Some(make_socket_addr()),
-            )
-            .await
+    let caller_task = tokio::spawn({
+        let orchestrator = orchestrator.clone();
+        let txn = txn.clone();
+        async move {
+            orchestrator
+                .execute_transaction_block(
+                    ExecuteTransactionRequestV1::new(txn),
+                    ExecuteTransactionRequestType::WaitForLocalExecution,
+                    Some(make_socket_addr()),
+                )
+                .await
+        }
     });
     tokio::time::sleep(Duration::from_secs(1)).await;
     caller_task.abort();
@@ -1173,6 +1186,33 @@ async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
             .is_cancelled(),
         "caller task should have been aborted, not have panicked"
     );
+    assert_eq!(
+        orchestrator.in_flight_duplicates_for_testing(&digest),
+        Some(0),
+        "the submission must still be in flight after the caller abort"
+    );
+
+    // A duplicate submitted while quorum is still broken must join the
+    // surviving submission instead of driving a second committee-wide one.
+    let duplicate_task = tokio::spawn({
+        let orchestrator = orchestrator.clone();
+        let txn = txn.clone();
+        async move {
+            orchestrator
+                .execute_transaction_block(
+                    ExecuteTransactionRequestV1::new(txn),
+                    ExecuteTransactionRequestType::WaitForLocalExecution,
+                    Some(make_socket_addr()),
+                )
+                .await
+        }
+    });
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_eq!(
+        orchestrator.in_flight_duplicates_for_testing(&digest),
+        Some(1),
+        "the duplicate must await the in-flight submission's outcome"
+    );
 
     // Restore quorum. The detached task inside the orchestrator — never
     // aborted — should still be retrying submission on its own and drive the
@@ -1180,6 +1220,23 @@ async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
     tokio::join!(
         test_cluster.start_node(&validator_addresses[0]),
         test_cluster.start_node(&validator_addresses[1]),
+    );
+
+    let (duplicate_response, _) = duplicate_task
+        .await
+        .expect("duplicate task should not panic")?;
+    assert!(
+        matches!(
+            duplicate_response.effects.finality_info,
+            EffectsFinalityInfo::Checkpointed(_, _)
+        ),
+        "the duplicate should resolve to Checkpointed via the surviving submission, got {:?}",
+        duplicate_response.effects.finality_info
+    );
+    assert_eq!(
+        duplicate_response.effects.effects.transaction_digest(),
+        &digest,
+        "the duplicate must return the aborted caller's transaction"
     );
 
     let inclusion = handle

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -759,6 +759,76 @@ async fn test_pcool_deduplicates_concurrent_submissions() -> Result<(), anyhow::
     Ok(())
 }
 
+/// A duplicate submission must inherit the outcome of the in-flight
+/// submission it waited on. With a transaction validators deterministically
+/// reject (its gas object version was already consumed), the duplicate must
+/// fail with the same error as the driving submission instead of waiting for
+/// a checkpoint inclusion that can never happen and timing out.
+#[sim_test]
+async fn test_pcool_duplicate_submission_inherits_failure() -> Result<(), anyhow::Error> {
+    let _env_guard = enable_pcool_env();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let context = &test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.iota_node;
+    let orchestrator = handle.with(|n| n.transaction_orchestrator().as_ref().unwrap().clone());
+
+    // Consume a gas object, then build a second transaction spending the
+    // same (now stale) gas object version: validators reject it as invalid,
+    // deterministically failing the driving submission.
+    let (sender, gas_object) = context.get_one_gas_object().await.unwrap().unwrap();
+    let gas_price = context.get_reference_gas_price().await.unwrap();
+    let spend = context.sign_transaction(
+        &TestTransactionBuilder::new(sender, gas_object, gas_price)
+            .transfer_iota(Some(1), sender)
+            .build(),
+    );
+    orchestrator
+        .execute_transaction_block(
+            ExecuteTransactionRequestV1::new(spend),
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(make_socket_addr()),
+        )
+        .await
+        .expect("spending the gas object must succeed");
+
+    let stale = context.sign_transaction(
+        &TestTransactionBuilder::new(sender, gas_object, gas_price)
+            .transfer_iota(Some(2), sender)
+            .build(),
+    );
+
+    let (first, second) = tokio::join!(
+        orchestrator.execute_transaction_block(
+            ExecuteTransactionRequestV1::new(stale.clone()),
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(make_socket_addr()),
+        ),
+        orchestrator.execute_transaction_block(
+            ExecuteTransactionRequestV1::new(stale.clone()),
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(make_socket_addr()),
+        ),
+    );
+
+    let first_err = first.expect_err("transaction spending a stale gas object must fail");
+    let second_err = second.expect_err("transaction spending a stale gas object must fail");
+    assert!(
+        matches!(first_err, QuorumDriverError::InvalidTransaction(_)),
+        "expected the submission to be rejected as invalid, got {first_err:?}"
+    );
+    assert_eq!(
+        first_err, second_err,
+        "the duplicate submission must inherit the in-flight submission's error"
+    );
+
+    Ok(())
+}
+
 /// Without consensus quorum, the skip-cert path can never observe checkpoint
 /// inclusion. The orchestrator must surface this as `TimeoutBeforeFinality`
 /// (a retriable transient), not `QuorumDriverInternal` — the latter would

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -829,6 +829,74 @@ async fn test_pcool_duplicate_submission_inherits_failure() -> Result<(), anyhow
     Ok(())
 }
 
+/// A duplicate that requires certified effects (v1 without checkpoint
+/// waiting) joining an in-flight skip-cert submission must not inherit the
+/// uncertified single-validator effects: it certifies the effects itself and
+/// returns certified finality.
+#[sim_test]
+async fn test_pcool_duplicate_requiring_certification_returns_certified_effects()
+-> Result<(), anyhow::Error> {
+    let _env_guard = enable_pcool_env();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let context = &mut test_cluster.wallet;
+    let handle = &test_cluster.fullnode_handle.iota_node;
+    let orchestrator = handle.with(|n| n.transaction_orchestrator().as_ref().unwrap().clone());
+
+    let txn = batch_make_transfer_transactions(context, 1)
+        .await
+        .pop()
+        .expect("gas objects should produce at least one tx");
+
+    let request = |txn: Transaction| ExecuteTransactionRequestV1 {
+        transaction: txn,
+        include_events: false,
+        include_input_objects: false,
+        include_output_objects: false,
+        include_auxiliary_data: false,
+    };
+
+    // `WaitForLocalExecution` drives a skip-cert submission; the head start
+    // lets the v1 call below join it as a duplicate instead of driving its
+    // own submission.
+    let (driving, duplicate) = tokio::join!(
+        orchestrator.execute_transaction_block(
+            request(txn.clone()),
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+            Some(make_socket_addr()),
+        ),
+        async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            orchestrator
+                .execute_transaction_v1(request(txn.clone()), false, Some(make_socket_addr()))
+                .await
+        },
+    );
+
+    let (driving_response, _) = driving?;
+    let duplicate_response = duplicate?;
+
+    assert!(
+        !matches!(
+            duplicate_response.effects.finality_info,
+            EffectsFinalityInfo::UncertifiedSingleValidator(_)
+        ),
+        "a certification-requiring duplicate must never see uncertified effects, got {:?}",
+        duplicate_response.effects.finality_info
+    );
+    assert_eq!(
+        driving_response.effects.effects.transaction_digest(),
+        duplicate_response.effects.effects.transaction_digest(),
+        "the duplicate must resolve to the same finalized effects"
+    );
+
+    Ok(())
+}
+
 /// Without consensus quorum, the skip-cert path can never observe checkpoint
 /// inclusion. The orchestrator must surface this as `TimeoutBeforeFinality`
 /// (a retriable transient), not `QuorumDriverInternal` — the latter would


### PR DESCRIPTION
# Description of change

Targets `consensus/upstream/detached-td-submission`, which already carries the detached-submission rework (#12244) and in-flight dedup (#12239). This PR adds the remaining piece: how duplicate driver-path submissions resolve from the in-flight submission's outcome.

- The in-flight set becomes a map of per-digest `watch` channels; the driving submission publishes its outcome (shared unfiltered driver response, or the error it failed with) and duplicates return that outcome directly instead of waiting for checkpoint inclusion. Duplicates apply their own `include_*` flags to the shared response, so requests with different flags stay correct.
- Errors propagate to duplicates immediately (e.g. a validator rejection) instead of surfacing as `TimeoutBeforeFinality` after the full 30s finality timeout.
- A duplicate that requires certified effects but inherits an uncertified (skip-cert) outcome runs only the effects-certification step for the already-submitted digest (new `TransactionDriver::certify_transaction`) — no second committee-wide submission, and no checkpoint wait the caller never asked for.
- A closed channel without any outcome (checkpoint-race cancellation of the driver, task panic, or shutdown) falls back to waiting for checkpoint inclusion and answering from the authoritative local cache. In the race-cancellation case — the routine one — the transaction is already checkpointed, so the fallback resolves immediately instead of surfacing a spurious retriable timeout at the moment the transaction became final.

How a duplicate resolves, by the driving submission's mode and its own certification requirement:

| Driving submission | Duplicate | Resolution |
|---|---|---|
| any | any | inherits errors as-is; unpublished outcome → checkpoint-inclusion fallback |
| skip-cert | skip-cert (block/WFLE, gRPC with checkpoint timeout) | returns the shared (possibly uncertified) response; the caller's existing checkpoint reconciliation finalizes it |
| skip-cert | requires certification (block/other, gRPC without timeout) | certifies the effects via `certify_transaction`, returns certified finality |
| certifying | any | returns the shared certified response |
| cancelled by checkpoint race | any | checkpoint-inclusion fallback resolves immediately from the local cache (`Checkpointed` finality) |

This is only sound because the base runs the driving submission detached: a client disconnect cannot cancel it mid-flight and strand the duplicates awaiting its outcome.

Follow-up: #12410 (move the gRPC handler's checkpoint waiting into `execute_transaction_v1` so the finality contract has a single implementation).

## Links to any relevant issues

Related: iotaledger/iota-private#466

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New coverage: guard/channel unit tests (publish survives guard drop for subscribed receivers; closed channel on unpublished drop; re-drive after release) and e2e sim tests asserting concurrent submissions deduplicate to the same effects, a duplicate inherits the driving submission's rejection error instead of timing out, and a certification-requiring duplicate joining a skip-cert submission returns certified effects.

