### PR TITLE
refactor(iota-rest-kv): refined logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7429,6 +7429,8 @@ dependencies = [
  "thiserror 1.0.64",
  "tokio",
  "tokio-util 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -14613,6 +14615,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5643,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "iota-bigtable"
 version = "0.1.2"
-source = "git+https://github.com/iotaledger/iota-bigtable.git?tag=v0.1.2#3c9c781e3db51206519992c0ed8ac94ce889095e"
+source = "git+https://github.com/iotaledger/iota-bigtable.git?tag=v0.1.2#e9292275b892cf0e81b5a4c0110b0a2a5b9c91be"
 dependencies = [
  "backoff",
  "gcp_auth",
@@ -5656,6 +5656,7 @@ dependencies = [
  "tonic 0.14.2",
  "tonic-prost",
  "tonic-prost-build",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -84,7 +84,7 @@ Checkpoint created: 4
 
 task 9, line 42:
 //# view-checkpoint
-CheckpointSummary { epoch: 0, sequence_number: 4, network_total_transactions: 4, content_digest: CheckpointContentsDigest("D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt"), previous_digest: Some(CheckpointDigest("2wh7A2YYqQ8ovUF6CzjBMPoLowwgGe76nWW3WCaC35gU")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, computation_cost_burned: 702000, storage_cost: 10138400, storage_rebate: 1960800, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
+CheckpointSummary { epoch: 0, sequence_number: 4, network_total_transactions: 4, contents_digest: CheckpointContentsDigest("D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt"), previous_digest: Some(CheckpointDigest("2wh7A2YYqQ8ovUF6CzjBMPoLowwgGe76nWW3WCaC35gU")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, computation_cost_burned: 702000, storage_cost: 10138400, storage_rebate: 1960800, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
 
 task 10, line 44:
 //# advance-epoch 6
@@ -92,7 +92,7 @@ Epoch advanced: 5
 
 task 11, line 46:
 //# view-checkpoint
-CheckpointSummary { epoch: 5, sequence_number: 10, network_total_transactions: 10, content_digest: CheckpointContentsDigest("FRPQVpwfjX5JZ8eNE5Abe6maxTFVT7rsuA8RKxmWHoGf"), previous_digest: Some(CheckpointDigest("5YsCsZSzHSJDoMVX2ZxZhVQRwXqLZ3kcyUcmsfe1pWff")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, computation_cost_burned: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: Some(EndOfEpochData { next_epoch_committee: [ValidatorCommitteeMember { public_key: Bls12381PublicKey("qqgbtEP57SCwGrO7tmcKwy/daeoOFwANmrMTm1Qu4jUJRhi2VePz/brF9YAcjmJ7BLOpN8c5Ia7zYzTNmGtGoaUnjoYrbvDG9E05s9antwSmkHAIGsM8mkmeBkSjSBrt"), stake: 10000 }], next_epoch_protocol_version: 13, epoch_commitments: [], epoch_supply_change: 0 }), version_specific_data: "AAA=" }
+CheckpointSummary { epoch: 5, sequence_number: 10, network_total_transactions: 10, contents_digest: CheckpointContentsDigest("FRPQVpwfjX5JZ8eNE5Abe6maxTFVT7rsuA8RKxmWHoGf"), previous_digest: Some(CheckpointDigest("5YsCsZSzHSJDoMVX2ZxZhVQRwXqLZ3kcyUcmsfe1pWff")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, computation_cost_burned: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: Some(EndOfEpochData { next_epoch_committee: [ValidatorCommitteeMember { public_key: Bls12381PublicKey("qqgbtEP57SCwGrO7tmcKwy/daeoOFwANmrMTm1Qu4jUJRhi2VePz/brF9YAcjmJ7BLOpN8c5Ia7zYzTNmGtGoaUnjoYrbvDG9E05s9antwSmkHAIGsM8mkmeBkSjSBrt"), stake: 10000 }], next_epoch_protocol_version: 13, epoch_commitments: [], epoch_supply_change: 0 }), version_specific_data: "AAA=" }
 
 task 12, lines 48-53:
 //# run-graphql
@@ -110,7 +110,7 @@ Checkpoint created: 11
 
 task 14, line 57:
 //# view-checkpoint
-CheckpointSummary { epoch: 6, sequence_number: 11, network_total_transactions: 10, content_digest: CheckpointContentsDigest("D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt"), previous_digest: Some(CheckpointDigest("2bbQchhrZwBcJW1zMGecEaRUZ4BR9i6wyJ2w4WxW6Df2")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, computation_cost_burned: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
+CheckpointSummary { epoch: 6, sequence_number: 11, network_total_transactions: 10, contents_digest: CheckpointContentsDigest("D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt"), previous_digest: Some(CheckpointDigest("2bbQchhrZwBcJW1zMGecEaRUZ4BR9i6wyJ2w4WxW6Df2")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, computation_cost_burned: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
 
 task 15, lines 59-64:
 //# run-graphql
@@ -152,7 +152,7 @@ Response: {
 
 task 17, line 73:
 //# view-checkpoint
-CheckpointSummary { epoch: 6, sequence_number: 11, network_total_transactions: 10, content_digest: CheckpointContentsDigest("D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt"), previous_digest: Some(CheckpointDigest("2bbQchhrZwBcJW1zMGecEaRUZ4BR9i6wyJ2w4WxW6Df2")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, computation_cost_burned: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
+CheckpointSummary { epoch: 6, sequence_number: 11, network_total_transactions: 10, contents_digest: CheckpointContentsDigest("D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt"), previous_digest: Some(CheckpointDigest("2bbQchhrZwBcJW1zMGecEaRUZ4BR9i6wyJ2w4WxW6Df2")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, computation_cost_burned: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
 
 task 18, lines 75-78:
 //# advance-epoch

--- a/crates/iota-graphql-e2e-tests/tests/objects/display.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/display.snap
@@ -19,7 +19,7 @@ Checkpoint created: 1
 
 task 3, line 135:
 //# view-checkpoint
-CheckpointSummary { epoch: 0, sequence_number: 1, network_total_transactions: 2, content_digest: CheckpointContentsDigest("BAkM5YV16J8zKxWoPgq7ik9tk1kB7shWsFVtWAuBJckx"), previous_digest: Some(CheckpointDigest("Emi2E1KQjsynFjeij1foreGGGav55TdbjRstFTSfALFX")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 21447200, storage_rebate: 0, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
+CheckpointSummary { epoch: 0, sequence_number: 1, network_total_transactions: 2, contents_digest: CheckpointContentsDigest("BAkM5YV16J8zKxWoPgq7ik9tk1kB7shWsFVtWAuBJckx"), previous_digest: Some(CheckpointDigest("Emi2E1KQjsynFjeij1foreGGGav55TdbjRstFTSfALFX")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 21447200, storage_rebate: 0, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
 
 task 4, line 137:
 //# run Test::boars::create_bear --sender A
@@ -39,7 +39,7 @@ Checkpoint created: 2
 
 task 7, line 143:
 //# view-checkpoint
-CheckpointSummary { epoch: 0, sequence_number: 2, network_total_transactions: 4, content_digest: CheckpointContentsDigest("4yTPbnm8FcY2vj3CxWizp66g3mNDwwmVCnVctE41rsVK"), previous_digest: Some(CheckpointDigest("7jELVoVfvi9RRbEro5YKoFHd8TjPFHmPRRjKKRYsNFCA")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, computation_cost_burned: 3000000, storage_cost: 27914800, storage_rebate: 3617600, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
+CheckpointSummary { epoch: 0, sequence_number: 2, network_total_transactions: 4, contents_digest: CheckpointContentsDigest("4yTPbnm8FcY2vj3CxWizp66g3mNDwwmVCnVctE41rsVK"), previous_digest: Some(CheckpointDigest("7jELVoVfvi9RRbEro5YKoFHd8TjPFHmPRRjKKRYsNFCA")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, computation_cost_burned: 3000000, storage_cost: 27914800, storage_rebate: 3617600, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
 
 task 8, lines 145-158:
 //# run-graphql
@@ -85,7 +85,7 @@ Checkpoint created: 3
 
 task 11, line 164:
 //# view-checkpoint
-CheckpointSummary { epoch: 0, sequence_number: 3, network_total_transactions: 5, content_digest: CheckpointContentsDigest("7v9TpB7Pxaay91Mpee7F1cci2TaWGki5REQbYVvUBg2Y"), previous_digest: Some(CheckpointDigest("GZZpmUaV8PcwcBo6k2PevuTkaVMCrb8FYTsiXqAYKttv")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 4000000, computation_cost_burned: 4000000, storage_cost: 30932000, storage_rebate: 6543600, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
+CheckpointSummary { epoch: 0, sequence_number: 3, network_total_transactions: 5, contents_digest: CheckpointContentsDigest("7v9TpB7Pxaay91Mpee7F1cci2TaWGki5REQbYVvUBg2Y"), previous_digest: Some(CheckpointDigest("GZZpmUaV8PcwcBo6k2PevuTkaVMCrb8FYTsiXqAYKttv")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 4000000, computation_cost_burned: 4000000, storage_cost: 30932000, storage_rebate: 6543600, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
 
 task 12, lines 166-179:
 //# run-graphql
@@ -136,7 +136,7 @@ Checkpoint created: 4
 
 task 15, line 185:
 //# view-checkpoint
-CheckpointSummary { epoch: 0, sequence_number: 4, network_total_transactions: 6, content_digest: CheckpointContentsDigest("J6Bc3qVD4ggmn2AqQ7jcrYEeTsAKY5T5xjk9ko1anWvq"), previous_digest: Some(CheckpointDigest("FmSAvF3kQjrc5x7FYitXYQ3ra7b6pTRBcywqEi4dzcAJ")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 5000000, computation_cost_burned: 5000000, storage_cost: 36153200, storage_rebate: 9560800, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
+CheckpointSummary { epoch: 0, sequence_number: 4, network_total_transactions: 6, contents_digest: CheckpointContentsDigest("J6Bc3qVD4ggmn2AqQ7jcrYEeTsAKY5T5xjk9ko1anWvq"), previous_digest: Some(CheckpointDigest("FmSAvF3kQjrc5x7FYitXYQ3ra7b6pTRBcywqEi4dzcAJ")), epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 5000000, computation_cost_burned: 5000000, storage_cost: 36153200, storage_rebate: 9560800, non_refundable_storage_fee: 0 }, timestamp_ms: 0, checkpoint_commitments: [], end_of_epoch_data: None, version_specific_data: "AAA=" }
 
 task 16, lines 187-200:
 //# run-graphql

--- a/crates/iota-rest-kv/Cargo.toml
+++ b/crates/iota-rest-kv/Cargo.toml
@@ -26,7 +26,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 tokio-util.workspace = true
 tower.workspace = true
-tower-http = { workspace = true, features = ["trace", "request-id"] }
+tower-http = { workspace = true, features = ["request-id"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/iota-rest-kv/Cargo.toml
+++ b/crates/iota-rest-kv/Cargo.toml
@@ -25,6 +25,8 @@ serde_yaml.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 tokio-util.workspace = true
+tower.workspace = true
+tower-http = { workspace = true, features = ["trace", "request-id"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -30,7 +30,7 @@ use iota_sdk_types::TransactionDigest;
 use iota_storage::http_key_value_store::{ItemType, Key};
 use iota_types::{effects::TransactionEvents, sdk_types::Address, storage::ObjectKey};
 use serde::{Deserialize, Serialize};
-use tracing::error;
+use tracing::{debug, error, info, instrument};
 
 use crate::errors::{ApiError, RangeKeyBoundError};
 
@@ -70,6 +70,11 @@ impl KvStoreClient {
     /// Internally it instantiates a BigTableDB client.
     pub async fn new(config: KvStoreConfig) -> Result<Self> {
         let bigtable_client = if let Some(emulator_host) = config.emulator_host {
+            info!(
+                instance_id = %config.instance_id,
+                %emulator_host,
+                "connecting to BigTable emulator"
+            );
             BigTableClient::new_local(
                 &emulator_host,
                 "iota-rest-kv",
@@ -77,6 +82,11 @@ impl KvStoreClient {
                 config.column_family,
             )?
         } else {
+            info!(
+                instance_id = %config.instance_id,
+                timeout_secs = config.timeout_secs,
+                "connecting to remote BigTable"
+            );
             BigTableClient::new_remote(
                 config.instance_id,
                 true,
@@ -283,6 +293,11 @@ impl KvStoreClient {
     /// - `Some(value)` at index `i` means `key[i]` exists and has data
     /// - `None` at index `i` means `key[i]` was not found or has no matching
     ///   data
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(table = table_name, column_qualifier = column_qualifier, num_keys = keys.len())
+    )]
     async fn fetch_from_bigtable(
         &self,
         table_name: &str,
@@ -300,6 +315,7 @@ impl KvStoreClient {
             .filter_map(|(index, key)| key.as_ref().map(|k| (k.clone(), index)))
             .collect::<HashMap<Vec<u8>, usize>>();
 
+        let start = Instant::now();
         for row in client
             .multi_get(
                 table_name,
@@ -319,6 +335,14 @@ impl KvStoreClient {
                 }
             }
         }
+
+        let found = results.iter().filter(|value| value.is_some()).count();
+        debug!(
+            found,
+            missing = results.len() - found,
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "fetched rows from BigTable"
+        );
 
         Ok(results)
     }
@@ -351,6 +375,7 @@ impl KvStoreClient {
     ///
     /// Returns `None` if no version below the requested one exists for that
     /// object (or if the object is not stored at all).
+    #[instrument(level = "debug", skip_all)]
     pub async fn object_before_version(
         &self,
         range: ObjectRangeKeyBound,
@@ -361,6 +386,7 @@ impl KvStoreClient {
 
         let mut client = self.bigtable_client.clone();
 
+        let start = Instant::now();
         let reversed = true;
         let rows_limit = 1;
         let rows = client
@@ -393,6 +419,12 @@ impl KvStoreClient {
                 error!("unexpected column {cell_name:?} in {OBJECTS_TABLE} table");
             }
         }
+
+        debug!(
+            found = value.is_some(),
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "range scanned object before version"
+        );
         Ok(value)
     }
 
@@ -404,11 +436,13 @@ impl KvStoreClient {
     /// from BigTableDB. Returns a vector of the same length and order as
     /// the input keys. Each entry is `Some(bytes)` if the key was found, or
     /// `None` if not found.
+    #[instrument(level = "debug", skip_all)]
     pub async fn objects_before_version(
         &self,
         req: ObjectsBeforeVersionRequest,
     ) -> Result<Vec<Option<Bytes>>, anyhow::Error> {
         let req = req.into_inner();
+        debug!(num_keys = req.len(), "fetching objects before version");
 
         // `multiget_max_items` bounds the size of an incoming request, but it is
         // an operator-configurable value. Concurrency is capped independently via
@@ -435,6 +469,7 @@ impl KvStoreClient {
     ///
     /// When `None`, the scan starts from the beginning of the requested
     /// `oldest_first` order.
+    #[instrument(level = "debug", skip(self))]
     pub async fn transactions_by_address(
         &self,
         address: Address,
@@ -449,9 +484,17 @@ impl KvStoreClient {
             false => TransactionsOrder::NewestFirst,
         };
 
-        client
+        let start = Instant::now();
+        let transactions = client
             .get_transaction_digests_by_address(address, cursor, limit, order)
-            .await
+            .await?;
+
+        debug!(
+            found = transactions.len(),
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "fetched transaction digests by address"
+        );
+        Ok(transactions)
     }
 }
 

--- a/crates/iota-rest-kv/src/errors.rs
+++ b/crates/iota-rest-kv/src/errors.rs
@@ -21,14 +21,7 @@ pub enum ApiError {
     #[error("not found")]
     NotFound,
     #[error("internal server error")]
-    InternalServerError,
-}
-
-impl From<anyhow::Error> for ApiError {
-    fn from(err: anyhow::Error) -> Self {
-        tracing::error!("internal server error: {err}");
-        ApiError::InternalServerError
-    }
+    InternalServerError(#[from] anyhow::Error),
 }
 
 impl IntoResponse for ApiError {
@@ -36,8 +29,18 @@ impl IntoResponse for ApiError {
         let status_code = match self {
             ApiError::BadRequest(_) => StatusCode::BAD_REQUEST,
             ApiError::NotFound => StatusCode::NOT_FOUND,
-            ApiError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
+            ApiError::InternalServerError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
+
+        match self {
+            ApiError::InternalServerError(ref e) => {
+                tracing::Span::current().record("error", format_args!("{e:#}"));
+            }
+            ApiError::BadRequest(ref e) => {
+                tracing::Span::current().record("error", format_args!("{e}"));
+            }
+            ApiError::NotFound => {}
+        }
 
         let body = Json(ErrorResponse {
             error_code: status_code.as_u16().to_string(),

--- a/crates/iota-rest-kv/src/main.rs
+++ b/crates/iota-rest-kv/src/main.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use server::Server;
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
-use tracing_subscriber::FmtSubscriber;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 /// This module contains the DynamoDb and S3 implementation of the KV store
 /// client.
@@ -75,8 +75,16 @@ async fn main() -> Result<()> {
 }
 
 /// Initialize the tracing with custom subscribers.
+///
+/// The default level can be overridden with per-module directives (e.g.
+/// `RUST_LOG=iota_rest_kv=debug,info`).
 fn init_tracing(log_level: Level) {
-    let subscriber = FmtSubscriber::builder().with_max_level(log_level).finish();
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level.to_string()));
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(env_filter)
+        .finish();
+
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 }
 

--- a/crates/iota-rest-kv/src/routes/kv_store.rs
+++ b/crates/iota-rest-kv/src/routes/kv_store.rs
@@ -62,6 +62,8 @@ pub async fn data_as_bytes(
     ExtractPath(key): ExtractPath,
     Query(BeforeVersion { before_version }): Query<BeforeVersion>,
 ) -> Result<impl IntoResponse, ApiError> {
+    tracing::debug!(?key, before_version, "get item");
+
     if before_version {
         let range = ObjectRangeKeyBound::try_from(key)
             .map_err(|_| ApiError::BadRequest(BEFORE_VERSION_REQUIRES_OB_ERROR_MSG.into()))?;
@@ -144,6 +146,13 @@ pub async fn multi_get_data(
         )));
     }
 
+    tracing::debug!(
+        %item_type,
+        num_keys = payload.keys.len(),
+        before_version,
+        "multi-get items"
+    );
+
     let item_type_str = item_type.to_string();
     let keys = payload
         .keys
@@ -165,7 +174,9 @@ pub async fn multi_get_data(
         app_state.kv_store_client.get_items(keys).await?
     };
 
-    let bcs_data = bcs::to_bytes(&results).map_err(|_| ApiError::InternalServerError)?;
+    let bcs_data = bcs::to_bytes(&results)
+        .map_err(Into::into)
+        .map_err(ApiError::InternalServerError)?;
     Ok(bcs_data.into_response())
 }
 
@@ -222,6 +233,14 @@ pub async fn transaction_digests_by_address(
         oldest_first,
     } = query;
 
+    tracing::debug!(
+        %address,
+        ?cursor,
+        ?limit,
+        oldest_first,
+        "get transaction digests by address"
+    );
+
     let max_limit = app_state.multiget_max_items.get();
     let limit = limit.map_or(max_limit, |l| l.get());
 
@@ -236,6 +255,8 @@ pub async fn transaction_digests_by_address(
         .transactions_by_address(address, cursor, limit, oldest_first)
         .await?;
 
-    let bcs_data = bcs::to_bytes(&transactions).map_err(|_| ApiError::InternalServerError)?;
+    let bcs_data = bcs::to_bytes(&transactions)
+        .map_err(Into::into)
+        .map_err(ApiError::InternalServerError)?;
     Ok(bcs_data.into_response())
 }

--- a/crates/iota-rest-kv/src/server.rs
+++ b/crates/iota-rest-kv/src/server.rs
@@ -3,16 +3,27 @@
 
 //! This module includes helper wrappers for building and starting a REST API
 //! server.
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use axum::{
     Router,
-    response::IntoResponse,
+    extract::{MatchedPath, Request},
+    http::{StatusCode, header::HeaderName},
+    response::{IntoResponse, Response},
     routing::{get, post},
 };
 use iota_storage::http_key_value_store::ItemType;
 use tokio_util::sync::CancellationToken;
+use tower::ServiceBuilder;
+use tower_http::{
+    classify::ServerErrorsFailureClass,
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    trace::TraceLayer,
+};
+use tracing::{Span, field};
+
+const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
 
 use crate::{
     RestApiConfig,
@@ -53,8 +64,29 @@ impl Server {
                 &format!("/{}/{{address}}", ItemType::TransactionDigestsByAddress),
                 get(kv_store::transaction_digests_by_address),
             )
-            .with_state(shared_state)
-            .fallback(fallback);
+            // register the fallback before the layers so that requests to
+            // unmatched routes are traced as well
+            .fallback(fallback)
+            .layer(
+                ServiceBuilder::new()
+                    .layer(SetRequestIdLayer::new(REQUEST_ID_HEADER, MakeRequestUuid))
+                    .layer(
+                        TraceLayer::new_for_http()
+                            .make_span_with(make_request_span)
+                            .on_response(log_response)
+                            .on_failure(
+                                |class: ServerErrorsFailureClass, latency: Duration, _: &Span| {
+                                    tracing::error!(
+                                        %class,
+                                        latency_ms = latency.as_millis() as u64,
+                                        "request failed"
+                                    );
+                                },
+                            ),
+                    )
+                    .layer(PropagateRequestIdLayer::new(REQUEST_ID_HEADER)),
+            )
+            .with_state(shared_state);
 
         Ok(Self {
             router,
@@ -92,4 +124,54 @@ impl Server {
 /// the request.
 async fn fallback() -> impl IntoResponse {
     ApiError::NotFound
+}
+
+/// Creates the tracing span that wraps a single request.
+///
+/// - `request_id` is the unique identifier for this request.
+/// - `method` is the HTTP method of the request (e.g. `GET`, `POST`).
+/// - `route` is the matched route template (e.g. `/{item_type}/{key}`)
+/// - `uri` carries the concrete request path data (e.g.
+///   `/txa/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk`).
+/// - The `error` field starts empty and is recorded by
+///   [`ApiError::into_response`] when the request fails.
+fn make_request_span(request: &Request) -> Span {
+    let request_id = request
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map_or_else(|| request.uri().path(), MatchedPath::as_str);
+
+    tracing::info_span!(
+        "request",
+        request_id,
+        method = %request.method(),
+        route,
+        uri = %request.uri(),
+        error = field::Empty,
+    )
+}
+
+/// Logs the completion of a request, choosing the level by status code range.
+///
+/// # Note
+/// Server errors are skipped here, they are logged by
+/// [`TraceLayer::on_failure`] together with the failure class.
+fn log_response(response: &Response, latency: Duration, _: &Span) {
+    let status = response.status();
+    let latency_ms = latency.as_millis() as u64;
+
+    if status.is_server_error() {
+        return;
+    }
+
+    if status.is_client_error() && status != StatusCode::NOT_FOUND {
+        tracing::warn!(%status, latency_ms, "request failed with client error");
+    } else {
+        tracing::info!(%status, latency_ms, "request completed");
+    }
 }

--- a/crates/iota-rest-kv/src/server.rs
+++ b/crates/iota-rest-kv/src/server.rs
@@ -21,7 +21,7 @@ use tower_http::{
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
     trace::TraceLayer,
 };
-use tracing::{Span, field};
+use tracing::{Level, Span, field};
 
 const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
 
@@ -126,34 +126,43 @@ async fn fallback() -> impl IntoResponse {
     ApiError::NotFound
 }
 
-/// Creates the tracing span that wraps a single request.
+/// Creates a tracing span that wraps a single request.
 ///
-/// - `request_id` is the unique identifier for this request.
-/// - `method` is the HTTP method of the request (e.g. `GET`, `POST`).
-/// - `route` is the matched route template (e.g. `/{item_type}/{key}`)
-/// - `uri` carries the concrete request path data (e.g.
-///   `/txa/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk`).
-/// - The `error` field starts empty and is recorded by
-///   [`ApiError::into_response`] when the request fails.
+/// - If `DEBUG` logging is enabled, a detailed span is created containing:
+///   - `request_id`: Extracted from the request header (or empty if missing).
+///   - `method`: The HTTP method of the request.
+///   - `route`: The matched route template (falling back to the raw URI path).
+///   - `uri`: The concrete request path data.
+///   - `error`: Starts empty and is recorded by [`ApiError::into_response`]
+///     when the request fails.
+/// - Otherwise, a lighter span is created containing only `uri` and `error`.
 fn make_request_span(request: &Request) -> Span {
-    let request_id = request
-        .headers()
-        .get(REQUEST_ID_HEADER)
-        .and_then(|value| value.to_str().ok())
-        .unwrap_or_default();
-    let route = request
-        .extensions()
-        .get::<MatchedPath>()
-        .map_or_else(|| request.uri().path(), MatchedPath::as_str);
+    if tracing::span_enabled!(Level::DEBUG) {
+        let request_id = request
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        let route = request
+            .extensions()
+            .get::<MatchedPath>()
+            .map_or_else(|| request.uri().path(), MatchedPath::as_str);
 
-    tracing::info_span!(
-        "request",
-        request_id,
-        method = %request.method(),
-        route,
-        uri = %request.uri(),
-        error = field::Empty,
-    )
+        tracing::debug_span!(
+            "request",
+            request_id,
+            method = %request.method(),
+            route,
+            uri = %request.uri(),
+            error = field::Empty,
+        )
+    } else {
+        tracing::info_span!(
+            "request",
+            uri = %request.uri(),
+            error = field::Empty,
+        )
+    }
 }
 
 /// Logs the completion of a request, choosing the level by status code range.


### PR DESCRIPTION
# Description of change

This PR adds more refined logging to the `iota-rest-kv` crate. Previously the service logs said almost nothing about its operations, which made debugging difficult.

- Every incoming request is wrapped in a tracing span carrying a unique `request_id`, the HTTP method, the matched route template, and the full URI. The `request_id` is generated by the server (or taken from the client's `x-request-id` header if present) and echoed back in the response header. This makes it possible to correlate a client-reported failure with the exact server-side log lines, which is especially handy under high traffic since axum processes requests concurrently and their log lines interleave.
- Each request logs one completion line with status code and latency: `info` for success, `warn` for client errors, `error` for server errors. `404` stays at `info` since a key miss is a normal outcome for a KV lookup, not a client mistake.
- Bad request and internal error causes are recorded on the span's `error` field. Clients still receive only a generic "internal server error" for 500s; the details stay server-side.
- Handlers log the parsed request parameters at `debug` (item type, key, number of keys, pagination options).
- Every BigTable call logs a `debug` line with table, column qualifier, found/missing counts, and elapsed time.
- The level from `--log-level`/`LOG_LEVEL` now acts as the default of an `EnvFilter`, so `RUST_LOG` can override it with per-module directives (e.g. `RUST_LOG=iota_rest_kv=debug,iota_bigtable=debug,info`).
- The bumped `iota-bigtable` dependency logs transient gRPC errors at `warn` on every retry together with the next backoff delay (previously retries were completely silent), and logs its read/write calls at `debug`.

> [!NOTE]
> For now we pin the commit hash, once the `iota-bigtable` PR is merged, a new tag will be created and used in place of the commit hash.

## Links to any relevant issues

fixes #11977 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

INFO logs
```logs
2026-07-17T13:30:16.697162Z  INFO iota_rest_kv::bigtable: connecting to remote BigTable instance_id=testnet timeout_secs=60
2026-07-17T13:30:16.959903Z  INFO iota_rest_kv::server: listening on: 0.0.0.0:3555
2026-07-17T13:31:17.622986Z  INFO request{request_id="c95e3714-6aba-4854-b237-2478ffb14b70" method=POST route="/{item_type}" uri=/tx}: iota_rest_kv::server: request completed status=200 OK latency_ms=586
2026-07-17T13:31:19.753637Z  INFO request{request_id="7e397e68-45f7-4a44-b771-a46a34cfc9ce" method=POST route="/{item_type}" uri=/tx}: iota_rest_kv::server: request completed status=200 OK latency_ms=25
2026-07-17T13:31:27.655548Z  INFO request{request_id="7f513f59-9f06-4c5c-8f6f-1dca39faed0e" method=GET route="/{item_type}/{key}" uri=/ob/ALcl0KGsNVxB3_-w5Jebr7-dOIgpyvMxgJ0C_RyhqdevqydNAgAAAA?before_version=true}: iota_rest_kv::server: request completed status=200 OK latency_ms=89
2026-07-17T13:31:33.281163Z  INFO request{request_id="a47bad5a-98e5-4df8-a143-72ce006f41b9" method=GET route="/health" uri=/health}: iota_rest_kv::server: request completed status=200 OK latency_ms=0
2026-07-17T13:31:54.975489Z  INFO request{request_id="90df5add-13cf-496d-ab6c-2eada08a8675" method=GET route="/{item_type}/{key}" uri=/tx/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}: iota_rest_kv::server: request completed status=404 Not Found latency_ms=71
2026-07-17T13:32:00.264121Z  WARN request{request_id="5333fa1f-9560-4554-8bc1-90f6f3324dcb" method=GET route="/{item_type}/{key}" uri=/tx/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqF error=invalid input: invalid base64 url string: Invalid last symbol 70, offset 41.}: iota_rest_kv::server: request failed with client error status=400 Bad Request latency_ms=0
2026-07-17T13:32:15.170240Z  INFO request{request_id="7c902edb-2468-4d57-9af6-cbadb891204c" method=GET route="/{item_type}/{key}" uri=/tx/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}: iota_rest_kv::server: request completed status=404 Not Found latency_ms=25
2026-07-17T13:32:59.134335Z  WARN request{request_id="282ff130-da31-4ffd-9de6-7447175e368b" method=GET route="/txa/{address}" uri=/txa/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk?oldest_first=false?limit=0}: iota_rest_kv::server: request failed with client error status=400 Bad Request latency_ms=0
2026-07-17T13:33:05.973448Z  INFO request{request_id="593aa732-40ee-421f-894f-0b8a1375a808" method=GET route="/txa/{address}" uri=/txa/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}: iota_rest_kv::server: request completed status=200 OK latency_ms=57
```

DEBUG Logs

```logs
2026-07-17T13:35:22.370154Z  INFO iota_rest_kv::bigtable: connecting to remote BigTable instance_id=testnet timeout_secs=60
2026-07-17T13:35:22.630254Z  INFO iota_rest_kv::server: listening on: 0.0.0.0:3555
2026-07-17T13:35:24.371765Z DEBUG request{request_id="9a9c99b6-1d6c-44ed-a64d-10ad8ab014bc" method=GET route="/txa/{address}" uri=/txa/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}: iota_rest_kv::routes::kv_store: get transaction digests by address address=0x30cc1fd7d8fb786af29eb1cfe14a69ef5fb2bdb25bafe1a9aa745853c2e8a859 cursor=None limit=None oldest_first=false
2026-07-17T13:35:24.676811Z DEBUG request{request_id="9a9c99b6-1d6c-44ed-a64d-10ad8ab014bc" method=GET route="/txa/{address}" uri=/txa/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}:transactions_by_address{address=Address("0x30cc1fd7d8fb786af29eb1cfe14a69ef5fb2bdb25bafe1a9aa745853c2e8a859") cursor=None limit=100 oldest_first=false}: iota_rest_kv::bigtable: fetched transaction digests by address found=0 elapsed_ms=304
2026-07-17T13:35:24.677325Z  INFO request{request_id="9a9c99b6-1d6c-44ed-a64d-10ad8ab014bc" method=GET route="/txa/{address}" uri=/txa/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}: iota_rest_kv::server: request completed status=200 OK latency_ms=306
2026-07-17T13:35:54.507309Z DEBUG request{request_id="822a3dcc-89c5-4b8f-a406-b163afaa5b77" method=POST route="/{item_type}" uri=/tx}: iota_rest_kv::routes::kv_store: multi-get items item_type=tx num_keys=2 before_version=false
2026-07-17T13:35:54.545127Z DEBUG request{request_id="822a3dcc-89c5-4b8f-a406-b163afaa5b77" method=POST route="/{item_type}" uri=/tx}:fetch_from_bigtable{table="transactions" column_qualifier="tx" num_keys=2}: iota_rest_kv::bigtable: fetched rows from BigTable found=1 missing=1 elapsed_ms=37
2026-07-17T13:35:54.545359Z  INFO request{request_id="822a3dcc-89c5-4b8f-a406-b163afaa5b77" method=POST route="/{item_type}" uri=/tx}: iota_rest_kv::server: request completed status=200 OK latency_ms=38
2026-07-17T13:35:58.196724Z DEBUG request{request_id="86f3735d-c156-482a-88ed-5d11c9b7e599" method=GET route="/{item_type}/{key}" uri=/ob/ALcl0KGsNVxB3_-w5Jebr7-dOIgpyvMxgJ0C_RyhqdevqydNAgAAAA?before_version=true}: iota_rest_kv::routes::kv_store: get item key=ObjectKey(ObjectKey(ObjectId("0x00b725d0a1ac355c41dfffb0e4979bafbf9d388829caf331809d02fd1ca1a9d7"), Version(9884380079))) before_version=true
2026-07-17T13:35:58.240019Z DEBUG request{request_id="86f3735d-c156-482a-88ed-5d11c9b7e599" method=GET route="/{item_type}/{key}" uri=/ob/ALcl0KGsNVxB3_-w5Jebr7-dOIgpyvMxgJ0C_RyhqdevqydNAgAAAA?before_version=true}:object_before_version: iota_rest_kv::bigtable: range scanned object before version found=true elapsed_ms=43
2026-07-17T13:35:58.240178Z  INFO request{request_id="86f3735d-c156-482a-88ed-5d11c9b7e599" method=GET route="/{item_type}/{key}" uri=/ob/ALcl0KGsNVxB3_-w5Jebr7-dOIgpyvMxgJ0C_RyhqdevqydNAgAAAA?before_version=true}: iota_rest_kv::server: request completed status=200 OK latency_ms=43
2026-07-17T13:36:02.431825Z DEBUG request{request_id="765ca389-ade1-41f0-b614-5fdd5e1fda97" method=GET route="/{item_type}/{key}" uri=/tx/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}: iota_rest_kv::routes::kv_store: get item key=Transaction(TransactionDigest("4HV6h8QgQDTsaqDN8XB3bw6gti62tskqaa3gsn8TWCgp")) before_version=false
2026-07-17T13:36:02.458978Z DEBUG request{request_id="765ca389-ade1-41f0-b614-5fdd5e1fda97" method=GET route="/{item_type}/{key}" uri=/tx/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}:fetch_from_bigtable{table="transactions" column_qualifier="tx" num_keys=1}: iota_rest_kv::bigtable: fetched rows from BigTable found=0 missing=1 elapsed_ms=26
2026-07-17T13:36:02.459136Z  INFO request{request_id="765ca389-ade1-41f0-b614-5fdd5e1fda97" method=GET route="/{item_type}/{key}" uri=/tx/MMwf19j7eGrynrHP4Upp71-yvbJbr-GpqnRYU8LoqFk}: iota_rest_kv::server: request completed status=404 Not Found latency_ms=27
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the `iota-indexer`, thus no further tests were conducted.
