### PR TITLE
fix(starfish): validate shard transaction author at bundle ingest

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -401,6 +401,17 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 return Err(e);
             }
 
+            if let Err(e) = check_shard_transaction_author(&shard, peer, &self.context) {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .bundles_with_invalid_parts
+                    .with_label_values(&[peer_hostname, "shard", e.name()])
+                    .inc();
+                info!("Invalid shard from {}: {}", peer, e);
+                return Err(e);
+            }
+
             if shard.round() >= block_round {
                 let e = ConsensusError::TooBigShardRoundInABundle {
                     shard_round: shard.round(),
@@ -669,6 +680,22 @@ pub(crate) fn check_shard_version(shard: &ShardWithProof) -> ConsensusResult<()>
         ShardWithProof::V2(_) => Ok(()),
         ShardWithProof::V1(_) => Err(ConsensusError::WrongShardVersion { actual: "V1" }),
     }
+}
+
+pub(crate) fn check_shard_transaction_author(
+    shard: &ShardWithProof,
+    peer: AuthorityIndex,
+    context: &Context,
+) -> ConsensusResult<()> {
+    let index = shard.author();
+    if !context.committee.is_valid_index(index) {
+        return Err(ConsensusError::InvalidAuthorityIndexRequested {
+            index,
+            max: context.committee.size(),
+            peer,
+        });
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -4155,5 +4182,46 @@ mod tests {
             TransactionsCommitment::default(),
         );
         check_shard_version(&shard_v2).unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_shard_transaction_author_rejects_invalid_author() {
+        use super::check_shard_transaction_author;
+        use crate::{
+            block_header::{ShardWithProof, ShardWithProofV2},
+            error::ConsensusError,
+            transaction_ref::TransactionRef,
+        };
+
+        let (context, _) = Context::new_for_test(4);
+        let peer = context.committee.to_authority_index(1).unwrap();
+        let invalid_author = AuthorityIndex::new_for_test(context.committee.size() as u8);
+        let shard = ShardWithProof::V2(ShardWithProofV2 {
+            shard: vec![],
+            proof: vec![],
+            transaction_ref: TransactionRef {
+                round: 1,
+                author: invalid_author,
+                transactions_commitment: TransactionsCommitment::default(),
+            },
+        });
+
+        let result = check_shard_transaction_author(&shard, peer, &context);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::InvalidAuthorityIndexRequested {
+                index,
+                max: 4,
+                peer: err_peer,
+            }) if index == invalid_author && err_peer == peer
+        ));
+
+        let valid_shard = ShardWithProof::new(
+            vec![],
+            vec![],
+            BlockRef::new(1, peer, BlockHeaderDigest::default()),
+            TransactionsCommitment::default(),
+        );
+        check_shard_transaction_author(&valid_shard, peer, &context).unwrap();
     }
 }


### PR DESCRIPTION
# Description of change

Range-check the peer-supplied `author` of every shard at bundle ingest (`extract_shards_from_bundle`), before the shard is forwarded to the shard reconstructor. The field arrives from the network unvalidated and is later used to index committee-sized structures, where an out-of-range value panics. This mirrors the validation already applied to peer-supplied authority indices on the other ingest paths (`quick_validation_*` helpers, block verifier).

## Links to any relevant issues

Fixes iotaledger/iota-private#473

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes