### PR TITLE
feat(starfish-config): reduce default soft_leader_timeout to 5 ms

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -191,7 +191,7 @@ impl Parameters {
     }
 
     pub(crate) fn default_soft_leader_timeout() -> Duration {
-        Duration::from_millis(100)
+        Duration::from_millis(5)
     }
 
     pub(crate) fn default_block_rate_window() -> Duration {

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -10,7 +10,7 @@ min_block_delay:
   nanos: 50000000
 soft_leader_timeout:
   secs: 0
-  nanos: 100000000
+  nanos: 5000000
 block_rate_window:
   secs: 2
   nanos: 0


### PR DESCRIPTION
# Description of change

Reduce the default StarfishSpeed `soft_leader_timeout` from 100 ms to 5 ms. Local operational parameter only — no protocol version change; per-authority inconsistency is tolerated by design.

Rationale, from a 10-run sweep of the timer (0-100 ms) on a 20-validator network with the geodistributed latency matrix (#12280):

- Commit latency and commits/s are insensitive to the timer across the whole range (tx commit p50 254-263 ms, p95 740-745 ms, ~2000 commits/s everywhere).
- Smaller values let high-latency validators propose without waiting on strong-vote propagation: at the low end their own-block production reaches full parity with the rest of the committee (16.2 blocks/s across all 20 validators at 0 ms), and their leader votes leave earlier — which is what reputation scoring rewards, since a vote only earns credit while other validators still strong-link it.
- Proposing on soft timeout never skips the leader link (`Core::try_new_block` requires the parent-round leader header for non-forced proposals), so no votes are forfeited by proposing earlier.
- 5 ms rather than 0: the strong-vote readiness check stays armed for votes arriving together with the parent-round quorum, instead of being bypassed the instant a round opens. Behaviorally near-identical on geodistributed topologies (SoftTimeout proposal share 16.3% vs 16.9%).

Full sweep data and discussion: #12280.

## Links to any relevant issues

#12280

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`starfish-config` (12) and `starfish-core --lib` (336) tests pass with the new default. The 5 ms value itself was exercised live in the sweep (10x 20-validator runs incl. 5 ms, all clean, zero stalls).

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): The default Starfish `soft_leader_timeout` is reduced from 100 ms to 5 ms; validators propose sooner when strong votes for the previous leader are slow to arrive. Operators can override it via `consensus-config.parameters.soft_leader_timeout`.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC: