### PR TITLE
refactor(iota-data-ingestion-core): reduce INFO log verbosity

### DIFF
--- a/crates/iota-data-ingestion-core/src/reader/fetch.rs
+++ b/crates/iota-data-ingestion-core/src/reader/fetch.rs
@@ -132,7 +132,7 @@ pub(crate) trait LocalRead {
 
     /// Cleans the local directory by removing all processed checkpoint files.
     fn gc_processed_files(&mut self, watermark: CheckpointSequenceNumber) -> IngestionResult<()> {
-        info!("cleaning processed files, watermark is {watermark}");
+        debug!("cleaning processed files, watermark is {watermark}");
         self.update_last_pruned_watermark(watermark);
         for entry in fs::read_dir(self.path())? {
             let entry = entry?;

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -18,7 +18,7 @@ use iota_types::{
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     IngestionError, IngestionResult, Reducer, Worker, executor::MAX_CHECKPOINTS_IN_PROGRESS,
@@ -399,17 +399,17 @@ impl<W: Worker + 'static> WorkerPool<W> {
                         },
                         Some(checkpoint) = worker_recv.recv() => {
                             let sequence_number = checkpoint.checkpoint_summary.sequence_number;
-                            info!("received checkpoint for processing {sequence_number} for workflow {task_name}", );
+                            debug!("received checkpoint for processing {sequence_number} for workflow {task_name}", );
                             let start_time = Instant::now();
                             let status = Self::process_checkpoint_with_retry(worker_id, &worker, checkpoint, reset_backoff(&backoff), &token).await;
                             if matches!(status, WorkerStatus::Running((_,_, None))) {
-                                info!("checkpoint {sequence_number} for workflow {task_name} filtered out");
+                                debug!("checkpoint {sequence_number} for workflow {task_name} filtered out");
                             }
                             let trigger_shutdown = matches!(status, WorkerStatus::Shutdown(_));
                             if cloned_progress_sender.send(status).await.is_err() || trigger_shutdown {
                                 break;
                             }
-                            info!(
+                            debug!(
                                 "finished checkpoint processing {sequence_number} for workflow {task_name} in {:?}",
                                 start_time.elapsed()
                             );


### PR DESCRIPTION
# Description of change

This PR lowers the noisy per-checkpoint logs from `INFO` to `DEBUG`:

- `worker_pool.rs`: "received checkpoint for processing", "checkpoint filtered out", and "finished checkpoint processing" (emitted for every checkpoint per worker)
- `reader/fetch.rs`: "cleaning processed files" (emitted on every pruning cycle)

## Links to any relevant issues

fixes #12339 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

Ran the iota-indexer against the `testnet` historical checkpoint store:
```shell
RUST_LOG=iota_data_ingestion_core=info cargo r -p iota-indexer -- --database-url=postgres://postgres:postgrespw@localhost:5432/iota_indexer indexer --remote-store-url=https://checkpoints.testnet.iota.cafe/ingestion/historical --reset-db
```
```logs
2026-07-20T13:18:42.196537Z  INFO iota_data_ingestion_core::worker_pool: Starting indexing pipeline primary with concurrency 200. Current watermark is 0.
2026-07-20T13:18:45.930022Z  INFO iota_data_ingestion_core::reader::v2: Read from remote. Current checkpoint number: 3869, pruning watermark: 0
2026-07-20T13:18:48.359451Z  INFO iota_data_ingestion_core::reader::v2: Read from remote. Current checkpoint number: 7848, pruning watermark: 3869
2026-07-20T13:18:50.800574Z  INFO iota_data_ingestion_core::reader::v2: Read from remote. Current checkpoint number: 11778, pruning watermark: 7848
2026-07-20T13:18:53.332826Z  INFO iota_data_ingestion_core::reader::v2: Read from remote. Current checkpoint number: 15724, pruning watermark: 11778
2026-07-20T13:18:55.965785Z  INFO iota_data_ingestion_core::reader::v2: Read from remote. Current checkpoint number: 19661, pruning watermark: 15724
```

> [!NOTE]
> When ingesting via the IOTA node gRPC stream, the "Read from remote" line is even less frequent, since it is only emitted when the stream is interrupted and reconnected.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
>  This patch only changes log levels of the `iota-data-ingestion-core`; it does not affect ingestion behavior, so no further tests were conducted.
