### PR TITLE
feat(iota-protocol-config): enable StarfishSpeed on devnet

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1316,7 +1316,7 @@
                 "consensus_round_prober": true,
                 "consensus_round_prober_probe_accepted_rounds": true,
                 "consensus_smart_ancestor_selection": false,
-                "consensus_starfish_speed": false,
+                "consensus_starfish_speed": true,
                 "consensus_zstd_compression": true,
                 "convert_type_argument_error": true,
                 "deny_rule_governance": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -3039,10 +3039,9 @@ impl ProtocolConfig {
                 31 => {
                     cfg.feature_flags.validator_metadata_verify_v2 = true;
 
-                    // Amortize the minimum checkpoint interval over a sliding
-                    // window so the checkpoint rate holds at the ceiling.
-                    // Enabled on non-Mainnet/Testnet chains only for now.
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        // Amortize the minimum checkpoint interval over a sliding
+                        // window so the checkpoint rate holds at the ceiling.
                         cfg.checkpoint_rate_window_size = Some(20);
                         // Publish package metadata with the module metadata stored as a
                         // dynamic field.

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -182,6 +182,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             dynamic field.
 //             Report a failure of the Move authentication with a distinct
 //             `MoveAuthenticationError` execution error.
+//             Enable the optimistic commit rule (StarfishSpeed) in Starfish
+//             consensus on devnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3046,6 +3048,9 @@ impl ProtocolConfig {
                         // dynamic field.
                         cfg.feature_flags
                             .package_metadata_with_dynamic_module_metadata = true;
+                        // Enable the optimistic commit rule (StarfishSpeed) in
+                        // Starfish consensus.
+                        cfg.feature_flags.consensus_starfish_speed = true;
                     }
 
                     cfg.feature_flags.report_move_authentication_error = true;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_31.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_31.snap
@@ -52,6 +52,7 @@ feature_flags:
   move_native_tx_context: true
   additional_borrow_checks: true
   pre_consensus_sponsor_only_move_authentication: true
+  consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
   validator_metadata_verify_v2: true
   package_metadata_with_dynamic_module_metadata: true


### PR DESCRIPTION
# Description of change

Enable the optimistic commit rule (StarfishSpeed) in Starfish consensus on devnet

## Links to any relevant issues

fixes #12283

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
