### PR TITLE
fix(core): expose starfish-dashboard metrics at the default metric level

### DIFF
--- a/crates/iota-core/src/checkpoints/metrics.rs
+++ b/crates/iota-core/src/checkpoints/metrics.rs
@@ -72,7 +72,7 @@ impl CheckpointMetrics {
                 "transactions_included_in_checkpoint",
                 "Transactions included in a checkpoint",
                 registry;
-                MetricLevel::Info,
+                MetricLevel::Warn,
             )
             .unwrap(),
             checkpoint_roots_count: register_int_counter_with_registry!(
@@ -131,7 +131,8 @@ impl CheckpointMetrics {
                 "commits_per_checkpoint",
                 "Number of consensus commits coalesced into a single checkpoint",
                 vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             remote_checkpoint_forks: register_int_counter_with_registry!(
                 "remote_checkpoint_forks",

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -91,7 +91,8 @@ impl ConsensusAdapterMetrics {
                 "sequencing_certificate_attempt",
                 "Counts the number of certificates the validator attempts to sequence.",
                 &["tx_type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             sequencing_certificate_success: register_int_counter_vec_with_registry!(
@@ -112,7 +113,8 @@ impl ConsensusAdapterMetrics {
                 "sequencing_certificate_status",
                 "The status of the certificate sequencing as reported by consensus. The status can be either sequenced or garbage collected.",
                 &["tx_type", "status"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             sequencing_certificate_inflight: register_int_gauge_vec_with_registry!(
@@ -165,7 +167,8 @@ impl ConsensusAdapterMetrics {
                 "sequencing_certificate_processed",
                 "The number of certificates that have been processed either by consensus or checkpoint.",
                 &["source"],
-                registry
+                registry;
+                MetricLevel::Warn,
             )
             .unwrap(),
             sequencing_in_flight_semaphore_wait: register_int_gauge_with_registry!(


### PR DESCRIPTION
# Description of change

Several metrics queried by the starfish Grafana dashboard are not exposed under the default metric-group levels (`warn` per group), so their panels stay empty on nodes running the default config. Tag them `MetricLevel::Warn` so they are exported by default:

- `transactions_included_in_checkpoint` (was `info`)
- `commits_per_checkpoint` (was untagged, i.e. `debug`)
- `sequencing_certificate_attempt` / `sequencing_certificate_status` / `sequencing_certificate_processed` (were untagged)

The filter only gates exposure on the metrics endpoint; collection is unchanged.

## Links to any relevant issues

Fixes #12353

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

