### PR TITLE
feat(indexer): restore live object_versions

### DIFF
--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -17,7 +17,10 @@ use strum::IntoEnumIterator;
 use crate::{
     chunk,
     errors::{IndexerError, IndexerResult},
-    ingestion::{common::prepare::LiveObject, primary::persist::EpochToCommit},
+    ingestion::{
+        common::{persist::CommitterTables, prepare::LiveObject},
+        primary::persist::EpochToCommit,
+    },
     models::{
         checkpoints::StoredChainIdentifier,
         display::StoredDisplay,
@@ -219,8 +222,9 @@ pub(crate) async fn populate_remaining_tables(
         &snapshot_epoch_boundary.last_checkpoint_contents,
         Default::default(), // We don't store this as part of the checkpoint so it's ok to set to 0
     );
+    let next_epoch = sync_watermark.epoch + 1;
     let pruning_watermarks: Vec<_> = PrunableTable::iter()
-        .map(|table| (table, sync_watermark.epoch + 1))
+        .map(|table| (table, next_epoch))
         .collect();
     tokio::try_join!(
         populate_epochs(store, verified_epoch_info),
@@ -229,7 +233,8 @@ pub(crate) async fn populate_remaining_tables(
     )?;
     tokio::try_join!(
         populate_protocol_and_feature_flags(store, snapshot_chain_id),
-        store.update_watermarks_lower_bound(pruning_watermarks.clone())
+        store.update_watermarks_lower_bound(pruning_watermarks.clone()),
+        store.update_watermarks_lower_bound(vec![(CommitterTables::ObjectsVersion, next_epoch)])
     )?;
     // finally align the lowest unpruned key with the lower bounds
     // to let the pruner know the pruning range start after restoring
@@ -241,7 +246,15 @@ pub(crate) async fn populate_remaining_tables(
             (table, table.pruning_strategy().range_end(watermark))
         })
         .collect::<Vec<_>>();
-    store
-        .update_watermarks_lowest_unpruned_key(lowest_unpruned_keys)
-        .await
+    tokio::try_join!(
+        store.update_watermarks_lowest_unpruned_key(lowest_unpruned_keys),
+        // object_versions is not pruned through the perioding pruning task, hence
+        // there is not pruning strategy. It is pruned only as a side-effect of the
+        // restore. so lowest_unpruned_key falls back to the `next_epoch`
+        store.update_watermarks_lowest_unpruned_key(vec![(
+            CommitterTables::ObjectsVersion,
+            next_epoch
+        )])
+    )?;
+    Ok(())
 }

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -22,6 +22,7 @@ use crate::{
         checkpoints::StoredChainIdentifier,
         display::StoredDisplay,
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate, extract_epoch_info_event},
+        obj_indices::StoredObjectVersion,
         packages::StoredPackage,
     },
     pruning::pruner::PrunableTable,
@@ -35,6 +36,7 @@ struct ObjectDerivedData {
     hasher: Sha3_256,
     displays: BTreeMap<String, StoredDisplay>,
     packages: Vec<StoredPackage>,
+    object_versions: Vec<StoredObjectVersion>,
 }
 
 impl ObjectDerivedData {
@@ -47,6 +49,11 @@ impl ObjectDerivedData {
             self.packages
                 .push(IndexedPackage::new(package.clone(), checkpoint_sequence_number).into());
         }
+        self.object_versions.push(StoredObjectVersion {
+            object_id: object.id().as_bytes().to_vec(),
+            object_version: object.version().as_u64() as i64,
+            cp_sequence_number: checkpoint_sequence_number as i64,
+        })
     }
 }
 
@@ -105,6 +112,8 @@ impl Restore for PgIndexerStore {
         self.persist_displays(derived_data.displays.into_values().collect())
             .await?;
         self.persist_packages(derived_data.packages).await?;
+        self.persist_object_versions(derived_data.object_versions)
+            .await?;
         Ok(())
     }
 }

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -108,9 +108,9 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 
     /// Updates each watermark entry's lower bounds per the list of tables and
     /// their new epoch lower bounds.
-    async fn update_watermarks_lower_bound(
+    async fn update_watermarks_lower_bound<Table: AsRef<str> + Send + 'static>(
         &self,
-        watermarks: Vec<(PrunableTable, u64)>,
+        watermarks: Vec<(Table, u64)>,
     ) -> Result<(), IndexerError>;
 
     /// Load all watermark entries from the store, and the latest timestamp from
@@ -178,9 +178,9 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         lowest_unpruned_key: u64,
     ) -> Result<(), IndexerError>;
 
-    async fn update_watermarks_lowest_unpruned_key(
+    async fn update_watermarks_lowest_unpruned_key<Table: AsRef<str> + Send + 'static>(
         &self,
-        unpruned_keys: Vec<(PrunableTable, u64)>,
+        unpruned_keys: Vec<(Table, u64)>,
     ) -> Result<(), IndexerError>;
 
     async fn get_watermark_by_entity(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1592,9 +1592,9 @@ impl PgIndexerStore {
             .collect())
     }
 
-    fn update_watermarks_lower_bound(
+    fn update_watermarks_lower_bound<Table: AsRef<str>>(
         &self,
-        watermarks: Vec<(PrunableTable, u64)>,
+        watermarks: Vec<(Table, u64)>,
     ) -> Result<(), IndexerError> {
         use diesel::query_dsl::methods::FilterDsl;
 
@@ -1687,9 +1687,9 @@ impl PgIndexerStore {
         )
     }
 
-    fn update_watermark_lowest_unpruned_keys(
+    fn update_watermark_lowest_unpruned_keys<Table: AsRef<str>>(
         &self,
-        unpruned_keys: &[(PrunableTable, u64)],
+        unpruned_keys: &[(Table, u64)],
     ) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
@@ -2372,9 +2372,9 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn update_watermarks_lower_bound(
+    async fn update_watermarks_lower_bound<Table: AsRef<str> + Send + 'static>(
         &self,
-        watermarks: Vec<(PrunableTable, u64)>,
+        watermarks: Vec<(Table, u64)>,
     ) -> Result<(), IndexerError> {
         self.execute_in_blocking_worker(move |this| this.update_watermarks_lower_bound(watermarks))
             .await
@@ -2467,9 +2467,9 @@ impl IndexerStore for PgIndexerStore {
         .await
     }
 
-    async fn update_watermarks_lowest_unpruned_key(
+    async fn update_watermarks_lowest_unpruned_key<Table: AsRef<str> + Send + 'static>(
         &self,
-        unpruned_keys: Vec<(PrunableTable, u64)>,
+        unpruned_keys: Vec<(Table, u64)>,
     ) -> Result<(), IndexerError> {
         self.execute_in_blocking_worker(move |this| {
             this.update_watermark_lowest_unpruned_keys(&unpruned_keys)


### PR DESCRIPTION
# Description of change

This patch derives the object-version data from the live object set to restore the respective table from a formal snapshot.

## Links to any relevant issues

Resolves #12279 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
