### PR TITLE
chore(consensus): check leader-schedule window invariant for all configs

### DIFF
--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -1332,4 +1332,24 @@ mod tests {
         // Update leader from old swap table to new invalid swap table
         leader_schedule.update_leader_swap_table_strict_for_test(leader_swap_table);
     }
+
+    #[test]
+    fn test_leader_schedule_window_invariant_for_all_protocol_configs() {
+        use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+
+        // The getter assert enforcing this only fires once consensus starts at
+        // the adopting epoch; check every defined config here so that a
+        // misconfigured version fails CI, which runs this without msim and so
+        // compares the real, unclamped values.
+        for chain in [Chain::Unknown, Chain::Mainnet, Chain::Testnet] {
+            for version in ProtocolVersion::MIN.as_u64()..=ProtocolVersion::MAX.as_u64() {
+                let config = ProtocolConfig::get_for_version(ProtocolVersion::new(version), chain);
+                assert!(
+                    !config.consensus_enable_sliding_window_leader_schedule()
+                        || config.leader_schedule_window_size() >= config.commits_per_schedule(),
+                    "{chain:?} v{version}: leader_schedule_window_size must be >= commits_per_schedule"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Description of change

The `leader_schedule_window_size >= commits_per_schedule` invariant behind the sliding-window leader schedule is enforced by an assert in the flag getter, which only runs when consensus reads the config — i.e. at the epoch boundary that adopts an enabling protocol version — and simtests see msim-clamped values (`commits_per_schedule()` is capped at 10 under msim), so no CI job checks the real values for a newly defined version. A future version enabling the flag with a too-small window would ship green and panic every validator at the epoch flip.

Close the CI gap with a leader-schedule unit test that compares the two getters for every `(version, chain)` pair. It runs without msim, so a misconfigured version definition fails CI with production semantics. No production code changes; no default values change and the flag stays disabled.

## Links to any relevant issues

Closes iotaledger/iota-private#460.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
