### PR TITLE
feat(indexer): restore packages

### DIFF
--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -168,7 +168,8 @@ impl PrimaryWriter {
                 self.state.persist_events(events_batch),
                 self.state.persist_event_indices(event_indices_batch),
                 self.state.persist_displays(displays_batch),
-                self.state.persist_packages(packages_batch),
+                self.state
+                    .persist_packages(packages_batch.into_iter().map(Into::into).collect()),
                 self.state
                     .persist_object_versions(object_versions_batch.clone()),
                 Box::pin({

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -22,6 +22,7 @@ use crate::{
         checkpoints::StoredChainIdentifier,
         display::StoredDisplay,
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate, extract_epoch_info_event},
+        packages::StoredPackage,
     },
     pruning::pruner::PrunableTable,
     store::{IndexerStore, PgIndexerStore},
@@ -33,7 +34,7 @@ use crate::{
 struct ObjectDerivedData {
     hasher: Sha3_256,
     displays: BTreeMap<String, StoredDisplay>,
-    packages: Vec<IndexedPackage>,
+    packages: Vec<StoredPackage>,
 }
 
 impl ObjectDerivedData {
@@ -43,10 +44,8 @@ impl ObjectDerivedData {
             self.displays.insert(display.object_type.clone(), display);
         }
         if let iota_sdk_types::ObjectData::Package(package) = object.data() {
-            self.packages.push(IndexedPackage::new(
-                package.clone(),
-                checkpoint_sequence_number,
-            ));
+            self.packages
+                .push(IndexedPackage::new(package.clone(), checkpoint_sequence_number).into());
         }
     }
 }

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     pruning::pruner::PrunableTable,
     store::{IndexerStore, PgIndexerStore},
-    types::IndexedCheckpoint,
+    types::{IndexedCheckpoint, IndexedPackage},
 };
 
 /// Data derived from the live-object set included in the snapshot.
@@ -38,7 +38,7 @@ struct ObjectDerivedData {
 }
 
 impl ObjectDerivedData {
-    fn extend(&mut self, object: &Object) {
+    fn extend(&mut self, object: &Object, checkpoint_sequence_number: u64) {
         self.hasher.update(object.object_ref().digest.inner());
         if let Some(display) = StoredDisplay::try_from_object(object) {
             self.displays.insert(display.object_type.clone(), display);
@@ -67,7 +67,7 @@ impl Restore for PgIndexerStore {
                 } = snapshot_object;
                 let checkpoint_sequence_number =
                     previous_transaction_checkpoint.unwrap_or_default();
-                derived_data.extend(&object);
+                derived_data.extend(&object, checkpoint_sequence_number);
                 Some(LiveObject::new(checkpoint_sequence_number, object))
             },
         );

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -33,6 +33,7 @@ use crate::{
 struct ObjectDerivedData {
     hasher: Sha3_256,
     displays: BTreeMap<String, StoredDisplay>,
+    packages: Vec<IndexedPackage>,
 }
 
 impl ObjectDerivedData {
@@ -40,6 +41,12 @@ impl ObjectDerivedData {
         self.hasher.update(object.object_ref().digest.inner());
         if let Some(display) = StoredDisplay::try_from_object(object) {
             self.displays.insert(display.object_type.clone(), display);
+        }
+        if let iota_sdk_types::ObjectData::Package(package) = object.data() {
+            self.packages.push(IndexedPackage::new(
+                package.clone(),
+                checkpoint_sequence_number,
+            ));
         }
     }
 }
@@ -98,6 +105,7 @@ impl Restore for PgIndexerStore {
             })?;
         self.persist_displays(derived_data.displays.into_values().collect())
             .await?;
+        self.persist_packages(derived_data.packages).await?;
         Ok(())
     }
 }

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -18,13 +18,12 @@ use crate::{
         display::StoredDisplay,
         obj_indices::StoredObjectVersion,
         objects::StoredBackwardHistoryObject,
+        packages::StoredPackage,
         transactions::{OptimisticTransaction, TxGlobalOrder},
         watermarks::StoredWatermark,
     },
     pruning::pruner::PrunableTable,
-    types::{
-        EventIndex, IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction, TxIndex,
-    },
+    types::{EventIndex, IndexedCheckpoint, IndexedEvent, IndexedTransaction, TxIndex},
 };
 
 #[async_trait]
@@ -72,7 +71,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 
     async fn persist_displays(&self, displays: Vec<StoredDisplay>) -> Result<(), IndexerError>;
 
-    async fn persist_packages(&self, packages: Vec<IndexedPackage>) -> Result<(), IndexerError>;
+    async fn persist_packages(&self, packages: Vec<StoredPackage>) -> Result<(), IndexerError>;
 
     async fn persist_epoch(&self, epoch: EpochToCommit) -> Result<(), IndexerError>;
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -70,7 +70,7 @@ use crate::{
     transactional_blocking_with_retry,
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEvent, IndexedObject,
-        IndexedPackage, IndexedTransaction, TxIndex,
+        IndexedTransaction, TxIndex,
     },
 };
 
@@ -793,18 +793,22 @@ impl PgIndexerStore {
         })
     }
 
-    fn persist_packages(&self, packages: Vec<IndexedPackage>) -> Result<(), IndexerError> {
-        if packages.is_empty() {
-            return Ok(());
-        }
-        let guard = self
-            .metrics
-            .checkpoint_db_commit_latency_packages
-            .start_timer();
-        let packages = packages
+    async fn persist_packages_in_chunks(
+        &self,
+        packages: Vec<StoredPackage>,
+    ) -> Result<(), IndexerError> {
+        let chunks = chunk!(packages, self.config.parallel_objects_chunk_size);
+        let persist_tasks = chunks
             .into_iter()
-            .map(StoredPackage::from)
-            .collect::<Vec<_>>();
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_packages(&c)));
+        futures::future::try_join_all(persist_tasks)
+            .await
+            .inspect_err(|e| tracing::error!("failed to join persist_packages futures: {e}"))?
+            .into_iter()
+            .collect()
+    }
+
+    fn persist_packages(&self, packages: &[StoredPackage]) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
@@ -824,13 +828,6 @@ impl PgIndexerStore {
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )
-        .tap_ok(|_| {
-            let elapsed = guard.stop_and_record();
-            info!(elapsed, "Persisted {} packages", packages.len());
-        })
-        .tap_err(|e| {
-            tracing::error!("failed to persist packages with error: {e}");
-        })
     }
 
     async fn persist_event_indices_chunk(
@@ -1997,12 +1994,35 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_packages(&self, packages: Vec<IndexedPackage>) -> Result<(), IndexerError> {
+    async fn persist_packages(&self, packages: Vec<StoredPackage>) -> Result<(), IndexerError> {
         if packages.is_empty() {
             return Ok(());
         }
-        self.execute_in_blocking_worker(move |this| this.persist_packages(packages))
-            .await
+        let len = packages.len();
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_packages
+            .start_timer();
+        let persist_result = if len <= self.config.parallel_objects_chunk_size {
+            self.execute_in_blocking_worker(move |this| this.persist_packages(&packages))
+                .await
+        } else {
+            self.persist_packages_in_chunks(packages)
+                .await
+                .map_err(|e| {
+                    IndexerError::PostgresWrite(format!(
+                        "Failed to persist all packages chunks: {e:?}"
+                    ))
+                })
+        };
+        persist_result
+            .tap_ok(|_| {
+                let elapsed = guard.stop_and_record();
+                info!(elapsed, "Persisted {len} packages");
+            })
+            .tap_err(|e| {
+                tracing::error!("failed to persist packages with error: {e}");
+            })
     }
 
     async fn persist_event_indices(&self, indices: Vec<EventIndex>) -> Result<(), IndexerError> {


### PR DESCRIPTION
# Description of change

This patch adds the necessary logic to derive packages from the live object set and restore the respective table from a formal snapshot.

## Links to any relevant issues

Resolves #12254 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

Restore tests with `testnet`, `mainnet` snapshots.