### PR TITLE
feat(gRPC): add `epoch_close_proof` field to `Epoch`

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/utils.rs
+++ b/crates/iota-e2e-tests/tests/grpc/utils.rs
@@ -644,6 +644,14 @@ macro_rules! impl_field_presence_checker {
         Some((present, nested))
     }};
 
+    // Helper rule for repeated leaf fields (when `: []` is specified, i.e. no
+    // element type). Use for repeated fields whose element type has no
+    // presence-checkable substructure of its own (e.g. `BcsData`, which is
+    // just raw bytes with nothing to recurse into).
+    (@field_check $self:ident, $field:ident, []) => {
+        Some((!$self.$field.is_empty(), None))
+    };
+
     // Helper rule for nested fields (when `: Type` is specified)
     (@field_check $self:ident, $field:ident, $nested_type:ty) => {{
         // Check if the field is Some (present) or None (absent)

--- a/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_epoch.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/get_epoch.rs
@@ -8,7 +8,17 @@ use iota_grpc_types::{
 use iota_macros::sim_test;
 use prost_types::FieldMask;
 
-use crate::utils::{assert_field_presence, comma_separated_field_mask_to_paths, setup_grpc_test};
+use crate::utils::{
+    assert_field_presence, comma_separated_field_mask_to_paths, setup_grpc_test,
+    setup_grpc_test_with_builder,
+};
+
+const EPOCH_CLOSE_PROOF_PATHS: [&str; 4] = [
+    "epoch_close_proof.checkpoint",
+    "epoch_close_proof.end_of_epoch_transaction_effects",
+    "epoch_close_proof.end_of_epoch_transaction_events",
+    "epoch_close_proof.bcs_next_epoch_system_state_objects",
+];
 
 #[sim_test]
 async fn get_epoch_current_and_by_number() {
@@ -104,4 +114,107 @@ async fn get_epoch_readmask_scenarios() {
 
         assert_field_presence(&epoch, &expected_paths, &[], scenario);
     }
+}
+
+#[sim_test]
+async fn get_epoch_close_proof_absent_for_current_epoch() {
+    let (_test_cluster, client) = setup_grpc_test(Some(1), None).await;
+    let mut ledger_client = client.ledger_service_client();
+
+    let read_mask = FieldMask::from_paths(EPOCH_CLOSE_PROOF_PATHS);
+
+    let epoch = ledger_client
+        .get_epoch(GetEpochRequest::default().with_read_mask(read_mask))
+        .await
+        .unwrap()
+        .into_inner()
+        .epoch
+        .unwrap();
+
+    assert!(
+        epoch.epoch_close_proof.is_none(),
+        "epoch_close_proof must be absent (not an error) for the current, still-open epoch"
+    );
+}
+
+#[sim_test]
+async fn get_epoch_close_proof_present_for_closed_epoch() {
+    // Long epoch duration so the epoch only advances when forced.
+    let (test_cluster, client) = setup_grpc_test_with_builder(
+        |builder| builder.with_epoch_duration_ms(600_000),
+        None,
+        None,
+    )
+    .await;
+    test_cluster.force_new_epoch().await;
+
+    let mut ledger_client = client.ledger_service_client();
+
+    let mut full_paths = vec!["last_checkpoint"];
+    full_paths.extend(EPOCH_CLOSE_PROOF_PATHS);
+    let full_mask = FieldMask::from_paths(full_paths.clone());
+
+    // epoch_info indexing can lag slightly behind the reconfiguration signal
+    // that `force_new_epoch` waits on, so poll briefly instead of asserting
+    // on the first response.
+    let epoch_0 = loop {
+        let epoch = ledger_client
+            .get_epoch(
+                GetEpochRequest::default()
+                    .with_epoch(0)
+                    .with_read_mask(full_mask.clone()),
+            )
+            .await
+            .unwrap()
+            .into_inner()
+            .epoch
+            .unwrap();
+        if epoch.epoch_close_proof.is_some() {
+            break epoch;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    };
+
+    assert_field_presence(
+        &epoch_0,
+        &full_paths,
+        &[],
+        "closed epoch, full proof requested",
+    );
+
+    let proof = epoch_0.epoch_close_proof.clone().unwrap();
+    let checkpoint = proof.checkpoint.unwrap();
+    assert_eq!(
+        checkpoint.sequence_number, epoch_0.last_checkpoint,
+        "the closing checkpoint's sequence number must match the epoch's last_checkpoint"
+    );
+    assert_eq!(
+        proof.bcs_next_epoch_system_state_objects.len(),
+        2,
+        "the system-state wrapper object and its inner state object must both be present"
+    );
+
+    // Narrowing the mask to only `epoch_close_proof.checkpoint` must leave
+    // the other three sub-fields absent — verifies independent subtree
+    // gating (would catch a bug where all four are fetched unconditionally
+    // once the parent subtree exists at all).
+    let narrow_mask = FieldMask::from_paths(["epoch_close_proof.checkpoint"]);
+    let epoch_0_narrow = ledger_client
+        .get_epoch(
+            GetEpochRequest::default()
+                .with_epoch(0)
+                .with_read_mask(narrow_mask),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .epoch
+        .unwrap();
+
+    assert_field_presence(
+        &epoch_0_narrow,
+        &["epoch_close_proof.checkpoint"],
+        &[],
+        "closed epoch, only epoch_close_proof.checkpoint requested",
+    );
 }

--- a/crates/iota-e2e-tests/tests/grpc/v1/mod.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/mod.rs
@@ -15,7 +15,7 @@ use iota_grpc_types::v1::{
         argument::{Input, Result},
     },
     dynamic_field::DynamicField,
-    epoch::{Epoch, ProtocolConfig},
+    epoch::{Epoch, EpochCloseProof, ProtocolConfig},
     event::Event,
     ledger_service::GetServiceInfoResponse,
     move_package_service::PackageVersion,
@@ -134,6 +134,13 @@ impl_field_presence_checker!(Epoch {
     end,
     reference_gas_price,
     protocol_config: ProtocolConfig,
+    epoch_close_proof: EpochCloseProof,
+});
+impl_field_presence_checker!(EpochCloseProof {
+    checkpoint: Checkpoint,
+    end_of_epoch_transaction_effects: TransactionEffects,
+    end_of_epoch_transaction_events: TransactionEvents,
+    bcs_next_epoch_system_state_objects: [],
 });
 
 impl_field_presence_checker!(DynamicField {

--- a/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_epoch.rs
@@ -10,7 +10,7 @@ use iota_grpc_types::{
     read_masks::GET_EPOCH_READ_MASK,
     v1::{
         bcs::BcsData,
-        epoch::{Epoch, ProtocolConfig},
+        epoch::{Epoch, EpochCloseProof, ProtocolConfig},
         ledger_service::{GetEpochRequest, GetEpochResponse},
     },
 };
@@ -46,6 +46,7 @@ impl Merge<&EpochReadSource> for Epoch {
             || mask.contains(Self::END_FIELD.name)
             || mask.contains(Self::REFERENCE_GAS_PRICE_FIELD.name)
             || mask.subtree(Self::PROTOCOL_CONFIG_FIELD.name).is_some()
+            || mask.subtree(Self::EPOCH_CLOSE_PROOF_FIELD.name).is_some()
             || (mask.contains(Self::BCS_SYSTEM_STATE_FIELD.name)
                 && source.epoch != source.current_epoch);
 
@@ -91,6 +92,17 @@ impl Merge<&EpochReadSource> for Epoch {
                 )
                 .ok_or_else(|| ProtocolVersionNotFoundError::new(protocol_version))?;
                 self.protocol_config = Some(ProtocolConfig::merge_from(&iota_config, &submask)?);
+            }
+
+            // `epoch_close_proof` is `None` until this epoch's boundary is
+            // indexed (including for the still-open current epoch) — absence
+            // is not an error, the field is simply omitted from the response.
+            if let Some(submask) = mask.subtree(Self::EPOCH_CLOSE_PROOF_FIELD.name) {
+                self.epoch_close_proof = epoch_info
+                    .epoch_close_proof
+                    .as_ref()
+                    .map(|entry| EpochCloseProof::merge_from(entry, &submask))
+                    .transpose()?;
             }
         }
 
@@ -165,6 +177,20 @@ impl Merge<&EpochReadSource> for Epoch {
 ///   - `protocol_config.attributes` - the individual protocol attributes during
 ///     the epoch (use `protocol_config.attributes.<key>` to filter specific
 ///     attributes)
+///
+/// ## Epoch Close Proof Fields
+/// - `epoch_close_proof` - proof of how this epoch closed; absent (not an
+///   error) until the epoch closes.
+///   - `epoch_close_proof.checkpoint` - the certified checkpoint that closed
+///     the epoch (see `get_checkpoint`'s doc comment for the full nested list
+///     of `checkpoint.*` sub-paths)
+///   - `epoch_close_proof.end_of_epoch_transaction_effects` - effects of the
+///     epoch-change transaction
+///   - `epoch_close_proof.end_of_epoch_transaction_events` - events emitted by
+///     the epoch-change transaction (may be empty on safe-mode boundaries)
+///   - `epoch_close_proof.bcs_next_epoch_system_state_objects` - raw BCS of the
+///     system-state wrapper (`0x5`) and inner state objects written by this
+///     epoch boundary, byte-for-byte as stored
 #[tracing::instrument(skip(service))]
 pub fn get_epoch(
     service: &LedgerGrpcService,

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -7,7 +7,7 @@ use iota_grpc_types::{
     v1::{
         bcs::BcsData,
         checkpoint::{Checkpoint, CheckpointContents, CheckpointSummary},
-        epoch::{ProtocolAttributes, ProtocolConfig, ProtocolFeatureFlags},
+        epoch::{EpochCloseProof, ProtocolAttributes, ProtocolConfig, ProtocolFeatureFlags},
         event::{Event, Events},
         object::{Object, Objects},
         signatures::{UserSignature, UserSignatures},
@@ -755,6 +755,66 @@ impl Merge<&Transaction> for Transaction {
 
         if mask.contains(Self::BCS_FIELD.name) {
             self.bcs = bcs.clone();
+        }
+
+        Ok(())
+    }
+}
+
+// EpochCloseProof implementation
+impl Merge<&iota_types::storage::EpochInfoV1Entry> for EpochCloseProof {
+    type Error = RpcError;
+
+    fn merge(
+        &mut self,
+        source: &iota_types::storage::EpochInfoV1Entry,
+        mask: &FieldMaskTree,
+    ) -> Result<(), Self::Error> {
+        if let Some(submask) = mask.subtree(Self::CHECKPOINT_FIELD.name) {
+            let summary = &source.last_checkpoint_summary;
+            let sdk_signature =
+                iota_sdk_types::ValidatorAggregatedSignature::from(summary.auth_sig().clone());
+
+            let mut checkpoint_proto =
+                Checkpoint::default().with_sequence_number(summary.data().sequence_number());
+
+            Merge::merge(&mut checkpoint_proto, summary.data(), &submask)
+                .map_err(|e| e.with_context("failed to merge checkpoint summary"))?;
+            Merge::merge(
+                &mut checkpoint_proto,
+                source.last_checkpoint_contents.clone(),
+                &submask,
+            )
+            .map_err(|e| e.with_context("failed to merge checkpoint contents"))?;
+            Merge::merge(&mut checkpoint_proto, sdk_signature, &submask)
+                .map_err(|e| e.with_context("failed to merge checkpoint signature"))?;
+
+            self.checkpoint = Some(checkpoint_proto);
+        }
+
+        if let Some(submask) = mask.subtree(Self::END_OF_EPOCH_TRANSACTION_EFFECTS_FIELD.name) {
+            self.end_of_epoch_transaction_effects = Some(TransactionEffects::merge_from(
+                &source.end_of_epoch_tx_effects,
+                &submask,
+            )?);
+        }
+
+        if let Some(submask) = mask.subtree(Self::END_OF_EPOCH_TRANSACTION_EVENTS_FIELD.name) {
+            self.end_of_epoch_transaction_events = Some(TransactionEvents::merge_from(
+                &source.end_of_epoch_tx_events,
+                &submask,
+            )?);
+        }
+
+        if mask.contains(Self::BCS_NEXT_EPOCH_SYSTEM_STATE_OBJECTS_FIELD.name) {
+            // Raw bytes as originally stored, not re-serialized — unlike the
+            // generic `Object` conversion, this preserves the exact bytes a
+            // caller's `ObjectDigest`s commit to.
+            self.bcs_next_epoch_system_state_objects = source
+                .next_epoch_start_system_state_objects
+                .iter()
+                .map(|raw_bytes| BcsData::from(raw_bytes.clone()))
+                .collect();
         }
 
         Ok(())

--- a/crates/iota-grpc-server/src/merge.rs
+++ b/crates/iota-grpc-server/src/merge.rs
@@ -99,16 +99,16 @@ fn protocol_config_value_to_string(v: ProtocolConfigValue) -> String {
 }
 
 // Signature implementations
-impl Merge<iota_sdk_types::UserSignature> for UserSignature {
+impl Merge<&iota_sdk_types::UserSignature> for UserSignature {
     type Error = RpcError;
 
     fn merge(
         &mut self,
-        source: iota_sdk_types::UserSignature,
+        source: &iota_sdk_types::UserSignature,
         mask: &FieldMaskTree,
     ) -> Result<(), Self::Error> {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = Some(BcsData::serialize(&source)?);
+            self.bcs = Some(BcsData::serialize(source)?);
         }
 
         Ok(())
@@ -129,12 +129,12 @@ impl Merge<&UserSignature> for UserSignature {
     }
 }
 
-impl Merge<iota_types::transaction::Transaction> for UserSignatures {
+impl Merge<&iota_types::transaction::Transaction> for UserSignatures {
     type Error = RpcError;
 
     fn merge(
         &mut self,
-        source: iota_types::transaction::Transaction,
+        source: &iota_types::transaction::Transaction,
         mask: &FieldMaskTree,
     ) -> Result<(), Self::Error> {
         // Get signatures directly from transaction without converting the whole
@@ -143,7 +143,7 @@ impl Merge<iota_types::transaction::Transaction> for UserSignatures {
 
         self.signatures = tx_signatures
             .iter()
-            .map(|sig| UserSignature::merge_from(sig.clone(), mask))
+            .map(|sig| UserSignature::merge_from(sig, mask))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(())
@@ -162,7 +162,7 @@ impl Merge<&iota_sdk_types::SignedTransaction> for UserSignatures {
         self.signatures = source
             .signatures
             .iter()
-            .map(|sig| UserSignature::merge_from(sig.clone(), mask))
+            .map(|sig| UserSignature::merge_from(sig, mask))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(())
@@ -368,12 +368,12 @@ impl Merge<&Objects> for Objects {
 }
 
 // Checkpoint implementations
-impl Merge<iota_sdk_types::CheckpointSummary> for CheckpointSummary {
+impl Merge<&iota_sdk_types::CheckpointSummary> for CheckpointSummary {
     type Error = RpcError;
 
     fn merge(
         &mut self,
-        source: iota_sdk_types::CheckpointSummary,
+        source: &iota_sdk_types::CheckpointSummary,
         mask: &FieldMaskTree,
     ) -> Result<(), Self::Error> {
         if mask.contains(Self::BCS_FIELD.name) {
@@ -412,18 +412,18 @@ impl Merge<&CheckpointSummary> for CheckpointSummary {
     }
 }
 
-impl Merge<iota_sdk_types::CheckpointContents> for CheckpointContents {
+impl Merge<&iota_sdk_types::CheckpointContents> for CheckpointContents {
     type Error = RpcError;
 
     fn merge(
         &mut self,
-        source: iota_sdk_types::CheckpointContents,
+        source: &iota_sdk_types::CheckpointContents,
         mask: &FieldMaskTree,
     ) -> Result<(), Self::Error> {
         if mask.contains(Self::BCS_FIELD.name) {
             // CheckpointContents has a custom Serialize impl that embeds
             // a BCS enum discriminant byte, so no versioned wrapper needed.
-            self.bcs = Some(BcsData::serialize(&source)?);
+            self.bcs = Some(BcsData::serialize(source)?);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {
@@ -465,35 +465,36 @@ impl Merge<&iota_sdk_types::CheckpointSummary> for Checkpoint {
         mask: &FieldMaskTree,
     ) -> Result<(), Self::Error> {
         if let Some(submask) = mask.subtree(Self::SUMMARY_FIELD.name) {
-            self.summary = Some(CheckpointSummary::merge_from(source.clone(), &submask)?);
+            self.summary = Some(CheckpointSummary::merge_from(source, &submask)?);
         }
 
         Ok(())
     }
 }
 
-impl Merge<iota_sdk_types::ValidatorAggregatedSignature> for Checkpoint {
+impl Merge<&iota_types::crypto::AuthorityStrongQuorumSignInfo> for Checkpoint {
     type Error = RpcError;
 
     fn merge(
         &mut self,
-        source: iota_sdk_types::ValidatorAggregatedSignature,
+        source: &iota_types::crypto::AuthorityStrongQuorumSignInfo,
         mask: &FieldMaskTree,
     ) -> Result<(), Self::Error> {
         if mask.contains(Self::SIGNATURE_FIELD.name) {
-            self.signature = Some(source.into());
+            let signature = iota_sdk_types::ValidatorAggregatedSignature::from(source.clone());
+            self.signature = Some(signature.into());
         }
 
         Ok(())
     }
 }
 
-impl Merge<iota_sdk_types::CheckpointContents> for Checkpoint {
+impl Merge<&iota_sdk_types::CheckpointContents> for Checkpoint {
     type Error = RpcError;
 
     fn merge(
         &mut self,
-        source: iota_sdk_types::CheckpointContents,
+        source: &iota_sdk_types::CheckpointContents,
         mask: &FieldMaskTree,
     ) -> Result<(), Self::Error> {
         if let Some(submask) = mask.subtree(Self::CONTENTS_FIELD.name) {
@@ -543,18 +544,6 @@ impl Merge<&Checkpoint> for Checkpoint {
 }
 
 // Transaction implementations
-impl Merge<iota_types::effects::TransactionEffects> for TransactionEffects {
-    type Error = RpcError;
-
-    fn merge(
-        &mut self,
-        source: iota_types::effects::TransactionEffects,
-        mask: &FieldMaskTree,
-    ) -> Result<(), Self::Error> {
-        Merge::merge(self, &source, mask)
-    }
-}
-
 impl Merge<&iota_types::effects::TransactionEffects> for TransactionEffects {
     type Error = RpcError;
 
@@ -706,12 +695,12 @@ impl Merge<&ExecutedTransaction> for ExecutedTransaction {
     }
 }
 
-impl Merge<iota_types::transaction::Transaction> for Transaction {
+impl Merge<&iota_types::transaction::Transaction> for Transaction {
     type Error = RpcError;
 
     fn merge(
         &mut self,
-        source: iota_types::transaction::Transaction,
+        source: &iota_types::transaction::Transaction,
         mask: &FieldMaskTree,
     ) -> Result<(), Self::Error> {
         if !mask.contains(Self::DIGEST_FIELD.name) && !mask.contains(Self::BCS_FIELD.name) {
@@ -772,8 +761,6 @@ impl Merge<&iota_types::storage::EpochInfoV1Entry> for EpochCloseProof {
     ) -> Result<(), Self::Error> {
         if let Some(submask) = mask.subtree(Self::CHECKPOINT_FIELD.name) {
             let summary = &source.last_checkpoint_summary;
-            let sdk_signature =
-                iota_sdk_types::ValidatorAggregatedSignature::from(summary.auth_sig().clone());
 
             let mut checkpoint_proto =
                 Checkpoint::default().with_sequence_number(summary.data().sequence_number());
@@ -782,11 +769,11 @@ impl Merge<&iota_types::storage::EpochInfoV1Entry> for EpochCloseProof {
                 .map_err(|e| e.with_context("failed to merge checkpoint summary"))?;
             Merge::merge(
                 &mut checkpoint_proto,
-                source.last_checkpoint_contents.clone(),
+                &source.last_checkpoint_contents,
                 &submask,
             )
             .map_err(|e| e.with_context("failed to merge checkpoint contents"))?;
-            Merge::merge(&mut checkpoint_proto, sdk_signature, &submask)
+            Merge::merge(&mut checkpoint_proto, summary.auth_sig(), &submask)
                 .map_err(|e| e.with_context("failed to merge checkpoint signature"))?;
 
             self.checkpoint = Some(checkpoint_proto);

--- a/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/transaction.rs
@@ -219,7 +219,7 @@ impl Merge<&TransactionReadSource<'_>> for grpc_tx::TransactionEffects {
             return Ok(());
         };
 
-        Merge::merge(self, effects.clone(), mask)
+        Merge::merge(self, effects, mask)
     }
 }
 
@@ -279,7 +279,7 @@ impl Merge<&TransactionReadSource<'_>> for grpc_sig::UserSignatures {
         if let Some(signatures) = source.signatures.as_ref() {
             self.signatures = signatures
                 .iter()
-                .map(|sig| grpc_sig::UserSignature::merge_from(sig.clone(), mask))
+                .map(|sig| grpc_sig::UserSignature::merge_from(sig, mask))
                 .collect::<Result<Vec<_>, _>>()?;
         }
 

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -435,14 +435,12 @@ impl GrpcReader {
             let mut checkpoint_proto = grpc_checkpoint::Checkpoint::default()
                 .with_sequence_number(sequence_number);
 
-            let sdk_signature = iota_sdk_types::ValidatorAggregatedSignature::from(checkpoint_summary.auth_sig().clone());
-
             // Use Merge to populate based on mask
             Merge::merge(&mut checkpoint_proto, checkpoint_summary.data(), &checkpoint_mask)
                 .map_err(|e| e.with_context("failed to merge summary"))?;
-            Merge::merge(&mut checkpoint_proto, checkpoint_contents, &checkpoint_mask)
+            Merge::merge(&mut checkpoint_proto, &checkpoint_contents, &checkpoint_mask)
                 .map_err(|e| e.with_context("failed to merge contents"))?;
-            Merge::merge(&mut checkpoint_proto, sdk_signature, &checkpoint_mask)
+            Merge::merge(&mut checkpoint_proto, checkpoint_summary.auth_sig(), &checkpoint_mask)
                 .map_err(|e| e.with_context("failed to merge signature"))?;
 
             yield Ok(grpc_ledger_service::CheckpointData::default().with_checkpoint(checkpoint_proto));
@@ -1349,14 +1347,14 @@ impl Merge<CheckpointTransactionWithContext>
     ) -> Result<(), Self::Error> {
         if let Some(submask) = mask.subtree(Self::TRANSACTION_FIELD.name) {
             self.transaction = Some(iota_grpc_types::v1::transaction::Transaction::merge_from(
-                source.transaction.transaction.clone(),
+                &source.transaction.transaction,
                 &submask,
             )?);
         }
 
         if let Some(submask) = mask.subtree(Self::SIGNATURES_FIELD.name) {
             self.signatures = Some(iota_grpc_types::v1::signatures::UserSignatures::merge_from(
-                source.transaction.transaction.clone(),
+                &source.transaction.transaction,
                 &submask,
             )?);
         }
@@ -1364,7 +1362,7 @@ impl Merge<CheckpointTransactionWithContext>
         if let Some(submask) = mask.subtree(Self::EFFECTS_FIELD.name) {
             self.effects = Some(
                 iota_grpc_types::v1::transaction::TransactionEffects::merge_from(
-                    source.transaction.effects.clone(),
+                    &source.transaction.effects,
                     &submask,
                 )?,
             );


### PR DESCRIPTION
# Description of change

Adds an `epoch_close_proof` field to the `GetEpoch` gRPC response, exposing the certified closing checkpoint, the epoch-change transaction's effects/events, and the raw next-epoch system-state object bytes for a closed epoch.

- Gated behind the read mask, off by default (same pattern as `committee`/`bcs_system_state`); each sub-field (`checkpoint`, `end_of_epoch_transaction_effects`, `end_of_epoch_transaction_events`, `bcs_next_epoch_system_state_objects`) has independent read-mask subtree granularity.
- Absent (not an error) for the current, still-open epoch, or any epoch whose closing boundary hasn't been indexed yet.
- Bundled data is sourced from the node's `epoch_info` table, which is never pruned — unlike checkpoints/transactions/objects, so this remains available for arbitrarily old epochs even on a pruning node. This is the enabling change for a proof-of-inclusion client built on `iota-rust-sdk` types + gRPC only.
- Vendored SDK types (`iota-rust-sdk`) bumped to the commit adding the corresponding `Epoch`/`EpochCloseProof` proto types.

## Links to any relevant issues

N/A

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] gRPC: `GetEpoch` can now return `epoch_close_proof`, the certified proof of how an epoch closed, available even for old, pruned epochs.