### PR TITLE
feat(ci): use merge queues

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -51,8 +51,10 @@ jobs:
       isRustExample: ${{ inputs.isRustExample }}
       isNightly: ${{ inputs.isNightly }}
 
+  # Only feeds rust-tests, which doesn't run on pull_request events (below).
   crates-changes:
     needs: rust-lints
+    if: (!cancelled() && !failure() && github.event_name != 'pull_request')
     runs-on: [self-hosted-x64]
     outputs:
       components: ${{ steps.filter.outputs.changes }}
@@ -66,10 +68,11 @@ jobs:
           list-files: "json"
           filters: .github/crates-filters.yml
 
+  # Only feeds rust-tests, which doesn't run on pull_request events (below).
   external-changes:
     needs: rust-lints
     runs-on: [self-hosted-x64]
-    if: (!cancelled() && !failure())
+    if: (!cancelled() && !failure() && github.event_name != 'pull_request')
     outputs:
       components: ${{ steps.filter.outputs.changes }}
     steps:
@@ -82,8 +85,12 @@ jobs:
           list-files: "json"
           filters: .github/external-crates-filters.yml
 
+  # Heavy chain (tests + simtests): not on pull_request events — PRs get
+  # these in the merge queue (merge_group) via `heavy-tests-status` in
+  # hierarchy.yml. Pushes to long-lived branches are unchanged; nightly
+  # calls _rust_tests.yml directly and is unaffected.
   rust-tests:
-    if: (!cancelled() && !failure() && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers))
+    if: (!cancelled() && !failure() && github.event_name != 'pull_request' && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers))
     needs:
       - crates-changes
       - external-changes

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -10,14 +10,24 @@ on:
       - "releases/iota-*-release"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # Fired by the merge queue: GitHub merges the queued PR(s) onto the target
+  # branch in a temporary `gh-readonly-queue/*` branch and requests checks on
+  # that result. Light jobs run here again, and the heavy jobs (rust-tests,
+  # split-cluster, split-cluster-sync-check) run ONLY here and on pushes to
+  # long-lived branches — not on pull_request events.
+  merge_group:
 
 jobs:
+  # Central CI gate: skipped for draft PRs unless the PR body contains
+  # '[run-ci]'; push and merge_group events always run. Except for
+  # release-notes-check, every job below is conditioned on this job's success
+  # or outputs, so skipping it skips the rest of CI.
   diff:
     runs-on: [ubuntu-latest]
     concurrency:
       group: diff-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
-    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
       isRustWorkspaceConfig: ${{ steps.diff.outputs.isRustWorkspaceConfig }}
@@ -54,14 +64,16 @@ jobs:
     concurrency:
       group: dprint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
-    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
+    needs: diff
+    if: (!cancelled() && !failure() && needs.diff.result == 'success')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check dprint formatting
         run: dprint check
 
   typos:
-    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
+    needs: diff
+    if: (!cancelled() && !failure() && needs.diff.result == 'success')
     uses: ./.github/workflows/_typos.yml
 
   license-check:
@@ -70,7 +82,7 @@ jobs:
       group: license-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     needs: diff
-    if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true')
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -80,12 +92,12 @@ jobs:
 
   docusaurus:
     needs: diff
-    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true')
     uses: ./.github/workflows/_docusaurus.yml
 
   docs-lint:
     needs: diff
-    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true')
     uses: ./.github/workflows/_docs_lint.yml
 
   rust:
@@ -94,7 +106,7 @@ jobs:
       - dprint-format
       - license-check
       - typos
-    if: (!cancelled() && !failure() && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.result == 'success')
     uses: ./.github/workflows/_rust.yml
     secrets: inherit
     with:
@@ -110,9 +122,11 @@ jobs:
       - dprint-format
       - license-check
       - typos
-    if: (!cancelled() && !failure() && needs.diff.outputs.isExternalCrates == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && needs.diff.outputs.isExternalCrates == 'true')
     uses: ./.github/workflows/_move_ide.yml
 
+  # Heavy job: runs in the merge queue (merge_group) and on pushes to
+  # long-lived branches, not on pull_request events.
   split-cluster:
     needs:
       - diff
@@ -120,12 +134,40 @@ jobs:
       - license-check
       - typos
       - rust
-    if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && github.event_name != 'pull_request' && needs.diff.outputs.isRust == 'true')
     uses: ./.github/workflows/_split_cluster.yml
 
+  # Heavy job: runs in the merge queue (merge_group) and on pushes to
+  # long-lived branches, not on pull_request events.
   split-cluster-sync-check:
     needs:
       - diff
       - rust
-    if: (!cancelled() && !failure() && needs.diff.outputs.isStarfishSynchronization == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
+    if: (!cancelled() && !failure() && github.event_name != 'pull_request' && needs.diff.outputs.isStarfishSynchronization == 'true')
     uses: ./.github/workflows/_split_cluster_sync_check.yml
+
+  # Single status check covering the heavy jobs (the rust-tests chain inside
+  # `rust`, split-cluster, and split-cluster-sync-check), so the merge queue
+  # can gate on one required check: `heavy-tests-status`.
+  #
+  # It must report on pull_request events too — a required check that never
+  # reports would keep PRs from entering the merge queue — which is why this
+  # is a plain job with `always()` rather than a required check on the heavy
+  # jobs themselves: those are skipped reusable-workflow calls on PRs, and a
+  # skipped `uses:` job never expands its nested check runs.
+  heavy-tests-status:
+    needs:
+      - rust
+      - split-cluster
+      - split-cluster-sync-check
+    if: always()
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Fail if a needed job failed or was cancelled
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "results: $RESULTS"
+          case "$RESULTS" in
+            *failure* | *cancelled*) exit 1 ;;
+          esac

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -157,6 +157,7 @@ jobs:
   # skipped `uses:` job never expands its nested check runs.
   heavy-tests-status:
     needs:
+      - diff
       - rust
       - split-cluster
       - split-cluster-sync-check

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -8,10 +8,15 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  # "Validate PR title" is a required status check, so it must also report on
+  # merge queue runs; there is no PR to validate there, so the job is skipped
+  # (a skipped check run counts as passed).
+  merge_group:
 
 jobs:
   main:
     name: Validate PR title
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
# Description of change

## Motivation

Heavy CI (Rust tests + simtests, split-cluster compatibility checks) currently runs on every non-draft PR push. Contributors pushing several commits in a row saturate the self-hosted runner pool with runs on work that isn't ready for that level of verification, starving other PRs and `develop` (#11253).

Two earlier approaches gated heavy tests behind explicit opt-ins — a "ready" label (#11263) and a PR-description checkbox (#11540) — but both required custom dispatcher machinery (`pull_request_target` + `workflow_dispatch`) with many edge cases: results not attached to the PR, no way to enforce that heavy tests passed before merge, and logic that can only be tested after merging.

GitHub's **merge queue** solves the same problem with built-in machinery: heavy tests run **exactly once per merge, pre-merge**, on the PR merged onto the latest `develop`, and are enforceable as a required status check.

## How it works

- `hierarchy.yml` and `pr_lint.yml` get a `merge_group` trigger. When a PR is queued, GitHub merges it (plus any PRs ahead of it) onto `develop` in a temporary `gh-readonly-queue/*` branch and requests checks on that result.
- The heavy jobs — the `rust-tests` chain in `_rust.yml` (incl. the two paths-filter jobs that only feed it), `split-cluster`, and `split-cluster-sync-check` — now run only on `merge_group` and on pushes to long-lived branches, no longer on `pull_request` events. `dorny/paths-filter` (pinned v4.0.1) supports `merge_group` natively (diffs `base_sha..head_sha`), so crate change filtering keeps working in the queue.
- A new plain job **`heavy-tests-status`** aggregates the heavy jobs' results and is the single check to mark as required. It has to be a plain `always()` job rather than requiring the nested heavy checks directly: on `pull_request` events the heavy jobs are skipped reusable-workflow calls, and a skipped `uses:` job never expands its nested check runs — a required check that never reports would keep PRs from entering the queue. This job always reports: trivially green on PRs, real results on merge groups and pushes.
- `Validate PR title` (required check) skips itself on `merge_group` runs — there is no PR to validate there, and a skipped check run counts as passed.
- The draft/`[run-ci]` gate, previously copied into 8 job conditions, is centralized on the `diff` job; all other jobs are gated via `needs.diff.result` or `diff` outputs. Behavior is unchanged: drafts skip CI unless the body contains `[run-ci]`.

## Behavior

- PR push → lint/format/typos/license/clippy/execution-cut as before; heavy tests no longer run.
- PR queued for merge → full CI including heavy tests on the merged result; failure removes the PR from the queue without touching `develop`.
- Push to `develop` / `devnet` / `testnet` / `mainnet` / release branches → unchanged (heavy tests still run). For queue-merged commits this duplicates the queue run; kept for now to also cover direct pushes — dropping it is a possible follow-up.
- Nightly → unchanged (calls the test workflows directly, unaffected by the event gates).

## Rollout (repo admin, after this merges)

1. In the `develop` ruleset, enable **Require merge queue**. Set the status-check timeout generously (simtests are slow; 120+ min) and consider allowing several PRs per merge group to amortize heavy runs.
2. Add **`heavy-tests-status`** (GitHub Actions) to the required status checks. The existing required checks stay unchanged.

## Known trade-offs

- The light jobs run twice per merged PR (once on the PR, once in the queue) — inherent to merge queues, cheap compared to the heavy suite no longer running on every push.
- `[run-ci]` on a draft still triggers light CI only; there is no way to run heavy tests on a PR before queueing (`_split_cluster.yml` still has `workflow_dispatch` for manual runs).
- `develop_ci_slack_report.yml` filters on the `develop` branch and won't report merge-queue failures; PR authors get GitHub's dequeue notification instead.

## Links to any relevant issues

fixes #11253

Supersedes the approaches explored in #11263 and #11540.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests): `dprint check` and `actionlint` pass on the changed workflows.
- [ ] Patch-specific tests (correctness, functionality coverage): the `merge_group` flow can only be exercised once the queue is enabled on `develop`; verify with a test PR right after enabling it.
