### PR TITLE
feat(graphql): KV fallback for fetching objects

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
@@ -185,3 +185,18 @@ fragment DynamicFieldsSelect on DynamicFieldConnection {
     }
   }
 }
+
+//# run-graphql
+# The dynamic field wrapper object was deleted when the child was reclaimed:
+# fetching it at the exact deletion version resolves as non-existent, while
+# the version before still resolves.
+{
+  wrapper_at_deletion_version: object(address: "@{obj_3_0}", version: 4) {
+    version
+    status
+  }
+  wrapper_before_deletion: object(address: "@{obj_3_0}", version: 3) {
+    version
+    status
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 9 tasks
+processed 10 tasks
 
 init:
 A: object(0,0)
@@ -193,6 +193,18 @@ Response: {
         "edges": []
       },
       "dynamicObjectField": null
+    }
+  }
+}
+
+task 9, lines 189-202:
+//# run-graphql
+Response: {
+  "data": {
+    "wrapper_at_deletion_version": null,
+    "wrapper_before_deletion": {
+      "status": "INDEXED",
+      "version": 3
     }
   }
 }

--- a/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.move
@@ -61,7 +61,8 @@ module P0::m {
 
 //# run-graphql --wait-for-checkpoint-pruned 6
 # A: Query.object at a version whose row content has been pruned — no
-# fallback. The version resolves as non-existent.
+# fallback. The version is known to `objects_version`, so the request errors
+# with DATA_PRUNED.
 {
   object(address: "@{obj_2_0}", version: 3) {
     version
@@ -92,8 +93,8 @@ module P0::m {
 
 //# run-graphql
 # D: a dynamic field looked up at a pruned parent version — the field
-# object's history at that version has been pruned, so the field resolves as
-# non-existent.
+# object's history at that version has been pruned, so the field errors with
+# DATA_PRUNED.
 {
   owner(address: "@{obj_2_0}", rootVersion: 3) {
     dynamicField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {

--- a/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.move
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL object-at-version queries under pruning, with no
+// historical fallback configured. Covers:
+// - `Query.object(address, version)`
+// - `Owner.dynamicField` at a `rootVersion`
+
+//# init --protocol-version 12 --addresses P0=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module P0::m {
+    use iota::dynamic_field as field;
+
+    public struct Foo has key, store { id: UID, value: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), value: 0 }, ctx.sender())
+    }
+
+    public entry fun bump(foo: &mut Foo) {
+        foo.value = foo.value + 1;
+    }
+
+    public entry fun add_df(foo: &mut Foo, name: u64, value: u64) {
+        field::add(&mut foo.id, name, value);
+    }
+
+    public entry fun mutate_df(foo: &mut Foo, name: u64, value: u64) {
+        *field::borrow_mut<u64, u64>(&mut foo.id, name) = value;
+    }
+}
+
+//# run P0::m::create --sender A
+
+//# run P0::m::add_df --sender A --args object(2,0) 42 1
+
+//# create-checkpoint
+
+//# run P0::m::mutate_df --sender A --args object(2,0) 42 2
+
+//# run P0::m::bump --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: Query.object at a version whose row content has been pruned — no
+# fallback. The version resolves as non-existent.
+{
+  object(address: "@{obj_2_0}", version: 3) {
+    version
+    status
+  }
+}
+
+//# run-graphql
+# B: Query.object at the current version resolves.
+{
+  object(address: "@{obj_2_0}", version: 5) {
+    version
+    status
+    asMoveObject {
+      contents { json }
+    }
+  }
+}
+
+//# run-graphql
+# C: Query.object at a version that never existed resolves as non-existent.
+{
+  object(address: "@{obj_2_0}", version: 100) {
+    version
+    status
+  }
+}
+
+//# run-graphql
+# D: a dynamic field looked up at a pruned parent version — the field
+# object's history at that version has been pruned, so the field resolves as
+# non-existent.
+{
+  owner(address: "@{obj_2_0}", rootVersion: 3) {
+    dynamicField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+      value {
+        ... on MoveValue { json }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# E: the same dynamic field at the current parent version resolves.
+{
+  owner(address: "@{obj_2_0}", rootVersion: 5) {
+    dynamicField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+      value {
+        ... on MoveValue { json }
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.snap
@@ -74,15 +74,30 @@ task 15, line 60:
 //# create-checkpoint
 Checkpoint created: 10
 
-task 16, lines 62-70:
+task 16, lines 62-71:
 //# run-graphql --wait-for-checkpoint-pruned 6
 Response: {
-  "data": {
-    "object": null
-  }
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: data for object 0x843c5fd93fafc7cfca2e5650b9a80981090d17f139f52833326078623e814353 potentially pruned",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "object"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
 }
 
-task 17, lines 72-82:
+task 17, lines 73-83:
 //# run-graphql
 Response: {
   "data": {
@@ -101,7 +116,7 @@ Response: {
   }
 }
 
-task 18, lines 84-91:
+task 18, lines 85-92:
 //# run-graphql
 Response: {
   "data": {
@@ -109,17 +124,33 @@ Response: {
   }
 }
 
-task 19, lines 93-105:
+task 19, lines 94-106:
 //# run-graphql
 Response: {
   "data": {
-    "owner": {
-      "dynamicField": null
+    "owner": null
+  },
+  "errors": [
+    {
+      "message": "Requested data has been pruned: data for object 0xac52fe97efc94b3b3426355ae8545a236c90588040d60efe51e600aa08302bc5 potentially pruned",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "owner",
+        "dynamicField"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
     }
-  }
+  ]
 }
 
-task 20, lines 107-117:
+task 20, lines 108-118:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.snap
@@ -1,0 +1,134 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 21 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-32:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6703200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 34:
+//# run P0::m::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 36:
+//# run P0::m::add_df --sender A --args object(2,0) 42 1
+created: object(3,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3716400, storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 4, line 38:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, line 40:
+//# run P0::m::mutate_df --sender A --args object(2,0) 42 2
+mutated: object(0,0), object(2,0), object(3,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3716400, storage_rebate: 3716400, non_refundable_storage_fee: 0
+
+task 6, line 42:
+//# run P0::m::bump --sender A --args object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 7, line 44:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, line 46:
+//# advance-epoch
+Epoch advanced: 0
+
+task 9, line 48:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 10, line 50:
+//# advance-epoch
+Epoch advanced: 1
+
+task 11, line 52:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 12, line 54:
+//# advance-epoch
+Epoch advanced: 2
+
+task 13, line 56:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 14, line 58:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 15, line 60:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 16, lines 62-70:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "object": null
+  }
+}
+
+task 17, lines 72-82:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x843c5fd93fafc7cfca2e5650b9a80981090d17f139f52833326078623e814353",
+            "value": "1"
+          }
+        }
+      },
+      "status": "INDEXED",
+      "version": 5
+    }
+  }
+}
+
+task 18, lines 84-91:
+//# run-graphql
+Response: {
+  "data": {
+    "object": null
+  }
+}
+
+task 19, lines 93-105:
+//# run-graphql
+Response: {
+  "data": {
+    "owner": {
+      "dynamicField": null
+    }
+  }
+}
+
+task 20, lines 107-117:
+//# run-graphql
+Response: {
+  "data": {
+    "owner": {
+      "dynamicField": {
+        "value": {
+          "json": "2"
+        }
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -1402,6 +1402,36 @@ const OBJECT_STATUS_PRUNED: i16 = -1;
 
 const OBJECT_STATUS_WRAPPED_OR_DELETED: i16 = NativeObjectStatus::WrappedOrDeleted as i16;
 
+const OBJECT_STATUS_ACTIVE: i16 = NativeObjectStatus::Active as i16;
+
+/// Supplies the parameters needed to build an [`Object`] from a row fetched
+/// from the historical fallback: the checkpoint it is viewed at, and the root
+/// version to record on it.
+trait FallbackObjectKey: Eq + std::hash::Hash {
+    /// The checkpoint the object is viewed at.
+    fn checkpoint_viewed_at(&self) -> u64;
+    /// The root version to record on the resulting object, if any.
+    fn root_version(&self) -> Option<u64>;
+}
+
+impl FallbackObjectKey for HistoricalKey {
+    fn checkpoint_viewed_at(&self) -> u64 {
+        self.checkpoint_viewed_at
+    }
+    fn root_version(&self) -> Option<u64> {
+        None
+    }
+}
+
+impl FallbackObjectKey for ParentVersionKey {
+    fn checkpoint_viewed_at(&self) -> u64 {
+        self.checkpoint_viewed_at
+    }
+    fn root_version(&self) -> Option<u64> {
+        Some(self.parent_version)
+    }
+}
+
 /// Checks if `objects_version` table covers the whole chain history.
 ///
 /// This function currently returns false for indexer restored from snapshot.
@@ -1411,20 +1441,17 @@ fn objects_version_complete(db: &Db) -> bool {
         .is_ok()
 }
 
-/// Fetches specified object versions from the historical fallback and stores
-/// them per key in `results`.
+/// Fills the missing `results` entries with objects fetched from the
+/// historical fallback.
 ///
 /// It stores nothing when the object does not exist at the requested version
 /// (e.g. when the object is wrapped or deleted). It stores
 /// [`Error::DataPruned`] per key when the historical fallback is not
 /// configured.
-///
-/// `to_object` builds the [`Object`] that is then stored in `results`.
-async fn fetch_missing_objects_from_fallback<K: Eq + std::hash::Hash>(
+async fn fill_missing_objects_from_fallback<K: FallbackObjectKey>(
     db: &Db,
     keys_with_refs: Vec<(K, (ObjectId, Version))>,
     results: &mut HashMap<K, Result<Object, Error>>,
-    to_object: impl Fn(&K, StoredObject) -> Result<Object, Error>,
 ) -> Result<(), Error> {
     if keys_with_refs.is_empty() {
         return Ok(());
@@ -1455,7 +1482,11 @@ async fn fetch_missing_objects_from_fallback<K: Eq + std::hash::Hash>(
     for ((key, _), fetched) in keys_with_refs.into_iter().zip(fetched) {
         match fetched {
             Ok(Some(stored)) => {
-                let object = to_object(&key, stored)?;
+                let object = Object::try_from_stored_object(
+                    stored,
+                    key.checkpoint_viewed_at(),
+                    key.root_version(),
+                )?;
                 results.insert(key, Ok(object));
             }
             // The object does not exist at the requested version.
@@ -1574,11 +1605,9 @@ impl Loader<HistoricalKey> for Db {
                     fallback_keys.push(*key);
                     continue;
                 }
-                // The version exists but the object was wrapped or deleted at
-                // it: resolve as non-existent.
-                OBJECT_STATUS_WRAPPED_OR_DELETED => continue,
-                // A live version; the conversion rejects any other status.
-                _ => ActiveObject::try_from(stored.clone())?,
+                OBJECT_STATUS_ACTIVE => ActiveObject::try_from(stored.clone())?,
+                // Wrapped, deleted, or not yet created: resolve as non-existent.
+                _ => continue,
             };
             // This conversion will use the object's own version as the
             // `Object::root_version`.
@@ -1597,10 +1626,7 @@ impl Loader<HistoricalKey> for Db {
             .into_iter()
             .map(|key| (key, (key.id.into(), Version::from(key.version))))
             .collect();
-        fetch_missing_objects_from_fallback(self, keys_with_refs, &mut result, |key, stored| {
-            Object::try_from_stored_object(stored, key.checkpoint_viewed_at, None)
-        })
-        .await?;
+        fill_missing_objects_from_fallback(self, keys_with_refs, &mut result).await?;
 
         Ok(result)
     }
@@ -1830,11 +1856,9 @@ impl Loader<ParentVersionKey> for Db {
                     fallback_keys.push((*key, object_ref));
                     continue;
                 }
-                // The version exists but the object was wrapped or deleted at
-                // it: resolve as non-existent.
-                OBJECT_STATUS_WRAPPED_OR_DELETED => continue,
-                // A live version; the conversion rejects any other status.
-                _ => ActiveObject::try_from(stored.clone())?,
+                OBJECT_STATUS_ACTIVE => ActiveObject::try_from(stored.clone())?,
+                // Wrapped, deleted, or not yet created: resolve as non-existent.
+                _ => continue,
             };
             // If `LatestAtKey::parent_version` is set, it must have been correctly
             // propagated from the `Object::root_version` of some object.
@@ -1864,14 +1888,7 @@ impl Loader<ParentVersionKey> for Db {
             }
         }
 
-        fetch_missing_objects_from_fallback(self, fallback_keys, &mut results, |key, stored| {
-            Object::try_from_stored_object(
-                stored,
-                key.checkpoint_viewed_at,
-                Some(key.parent_version),
-            )
-        })
-        .await?;
+        fill_missing_objects_from_fallback(self, fallback_keys, &mut results).await?;
 
         Ok(results)
     }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -18,7 +18,9 @@ use iota_indexer::{
     schema::objects,
     types::{ObjectStatus as NativeObjectStatus, OwnerType},
 };
-use iota_sdk_types::{MoveStruct as NativeMoveStruct, Owner as NativeOwner, StructTag, TypeTag};
+use iota_sdk_types::{
+    MoveStruct as NativeMoveStruct, ObjectId, Owner as NativeOwner, StructTag, TypeTag, Version,
+};
 use iota_types::object::{Object as NativeObject, bounded_visitor::BoundedVisitor};
 use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout};
 use serde::{Deserialize, Serialize};
@@ -1009,6 +1011,7 @@ impl Object {
     pub(crate) fn try_from_stored_object(
         stored_object: StoredObject,
         checkpoint_viewed_at: u64,
+        root_version: Option<u64>,
     ) -> Result<Self, Error> {
         let active_object = ActiveObject {
             native: NativeObject::try_from(&stored_object)?,
@@ -1018,7 +1021,7 @@ impl Object {
         Ok(Self::from_active_object(
             active_object,
             checkpoint_viewed_at,
-            None,
+            root_version,
         ))
     }
 }
@@ -1466,8 +1469,11 @@ impl Loader<HistoricalKey> for Db {
         }
 
         let mut result = HashMap::new();
+        // Keys not found in the DB, to be queried from fallback
+        let mut fallback_keys = Vec::new();
         for key in keys {
             let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) else {
+                fallback_keys.push(*key);
                 continue;
             };
 
@@ -1483,6 +1489,29 @@ impl Loader<HistoricalKey> for Db {
             // `Object::root_version`.
             let object = Object::from_active_object(active_object, key.checkpoint_viewed_at, None);
             result.insert(*key, object);
+        }
+
+        // Try to fill the keys not found in the DB from the KV
+        if self.inner.is_fallback_enabled() && !fallback_keys.is_empty() {
+            let object_refs: Vec<(ObjectId, Version)> = fallback_keys
+                .iter()
+                .map(|key| (key.id.into(), Version::from(key.version)))
+                .collect();
+            let fetched = self
+                .inner
+                .multi_get_fallback_objects(&object_refs, false)
+                .await
+                .map_err(|e| {
+                    Error::Internal(format!("failed to fetch objects from fallback: {e}"))
+                })?;
+            for (key, stored) in fallback_keys.into_iter().zip(fetched) {
+                let Some(stored) = stored else {
+                    continue;
+                };
+                let object =
+                    Object::try_from_stored_object(stored, key.checkpoint_viewed_at, None)?;
+                result.insert(key, object);
+            }
         }
 
         Ok(result)
@@ -1531,7 +1560,7 @@ impl Loader<OptimisticKey> for Db {
         let mut missing_keys = Vec::new();
         for key in keys {
             if let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) {
-                let object = Object::try_from_stored_object(stored.clone(), u64::MAX)?;
+                let object = Object::try_from_stored_object(stored.clone(), u64::MAX, None)?;
                 result.insert(*key, object);
             } else {
                 missing_keys.push(*key);
@@ -1695,6 +1724,39 @@ impl Loader<ParentVersionKey> for Db {
                     parent_version: group_key.parent_version,
                 };
 
+                results.insert(key, object);
+            }
+        }
+
+        // Try to fill the keys not found in the DB from the KV
+        let fallback_keys: Vec<(ParentVersionKey, (ObjectId, Version))> = keys
+            .iter()
+            .filter(|key| !results.contains_key(*key))
+            .filter_map(|key| {
+                // `before_version` look-ups are exclusive, so we do +1
+                let before = key.parent_version.checked_add(1)?;
+                Some((*key, (key.id.into(), Version::from(before))))
+            })
+            .collect();
+        if self.inner.is_fallback_enabled() && !fallback_keys.is_empty() {
+            let object_refs: Vec<(ObjectId, Version)> =
+                fallback_keys.iter().map(|(_, obj_ref)| *obj_ref).collect();
+            let fetched = self
+                .inner
+                .multi_get_fallback_objects(&object_refs, true)
+                .await
+                .map_err(|e| {
+                    Error::Internal(format!("failed to fetch objects from fallback: {e}"))
+                })?;
+            for ((key, _), stored) in fallback_keys.into_iter().zip(fetched) {
+                let Some(stored) = stored else {
+                    continue;
+                };
+                let object = Object::try_from_stored_object(
+                    stored,
+                    key.checkpoint_viewed_at,
+                    Some(key.parent_version),
+                )?;
                 results.insert(key, object);
             }
         }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -14,6 +14,7 @@ use async_graphql::{
 };
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, SelectableHelper, sql_types};
 use iota_indexer::{
+    ingestion::common::CommitterTables,
     models::objects::{StoredHistoryObject, StoredObject},
     schema::objects,
     types::{ObjectStatus as NativeObjectStatus, OwnerType},
@@ -920,32 +921,31 @@ impl Object {
             ObjectLookup::VersionAt {
                 version,
                 checkpoint_viewed_at,
-            } => {
-                loader
-                    .load_one(HistoricalKey {
-                        id,
-                        version,
-                        checkpoint_viewed_at,
-                    })
-                    .await
-            }
+            } => loader
+                .load_one(HistoricalKey {
+                    id,
+                    version,
+                    checkpoint_viewed_at,
+                })
+                .await?
+                .transpose(),
 
-            ObjectLookup::OptimisticVersion { version } => {
-                loader.load_one(OptimisticKey { id, version }).await
-            }
+            ObjectLookup::OptimisticVersion { version } => loader
+                .load_one(OptimisticKey { id, version })
+                .await?
+                .transpose(),
 
             ObjectLookup::UnderParent {
                 parent_version,
                 checkpoint_viewed_at,
-            } => {
-                loader
-                    .load_one(ParentVersionKey {
-                        id,
-                        parent_version,
-                        checkpoint_viewed_at,
-                    })
-                    .await
-            }
+            } => loader
+                .load_one(ParentVersionKey {
+                    id,
+                    parent_version,
+                    checkpoint_viewed_at,
+                })
+                .await?
+                .transpose(),
 
             ObjectLookup::LatestAt {
                 checkpoint_viewed_at,
@@ -1395,11 +1395,90 @@ impl Target<Cursor> for StoredBackwardObject {
     }
 }
 
+/// Synthetic `object_status` for object versions that still exist in
+/// `objects_version` table, but are already pruned from
+/// `objects_backward_history`.
+const OBJECT_STATUS_PRUNED: i16 = -1;
+
+const OBJECT_STATUS_WRAPPED_OR_DELETED: i16 = NativeObjectStatus::WrappedOrDeleted as i16;
+
+/// Checks if `objects_version` table covers the whole chain history.
+///
+/// This function currently returns false for indexer restored from snapshot.
+fn objects_version_complete(db: &Db) -> bool {
+    db.inner
+        .ensure_data_not_pruned_for_checkpoint(0, &[CommitterTables::ObjectsVersion])
+        .is_ok()
+}
+
+/// Fetches specified object versions from the historical fallback and stores
+/// them per key in `results`.
+///
+/// It stores nothing when the object does not exist at the requested version
+/// (e.g. when the object is wrapped or deleted). It stores
+/// [`Error::DataPruned`] per key when the historical fallback is not
+/// configured.
+///
+/// `to_object` builds the [`Object`] that is then stored in `results`.
+async fn fetch_missing_objects_from_fallback<K: Eq + std::hash::Hash>(
+    db: &Db,
+    keys_with_refs: Vec<(K, (ObjectId, Version))>,
+    results: &mut HashMap<K, Result<Object, Error>>,
+    to_object: impl Fn(&K, StoredObject) -> Result<Object, Error>,
+) -> Result<(), Error> {
+    if keys_with_refs.is_empty() {
+        return Ok(());
+    }
+
+    let object_refs: Vec<(ObjectId, Version)> =
+        keys_with_refs.iter().map(|(_, obj_ref)| *obj_ref).collect();
+
+    let fetched: Vec<Result<Option<StoredObject>, Error>> = if db.inner.is_fallback_enabled() {
+        db.inner
+            .multi_get_fallback_objects(&object_refs, false)
+            .await
+            .map_err(Error::from)?
+            .into_iter()
+            .map(Ok)
+            .collect()
+    } else {
+        object_refs
+            .iter()
+            .map(|(id, _)| {
+                Err(Error::DataPruned(format!(
+                    "data for object {id} potentially pruned"
+                )))
+            })
+            .collect()
+    };
+
+    for ((key, _), fetched) in keys_with_refs.into_iter().zip(fetched) {
+        match fetched {
+            Ok(Some(stored)) => {
+                let object = to_object(&key, stored)?;
+                results.insert(key, Ok(object));
+            }
+            // The object does not exist at the requested version.
+            Ok(None) => {}
+            // Only this key cannot be served.
+            Err(e) => {
+                results.insert(key, Err(e));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 impl Loader<HistoricalKey> for Db {
-    type Value = Object;
+    /// Error stored per key, e.g. when object version is pruned.
+    type Value = Result<Object, Error>;
     type Error = Error;
 
-    async fn load(&self, keys: &[HistoricalKey]) -> Result<HashMap<HistoricalKey, Object>, Error> {
+    async fn load(
+        &self,
+        keys: &[HistoricalKey],
+    ) -> Result<HashMap<HistoricalKey, Result<Object, Error>>, Error> {
         if keys.is_empty() {
             return Ok(HashMap::new());
         }
@@ -1411,22 +1490,27 @@ impl Loader<HistoricalKey> for Db {
             .into_iter()
             .unzip();
 
-        let active = NativeObjectStatus::Active as i16;
-
         // For each `(object_id, object_version)` pair, locate the row content
         // in `checkpointed_objects` (current state of the object) or
         // `objects_backward_history` (a superseded prior state). The
         // `objects_version` join confirms the version is real and supplies the
         // checkpoint at which it became current.
         //
-        // Only active rows are returned: wrapped or deleted tombstones (and
-        // versions present only in `objects_version`) fail the active status
-        // check, so such versions resolve as non-existent.
+        // A row is returned for every version found in `objects_version`.
+        // Wrapped-or-deleted status is reported for versions without row
+        // content that are in the retention window of
+        // `objects_backward_history`. Versions outside of this retention
+        // window are returned with the synthetic `OBJECT_STATUS_PRUNED`
+        // status.
         let sql = "SELECT \
                 v.object_id, \
                 v.object_version, \
                 v.cp_sequence_number AS checkpoint_sequence_number, \
-                COALESCE(co.object_status, bh.object_status) AS object_status, \
+                COALESCE(co.object_status, bh.object_status, \
+                    CASE WHEN v.cp_sequence_number >= COALESCE((\
+                        SELECT min_available_cp FROM watermarks \
+                        WHERE entity = 'objects_backward_history'), 0) \
+                    THEN $3 ELSE $4 END) AS object_status, \
                 COALESCE(co.object_digest, bh.object_digest) AS object_digest, \
                 COALESCE(co.owner_type, bh.owner_type) AS owner_type, \
                 COALESCE(co.owner_id, bh.owner_id) AS owner_id, \
@@ -1447,8 +1531,7 @@ impl Loader<HistoricalKey> for Db {
                   AND co.object_version = v.object_version \
             LEFT JOIN objects_backward_history bh \
                    ON bh.object_id = v.object_id \
-                  AND bh.object_version = v.object_version \
-            WHERE COALESCE(co.object_status, bh.object_status) = $3";
+                  AND bh.object_version = v.object_version";
 
         let objects: Vec<StoredHistoryObject> = self
             .execute(move |conn| {
@@ -1456,7 +1539,8 @@ impl Loader<HistoricalKey> for Db {
                     diesel::sql_query(sql)
                         .bind::<sql_types::Array<sql_types::Binary>, _>(ids.clone())
                         .bind::<sql_types::Array<sql_types::BigInt>, _>(versions.clone())
-                        .bind::<sql_types::SmallInt, _>(active)
+                        .bind::<sql_types::SmallInt, _>(OBJECT_STATUS_WRAPPED_OR_DELETED)
+                        .bind::<sql_types::SmallInt, _>(OBJECT_STATUS_PRUNED)
                 })
             })
             .await
@@ -1469,11 +1553,12 @@ impl Loader<HistoricalKey> for Db {
         }
 
         let mut result = HashMap::new();
-        // Keys not found in the DB, to be queried from fallback
         let mut fallback_keys = Vec::new();
+        // Keys with no `objects_version` entry at all.
+        let mut unresolved_keys = Vec::new();
         for key in keys {
             let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) else {
-                fallback_keys.push(*key);
+                unresolved_keys.push(*key);
                 continue;
             };
 
@@ -1484,45 +1569,52 @@ impl Loader<HistoricalKey> for Db {
                 continue;
             }
 
-            let active_object = ActiveObject::try_from(stored.clone())?;
+            let active_object = match stored.object_status {
+                OBJECT_STATUS_PRUNED => {
+                    fallback_keys.push(*key);
+                    continue;
+                }
+                // The version exists but the object was wrapped or deleted at
+                // it: resolve as non-existent.
+                OBJECT_STATUS_WRAPPED_OR_DELETED => continue,
+                // A live version; the conversion rejects any other status.
+                _ => ActiveObject::try_from(stored.clone())?,
+            };
             // This conversion will use the object's own version as the
             // `Object::root_version`.
             let object = Object::from_active_object(active_object, key.checkpoint_viewed_at, None);
-            result.insert(*key, object);
+            result.insert(*key, Ok(object));
         }
 
-        // Try to fill the keys not found in the DB from the KV
-        if self.inner.is_fallback_enabled() && !fallback_keys.is_empty() {
-            let object_refs: Vec<(ObjectId, Version)> = fallback_keys
-                .iter()
-                .map(|key| (key.id.into(), Version::from(key.version)))
-                .collect();
-            let fetched = self
-                .inner
-                .multi_get_fallback_objects(&object_refs, false)
-                .await
-                .map_err(|e| {
-                    Error::Internal(format!("failed to fetch objects from fallback: {e}"))
-                })?;
-            for (key, stored) in fallback_keys.into_iter().zip(fetched) {
-                let Some(stored) = stored else {
-                    continue;
-                };
-                let object =
-                    Object::try_from_stored_object(stored, key.checkpoint_viewed_at, None)?;
-                result.insert(key, object);
-            }
+        // When version history is complete, unresolved key = nonexisting object
+        // version. When history is incomplete we have to query the KV to know
+        // if object exists or not.
+        if !objects_version_complete(self) {
+            fallback_keys.append(&mut unresolved_keys);
         }
+
+        let keys_with_refs = fallback_keys
+            .into_iter()
+            .map(|key| (key, (key.id.into(), Version::from(key.version))))
+            .collect();
+        fetch_missing_objects_from_fallback(self, keys_with_refs, &mut result, |key, stored| {
+            Object::try_from_stored_object(stored, key.checkpoint_viewed_at, None)
+        })
+        .await?;
 
         Ok(result)
     }
 }
 
 impl Loader<OptimisticKey> for Db {
-    type Value = Object;
+    /// Error stored per key, e.g. when object version is pruned.
+    type Value = Result<Object, Error>;
     type Error = Error;
 
-    async fn load(&self, keys: &[OptimisticKey]) -> Result<HashMap<OptimisticKey, Object>, Error> {
+    async fn load(
+        &self,
+        keys: &[OptimisticKey],
+    ) -> Result<HashMap<OptimisticKey, Result<Object, Error>>, Error> {
         use objects::dsl as o;
 
         if keys.is_empty() {
@@ -1561,7 +1653,7 @@ impl Loader<OptimisticKey> for Db {
         for key in keys {
             if let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) {
                 let object = Object::try_from_stored_object(stored.clone(), u64::MAX, None)?;
-                result.insert(*key, object);
+                result.insert(*key, Ok(object));
             } else {
                 missing_keys.push(*key);
             }
@@ -1578,7 +1670,7 @@ impl Loader<OptimisticKey> for Db {
                 })
                 .collect();
 
-            let historical_result: HashMap<HistoricalKey, Object> =
+            let historical_result: HashMap<HistoricalKey, Result<Object, Error>> =
                 self.load(&historical_keys).await?;
 
             for (historical_key, object) in historical_result {
@@ -1595,13 +1687,14 @@ impl Loader<OptimisticKey> for Db {
 }
 
 impl Loader<ParentVersionKey> for Db {
-    type Value = Object;
+    /// Error stored per key, e.g. when object version is pruned.
+    type Value = Result<Object, Error>;
     type Error = Error;
 
     async fn load(
         &self,
         keys: &[ParentVersionKey],
-    ) -> Result<HashMap<ParentVersionKey, Object>, Error> {
+    ) -> Result<HashMap<ParentVersionKey, Result<Object, Error>>, Error> {
         // Group keys by checkpoint viewed at and parent version -- we'll issue a
         // separate query for each group.
         #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
@@ -1623,18 +1716,18 @@ impl Loader<ParentVersionKey> for Db {
                 .insert(key.id.into_vec());
         }
 
-        let active = NativeObjectStatus::Active as i16;
-
         // For each id, pick the largest version `≤ parent_version` from
         // `objects_version` (versions table contains all current and past versions of
         // objects), then locate the row content in `checkpointed_objects`
         // (current state of the object) or `objects_backward_history` (a
         // superseded prior state).
         //
-        // Only active rows are returned: when the latest version `≤
-        // parent_version` is a wrapped or deleted tombstone (or exists only in
-        // `objects_version`), it fails the active status check and the object
-        // resolves as non-existent at `parent_version`.
+        // A row is returned for the largest version `≤ parent_version` found
+        // in `objects_version`. Wrapped-or-deleted status is reported for
+        // versions without row content that are in the retention window of
+        // `objects_backward_history`. Versions outside of this retention
+        // window are returned with the synthetic `OBJECT_STATUS_PRUNED`
+        // status.
         let sql = "WITH ids AS (SELECT unnest($1::bytea[]) AS object_id), \
                         latest_per_id AS (\
                        SELECT i.object_id, o.object_version, o.cp_sequence_number \
@@ -1650,7 +1743,11 @@ impl Loader<ParentVersionKey> for Db {
                        v.object_id, \
                        v.object_version, \
                        v.cp_sequence_number AS checkpoint_sequence_number, \
-                       COALESCE(co.object_status, bh.object_status) AS object_status, \
+                       COALESCE(co.object_status, bh.object_status, \
+                           CASE WHEN v.cp_sequence_number >= COALESCE((\
+                               SELECT min_available_cp FROM watermarks \
+                               WHERE entity = 'objects_backward_history'), 0) \
+                           THEN $3 ELSE $4 END) AS object_status, \
                        COALESCE(co.object_digest, bh.object_digest) AS object_digest, \
                        COALESCE(co.owner_type, bh.owner_type) AS owner_type, \
                        COALESCE(co.owner_id, bh.owner_id) AS owner_id, \
@@ -1668,8 +1765,7 @@ impl Loader<ParentVersionKey> for Db {
                          AND co.object_version = v.object_version \
                    LEFT JOIN objects_backward_history bh \
                           ON bh.object_id = v.object_id \
-                         AND bh.object_version = v.object_version \
-                   WHERE COALESCE(co.object_status, bh.object_status) = $3";
+                         AND bh.object_version = v.object_version";
 
         // Issue concurrent reads for each group of keys.
         let futures = keys_by_cursor_and_parent_version
@@ -1683,7 +1779,8 @@ impl Loader<ParentVersionKey> for Db {
                         diesel::sql_query(sql)
                             .bind::<sql_types::Array<sql_types::Binary>, _>(ids.clone())
                             .bind::<sql_types::BigInt, _>(parent_version)
-                            .bind::<sql_types::SmallInt, _>(active)
+                            .bind::<sql_types::SmallInt, _>(OBJECT_STATUS_WRAPPED_OR_DELETED)
+                            .bind::<sql_types::SmallInt, _>(OBJECT_STATUS_PRUNED)
                     })?;
 
                     Ok::<_, diesel::result::Error>(
@@ -1698,68 +1795,83 @@ impl Loader<ParentVersionKey> for Db {
         // Wait for the reads to all finish, and gather them into the result map.
         let groups = futures::future::join_all(futures).await;
 
-        let mut results = HashMap::new();
+        let mut key_to_stored = HashMap::new();
         for group in groups {
             for (group_key, stored) in
                 group.map_err(|e| Error::Internal(format!("Failed to fetch objects: {e}")))?
             {
-                // This particular object is invalid -- it didn't exist at the checkpoint we are
-                // viewing at.
-                if group_key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                    continue;
-                }
-
-                let active_object = ActiveObject::try_from(stored)?;
-                // If `LatestAtKey::parent_version` is set, it must have been correctly
-                // propagated from the `Object::root_version` of some object.
-                let object = Object::from_active_object(
-                    active_object,
-                    group_key.checkpoint_viewed_at,
-                    Some(group_key.parent_version),
-                );
-
                 let key = ParentVersionKey {
-                    id: object.address,
+                    id: addr(&stored.object_id)?,
                     checkpoint_viewed_at: group_key.checkpoint_viewed_at,
                     parent_version: group_key.parent_version,
                 };
-
-                results.insert(key, object);
+                key_to_stored.insert(key, stored);
             }
         }
 
-        // Try to fill the keys not found in the DB from the KV
-        let fallback_keys: Vec<(ParentVersionKey, (ObjectId, Version))> = keys
-            .iter()
-            .filter(|key| !results.contains_key(*key))
-            .filter_map(|key| {
-                // `before_version` look-ups are exclusive, so we do +1
-                let before = key.parent_version.checked_add(1)?;
-                Some((*key, (key.id.into(), Version::from(before))))
-            })
-            .collect();
-        if self.inner.is_fallback_enabled() && !fallback_keys.is_empty() {
-            let object_refs: Vec<(ObjectId, Version)> =
-                fallback_keys.iter().map(|(_, obj_ref)| *obj_ref).collect();
-            let fetched = self
-                .inner
-                .multi_get_fallback_objects(&object_refs, true)
-                .await
-                .map_err(|e| {
-                    Error::Internal(format!("failed to fetch objects from fallback: {e}"))
-                })?;
-            for ((key, _), stored) in fallback_keys.into_iter().zip(fetched) {
-                let Some(stored) = stored else {
+        let mut results = HashMap::new();
+        let mut fallback_keys = Vec::new();
+        // Keys with no version `≤ parent_version` in `objects_version` at all.
+        let mut unresolved_keys = Vec::new();
+        for key in keys {
+            let Some(stored) = key_to_stored.get(key) else {
+                unresolved_keys.push(*key);
+                continue;
+            };
+
+            // This version didn't exist at the checkpoint we are viewing at.
+            if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                continue;
+            }
+
+            let active_object = match stored.object_status {
+                OBJECT_STATUS_PRUNED => {
+                    let object_ref = (key.id.into(), Version::from(stored.object_version as u64));
+                    fallback_keys.push((*key, object_ref));
                     continue;
-                };
-                let object = Object::try_from_stored_object(
-                    stored,
-                    key.checkpoint_viewed_at,
-                    Some(key.parent_version),
-                )?;
-                results.insert(key, object);
+                }
+                // The version exists but the object was wrapped or deleted at
+                // it: resolve as non-existent.
+                OBJECT_STATUS_WRAPPED_OR_DELETED => continue,
+                // A live version; the conversion rejects any other status.
+                _ => ActiveObject::try_from(stored.clone())?,
+            };
+            // If `LatestAtKey::parent_version` is set, it must have been correctly
+            // propagated from the `Object::root_version` of some object.
+            let object = Object::from_active_object(
+                active_object,
+                key.checkpoint_viewed_at,
+                Some(key.parent_version),
+            );
+
+            results.insert(*key, Ok(object));
+        }
+
+        // When version history is complete, unresolved key = nonexisting object
+        // version. When history is incomplete we return DataPruned for such
+        // cases, since this cannot be handled by KV currently: before_version
+        // query will not work properly since we don't store wrapped-or-deleted
+        // version in the KV.
+        if !objects_version_complete(self) {
+            for key in unresolved_keys {
+                let id = key.id;
+                results.insert(
+                    key,
+                    Err(Error::DataPruned(format!(
+                        "data for object {id} potentially pruned"
+                    ))),
+                );
             }
         }
+
+        fetch_missing_objects_from_fallback(self, fallback_keys, &mut results, |key, stored| {
+            Object::try_from_stored_object(
+                stored,
+                key.checkpoint_viewed_at,
+                Some(key.parent_version),
+            )
+        })
+        .await?;
 
         Ok(results)
     }

--- a/crates/iota-indexer/src/ingestion/common/mod.rs
+++ b/crates/iota-indexer/src/ingestion/common/mod.rs
@@ -5,3 +5,5 @@ pub(crate) mod connection;
 pub(crate) mod orchestration;
 pub(crate) mod persist;
 pub mod prepare;
+
+pub use persist::CommitterTables;

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -521,6 +521,28 @@ impl IndexerReader {
         }
     }
 
+    /// Fetches objects by their ID and version from the historical fallback
+    /// storage. Returns one entry per requested pair in the same order, `None`
+    /// when the fallback does not have the object.
+    ///
+    /// - If `before_version` is `false`, it looks for the exact version.
+    /// - If `true`, it finds the latest version before the given one.
+    ///
+    /// Returns [`IndexerError::NotSupported`] when the historical fallback is
+    /// not configured; check [`Self::is_fallback_enabled`] before calling.
+    pub async fn multi_get_fallback_objects(
+        &self,
+        object_refs: &[(ObjectId, Version)],
+        before_version: bool,
+    ) -> IndexerResult<Vec<Option<StoredObject>>> {
+        let Some(kv_reader) = self.fallback_reader() else {
+            return Err(IndexerError::NotSupported(
+                "historical fallback is not configured".to_string(),
+            ));
+        };
+        kv_reader.objects(object_refs, before_version).await
+    }
+
     pub async fn get_package(&self, package_id: ObjectId) -> Result<Package, IndexerError> {
         let store = self.package_resolver.package_store();
         let pkg = store


### PR DESCRIPTION
# Description of change

Make GraphQL fall back to the archival KV store when reading an object at a version whose row has been pruned from Postgres.

Covered paths:

- `Query.object(address, version)`
- `Query.owner(address, rootVersion)` → `MoveObject.dynamicField` / `dynamicObjectField` — the field object's ID is derived from the parent and the field name, and looked up at the latest version `<= rootVersion`

Notes:

- The fallback is wired into the two object DataLoaders (batched KV multi-gets) through a new `IndexerReader::multi_get_fallback_objects`.
- Both loaders (`HistoricalKey` — an exact version, `ParentVersionKey` — the largest version `<= parent_version`) resolve the requested version through `objects_version` and join it with the row content from `checkpointed_objects` / `objects_backward_history`:
  - an active row is served from Postgres,
  - a wrapped or deleted version resolves as non-existent, without consulting the fallback,
  - a version whose row content is outside the retention window of `objects_backward_history` is fetched from the fallback at the exact resolved version
  - a key with no `objects_version` entry resolves as non-existent when the table covers the whole chain history, and errors with `DATA_PRUNED` when it is incomplete
  - `ParentVersionKey` loader does not support fallback for versions not in `objects_version` because KV doesnt store wrapped-or-deleted objects and therefore `before_version` queries would not return correct version for this kind of query
- Look-ups that cannot be served return a `DATA_PRUNED` error per key (instead of failing the whole batch)

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11933

## How the change has been tested

- New e2e test `crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.move`: pruned versions and a pruned dynamic field error with `DATA_PRUNED` (no fallback configured); current and never-existing versions resolve as before.
- Extended `consistency/dynamic_fields/dof_add_reclaim_transfer.move`: fetching the deleted field wrapper at its exact deletion version resolves as non-existent.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: `Query.object(address, version)` and dynamic field look-ups at a `rootVersion` resolve pruned object versions from the archival store when the historical fallback is configured; look-ups that cannot be served return a `DATA_PRUNED` error instead of resolving as non-existent.
