### PR TITLE
upstream(core): Disable write throttling for gRPC index tables and L0 file count triggers

### DIFF
--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -316,6 +316,10 @@ fn make_owner_key(owner: Address, object: &Object) -> Option<(OwnerIndexKey, Own
     Some((key, info))
 }
 
+fn default_table_options() -> typed_store::rocks::DBOptions {
+    typed_store::rocks::default_db_options().disable_write_throttling()
+}
+
 /// RocksDB tables for the GrpcIndexesStore
 ///
 /// Anytime a new table is added, or an existing one has its schema changed,
@@ -342,6 +346,7 @@ struct IndexStoreTables {
     /// the event that the node was running with indexes enabled, then run
     /// for a period of time with indexes disabled, and then run with them
     /// enabled again so that the tables can be reinitialized.
+    #[default_options_override_fn = "default_table_options"]
     watermark: DBMap<Watermark, CheckpointSequenceNumber>,
 
     /// Deprecated: per-epoch metadata moved to the CheckpointStore's
@@ -355,6 +360,7 @@ struct IndexStoreTables {
     ///
     /// Only contains entries for transactions which have yet to be pruned from
     /// the main database.
+    #[default_options_override_fn = "default_table_options"]
     transaction_checkpoints: DBMap<TransactionDigest, CheckpointSequenceNumber>,
 
     /// An index of object ownership.
@@ -366,6 +372,7 @@ struct IndexStoreTables {
     /// Full `StructTag` stored in value for collision filtering & API
     /// responses. Bounded by the live object set (one entry per
     /// address-owned object).
+    #[default_options_override_fn = "default_table_options"]
     owner: DBMap<OwnerIndexKey, OwnerIndexInfo>,
 
     /// An index of dynamic fields (children objects).
@@ -373,10 +380,12 @@ struct IndexStoreTables {
     /// Allows an efficient iterator to list all of the dynamic fields owned by
     /// a particular ObjectId. Only the key is stored; field metadata is loaded
     /// on demand from the object store.
+    #[default_options_override_fn = "default_table_options"]
     dynamic_field: DBMap<DynamicFieldKey, ()>,
 
     /// Coin info with regulated coin metadata.
     /// Bounded by the live object set (one entry per coin type).
+    #[default_options_override_fn = "default_table_options"]
     coin: DBMap<CoinIndexKey, CoinIndexInfo>,
 
     /// An index of Package versions.
@@ -385,6 +394,7 @@ struct IndexStoreTables {
     /// Allows efficient listing of all versions of a package, including
     /// upgraded user packages that have different storage IDs.
     /// Bounded by the live object set (one entry per package version).
+    #[default_options_override_fn = "default_table_options"]
     package_version: DBMap<PackageVersionKey, PackageVersionInfo>,
     // NOTE: Authors and Reviewers before adding any new tables ensure that they are either:
     // - bounded in size by the live object set

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -379,6 +379,8 @@ impl DBOptions {
     pub fn disable_write_throttling(mut self) -> DBOptions {
         self.options.set_soft_pending_compaction_bytes_limit(0);
         self.options.set_hard_pending_compaction_bytes_limit(0);
+        self.options.set_level_zero_slowdown_writes_trigger(512);
+        self.options.set_level_zero_stop_writes_trigger(1024);
         self
     }
 }


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.52.3, v1.53.2)
- Port commit:
  - [MystenLabs/sui@03db26e](https://github.com/MystenLabs/sui/commit/03db26efe6c78daf8cf49b759f68bce8ad39aa11)
  - [MystenLabs/sui@192440b](https://github.com/MystenLabs/sui/commit/192440b9fbaa9b2a92d2b569aeaf6cd3b45edc49)
- Description:

`DBOptions::disable_write_throttling()` previously only disabled write throttling based on pending compaction bytes. It now also raises the L0 file count triggers, so that a high number of L0 files no longer slows or stops writes during bulk ingestion.

`disable_write_throttling()` is now also applied to the gRPC index tables via a `default_table_options()`, so bulk index rebuilds aren't stalled by RocksDB write throttling.

## Links to any relevant issues

Part of #12269

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes