### PR TITLE
fix(node): Tag metrics used by Grafana dashboards as warn

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -430,7 +430,8 @@ impl AuthorityMetrics {
             total_effects: register_int_counter_with_registry!(
                 "total_transaction_effects",
                 "Total number of transaction effects produced",
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
                 .unwrap(),
 
@@ -459,7 +460,8 @@ impl AuthorityMetrics {
                 "num_input_objects",
                 "Distribution of number of input TX objects per TX",
                 POSITIVE_INT_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
                 .unwrap(),
             num_shared_objects: register_histogram_with_registry!(
@@ -568,7 +570,7 @@ impl AuthorityMetrics {
                 "authority_overload_status",
                 "Whether authority is current experiencing overload and enters load shedding mode.",
                 registry;
-                MetricLevel::Info,)
+                MetricLevel::Warn,)
                 .unwrap(),
             local_post_consensus_load_shedding_percentage: register_int_gauge_with_registry!(
                 "authority_load_shedding_percentage",
@@ -785,7 +787,8 @@ impl AuthorityMetrics {
                 "consensus_committed_messages",
                 "Total number of committed consensus messages, sliced by author",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             consensus_committed_user_transactions: register_int_gauge_vec_with_registry!(
                 "consensus_committed_user_transactions",

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -74,32 +74,38 @@ impl AuthorityStoreMetrics {
             iota_conservation_check_latency: register_int_gauge_with_registry!(
                 "iota_conservation_check_latency",
                 "Number of seconds took to scan all live objects in the store for IOTA conservation check",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             iota_conservation_live_object_count: register_int_gauge_with_registry!(
                 "iota_conservation_live_object_count",
                 "Number of live objects in the store",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             iota_conservation_live_object_size: register_int_gauge_with_registry!(
                 "iota_conservation_live_object_size",
                 "Size in bytes of live objects in the store",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             iota_conservation_imbalance: register_int_gauge_with_registry!(
                 "iota_conservation_imbalance",
                 "Total amount of IOTA in the network - 10B * 10^9. This delta shows the amount of imbalance",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             iota_conservation_storage_fund: register_int_gauge_with_registry!(
                 "iota_conservation_storage_fund",
                 "Storage Fund pool balance (only includes the storage fund proper that represents object storage)",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             iota_conservation_storage_fund_imbalance: register_int_gauge_with_registry!(
                 "iota_conservation_storage_fund_imbalance",
                 "Imbalance of storage fund, computed with storage_fund_balance - total_object_storage_rebates",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             epoch_flags: register_int_gauge_vec_with_registry!(
                 "epoch_flags",

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -25,7 +25,7 @@ use iota_types::{
 };
 use once_cell::sync::Lazy;
 use prometheus_filtered::{
-    IntCounter, IntGauge, Registry, register_int_counter_with_registry,
+    IntCounter, IntGauge, MetricLevel, Registry, register_int_counter_with_registry,
     register_int_gauge_with_registry,
 };
 use tokio::{
@@ -145,25 +145,29 @@ impl AuthorityStorePruningMetrics {
             last_pruned_checkpoint: register_int_gauge_with_registry!(
                 "last_pruned_checkpoint",
                 "Last pruned checkpoint",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             num_pruned_objects: register_int_counter_with_registry!(
                 "num_pruned_objects",
                 "Number of pruned objects",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             num_pruned_tombstones: register_int_counter_with_registry!(
                 "num_pruned_tombstones",
                 "Number of pruned tombstones",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             last_pruned_effects_checkpoint: register_int_gauge_with_registry!(
                 "last_pruned_effects_checkpoint",
                 "Last pruned effects checkpoint",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             last_pruned_indexes_transaction: register_int_gauge_with_registry!(
@@ -175,7 +179,8 @@ impl AuthorityStorePruningMetrics {
             num_epochs_to_retain_for_objects: register_int_gauge_with_registry!(
                 "num_epochs_to_retain_for_objects",
                 "Number of epochs to retain for objects",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             num_epochs_to_retain_for_checkpoints: register_int_gauge_with_registry!(

--- a/crates/iota-core/src/checkpoints/metrics.rs
+++ b/crates/iota-core/src/checkpoints/metrics.rs
@@ -98,7 +98,8 @@ impl CheckpointMetrics {
             last_sent_checkpoint_signature: register_int_gauge_with_registry!(
                 "last_sent_checkpoint_signature",
                 "Last checkpoint signature sent by myself",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             last_skipped_checkpoint_signature_submission: register_int_gauge_with_registry!(

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -137,7 +137,7 @@ impl ConsensusAdapterMetrics {
                 &["position", "tx_type", "processed_method"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry;
-                MetricLevel::Info,
+                MetricLevel::Warn,
             )
             .unwrap(),
             sequencing_certificate_authority_position: register_histogram_with_registry!(

--- a/crates/iota-core/src/quorum_driver/metrics.rs
+++ b/crates/iota-core/src/quorum_driver/metrics.rs
@@ -62,7 +62,7 @@ impl QuorumDriverMetrics {
                 "Total number of requests returned with Err responses, grouped by error type",
                 &["error"],
                 registry;
-                MetricLevel::Info,
+                MetricLevel::Warn,
             )
             .unwrap(),
             attempt_times_ok_response: register_histogram_with_registry!(

--- a/crates/iota-metrics/src/metrics_network.rs
+++ b/crates/iota-metrics/src/metrics_network.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use anemo_tower::callback::{MakeCallbackHandler, ResponseHandler};
 use prometheus_filtered::{
-    HistogramTimer, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    HistogramTimer, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, MetricLevel, Registry,
     register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
 };
@@ -70,7 +70,8 @@ impl NetworkConnectionMetrics {
             network_peers: register_int_gauge_with_registry!(
                 format!("{node}_network_peers"),
                 "The number of connected peers.",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             network_peer_disconnects: register_int_counter_vec_with_registry!(
@@ -226,7 +227,8 @@ impl NetworkMetrics {
             format!("{node}_{direction}_requests"),
             "The number of requests made on the network",
             &["route"],
-            registry
+            registry;
+            MetricLevel::Warn,
         )
         .unwrap();
 
@@ -235,7 +237,8 @@ impl NetworkMetrics {
             "Latency of a request by route",
             &["route"],
             LATENCY_SEC_BUCKETS.to_vec(),
-            registry,
+            registry;
+            MetricLevel::Warn,
         )
         .unwrap();
 

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -369,7 +369,8 @@ impl NodeMetrics {
                 "highest_verified_authority_round",
                 "The highest round of received verified block for the corresponding authority",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             lowest_verified_authority_round: register_int_gauge_vec_with_registry!(
                 "lowest_verified_authority_round",
@@ -480,7 +481,8 @@ impl NodeMetrics {
                 "highest_accepted_authority_round",
                 "The highest round where a block header has been accepted per authority. Resets on restart.",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             highest_accepted_round: register_int_gauge_with_registry!(
                 "highest_accepted_round",
@@ -813,7 +815,8 @@ impl NodeMetrics {
                 "last_committed_authority_round",
                 "The last round committed by authority.",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             last_committed_leader_round: register_int_gauge_with_registry!(
                 "last_committed_leader_round",
@@ -823,7 +826,8 @@ impl NodeMetrics {
             last_commit_index: register_int_gauge_with_registry!(
                 "last_commit_index",
                 "Index of the last commit.",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_observer_last_recovered_commit_index: register_int_gauge_with_registry!(
                 "commit_observer_last_recovered_commit_index",
@@ -953,12 +957,14 @@ impl NodeMetrics {
             block_manager_suspended_blocks: register_int_gauge_with_registry!(
                 "block_manager_suspended_blocks",
                 "The number of full blocks suspended in the block manager awaiting header acceptance",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_missing_ancestors: register_int_gauge_with_registry!(
                 "block_manager_missing_ancestors",
                 "The number of headers that are missing or suspended in the block manager",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_missing_block_headers: register_int_gauge_with_registry!(
                 "block_manager_missing_block_headers",


### PR DESCRIPTION
# Description of change

Tag more dashboard metrics to  `MetricLevel::Warn` so the dashboards work by default.


## Links to any relevant issues

Part of #12067 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
