### PR TITLE
backport(node): Tag metric `current_voting_right` as warn

### DIFF
--- a/crates/iota-core/src/epoch/epoch_metrics.rs
+++ b/crates/iota-core/src/epoch/epoch_metrics.rs
@@ -136,7 +136,8 @@ impl EpochMetrics {
             current_voting_right: register_int_gauge_with_registry!(
                 "current_voting_right",
                 "Current voting right of the validator",
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             epoch_checkpoint_count: register_int_gauge_with_registry!(


### PR DESCRIPTION
Backport of #12291 to the `1.28.0` release branch, so the dashboards work properly on devnet for Monday's release.

Original commit: bc331bdf1b516a7fae9962fc868f49207d557466
Original PR: https://github.com/iotaledger/iota/pull/12291
