### PR TITLE
fix(starfish-core): keep consensus sync metrics in /metrics by default

### DIFF
--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -627,7 +627,8 @@ impl NodeMetrics {
                 "synchronizer_fetched_block_headers_by_peer",
                 "Number of fetched block headers per peer authority via the synchronizer and also by block authority",
                 &["peer", "type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             synchronizer_skipped_block_headers_by_peer: register_int_counter_vec_with_registry!(
                 "synchronizer_skipped_block_headers_by_peer",
@@ -823,7 +824,8 @@ impl NodeMetrics {
             last_commit_index: register_int_gauge_with_registry!(
                 "last_commit_index",
                 "Index of the last commit.",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_observer_last_recovered_commit_index: register_int_gauge_with_registry!(
                 "commit_observer_last_recovered_commit_index",
@@ -883,7 +885,8 @@ impl NodeMetrics {
                 "transaction_synchronizer_fetched_transactions_by_peer",
                 "Number of fetched transactions per peer authority via the transaction synchronizer",
                 &["peer", "type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transactions_synchronizer_fetched_transactions_by_authority: register_int_counter_vec_with_registry!(
                 "transaction_synchronizer_fetched_transactions_by_authority",
@@ -1053,7 +1056,8 @@ impl NodeMetrics {
                 "commit_sync_fetched_commits",
                 "The number of commits fetched via commit syncer",
                 &["source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_sync_fetched_block_headers: register_int_counter_with_registry!(
                 "commit_sync_fetched_block_headers",

--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -85,6 +85,10 @@ done < <(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print0)
 
 export RUST_LOG=iota=debug,info
 
+# The node trims low-verbosity metrics from /metrics by default. This check
+# scrapes the consensus sync metrics below that cutoff, so expose every level.
+export METRICS_FILTER=trace
+
 # Track child PIDs (and which binary version each runs) so we can report
 # liveness and tear the cluster down cleanly. node-3 is appended only once it
 # starts (late), so the warmup liveness check naturally covers just the initial


### PR DESCRIPTION
# Description of change

The nightly `split-cluster-sync-check` started failing once the node's Prometheus `/metrics` output began filtering low-verbosity metrics by default. The check scrapes four consensus synchronization metrics off the late-joining candidate node to confirm it catches up, but those metrics were left at the default (`debug`) exposure level and so were dropped from `/metrics`. The check read them as `0` and reported a false "node did not sync" failure — the candidate was actually synchronizing normally.

Two changes:

- `starfish-core`: tag `last_commit_index`, `commit_sync_fetched_commits`, `synchronizer_fetched_block_headers_by_peer`, and `transaction_synchronizer_fetched_transactions_by_peer` as `MetricLevel::Warn` so they remain in the default `/metrics` output.
- `split-cluster-sync-check.sh`: set `METRICS_FILTER=trace` when launching the cluster, so the check keeps observing all metric levels even if metric exposure levels change again later.

## Links to any relevant issues

fixes #12284

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Ran the mainnet variant CI uses locally: `scripts/compatibility/split-cluster-sync-check.sh origin/mainnet <candidate>`. The candidate node now reports non-zero sync metrics (`last_commit_index: 1817`, `commit_sync_fetched_commits: 1413`, `synchronizer_fetched_block_headers_by_peer: 312`) and the check passes.

### Release Notes

- [x] Nodes (Validators and Full nodes): Consensus synchronization metrics (`last_commit_index`, `commit_sync_fetched_commits`, `synchronizer_fetched_block_headers_by_peer`, `transaction_synchronizer_fetched_transactions_by_peer`) are exposed in `/metrics` by default again.
