### PR TITLE
fix(indexer): make conversion of stored watermarks to prunable table fallible

### DIFF
--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -89,13 +89,13 @@ pub enum PrunableTable {
     ObjectsBackwardHistory,
 }
 
-impl From<&StoredWatermark> for PrunableTable {
-    fn from(watermark: &StoredWatermark) -> Self {
-        watermark
-            .entity
-            .as_str()
-            .parse()
-            .expect("stored watermarks should correspond to prunable tables")
+impl TryFrom<&StoredWatermark> for PrunableTable {
+    type Error = IndexerError;
+
+    fn try_from(watermark: &StoredWatermark) -> Result<Self, Self::Error> {
+        watermark.entity.as_str().parse().map_err(|_| {
+            IndexerError::Generic("watermark does not correspond to a prunable table".into())
+        })
     }
 }
 
@@ -366,7 +366,7 @@ impl<'a> TablePruner<'a> {
                         "pruning task for table {} cancelled during delay",
                         self.table.as_ref()
                     );
-                    IndexerError::Generic("Pruning task cancelled".to_string())
+                    IndexerError::Generic("pruning task cancelled".to_string())
                 })?;
         }
 

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -247,9 +247,9 @@ pub(crate) async fn populate_remaining_tables(
     let (stored_watermarks, _) = store.get_watermarks().await?;
     let lowest_unpruned_keys = stored_watermarks
         .iter()
-        .map(|watermark| {
-            let table = PrunableTable::from(watermark);
-            (table, table.pruning_strategy().range_end(watermark))
+        .filter_map(|watermark| {
+            let table = PrunableTable::try_from(watermark).ok()?;
+            Some((table, table.pruning_strategy().range_end(watermark)))
         })
         .collect::<Vec<_>>();
     tokio::try_join!(


### PR DESCRIPTION
# Description of change

After #12279, the restore of watermark lower-bounds for prunable tables would fail, as the operation expected that the `watermarks` table only contained prunable tables. This is no longer true.

This patch solves this issue by making the conversion fallible and filtering out non-prunable tables while updating the lower bounds.

## Links to any relevant issues

Part of #12061 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
