### PR TITLE
fix(iota-e2e-tests): wait for all nodes before clearing safe-mode expectation in `test_safe_mode_recovery`

### DIFF
--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -807,6 +807,7 @@ mod sim_only_tests {
         assert!(system_state.epoch_start_timestamp_ms() >= genesis_epoch_start_time + 20000);
 
         // We are getting out of safe mode soon.
+        test_cluster.wait_for_epoch_all_nodes(1).await;
         test_cluster.set_safe_mode_expected(false);
 
         // This epoch change should execute successfully without any upgrade and get us


### PR DESCRIPTION
# Description of change

`test_safe_mode_recovery` clears `sim_safe_mode_expected` as soon as one node reports epoch 1, but `wait_for_epoch` does not guarantee that other nodes have reached that epoch. A validator still completing its epoch 0 -> 1 reconfiguration—where the system state legitimately reports safe mode—then fails `debug_assert!(!latest_system_state.safe_mode())` and panics.

This PR adds the `wait_for_epoch_all_nodes(1)` wait before calling `set_safe_mode_expected(false)`, so the expectation flips only after every node has passed the transition where safe mode is expected.

The race is pre-existing and seed-dependent, not a regression: the test fails with `MSIM_TEST_SEED=398385738518934669` on both `88ce343810` (#12298) and its parent `def747b551`.

## Links to any relevant issues

First surfaced by the develop CI run for #12298: https://github.com/iotaledger/iota/actions/runs/29615250902/job/88004186981

## How the change has been tested

```shell
MSIM_TEST_SEED=398385738518934669 cargo simtest -p iota-e2e-tests --test protocol_version_tests test_safe_mode_recovery
MSIM_TEST_NUM=20 MSIM_TEST_SEED=2 MSIM_WATCHDOG_TIMEOUT_MS=180000 cargo simtest --profile simtestnightly -p iota-e2e-tests --test protocol_version_tests test_safe_mode_recovery
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
