### PR TITLE
fix(iota-private-network): expose all metric levels on experiment nodes

### DIFF
--- a/dev-tools/iota-private-network/experiments/experiment_common.py
+++ b/dev-tools/iota-private-network/experiments/experiment_common.py
@@ -630,6 +630,12 @@ def generate_compose_file(
         lines.append("      - RPC_WORKER_THREAD=12")
         lines.append("      - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000")
         lines.append("      - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000")
+        # Expose all metric levels: the default /metrics output hides
+        # debug-tier metrics, which include the consensus commit-latency
+        # histograms and accepted_block_headers that measure_block_production
+        # queries. Images predating the metric-groups change ignore the
+        # unknown level token and stay permissive.
+        lines.append("      - METRICS_FILTER=trace")
         lines.append(f"      - IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE={chain_override}")
         lines.append("    command:")
         lines.append("      [")
@@ -669,6 +675,7 @@ def generate_compose_file(
             "      - RUST_LOG=info,iota_core=debug,iota_network=debug,"
             "iota_node=debug,jsonrpsee=error"
         )
+        lines.append("      - METRICS_FILTER=trace")
         lines.append(f"      - IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE={chain_override}")
         lines.append("    command:")
         lines.append("      [")

--- a/dev-tools/iota-private-network/experiments/run-migration-test.py
+++ b/dev-tools/iota-private-network/experiments/run-migration-test.py
@@ -1003,6 +1003,12 @@ def phase2_generate_compose(cfg: Config) -> None:
         lines.append("      - RPC_WORKER_THREAD=12")
         lines.append("      - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000")
         lines.append("      - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000")
+        # Expose all metric levels: the default /metrics exposure hides
+        # debug-tier metrics (e.g. the consensus commit-latency histograms
+        # the stable-window comparison queries). Images predating the
+        # metric-groups change ignore the unknown level token and stay
+        # permissive.
+        lines.append("      - METRICS_FILTER=trace")
         lines.append(
             f"      - IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE={cfg.chain_override}"
         )
@@ -1043,6 +1049,7 @@ def phase2_generate_compose(cfg: Config) -> None:
             "      - RUST_LOG=info,iota_core=debug,iota_network=debug,"
             "iota_node=debug,jsonrpsee=error"
         )
+        lines.append("      - METRICS_FILTER=trace")
         lines.append(
             f"      - IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE={cfg.chain_override}"
         )


### PR DESCRIPTION
# Description of change

Since the node's `/metrics` output filters low-verbosity metrics by default (#12105), the private-network experiment runners silently lost the debug-tier metrics they measure: the consensus commit-latency histograms (`consensus_block_header_commit_latency`, `consensus_transaction_commit_latency`) and `consensus_accepted_block_headers`. `measure_block_production` and the migration test's stable-window comparison then report empty latency columns while everything else keeps working.

- Set `METRICS_FILTER=trace` on the validator and fullnode services generated by the experiment runners — the migration test's own compose generator and the shared one used by the benchmark/fuzz runners.
- Safe across image versions: images predating the metric-groups change parse the unknown `trace` token as invalid, warn, and stay permissive (their previous behavior).


## Links to any relevant issues

fixes #12289

Context: #12105. Analogous CI fix: #12282.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes