### PR TITLE
feat(graphql): Support fallback for fetching events by tx

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.move
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL event queries filtered by transaction digest under
+// pruning, with no historical fallback configured. Covers:
+// - `Query.events(filter: { transactionDigest })`
+// - `TransactionBlockEffects.events`
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    use iota::event;
+
+    public struct Foo has key, store { id: UID, v: u64 }
+    public struct Bumped has copy, drop { v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+
+    public entry fun bump(foo: &mut Foo, times: u64) {
+        let mut i = 0;
+        while (i < times) {
+            foo.v = foo.v + 1;
+            event::emit(Bumped { v: foo.v });
+            i = i + 1;
+        }
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# run Test::M::bump --sender A --args object(2,0) 3
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run Test::M::bump --sender A --args object(2,0) 3
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: Query.events on a pruned transaction — no fallback.
+# The transaction has been pruned, so the request errors with DATA_PRUNED.
+{
+  events(filter: { transactionDigest: "@{digest_3}" }) {
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# B: Query.events on an unpruned transaction resolves. The cursors printed
+# here are the inputs for the window in D.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }) {
+    pageInfo { hasPreviousPage hasNextPage startCursor endCursor }
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# C: TransactionBlockEffects.events on an unpruned transaction.
+{
+  transactionBlock(digest: "@{digest_11}") {
+    effects {
+      events {
+        nodes { json }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"tx":7,"e":0,"c":10} {"tx":7,"e":2,"c":10}
+# D: both cursors set — the window between the first and the last event of
+# the transaction. Only the middle event is inside the window (cursors are
+# exclusive). Both page flags are true because events exist at the cursor
+# positions, outside the window.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}
+
+//# run-graphql --cursors {"tx":5,"e":0,"c":10}
+# E: `after` cursor from a different transaction. No event of this
+# transaction sits at the cursor, so the bound is invalid and the connection
+# comes back empty, as for other event queries.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# F: digest combined with another filter — served by the lookup-table path,
+# without fallback support.
+{
+  events(filter: { transactionDigest: "@{digest_11}", sender: "@{A}" }) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.snap
@@ -1,0 +1,220 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 21 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-30:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6604400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 32:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 34:
+//# run Test::M::bump --sender A --args object(2,0) 3
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AQAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AgAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AwAAAAAAAAA=" }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 4, line 36:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, line 38:
+//# advance-epoch
+Epoch advanced: 0
+
+task 6, line 40:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 42:
+//# advance-epoch
+Epoch advanced: 1
+
+task 8, line 44:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 9, line 46:
+//# advance-epoch
+Epoch advanced: 2
+
+task 10, line 48:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 11, line 50:
+//# run Test::M::bump --sender A --args object(2,0) 3
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BAAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BQAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BgAAAAAAAAA=" }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 12, line 52:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 13, line 54:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 14, line 56:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 15, lines 58-65:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: data for tx BFJpQE4QdDmhuC72E6cqJMmvhBhiA8gTdqH5AZ8NRhHk potentially pruned",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "events"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 16, lines 67-75:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "4"
+          }
+        },
+        {
+          "json": {
+            "v": "5"
+          }
+        },
+        {
+          "json": {
+            "v": "6"
+          }
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJ0eCI6NywiZSI6MiwiYyI6MTB9",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "eyJ0eCI6NywiZSI6MCwiYyI6MTB9"
+      }
+    }
+  }
+}
+
+task 17, lines 77-87:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlock": {
+      "effects": {
+        "events": {
+          "nodes": [
+            {
+              "json": {
+                "v": "4"
+              }
+            },
+            {
+              "json": {
+                "v": "5"
+              }
+            },
+            {
+              "json": {
+                "v": "6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 18, lines 89-99:
+//# run-graphql --cursors {"tx":7,"e":0,"c":10} {"tx":7,"e":2,"c":10}
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "5"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 19, lines 101-110:
+//# run-graphql --cursors {"tx":5,"e":0,"c":10}
+Response: {
+  "data": {
+    "events": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 20, lines 112-120:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "4"
+          }
+        },
+        {
+          "json": {
+            "v": "5"
+          }
+        },
+        {
+          "json": {
+            "v": "6"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/src/types/event/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/event/filter.rs
@@ -50,3 +50,14 @@ pub(crate) struct EventFilter {
     // pub all
     // pub not
 }
+
+impl EventFilter {
+    /// Returns the transaction digest when `transaction_digest` is the only
+    /// filter set.
+    pub(crate) fn only_transaction_digest(&self) -> Option<Digest> {
+        if self.sender.is_some() || self.emitting_module.is_some() || self.event_type.is_some() {
+            return None;
+        }
+        self.transaction_digest
+    }
+}

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Bound;
+
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
@@ -171,6 +173,30 @@ impl Event {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
+        use checkpoints::dsl;
+        // Exclusive upperbound, we cannot return newer data than `checkpoint_viewed_at`
+        let tx_hi: i64 = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    dsl::checkpoints
+                        .select(dsl::network_total_transactions)
+                        .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
+                })
+            })
+            .await?;
+
+        // For the only-`transactionDigest` case, we support fallback.
+        if let Some(tx_digest) = filter.only_transaction_digest() {
+            return Self::paginate_by_tx_digest_with_fallback(
+                db,
+                page,
+                tx_digest,
+                checkpoint_viewed_at,
+                tx_hi,
+            )
+            .await;
+        }
+
         // Construct tx and ev sequence number query with table-relevant filters, if
         // they exist. The resulting query will look something like `SELECT
         // tx_sequence_number, event_sequence_number FROM lookup_table WHERE
@@ -188,14 +214,8 @@ impl Event {
             }
         };
 
-        use checkpoints::dsl;
         let (prev, next, results) = db
             .execute(move |conn| {
-                let tx_hi: i64 = conn.first(move || {
-                    dsl::checkpoints.select(dsl::network_total_transactions)
-                        .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
-                })?;
-
                 let (prev, next, mut events): (bool, bool, Vec<StoredEvent>) =
                     if let Some(filter_query) =  query_constraint {
                         let query = add_bounds(filter_query, &filter.transaction_digest, &page, tx_hi);
@@ -262,6 +282,58 @@ impl Event {
             ));
         }
 
+        Ok(conn)
+    }
+
+    /// Paginates events of a single transaction with fallback support.
+    ///
+    /// `tx_hi` is the exclusive upperbound on transaction sequence numbers
+    async fn paginate_by_tx_digest_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        tx_digest: Digest,
+        checkpoint_viewed_at: u64,
+        tx_hi: i64,
+    ) -> Result<Connection<String, Event>, Error> {
+        // Fetch the page plus the rows at the cursors, to later compute
+        // `has_next`/`has_prev` via `paginate_results`.
+        let min_tx_ev_seq = page
+            .after()
+            .map_or(Bound::Unbounded, |c| Bound::Included((c.tx, c.e)));
+        // Events of transactions at or above `tx_hi` are not visible at
+        // `checkpoint_viewed_at`.
+        let max_tx_ev_seq = match page.before() {
+            Some(c) if c.tx < tx_hi as u64 => Bound::Included((c.tx, c.e)),
+            _ => Bound::Excluded((tx_hi as u64, 0)),
+        };
+        let mut results = db
+            .inner
+            .query_stored_events_by_tx_digest_with_fallback(
+                tx_digest.into(),
+                (min_tx_ev_seq, max_tx_ev_seq),
+                page.limit() + 2,
+                !page.is_from_front(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !page.is_from_front() {
+            results.reverse();
+        }
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = Connection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            conn.edges.push(Edge::new(
+                cursor,
+                Event::try_from_stored_event(stored, checkpoint_viewed_at)?,
+            ));
+        }
         Ok(conn)
     }
 

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Bound;
-
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
@@ -18,7 +16,7 @@ use iota_indexer::{
     schema::{checkpoints, events},
 };
 use iota_sdk_types::{Address as NativeAddress, Event as NativeEvent, Identifier, ObjectId};
-use iota_types::parse_iota_struct_tag;
+use iota_types::{event::EventID, parse_iota_struct_tag};
 use lookups::{add_bounds, select_emit_module, select_event_type, select_sender};
 
 use crate::{
@@ -295,22 +293,32 @@ impl Event {
         checkpoint_viewed_at: u64,
         tx_hi: i64,
     ) -> Result<Connection<String, Event>, Error> {
-        // Fetch the page plus the rows at the cursors, to later compute
-        // `has_next`/`has_prev` via `paginate_results`.
-        let min_tx_ev_seq = page
-            .after()
-            .map_or(Bound::Unbounded, |c| Bound::Included((c.tx, c.e)));
-        // Events of transactions at or above `tx_hi` are not visible at
-        // `checkpoint_viewed_at`.
-        let max_tx_ev_seq = match page.before() {
-            Some(c) if c.tx < tx_hi as u64 => Bound::Included((c.tx, c.e)),
-            _ => Bound::Excluded((tx_hi as u64, 0)),
+        // Page cursors are inclusive, we need to convert them to exclusive
+        let cursor = if page.is_from_front() {
+            // Cannot do -1 when cursor=0
+            page.after().and_then(|cursor| {
+                cursor.e.checked_sub(1).map(|event_seq| EventID {
+                    tx_digest: tx_digest.into(),
+                    event_seq,
+                })
+            })
+        } else {
+            // Cannot do +1 when cursor=`u64::MAX`
+            page.before().and_then(|cursor| {
+                cursor.e.checked_add(1).map(|event_seq| EventID {
+                    tx_digest: tx_digest.into(),
+                    event_seq,
+                })
+            })
         };
+
+        // we fetch with limit+2, so that we receive back both cursors in case of full
+        // page, as required by `page.paginate_results`
         let mut results = db
             .inner
             .query_stored_events_by_tx_digest_with_fallback(
                 tx_digest.into(),
-                (min_tx_ev_seq, max_tx_ev_seq),
+                cursor,
                 page.limit() + 2,
                 !page.is_from_front(),
             )
@@ -319,6 +327,18 @@ impl Event {
         if !page.is_from_front() {
             results.reverse();
         }
+
+        // Initial fetch above honored only the start cursor. We filter the result to
+        // also honor the end cursor and the `tx_hi`
+        results.retain(|ev| {
+            let key = (
+                ev.tx_sequence_number as u64,
+                ev.event_sequence_number as u64,
+            );
+            ev.tx_sequence_number < tx_hi
+                && page.after().is_none_or(|c| (c.tx, c.e) <= key)
+                && page.before().is_none_or(|c| key <= (c.tx, c.e))
+        });
 
         let (prev, next, results) = page.paginate_results(
             results.first().map(|f| f.cursor(checkpoint_viewed_at)),

--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -15,7 +15,10 @@ use iota_types::{
     digests::TransactionDigest,
     effects::TransactionEvents,
     full_checkpoint_content::CheckpointTransaction,
-    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt,
+        CheckpointSequenceNumber,
+    },
     object::Object,
 };
 use prometheus_filtered::Registry;
@@ -26,10 +29,11 @@ use crate::{
     metrics::IndexerMetrics,
     models::{
         checkpoints::StoredCheckpoint,
+        events::StoredEvent,
         objects::StoredObject,
         transactions::{StoredTransaction, tx_events_to_iota_tx_events},
     },
-    types::{IndexedCheckpoint, IndexedObject},
+    types::{IndexedCheckpoint, IndexedEvent, IndexedObject},
 };
 
 /// Alias for an [`Object`] fetched from historical fallback storage.
@@ -66,21 +70,52 @@ impl From<HistoricalFallbackCheckpoint> for StoredCheckpoint {
 /// Wrapper for [`TransactionEvents`] and additional data fetched from
 /// historical fallback storage.
 ///
-/// Contains all data needed to reconstruct [`IotaEvent`]s.
+/// Contains all data needed to reconstruct [`IotaEvent`]s or [`StoredEvent`]s.
 #[derive(Debug, Clone)]
 pub struct HistoricalFallbackEvents {
     /// Events emitted during transaction execution.
     events: TransactionEvents,
+    /// Digest of the transaction that emitted the events.
+    tx_digest: TransactionDigest,
+    /// Sequence number of the transaction that emitted the events.
+    tx_sequence_number: u64,
+    /// Sequence number of the checkpoint the transaction is part of.
+    checkpoint_sequence_number: CheckpointSequenceNumber,
     /// Checkpoint timestamp.
     timestamp: u64,
 }
 
 impl HistoricalFallbackEvents {
-    pub fn new(events: TransactionEvents, checkpoint_summary: CertifiedCheckpointSummary) -> Self {
-        Self {
+    /// Creates the wrapper from the events of the `tx_digest` transaction and
+    /// the checkpoint the transaction is part of.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IndexerError::HistoricalFallbackStorageError`] when
+    /// transaction is not part of the provided checkpoint.
+    pub fn new(
+        events: TransactionEvents,
+        tx_digest: TransactionDigest,
+        checkpoint_summary: &CertifiedCheckpointSummary,
+        checkpoint_contents: &CheckpointContents,
+    ) -> IndexerResult<Self> {
+        let Some(tx_sequence_number) = checkpoint_contents
+            .enumerate_transactions(checkpoint_summary)
+            .find(|(_, execution_digest)| execution_digest.transaction == tx_digest)
+            .map(|(seq, _)| seq)
+        else {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "cannot find transaction sequence number to transaction: {tx_digest}"
+            )));
+        };
+
+        Ok(Self {
             events,
+            tx_digest,
+            tx_sequence_number,
+            checkpoint_sequence_number: checkpoint_summary.sequence_number,
             timestamp: checkpoint_summary.timestamp_ms,
-        }
+        })
     }
 
     /// Converts the raw [`TransactionEvents`] into JSON RPC compatible
@@ -88,16 +123,33 @@ impl HistoricalFallbackEvents {
     pub(crate) async fn into_iota_events(
         self,
         package_resolver: &Arc<Resolver<impl PackageStore>>,
-        tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
         tx_events_to_iota_tx_events(
             self.events,
             package_resolver,
-            tx_digest,
+            self.tx_digest,
             Some(self.timestamp),
         )
         .await
         .map(|tx_block_event| tx_block_event.data)
+    }
+
+    /// Converts the raw [`TransactionEvents`] into [`StoredEvent`]s.
+    pub(crate) fn into_stored_events(self) -> Vec<StoredEvent> {
+        self.events
+            .iter()
+            .enumerate()
+            .map(|(idx, event)| {
+                StoredEvent::from(IndexedEvent::from_event(
+                    self.tx_sequence_number,
+                    idx as u64,
+                    self.checkpoint_sequence_number,
+                    self.tx_digest,
+                    event,
+                    self.timestamp,
+                ))
+            })
+            .collect()
     }
 }
 

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -19,8 +19,9 @@ use iota_json_rpc_types::{CheckpointId, IotaEvent};
 use iota_sdk_types::{Address, ObjectId, Version};
 use iota_types::{
     digests::TransactionDigest,
-    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
-    event::EventID,
+    effects::{
+        TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt, TransactionEvents,
+    },
     full_checkpoint_content::CheckpointTransaction,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt, CheckpointDigest,
@@ -45,9 +46,11 @@ use crate::{
         metrics::HistoricalFallbackClientMetrics,
     },
     models::{
-        checkpoints::StoredCheckpoint, objects::StoredObject, transactions::StoredTransaction,
+        checkpoints::StoredCheckpoint, events::StoredEvent, objects::StoredObject,
+        transactions::StoredTransaction,
     },
     read::PackageResolver,
+    types::IndexedEvent,
 };
 
 /// Represents the Input objects of a transaction.
@@ -331,24 +334,8 @@ impl HistoricalFallbackReader {
         &self,
         tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
-        let tx_digests = &[tx_digest];
-        let (events, checkpoint_summaries) = tokio::try_join!(
-            self.client.multi_get_events_by_tx_digests(tx_digests),
-            self.resolve_checkpoints(tx_digests)
-        )?;
-
-        // check first if transaction exists, all valid transaction are part of a
-        // checkpoint, if not found then the provided digest is invalid.
-        let (summary, _) = checkpoint_summaries
-            .get(&tx_digest)
-            .cloned()
-            .ok_or_else(|| {
-                IndexerError::HistoricalFallbackStorageError(format!(
-                    "transaction: {tx_digest} does not exist"
-                ))
-            })?;
-
-        let Some(Some(events)) = events.into_iter().next() else {
+        let (events, (summary, _)) = self.events_with_checkpoint(tx_digest).await?;
+        let Some(events) = events else {
             // transaction does not have associated events.
             return Ok(vec![]);
         };
@@ -356,6 +343,31 @@ impl HistoricalFallbackReader {
         HistoricalFallbackEvents::new(events, summary)
             .into_iota_events(&self.package_resolver, tx_digest)
             .await
+    }
+
+    /// Fetches the events of a transaction together with the checkpoint the
+    /// transaction belongs to.
+    ///
+    /// The events are `None` when the transaction did not emit any.
+    async fn events_with_checkpoint(
+        &self,
+        tx_digest: TransactionDigest,
+    ) -> IndexerResult<(Option<TransactionEvents>, HistoricalFallbackCheckpoint)> {
+        let tx_digests = &[tx_digest];
+        let (events, checkpoints) = tokio::try_join!(
+            self.client.multi_get_events_by_tx_digests(tx_digests),
+            self.resolve_checkpoints(tx_digests)
+        )?;
+
+        // check first if transaction exists, all valid transaction are part of a
+        // checkpoint, if not found then the provided digest is invalid.
+        let checkpoint = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
+            IndexerError::HistoricalFallbackStorageError(format!(
+                "transaction: {tx_digest} does not exist"
+            ))
+        })?;
+
+        Ok((events.into_iter().next().flatten(), checkpoint))
     }
 
     /// Fetches transactions from the provided transaction digests.
@@ -555,69 +567,64 @@ impl HistoricalFallbackReader {
         Ok(transactions.into_iter().flatten().collect())
     }
 
-    /// Fetches events for a specific transaction.
+    /// Fetches events of a transaction from `event_seq` range.
     ///
-    /// Returns events emitted by the specified transaction, with support for
-    /// cursor-based pagination and ordering.
-    ///
-    /// # Pagination Behavior
-    ///
-    /// Events are indexed by their position in the transaction (event_seq = 0,
-    /// 1, 2, ...).
-    ///
-    /// | cursor      | descending | Result                   |
-    /// |-------------|------------|--------------------------|
-    /// | `None`      | `false`    | Starts from event_seq 0  |
-    /// | `None`      | `true`     | Starts from last event   |
-    /// | `Some(seq)` | `false`    | Starts after event_seq   |
-    /// | `Some(seq)` | `true`     | Starts before event_seq  |
-    pub(crate) async fn events(
+    /// Returns up to `limit` events ordered by `event_seq` according to
+    /// `is_descending` flag.
+    pub(crate) async fn events_in_seq_range(
         &self,
         tx_digest: TransactionDigest,
-        cursor: Option<EventID>,
+        ev_seq_range: (Bound<u64>, Bound<u64>),
         limit: usize,
-        descending_order: bool,
-    ) -> IndexerResult<Vec<IotaEvent>> {
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
         if limit == 0 {
             return Ok(vec![]);
         }
 
-        // validate cursor if provided
-        let start_seq = if let Some(cursor) = cursor {
-            if cursor.tx_digest != tx_digest {
-                return Err(IndexerError::InvalidArgument(format!(
-                    "Cursor tx_digest {} does not match requested tx_digest {tx_digest}",
-                    cursor.tx_digest
-                )));
-            }
-            Some(cursor.event_seq)
-        } else {
-            None
+        let (events, (summary, contents)) = self.events_with_checkpoint(tx_digest).await?;
+        let Some(events) = events else {
+            // transaction does not have associated events.
+            return Ok(vec![]);
         };
 
-        let events = self.all_events(tx_digest).await?;
-
-        // apply ordering, cursor, and limit
-        let events = if descending_order {
-            events
-                .into_iter()
-                .enumerate()
-                .rev() // reverse for descending
-                .filter(|(idx, _)| start_seq.is_none_or(|seq| (*idx as u64) < seq))
-                .take(limit)
-                .map(|(_, event)| event)
-                .collect()
-        } else {
-            events
-                .into_iter()
-                .enumerate()
-                .filter(|(idx, _)| start_seq.is_none_or(|seq| (*idx as u64) > seq))
-                .take(limit)
-                .map(|(_, event)| event)
-                .collect()
+        let Some(tx_sequence_number) = contents
+            .enumerate_transactions(&summary)
+            .find(|(_, execution_digest)| execution_digest.transaction == tx_digest)
+            .map(|(seq, _)| seq)
+        else {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "cannot find transaction sequence number to transaction: {tx_digest}"
+            )));
         };
 
-        Ok(events)
+        // events are indexed by their position in the transaction
+        // (event_sequence_number = 0, 1, 2, ...)
+        let in_range = events
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| ev_seq_range.contains(&(*idx as u64)))
+            .map(|(idx, event)| {
+                StoredEvent::from(IndexedEvent::from_event(
+                    tx_sequence_number,
+                    idx as u64,
+                    summary.sequence_number,
+                    tx_digest,
+                    event,
+                    summary.timestamp_ms,
+                ))
+            });
+
+        let stored_events: Vec<StoredEvent> = if is_descending {
+            let mut stored_events: Vec<_> = in_range.collect();
+            stored_events.reverse();
+            stored_events.truncate(limit);
+            stored_events
+        } else {
+            in_range.take(limit).collect()
+        };
+
+        Ok(stored_events)
     }
 
     /// Resolves the sequence number for a given [`TransactionDigest`] by
@@ -634,7 +641,7 @@ impl HistoricalFallbackReader {
     /// If the resolved checkpoint's contents do not contain the digest,
     /// which would indicate inconsistency between the historical store's index
     /// and its checkpoint contents.
-    async fn resolve_transaction_sequence_number(
+    pub(crate) async fn resolve_transaction_sequence_number(
         &self,
         digest: TransactionDigest,
     ) -> IndexerResult<TransactionSequenceNumber> {

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -19,9 +19,8 @@ use iota_json_rpc_types::{CheckpointId, IotaEvent};
 use iota_sdk_types::{Address, ObjectId, Version};
 use iota_types::{
     digests::TransactionDigest,
-    effects::{
-        TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt, TransactionEvents,
-    },
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
+    event::EventID,
     full_checkpoint_content::CheckpointTransaction,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt, CheckpointDigest,
@@ -50,7 +49,6 @@ use crate::{
         transactions::StoredTransaction,
     },
     read::PackageResolver,
-    types::IndexedEvent,
 };
 
 /// Represents the Input objects of a transaction.
@@ -334,25 +332,19 @@ impl HistoricalFallbackReader {
         &self,
         tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
-        let (events, (summary, _)) = self.events_with_checkpoint(tx_digest).await?;
-        let Some(events) = events else {
-            // transaction does not have associated events.
-            return Ok(vec![]);
-        };
-
-        HistoricalFallbackEvents::new(events, summary)
-            .into_iota_events(&self.package_resolver, tx_digest)
+        self.fetch_events(tx_digest)
+            .await?
+            .into_iota_events(&self.package_resolver)
             .await
     }
 
-    /// Fetches the events of a transaction together with the checkpoint the
-    /// transaction belongs to.
-    ///
-    /// The events are `None` when the transaction did not emit any.
-    async fn events_with_checkpoint(
+    /// Fetches the events of a transaction from the historical fallback
+    /// storage, together with the transaction and checkpoint data needed to
+    /// convert them to other formats.
+    async fn fetch_events(
         &self,
         tx_digest: TransactionDigest,
-    ) -> IndexerResult<(Option<TransactionEvents>, HistoricalFallbackCheckpoint)> {
+    ) -> IndexerResult<HistoricalFallbackEvents> {
         let tx_digests = &[tx_digest];
         let (events, checkpoints) = tokio::try_join!(
             self.client.multi_get_events_by_tx_digests(tx_digests),
@@ -361,13 +353,16 @@ impl HistoricalFallbackReader {
 
         // check first if transaction exists, all valid transaction are part of a
         // checkpoint, if not found then the provided digest is invalid.
-        let checkpoint = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
+        let (summary, contents) = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
             IndexerError::HistoricalFallbackStorageError(format!(
                 "transaction: {tx_digest} does not exist"
             ))
         })?;
 
-        Ok((events.into_iter().next().flatten(), checkpoint))
+        // the transaction did not emit any events when `None`.
+        let events = events.into_iter().next().flatten().unwrap_or_default();
+
+        HistoricalFallbackEvents::new(events, tx_digest, &summary, &contents)
     }
 
     /// Fetches transactions from the provided transaction digests.
@@ -567,64 +562,69 @@ impl HistoricalFallbackReader {
         Ok(transactions.into_iter().flatten().collect())
     }
 
-    /// Fetches events of a transaction from `event_seq` range.
+    /// Fetches events for a specific transaction.
     ///
-    /// Returns up to `limit` events ordered by `event_seq` according to
-    /// `is_descending` flag.
-    pub(crate) async fn events_in_seq_range(
+    /// Returns events emitted by the specified transaction, with support for
+    /// cursor-based pagination and ordering.
+    ///
+    /// # Pagination Behavior
+    ///
+    /// Events are indexed by their position in the transaction (event_seq = 0,
+    /// 1, 2, ...).
+    ///
+    /// | cursor      | descending | Result                   |
+    /// |-------------|------------|--------------------------|
+    /// | `None`      | `false`    | Starts from event_seq 0  |
+    /// | `None`      | `true`     | Starts from last event   |
+    /// | `Some(seq)` | `false`    | Starts after event_seq   |
+    /// | `Some(seq)` | `true`     | Starts before event_seq  |
+    pub(crate) async fn events(
         &self,
         tx_digest: TransactionDigest,
-        ev_seq_range: (Bound<u64>, Bound<u64>),
+        cursor: Option<EventID>,
         limit: usize,
-        is_descending: bool,
+        descending_order: bool,
     ) -> IndexerResult<Vec<StoredEvent>> {
         if limit == 0 {
             return Ok(vec![]);
         }
 
-        let (events, (summary, contents)) = self.events_with_checkpoint(tx_digest).await?;
-        let Some(events) = events else {
-            // transaction does not have associated events.
-            return Ok(vec![]);
-        };
-
-        let Some(tx_sequence_number) = contents
-            .enumerate_transactions(&summary)
-            .find(|(_, execution_digest)| execution_digest.transaction == tx_digest)
-            .map(|(seq, _)| seq)
-        else {
-            return Err(IndexerError::HistoricalFallbackStorageError(format!(
-                "cannot find transaction sequence number to transaction: {tx_digest}"
-            )));
-        };
-
-        // events are indexed by their position in the transaction
-        // (event_sequence_number = 0, 1, 2, ...)
-        let in_range = events
-            .iter()
-            .enumerate()
-            .filter(|(idx, _)| ev_seq_range.contains(&(*idx as u64)))
-            .map(|(idx, event)| {
-                StoredEvent::from(IndexedEvent::from_event(
-                    tx_sequence_number,
-                    idx as u64,
-                    summary.sequence_number,
-                    tx_digest,
-                    event,
-                    summary.timestamp_ms,
-                ))
-            });
-
-        let stored_events: Vec<StoredEvent> = if is_descending {
-            let mut stored_events: Vec<_> = in_range.collect();
-            stored_events.reverse();
-            stored_events.truncate(limit);
-            stored_events
+        // validate cursor if provided
+        let start_seq = if let Some(cursor) = cursor {
+            if cursor.tx_digest != tx_digest {
+                return Err(IndexerError::InvalidArgument(format!(
+                    "Cursor tx_digest {} does not match requested tx_digest {tx_digest}",
+                    cursor.tx_digest
+                )));
+            }
+            Some(cursor.event_seq)
         } else {
-            in_range.take(limit).collect()
+            None
         };
 
-        Ok(stored_events)
+        let events = self.fetch_events(tx_digest).await?.into_stored_events();
+
+        // apply ordering, cursor, and limit
+        let events = if descending_order {
+            events
+                .into_iter()
+                .rev() // reverse for descending
+                .filter(|event| {
+                    start_seq.is_none_or(|seq| (event.event_sequence_number as u64) < seq)
+                })
+                .take(limit)
+                .collect()
+        } else {
+            events
+                .into_iter()
+                .filter(|event| {
+                    start_seq.is_none_or(|seq| (event.event_sequence_number as u64) > seq)
+                })
+                .take(limit)
+                .collect()
+        };
+
+        Ok(events)
     }
 
     /// Resolves the sequence number for a given [`TransactionDigest`] by
@@ -641,7 +641,7 @@ impl HistoricalFallbackReader {
     /// If the resolved checkpoint's contents do not contain the digest,
     /// which would indicate inconsistency between the historical store's index
     /// and its checkpoint contents.
-    pub(crate) async fn resolve_transaction_sequence_number(
+    async fn resolve_transaction_sequence_number(
         &self,
         digest: TransactionDigest,
     ) -> IndexerResult<TransactionSequenceNumber> {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -92,7 +92,7 @@ use crate::{
         diesel_macro::{mark_in_blocking_pool, *},
         package_resolver::IndexerStorePackageResolver,
     },
-    types::{IndexerResult, OwnerType},
+    types::{IndexerResult, OwnerType, TxEventSeqRange},
 };
 
 pub const TX_SEQUENCE_NUMBER_STR: &str = "tx_sequence_number";
@@ -1339,6 +1339,55 @@ impl IndexerReader {
         db_res
     }
 
+    /// Fetches events belonging to a transaction from given `(tx_seq,
+    /// event_seq)` range. Falls back to the historical storage (when
+    /// configured) if the transaction has been pruned from Postgres.
+    pub async fn query_stored_events_by_tx_digest_with_fallback(
+        &self,
+        tx_digest: TransactionDigest,
+        tx_ev_seq_range: TxEventSeqRange,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
+        if let Some(tx_seq) = self
+            .db()
+            .resolve_cursor_tx_digest_to_seq_num_maybe(tx_digest)
+            .await?
+        {
+            // resolve  `(tx_seq, event_seq)` range to just `event_seq` range
+            let Some(ev_seq_range) = event_seq_range_for_tx(tx_ev_seq_range, tx_seq as u64) else {
+                return Ok(vec![]);
+            };
+            return self
+                .db()
+                .query_events_by_tx_digest_in_seq_range(
+                    tx_digest,
+                    ev_seq_range,
+                    limit,
+                    is_descending,
+                )
+                .await;
+        }
+
+        let Some(kv_reader) = self.fallback_reader() else {
+            return Err(IndexerError::DataPruned(format!(
+                "data for tx {tx_digest} potentially pruned"
+            )));
+        };
+        let context = format!("fallback triggered by tx {tx_digest} missing from Postgres");
+        let tx_seq = kv_reader
+            .resolve_transaction_sequence_number(tx_digest)
+            .await
+            .context(&context)?;
+        let Some(ev_seq_range) = event_seq_range_for_tx(tx_ev_seq_range, tx_seq) else {
+            return Ok(vec![]);
+        };
+        kv_reader
+            .events_in_seq_range(tx_digest, ev_seq_range, limit, is_descending)
+            .await
+            .context(&context)
+    }
+
     /// Fetches a paginated list of transactions that affect a given address,
     /// using the fallback storage if the database is pruned.
     async fn query_transactions_by_affected_addresses_with_fallback(
@@ -2024,35 +2073,58 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<IotaEvent>> {
+        let ev_seq_range = match cursor {
+            Some(cursor) => {
+                if cursor.tx_digest != tx_digest {
+                    return Err(IndexerError::InvalidArgument(
+                        "Cursor tx_digest does not match the tx_digest in the query.".into(),
+                    ));
+                }
+                // the cursor is exclusive
+                if descending_order {
+                    (Bound::Unbounded, Bound::Excluded(cursor.event_seq))
+                } else {
+                    (Bound::Excluded(cursor.event_seq), Bound::Unbounded)
+                }
+            }
+            None => (Bound::Unbounded, Bound::Unbounded),
+        };
         let db_res = self
             .db()
-            .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
+            .query_events_by_tx_digest_in_seq_range(
+                tx_digest,
+                ev_seq_range,
+                limit,
+                descending_order,
+            )
             .await;
 
-        if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
+        let stored_events = if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
             (db_res.as_ref(), self.fallback_reader())
         {
             kv_reader
-                .events(tx_digest, cursor, limit, descending_order)
+                .events_in_seq_range(tx_digest, ev_seq_range, limit, descending_order)
                 .await
-                .context(&format!("fallback triggered by {err}"))
+                .context(&format!("fallback triggered by {err}"))?
         } else {
-            let mut iota_event_futures = vec![];
-            for stored_event in db_res? {
-                iota_event_futures.push(tokio::task::spawn(
-                    stored_event.try_into_iota_event(self.package_resolver.clone()),
-                ));
-            }
+            db_res?
+        };
 
-            futures::future::join_all(iota_event_futures)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
+        let mut iota_event_futures = vec![];
+        for stored_event in stored_events {
+            iota_event_futures.push(tokio::task::spawn(
+                stored_event.try_into_iota_event(self.package_resolver.clone()),
+            ));
         }
+
+        futures::future::join_all(iota_event_futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
     }
 
     pub(crate) async fn query_only_checkpointed_events_in_blocking_task(
@@ -2898,6 +2970,28 @@ impl DataReader for IndexerReader {
     }
 }
 
+/// Narrows a `(tx_seq, event_seq)` range to just `event_seq` range, for events
+/// of the `tx_seq` transaction. Returns `None` when no event of that
+/// transaction is in the range.
+fn event_seq_range_for_tx(
+    (min, max): TxEventSeqRange,
+    tx_seq: u64,
+) -> Option<(Bound<u64>, Bound<u64>)> {
+    let min_ev_seq = match min {
+        Bound::Included((tx, ev)) if tx == tx_seq => Bound::Included(ev),
+        Bound::Excluded((tx, ev)) if tx == tx_seq => Bound::Excluded(ev),
+        Bound::Included((tx, _)) | Bound::Excluded((tx, _)) if tx > tx_seq => return None,
+        _ => Bound::Unbounded,
+    };
+    let max_ev_seq = match max {
+        Bound::Included((tx, ev)) if tx == tx_seq => Bound::Included(ev),
+        Bound::Excluded((tx, ev)) if tx == tx_seq => Bound::Excluded(ev),
+        Bound::Included((tx, _)) | Bound::Excluded((tx, _)) if tx < tx_seq => return None,
+        _ => Bound::Unbounded,
+    };
+    Some((min_ev_seq, max_ev_seq))
+}
+
 impl<'a> DBReader<'a> {
     pub fn new(reader: &'a IndexerReader) -> Self {
         Self {
@@ -2998,36 +3092,38 @@ impl<'a> DBReader<'a> {
             .load::<StoredTransaction>(conn))
     }
 
-    async fn query_events_by_tx_digest(
+    /// Fetches events of a transaction from `event_seq` range.
+    ///
+    /// Returns up to `limit` events ordered by `event_seq` according to
+    /// `is_descending` flag. Returns [`IndexerError::DataPruned`] when
+    /// nothing matches and the transaction is missing from Postgres.
+    async fn query_events_by_tx_digest_in_seq_range(
         &self,
         tx_digest: TransactionDigest,
-        cursor: Option<EventID>,
+        ev_seq_range: (Bound<u64>, Bound<u64>),
         limit: usize,
-        descending_order: bool,
+        is_descending: bool,
     ) -> IndexerResult<Vec<StoredEvent>> {
+        use events::dsl::{event_sequence_number as ev_seq, tx_sequence_number as tx_seq};
+
         let mut query = events::table.into_boxed();
 
-        if let Some(cursor) = cursor {
-            if cursor.tx_digest != tx_digest {
-                return Err(IndexerError::InvalidArgument(
-                    "Cursor tx_digest does not match the tx_digest in the query.".into(),
-                ));
-            }
-            if descending_order {
-                query = query.filter(events::event_sequence_number.lt(cursor.event_seq as i64));
-            } else {
-                query = query.filter(events::event_sequence_number.gt(cursor.event_seq as i64));
-            }
-        } else if descending_order {
-            query = query.filter(events::event_sequence_number.le(i64::MAX));
-        } else {
-            query = query.filter(events::event_sequence_number.ge(0));
+        let (min_ev_seq, max_ev_seq) = ev_seq_range;
+        query = match min_ev_seq {
+            Bound::Included(min) => query.filter(ev_seq.ge(min as i64)),
+            Bound::Excluded(min) => query.filter(ev_seq.gt(min as i64)),
+            Bound::Unbounded => query,
+        };
+        query = match max_ev_seq {
+            Bound::Included(max) => query.filter(ev_seq.le(max as i64)),
+            Bound::Excluded(max) => query.filter(ev_seq.lt(max as i64)),
+            Bound::Unbounded => query,
         };
 
-        if descending_order {
-            query = query.order(events::event_sequence_number.desc());
+        if is_descending {
+            query = query.order((tx_seq.desc(), ev_seq.desc()));
         } else {
-            query = query.order(events::event_sequence_number.asc());
+            query = query.order((tx_seq.asc(), ev_seq.asc()));
         }
 
         query = query.filter(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -92,7 +92,7 @@ use crate::{
         diesel_macro::{mark_in_blocking_pool, *},
         package_resolver::IndexerStorePackageResolver,
     },
-    types::{IndexerResult, OwnerType, TxEventSeqRange},
+    types::{IndexerResult, OwnerType},
 };
 
 pub const TX_SEQUENCE_NUMBER_STR: &str = "tx_sequence_number";
@@ -1339,55 +1339,6 @@ impl IndexerReader {
         db_res
     }
 
-    /// Fetches events belonging to a transaction from given `(tx_seq,
-    /// event_seq)` range. Falls back to the historical storage (when
-    /// configured) if the transaction has been pruned from Postgres.
-    pub async fn query_stored_events_by_tx_digest_with_fallback(
-        &self,
-        tx_digest: TransactionDigest,
-        tx_ev_seq_range: TxEventSeqRange,
-        limit: usize,
-        is_descending: bool,
-    ) -> IndexerResult<Vec<StoredEvent>> {
-        if let Some(tx_seq) = self
-            .db()
-            .resolve_cursor_tx_digest_to_seq_num_maybe(tx_digest)
-            .await?
-        {
-            // resolve  `(tx_seq, event_seq)` range to just `event_seq` range
-            let Some(ev_seq_range) = event_seq_range_for_tx(tx_ev_seq_range, tx_seq as u64) else {
-                return Ok(vec![]);
-            };
-            return self
-                .db()
-                .query_events_by_tx_digest_in_seq_range(
-                    tx_digest,
-                    ev_seq_range,
-                    limit,
-                    is_descending,
-                )
-                .await;
-        }
-
-        let Some(kv_reader) = self.fallback_reader() else {
-            return Err(IndexerError::DataPruned(format!(
-                "data for tx {tx_digest} potentially pruned"
-            )));
-        };
-        let context = format!("fallback triggered by tx {tx_digest} missing from Postgres");
-        let tx_seq = kv_reader
-            .resolve_transaction_sequence_number(tx_digest)
-            .await
-            .context(&context)?;
-        let Some(ev_seq_range) = event_seq_range_for_tx(tx_ev_seq_range, tx_seq) else {
-            return Ok(vec![]);
-        };
-        kv_reader
-            .events_in_seq_range(tx_digest, ev_seq_range, limit, is_descending)
-            .await
-            .context(&context)
-    }
-
     /// Fetches a paginated list of transactions that affect a given address,
     /// using the fallback storage if the database is pruned.
     async fn query_transactions_by_affected_addresses_with_fallback(
@@ -2066,6 +2017,32 @@ impl IndexerReader {
             .map(|iota_tx_event| iota_tx_event.data)
     }
 
+    /// Fetches events belonging to a transaction, paginated by an exclusive
+    /// `cursor`. Falls back to the historical storage (when configured) if the
+    /// transaction has been pruned from Postgres.
+    pub async fn query_stored_events_by_tx_digest_with_fallback(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
+        let db_res = self
+            .db()
+            .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
+            .await;
+
+        if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.fallback_reader())
+        {
+            return kv_reader
+                .events(tx_digest, cursor, limit, descending_order)
+                .await
+                .context(&format!("fallback triggered by {err}"));
+        }
+        db_res
+    }
+
     async fn query_events_by_tx_digest_with_fallback(
         &self,
         tx_digest: TransactionDigest,
@@ -2073,42 +2050,14 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<IotaEvent>> {
-        let ev_seq_range = match cursor {
-            Some(cursor) => {
-                if cursor.tx_digest != tx_digest {
-                    return Err(IndexerError::InvalidArgument(
-                        "Cursor tx_digest does not match the tx_digest in the query.".into(),
-                    ));
-                }
-                // the cursor is exclusive
-                if descending_order {
-                    (Bound::Unbounded, Bound::Excluded(cursor.event_seq))
-                } else {
-                    (Bound::Excluded(cursor.event_seq), Bound::Unbounded)
-                }
-            }
-            None => (Bound::Unbounded, Bound::Unbounded),
-        };
-        let db_res = self
-            .db()
-            .query_events_by_tx_digest_in_seq_range(
+        let stored_events = self
+            .query_stored_events_by_tx_digest_with_fallback(
                 tx_digest,
-                ev_seq_range,
+                cursor,
                 limit,
                 descending_order,
             )
-            .await;
-
-        let stored_events = if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
-            (db_res.as_ref(), self.fallback_reader())
-        {
-            kv_reader
-                .events_in_seq_range(tx_digest, ev_seq_range, limit, descending_order)
-                .await
-                .context(&format!("fallback triggered by {err}"))?
-        } else {
-            db_res?
-        };
+            .await?;
 
         let mut iota_event_futures = vec![];
         for stored_event in stored_events {
@@ -2970,28 +2919,6 @@ impl DataReader for IndexerReader {
     }
 }
 
-/// Narrows a `(tx_seq, event_seq)` range to just `event_seq` range, for events
-/// of the `tx_seq` transaction. Returns `None` when no event of that
-/// transaction is in the range.
-fn event_seq_range_for_tx(
-    (min, max): TxEventSeqRange,
-    tx_seq: u64,
-) -> Option<(Bound<u64>, Bound<u64>)> {
-    let min_ev_seq = match min {
-        Bound::Included((tx, ev)) if tx == tx_seq => Bound::Included(ev),
-        Bound::Excluded((tx, ev)) if tx == tx_seq => Bound::Excluded(ev),
-        Bound::Included((tx, _)) | Bound::Excluded((tx, _)) if tx > tx_seq => return None,
-        _ => Bound::Unbounded,
-    };
-    let max_ev_seq = match max {
-        Bound::Included((tx, ev)) if tx == tx_seq => Bound::Included(ev),
-        Bound::Excluded((tx, ev)) if tx == tx_seq => Bound::Excluded(ev),
-        Bound::Included((tx, _)) | Bound::Excluded((tx, _)) if tx < tx_seq => return None,
-        _ => Bound::Unbounded,
-    };
-    Some((min_ev_seq, max_ev_seq))
-}
-
 impl<'a> DBReader<'a> {
     pub fn new(reader: &'a IndexerReader) -> Self {
         Self {
@@ -3092,38 +3019,36 @@ impl<'a> DBReader<'a> {
             .load::<StoredTransaction>(conn))
     }
 
-    /// Fetches events of a transaction from `event_seq` range.
-    ///
-    /// Returns up to `limit` events ordered by `event_seq` according to
-    /// `is_descending` flag. Returns [`IndexerError::DataPruned`] when
-    /// nothing matches and the transaction is missing from Postgres.
-    async fn query_events_by_tx_digest_in_seq_range(
+    async fn query_events_by_tx_digest(
         &self,
         tx_digest: TransactionDigest,
-        ev_seq_range: (Bound<u64>, Bound<u64>),
+        cursor: Option<EventID>,
         limit: usize,
-        is_descending: bool,
+        descending_order: bool,
     ) -> IndexerResult<Vec<StoredEvent>> {
-        use events::dsl::{event_sequence_number as ev_seq, tx_sequence_number as tx_seq};
-
         let mut query = events::table.into_boxed();
 
-        let (min_ev_seq, max_ev_seq) = ev_seq_range;
-        query = match min_ev_seq {
-            Bound::Included(min) => query.filter(ev_seq.ge(min as i64)),
-            Bound::Excluded(min) => query.filter(ev_seq.gt(min as i64)),
-            Bound::Unbounded => query,
-        };
-        query = match max_ev_seq {
-            Bound::Included(max) => query.filter(ev_seq.le(max as i64)),
-            Bound::Excluded(max) => query.filter(ev_seq.lt(max as i64)),
-            Bound::Unbounded => query,
+        if let Some(cursor) = cursor {
+            if cursor.tx_digest != tx_digest {
+                return Err(IndexerError::InvalidArgument(
+                    "Cursor tx_digest does not match the tx_digest in the query.".into(),
+                ));
+            }
+            if descending_order {
+                query = query.filter(events::event_sequence_number.lt(cursor.event_seq as i64));
+            } else {
+                query = query.filter(events::event_sequence_number.gt(cursor.event_seq as i64));
+            }
+        } else if descending_order {
+            query = query.filter(events::event_sequence_number.le(i64::MAX));
+        } else {
+            query = query.filter(events::event_sequence_number.ge(0));
         };
 
-        if is_descending {
-            query = query.order((tx_seq.desc(), ev_seq.desc()));
+        if descending_order {
+            query = query.order(events::event_sequence_number.desc());
         } else {
-            query = query.order((tx_seq.asc(), ev_seq.asc()));
+            query = query.order(events::event_sequence_number.asc());
         }
 
         query = query.filter(

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Bound;
+
 use iota_json_rpc_types::{
     BalanceChange, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
     IotaTransactionKind, ObjectChange,
@@ -32,6 +34,10 @@ use serde_with::{DisplayFromStr, serde_as};
 use crate::errors::IndexerError;
 
 pub type IndexerResult<T> = Result<T, IndexerError>;
+
+/// Range of events, in the form of `(tx_sequence_number,
+/// event_sequence_number)` cursors
+pub type TxEventSeqRange = (Bound<(u64, u64)>, Bound<(u64, u64)>);
 
 #[derive(Debug)]
 pub struct IndexedCheckpoint {

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Bound;
-
 use iota_json_rpc_types::{
     BalanceChange, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
     IotaTransactionKind, ObjectChange,
@@ -34,10 +32,6 @@ use serde_with::{DisplayFromStr, serde_as};
 use crate::errors::IndexerError;
 
 pub type IndexerResult<T> = Result<T, IndexerError>;
-
-/// Range of events, in the form of `(tx_sequence_number,
-/// event_sequence_number)` cursors
-pub type TxEventSeqRange = (Bound<(u64, u64)>, Bound<(u64, u64)>);
 
 #[derive(Debug)]
 pub struct IndexedCheckpoint {


### PR DESCRIPTION
# Description of change

Make GraphQL fall back to the archival store when reading events of a single transaction.

Covered paths:

- `Query.events(filter: { transactionDigest })` — when this is the only filter, the query is served by `IndexerReader::query_stored_events_by_tx_digest_with_fallback`, which reads from Postgres and falls back to the archival store when the transaction has been pruned. Uses `Page::paginate_results`.
- `TransactionBlockEffects.events` — worked already, no change needed

Event filters (sender, emitting module, event type) disable the fallback.

To have common code between JSON-RPC and Graphql the PR refactors some of DBReader and HistoricalFallbackReader functions to accept only `event_seq` cursor/range, instead of JSON-RPC  or Graphql specific cursors. (JSON-RPC use (tx_digest, event_seq) cursor, Graphql uses (tx_seq, event_seq) ranges).
The tx part of the cursor can be stripped away after proper validation, since we are fetching events from single transaction anyway.

Behavior change: `Query.events(filter: { transactionDigest })` on a pruned (or unknown) transaction now errors with `DATA_PRUNED` when no fallback is configured, instead of returning an empty connection. This matches JSON-RPC.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11938

## How the change has been tested

- New e2e test `crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.move`: `DATA_PRUNED` error on a pruned transaction, events of an unpruned transaction, cursor window, cursor from a different transaction, digest combined with sender.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: `Query.events(filter: { transactionDigest })` now supports fallback for pruned transactions.


