### PR TITLE
chore: remove leftover keypair conversions from the SDK signature migration

### DIFF
--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -27,8 +27,8 @@ use iota_types::{
     base_types::{ExecutionData, ExecutionDigests},
     crypto::{
         AccountKeyPair, AggregateAuthoritySignature, AuthorityKeyPair, AuthorityPublicKeyBytes,
-        AuthorityQuorumSignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo, IotaKeyPair,
-        KeypairTraits, Signature, Signer, get_key_pair,
+        AuthorityQuorumSignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo, KeypairTraits,
+        Signature, Signer, get_key_pair,
     },
     effects::{
         IDOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsExtForTesting,
@@ -174,14 +174,14 @@ fn get_registry() -> Result<Registry> {
     // include the PubKey ...
     let sig: AuthoritySignature = Signer::sign(&kp, b"hello world");
     tracer.trace_value(&mut samples, &sig).unwrap();
-    // ... and the user signature which does
-
-    let sig: Signature = IotaKeyPair::from(s_kp).sign(b"hello world");
-    tracer.trace_value(&mut samples, &sig).unwrap();
 
     let kp1 = Ed25519PrivateKey::generate(StdRng::from_seed([0; 32]));
     let kp2 = Secp256k1PrivateKey::generate(StdRng::from_seed([0; 32]));
     let kp3 = Secp256r1PrivateKey::generate(StdRng::from_seed([0; 32]));
+
+    // ... and the user signature which does
+    let sig: Signature = kp1.sign(b"hello world");
+    tracer.trace_value(&mut samples, &sig).unwrap();
 
     let multisig_pk = MultiSigPublicKey::new(
         vec![

--- a/crates/iota-test-transaction-builder/src/lib.rs
+++ b/crates/iota-test-transaction-builder/src/lib.rs
@@ -13,7 +13,7 @@ use iota_sdk::{
     },
     wallet_context::WalletContext,
 };
-use iota_sdk_crypto::Signer as SdkSigner;
+use iota_sdk_crypto::Signer;
 use iota_sdk_transaction_builder::{PTBArgumentList, TransactionBuilder};
 use iota_sdk_types::{
     Address, Identifier, Input, ObjectId, ObjectReference, Owner, ProgrammableTransaction,
@@ -417,7 +417,7 @@ impl TestTransactionBuilder {
     pub fn build_and_sign_multisig(
         self,
         multisig_pk: MultiSigPublicKey,
-        signers: &[&dyn SdkSigner<SimpleSignature>],
+        signers: &[&dyn Signer<SimpleSignature>],
         bitmap: BitmapUnit,
     ) -> Transaction {
         let data = self.build();

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -12,7 +12,7 @@ use fastcrypto::{
     ed25519::Ed25519KeyPair,
     traits::{AggregateAuthenticator, KeyPair},
 };
-use iota_sdk_crypto::simple::SimpleKeypair;
+use iota_sdk_crypto::{ed25519::Ed25519PrivateKey, simple::SimpleKeypair};
 use iota_sdk_types::{
     Address, ExecutionStatus, GasPayment, Owner, SharedObjectReference, StructTag,
     TransactionEventsDigest, gas::GasCostSummary,
@@ -1396,9 +1396,8 @@ fn auth_digest_for_move_authenticator_equals_authenticator_digest() {
 
 #[test]
 fn auth_digest_for_regular_signature_is_hash_of_sig_bytes() {
-    let (sender, kp): (_, AccountKeyPair) = get_key_pair();
-    // TODO remove conversion https://github.com/iotaledger/iota/issues/11590
-    let kp = SimpleKeypair::from_bytes(IotaKeyPair::Ed25519(kp).to_bytes()).unwrap();
+    let kp = SimpleKeypair::from(Ed25519PrivateKey::generate(rand::thread_rng()));
+    let sender = kp.public_key().derive_address();
     let tx = make_transaction(sender, &kp);
     let sig = tx.tx_signatures().first().unwrap();
     assert_eq!(auth_digest_for_sig(sig).unwrap(), blake2b256_of_sig(sig));
@@ -1429,9 +1428,8 @@ fn compute_auth_digests_non_sponsored_move_authenticator() {
 
 #[test]
 fn compute_auth_digests_non_sponsored_regular_signature() {
-    let (sender, kp): (_, AccountKeyPair) = get_key_pair();
-    // TODO remove conversion https://github.com/iotaledger/iota/issues/11590
-    let kp = SimpleKeypair::from_bytes(IotaKeyPair::Ed25519(kp).to_bytes()).unwrap();
+    let kp = SimpleKeypair::from(Ed25519PrivateKey::generate(rand::thread_rng()));
+    let sender = kp.public_key().derive_address();
     let tx = make_transaction(sender, &kp);
     let sig = tx.tx_signatures().first().unwrap();
     let (sender_digest, sponsor_digest) = tx.data().compute_auth_digests().unwrap();

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -122,9 +122,8 @@ pub fn make_sponsored_transaction_data(sender: Address, sponsor: Address) -> Tra
 /// is not verified or signed by authority.
 pub fn make_transaction(sender: Address, kp: &SimpleKeypair) -> Transaction {
     let data = make_transaction_data(sender);
-    // TODO remove conversion https://github.com/iotaledger/iota/issues/11590
-    let kp = IotaKeyPair::from_bytes(&kp.to_bytes()).unwrap();
-    Transaction::from_data_and_signer(data, vec![&kp])
+    let digest = IntentMessage::new(Intent::iota_transaction(), data.clone()).signing_digest();
+    Transaction::from_data(data, vec![kp.sign(&*digest)])
 }
 
 // This is used to sign transaction with signer using default Intent.


### PR DESCRIPTION
# Description of change

Removes the keypair conversions left behind by the SDK signature migration, where the SDK signing types can already be used directly:

- drop the `Signer as SdkSigner` import alias in `iota-test-transaction-builder`
- `utils::make_transaction` signs directly with the SDK `SimpleKeypair` instead of round-tripping the key bytes through `IotaKeyPair`
- the `auth_digest`/`compute_auth_digests` tests generate an SDK `Ed25519PrivateKey` directly instead of converting a fastcrypto keypair through `SimpleKeypair::from_bytes`
- `generate_format` signs the user-signature sample with the SDK `Ed25519PrivateKey` it already generates, instead of `IotaKeyPair::from(s_kp)` (same Ed25519 flag; the staged `iota.yaml` is unchanged)

The remaining items in #11590 (replacing the `impl Into<IotaKeyPair>` signing helpers with `&impl Signer`, removing `multisig_keys()`, the `SignatureScheme`/`IotaSignature` follow-ups) stay open — they depend on migrating the node keypair types to the SDK signing types.

## Links to any relevant issues

Part of #11590.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check --all-targets` on the touched crates, `cargo test -p iota-types --lib` (202 passed), and `generate-format` output verified byte-identical to the staged `iota.yaml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8HDhvVEyBujVabtPaZtoe)_