### PR TITLE
fix(consensus): rebuild sliding-window leader schedule from a recovered scoring backlog

### DIFF
--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -408,12 +408,12 @@ impl LeaderSchedule {
     /// window becomes the live scoring subdag.
     fn update_leader_schedule_from_backlog(&self, dag_state_write_lock: &mut DagState) {
         let backlog_range = dag_state_write_lock.scoring_subdag_commit_range();
-        let window_size = self.num_commits_per_schedule;
-        // The caller only routes here when the backlog exceeds one window, so
-        // there is at least one full window.
-        let full_windows = backlog_range.size() as u32 / window_size;
-        let window_start = backlog_range.start() + (full_windows - 1) * window_size;
-        let window_end = window_start + (window_size - 1);
+        let commits_per_schedule = self.num_commits_per_schedule;
+        // The caller only routes here when the backlog exceeds
+        // `commits_per_schedule`, so there is at least one full window.
+        let full_windows = backlog_range.size() as u32 / commits_per_schedule;
+        let window_start = backlog_range.start() + (full_windows - 1) * commits_per_schedule;
+        let window_end = window_start + (commits_per_schedule - 1);
 
         tracing::info!(
             "Rebuilding leader schedule from the last full window \
@@ -422,12 +422,31 @@ impl LeaderSchedule {
 
         dag_state_write_lock.clear_scoring_subdag();
 
-        let mut scoring_subdag = ScoringSubdag::new(self.context.clone());
-        scoring_subdag.add_subdags(
-            dag_state_write_lock
-                .load_scoring_subdags_from_store((window_start..=window_end).into()),
-        );
-        let reputation_scores = scoring_subdag.calculate_distributed_vote_scores();
+        let reputation_scores = if self.sliding_window.is_some() {
+            // Rebuild the window aggregate a continuously running node had when
+            // it rotated at window_end. The live scorer stays as recovered —
+            // current up to the last commit — for the rotations that follow.
+            let scorer_window_size = self.context.protocol_config.leader_schedule_window_size();
+            let replay_start = SlidingWindowSchedule::replay_start(window_end, scorer_window_size);
+            let mut scorer = SlidingWindowSchedule::new(self.context.clone(), scorer_window_size);
+            for subdag in dag_state_write_lock
+                .load_scoring_subdags_from_store((replay_start..=window_end).into())
+            {
+                scorer.add_commit(subdag);
+            }
+            let scores = scorer.reputation_scores().scores_per_authority;
+            // The recorded range is the span between the previous schedule
+            // update and this one: recovery resumes the commit count after
+            // its end, and the next update's range must directly follow it.
+            ReputationScores::new(CommitRange::new(window_start..=window_end), scores)
+        } else {
+            let mut scoring_subdag = ScoringSubdag::new(self.context.clone());
+            scoring_subdag.add_subdags(
+                dag_state_write_lock
+                    .load_scoring_subdags_from_store((window_start..=window_end).into()),
+            );
+            scoring_subdag.calculate_distributed_vote_scores()
+        };
         // The window is interval-wide and lands on the rotation boundaries by
         // construction, so the steady-state range validation is not repeated.
         let table =
@@ -1676,5 +1695,215 @@ mod tests {
                 );
             }
         }
+    }
+
+    // Recovers a sliding-window schedule from a store whose last CommitInfo
+    // lags the last commit by more than one rotation interval, and checks that
+    // the schedule is rebuilt onto the same rotation boundaries a continuously
+    // running node used.
+    async fn run_sliding_window_update_after_recovery_backlog(restart: bool) {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+
+        const INTERVAL: u32 = 3;
+
+        // Persist commits 1..=11 but only one CommitInfo, covering (1..=3):
+        // recovery rebuilds a backlog of 8 commits — two full windows (4..=6)
+        // and (7..=9) plus the partial window (10..=11).
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=12).build();
+        let first_window = dag_builder.get_sub_dag_and_commits(1..=INTERVAL);
+        let committed_rounds = dag_builder.last_committed_rounds.clone();
+        let rest = dag_builder.get_sub_dag_and_commits(INTERVAL + 1..=12);
+
+        let mut headers_to_write = vec![];
+        let mut commits_to_write = vec![];
+        for (sub_dag, commit) in first_window.iter().chain(&rest[..8]) {
+            headers_to_write.extend(sub_dag.headers.iter().cloned());
+            commits_to_write.push(commit.clone());
+        }
+        let commit_info = CommitInfo {
+            reputation_scores: ReputationScores::new((1..=INTERVAL).into(), vec![1, 2, 4, 3]),
+            committed_rounds,
+        };
+        let commit_ref = first_window.last().unwrap().1.reference();
+        store
+            .write(
+                WriteBatch::default()
+                    .commit_info(vec![(commit_ref, commit_info)])
+                    .block_headers(headers_to_write)
+                    .commits(commits_to_write),
+            )
+            .unwrap();
+
+        let mut dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        assert_eq!(dag_state.read().scoring_subdags_count(), 8);
+
+        let mut leader_schedule = LeaderSchedule::from_store(context.clone(), dag_state.clone())
+            .with_num_commits_per_schedule(INTERVAL);
+        assert_eq!(
+            leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range,
+            (1..=3).into()
+        );
+
+        // The backlog forces an immediate schedule update.
+        assert_eq!(
+            leader_schedule.commits_until_leader_schedule_update(dag_state.clone()),
+            0
+        );
+
+        // The rebuilt table lands on the end of the backlog's last full
+        // window; the partial window stays live.
+        leader_schedule.update_leader_schedule(&mut dag_state.write());
+        {
+            let table = leader_schedule.leader_swap_table.read();
+            assert_eq!(table.reputation_scores.commit_range, (7..=9).into());
+            assert_eq!(table.good_nodes.len(), 1);
+            assert_eq!(table.bad_nodes.len(), 1);
+        }
+        assert_eq!(dag_state.read().scoring_subdags_count(), 2);
+
+        if restart {
+            dag_state.write().flush();
+            assert_eq!(dag_state.read().last_commit_info_index(), 9);
+            dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            assert_eq!(dag_state.read().scoring_subdags_count(), 2);
+            leader_schedule = LeaderSchedule::from_store(context, dag_state.clone())
+                .with_num_commits_per_schedule(INTERVAL);
+            assert_eq!(
+                leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .reputation_scores
+                    .commit_range,
+                (7..=9).into()
+            );
+        }
+
+        // The next rotation triggers after commit 12 and validates strictly:
+        // (10..=12) continues on the same window boundaries.
+        let (sub_dag, commit) = &rest[8];
+        leader_schedule.feed_committed_subdags([sub_dag.base.clone()]);
+        {
+            let mut write = dag_state.write();
+            write.add_commit(commit.clone());
+            write.add_scoring_subdags(vec![sub_dag.base.clone()]);
+        }
+        assert_eq!(
+            leader_schedule.commits_until_leader_schedule_update(dag_state.clone()),
+            0
+        );
+        leader_schedule.update_leader_schedule(&mut dag_state.write());
+        assert_eq!(
+            leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range,
+            (10..=12).into()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sliding_window_update_after_recovery_backlog() {
+        run_sliding_window_update_after_recovery_backlog(false).await;
+    }
+
+    #[tokio::test]
+    async fn test_sliding_window_update_after_recovery_backlog_with_restart() {
+        run_sliding_window_update_after_recovery_backlog(true).await;
+    }
+
+    /// Verifies that rebuilding the schedule from an oversized recovered
+    /// backlog produces the exact same `LeaderSwapTable` as a node that never
+    /// crashed and rotated its schedule incrementally over the same commits.
+    #[tokio::test]
+    async fn test_sliding_window_backlog_rebuild_matches_live_schedule() {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+
+        // Two full 5-commit rotation windows, built once and shared by both
+        // scenarios so both operate on identical committed subdags.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=10).build();
+        let sub_dags_and_commits = dag_builder.get_sub_dag_and_commits(1..=10);
+
+        // Live scenario: commits are fed one at a time and the schedule is
+        // rotated as soon as each 5-commit window fills up.
+        let dag_state_live = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let leader_schedule_live = LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
+            .with_num_commits_per_schedule(5);
+        for (index, (sub_dag, commit)) in sub_dags_and_commits.iter().enumerate() {
+            leader_schedule_live.feed_committed_subdags([sub_dag.base.clone()]);
+            let mut dag_state_write = dag_state_live.write();
+            dag_state_write.set_last_commit(commit.clone());
+            dag_state_write.add_scoring_subdags(vec![sub_dag.base.clone()]);
+            if (index + 1) % 5 == 0 {
+                leader_schedule_live.update_leader_schedule(&mut dag_state_write);
+            }
+        }
+        let live_table_window_2 = leader_schedule_live.leader_swap_table.read().clone();
+
+        // Recovered scenario: the same 10 commits are persisted with no
+        // CommitInfo at all, so DagState recovers them as a single 10-commit
+        // backlog exceeding the 5-commit rotation interval.
+        let store = Arc::new(MemStore::new());
+        let mut headers_to_write = vec![];
+        let mut commits_to_write = vec![];
+        for (sub_dag, commit) in &sub_dags_and_commits {
+            headers_to_write.extend(sub_dag.headers.iter().cloned());
+            commits_to_write.push(commit.clone());
+        }
+        store
+            .write(
+                WriteBatch::default()
+                    .block_headers(headers_to_write)
+                    .commits(commits_to_write),
+            )
+            .unwrap();
+
+        let dag_state_recovered = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        assert_eq!(dag_state_recovered.read().scoring_subdags_count(), 10);
+
+        let leader_schedule_recovered =
+            LeaderSchedule::from_store(context, dag_state_recovered.clone())
+                .with_num_commits_per_schedule(5);
+        leader_schedule_recovered.update_leader_schedule(&mut dag_state_recovered.write());
+        let recovered_table = leader_schedule_recovered.leader_swap_table.read().clone();
+
+        // The backlog is an exact multiple of the interval, so nothing stays
+        // live after the rebuild.
+        assert_eq!(dag_state_recovered.read().scoring_subdags_count(), 0);
+
+        // The table rebuilt from the backlog (last full window) must match the
+        // live node's window-2 table exactly.
+        assert_eq!(
+            recovered_table.reputation_scores,
+            live_table_window_2.reputation_scores
+        );
+        assert_eq!(recovered_table.good_nodes, live_table_window_2.good_nodes);
+        assert_eq!(recovered_table.bad_nodes, live_table_window_2.bad_nodes);
     }
 }

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -96,6 +96,14 @@ impl SlidingWindowSchedule {
     /// Ingest a new committed subdag, updating the running aggregate. Commits
     /// must be supplied in consecutive index order.
     pub(crate) fn add_commit(&mut self, c: SubDagBase) {
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["SlidingWindowSchedule::add_commit"])
+            .start_timer();
+
         if let Some(last) = self.pending_commits.back() {
             assert_eq!(c.commit_ref.index, last.commit_ref.index + 1);
         }


### PR DESCRIPTION
# Description of change

A recovered scoring backlog spanning more than one rotation interval is rebuilt by `update_leader_schedule_from_backlog` from the backlog's last full window. Its score source is the V2 `ScoringSubdag` — which on the sliding-window path computes no vote scores (V2 scoring is skipped there), so the rebuilt swap table would come out all-zero, different from the table a continuously running node built at that rotation boundary.

Give the backlog rebuild a sliding-window score source: replay the stored commits into a fresh window scorer up to the boundary, reproducing exactly the aggregate a continuously running node had when it rotated there. The recorded commit range, the persisted `CommitInfo`, and the partial-tail handling are shared with the V2 path and unchanged; the live scorer stays as recovered. Two different window lengths now meet in the shared function, so its locals are named after the config parameters they hold: `commits_per_schedule` (the rotation window) and `scorer_window_size` (the scorer's aggregation window).

Like the V2 half, the triggering state is unreachable by current persistence (commits and the `CommitInfo` covering them flush in one write batch) but recoverable, so recovering deterministically is preferred over degrading.

A separate commit adds a `scope_processing_time` timer to `SlidingWindowSchedule::add_commit`, giving the sliding path the same instrumentation the V2 scorer has in `ScoringSubdag::add_subdags`.

## Links to any relevant issues

Relates to iotaledger/iota-private#459 (sliding-window half; the V2 half landed in #12268).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
