### PR TITLE
fix(docs): Fix Docusaurus build crash   

### DIFF
--- a/crates/iota-framework/tests/build-system-packages.rs
+++ b/crates/iota-framework/tests/build-system-packages.rs
@@ -301,7 +301,9 @@ fn relocate_docs(files: &[(String, String)], output: &mut BTreeMap<String, Strin
         // from mdx. MDX also strips leading whitespace inside `<code>` blocks
         // (it parses the content as a paragraph), which silently drops indentation
         // from Move implementations — encode leading spaces as `&nbsp;` so the
-        // browser still renders them as regular spaces.
+        // browser still renders them as regular spaces. Escape `*` as well: MDX
+        // parses the block content as markdown, so a pair of `*` (e.g. two `*x`
+        // dereferences) would be read as emphasis and mangle the code.
         let content = code_regex.replace_all(&content, |caps: &regex::Captures| {
             let match_content = caps.get(0).unwrap().as_str();
             let code_content = caps.get(1).unwrap().as_str();
@@ -310,6 +312,7 @@ fn relocate_docs(files: &[(String, String)], output: &mut BTreeMap<String, Strin
             }
             let escaped = code_content
                 .replace('{', "\\{")
+                .replace('*', "\\*")
                 .split('\n')
                 .map(|line| {
                     let stripped = line.trim_start_matches(' ');

--- a/docs/site/config/rehype-jargon-safe.js
+++ b/docs/site/config/rehype-jargon-safe.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+const jargonModule = require("rehype-jargon");
+
+// rehype-jargon@3.1.0 assumes every <em> node's first child is a text node and
+// calls `children[0].value.toLowerCase()` on it. Generated Move reference docs
+// can produce an <em> that wraps a JSX element instead of text — for example a
+// `(*x)` dereference that CommonMark reads as emphasis — whose first child has
+// no `value`, which throws and aborts the whole build. Prepending an empty text
+// node makes the term lookup miss safely instead of crashing.
+function guardEmphasisFirstChild(node) {
+  if (!node || typeof node !== "object") return;
+
+  if (node.tagName === "em") {
+    const first = node.children && node.children[0];
+    if (!first || typeof first.value !== "string") {
+      node.children = node.children || [];
+      node.children.unshift({ type: "text", value: "" });
+    }
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) guardEmphasisFirstChild(child);
+  }
+}
+
+module.exports = function rehypeJargonSafe(options) {
+  const rehypeJargon = jargonModule.default || jargonModule;
+  const transform = rehypeJargon(options);
+  return (tree, file) => {
+    guardEmphasisFirstChild(tree);
+    return transform(tree, file);
+  };
+};

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -453,7 +453,6 @@ const config = {
           ],
           rehypePlugins: [
             katex,
-            [require("rehype-jargon"), { jargon: jargonConfig }],
             [
               require("./config/rehype-jargon-safe.js"),
               { jargon: jargonConfig },

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -10,7 +10,7 @@ import codeImport from "remark-code-import";
 
 require("dotenv").config();
 
-const jargonConfig = require('./config/jargon.js');
+const jargonConfig = require("./config/jargon.js");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -20,7 +20,7 @@ const config = {
   favicon: "/icons/favicon.ico",
   url: "https://docs.iota.org",
   baseUrl: "/",
-  
+
   customFields: {
     amplitudeKey: process.env.AMPLITUDE_KEY,
   },
@@ -42,193 +42,204 @@ const config = {
   },
   plugins: [
     [
-      'docusaurus-plugin-llms',
+      "docusaurus-plugin-llms",
       {
-        docsDir: '../content',
+        docsDir: "../content",
         pathTransformation: {
-          ignorePaths: ['docs', '..', 'content']
+          ignorePaths: ["docs", "..", "content"],
         },
         // Ignore everything with an underscore which is docusaurus default behaviour
-        ignoreFiles: [ '**/_**' ],
+        ignoreFiles: ["**/_**"],
         // llms.txt is maintained by the llms-txt plugin at src/plugins/llms-txt
         generateLLMsTxt: false,
         customLLMFiles: [
           {
-            filename: 'llms-full-about.txt',
-            title: 'IOTA Documentation - About IOTA',
-            description: 'Complete About IOTA documentation covering architecture, tokenomics, and programs',
-            includePatterns: ['about-iota/**'],
+            filename: "llms-full-about.txt",
+            title: "IOTA Documentation - About IOTA",
+            description:
+              "Complete About IOTA documentation covering architecture, tokenomics, and programs",
+            includePatterns: ["about-iota/**"],
             fullContent: true,
           },
           {
-            filename: 'llms-full-operator.txt',
-            title: 'IOTA Documentation - Operators',
-            description: 'Complete operator documentation for running full nodes, validators, and infrastructure',
-            includePatterns: ['operator/**'],
+            filename: "llms-full-operator.txt",
+            title: "IOTA Documentation - Operators",
+            description:
+              "Complete operator documentation for running full nodes, validators, and infrastructure",
+            includePatterns: ["operator/**"],
             fullContent: true,
           },
           {
-            filename: 'llms-full-users.txt',
-            title: 'IOTA Documentation - Users',
-            description: 'Complete user documentation for wallets and IOTA applications',
-            includePatterns: ['users/**'],
+            filename: "llms-full-users.txt",
+            title: "IOTA Documentation - Users",
+            description:
+              "Complete user documentation for wallets and IOTA applications",
+            includePatterns: ["users/**"],
             fullContent: true,
           },
           {
-            filename: 'llms-full-workshops.txt',
-            title: 'IOTA Documentation - Workshops',
-            description: 'Workshop materials for hands-on learning with IOTA',
-            includePatterns: ['developer/workshops/**'],
+            filename: "llms-full-workshops.txt",
+            title: "IOTA Documentation - Workshops",
+            description: "Workshop materials for hands-on learning with IOTA",
+            includePatterns: ["developer/workshops/**"],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-getting-started.txt',
-            title: 'IOTA Developer Documentation - Getting Started',
-            description: 'Getting started guides including installation, environment setup, and first steps with IOTA development',
+            filename: "llms-full-developer-getting-started.txt",
+            title: "IOTA Developer Documentation - Getting Started",
+            description:
+              "Getting started guides including installation, environment setup, and first steps with IOTA development",
             includePatterns: [
-              'developer/developer.md',
-              'developer/network-overview.md',
-              'developer/getting-started/**',
+              "developer/developer.md",
+              "developer/network-overview.md",
+              "developer/getting-started/**",
             ],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-explanations.txt',
-            title: 'IOTA Developer Documentation - Explanations',
-            description: 'Conceptual explanations including cryptography, transaction authentication, and smart contract security',
+            filename: "llms-full-developer-explanations.txt",
+            title: "IOTA Developer Documentation - Explanations",
+            description:
+              "Conceptual explanations including cryptography, transaction authentication, and smart contract security",
+            includePatterns: ["developer/cryptography/**"],
+            fullContent: true,
+          },
+          {
+            filename: "llms-full-developer-how-to.txt",
+            title: "IOTA Developer Documentation - How To",
+            description:
+              "How-to guides for transactions, sponsored transactions, PTBs, and exchange integration",
             includePatterns: [
-              'developer/cryptography/**',
+              "developer/iota-101/transactions/**",
+              "developer/exchange-integration.md",
+              "developer/advanced/custom-indexer.md",
             ],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-how-to.txt',
-            title: 'IOTA Developer Documentation - How To',
-            description: 'How-to guides for transactions, sponsored transactions, PTBs, and exchange integration',
+            filename: "llms-full-developer-tutorials.txt",
+            title: "IOTA Developer Documentation - Tutorials",
+            description:
+              "Step-by-step tutorials for building applications on IOTA",
+            includePatterns: ["developer/tutorials/**"],
+            fullContent: true,
+          },
+          {
+            filename: "llms-full-developer-move.txt",
+            title: "IOTA Developer Documentation - Move",
+            description:
+              "Move language documentation including the object model, standards, patterns, framework references, and challenges",
             includePatterns: [
-              'developer/iota-101/transactions/**',
-              'developer/exchange-integration.md',
-              'developer/advanced/custom-indexer.md',
+              "developer/iota-101/objects/**",
+              "developer/iota-101/move-overview/**",
+              "developer/iota-101/create-coin/**",
+              "developer/iota-101/nft/**",
+              "developer/iota-101/using-events.md",
+              "developer/iota-101/access-time.md",
+              "developer/references/framework/**",
+              "developer/references/iota-move.md",
+              "developer/references/move/**",
+              "developer/standards/**",
+              "developer/advanced/introducing-move-2024.md",
+              "developer/advanced/onchain-randomness.md",
+              "developer/advanced/asset-tokenization.md",
+              "developer/iota-move-ctf/**",
+              "developer/evm-to-move/**",
             ],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-tutorials.txt',
-            title: 'IOTA Developer Documentation - Tutorials',
-            description: 'Step-by-step tutorials for building applications on IOTA',
+            filename: "llms-full-developer-sdks.txt",
+            title: "IOTA Developer Documentation - SDKs",
+            description:
+              "TypeScript and Rust SDK documentation for building applications on IOTA",
             includePatterns: [
-              'developer/tutorials/**',
+              "developer/ts-sdk/**",
+              "developer/references/rust-sdk.md",
             ],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-move.txt',
-            title: 'IOTA Developer Documentation - Move',
-            description: 'Move language documentation including the object model, standards, patterns, framework references, and challenges',
+            filename: "llms-full-developer-graphql.txt",
+            title: "IOTA Developer Documentation - GraphQL",
+            description:
+              "GraphQL API how-to guides and reference documentation",
             includePatterns: [
-              'developer/iota-101/objects/**',
-              'developer/iota-101/move-overview/**',
-              'developer/iota-101/create-coin/**',
-              'developer/iota-101/nft/**',
-              'developer/iota-101/using-events.md',
-              'developer/iota-101/access-time.md',
-              'developer/references/framework/**',
-              'developer/references/iota-move.md',
-              'developer/references/move/**',
-              'developer/standards/**',
-              'developer/advanced/introducing-move-2024.md',
-              'developer/advanced/onchain-randomness.md',
-              'developer/advanced/asset-tokenization.md',
-              'developer/iota-move-ctf/**',
-              'developer/evm-to-move/**',
+              "developer/getting-started/graphql-rpc.md",
+              "developer/graphql-rpc.md",
+              "developer/advanced/graphql-migration.md",
+              "developer/references/iota-graphql.md",
+              "developer/references/iota-api/iota-graphql/**",
             ],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-sdks.txt',
-            title: 'IOTA Developer Documentation - SDKs',
-            description: 'TypeScript and Rust SDK documentation for building applications on IOTA',
+            filename: "llms-full-developer-cli.txt",
+            title: "IOTA Developer Documentation - CLI",
+            description:
+              "Complete CLI reference for the IOTA command-line interface",
             includePatterns: [
-              'developer/ts-sdk/**',
-              'developer/references/rust-sdk.md',
+              "developer/references/cli.md",
+              "developer/references/cli/**",
             ],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-graphql.txt',
-            title: 'IOTA Developer Documentation - GraphQL',
-            description: 'GraphQL API how-to guides and reference documentation',
+            filename: "llms-full-developer-trust-framework.txt",
+            title: "IOTA Developer Documentation - IOTA Trust Framework",
+            description:
+              "IOTA Trust Framework documentation including Identity, Notarization, and Hierarchies",
             includePatterns: [
-              'developer/getting-started/graphql-rpc.md',
-              'developer/graphql-rpc.md',
-              'developer/advanced/graphql-migration.md',
-              'developer/references/iota-graphql.md',
-              'developer/references/iota-api/iota-graphql/**',
+              "developer/iota-trust-framework.md",
+              "developer/iota-identity/**",
+              "developer/iota-notarization/**",
+              "developer/iota-hierarchies/**",
             ],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-cli.txt',
-            title: 'IOTA Developer Documentation - CLI',
-            description: 'Complete CLI reference for the IOTA command-line interface',
+            filename: "llms-full-developer-stardust.txt",
+            title: "IOTA Developer Documentation - Migrating from Stardust",
+            description:
+              "Migration guides and documentation for transitioning from IOTA Stardust to the new IOTA network",
             includePatterns: [
-              'developer/references/cli.md',
-              'developer/references/cli/**',
+              "developer/stardust/**",
+              "developer/dev-cheat-sheet.md",
             ],
             fullContent: true,
           },
           {
-            filename: 'llms-full-developer-trust-framework.txt',
-            title: 'IOTA Developer Documentation - IOTA Trust Framework',
-            description: 'IOTA Trust Framework documentation including Identity, Notarization, and Hierarchies',
+            filename: "llms-full-developer-references.txt",
+            title: "IOTA Developer Documentation - References",
+            description:
+              "API references, execution architecture, research papers, glossary, and contribution guides",
             includePatterns: [
-              'developer/iota-trust-framework.md',
-              'developer/iota-identity/**',
-              'developer/iota-notarization/**',
-              'developer/iota-hierarchies/**',
-            ],
-            fullContent: true,
-          },
-          {
-            filename: 'llms-full-developer-stardust.txt',
-            title: 'IOTA Developer Documentation - Migrating from Stardust',
-            description: 'Migration guides and documentation for transitioning from IOTA Stardust to the new IOTA network',
-            includePatterns: [
-              'developer/stardust/**',
-              'developer/dev-cheat-sheet.md',
-            ],
-            fullContent: true,
-          },
-          {
-            filename: 'llms-full-developer-references.txt',
-            title: 'IOTA Developer Documentation - References',
-            description: 'API references, execution architecture, research papers, glossary, and contribution guides',
-            includePatterns: [
-              'developer/references/references.md',
-              'developer/references/iota-api/**',
-              'developer/references/execution-architecture/**',
-              'developer/references/research-papers.md',
-              'developer/references/iota-glossary.md',
-              'developer/references/contribute/**',
+              "developer/references/references.md",
+              "developer/references/iota-api/**",
+              "developer/references/execution-architecture/**",
+              "developer/references/research-papers.md",
+              "developer/references/iota-glossary.md",
+              "developer/references/contribute/**",
             ],
             fullContent: true,
           },
         ],
-      }
+      },
     ],
-    path.resolve(__dirname, './src/plugins/llms-txt/index.ts'),
+    path.resolve(__dirname, "./src/plugins/llms-txt/index.ts"),
     [
       "@graphql-markdown/docusaurus",
       /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
-        id:'mainnet',
-        schema: "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/mainnet/crates/iota-graphql-rpc/schema.graphql",
+        id: "mainnet",
+        schema:
+          "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/mainnet/crates/iota-graphql-rpc/schema.graphql",
         rootPath: "../content", // docs will be generated under rootPath/baseURL
         baseURL: "developer/references/iota-api/iota-graphql/reference/",
         loaders: {
           UrlLoader: {
             module: "@graphql-tools/url-loader",
-          }
+          },
         },
       },
     ],
@@ -236,14 +247,16 @@ const config = {
       "@graphql-markdown/docusaurus",
       /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
-        id:'testnet',
-        schema: "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/testnet/crates/iota-graphql-rpc/schema.graphql",
+        id: "testnet",
+        schema:
+          "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/testnet/crates/iota-graphql-rpc/schema.graphql",
         rootPath: "../content", // docs will be generated under rootPath/baseURL
-        baseURL: "developer/references/iota-api/iota-graphql/reference/Testnet/",
+        baseURL:
+          "developer/references/iota-api/iota-graphql/reference/Testnet/",
         loaders: {
           UrlLoader: {
             module: "@graphql-tools/url-loader",
-          }
+          },
         },
       },
     ],
@@ -251,14 +264,15 @@ const config = {
       "@graphql-markdown/docusaurus",
       /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
-        id:'devnet',
-        schema: "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/devnet/crates/iota-graphql-rpc/schema.graphql",
+        id: "devnet",
+        schema:
+          "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/devnet/crates/iota-graphql-rpc/schema.graphql",
         rootPath: "../content", // docs will be generated under rootPath/baseURL
         baseURL: "developer/references/iota-api/iota-graphql/reference/Devnet/",
         loaders: {
           UrlLoader: {
             module: "@graphql-tools/url-loader",
-          }
+          },
         },
       },
     ],
@@ -275,77 +289,77 @@ const config = {
     },
     path.resolve(__dirname, `./src/plugins/descriptions`),
     [
-      '@docusaurus/plugin-client-redirects',
+      "@docusaurus/plugin-client-redirects",
       {
         createRedirects(existingPath) {
           const redirects = [
             {
-              from: '/references/ts-sdk',
-              to: '/developer/ts-sdk/typescript',
+              from: "/references/ts-sdk",
+              to: "/developer/ts-sdk/typescript",
             },
             {
-              from: '/references/iota-identity',
-              to: '/developer/iota-identity/references',
+              from: "/references/iota-identity",
+              to: "/developer/iota-identity/references",
             },
             {
-              from: '/references',
-              to: '/developer/references',
+              from: "/references",
+              to: "/developer/references",
             },
             {
-              from: '/iota-evm',
-              to: '/developer/iota-evm',
+              from: "/iota-evm",
+              to: "/developer/iota-evm",
             },
             {
-              from: '/iota-identity',
-              to: '/developer/iota-identity',
+              from: "/iota-identity",
+              to: "/developer/iota-identity",
             },
             {
-              from: '/ts-sdk',
-              to: '/developer/ts-sdk/typescript',
+              from: "/ts-sdk",
+              to: "/developer/ts-sdk/typescript",
             },
             {
-              from: '/developer/ts-sdk',
-              to: '/developer/ts-sdk/typescript',
+              from: "/developer/ts-sdk",
+              to: "/developer/ts-sdk/typescript",
             },
             {
-              from: '/about-iota/wallets',
-              to: '/users/wallets',
+              from: "/about-iota/wallets",
+              to: "/users/wallets",
             },
             {
-              from: '/about-iota/iota-wallet',
-              to: '/users/iota-wallet',
+              from: "/about-iota/iota-wallet",
+              to: "/users/iota-wallet",
             },
             {
-              from: '/about-iota/wallet-dashboard',
-              to: '/users/iota-wallet-dashboard',
+              from: "/about-iota/wallet-dashboard",
+              to: "/users/iota-wallet-dashboard",
             },
             {
-              from: '/about-iota/iota-wallet/how-to/integrate-ledger',
-              to: '/users/iota-wallet/how-to/import/ledger',
+              from: "/about-iota/iota-wallet/how-to/integrate-ledger",
+              to: "/users/iota-wallet/how-to/import/ledger",
             },
             {
-              from: '/developer/iota-notarization/getting-started',
-              to: '/developer/iota-notarization/single-notarization/getting-started',
+              from: "/developer/iota-notarization/getting-started",
+              to: "/developer/iota-notarization/single-notarization/getting-started",
             },
             {
-              from: '/developer/iota-notarization/explanations',
-              to: '/developer/iota-notarization/single-notarization/explanations',
+              from: "/developer/iota-notarization/explanations",
+              to: "/developer/iota-notarization/single-notarization/explanations",
             },
             {
-              from: '/developer/iota-notarization/how-tos',
-              to: '/developer/iota-notarization/single-notarization/how-tos',
+              from: "/developer/iota-notarization/how-tos",
+              to: "/developer/iota-notarization/single-notarization/how-tos",
             },
             {
-              from: '/developer/iota-notarization/references',
-              to: '/developer/iota-notarization/single-notarization/references',
+              from: "/developer/iota-notarization/references",
+              to: "/developer/iota-notarization/single-notarization/references",
             },
             {
-              from: '/developer/iota-notarization/how-tos/real-world',
-              to: '/developer/iota-notarization/single-notarization/real-world-examples',
+              from: "/developer/iota-notarization/how-tos/real-world",
+              to: "/developer/iota-notarization/single-notarization/real-world-examples",
             },
             {
-              from: '/operator/extensions/indexer-functions',
-              to: '/operator/extended-data-services/iota-indexer',
+              from: "/operator/extensions/indexer-functions",
+              to: "/operator/extended-data-services/iota-indexer",
             },
           ];
           let paths = [];
@@ -358,29 +372,28 @@ const config = {
         },
       },
     ],
-    'plugin-image-zoom',
+    "plugin-image-zoom",
     [
-      'docusaurus-plugin-openapi-docs',
+      "docusaurus-plugin-openapi-docs",
       {
-        id: 'openapi',
-        docsPluginId: 'classic',
+        id: "openapi",
+        docsPluginId: "classic",
         config: {
           coreApiV2: {
             specPath:
-              'https://raw.githubusercontent.com/iotaledger/wasp/refs/heads/develop/clients/apiclient/api/openapi.yaml',
-            outputDir: 
-              '../content/developer/iota-evm/references/openapi',
+              "https://raw.githubusercontent.com/iotaledger/wasp/refs/heads/develop/clients/apiclient/api/openapi.yaml",
+            outputDir: "../content/developer/iota-evm/references/openapi",
             sidebarOptions: {
-              groupPathsBy: 'tag',
-            }
-          }
-        }
-      }
+              groupPathsBy: "tag",
+            },
+          },
+        },
+      },
     ],
     [
-      '@docusaurus/plugin-google-gtag',
+      "@docusaurus/plugin-google-gtag",
       {
-        trackingID: 'G-SEE2W8WK21',
+        trackingID: "G-SEE2W8WK21",
         anonymizeIP: true,
       },
     ],
@@ -404,7 +417,10 @@ const config = {
             return defaultSidebarItemsGenerator({
               ...args,
               isCategoryIndex(doc) {
-                if(doc.fileName === 'index' && doc.directories.includes('ts-sdk'))
+                if (
+                  doc.fileName === "index" &&
+                  doc.directories.includes("ts-sdk")
+                )
                   return true;
                 // No doc will be automatically picked as category index
                 return false;
@@ -414,7 +430,7 @@ const config = {
           // the double docs below is a fix for having the path set to ../content
           editUrl: "https://github.com/iotaledger/iota/tree/develop/docs/docs",
           onInlineTags: "throw",
-          
+
           /*disableVersioning: true,
           lastVersion: "current",
           versions: {
@@ -428,7 +444,7 @@ const config = {
             "1.0.0",
           ],*/
           remarkPlugins: [
-            [math,{singleDollarTextMath:false}],
+            [math, { singleDollarTextMath: false }],
             [
               require("@docusaurus/remark-plugin-npm2yarn"),
               { sync: true, converters: ["yarn", "pnpm"] },
@@ -437,7 +453,11 @@ const config = {
           ],
           rehypePlugins: [
             katex,
-            [require('rehype-jargon'), { jargon: jargonConfig}]
+            [require("rehype-jargon"), { jargon: jargonConfig }],
+            [
+              require("./config/rehype-jargon-safe.js"),
+              { jargon: jargonConfig },
+            ],
           ],
         },
         theme: {
@@ -467,18 +487,18 @@ const config = {
     },
   ],
   themes: [
-    '@docusaurus/theme-mermaid',
-    '@saucelabs/theme-github-codeblock', 
-    '@docusaurus/theme-live-codeblock',
-    'docusaurus-theme-openapi-docs',
+    "@docusaurus/theme-mermaid",
+    "@saucelabs/theme-github-codeblock",
+    "@docusaurus/theme-live-codeblock",
+    "docusaurus-theme-openapi-docs",
   ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       algolia: {
-        apiKey: '24b141ea7e65db2181463e44dbe564a5',
-        appId: '9PMBZGRP3B',
-        indexName: 'iota',
+        apiKey: "24b141ea7e65db2181463e44dbe564a5",
+        appId: "9PMBZGRP3B",
+        indexName: "iota",
       },
       image: "img/iota-doc-og.png",
       docs: {
@@ -511,32 +531,32 @@ const config = {
           {
             label: "About IOTA",
             to: "about-iota",
-            className: 'navbar-icon-about',
+            className: "navbar-icon-about",
           },
           {
             label: "Developers",
             to: "developer",
-            className: 'navbar-icon-developer',
+            className: "navbar-icon-developer",
           },
           {
             label: "Operators",
             to: "operator",
-            className: 'navbar-icon-operator',
+            className: "navbar-icon-operator",
           },
           {
             label: "Users",
             to: "users",
-            className: 'navbar-icon-users',
+            className: "navbar-icon-users",
           },
           {
             label: "Workshops",
             to: "developer/workshops",
-            className: 'navbar-icon-workshops',
-            position: 'right',
+            className: "navbar-icon-workshops",
+            position: "right",
           },
           {
-            type: 'custom-WalletConnectButton',
-            position: 'right',
+            type: "custom-WalletConnectButton",
+            position: "right",
           },
         ],
       },
@@ -550,14 +570,14 @@ const config = {
                     The documentation on this website is adapted from the <a href='https://docs.sui.io/'>SUI Documentation</a>, © 2024 by <a href='https://sui.io/'>SUI Foundation</a>, licensed under <a href="https://github.com/MystenLabs/sui/blob/main/docs/site/LICENSE">CC BY 4.0</a>.`,
       },
       socials: [
-        'https://www.youtube.com/c/iotafoundation',
-        'https://www.github.com/iotaledger/',
-        'https://discord.gg/iota-builders',
-        'https://discord.iota.org/',
-        'https://www.twitter.com/iota/',
-        'https://www.reddit.com/r/iota/',
-        'https://www.linkedin.com/company/iotafoundation/',
-        'https://www.instagram.com/iotafoundation/',
+        "https://www.youtube.com/c/iotafoundation",
+        "https://www.github.com/iotaledger/",
+        "https://discord.gg/iota-builders",
+        "https://discord.iota.org/",
+        "https://www.twitter.com/iota/",
+        "https://www.reddit.com/r/iota/",
+        "https://www.linkedin.com/company/iotafoundation/",
+        "https://www.instagram.com/iotafoundation/",
       ],
       prism: {
         theme: themes.vsLight,
@@ -565,13 +585,13 @@ const config = {
         additionalLanguages: ["rust", "typescript", "solidity", "move"],
       },
       imageZoom: {
-        selector: '.markdown img',
+        selector: ".markdown img",
         // Optional medium-zoom options
         // see: https://www.npmjs.com/package/medium-zoom#options
         options: {
           background: "var(--iota-imagezoom-options)",
         },
-      }
+      },
     }),
 };
 

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -10,7 +10,7 @@ import codeImport from "remark-code-import";
 
 require("dotenv").config();
 
-const jargonConfig = require("./config/jargon.js");
+const jargonConfig = require('./config/jargon.js');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -20,7 +20,7 @@ const config = {
   favicon: "/icons/favicon.ico",
   url: "https://docs.iota.org",
   baseUrl: "/",
-
+  
   customFields: {
     amplitudeKey: process.env.AMPLITUDE_KEY,
   },
@@ -42,204 +42,193 @@ const config = {
   },
   plugins: [
     [
-      "docusaurus-plugin-llms",
+      'docusaurus-plugin-llms',
       {
-        docsDir: "../content",
+        docsDir: '../content',
         pathTransformation: {
-          ignorePaths: ["docs", "..", "content"],
+          ignorePaths: ['docs', '..', 'content']
         },
         // Ignore everything with an underscore which is docusaurus default behaviour
-        ignoreFiles: ["**/_**"],
+        ignoreFiles: [ '**/_**' ],
         // llms.txt is maintained by the llms-txt plugin at src/plugins/llms-txt
         generateLLMsTxt: false,
         customLLMFiles: [
           {
-            filename: "llms-full-about.txt",
-            title: "IOTA Documentation - About IOTA",
-            description:
-              "Complete About IOTA documentation covering architecture, tokenomics, and programs",
-            includePatterns: ["about-iota/**"],
+            filename: 'llms-full-about.txt',
+            title: 'IOTA Documentation - About IOTA',
+            description: 'Complete About IOTA documentation covering architecture, tokenomics, and programs',
+            includePatterns: ['about-iota/**'],
             fullContent: true,
           },
           {
-            filename: "llms-full-operator.txt",
-            title: "IOTA Documentation - Operators",
-            description:
-              "Complete operator documentation for running full nodes, validators, and infrastructure",
-            includePatterns: ["operator/**"],
+            filename: 'llms-full-operator.txt',
+            title: 'IOTA Documentation - Operators',
+            description: 'Complete operator documentation for running full nodes, validators, and infrastructure',
+            includePatterns: ['operator/**'],
             fullContent: true,
           },
           {
-            filename: "llms-full-users.txt",
-            title: "IOTA Documentation - Users",
-            description:
-              "Complete user documentation for wallets and IOTA applications",
-            includePatterns: ["users/**"],
+            filename: 'llms-full-users.txt',
+            title: 'IOTA Documentation - Users',
+            description: 'Complete user documentation for wallets and IOTA applications',
+            includePatterns: ['users/**'],
             fullContent: true,
           },
           {
-            filename: "llms-full-workshops.txt",
-            title: "IOTA Documentation - Workshops",
-            description: "Workshop materials for hands-on learning with IOTA",
-            includePatterns: ["developer/workshops/**"],
+            filename: 'llms-full-workshops.txt',
+            title: 'IOTA Documentation - Workshops',
+            description: 'Workshop materials for hands-on learning with IOTA',
+            includePatterns: ['developer/workshops/**'],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-getting-started.txt",
-            title: "IOTA Developer Documentation - Getting Started",
-            description:
-              "Getting started guides including installation, environment setup, and first steps with IOTA development",
+            filename: 'llms-full-developer-getting-started.txt',
+            title: 'IOTA Developer Documentation - Getting Started',
+            description: 'Getting started guides including installation, environment setup, and first steps with IOTA development',
             includePatterns: [
-              "developer/developer.md",
-              "developer/network-overview.md",
-              "developer/getting-started/**",
+              'developer/developer.md',
+              'developer/network-overview.md',
+              'developer/getting-started/**',
             ],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-explanations.txt",
-            title: "IOTA Developer Documentation - Explanations",
-            description:
-              "Conceptual explanations including cryptography, transaction authentication, and smart contract security",
-            includePatterns: ["developer/cryptography/**"],
-            fullContent: true,
-          },
-          {
-            filename: "llms-full-developer-how-to.txt",
-            title: "IOTA Developer Documentation - How To",
-            description:
-              "How-to guides for transactions, sponsored transactions, PTBs, and exchange integration",
+            filename: 'llms-full-developer-explanations.txt',
+            title: 'IOTA Developer Documentation - Explanations',
+            description: 'Conceptual explanations including cryptography, transaction authentication, and smart contract security',
             includePatterns: [
-              "developer/iota-101/transactions/**",
-              "developer/exchange-integration.md",
-              "developer/advanced/custom-indexer.md",
+              'developer/cryptography/**',
             ],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-tutorials.txt",
-            title: "IOTA Developer Documentation - Tutorials",
-            description:
-              "Step-by-step tutorials for building applications on IOTA",
-            includePatterns: ["developer/tutorials/**"],
-            fullContent: true,
-          },
-          {
-            filename: "llms-full-developer-move.txt",
-            title: "IOTA Developer Documentation - Move",
-            description:
-              "Move language documentation including the object model, standards, patterns, framework references, and challenges",
+            filename: 'llms-full-developer-how-to.txt',
+            title: 'IOTA Developer Documentation - How To',
+            description: 'How-to guides for transactions, sponsored transactions, PTBs, and exchange integration',
             includePatterns: [
-              "developer/iota-101/objects/**",
-              "developer/iota-101/move-overview/**",
-              "developer/iota-101/create-coin/**",
-              "developer/iota-101/nft/**",
-              "developer/iota-101/using-events.md",
-              "developer/iota-101/access-time.md",
-              "developer/references/framework/**",
-              "developer/references/iota-move.md",
-              "developer/references/move/**",
-              "developer/standards/**",
-              "developer/advanced/introducing-move-2024.md",
-              "developer/advanced/onchain-randomness.md",
-              "developer/advanced/asset-tokenization.md",
-              "developer/iota-move-ctf/**",
-              "developer/evm-to-move/**",
+              'developer/iota-101/transactions/**',
+              'developer/exchange-integration.md',
+              'developer/advanced/custom-indexer.md',
             ],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-sdks.txt",
-            title: "IOTA Developer Documentation - SDKs",
-            description:
-              "TypeScript and Rust SDK documentation for building applications on IOTA",
+            filename: 'llms-full-developer-tutorials.txt',
+            title: 'IOTA Developer Documentation - Tutorials',
+            description: 'Step-by-step tutorials for building applications on IOTA',
             includePatterns: [
-              "developer/ts-sdk/**",
-              "developer/references/rust-sdk.md",
+              'developer/tutorials/**',
             ],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-graphql.txt",
-            title: "IOTA Developer Documentation - GraphQL",
-            description:
-              "GraphQL API how-to guides and reference documentation",
+            filename: 'llms-full-developer-move.txt',
+            title: 'IOTA Developer Documentation - Move',
+            description: 'Move language documentation including the object model, standards, patterns, framework references, and challenges',
             includePatterns: [
-              "developer/getting-started/graphql-rpc.md",
-              "developer/graphql-rpc.md",
-              "developer/advanced/graphql-migration.md",
-              "developer/references/iota-graphql.md",
-              "developer/references/iota-api/iota-graphql/**",
+              'developer/iota-101/objects/**',
+              'developer/iota-101/move-overview/**',
+              'developer/iota-101/create-coin/**',
+              'developer/iota-101/nft/**',
+              'developer/iota-101/using-events.md',
+              'developer/iota-101/access-time.md',
+              'developer/references/framework/**',
+              'developer/references/iota-move.md',
+              'developer/references/move/**',
+              'developer/standards/**',
+              'developer/advanced/introducing-move-2024.md',
+              'developer/advanced/onchain-randomness.md',
+              'developer/advanced/asset-tokenization.md',
+              'developer/iota-move-ctf/**',
+              'developer/evm-to-move/**',
             ],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-cli.txt",
-            title: "IOTA Developer Documentation - CLI",
-            description:
-              "Complete CLI reference for the IOTA command-line interface",
+            filename: 'llms-full-developer-sdks.txt',
+            title: 'IOTA Developer Documentation - SDKs',
+            description: 'TypeScript and Rust SDK documentation for building applications on IOTA',
             includePatterns: [
-              "developer/references/cli.md",
-              "developer/references/cli/**",
+              'developer/ts-sdk/**',
+              'developer/references/rust-sdk.md',
             ],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-trust-framework.txt",
-            title: "IOTA Developer Documentation - IOTA Trust Framework",
-            description:
-              "IOTA Trust Framework documentation including Identity, Notarization, and Hierarchies",
+            filename: 'llms-full-developer-graphql.txt',
+            title: 'IOTA Developer Documentation - GraphQL',
+            description: 'GraphQL API how-to guides and reference documentation',
             includePatterns: [
-              "developer/iota-trust-framework.md",
-              "developer/iota-identity/**",
-              "developer/iota-notarization/**",
-              "developer/iota-hierarchies/**",
+              'developer/getting-started/graphql-rpc.md',
+              'developer/graphql-rpc.md',
+              'developer/advanced/graphql-migration.md',
+              'developer/references/iota-graphql.md',
+              'developer/references/iota-api/iota-graphql/**',
             ],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-stardust.txt",
-            title: "IOTA Developer Documentation - Migrating from Stardust",
-            description:
-              "Migration guides and documentation for transitioning from IOTA Stardust to the new IOTA network",
+            filename: 'llms-full-developer-cli.txt',
+            title: 'IOTA Developer Documentation - CLI',
+            description: 'Complete CLI reference for the IOTA command-line interface',
             includePatterns: [
-              "developer/stardust/**",
-              "developer/dev-cheat-sheet.md",
+              'developer/references/cli.md',
+              'developer/references/cli/**',
             ],
             fullContent: true,
           },
           {
-            filename: "llms-full-developer-references.txt",
-            title: "IOTA Developer Documentation - References",
-            description:
-              "API references, execution architecture, research papers, glossary, and contribution guides",
+            filename: 'llms-full-developer-trust-framework.txt',
+            title: 'IOTA Developer Documentation - IOTA Trust Framework',
+            description: 'IOTA Trust Framework documentation including Identity, Notarization, and Hierarchies',
             includePatterns: [
-              "developer/references/references.md",
-              "developer/references/iota-api/**",
-              "developer/references/execution-architecture/**",
-              "developer/references/research-papers.md",
-              "developer/references/iota-glossary.md",
-              "developer/references/contribute/**",
+              'developer/iota-trust-framework.md',
+              'developer/iota-identity/**',
+              'developer/iota-notarization/**',
+              'developer/iota-hierarchies/**',
+            ],
+            fullContent: true,
+          },
+          {
+            filename: 'llms-full-developer-stardust.txt',
+            title: 'IOTA Developer Documentation - Migrating from Stardust',
+            description: 'Migration guides and documentation for transitioning from IOTA Stardust to the new IOTA network',
+            includePatterns: [
+              'developer/stardust/**',
+              'developer/dev-cheat-sheet.md',
+            ],
+            fullContent: true,
+          },
+          {
+            filename: 'llms-full-developer-references.txt',
+            title: 'IOTA Developer Documentation - References',
+            description: 'API references, execution architecture, research papers, glossary, and contribution guides',
+            includePatterns: [
+              'developer/references/references.md',
+              'developer/references/iota-api/**',
+              'developer/references/execution-architecture/**',
+              'developer/references/research-papers.md',
+              'developer/references/iota-glossary.md',
+              'developer/references/contribute/**',
             ],
             fullContent: true,
           },
         ],
-      },
+      }
     ],
-    path.resolve(__dirname, "./src/plugins/llms-txt/index.ts"),
+    path.resolve(__dirname, './src/plugins/llms-txt/index.ts'),
     [
       "@graphql-markdown/docusaurus",
       /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
-        id: "mainnet",
-        schema:
-          "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/mainnet/crates/iota-graphql-rpc/schema.graphql",
+        id:'mainnet',
+        schema: "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/mainnet/crates/iota-graphql-rpc/schema.graphql",
         rootPath: "../content", // docs will be generated under rootPath/baseURL
         baseURL: "developer/references/iota-api/iota-graphql/reference/",
         loaders: {
           UrlLoader: {
             module: "@graphql-tools/url-loader",
-          },
+          }
         },
       },
     ],
@@ -247,16 +236,14 @@ const config = {
       "@graphql-markdown/docusaurus",
       /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
-        id: "testnet",
-        schema:
-          "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/testnet/crates/iota-graphql-rpc/schema.graphql",
+        id:'testnet',
+        schema: "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/testnet/crates/iota-graphql-rpc/schema.graphql",
         rootPath: "../content", // docs will be generated under rootPath/baseURL
-        baseURL:
-          "developer/references/iota-api/iota-graphql/reference/Testnet/",
+        baseURL: "developer/references/iota-api/iota-graphql/reference/Testnet/",
         loaders: {
           UrlLoader: {
             module: "@graphql-tools/url-loader",
-          },
+          }
         },
       },
     ],
@@ -264,15 +251,14 @@ const config = {
       "@graphql-markdown/docusaurus",
       /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
-        id: "devnet",
-        schema:
-          "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/devnet/crates/iota-graphql-rpc/schema.graphql",
+        id:'devnet',
+        schema: "https://raw.githubusercontent.com/iotaledger/iota/refs/heads/devnet/crates/iota-graphql-rpc/schema.graphql",
         rootPath: "../content", // docs will be generated under rootPath/baseURL
         baseURL: "developer/references/iota-api/iota-graphql/reference/Devnet/",
         loaders: {
           UrlLoader: {
             module: "@graphql-tools/url-loader",
-          },
+          }
         },
       },
     ],
@@ -289,77 +275,77 @@ const config = {
     },
     path.resolve(__dirname, `./src/plugins/descriptions`),
     [
-      "@docusaurus/plugin-client-redirects",
+      '@docusaurus/plugin-client-redirects',
       {
         createRedirects(existingPath) {
           const redirects = [
             {
-              from: "/references/ts-sdk",
-              to: "/developer/ts-sdk/typescript",
+              from: '/references/ts-sdk',
+              to: '/developer/ts-sdk/typescript',
             },
             {
-              from: "/references/iota-identity",
-              to: "/developer/iota-identity/references",
+              from: '/references/iota-identity',
+              to: '/developer/iota-identity/references',
             },
             {
-              from: "/references",
-              to: "/developer/references",
+              from: '/references',
+              to: '/developer/references',
             },
             {
-              from: "/iota-evm",
-              to: "/developer/iota-evm",
+              from: '/iota-evm',
+              to: '/developer/iota-evm',
             },
             {
-              from: "/iota-identity",
-              to: "/developer/iota-identity",
+              from: '/iota-identity',
+              to: '/developer/iota-identity',
             },
             {
-              from: "/ts-sdk",
-              to: "/developer/ts-sdk/typescript",
+              from: '/ts-sdk',
+              to: '/developer/ts-sdk/typescript',
             },
             {
-              from: "/developer/ts-sdk",
-              to: "/developer/ts-sdk/typescript",
+              from: '/developer/ts-sdk',
+              to: '/developer/ts-sdk/typescript',
             },
             {
-              from: "/about-iota/wallets",
-              to: "/users/wallets",
+              from: '/about-iota/wallets',
+              to: '/users/wallets',
             },
             {
-              from: "/about-iota/iota-wallet",
-              to: "/users/iota-wallet",
+              from: '/about-iota/iota-wallet',
+              to: '/users/iota-wallet',
             },
             {
-              from: "/about-iota/wallet-dashboard",
-              to: "/users/iota-wallet-dashboard",
+              from: '/about-iota/wallet-dashboard',
+              to: '/users/iota-wallet-dashboard',
             },
             {
-              from: "/about-iota/iota-wallet/how-to/integrate-ledger",
-              to: "/users/iota-wallet/how-to/import/ledger",
+              from: '/about-iota/iota-wallet/how-to/integrate-ledger',
+              to: '/users/iota-wallet/how-to/import/ledger',
             },
             {
-              from: "/developer/iota-notarization/getting-started",
-              to: "/developer/iota-notarization/single-notarization/getting-started",
+              from: '/developer/iota-notarization/getting-started',
+              to: '/developer/iota-notarization/single-notarization/getting-started',
             },
             {
-              from: "/developer/iota-notarization/explanations",
-              to: "/developer/iota-notarization/single-notarization/explanations",
+              from: '/developer/iota-notarization/explanations',
+              to: '/developer/iota-notarization/single-notarization/explanations',
             },
             {
-              from: "/developer/iota-notarization/how-tos",
-              to: "/developer/iota-notarization/single-notarization/how-tos",
+              from: '/developer/iota-notarization/how-tos',
+              to: '/developer/iota-notarization/single-notarization/how-tos',
             },
             {
-              from: "/developer/iota-notarization/references",
-              to: "/developer/iota-notarization/single-notarization/references",
+              from: '/developer/iota-notarization/references',
+              to: '/developer/iota-notarization/single-notarization/references',
             },
             {
-              from: "/developer/iota-notarization/how-tos/real-world",
-              to: "/developer/iota-notarization/single-notarization/real-world-examples",
+              from: '/developer/iota-notarization/how-tos/real-world',
+              to: '/developer/iota-notarization/single-notarization/real-world-examples',
             },
             {
-              from: "/operator/extensions/indexer-functions",
-              to: "/operator/extended-data-services/iota-indexer",
+              from: '/operator/extensions/indexer-functions',
+              to: '/operator/extended-data-services/iota-indexer',
             },
           ];
           let paths = [];
@@ -372,28 +358,29 @@ const config = {
         },
       },
     ],
-    "plugin-image-zoom",
+    'plugin-image-zoom',
     [
-      "docusaurus-plugin-openapi-docs",
+      'docusaurus-plugin-openapi-docs',
       {
-        id: "openapi",
-        docsPluginId: "classic",
+        id: 'openapi',
+        docsPluginId: 'classic',
         config: {
           coreApiV2: {
             specPath:
-              "https://raw.githubusercontent.com/iotaledger/wasp/refs/heads/develop/clients/apiclient/api/openapi.yaml",
-            outputDir: "../content/developer/iota-evm/references/openapi",
+              'https://raw.githubusercontent.com/iotaledger/wasp/refs/heads/develop/clients/apiclient/api/openapi.yaml',
+            outputDir: 
+              '../content/developer/iota-evm/references/openapi',
             sidebarOptions: {
-              groupPathsBy: "tag",
-            },
-          },
-        },
-      },
+              groupPathsBy: 'tag',
+            }
+          }
+        }
+      }
     ],
     [
-      "@docusaurus/plugin-google-gtag",
+      '@docusaurus/plugin-google-gtag',
       {
-        trackingID: "G-SEE2W8WK21",
+        trackingID: 'G-SEE2W8WK21',
         anonymizeIP: true,
       },
     ],
@@ -417,10 +404,7 @@ const config = {
             return defaultSidebarItemsGenerator({
               ...args,
               isCategoryIndex(doc) {
-                if (
-                  doc.fileName === "index" &&
-                  doc.directories.includes("ts-sdk")
-                )
+                if(doc.fileName === 'index' && doc.directories.includes('ts-sdk'))
                   return true;
                 // No doc will be automatically picked as category index
                 return false;
@@ -430,7 +414,7 @@ const config = {
           // the double docs below is a fix for having the path set to ../content
           editUrl: "https://github.com/iotaledger/iota/tree/develop/docs/docs",
           onInlineTags: "throw",
-
+          
           /*disableVersioning: true,
           lastVersion: "current",
           versions: {
@@ -444,7 +428,7 @@ const config = {
             "1.0.0",
           ],*/
           remarkPlugins: [
-            [math, { singleDollarTextMath: false }],
+            [math,{singleDollarTextMath:false}],
             [
               require("@docusaurus/remark-plugin-npm2yarn"),
               { sync: true, converters: ["yarn", "pnpm"] },
@@ -453,10 +437,7 @@ const config = {
           ],
           rehypePlugins: [
             katex,
-            [
-              require("./config/rehype-jargon-safe.js"),
-              { jargon: jargonConfig },
-            ],
+            [require('./config/rehype-jargon-safe.js'), { jargon: jargonConfig}]
           ],
         },
         theme: {
@@ -486,18 +467,18 @@ const config = {
     },
   ],
   themes: [
-    "@docusaurus/theme-mermaid",
-    "@saucelabs/theme-github-codeblock",
-    "@docusaurus/theme-live-codeblock",
-    "docusaurus-theme-openapi-docs",
+    '@docusaurus/theme-mermaid',
+    '@saucelabs/theme-github-codeblock', 
+    '@docusaurus/theme-live-codeblock',
+    'docusaurus-theme-openapi-docs',
   ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       algolia: {
-        apiKey: "24b141ea7e65db2181463e44dbe564a5",
-        appId: "9PMBZGRP3B",
-        indexName: "iota",
+        apiKey: '24b141ea7e65db2181463e44dbe564a5',
+        appId: '9PMBZGRP3B',
+        indexName: 'iota',
       },
       image: "img/iota-doc-og.png",
       docs: {
@@ -530,32 +511,32 @@ const config = {
           {
             label: "About IOTA",
             to: "about-iota",
-            className: "navbar-icon-about",
+            className: 'navbar-icon-about',
           },
           {
             label: "Developers",
             to: "developer",
-            className: "navbar-icon-developer",
+            className: 'navbar-icon-developer',
           },
           {
             label: "Operators",
             to: "operator",
-            className: "navbar-icon-operator",
+            className: 'navbar-icon-operator',
           },
           {
             label: "Users",
             to: "users",
-            className: "navbar-icon-users",
+            className: 'navbar-icon-users',
           },
           {
             label: "Workshops",
             to: "developer/workshops",
-            className: "navbar-icon-workshops",
-            position: "right",
+            className: 'navbar-icon-workshops',
+            position: 'right',
           },
           {
-            type: "custom-WalletConnectButton",
-            position: "right",
+            type: 'custom-WalletConnectButton',
+            position: 'right',
           },
         ],
       },
@@ -569,14 +550,14 @@ const config = {
                     The documentation on this website is adapted from the <a href='https://docs.sui.io/'>SUI Documentation</a>, © 2024 by <a href='https://sui.io/'>SUI Foundation</a>, licensed under <a href="https://github.com/MystenLabs/sui/blob/main/docs/site/LICENSE">CC BY 4.0</a>.`,
       },
       socials: [
-        "https://www.youtube.com/c/iotafoundation",
-        "https://www.github.com/iotaledger/",
-        "https://discord.gg/iota-builders",
-        "https://discord.iota.org/",
-        "https://www.twitter.com/iota/",
-        "https://www.reddit.com/r/iota/",
-        "https://www.linkedin.com/company/iotafoundation/",
-        "https://www.instagram.com/iotafoundation/",
+        'https://www.youtube.com/c/iotafoundation',
+        'https://www.github.com/iotaledger/',
+        'https://discord.gg/iota-builders',
+        'https://discord.iota.org/',
+        'https://www.twitter.com/iota/',
+        'https://www.reddit.com/r/iota/',
+        'https://www.linkedin.com/company/iotafoundation/',
+        'https://www.instagram.com/iotafoundation/',
       ],
       prism: {
         theme: themes.vsLight,
@@ -584,13 +565,13 @@ const config = {
         additionalLanguages: ["rust", "typescript", "solidity", "move"],
       },
       imageZoom: {
-        selector: ".markdown img",
+        selector: '.markdown img',
         // Optional medium-zoom options
         // see: https://www.npmjs.com/package/medium-zoom#options
         options: {
           background: "var(--iota-imagezoom-options)",
         },
-      },
+      }
     }),
 };
 


### PR DESCRIPTION
# Description of change

## Problem
The Docusaurus build crashes during compilation of the reference documentation page for the `package_metadata` framework module.
The `try_get_modules_metadata_v1` function contains two dereference operators, where each `*` appears immediately after a `(`.

During the docs build, docgen renders the identifiers as links with the `<Link>` tag, so the `(*` triggering sequence becomes `(*<`. This sequence is parsed as MDX and it acts as both an opening and a closing emphasis delimiter, so the two `*` pair up: the text between them is rendered into an `<em>` whose first child is a `<Link>` element.

The build's `rehype-jargon` plugin assumes every `<em>`'s first child is plain text and calls `.toLowerCase()` on it. A `<Link>` element has no text value, so the call throws and aborts the whole build.

## Fix

- (Root cause): Escape `*` in the framework docgen so it can never be read as markdown emphasis.
- (Workaround): Make docusaurus aware of this pattern and add an empty text value inside the `<em>` block, so it won't fail during the build process

## Changes

- `crates/iota-framework/tests/build-system-packages.rs`: escape `*` alongside `{` when emitting code blocks in `relocate_docs`.
- `docs/site/config/rehype-jargon-safe.js` (new): wrap rehype-jargon so an `<em>` whose first child is not a text node can't crash the build.
- `docs/site/docusaurus.config.js`: use the safe wrapper.

## **Why both fixes are needed now**

**Framework reference docs are not generated per-PR: the Docusaurus build downloads them from a prebuilt S3 archive, which is only regenerated and republished on pushes to `devnet/testnet/mainnet`. The current devnet archive contains the unescaped .`mdx` that triggers the crash.**
**The parser fix only changes what the generator produces and it does not touch the S3 archive. Until a new release recompiles and republishes it, every PR that touches docs downloads the same broken archive and hits the same crash, regardless of the PR's content.**
**The parser fix therefore does not unblock CI on its own right now. The Docusaurus guard is what unblocks it, and it works independently of the archive. The guard must be used until the recompiled archive is released. It can be removed once the escaped docs are live on S3.**

**The workaround only makes the docs build, but it doesn't undo the emphasis. So for now the `*` are not shown in `PackageMetadata` reference until we ship a new release.**

## Links to any relevant issues

fixes #12355

## How the change has been tested

Locally reproduced and tested.

