### PR TITLE
fix(docs): fix wiki build crash on devnet framework docs

### DIFF
--- a/crates/iota-framework/tests/build-system-packages.rs
+++ b/crates/iota-framework/tests/build-system-packages.rs
@@ -297,8 +297,10 @@ fn relocate_docs(files: &[(String, String)], output: &mut BTreeMap<String, Strin
         // need to make sure that `to` path don't contain extensions in a later step.
         let content = link_to_regex.replace_all(&content, r#"<Link to="$1">$2</Link>"#);
 
-        // Escape `{` in multi-line <code> and add new lines as this is a requirement
-        // from mdx. MDX also strips leading whitespace inside `<code>` blocks
+        // Escape `{` and `*` in multi-line <code> and add new lines as this is
+        // a requirement from mdx. Unescaped `{` starts a JSX expression, and a
+        // pair of `*` (e.g. two dereferences) becomes markdown emphasis. MDX
+        // also strips leading whitespace inside `<code>` blocks
         // (it parses the content as a paragraph), which silently drops indentation
         // from Move implementations — encode leading spaces as `&nbsp;` so the
         // browser still renders them as regular spaces.
@@ -310,6 +312,7 @@ fn relocate_docs(files: &[(String, String)], output: &mut BTreeMap<String, Strin
             }
             let escaped = code_content
                 .replace('{', "\\{")
+                .replace('*', "\\*")
                 .split('\n')
                 .map(|line| {
                     let stripped = line.trim_start_matches(' ');
@@ -361,6 +364,25 @@ fn relocate_docs(files: &[(String, String)], output: &mut BTreeMap<String, Strin
             }).to_string()
         });
     }
+}
+
+#[test]
+fn relocate_docs_escapes_asterisks_in_code_blocks() {
+    // Two `*` dereferences in one code block pair up as markdown emphasis when
+    // MDX parses the block, which corrupts the rendered code and crashes
+    // rehype plugins that expect emphasis to contain plain text.
+    let input = "<pre><code>let a = f(*x);\nlet b = g(*y);\n</code></pre>\n";
+    let mut output = BTreeMap::new();
+    relocate_docs(&[("m.md".to_string(), input.to_string())], &mut output);
+    let content = &output["m.mdx"];
+    assert!(
+        !content.contains("(*"),
+        "unescaped `*` in code block: {content}"
+    );
+    assert!(
+        content.contains("f(\\*x)"),
+        "expected escaped `*`: {content}"
+    );
 }
 
 fn serialize_modules_to_file<'a>(

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
 			"minimatch@>=3.0.0": "^3.1.5",
 			"minimatch@>=5.0.0": "^5.1.9",
 			"minimatch@>=9.0.0": "^9.0.9"
+		},
+		"patchedDependencies": {
+			"rehype-jargon@3.1.0": "patches/rehype-jargon@3.1.0.patch"
 		}
 	},
 	"engines": {

--- a/patches/rehype-jargon@3.1.0.patch
+++ b/patches/rehype-jargon@3.1.0.patch
@@ -1,0 +1,11 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 2fc1734161128cc2d181abdb9844a01167471eff..f2ae0cf2d03a94273132444a37a70c307a999a81 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -4,5 +4,5 @@
+  * (c) 2023 Joost De Cock <joost@joost.at> (https://github.com/joostdecock)
+  * @license MIT
+  */
+-import{visit as s}from"unist-util-visit";import{fromHtml as o}from"hast-util-from-html";var i=(r,e)=>`<span class="jargon-term">${r}<span class="jargon-info">${e}</span></span>`,l=r=>{if(!r||!r.jargon)throw Error('Required "jargon" option is missing in remark-jargon configuration');r.transform||(r.transform=i);let e=a=>a.tagName==="em"&&Object.keys(r.jargon).indexOf(a.children[0].value.toLowerCase())!==-1,n=a=>{if(e(a)){let t=o(r.transform(a.children[0].value,r.jargon[a.children[0].value.toLowerCase()]),{fragment:!0});a.children=t.children}};return a=>{s(a,"element",n)}};export{l as default};
++import{visit as s}from"unist-util-visit";import{fromHtml as o}from"hast-util-from-html";var i=(r,e)=>`<span class="jargon-term">${r}<span class="jargon-info">${e}</span></span>`,l=r=>{if(!r||!r.jargon)throw Error('Required "jargon" option is missing in remark-jargon configuration');r.transform||(r.transform=i);let e=a=>a.tagName==="em"&&typeof a.children[0]?.value=="string"&&Object.keys(r.jargon).indexOf(a.children[0].value.toLowerCase())!==-1,n=a=>{if(e(a)){let t=o(r.transform(a.children[0].value,r.jargon[a.children[0].value.toLowerCase()]),{fragment:!0});a.children=t.children}};return a=>{s(a,"element",n)}};export{l as default};
+ //# sourceMappingURL=index.mjs.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,11 @@ overrides:
   minimatch@>=5.0.0: ^5.1.9
   minimatch@>=9.0.0: ^9.0.9
 
+patchedDependencies:
+  rehype-jargon@3.1.0:
+    hash: 76f84242734e853251e3778c659dd3d3635e8bbdaf7ffd056950e82b43c2abb2
+    path: patches/rehype-jargon@3.1.0.patch
+
 importers:
 
   .:
@@ -147,7 +152,7 @@ importers:
         version: 2.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rehype-jargon:
         specifier: ^3.1.0
-        version: 3.1.0
+        version: 3.1.0(patch_hash=76f84242734e853251e3778c659dd3d3635e8bbdaf7ffd056950e82b43c2abb2)
       rehype-katex:
         specifier: ^7.0.0
         version: 7.0.1
@@ -18048,7 +18053,7 @@ snapshots:
     dependencies:
       jsesc: 0.5.0
 
-  rehype-jargon@3.1.0:
+  rehype-jargon@3.1.0(patch_hash=76f84242734e853251e3778c659dd3d3635e8bbdaf7ffd056950e82b43c2abb2):
     dependencies:
       hast-util-from-html: 2.0.1
       unist-util-visit: 5.0.0


### PR DESCRIPTION
## Description

Fixes the nightly [Release Wiki](https://github.com/iotaledger/iota/actions/runs/29881175785/job/88802179848) failure: the wiki build crashes compiling `framework/devnet/iota/package_metadata.mdx` with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` in `rehype-jargon`.

**Cause:**

- `relocate_docs` (in `build-system-packages.rs`) escapes `{` in generated framework doc code blocks, but not `*`.
- 7912f3c983 (#11616) added `iota::package_metadata::try_get_modules_metadata_v1`, the first framework function with two `*` dereferences in one doc code block. MDX pairs the two `*` as markdown emphasis, wrapping a `<Link>` tag in `<em>`.
- b1781b7814 (merge of the `v1.28.0` release into `devnet`, 2026-07-20) shipped this to the `devnet` branch, regenerating the framework docs tarball on S3. The next nightly wiki build (2026-07-21) picked it up and has failed since.
- `rehype-jargon` calls `children[0].value.toLowerCase()` on every `em` element and crashes when the first child is an element instead of a text node.

**Fix (two layers):**

- Escape `*` in multi-line code blocks in `relocate_docs`, with a regression test — fixes future tarball generation and the emphasis corruption in rendered code.
- Patch `rehype-jargon` (via `pnpm.patchedDependencies`) to skip `em` elements whose first child is not a text node — jargon terms are always plain text, so nothing is lost. This makes the wiki build tolerate the already-published broken tarball, which only regenerates on the next push to `devnet`.

**Note:** the `build-system-packages.rs` fix must reach the `devnet`/`testnet`/`mainnet` branches (normal release flow) before their tarballs regenerate without the corruption; the plugin patch keeps the build green until then.
