### PR TITLE
refactor(iota-config): move migration execution into iota-genesis-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5679,7 +5679,6 @@ dependencies = [
  "csv",
  "dirs",
  "fastcrypto",
- "iota-genesis-common",
  "iota-keys",
  "iota-metrics",
  "iota-names",
@@ -5732,6 +5731,7 @@ dependencies = [
  "iota-execution",
  "iota-framework",
  "iota-genesis-builder",
+ "iota-genesis-common",
  "iota-json-rpc-types",
  "iota-macros",
  "iota-metrics",
@@ -6138,6 +6138,7 @@ dependencies = [
 name = "iota-genesis-common"
 version = "1.30.0-alpha"
 dependencies = [
+ "iota-config",
  "iota-execution",
  "iota-protocol-config",
  "iota-sdk-types",
@@ -7044,6 +7045,7 @@ dependencies = [
  "iota-common",
  "iota-config",
  "iota-core",
+ "iota-genesis-common",
  "iota-grpc-server",
  "iota-http",
  "iota-json-rpc",

--- a/crates/iota-config/Cargo.toml
+++ b/crates/iota-config/Cargo.toml
@@ -39,7 +39,6 @@ reqwest.workspace = true
 serde_yaml.workspace = true
 
 # internal dependencies
-iota-genesis-common.workspace = true
 iota-keys.workspace = true
 iota-metrics.workspace = true
 iota-names.workspace = true

--- a/crates/iota-config/src/migration_tx_data.rs
+++ b/crates/iota-config/src/migration_tx_data.rs
@@ -4,31 +4,25 @@
 use std::{
     collections::{BTreeMap, HashSet},
     fs::File,
-    io::{BufReader, BufWriter},
+    io::BufReader,
     path::Path,
 };
 
 use anyhow::{Context, Result};
-use iota_genesis_common::prepare_and_execute_genesis_transaction;
 use iota_sdk_types::{
-    ObjectData, TransactionDigest,
+    TransactionDigest,
     checkpoint::{CheckpointContents, CheckpointSummary},
 };
 use iota_types::{
-    balance::Balance,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
-    gas_coin::GasCoin,
     message_envelope::Message,
     messages_checkpoint::CheckpointContentsExt,
-    object::Object,
-    stardust::output::{AliasOutput, BasicOutput, NftOutput},
-    timelock::timelock::{TimeLock, is_timelocked_gas_balance},
     transaction::TransactionEnvelope,
 };
 use serde::{Deserialize, Serialize};
 use tracing::trace;
 
-use crate::genesis::{Genesis, GenesisCeremonyParameters, UnsignedGenesis};
+use crate::genesis::Genesis;
 
 pub type TransactionsData =
     BTreeMap<TransactionDigest, (TransactionEnvelope, TransactionEffects, TransactionEvents)>;
@@ -41,53 +35,8 @@ pub struct MigrationTxData {
 }
 
 impl MigrationTxData {
-    pub fn new(txs_data: TransactionsData) -> Self {
-        Self { inner: txs_data }
-    }
-
     pub fn txs_data(&self) -> &TransactionsData {
         &self.inner
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
-    }
-
-    /// Executes all the migration transactions for this migration data and
-    /// returns the vector of objects created by these executions.
-    pub fn get_objects(&self) -> impl Iterator<Item = Object> + '_ {
-        self.inner.values().flat_map(|(tx, _, _)| {
-            self.objects_by_tx_digest(*tx.digest())
-                .expect("the migration data is corrupted")
-                .into_iter()
-        })
-    }
-
-    /// Executes the migration transaction identified by `digest` and returns
-    /// the vector of objects created by the execution.
-    pub fn objects_by_tx_digest(&self, digest: TransactionDigest) -> Option<Vec<Object>> {
-        let (tx, effects, _) = self.inner.get(&digest)?;
-
-        // We use default ceremony parameters, not the real ones. This should not affect
-        // the execution of a genesis transaction.
-        let default_ceremony_parameters = GenesisCeremonyParameters::default();
-
-        // Execute the transaction
-        let (execution_effects, _, execution_objects) = prepare_and_execute_genesis_transaction(
-            default_ceremony_parameters.chain_start_timestamp_ms,
-            default_ceremony_parameters.protocol_version,
-            tx,
-        );
-
-        // Validate the results
-        assert_eq!(
-            effects.digest(),
-            execution_effects.digest(),
-            "invalid execution"
-        );
-
-        // Return
-        Some(execution_objects)
     }
 
     fn validate_from_genesis_components(
@@ -149,52 +98,6 @@ impl MigrationTxData {
         )
     }
 
-    /// Validates the content of the migration data through an
-    /// `UnsignedGenesis`. The validation is based on cryptographic links
-    /// (i.e., hash digests) between transactions, transaction effects and
-    /// events.
-    pub fn validate_from_unsigned_genesis(
-        &self,
-        unsigned_genesis: &UnsignedGenesis,
-    ) -> anyhow::Result<()> {
-        self.validate_from_genesis_components(
-            unsigned_genesis.checkpoint(),
-            unsigned_genesis.checkpoint_contents(),
-            *unsigned_genesis.transaction().digest(),
-        )
-    }
-
-    /// Validates the total supply of the migration data adding up the amount of
-    /// gas coins found in migrated objects.
-    pub fn validate_total_supply(&self, expected_total_supply: u64) -> anyhow::Result<()> {
-        let total_supply: u64 = self
-            .get_objects()
-            .map(|object| match &object.data {
-                ObjectData::Struct(_) => GasCoin::try_from(&object)
-                    .map(|gas| gas.value())
-                    .or_else(|_| {
-                        TimeLock::<Balance>::try_from(&object).map(|t| {
-                            assert!(is_timelocked_gas_balance(
-                                &object.struct_tag().expect("should not be a package")
-                            ));
-                            t.locked().value()
-                        })
-                    })
-                    .or_else(|_| AliasOutput::try_from(&object).map(|a| a.balance.value()))
-                    .or_else(|_| BasicOutput::try_from(&object).map(|b| b.balance.value()))
-                    .or_else(|_| NftOutput::try_from(&object).map(|n| n.balance.value()))
-                    .unwrap_or(0),
-                ObjectData::Package(_) => 0,
-            })
-            .sum();
-
-        anyhow::ensure!(
-            total_supply == expected_total_supply,
-            "the migration data total supply of {total_supply} does not match the expected total supply of {expected_total_supply}"
-        );
-        Ok(())
-    }
-
     /// Loads a `MigrationTxData` in memory from a file found in `path`.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
         let path = path.as_ref();
@@ -211,19 +114,5 @@ impl MigrationTxData {
                 path.display()
             )
         })
-    }
-
-    /// Saves a `MigrationTxData` from memory into a file in `path`.
-    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), anyhow::Error> {
-        let path = path.as_ref();
-        trace!("writing Migration transaction data to {}", path.display());
-        let mut write = BufWriter::new(File::create(path)?);
-        bcs::serialize_into(&mut write, &self).with_context(|| {
-            format!(
-                "unable to save Migration transaction data to {}",
-                path.display()
-            )
-        })?;
-        Ok(())
     }
 }

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -64,6 +64,7 @@ iota-common.workspace = true
 iota-config.workspace = true
 iota-execution.workspace = true
 iota-framework.workspace = true
+iota-genesis-common.workspace = true
 iota-json-rpc-types.workspace = true
 iota-macros.workspace = true
 iota-metrics.workspace = true

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -9,6 +9,7 @@ use fastcrypto::hash::{HashFunction, Sha3_256};
 use futures::stream::FuturesUnordered;
 use iota_common::sync::notify_read::NotifyRead;
 use iota_config::{migration_tx_data::MigrationTxData, node::AuthorityStorePruningConfig};
+use iota_genesis_common::MigrationTxDataExt;
 use iota_macros::fail_point_arg;
 use iota_sdk_types::Version;
 use iota_storage::mutex_table::{MutexGuard, MutexTable};

--- a/crates/iota-genesis-common/Cargo.toml
+++ b/crates/iota-genesis-common/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
+iota-config.workspace = true
 iota-execution.workspace = true
 iota-protocol-config.workspace = true
 iota-sdk-types.workspace = true

--- a/crates/iota-genesis-common/src/lib.rs
+++ b/crates/iota-genesis-common/src/lib.rs
@@ -3,6 +3,8 @@
 
 use std::{collections::HashSet, sync::Arc};
 
+mod migration_tx_data_ext;
+
 use iota_execution::executor;
 use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::TransactionKind;
@@ -17,6 +19,7 @@ use iota_types::{
     object::Object,
     transaction::{CheckedInputObjects, TransactionDataAPI, TransactionEnvelope},
 };
+pub use migration_tx_data_ext::MigrationTxDataExt;
 use prometheus_filtered::Registry;
 
 /// Gets a `ProtocolConfig` for genesis based on a `ProtocolVersion`.

--- a/crates/iota-genesis-common/src/migration_tx_data_ext.rs
+++ b/crates/iota-genesis-common/src/migration_tx_data_ext.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_config::{genesis::GenesisCeremonyParameters, migration_tx_data::MigrationTxData};
+use iota_sdk_types::TransactionDigest;
+use iota_types::object::Object;
+
+use crate::prepare_and_execute_genesis_transaction;
+
+/// Recovers the objects created by the migration transactions of a
+/// [`MigrationTxData`] by re-executing them. Executing needs the Move VM, so
+/// these operations live here instead of next to the data type in
+/// `iota-config`.
+pub trait MigrationTxDataExt {
+    /// Executes all the migration transactions for this migration data and
+    /// returns the objects created by these executions.
+    fn get_objects(&self) -> impl Iterator<Item = Object> + '_;
+
+    /// Executes the migration transaction identified by `digest` and returns
+    /// the vector of objects created by the execution.
+    fn objects_by_tx_digest(&self, digest: TransactionDigest) -> Option<Vec<Object>>;
+}
+
+impl MigrationTxDataExt for MigrationTxData {
+    fn get_objects(&self) -> impl Iterator<Item = Object> + '_ {
+        self.txs_data().values().flat_map(|(tx, _, _)| {
+            self.objects_by_tx_digest(*tx.digest())
+                .expect("the migration data is corrupted")
+                .into_iter()
+        })
+    }
+
+    fn objects_by_tx_digest(&self, digest: TransactionDigest) -> Option<Vec<Object>> {
+        let (tx, effects, _) = self.txs_data().get(&digest)?;
+
+        // We use default ceremony parameters, not the real ones. This should not affect
+        // the execution of a genesis transaction.
+        let default_ceremony_parameters = GenesisCeremonyParameters::default();
+
+        // Execute the transaction
+        let (execution_effects, _, execution_objects) = prepare_and_execute_genesis_transaction(
+            default_ceremony_parameters.chain_start_timestamp_ms,
+            default_ceremony_parameters.protocol_version,
+            tx,
+        );
+
+        // Validate the results
+        assert_eq!(
+            effects.digest(),
+            execution_effects.digest(),
+            "invalid execution"
+        );
+
+        // Return
+        Some(execution_objects)
+    }
+}

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -40,6 +40,7 @@ bin-version.workspace = true
 iota-common.workspace = true
 iota-config.workspace = true
 iota-core.workspace = true
+iota-genesis-common.workspace = true
 iota-grpc-server.workspace = true
 iota-http.workspace = true
 iota-json-rpc.workspace = true

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -75,6 +75,7 @@ use iota_core::{
     transaction_orchestrator::TransactionOrchestrator,
     validator_tx_finalizer::ValidatorTxFinalizer,
 };
+use iota_genesis_common::MigrationTxDataExt;
 use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
 use iota_json_rpc::{
     JsonRpcServerBuilder, coin_api::CoinReadApi, governance_api::GovernanceReadApi,


### PR DESCRIPTION
# Description of change

`MigrationTxData` was the only reason `iota-config` depended on `iota-genesis-common` — and thereby on `iota-execution` and the Move VM. Only two of its methods need the VM: `get_objects` and `objects_by_tx_digest` re-execute migration transactions via `prepare_and_execute_genesis_transaction`. The data type, its serialization and its digest-only validation need `iota-types` only.

- Move both execution-backed methods into a `MigrationTxDataExt` trait in `iota-genesis-common`, which already owns the genesis executor.
- Drop the `iota-genesis-common` dependency from `iota-config`.
- Update the two call sites, in `iota-node` and `iota-core`. Both crates already carry `iota-execution`, so no crate newly gains the Move VM.

Removing the creation of migration genesis data in #12426 left several members of `MigrationTxData` without callers. These are deleted rather than moved: `validate_total_supply`, `validate_from_unsigned_genesis`, `new`, `is_empty` and `save`.

Node behavior is unchanged: nodes still load `migration.blob` via `migration-tx-data-path` and execute the migration transactions when bootstrapping from a genesis that contains them.

## Build graph effect

Measured on `develop` at `441767e9` with `cargo metadata`, counting workspace crates only and excluding `cfg(msim)` / `wasm32`-gated edges:

| | before | after |
| --- | --- | --- |
| longest compilation chain | 20 | **18** |
| `iota-config` | 9 | **6** |
| `iota-core` | 14 | 12 |
| `iota-node` | 16 | 14 |
| `test-cluster` | 18 | 16 |

`iota-config` is the workspace's largest bottleneck by level × dependents (level 9, 47 dependents); after this change none of those dependents reach the Move VM through it.

## Links to any relevant issues

fixes #12346 (Task 2 of epic #12234)

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

- `cargo check --all-targets` and `cargo clippy --all-targets` clean for `iota-config`, `iota-genesis-common`, `iota-genesis-builder`, `iota-core`, `iota-node`, `iota-swarm-config` and `iota-localnet`
- `cargo test -p iota-config -p iota-genesis-common --lib`: 9 passed, 0 failed
- `iota-config` still compiles for `wasm32-unknown-unknown`
- `scripts/cargo_sort/run_consolidate.sh` and `cargo +nightly fmt --check` clean

Code move plus dead-code removal; no behavior change.