### PR TITLE
fix(starfish-core): expose starfish dashboard metrics in /metrics by default

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -714,7 +714,8 @@ impl AuthorityMetrics {
                 "Sizes of each type of transactions processed by consensus handler",
                 &["class"],
                 POSITIVE_INT_BUCKETS.to_vec(),
-                registry
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             consensus_handler_num_low_scoring_authorities: register_int_gauge_with_registry!(
                 "consensus_handler_num_low_scoring_authorities",
@@ -799,7 +800,8 @@ impl AuthorityMetrics {
             consensus_handler_leader_round: register_int_gauge_with_registry!(
                 "consensus_handler_leader_round",
                 "The leader round of the current consensus output being processed in the consensus handler",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             limits_metrics: Arc::new(LimitsMetrics::new(registry)),
             bytecode_verifier_metrics: Arc::new(BytecodeVerifierMetrics::new(registry)),

--- a/crates/iota-core/src/epoch/epoch_metrics.rs
+++ b/crates/iota-core/src/epoch/epoch_metrics.rs
@@ -246,7 +246,8 @@ impl EpochMetrics {
             consensus_quarantine_queue_size: register_int_gauge_with_registry!(
                 "consensus_quarantine_queue_size",
                 "The number of consensus output items in the quarantine",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             shared_object_assignments_size: register_int_gauge_with_registry!(

--- a/crates/iota-metrics/src/lib.rs
+++ b/crates/iota-metrics/src/lib.rs
@@ -117,7 +117,8 @@ impl Metrics {
                 "monitored_channel_inflight",
                 "Inflight items in channels.",
                 &["name"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             channel_sent: register_int_gauge_vec_with_registry!(

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -287,19 +287,22 @@ impl NodeMetrics {
                 "delay_in_sending_blocks",
                 "The time taken between block creation and block sending.",
                 LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_header_commit_latency: register_histogram_with_registry!(
                 "block_header_commit_latency",
                 "The time taken between block creation and commit of block header.",
                 LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transaction_commit_latency: register_histogram_with_registry!(
                 "transaction_commit_latency",
                 "The time taken between inclusion transactions in a block and transactions are sequenced.",
                 LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             proposed_blocks: register_int_counter_vec_with_registry!(
                 "proposed_blocks",
@@ -312,13 +315,15 @@ impl NodeMetrics {
                 "proposed_block_header_size",
                 "The size (in bytes) of proposed block headers",
                 SIZE_BUCKETS.to_vec(),
-                registry
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             proposed_block_size: register_histogram_with_registry!(
                 "proposed_block_size",
                 "The size (in bytes) of proposed blocks",
                 SIZE_BUCKETS.to_vec(),
-                registry
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             proposed_block_transactions: register_histogram_with_registry!(
                 "proposed_block_transactions",
@@ -330,7 +335,8 @@ impl NodeMetrics {
                 "proposed_block_ancestors",
                 "Number of ancestors in proposed blocks",
                 exponential_buckets(1.0, 1.4, 20).unwrap(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             proposed_block_ancestors_depth: register_histogram_vec_with_registry!(
                 "proposed_block_ancestors_depth",
@@ -349,21 +355,24 @@ impl NodeMetrics {
                 "proposed_block_acknowledgments",
                 "Number of acknowledgments in proposed blocks",
                 exponential_buckets(1.0, 1.4, 20).unwrap(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             proposed_block_acknowledgments_depth: register_histogram_vec_with_registry!(
                 "proposed_block_acknowledgments_depth",
                 "The depth in rounds of acknowledgments included in newly proposed blocks",
                 &["authority"],
                 exponential_buckets(1.0, 2.0, 14).unwrap(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             latency_to_process_stream: register_histogram_vec_with_registry!(
                 "latency_to_process_stream",
                 "The latency between block creation and processing stream from peer",
                 &["peer"],
                 exponential_buckets(0.002, 1.5, 18).unwrap(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             highest_verified_authority_round: register_int_gauge_vec_with_registry!(
                 "highest_verified_authority_round",
@@ -382,7 +391,8 @@ impl NodeMetrics {
                 "block_proposal_interval",
                 "Intervals (in secs) between block proposals.",
                 FINE_GRAINED_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_proposal_leader_wait_ms: register_int_counter_vec_with_registry!(
                 "block_proposal_leader_wait_ms",
@@ -413,7 +423,8 @@ impl NodeMetrics {
                 "reconstruction_lag",
                 "The number of rounds between current round and reconstructed transactions.",
                 NUM_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             core_add_blocks_batch_size: register_histogram_with_registry!(
                 "core_add_blocks_batch_size",
@@ -430,12 +441,14 @@ impl NodeMetrics {
             gap_to_available_commit: register_int_gauge_with_registry!(
                 "gap_to_available_commit",
                 "Gap in rounds between last pending commit and last available commit",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             gap_to_unavailable_transactions: register_int_gauge_with_registry!(
                 "gap_to_unavailable_transactions",
                 "Gap in rounds between current round and the oldest unavailable transaction",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             reconstruction_jobs_started: register_int_counter_with_registry!(
                 "reconstruction_jobs_started",
@@ -445,20 +458,23 @@ impl NodeMetrics {
             reconstruction_jobs_finished: register_int_counter_with_registry!(
                 "reconstruction_jobs_finished",
                 "Number of reconstruction jobs finished",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             accepted_transactions_source: register_int_counter_vec_with_registry!(
                 "accepted_transactions_source",
                 "Number of accepted transactions by source and authority",
                 &["source", "authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             accepted_transactions_round_gap: register_histogram_vec_with_registry!(
                 "accepted_transactions_round_gap",
                 "Round gap of accepted transactions to clock round",
                 &["source"],
                 vec![0.0, 1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 80.0, 100.0, 200.0, 400.0, 800.0, 1000.0],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             core_lock_dequeued: register_int_counter_with_registry!(
                 "core_lock_dequeued",
@@ -499,57 +515,67 @@ impl NodeMetrics {
                 "accepted_block_headers",
                 "Number of accepted block headers by source (own, others)",
                 &["source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             accepted_block_headers_source: register_int_counter_vec_with_registry!(
                 "accepted_block_headers_source",
                 "Number of accepted block headers by source and authority",
                 &["source", "authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             accepted_block_headers_round_gap: register_histogram_vec_with_registry!(
                 "accepted_block_headers_round_gap",
                 "Round gap of accepted block headers to clock round",
                 &["source"],
                 vec![0.0, 1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 80.0, 100.0, 200.0, 400.0, 800.0, 1000.0],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             core_skipped_headers: register_int_counter_vec_with_registry!(
                 "core_skipped_headers",
                 "Number of block headers skipped in core because already in DAG or suspended",
                 &["authority", "source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             core_skipped_transactions: register_int_counter_vec_with_registry!(
                 "core_skipped_transactions",
                 "Number of non-empty transactions skipped in core because already in DAG",
                 &["authority", "source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             shard_accumulators: register_int_gauge_with_registry!(
                 "shard_accumulators",
                 "The number of shard accumulators currently in memory",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             reconstruction_queue: register_int_gauge_with_registry!(
                 "reconstruction_queue",
                 "The current number of pending reconstruction jobs in the queue",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             shard_reconstructor_processed_transactions: register_int_gauge_with_registry!(
                 "shard_reconstructor_processed_transactions",
                 "Number of processed transactions tracked to prevent duplicate reconstruction",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             reconstructed_transactions_unknown: register_int_gauge_with_registry!(
             "reconstructed_transactions_unknown",
             "The current number of reconstructed transactions which are unknown to dag state",
-            registry,
+            registry;
+            MetricLevel::Warn,
             ).unwrap(),
             dag_state_recent_transactions: register_int_gauge_with_registry!(
                 "dag_state_recent_transactions",
                 "Number of recent transactions cached in the DagState",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             dag_state_recent_headers: register_int_gauge_with_registry!(
                 "dag_state_recent_headers",
@@ -564,44 +590,52 @@ impl NodeMetrics {
             dag_state_recent_refs: register_int_gauge_with_registry!(
                 "dag_state_recent_refs",
                 "Number of recent refs cached in the DagState",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             dag_state_pending_commit_votes: register_int_gauge_with_registry!(
                 "dag_state_pending_commit_votes",
                 "Number of pending commit votes in the DagState",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             dag_state_pending_acknowledgments: register_int_gauge_with_registry!(
                 "dag_state_pending_acknowledgments",
                 "Number of pending acknowledgments in the DagState",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             cordial_knowledge_message_batch_size: register_histogram_with_registry!(
                 "cordial_knowledge_message_batch_size",
                 "Size of the batch of messages sent to connections in cordial knowledge",
                 vec![0.0, 1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 80.0, 100.0, 200.0, 400.0, 800.0, 1000.0],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             cordial_knowledge_processed_messages: register_int_counter_vec_with_registry!(
                 "cordial_knowledge_processed_messages",
                 "Number of Cordial Knowledge messages processed",
                 &["type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             cordial_knowledge_entries: register_int_gauge_with_registry!(
                 "cordial_knowledge_entries",
                 "Total entries in the global cordial knowledge map",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             cordial_knowledge_headers_not_known: register_int_gauge_with_registry!(
                 "cordial_knowledge_headers_not_known",
                 "Total unknown header entries across all connection knowledges",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             cordial_knowledge_shards_not_known: register_int_gauge_with_registry!(
                 "cordial_knowledge_shards_not_known",
                 "Total unknown shard entries across all connection knowledges",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             dag_state_store_read_count: register_int_counter_vec_with_registry!(
                 "dag_state_store_read_count",
@@ -617,7 +651,8 @@ impl NodeMetrics {
             synchronizer_fetch_block_headers_scheduler_inflight: register_int_gauge_with_registry!(
                 "synchronizer_fetch_block_headers_scheduler_inflight",
                 "Designates whether the synchronizer scheduler task to fetch block headers is currently running",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             synchronizer_fetch_block_headers_scheduler_skipped: register_int_counter_vec_with_registry!(
                 "synchronizer_fetch_block_headers_scheduler_skipped",
@@ -642,13 +677,15 @@ impl NodeMetrics {
                 "cordial_knowledge_useful_headers_authors",
                 "Useful authors for pushing headers to the local node",
                 &["peer", "author"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             cordial_knowledge_useful_shards_authors: register_int_counter_vec_with_registry!(
                 "cordial_knowledge_useful_shards_authors",
                 "Useful authors for pushing shards to the local node",
                 &["author"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             synchronizer_requested_block_headers_by_peer: register_int_counter_vec_with_registry!(
                 "synchronizer_requested_block_headers_by_peer",
@@ -690,13 +727,15 @@ impl NodeMetrics {
                 "synchronizer_fetched_block_headers_by_authority",
                 "Number of fetched block headers per block author via the synchronizer",
                 &["authority", "type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             synchronizer_requested_block_headers_by_authority: register_int_counter_vec_with_registry!(
                 "synchronizer_requested_block_headers_by_authority",
                 "Number of requested block headers per block author via the synchronizer",
                 &["authority", "type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             last_known_own_block_header_round: register_int_gauge_with_registry!(
                 "last_known_own_block_header_round",
@@ -732,7 +771,8 @@ impl NodeMetrics {
                 "bundles_with_invalid_parts",
                 "Number of bundles that contain invalid parts per peer",
                 &["authority", "invalid_part", "error"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             valid_headers_in_bundles: register_int_counter_vec_with_registry!(
                 "valid_headers_in_bundles",
@@ -744,49 +784,57 @@ impl NodeMetrics {
                 "filtered_headers_in_bundles",
                 "Number of filtered block headers received from block bundles per sender authority",
                 &["authority", "source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             received_unique_headers_from_bundles: register_int_counter_vec_with_registry!(
                 "received_unique_headers_from_a_bundle",
                 "Number of unique block headers received from block bundles per sender authority",
                 &["authority", "source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             processed_duplicated_headers_in_bundles: register_int_counter_vec_with_registry!(
                 "processed_duplicated_headers_in_bundles",
                 "Number of times block headers from bundles were not filtered and processed extra time (i.e. deserialized and verified) per sender authority",
                 &["authority", "source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             valid_shards_in_bundles: register_int_counter_vec_with_registry!(
                 "valid_shards_in_bundles",
                 "Number of valid shards received from block bundles per sender authority",
                 &["authority", "source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             missing_ancestors_from_streaming: register_histogram_vec_with_registry!(
                 "missing_ancestors_from_streaming",
                 "Number of missing ancestors of blocks and headers received through streaming",
                 &["source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             missing_ancestors_from_streaming_round_gap: register_histogram_with_registry!(
                 "missing_ancestors_from_streaming_round_gap",
                 "Round gap to missing ancestors of blocks and headers received through streaming",
                 vec![0.0, 1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 80.0, 100.0, 200.0, 400.0, 800.0, 1000.0],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             additional_headers_round_gap: register_histogram_with_registry!(
                 "additional_headers_round_gap",
                 "Round gap between additional block headers in bundles and the main block",
                 vec![0.0, 1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 80.0, 100.0, 200.0, 400.0, 800.0, 1000.0],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             rejected_blocks: register_int_counter_vec_with_registry!(
                 "rejected_blocks",
                 "Number of blocks rejected because last commit index is lagging quorum commit index too much",
                 &["reason"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             skipped_empty_transaction_acknowledgments: register_int_counter_vec_with_registry!(
                 "skipped_empty_transaction_acknowledgments",
@@ -822,7 +870,8 @@ impl NodeMetrics {
             last_committed_leader_round: register_int_gauge_with_registry!(
                 "last_committed_leader_round",
                 "The last round where a leader was committed to store and sent to commit consumer.",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             last_commit_index: register_int_gauge_with_registry!(
                 "last_commit_index",
@@ -865,24 +914,28 @@ impl NodeMetrics {
             num_of_bad_nodes: register_int_gauge_with_registry!(
                 "num_of_bad_nodes",
                 "The number of bad nodes in the new leader schedule",
-                registry
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             quorum_receive_latency: register_histogram_with_registry!(
                 "quorum_receive_latency",
                 "The time it took to receive a new round quorum of blocks",
-                registry
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_receive_delay: register_int_counter_vec_with_registry!(
                 "block_receive_delay",
                 "Total delay from the start of the round to receiving the block, in milliseconds per authority",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             invalid_transactions: register_int_counter_vec_with_registry!(
                 "invalid_transactions",
                 "Number of invalid transactions per peer authority",
                 &["authority", "source", "error"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transactions_synchronizer_fetched_transactions_by_peer: register_int_counter_vec_with_registry!(
                 "transaction_synchronizer_fetched_transactions_by_peer",
@@ -895,19 +948,22 @@ impl NodeMetrics {
                 "transaction_synchronizer_fetched_transactions_by_authority",
                 "Number of fetched transactions per block author via the transaction synchronizer",
                 &["authority", "type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transactions_synchronizer_missing_transactions_by_authority: register_int_counter_vec_with_registry!(
                 "transactions_synchronizer_missing_transactions_by_authority",
                 "Number of missing transactions per block author, as observed by the transaction synchronizer during periodic sync.",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transactions_synchronizer_current_missing_transactions_by_authority: register_int_gauge_vec_with_registry!(
                 "transactions_synchronizer_current_missing_transactions_by_authority",
                 "Current number of missing transactions per block author, as observed by the transaction synchronizer during periodic sync.",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transactions_synchronizer_periodic_inflight: register_int_gauge_with_registry!(
                 "fetch_transactions_scheduler_inflight",
@@ -918,20 +974,23 @@ impl NodeMetrics {
                 "reputation_scores",
                 "Reputation scores for each authority",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             scope_processing_time: register_histogram_vec_with_registry!(
                 "scope_processing_time",
                 "The processing time of a specific code scope",
                 &["scope"],
                 FINE_GRAINED_LATENCY_SEC_BUCKETS.to_vec(),
-                registry
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             sub_dags_per_commit_count: register_histogram_vec_with_registry!(
                 "sub_dags_per_commit_count",
                 "The number of subdags per commit.",
                 &["source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_headers_suspensions: register_int_counter_vec_with_registry!(
                 "block_headers_suspensions",
@@ -949,12 +1008,14 @@ impl NodeMetrics {
                 "suspended_block_header_time",
                 "The time for which a block header remains suspended",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_suspended_block_headers: register_int_gauge_with_registry!(
                 "block_manager_suspended_block_headers",
                 "The number of block headers currently suspended in the block manager",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_suspended_blocks: register_int_gauge_with_registry!(
                 "block_manager_suspended_blocks",
@@ -971,7 +1032,8 @@ impl NodeMetrics {
             block_manager_missing_block_headers: register_int_gauge_with_registry!(
                 "block_manager_missing_block_headers",
                 "The number of block headers that are missing in the block manager and should be fetched",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_missing_block_headers_by_authority: register_int_counter_vec_with_registry!(
                 "block_manager_missing_block_headers_by_authority",
@@ -983,43 +1045,51 @@ impl NodeMetrics {
                 "block_manager_missing_ancestors_by_authority",
                 "The number of headers that are missing or suspended in the block manager by authority",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_gc_floor: register_int_gauge_with_registry!(
                 "block_manager_gc_floor",
                 "The last GC round floor applied by the block manager. Suspended state at or below this round has been evicted.",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_gc_evicted_missing_ancestors_total: register_int_counter_with_registry!(
                 "block_manager_gc_evicted_missing_ancestors_total",
                 "Total number of missing-ancestor entries dropped by the block manager GC sweep",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_gc_evicted_fetch_entries_total: register_int_counter_with_registry!(
                 "block_manager_gc_evicted_fetch_entries_total",
                 "Total number of headers_to_fetch entries dropped by the block manager GC sweep",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_gc_unsuspended_total: register_int_counter_with_registry!(
                 "block_manager_gc_unsuspended_total",
                 "Total number of headers unsuspended by the block manager GC sweep because all their missing ancestors fell below the GC floor",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_gc_evicted_suspended_transactions_total: register_int_counter_with_registry!(
                 "block_manager_gc_evicted_suspended_transactions_total",
                 "Total number of suspended_transactions entries dropped by the block manager GC sweep",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             block_manager_gc_evicted_old_headers_total: register_int_counter_with_registry!(
                 "block_manager_gc_evicted_old_headers_total",
                 "Total number of incoming block headers dropped because their round is at or below the GC floor",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             dropped_far_future_headers_total: register_int_counter_vec_with_registry!(
                 "dropped_far_future_headers_total",
                 "Number of block headers dropped because their round is too far above the accepted frontier to ever connect, by source",
                 &["source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             threshold_clock_round: register_int_gauge_with_registry!(
                 "threshold_clock_round",
@@ -1037,25 +1107,29 @@ impl NodeMetrics {
                 "subscribed_to",
                 "Peers that this authority subscribed to for block streams.",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             subscribed_by: register_int_gauge_vec_with_registry!(
                 "subscribed_by",
                 "Peers subscribing for block streams from this authority.",
                 &["authority"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_sync_inflight_fetches: register_int_gauge_vec_with_registry!(
                 "commit_sync_inflight_fetches",
                 "The number of inflight fetches in commit syncer",
                 &["source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_sync_pending_fetches: register_int_gauge_vec_with_registry!(
                 "commit_sync_pending_fetches",
                 "The number of pending fetches in commit syncer",
                 &["source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_sync_fetched_commits: register_int_counter_vec_with_registry!(
                 "commit_sync_fetched_commits",
@@ -1108,7 +1182,8 @@ impl NodeMetrics {
                 "commit_sync_gap_on_processing",
                 "Number of instances where a gap was found in fetched commit processing",
                 &["source"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_sync_fetch_loop_latency: register_histogram_with_registry!(
                 "commit_sync_fetch_loop_latency",
@@ -1121,13 +1196,15 @@ impl NodeMetrics {
                 "The time taken to fetch commits and block headers once",
                 &["source"],
                 LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_sync_fetch_once_errors: register_int_counter_vec_with_registry!(
                 "commit_sync_fetch_once_errors",
                 "Number of errors when attempting to fetch commits and block headers from single authority during commit sync.",
                 &["authority", "error", "source"],
-                registry
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             commit_sync_fetch_commits_handler_uncertified_skipped: register_int_counter_vec_with_registry!(
                 "commit_sync_fetch_commits_handler_uncertified_skipped",
@@ -1176,24 +1253,28 @@ impl NodeMetrics {
                 "The time taken to fetch transactions from a peer",
                 &["peer", "type"],
                 LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transactions_synchronizer_success_by_peer: register_int_counter_vec_with_registry!(
                 "transaction_synchronizer_success_by_peer",
                 "Number of successful transaction fetches per peer",
                 &["peer", "type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transactions_synchronizer_failure_by_peer: register_int_counter_vec_with_registry!(
                 "transaction_synchronizer_failure_by_peer",
                 "Number of failed transaction fetches per peer",
                 &["peer", "type", "error"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             transactions_synchronizer_inflight_requests: register_int_gauge_with_registry!(
                 "transaction_synchronizer_concurrent_requests",
                 "Number of concurrent transaction fetch requests",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             faulty_blocks_provable_by_authority: register_int_gauge_vec_with_registry!(
                 "faulty_blocks_provable_by_authority",
@@ -1227,35 +1308,41 @@ impl NodeMetrics {
                 "strong_vote_extra_wait_seconds",
                 "Extra wait at block proposal time imposed by the StarfishSpeed strong-vote condition: time between when the ordinary (base Starfish) propose condition first became satisfiable for the current clock round and when the proposal actually happened. Observed only when consensus_starfish_speed is enabled.",
                 FINE_GRAINED_LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             strong_vote_missing_authorities: register_histogram_with_registry!(
                 "strong_vote_missing_authorities",
                 "Size of the `missing` set in the strong-vote payload of each proposed block: authorities whose transactions are not locally available among the leader and its acknowledgments. 0 means a clean strong vote; >0 means strong blame. Observed only when consensus_starfish_speed is enabled.",
                 COMMITTEE_COUNT_BUCKETS.to_vec(),
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             strong_blames_emitted_for_leader: register_int_counter_vec_with_registry!(
                 "strong_blames_emitted_for_leader",
                 "Number of proposed blocks that strong-blame the leader (non-empty `missing` set), labeled by leader authority.",
                 &["leader"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             strong_blames_received_from_voter: register_int_counter_vec_with_registry!(
                 "strong_blames_received_from_voter",
                 "Number of strong blames received against this node (when acting as leader), labeled by the voter authority that emitted the blame.",
                 &["voter"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             adaptive_ack_excluded_authorities: register_int_gauge_with_registry!(
                 "adaptive_ack_excluded_authorities",
                 "Number of authorities currently in the adaptive-ack exclusion set, as observed at the most recent leader block proposal. Empty when consensus_starfish_speed or enable_starfish_speed_adaptive_acknowledgments is off.",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             adaptive_ack_acks_dropped: register_int_counter_with_registry!(
                 "adaptive_ack_acks_dropped",
                 "Total pending acknowledgments skipped because their author was in the adaptive-ack exclusion set at proposal time. Skipped refs remain pending and may be included later if the author leaves the exclusion set.",
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
         }
     }

--- a/crates/starfish/core/src/network/metrics.rs
+++ b/crates/starfish/core/src/network/metrics.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use prometheus_filtered::{
-    HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, MetricLevel, Registry,
     register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
 };
@@ -42,14 +42,16 @@ impl NetworkMetrics {
                 "inbound_admission_rejected",
                 "Inbound consensus requests rejected by per-peer admission control, by RPC group",
                 &["group"],
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             admission_in_use: register_int_gauge_vec_with_registry!(
                 "inbound_admission_in_use",
                 "Inbound consensus requests currently in flight under admission control, by RPC group",
                 &["group"],
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
         }
@@ -139,7 +141,8 @@ impl NetworkRouteMetrics {
             format!("{direction}_requests"),
             "The number of requests made on the network",
             &["route"],
-            registry
+            registry;
+            MetricLevel::Warn,
         )
         .unwrap();
 
@@ -148,7 +151,8 @@ impl NetworkRouteMetrics {
             "Latency of a request by route",
             &["route"],
             LATENCY_SEC_BUCKETS.to_vec(),
-            registry,
+            registry;
+            MetricLevel::Warn,
         )
         .unwrap();
 
@@ -157,7 +161,8 @@ impl NetworkRouteMetrics {
             "Size of a request by route",
             &["route"],
             SIZE_BYTE_BUCKETS.to_vec(),
-            registry,
+            registry;
+            MetricLevel::Warn,
         )
         .unwrap();
 
@@ -166,7 +171,8 @@ impl NetworkRouteMetrics {
             "Size of a response by route",
             &["route"],
             SIZE_BYTE_BUCKETS.to_vec(),
-            registry,
+            registry;
+            MetricLevel::Warn,
         )
         .unwrap();
 


### PR DESCRIPTION
# Description of change

Against nodes running the default metric exposure (#12105), the starfish-overview Grafana dashboard shows data for only 17 of the 110 metric families it queries — the rest sit at the hidden debug tier. Tag every dashboard-queried metric as `MetricLevel::Warn` so the dashboard works against devnet/testnet/mainnet nodes without raising exposure per fleet:

- `starfish-core`: 93 node metrics (`metrics.rs`) and the network route request/latency/size + admission metrics (`network/metrics.rs`)
- `iota-core`: `consensus_committed_messages`, `consensus_handler_leader_round`, `consensus_handler_transaction_sizes`, `consensus_quarantine_queue_size`
- `iota-metrics`: `monitored_channel_inflight` (the dashboard reads the consensus core-thread channel through it)

Size impact, measured on a live 20-validator network: ~3.7k series added to a validator's `/metrics`. Most of it comes from a few per-authority/per-scope histograms — `scope_processing_time` (~870 series), `latency_to_process_stream` (~400), `proposed_block_acknowledgments_depth` (~340), `transaction_synchronizer_fetch_latency` (~280), `suspended_block_header_time` (~220) — which are the candidates if the output needs to get smaller later. Plain gauges/counters (~35 of the tagged families) cost one series each.

Same approach as #12282, extended from the sync-check metrics to the full dashboard set.

## Links to any relevant issues

fixes #12296

Stacked on #12291 (targets its branch; retargets to develop when it merges) — that PR covers the other dashboards, this one covers starfish-overview.

Context: #12105, #12289. Analogous fix: #12282.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
