### PR TITLE
upstream(core): Use the epoch state for latest epoch in simulator txn test

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -88,7 +88,7 @@ CheckpointSummary { epoch: 0, sequence_number: 4, network_total_transactions: 4,
 
 task 10, line 44:
 //# advance-epoch 6
-Epoch advanced: 5
+Epoch advanced: 6
 
 task 11, line 46:
 //# view-checkpoint
@@ -156,7 +156,7 @@ CheckpointSummary { epoch: 6, sequence_number: 11, network_total_transactions: 1
 
 task 18, lines 75-78:
 //# advance-epoch
-Epoch advanced: 6
+Epoch advanced: 7
 
 task 19, lines 80-95:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/checkpoints.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/checkpoints.snap
@@ -16,7 +16,7 @@ Checkpoint created: 2
 
 task 3, line 18:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 4, lines 20-35:
 //# run-graphql
@@ -61,7 +61,7 @@ Checkpoint created: 6
 
 task 8, line 43:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 9, line 45:
 //# create-checkpoint

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.snap
@@ -28,7 +28,7 @@ Checkpoint created: 2
 
 task 5, line 44:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 46-62:
 //# run-graphql
@@ -103,7 +103,7 @@ Checkpoint created: 6
 
 task 13, line 76:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 14, line 78:
 //# run Test::M1::create --args 0 @A --sender A
@@ -137,11 +137,11 @@ Checkpoint created: 10
 
 task 20, line 90:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 21, line 92:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 22, lines 94-158:
 //# run-graphql --cursors {"t":3,"i":false,"c":4} {"t":7,"i":false,"c":8} {"t":11,"i":false,"c":12}

--- a/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.snap
@@ -40,7 +40,7 @@ Checkpoint created: 1
 
 task 5, line 29:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 31-33:
 //# programmable --sender C --inputs 10000000000 @C
@@ -64,7 +64,7 @@ Checkpoint created: 3
 
 task 9, line 39:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, line 41:
 //# view-object 3,1

--- a/crates/iota-graphql-e2e-tests/tests/datetime/datetime.snap
+++ b/crates/iota-graphql-e2e-tests/tests/datetime/datetime.snap
@@ -33,7 +33,7 @@ Checkpoint created: 7
 
 task 15, line 42:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 16, lines 44-46:
 //# create-checkpoint
@@ -45,7 +45,7 @@ Checkpoint created: 10
 
 task 20, line 54:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 21, lines 56-67:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 11:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 13-15:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, lines 22-24:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, lines 25-29:
 //# programmable --sender C --inputs 10000000000 @C
@@ -53,7 +53,7 @@ Checkpoint created: 5
 
 task 9, lines 32-33:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 10, lines 34-73:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 9:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 11-13:
 //# programmable --sender C --inputs 10000000000 @C
@@ -101,7 +101,7 @@ Checkpoint created: 4
 
 task 9, line 69:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, line 71:
 //# create-checkpoint

--- a/crates/iota-graphql-e2e-tests/tests/epoch/system_state.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/system_state.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 13:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 15-17:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, line 23:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, line 25:
 //# create-checkpoint
@@ -44,7 +44,7 @@ Checkpoint created: 5
 
 task 8, line 27:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 9, lines 29-31:
 //# programmable --sender C --inputs 10000000000 @C
@@ -60,7 +60,7 @@ Checkpoint created: 7
 
 task 11, line 35:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 12, line 37:
 //# run 0x3::iota_system::request_withdraw_stake --args object(0x5) object(4,0) --sender C
@@ -76,7 +76,7 @@ Checkpoint created: 9
 
 task 14, line 41:
 //# advance-epoch
-Epoch advanced: 4
+Epoch advanced: 5
 
 task 15, lines 43-45:
 //# programmable --sender C --inputs 10000000000 @C
@@ -92,7 +92,7 @@ Checkpoint created: 11
 
 task 17, line 49:
 //# advance-epoch
-Epoch advanced: 5
+Epoch advanced: 6
 
 task 18, lines 51-61:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/objects/filter_by_type.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/filter_by_type.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 10:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 12-14:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, line 21:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, lines 23-38:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.snap
@@ -54,7 +54,7 @@ Checkpoint created: 1
 
 task 5, line 42:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 44-70:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/prune/backward_history_pruning.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/backward_history_pruning.snap
@@ -54,7 +54,7 @@ Checkpoint created: 2
 
 task 9, line 55:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 10, lines 57-59:
 //# programmable --sender A --inputs @A object(4,0)
@@ -81,7 +81,7 @@ Checkpoint created: 5
 
 task 14, line 68:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 15, lines 70-84:
 //# run-graphql
@@ -126,7 +126,7 @@ Checkpoint created: 7
 
 task 18, line 92:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 19, lines 94-96:
 //# programmable --sender A --inputs @A
@@ -142,7 +142,7 @@ Checkpoint created: 9
 
 task 21, line 100:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 22, lines 102-110:
 //# run-graphql --wait-for-checkpoint-pruned 4

--- a/crates/iota-graphql-e2e-tests/tests/prune/prune.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/prune.snap
@@ -21,7 +21,7 @@ Checkpoint created: 1
 
 task 4, line 32:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, line 34:
 //# run Test::M1::create --args 1 @A
@@ -35,7 +35,7 @@ Checkpoint created: 3
 
 task 7, line 38:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 8, line 40:
 //# run Test::M1::create --args 2 @A
@@ -49,7 +49,7 @@ Checkpoint created: 5
 
 task 10, line 44:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 11, lines 46-56:
 //# run-graphql --wait-for-checkpoint-pruned 4

--- a/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.snap
@@ -30,7 +30,7 @@ Checkpoint created: 1
 
 task 4, line 20:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, lines 22-46:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/transactions/system.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/system.snap
@@ -1455,7 +1455,7 @@ Response: {
 
 task 6, line 188:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 7, lines 190-277:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/validator/validator.snap
+++ b/crates/iota-graphql-e2e-tests/tests/validator/validator.snap
@@ -8,7 +8,7 @@ A: object(0,0)
 
 task 1, line 9:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 2, line 11:
 //# create-checkpoint
@@ -50,7 +50,7 @@ Checkpoint created: 3
 
 task 9, line 50:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, lines 52-66:
 //# run-graphql
@@ -169,7 +169,7 @@ Checkpoint created: 5
 
 task 27, lines 100-102:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 28, lines 104-120:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/validator/validator_iip8.snap
+++ b/crates/iota-graphql-e2e-tests/tests/validator/validator_iip8.snap
@@ -8,7 +8,7 @@ A: object(0,0)
 
 task 1, line 9:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 2, line 11:
 //# create-checkpoint
@@ -50,7 +50,7 @@ Checkpoint created: 3
 
 task 9, line 50:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, lines 52-66:
 //# run-graphql
@@ -169,7 +169,7 @@ Checkpoint created: 5
 
 task 27, lines 100-102:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 28, lines 104-120:
 //# run-graphql

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -41,7 +41,7 @@ use iota_swarm_config::{
     network_config_builder::ConfigBuilder,
 };
 use iota_types::{
-    base_types::{AuthorityName, VersionNumber},
+    base_types::{AuthorityName, EpochId, VersionNumber},
     committee::Committee,
     crypto::{AuthoritySignature, KeypairTraits},
     digests::{ConsensusCommitDigest, TransactionDigest},
@@ -576,6 +576,10 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
 
     fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         Ok(self.with_store(|store| store.get_highest_checkpoint().unwrap()))
+    }
+
+    fn try_get_latest_epoch_id(&self) -> iota_types::storage::error::Result<EpochId> {
+        Ok(self.inner.read().unwrap().epoch_state.epoch())
     }
 
     fn try_get_highest_verified_checkpoint(


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.52.3, v1.53.2)
- Port commit:
  - [MystenLabs/sui@9018737](https://github.com/MystenLabs/sui/commit/901873752f182e9d7708234df6a4ed84b841ef86)
- Description:

Before this change, the `ReadStore::try_get_latest_epoch_id` implementation for `Simulacrum` would use the default impl and return the epoch of the latest checkpoint instead of the latest epoch according to epoch state. This would result in `try_get_latest_epoch_id` returning the previous epoch number when the epoch change just happened and a new checkpoint hasn't been created yet.

As a consequence, `//# advance-epoch` in transactional tests now reports the new epoch, shifting every `Epoch advanced: N` line in `iota-graphql-e2e-tests` snapshots to `N+1`.


## Links to any relevant issues

Part of #12269

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes