### PR TITLE
chore: remove `SenderSignedData` re-export

### DIFF
--- a/crates/iota-analytics-indexer/src/handlers/mod.rs
+++ b/crates/iota-analytics-indexer/src/handlers/mod.rs
@@ -7,12 +7,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Result, bail};
 use iota_data_ingestion_core::Worker;
 use iota_package_resolver::{PackageStore, Resolver};
-use iota_sdk_types::{ObjectId, Owner, StructTag, TypeTag};
+use iota_sdk_types::{ObjectId, Owner, SenderSignedTransaction, StructTag, TypeTag};
 use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
     iota_sdk_types_conversions::struct_tag_core_to_sdk,
     object::{Object, bounded_visitor::BoundedVisitor},
-    transaction::{SenderSignedData, SenderSignedTransactionAPI, TransactionDataAPI},
+    transaction::{SenderSignedTransactionAPI, TransactionDataAPI},
 };
 use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout, MoveValue};
 
@@ -82,7 +82,7 @@ struct InputObjectTracker {
 }
 
 impl InputObjectTracker {
-    fn new(txn: &SenderSignedData) -> Self {
+    fn new(txn: &SenderSignedTransaction) -> Self {
         let shared: BTreeSet<ObjectId> = txn
             .shared_input_objects()
             .into_iter()

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1110,7 +1110,7 @@ impl AuthorityState {
                 .collect();
 
             // It is supposed that `MoveAuthenticator` availability is checked in
-            // `SenderSignedData::validity_check`.
+            // `SenderSignedTransaction::validity_check`.
 
             // Serialize the TransactionData for the auth context before decomposing.
             let tx_data_bytes =
@@ -1274,7 +1274,7 @@ impl AuthorityState {
     pub(crate) fn check_system_overload(
         &self,
         consensus_adapter: &Arc<ConsensusAdapter>,
-        tx_data: &SenderSignedData,
+        tx_data: &SenderSignedTransaction,
         do_authority_overload_check: bool,
         pcool_flow_enabled: bool,
     ) -> IotaResult {
@@ -1339,7 +1339,7 @@ impl AuthorityState {
     fn check_consensus_queue_graduated_limits(
         &self,
         consensus_adapter: &Arc<ConsensusAdapter>,
-        tx_data: &SenderSignedData,
+        tx_data: &SenderSignedTransaction,
     ) -> IotaResult {
         let num_inflight_txs = consensus_adapter.num_inflight_transactions() as usize;
 
@@ -1368,7 +1368,7 @@ impl AuthorityState {
         overload_monitor_accept_tx(shedding_pct, tx_data.digest())
     }
 
-    fn check_authority_overload(&self, tx_data: &SenderSignedData) -> IotaResult {
+    fn check_authority_overload(&self, tx_data: &SenderSignedTransaction) -> IotaResult {
         if !self.overload_info.is_overload.load(Ordering::Relaxed) {
             return Ok(());
         }
@@ -1927,7 +1927,7 @@ impl AuthorityState {
             // One or more `MoveAuthenticator` signatures present — authenticate each and
             // then execute the transaction.
             // It is supposed that `MoveAuthenticator` availability is checked in
-            // `SenderSignedData::validity_check`.
+            // `SenderSignedTransaction::validity_check`.
 
             debug_assert_eq!(
                 move_authenticators.len(),
@@ -4709,7 +4709,7 @@ impl AuthorityState {
         &self,
         transaction_digest: &TransactionDigest,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> IotaResult<Option<(SenderSignedData, TransactionStatus)>> {
+    ) -> IotaResult<Option<(SenderSignedTransaction, TransactionStatus)>> {
         // TODO: In the case of read path, we should not have to re-sign the effects.
         if let Some(effects) =
             self.get_signed_effects_and_maybe_resign(transaction_digest, epoch_store)?
@@ -6298,7 +6298,7 @@ impl ObjDumpFormat {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NodeStateDump {
     pub tx_digest: TransactionDigest,
-    pub sender_signed_data: SenderSignedData,
+    pub sender_signed_data: SenderSignedTransaction,
     pub executed_epoch: u64,
     pub reference_gas_price: u64,
     pub protocol_version: u64,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -47,8 +47,8 @@ use iota_metrics::{
 use iota_sdk_types::{
     Address, CheckpointContentsDigest, CheckpointDigest, Digest, EndOfEpochTransactionKind, Event,
     ExecutionStatus, GasPayment, ObjectDigest, ObjectId, ObjectReference, Owner, RandomnessRound,
-    StructTag, SystemPackage, TransactionDigest, TransactionEffectsDigest, TransactionExpiration,
-    TransactionKind, TypeTag, Version,
+    SenderSignedTransaction, StructTag, SystemPackage, TransactionDigest, TransactionEffectsDigest,
+    TransactionExpiration, TransactionKind, TypeTag, Version,
     crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
     gas::GasCostSummary,
 };

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -32,7 +32,8 @@ use iota_protocol_config::{
 };
 use iota_sdk_types::{
     Address, CancelledTransaction, CheckpointTimestamp, ObjectId, ObjectReference, RandomnessRound,
-    TransactionDigest, TransactionEffectsDigest, TransactionKind, Version, VersionAssignment,
+    SenderSignedTransaction, TransactionDigest, TransactionEffectsDigest, TransactionKind, Version,
+    VersionAssignment,
 };
 use iota_storage::mutex_table::{MutexGuard, MutexTable};
 use iota_types::{
@@ -63,9 +64,9 @@ use iota_types::{
     signature::UserSignature,
     storage::{BackingPackageStore, InputKey},
     transaction::{
-        CertifiedTransaction, InputObjectKind, SenderSignedData, SenderSignedTransactionAPI,
-        Transaction, TransactionDataAPI, TransactionKey, TxValidityCheckContext,
-        VerifiedCertificate, VerifiedSignedTransaction, VerifiedTransaction,
+        CertifiedTransaction, InputObjectKind, SenderSignedTransactionAPI, Transaction,
+        TransactionDataAPI, TransactionKey, TxValidityCheckContext, VerifiedCertificate,
+        VerifiedSignedTransaction, VerifiedTransaction,
     },
 };
 use itertools::izip;
@@ -784,7 +785,7 @@ pub struct AuthorityEpochTables {
     /// `transaction_lock`.
     #[default_options_override_fn = "signed_transactions_table_default_config"]
     signed_transactions:
-        DBMap<TransactionDigest, TrustedEnvelope<SenderSignedData, AuthoritySignInfo>>,
+        DBMap<TransactionDigest, TrustedEnvelope<SenderSignedTransaction, AuthoritySignInfo>>,
 
     /// Map from ObjectReference to transaction locking that object
     #[default_options_override_fn = "owned_object_locked_transactions_table_default_config"]

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -5,7 +5,8 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use iota_sdk_types::{
-    ObjectId, SharedObjectReference, TransactionDigest, Version, VersionAssignment,
+    ObjectId, SenderSignedTransaction, SharedObjectReference, TransactionDigest, Version,
+    VersionAssignment,
 };
 use iota_types::{
     effects::{TransactionEffects, TransactionEffectsAPI},
@@ -14,7 +15,7 @@ use iota_types::{
     storage::{
         ObjectKey, transaction_non_shared_input_object_keys, transaction_receiving_object_keys,
     },
-    transaction::{SenderSignedData, SenderSignedTransactionAPI, TransactionKey},
+    transaction::{SenderSignedTransactionAPI, TransactionKey},
 };
 use tracing::trace;
 
@@ -252,7 +253,7 @@ impl SharedObjVerManager {
 }
 
 fn get_or_init_versions<'a>(
-    transactions: impl Iterator<Item = &'a SenderSignedData>,
+    transactions: impl Iterator<Item = &'a SenderSignedTransaction>,
     epoch_store: &AuthorityPerEpochStore,
     cache_reader: &dyn ObjectCacheRead,
 ) -> IotaResult<HashMap<ObjectId, Version>> {
@@ -274,7 +275,9 @@ fn get_or_init_versions<'a>(
 mod tests {
     use std::collections::{BTreeMap, HashMap};
 
-    use iota_sdk_types::{Address, ObjectDigest, ObjectReference, RandomnessRound};
+    use iota_sdk_types::{
+        Address, ObjectDigest, ObjectReference, RandomnessRound, SenderSignedTransaction,
+    };
     use iota_test_transaction_builder::TestTransactionBuilder;
     use iota_types::{
         effects::TestEffectsBuilder,
@@ -283,7 +286,7 @@ mod tests {
         },
         object::Object,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::{CallArg, SenderSignedData, VerifiedTransaction},
+        transaction::{CallArg, VerifiedTransaction},
     };
 
     use super::*;
@@ -721,7 +724,7 @@ mod tests {
         )
         .programmable(builder.finish())
         .build();
-        let tx = SenderSignedData::new(tx_data, vec![]);
+        let tx = SenderSignedTransaction::new(tx_data, vec![]);
         VerifiedExecutableTransaction::new_unchecked(ExecutableTransaction::new_from_data_and_sig(
             tx,
             CertificateProof::new_system(0),

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -13,13 +13,15 @@ use arc_swap::ArcSwap;
 use iota_common::random_util::randomize_cache_capacity_in_tests;
 use iota_macros::{fail_point, fail_point_if};
 use iota_metrics::{monitored_mpsc, monitored_scope, spawn_monitored_task};
-use iota_sdk_types::{CancelledTransaction, ConsensusCommitDigest, TransactionDigest};
+use iota_sdk_types::{
+    CancelledTransaction, ConsensusCommitDigest, SenderSignedTransaction, TransactionDigest,
+};
 use iota_types::{
     base_types::AuthorityName,
     executable_transaction::{TrustedExecutableTransaction, VerifiedExecutableTransaction},
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind},
-    transaction::{SenderSignedData, SenderSignedTransactionAPI, VerifiedTransaction},
+    transaction::{SenderSignedTransactionAPI, VerifiedTransaction},
 };
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
@@ -800,7 +802,7 @@ impl SequencedConsensusTransaction {
     /// (`CertifiedTransaction` or `UserTransactionV1`) or system transaction
     /// that touches at least one shared object, and `None` otherwise (internal
     /// consensus messages, or a transaction with only owned objects).
-    pub fn as_shared_object_txn(&self) -> Option<&SenderSignedData> {
+    pub fn as_shared_object_txn(&self) -> Option<&SenderSignedTransaction> {
         match &self.transaction {
             SequencedConsensusTransactionKind::External(ext) => ext
                 .kind
@@ -914,7 +916,7 @@ mod tests {
     use arc_swap::ArcSwap;
     use futures::pin_mut;
     use iota_protocol_config::{Chain, ConsensusTransactionOrdering, ProtocolConfig};
-    use iota_sdk_types::{Address, ObjectId};
+    use iota_sdk_types::{Address, ObjectId, SenderSignedTransaction};
     use iota_types::{
         base_types::{AuthorityName, random_object_ref},
         committee::Committee,
@@ -927,8 +929,8 @@ mod tests {
             SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
         },
         transaction::{
-            CertifiedTransaction, SenderSignedData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
-            TransactionData, TransactionDataAPI,
+            CertifiedTransaction, TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData,
+            TransactionDataAPI,
         },
         utils::to_sender_signed_transaction,
     };
@@ -1335,7 +1337,7 @@ mod tests {
 
     fn user_txn(gas_price: u64) -> VerifiedSequencedConsensusTransaction {
         let (committee, keypairs) = Committee::new_simple_test_committee();
-        let data = SenderSignedData::new(
+        let data = SenderSignedTransaction::new(
             TransactionData::new_transfer(
                 Address::ZERO,
                 random_object_ref(),

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -16,9 +16,9 @@ use iota_sdk_types::{
     ConsensusDeterminedVersionAssignments, EndOfEpochTransactionKind, Event, ExecutionError,
     ExecutionStatus, GenesisObject, GenesisTransaction, Identifier, MoveLocation, MoveObjectType,
     ObjectData, ObjectDigest, ObjectId, ObjectReference, Owner, PackageUpgradeError,
-    ProgrammableTransaction, RandomnessStateUpdate, SharedObjectReference, SimpleSignature,
-    StructTag, TransactionDigest, TransactionEffectsDigest, TransactionExpiration, TransactionKind,
-    TypeArgumentError, TypeTag, UnchangedSharedKind,
+    ProgrammableTransaction, RandomnessStateUpdate, SenderSignedTransaction, SharedObjectReference,
+    SimpleSignature, StructTag, TransactionDigest, TransactionEffectsDigest, TransactionExpiration,
+    TransactionKind, TypeArgumentError, TypeTag, UnchangedSharedKind,
     crypto::{Intent, IntentMessage, PersonalMessage},
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
     validator::ValidatorCommitteeMember,
@@ -44,7 +44,7 @@ use iota_types::{
     object::{MoveObject, MoveObjectExt, ObjectInner},
     signature::UserSignature,
     storage::DeleteKind,
-    transaction::{CallArg, SenderSignedData, Transaction, TransactionData, TransactionDataAPI},
+    transaction::{CallArg, Transaction, TransactionData, TransactionDataAPI},
 };
 use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};
 use pretty_assertions::assert_str_eq;
@@ -551,7 +551,7 @@ fn get_registry() -> Result<Registry> {
         .trace_type::<ConsensusDeterminedVersionAssignments>(&samples)
         .unwrap();
 
-    let sender_data = SenderSignedData::new(
+    let sender_data = SenderSignedTransaction::new(
         TransactionData::new_with_gas_coins(
             TransactionKind::EndOfEpoch(vec![EndOfEpochTransactionKind::ChangeEpoch(
                 ChangeEpoch {

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -363,7 +363,7 @@ fn extract_owned_input_objects(
         });
     };
 
-    // Use SenderSignedData::input_objects() rather than
+    // Use SenderSignedTransaction::input_objects() rather than
     // TransactionData::input_objects() to also include any owned objects
     // that may come from MoveAuthenticator signatures in the future.
     let owned_objects = transaction_data

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -8,7 +8,9 @@ use either::Either;
 use fastcrypto::traits::{AggregateAuthenticator, ToFromBytes};
 use futures::pin_mut;
 use iota_metrics::monitored_scope;
-use iota_sdk_types::{CertificateDigest, SenderSignedDataDigest, crypto::Intent};
+use iota_sdk_types::{
+    CertificateDigest, SenderSignedDataDigest, SenderSignedTransaction, crypto::Intent,
+};
 use iota_types::{
     base_types::AuthorityName,
     committee::Committee,
@@ -19,7 +21,7 @@ use iota_types::{
     messages_consensus::{AuthorityCapabilitiesDigest, SignedAuthorityCapabilitiesV1},
     signature::VerifyParams,
     signature_verification::{VerifiedDigestCache, verify_sender_signed_data_message_signatures},
-    transaction::{CertifiedTransaction, SenderSignedData, VerifiedCertificate},
+    transaction::{CertifiedTransaction, VerifiedCertificate},
 };
 use itertools::{Itertools as _, izip};
 use parking_lot::{Mutex, MutexGuard};
@@ -323,7 +325,7 @@ impl SignatureVerifier {
     }
 
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?signed_tx.digest()))]
-    pub fn verify_tx(&self, signed_tx: &SenderSignedData) -> IotaResult {
+    pub fn verify_tx(&self, signed_tx: &SenderSignedTransaction) -> IotaResult {
         self.signed_data_cache.is_verified(
             signed_tx.full_message_digest(),
             || verify_sender_signed_data_message_signatures(signed_tx, &self.verify_params),

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -12,7 +12,9 @@ use std::{
 use iota_common::{fatal, random_util::randomize_cache_capacity_in_tests};
 use iota_config::node::AuthorityOverloadConfig;
 use iota_metrics::monitored_scope;
-use iota_sdk_types::{ObjectId, TransactionDigest, TransactionEffectsDigest, Version};
+use iota_sdk_types::{
+    ObjectId, SenderSignedTransaction, TransactionDigest, TransactionEffectsDigest, Version,
+};
 use iota_types::{
     committee::EpochId,
     error::{IotaError, IotaResult},
@@ -20,9 +22,7 @@ use iota_types::{
     fp_bail, fp_ensure,
     message_envelope::Message,
     storage::InputKey,
-    transaction::{
-        SenderSignedData, SenderSignedTransactionAPI, TransactionDataAPI, VerifiedCertificate,
-    },
+    transaction::{SenderSignedTransactionAPI, TransactionDataAPI, VerifiedCertificate},
 };
 use lru::LruCache;
 use parking_lot::RwLock;
@@ -875,7 +875,7 @@ impl TransactionManager {
     pub(crate) fn check_execution_overload(
         &self,
         overload_config: &AuthorityOverloadConfig,
-        tx_data: &SenderSignedData,
+        tx_data: &SenderSignedTransaction,
     ) -> IotaResult {
         // Too many transactions are pending execution.
         let inflight_queue_len = self.inflight_queue_len();

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -16,8 +16,8 @@ use iota_macros::sim_test;
 use iota_move_build::BuildConfig;
 use iota_protocol_config::Chain::Unknown;
 use iota_sdk_types::{
-    Address, ExecutionError, ExecutionStatus, Identifier, ObjectId, ObjectReference, StakeUnit,
-    TransactionDigest,
+    Address, ExecutionError, ExecutionStatus, Identifier, ObjectId, ObjectReference,
+    SenderSignedTransaction, StakeUnit, TransactionDigest,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 #[cfg(msim)]
@@ -46,7 +46,7 @@ use iota_types::{
     object::Object,
     supported_protocol_versions::SupportedProtocolVersions,
     transaction::{
-        CallArg, CertifiedTransaction, SenderSignedData, SignedTransaction,
+        CallArg, CertifiedTransaction, SignedTransaction,
         TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
         Transaction, TransactionData, TransactionDataAPI, VerifiedTransaction,
     },
@@ -216,7 +216,7 @@ where
     A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
     let mut votes = vec![];
-    let mut tx_data: Option<SenderSignedData> = None;
+    let mut tx_data: Option<SenderSignedTransaction> = None;
     for authority in authorities {
         let response = authority
             .handle_transaction_info_request(TransactionInfoRequest {

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -756,7 +756,7 @@ async fn test_handle_certificate_errors() {
         err,
         IotaError::UserInput {
             error: UserInputError::Unsupported(message)
-        } if message == "SenderSignedData must not contain system transaction"
+        } if message == "SenderSignedTransaction must not contain system transaction"
     );
 
     let mut invalid_sig_count_tx = transfer_transaction.clone();
@@ -1408,7 +1408,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
 #[test]
 fn sender_signed_data_serialized_intent() {
-    let txn = SenderSignedData::new(
+    let txn = SenderSignedTransaction::new(
         TransactionData::new_transfer(
             Address::ZERO,
             random_object_ref(),
@@ -1436,6 +1436,6 @@ fn sender_signed_data_serialized_intent() {
     // deser fails when intent is wrong
     let mut bytes = bytes;
     bytes[1] = IntentScope::TransactionEffects as u8;
-    let e = bcs::from_bytes::<SenderSignedData>(&bytes).unwrap_err();
+    let e = bcs::from_bytes::<SenderSignedTransaction>(&bytes).unwrap_err();
     assert!(e.to_string().contains("invalid intent"));
 }

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -1408,7 +1408,7 @@ async fn test_two_move_authenticators_rejected_with_disabled_move_auth_for_spons
             &err,
             IotaError::UserInput {
                 error: UserInputError::Unsupported(msg)
-            } if msg == "SenderSignedData with more than one MoveAuthenticator is not supported"
+            } if msg == "SenderSignedTransaction with more than one MoveAuthenticator is not supported"
         ),
         "Expected Unsupported error for >1 MoveAuthenticator, got: {err:?}"
     );
@@ -1488,7 +1488,7 @@ async fn test_sponsor_only_move_auth_rejected_with_disabled_move_auth_for_sponso
             &err,
             IotaError::UserInput {
                 error: UserInputError::Unsupported(msg)
-            } if msg == "SenderSignedData can have MoveAuthenticator only for the sender"
+            } if msg == "SenderSignedTransaction can have MoveAuthenticator only for the sender"
         ),
         "Expected Unsupported error for sponsor-only MoveAuthenticator, got: {err:?}"
     );

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -1180,8 +1180,8 @@ mod tests {
     use anyhow::*;
     use iota_json_rpc_types::{IotaExecutionStatus, IotaTransactionBlockEffects};
     use iota_sdk::wallet_context::WalletContext;
-    use iota_sdk_types::crypto::Intent;
-    use iota_types::transaction::{SenderSignedData, TransactionDataAPI};
+    use iota_sdk_types::{SenderSignedTransaction, crypto::Intent};
+    use iota_types::transaction::TransactionDataAPI;
     use test_cluster::TestClusterBuilder;
 
     use super::*;
@@ -1195,7 +1195,8 @@ mod tests {
             &tx_data,
             Intent::iota_transaction(),
         )?;
-        let sender_signed_data = SenderSignedData::new_from_sender_signature(tx_data, signature);
+        let sender_signed_data =
+            SenderSignedTransaction::new_from_sender_signature(tx_data, signature);
         let transaction = Transaction::new(sender_signed_data);
         let response = ctx.execute_transaction_may_fail(transaction).await?;
         let result_effects = response.effects;

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -15,14 +15,14 @@ use iota_indexer::{
     schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
 };
 use iota_json_rpc_api::ReadApiServer;
-use iota_sdk_types::{Address as NativeAddress, Event as NativeEvent, TransactionExpiration};
+use iota_sdk_types::{
+    Address as NativeAddress, Event as NativeEvent,
+    SenderSignedTransaction as NativeSenderSignedTransaction, TransactionExpiration,
+};
 use iota_types::{
     effects::TransactionEffects as NativeTransactionEffects,
     message_envelope::Message,
-    transaction::{
-        SenderSignedData as NativeSenderSignedData, TransactionData as NativeTransactionData,
-        TransactionDataAPI,
-    },
+    transaction::{TransactionData as NativeTransactionData, TransactionDataAPI},
 };
 use serde::{Deserialize, Serialize};
 
@@ -71,13 +71,13 @@ pub(crate) enum TransactionBlockInner {
     /// have, and more.
     Checkpointed {
         stored_tx: StoredTransaction,
-        native: NativeSenderSignedData,
+        native: NativeSenderSignedTransaction,
     },
     /// A transaction block that has been executed and indexed without
     /// checkpoint information.
     Executed {
         optimistic_tx: OptimisticTransaction,
-        native: NativeSenderSignedData,
+        native: NativeSenderSignedTransaction,
     },
 
     /// A transaction block that has been executed via dryRunTransactionBlock.
@@ -336,7 +336,7 @@ impl TransactionBlock {
         }
     }
 
-    fn native_signed_data(&self) -> Option<&NativeSenderSignedData> {
+    fn native_signed_data(&self) -> Option<&NativeSenderSignedTransaction> {
         match &self.inner {
             TransactionBlockInner::Checkpointed { native, .. } => Some(native),
             TransactionBlockInner::Executed { native, .. } => Some(native),
@@ -723,7 +723,7 @@ impl TryFrom<OptimisticTransaction> for TransactionBlockInner {
     fn try_from(optimistic_tx: OptimisticTransaction) -> Result<Self, Error> {
         let native = bcs::from_bytes(&optimistic_tx.raw_transaction).map_err(|e| {
             Error::Internal(format!(
-                "Failed to deserialize NativeSenderSignedData from optimistic transaction: {e}"
+                "Failed to deserialize NativeSenderSignedTransaction from optimistic transaction: {e}"
             ))
         })?;
 

--- a/crates/iota-grpc-server/src/changes.rs
+++ b/crates/iota-grpc-server/src/changes.rs
@@ -524,12 +524,11 @@ mod tests {
     /// of objects created by the `*_for_testing` constructors. Also returns
     /// the gas coin at its input version (0) and output version (1) so the
     /// derivation finds the mutated gas object.
-    fn version_zero_gas_transaction() -> (iota_types::transaction::SenderSignedData, Object, Object)
-    {
-        use iota_sdk_types::ObjectReference;
+    fn version_zero_gas_transaction() -> (iota_sdk_types::SenderSignedTransaction, Object, Object) {
+        use iota_sdk_types::{ObjectReference, SenderSignedTransaction};
         use iota_types::{
             programmable_transaction_builder::ProgrammableTransactionBuilder,
-            transaction::{SenderSignedData, TransactionData},
+            transaction::TransactionData,
         };
 
         let gas_id = ObjectId::random();
@@ -545,7 +544,7 @@ mod tests {
         );
         let gas_owner = Owner::Address(sender_address());
         (
-            SenderSignedData::new(transaction_data, vec![]),
+            SenderSignedTransaction::new(transaction_data, vec![]),
             Object::with_id_owner_version_for_testing(gas_id, 0u64.into(), gas_owner),
             Object::with_id_owner_version_for_testing(gas_id, 1u64.into(), gas_owner),
         )

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -25,8 +25,8 @@ use iota_json_rpc_types::{
 use iota_open_rpc::Module;
 use iota_package_resolver::{PackageStore, Resolver};
 use iota_sdk_types::{
-    Address, GasPayment, ObjectId, TransactionDigest, TransactionExpiration, TransactionKind,
-    Version,
+    Address, GasPayment, ObjectId, SenderSignedTransaction, TransactionDigest,
+    TransactionExpiration, TransactionKind, Version,
 };
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
@@ -35,7 +35,7 @@ use iota_types::{
     iota_serde::BigInt,
     object::{Object, PastObjectRead},
     signature::UserSignature,
-    transaction::{SenderSignedData, TransactionData, TransactionDataAPI, TransactionDataV1},
+    transaction::{TransactionData, TransactionDataAPI, TransactionDataV1},
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
 
@@ -136,7 +136,8 @@ impl WriteApi {
             .map(|s| -> IndexerResult<_> { Ok(s.signature()?) })
             .collect::<IndexerResult<Vec<UserSignature>>>()?;
 
-        let sender_signed_data = SenderSignedData::new(transaction_data.clone(), tx_signatures);
+        let sender_signed_data =
+            SenderSignedTransaction::new(transaction_data.clone(), tx_signatures);
 
         let tx_events = executed_transaction.events()?.events()?;
 

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -11,11 +11,8 @@ use iota_json_rpc_types::{
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
 };
 use iota_package_resolver::{PackageStore, Resolver};
-use iota_sdk_types::{Event, TransactionDigest, TypeTag};
-use iota_types::{
-    effects::{TransactionEffects, TransactionEvents},
-    transaction::SenderSignedData,
-};
+use iota_sdk_types::{Event, SenderSignedTransaction, TransactionDigest, TypeTag};
+use iota_types::effects::{TransactionEffects, TransactionEvents};
 use move_core_types::annotated_value::{MoveDatatypeLayout, MoveTypeLayout};
 #[cfg(feature = "shared_test_runtime")]
 use serde::Deserialize;
@@ -400,11 +397,11 @@ impl StoredTransaction {
         })
     }
 
-    pub fn try_into_sender_signed_data(&self) -> IndexerResult<SenderSignedData> {
-        let sender_signed_data: SenderSignedData =
-            bcs::from_bytes(&self.raw_transaction).map_err(|e| {
+    pub fn try_into_sender_signed_data(&self) -> IndexerResult<SenderSignedTransaction> {
+        let sender_signed_data: SenderSignedTransaction = bcs::from_bytes(&self.raw_transaction)
+            .map_err(|e| {
                 IndexerError::PersistentStorageDataCorruption(format!(
-                    "Can't convert raw_transaction of {} into SenderSignedData. Error: {e}",
+                    "Can't convert raw_transaction of {} into SenderSignedTransaction. Error: {e}",
                     self.tx_sequence_number
                 ))
             })?;

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -7,8 +7,8 @@ use iota_json_rpc_types::{
     IotaTransactionKind, ObjectChange,
 };
 use iota_sdk_types::{
-    Address, CheckpointDigest, ObjectDigest, ObjectId, Owner, StructTag, TransactionDigest,
-    TypeTag, Version, move_package::MovePackage,
+    Address, CheckpointDigest, ObjectDigest, ObjectId, Owner, SenderSignedTransaction, StructTag,
+    TransactionDigest, TypeTag, Version, move_package::MovePackage,
 };
 use iota_types::{
     crypto::AggregateAuthoritySignature,
@@ -20,7 +20,6 @@ use iota_types::{
         CheckpointCommitment, CheckpointContentsExt, CheckpointSequenceNumber, EndOfEpochData,
     },
     object::Object,
-    transaction::SenderSignedData,
 };
 #[cfg(any(test, feature = "shared_test_runtime", feature = "pg_integration"))]
 use rand::Rng;
@@ -400,7 +399,7 @@ pub struct IndexedPackage {
 pub struct IndexedTransaction {
     pub tx_sequence_number: u64,
     pub tx_digest: TransactionDigest,
-    pub sender_signed_data: SenderSignedData,
+    pub sender_signed_data: SenderSignedTransaction,
     pub effects: TransactionEffects,
     pub checkpoint_sequence_number: u64,
     pub timestamp_ms: u64,

--- a/crates/iota-json-rpc-tests/tests/transaction_tests.rs
+++ b/crates/iota-json-rpc-tests/tests/transaction_tests.rs
@@ -8,9 +8,8 @@ use iota_json_rpc_types::{
     IotaTransactionBlockResponseOptions, TransactionBlockBytes,
 };
 use iota_macros::sim_test;
-use iota_types::{
-    quorum_driver_types::ExecuteTransactionRequestType, transaction::SenderSignedData,
-};
+use iota_sdk_types::SenderSignedTransaction;
+use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
 use test_cluster::TestClusterBuilder;
 
 #[sim_test]
@@ -91,7 +90,7 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
     //     assert!(tx_responses.iter().any(
     //         |resp| matches!(resp, IotaTransactionBlockResponse {digest, ..} if *digest == response.digest)
     //     ));
-    //     let sender_signed_data: SenderSignedData =
+    //     let sender_signed_data: SenderSignedTransaction =
     //         bcs::from_bytes(&response.raw_transaction).unwrap();
     //     assert_eq!(sender_signed_data.digest(), tx_digest);
     // }
@@ -138,7 +137,7 @@ async fn test_get_raw_transaction() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let decode_sender_signed_data: SenderSignedData =
+    let decode_sender_signed_data: SenderSignedTransaction =
         bcs::from_bytes(&response.raw_transaction).unwrap();
     // verify that the raw transaction data returned by the response is the same
     // as the original transaction data

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -15,8 +15,9 @@ use iota_sdk_types::{
     ChangeEpochV4, Command, ConsensusCommitDigest, ConsensusDeterminedVersionAssignments,
     EndOfEpochTransactionKind, ExecutionError as ExecutionFailureStatus, ExecutionStatus,
     GenesisObject, Identifier, MoveCall, ObjectDigest, ObjectId, ObjectReference, Owner,
-    ProgrammableTransaction, SharedObjectReference, TransactionDigest, TransactionEventsDigest,
-    TransactionKind, TransferObjects, TypeTag, Version, VersionAssignment, gas::GasCostSummary,
+    ProgrammableTransaction, SenderSignedTransaction, SharedObjectReference, TransactionDigest,
+    TransactionEventsDigest, TransactionKind, TransferObjects, TypeTag, Version, VersionAssignment,
+    gas::GasCostSummary,
 };
 use iota_types::{
     base_types::EpochId,
@@ -32,9 +33,7 @@ use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType as NativeExecuteTransactionRequestType,
     signature::UserSignature,
     storage::{DeleteKind, WriteKind},
-    transaction::{
-        CallArg, InputObjectKind, SenderSignedData, TransactionData, TransactionDataAPI,
-    },
+    transaction::{CallArg, InputObjectKind, TransactionData, TransactionDataAPI},
 };
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
@@ -270,8 +269,8 @@ pub struct IotaTransactionBlockResponse {
     /// Transaction input data
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction: Option<IotaTransactionBlock>,
-    /// BCS encoded [SenderSignedData] that includes input object references
-    /// returns empty array if `show_raw_transaction` is false
+    /// BCS encoded [SenderSignedTransaction] that includes input object
+    /// references returns empty array if `show_raw_transaction` is false
     #[serde_as(as = "Base64")]
     #[schemars(with = "Base64Schema")]
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -1775,7 +1774,7 @@ pub struct IotaTransactionBlock {
 
 impl IotaTransactionBlock {
     pub fn try_from(
-        data: SenderSignedData,
+        data: SenderSignedTransaction,
         module_cache: &impl GetModule,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {
@@ -1793,7 +1792,7 @@ impl IotaTransactionBlock {
     // indexer v1, so are the related `try_from` methods for nested structs like
     // IotaTransactionBlockData etc.
     pub async fn try_from_with_package_resolver(
-        data: SenderSignedData,
+        data: SenderSignedTransaction,
         package_resolver: &Resolver<impl PackageStore>,
         tx_digest: TransactionDigest,
     ) -> Result<Self, anyhow::Error> {

--- a/crates/iota-replay/src/data_fetcher.rs
+++ b/crates/iota-replay/src/data_fetcher.rs
@@ -16,13 +16,12 @@ use iota_json_rpc_types::{
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_sdk::IotaClient;
 use iota_sdk_types::{
-    EndOfEpochTransactionKind, ObjectId, StructTag, TransactionDigest, TransactionKind, Version,
+    EndOfEpochTransactionKind, ObjectId, SenderSignedTransaction, StructTag, TransactionDigest,
+    TransactionKind, Version,
 };
 use iota_types::{
-    base_types::VersionNumber,
-    digests::ChainIdentifier,
-    object::Object,
-    transaction::{SenderSignedData, TransactionDataAPI},
+    base_types::VersionNumber, digests::ChainIdentifier, object::Object,
+    transaction::TransactionDataAPI,
 };
 use lru::LruCache;
 use parking_lot::RwLock;
@@ -547,7 +546,7 @@ impl DataFetcher for RemoteFetcher {
         // Fetch full transaction content
         let tx_info = self.get_transaction(&epoch_change_tx).await?;
 
-        let orig_tx: SenderSignedData = bcs::from_bytes(&tx_info.raw_transaction).unwrap();
+        let orig_tx: SenderSignedTransaction = bcs::from_bytes(&tx_info.raw_transaction).unwrap();
         let tx_kind_orig = orig_tx.transaction().kind();
 
         if let TransactionKind::EndOfEpoch(kinds) = tx_kind_orig {

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -19,8 +19,8 @@ use iota_json_rpc_types::{
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk::{IotaClient, IotaClientBuilder};
 use iota_sdk_types::{
-    GasPayment, ObjectData, ObjectDigest, ObjectId, ObjectReference, Owner, StructTag,
-    TransactionDigest, TransactionKind, Version,
+    GasPayment, ObjectData, ObjectDigest, ObjectId, ObjectReference, Owner,
+    SenderSignedTransaction, StructTag, TransactionDigest, TransactionKind, Version,
 };
 use iota_types::{
     IOTA_DENY_LIST_OBJECT_ID,
@@ -49,8 +49,7 @@ use iota_types::{
     },
     transaction::{
         CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
-        SenderSignedData, SenderSignedTransactionAPI, Transaction, TransactionDataAPI,
-        VerifiedTransaction,
+        SenderSignedTransactionAPI, Transaction, TransactionDataAPI, VerifiedTransaction,
     },
 };
 use move_binary_format::CompiledModule;
@@ -1768,7 +1767,7 @@ impl LocalExec {
         let config_objects = self.add_config_objects_if_needed(effects.status());
 
         let raw_tx_bytes = tx_info.clone().raw_transaction;
-        let orig_tx: SenderSignedData = bcs::from_bytes(&raw_tx_bytes).unwrap();
+        let orig_tx: SenderSignedTransaction = bcs::from_bytes(&raw_tx_bytes).unwrap();
         let input_objs = orig_tx
             .collect_all_input_object_kind_for_reading()
             .map_err(|e| match e {

--- a/crates/iota-replay/src/types.rs
+++ b/crates/iota-replay/src/types.rs
@@ -8,13 +8,14 @@ use iota_json_rpc_types::{IotaEvent, IotaObjectResponseError, IotaTransactionBlo
 use iota_protocol_config::{Chain, ProtocolVersion};
 use iota_sdk::error::Error as IotaRpcError;
 use iota_sdk_types::{
-    Address, ObjectDigest, ObjectId, ObjectReference, TransactionDigest, TransactionKind, Version,
+    Address, ObjectDigest, ObjectId, ObjectReference, SenderSignedTransaction, TransactionDigest,
+    TransactionKind, Version,
 };
 use iota_types::{
     base_types::VersionNumber,
     error::{IotaError, IotaResult, UserInputError},
     object::Object,
-    transaction::{InputObjectKind, SenderSignedData},
+    transaction::InputObjectKind,
 };
 use jsonrpsee::core::ClientError as JsonRpseeError;
 use move_binary_format::CompiledModule;
@@ -41,11 +42,11 @@ pub(crate) const EPOCH_CHANGE_STRUCT_TAGS: [&str; 2] = [
 ];
 
 // TODO: A lot of the information in OnChainTransactionInfo is redundant from
-// what's already in SenderSignedData. We should consider removing them.
+// what's already in SenderSignedTransaction. We should consider removing them.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OnChainTransactionInfo {
     pub tx_digest: TransactionDigest,
-    pub sender_signed_data: SenderSignedData,
+    pub sender_signed_data: SenderSignedTransaction,
     pub sender: Address,
     pub input_objects: Vec<InputObjectKind>,
     pub kind: TransactionKind,

--- a/crates/iota-storage/src/write_path_pending_tx_log.rs
+++ b/crates/iota-storage/src/write_path_pending_tx_log.rs
@@ -11,12 +11,12 @@
 
 use std::path::PathBuf;
 
-use iota_sdk_types::TransactionDigest;
+use iota_sdk_types::{SenderSignedTransaction, TransactionDigest};
 use iota_types::{
     crypto::EmptySignInfo,
     error::{IotaError, IotaResult},
     message_envelope::TrustedEnvelope,
-    transaction::{SenderSignedData, VerifiedTransaction},
+    transaction::VerifiedTransaction,
 };
 use tracing::instrument;
 use typed_store::{
@@ -32,7 +32,7 @@ const NUM_SHARDS: usize = 4096;
 
 #[derive(DBMapUtils)]
 struct WritePathPendingTransactionTable {
-    logs: DBMap<TransactionDigest, TrustedEnvelope<SenderSignedData, EmptySignInfo>>,
+    logs: DBMap<TransactionDigest, TrustedEnvelope<SenderSignedTransaction, EmptySignInfo>>,
 }
 
 pub struct WritePathPendingTransactionLog {

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -21,13 +21,13 @@ use iota_core::{
 use iota_protocol_config::Chain;
 use iota_replay::{ReplayToolCommand, execute_replay_command};
 use iota_sdk::{IotaClient, IotaClientBuilder, rpc_types::IotaTransactionBlockResponseOptions};
-use iota_sdk_types::{Address, ObjectId, TransactionDigest};
+use iota_sdk_types::{Address, ObjectId, SenderSignedTransaction, TransactionDigest};
 use iota_types::{
     base_types::*,
     crypto::AuthorityPublicKeyBytes,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber},
     messages_grpc::TransactionInfoRequest,
-    transaction::{SenderSignedData, Transaction},
+    transaction::Transaction,
 };
 use telemetry_subscribers::TracingHandle;
 
@@ -424,7 +424,7 @@ pub enum ToolCommand {
 
         #[arg(
             long,
-            help = "The Base64-encoding of the bcs bytes of SenderSignedData"
+            help = "The Base64-encoding of the bcs bytes of SenderSignedTransaction"
         )]
         sender_signed_data: String,
     },
@@ -1035,7 +1035,7 @@ impl ToolCommand {
                 sender_signed_data,
             } => {
                 let genesis = Genesis::load(genesis)?;
-                let sender_signed_data = bcs::from_bytes::<SenderSignedData>(
+                let sender_signed_data = bcs::from_bytes::<SenderSignedTransaction>(
                     &fastcrypto::encoding::Base64::decode(sender_signed_data.as_str()).unwrap(),
                 )
                 .unwrap();

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -753,7 +753,7 @@ pub trait IotaSignature: Sized {
         // transaction data, this is the BCS hash of `struct TransactionData`,
         // different from the transaction digest itself that computes the BCS
         // hash of the Rust type prefix and `struct TransactionData`.
-        // (See `fn digest` in `impl Message for SenderSignedData`).
+        // (See `fn digest` in `impl Message for SenderSignedTransaction`).
         let mut hasher = DefaultHash::default();
         hasher.update(bcs::to_bytes(&value).expect("Message serialization should not fail"));
 
@@ -1219,7 +1219,7 @@ mod bcs_signable {
     impl BcsSignable for crate::effects::TransactionEffects {}
     impl BcsSignable for crate::effects::TransactionEvents {}
     impl BcsSignable for crate::transaction::TransactionData {}
-    impl BcsSignable for crate::transaction::SenderSignedData {}
+    impl BcsSignable for iota_sdk_types::SenderSignedTransaction {}
     impl BcsSignable for crate::object::ObjectInner {}
 
     impl BcsSignable for crate::global_state_hash::GlobalStateHash {}

--- a/crates/iota-types/src/effects/test_effects_builder.rs
+++ b/crates/iota-types/src/effects/test_effects_builder.rs
@@ -5,8 +5,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use iota_sdk_types::{
-    ExecutionStatus, ObjectDigest, ObjectId, ObjectReference, Owner, TransactionEventsDigest,
-    Version, gas::GasCostSummary,
+    ExecutionStatus, ObjectDigest, ObjectId, ObjectReference, Owner, SenderSignedTransaction,
+    TransactionEventsDigest, Version, gas::GasCostSummary,
 };
 
 use crate::{
@@ -16,11 +16,11 @@ use crate::{
     },
     execution::SharedInput,
     message_envelope::Message,
-    transaction::{InputObjectKind, SenderSignedData, TransactionDataAPI},
+    transaction::{InputObjectKind, TransactionDataAPI},
 };
 
 pub struct TestEffectsBuilder {
-    transaction: SenderSignedData,
+    transaction: SenderSignedTransaction,
     /// Override the execution status if provided.
     status: Option<ExecutionStatus>,
     /// Provide the assigned versions for all shared objects.
@@ -40,7 +40,7 @@ pub struct TestEffectsBuilder {
 }
 
 impl TestEffectsBuilder {
-    pub fn new(transaction: &SenderSignedData) -> Self {
+    pub fn new(transaction: &SenderSignedTransaction) -> Self {
         Self {
             transaction: transaction.clone(),
             status: None,

--- a/crates/iota-types/src/executable_transaction.rs
+++ b/crates/iota-types/src/executable_transaction.rs
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use iota_sdk_types::SenderSignedTransaction;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -9,7 +10,7 @@ use crate::{
     crypto::AuthorityStrongQuorumSignInfo,
     message_envelope::{Envelope, TrustedEnvelope, VerifiedEnvelope},
     messages_checkpoint::CheckpointSequenceNumber,
-    transaction::{SenderSignedData, TransactionDataAPI},
+    transaction::TransactionDataAPI,
 };
 
 /// CertificateProof is a proof that a transaction certs existed at a given
@@ -64,9 +65,10 @@ impl CertificateProof {
 /// transaction, and hence it can be executed locally. This is an abstraction
 /// data structure to cover both the case where the transaction is certified or
 /// checkpointed when we schedule it for execution.
-pub type ExecutableTransaction = Envelope<SenderSignedData, CertificateProof>;
-pub type VerifiedExecutableTransaction = VerifiedEnvelope<SenderSignedData, CertificateProof>;
-pub type TrustedExecutableTransaction = TrustedEnvelope<SenderSignedData, CertificateProof>;
+pub type ExecutableTransaction = Envelope<SenderSignedTransaction, CertificateProof>;
+pub type VerifiedExecutableTransaction =
+    VerifiedEnvelope<SenderSignedTransaction, CertificateProof>;
+pub type TrustedExecutableTransaction = TrustedEnvelope<SenderSignedTransaction, CertificateProof>;
 
 impl VerifiedExecutableTransaction {
     pub fn certificate_sig(&self) -> Option<&AuthorityStrongQuorumSignInfo> {

--- a/crates/iota-types/src/message_envelope.rs
+++ b/crates/iota-types/src/message_envelope.rs
@@ -8,7 +8,10 @@ use std::{
 };
 
 use fastcrypto::traits::KeyPair;
-use iota_sdk_types::crypto::{Intent, IntentScope};
+use iota_sdk_types::{
+    SenderSignedTransaction,
+    crypto::{Intent, IntentScope},
+};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_name::{DeserializeNameAdapter, SerializeNameAdapter};
@@ -24,7 +27,6 @@ use crate::{
     error::IotaResult,
     executable_transaction::CertificateProof,
     messages_checkpoint::CheckpointSequenceNumber,
-    transaction::SenderSignedData,
 };
 
 pub trait Message {
@@ -180,7 +182,7 @@ where
     }
 }
 
-impl Envelope<SenderSignedData, AuthoritySignInfo> {
+impl Envelope<SenderSignedTransaction, AuthoritySignInfo> {
     #[instrument(level = "trace", skip_all)]
     pub fn verify_committee_sigs_only(&self, committee: &Committee) -> IotaResult {
         self.auth_signature.verify_secure(

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -14,7 +14,8 @@ use byteorder::{BigEndian, ReadBytesExt};
 use fastcrypto::{error::FastCryptoResult, groups::bls12381, hash::HashFunction};
 use fastcrypto_tbls::dkg_v1;
 use iota_sdk_types::{
-    Digest, MisbehaviorReportDigest, ObjectReference, TransactionDigest, crypto::IntentScope,
+    Digest, MisbehaviorReportDigest, ObjectReference, SenderSignedTransaction, TransactionDigest,
+    crypto::IntentScope,
 };
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -28,7 +29,7 @@ use crate::{
     supported_protocol_versions::{
         Chain, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
-    transaction::{CertifiedTransaction, SenderSignedData, Transaction},
+    transaction::{CertifiedTransaction, Transaction},
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -287,7 +288,7 @@ impl ConsensusTransactionKind {
 
     /// The signed data of the underlying certified or raw user transaction,
     /// or `None` for internal consensus messages.
-    pub fn as_sender_signed_data(&self) -> Option<&SenderSignedData> {
+    pub fn as_sender_signed_data(&self) -> Option<&SenderSignedTransaction> {
         self.map_cert_or_raw_user_tx(|c| c.data(), |t| t.data())
     }
 

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -2,7 +2,9 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::{ObjectId, TransactionDigest, TransactionEffectsDigest, Version};
+use iota_sdk_types::{
+    ObjectId, SenderSignedTransaction, TransactionDigest, TransactionEffectsDigest, Version,
+};
 use move_core_types::annotated_value::MoveStructLayout;
 use serde::{Deserialize, Serialize};
 
@@ -16,7 +18,7 @@ use crate::{
     error::IotaError,
     messages_consensus::SignedAuthorityCapabilitiesV1,
     object::Object,
-    transaction::{CertifiedTransaction, SenderSignedData, SignedTransaction},
+    transaction::{CertifiedTransaction, SignedTransaction},
 };
 
 /// Request for validator health information.
@@ -179,7 +181,7 @@ pub struct HandleTransactionResponse {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TransactionInfoResponse {
-    pub transaction: SenderSignedData,
+    pub transaction: SenderSignedTransaction,
     pub status: TransactionStatus,
 }
 

--- a/crates/iota-types/src/signature_verification.rs
+++ b/crates/iota-types/src/signature_verification.rs
@@ -5,6 +5,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use std::hash::Hash;
 
+use iota_sdk_types::SenderSignedTransaction;
 #[cfg(not(target_arch = "wasm32"))]
 use lru::LruCache;
 use nonempty::NonEmpty;
@@ -16,7 +17,7 @@ use prometheus_filtered::IntCounter;
 use crate::{
     error::{IotaError, IotaResult},
     signature::{AuthenticatorTrait, VerifyParams},
-    transaction::{SenderSignedData, SenderSignedTransactionAPI, TransactionDataAPI},
+    transaction::{SenderSignedTransactionAPI, TransactionDataAPI},
 };
 
 // Cache up to this many verified certs. We will need to tune this number in the
@@ -117,7 +118,7 @@ impl<D: Hash + Eq + Copy> VerifiedDigestCache<D> {
 /// Does crypto validation for a transaction which may be user-provided, or may
 /// be from a checkpoint.
 pub fn verify_sender_signed_data_message_signatures(
-    txn: &SenderSignedData,
+    txn: &SenderSignedTransaction,
     verify_params: &VerifyParams,
 ) -> IotaResult {
     let tx = txn.transaction();

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -17,7 +17,8 @@ use std::{
 };
 
 use iota_sdk_types::{
-    ObjectId, ObjectReference, TransactionDigest, Version, move_package::MovePackage,
+    ObjectId, ObjectReference, SenderSignedTransaction, TransactionDigest, Version,
+    move_package::MovePackage,
 };
 use itertools::Itertools;
 use move_binary_format::CompiledModule;
@@ -43,7 +44,7 @@ use crate::{
     iota_sdk_types_conversions::identifier_core_to_sdk,
     object::Object,
     storage::error::Error as StorageError,
-    transaction::{SenderSignedData, SenderSignedTransactionAPI, TransactionDataAPI},
+    transaction::{SenderSignedTransactionAPI, TransactionDataAPI},
 };
 
 /// A potential input to a transaction.
@@ -528,7 +529,7 @@ impl From<Object> for ObjectOrTombstone {
 /// Includes owned, and immutable objects as well as the gas objects, but not
 /// move packages or shared objects.
 pub fn transaction_non_shared_input_object_keys(
-    tx: &SenderSignedData,
+    tx: &SenderSignedTransaction,
 ) -> IotaResult<Vec<ObjectKey>> {
     use crate::transaction::InputObjectKind as I;
     Ok(tx
@@ -541,7 +542,7 @@ pub fn transaction_non_shared_input_object_keys(
         .collect())
 }
 
-pub fn transaction_receiving_object_keys(tx: &SenderSignedData) -> Vec<ObjectKey> {
+pub fn transaction_receiving_object_keys(tx: &SenderSignedTransaction) -> Vec<ObjectKey> {
     tx.transaction()
         .receiving_objects()
         .into_iter()

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -7,7 +7,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Address, EndOfEpochTransactionKind, Event, Identifier, ObjectId, ObjectReference, Owner,
-    SharedObjectReference, StructTag, TransactionDigest, TransactionKind, TypeTag, Version,
+    SenderSignedTransaction, SharedObjectReference, StructTag, TransactionDigest, TransactionKind,
+    TypeTag, Version,
 };
 use tap::Pipe;
 
@@ -27,7 +28,7 @@ use crate::{
     },
     object::{GAS_VALUE_FOR_TESTING, MoveObject, MoveObjectExt, Object},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{CallArg, SenderSignedData, Transaction, TransactionData, TransactionDataAPI},
+    transaction::{CallArg, Transaction, TransactionData, TransactionDataAPI},
 };
 
 /// A builder for creating test checkpoint data.
@@ -441,7 +442,7 @@ impl TestCheckpointDataBuilder {
 
         let pt = pt_builder.finish();
         let tx_data = TransactionData::new(TransactionKind::Programmable(pt), sender, gas, 1, 1);
-        let tx = Transaction::new(SenderSignedData::new(tx_data, vec![]));
+        let tx = Transaction::new(SenderSignedTransaction::new(tx_data, vec![]));
 
         let wrapped_objects: Vec<_> = wrapped_objects
             .into_iter()
@@ -566,7 +567,7 @@ impl TestCheckpointDataBuilder {
             1,
             1,
         )
-        .pipe(|data| SenderSignedData::new(data, vec![]))
+        .pipe(|data| SenderSignedTransaction::new(data, vec![]))
         .pipe(Transaction::new);
 
         let events = if !safe_mode {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -21,15 +21,12 @@ use iota_sdk_types::{
     ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, EndOfEpochTransactionKind,
     Event, GasPayment, GenesisObject, GenesisTransaction, Identifier, Input, MakeMoveVector,
     MergeCoins, MoveCall, ObjectDigest, ObjectId, ObjectReference, Owner, ProgrammableTransaction,
-    Publish, RandomnessRound, RandomnessStateUpdate, SharedObjectReference, SplitCoins,
-    TransactionDigest, TransactionExpiration, TransactionKind, TransferObjects, TypeTag, Upgrade,
-    Version,
+    Publish, RandomnessRound, RandomnessStateUpdate, SenderSignedTransaction,
+    SharedObjectReference, SplitCoins, TransactionDigest, TransactionExpiration, TransactionKind,
+    TransferObjects, TypeTag, Upgrade, Version,
     crypto::{Intent, IntentMessage, IntentScope},
 };
-pub use iota_sdk_types::{
-    SenderSignedTransaction as SenderSignedData, Transaction as TransactionData,
-    TransactionV1 as TransactionDataV1,
-};
+pub use iota_sdk_types::{Transaction as TransactionData, TransactionV1 as TransactionDataV1};
 use itertools::Either;
 use nonempty::{NonEmpty, nonempty};
 use serde::{Deserialize, Serialize};
@@ -994,7 +991,7 @@ pub trait TransactionDataAPI {
     ///
     /// IMPORTANT: This function does not return shared objects associated with
     /// `MoveAuthenticator` signatures. To check those objects as well, use the
-    /// corresponding function from `SenderSignedData`.
+    /// corresponding function from `SenderSignedTransaction`.
     fn shared_input_objects(&self) -> Vec<SharedObjectReference>;
 
     /// Returns a list of Move calls as `(package_id, module_name,
@@ -1838,7 +1835,7 @@ pub fn merge_authenticator_input_objects<'a>(
     Ok(())
 }
 
-/// API for accessing and constructing [`SenderSignedData`].
+/// API for accessing and constructing [`SenderSignedTransaction`].
 ///
 /// This trait provides node-internal methods on the SDK's
 /// [`SenderSignedTransaction`](iota_sdk_types::SenderSignedTransaction), which
@@ -1846,11 +1843,12 @@ pub fn merge_authenticator_input_objects<'a>(
 /// transaction participants. A non-participant signature must not be present,
 /// and the signature order does not matter.
 pub trait SenderSignedTransactionAPI {
-    /// Creates a new [`SenderSignedData`] with a single sender signature.
+    /// Creates a new [`SenderSignedTransaction`] with a single sender
+    /// signature.
     fn new_from_sender_signature(
         tx_data: TransactionData,
         tx_signature: Signature,
-    ) -> SenderSignedData;
+    ) -> SenderSignedTransaction;
 
     /// Adds a signature. Does not check the validity of the signature or
     /// perform any de-dup checks.
@@ -1896,9 +1894,9 @@ pub trait SenderSignedTransactionAPI {
         input_objects: InputObjects,
     ) -> IotaResult<(InputObjects, Vec<(InputObjects, ObjectReadResult)>)>;
 
-    /// Checks if [`SenderSignedData`] contains at least one shared object.
-    /// This function checks shared objects from the `MoveAuthenticator`s if
-    /// any.
+    /// Checks if [`SenderSignedTransaction`] contains at least one shared
+    /// object. This function checks shared objects from the
+    /// `MoveAuthenticator`s if any.
     fn contains_shared_object(&self) -> bool;
 
     /// Returns an iterator over all shared input objects related to this
@@ -1924,18 +1922,18 @@ pub trait SenderSignedTransactionAPI {
     /// Shared objects with the same ID but different versions are not allowed.
     fn input_objects(&self) -> IotaResult<Vec<InputObjectKind>>;
 
-    /// Checks if [`SenderSignedData`] contains the `Random` object as an
+    /// Checks if [`SenderSignedTransaction`] contains the `Random` object as an
     /// input.
     /// This function checks shared objects from the `MoveAuthenticator`s if
     /// any.
     fn uses_randomness(&self) -> bool;
 }
 
-impl SenderSignedTransactionAPI for SenderSignedData {
+impl SenderSignedTransactionAPI for SenderSignedTransaction {
     fn new_from_sender_signature(
         tx_data: TransactionData,
         tx_signature: Signature,
-    ) -> SenderSignedData {
+    ) -> SenderSignedTransaction {
         Self::new(tx_data, vec![tx_signature.into()])
     }
 
@@ -1982,7 +1980,7 @@ impl SenderSignedTransactionAPI for SenderSignedData {
             !tx.is_system_tx(),
             IotaError::UserInput {
                 error: UserInputError::Unsupported(
-                    "SenderSignedData must not contain system transaction".to_string()
+                    "SenderSignedTransaction must not contain system transaction".to_string()
                 )
             }
         );
@@ -2153,7 +2151,7 @@ impl SenderSignedTransactionAPI for SenderSignedData {
 }
 
 fn check_user_signature_protocol_compatibility(
-    data: &SenderSignedData,
+    data: &SenderSignedTransaction,
     config: &ProtocolConfig,
 ) -> IotaResult {
     for sig in data.signatures() {
@@ -2187,7 +2185,7 @@ fn check_user_signature_protocol_compatibility(
 }
 
 fn move_authenticators_validity_check(
-    data: &SenderSignedData,
+    data: &SenderSignedTransaction,
     config: &ProtocolConfig,
 ) -> IotaResult {
     let authenticators = data.move_authenticators();
@@ -2205,7 +2203,7 @@ fn move_authenticators_validity_check(
         fp_ensure!(
             tx.kind().is_programmable(),
             UserInputError::Unsupported(
-                "SenderSignedData with MoveAuthenticator must be a programmable transaction"
+                "SenderSignedTransaction with MoveAuthenticator must be a programmable transaction"
                     .to_string(),
             )
             .into()
@@ -2215,7 +2213,7 @@ fn move_authenticators_validity_check(
             fp_ensure!(
                 authenticators_num == 1,
                 UserInputError::Unsupported(
-                    "SenderSignedData with more than one MoveAuthenticator is not supported"
+                    "SenderSignedTransaction with more than one MoveAuthenticator is not supported"
                         .to_string(),
                 )
                 .into()
@@ -2224,7 +2222,8 @@ fn move_authenticators_validity_check(
             fp_ensure!(
                 data.sender_move_authenticator().is_some(),
                 UserInputError::Unsupported(
-                    "SenderSignedData can have MoveAuthenticator only for the sender".to_string(),
+                    "SenderSignedTransaction can have MoveAuthenticator only for the sender"
+                        .to_string(),
                 )
                 .into()
             );
@@ -2267,7 +2266,7 @@ fn check_move_authenticators_input_consistency(
     })
 }
 
-impl Message for SenderSignedData {
+impl Message for SenderSignedTransaction {
     type DigestType = TransactionDigest;
     const SCOPE: IntentScope = IntentScope::SenderSignedTransaction;
 
@@ -2278,7 +2277,7 @@ impl Message for SenderSignedData {
     }
 }
 
-impl<S> Envelope<SenderSignedData, S> {
+impl<S> Envelope<SenderSignedTransaction, S> {
     pub fn sender_address(&self) -> Address {
         self.data().transaction().sender()
     }
@@ -2350,7 +2349,7 @@ impl Transaction {
     }
 
     pub fn from_user_sig_data(data: TransactionData, signatures: Vec<UserSignature>) -> Self {
-        Self::new(SenderSignedData::new(data, signatures))
+        Self::new(SenderSignedTransaction::new(data, signatures))
     }
 
     /// Returns the Base64 encoded tx_bytes
@@ -2421,7 +2420,7 @@ impl VerifiedTransaction {
         system_transaction
             .pipe(TransactionData::new_system_transaction)
             .pipe(|data| {
-                SenderSignedData::new_from_sender_signature(data, zero_ed25519_signature())
+                SenderSignedTransaction::new_from_sender_signature(data, zero_ed25519_signature())
             })
             .pipe(Transaction::new)
             .pipe(Self::new_from_verified)
@@ -2447,13 +2446,13 @@ impl VerifiedSignedTransaction {
 }
 
 /// A transaction that is signed by a sender but not yet by an authority.
-pub type Transaction = Envelope<SenderSignedData, EmptySignInfo>;
-pub type VerifiedTransaction = VerifiedEnvelope<SenderSignedData, EmptySignInfo>;
-pub type TrustedTransaction = TrustedEnvelope<SenderSignedData, EmptySignInfo>;
+pub type Transaction = Envelope<SenderSignedTransaction, EmptySignInfo>;
+pub type VerifiedTransaction = VerifiedEnvelope<SenderSignedTransaction, EmptySignInfo>;
+pub type TrustedTransaction = TrustedEnvelope<SenderSignedTransaction, EmptySignInfo>;
 
 /// A transaction that is signed by a sender and also by an authority.
-pub type SignedTransaction = Envelope<SenderSignedData, AuthoritySignInfo>;
-pub type VerifiedSignedTransaction = VerifiedEnvelope<SenderSignedData, AuthoritySignInfo>;
+pub type SignedTransaction = Envelope<SenderSignedTransaction, AuthoritySignInfo>;
+pub type VerifiedSignedTransaction = VerifiedEnvelope<SenderSignedTransaction, AuthoritySignInfo>;
 
 impl Transaction {
     pub fn verify_signature_for_testing(&self, verify_params: &VerifyParams) -> IotaResult {
@@ -2498,7 +2497,7 @@ impl SignedTransaction {
     }
 }
 
-pub type CertifiedTransaction = Envelope<SenderSignedData, AuthorityStrongQuorumSignInfo>;
+pub type CertifiedTransaction = Envelope<SenderSignedTransaction, AuthorityStrongQuorumSignInfo>;
 
 impl CertifiedTransaction {
     pub fn certificate_digest(&self) -> CertificateDigest {
@@ -2546,8 +2545,10 @@ impl CertifiedTransaction {
     }
 }
 
-pub type VerifiedCertificate = VerifiedEnvelope<SenderSignedData, AuthorityStrongQuorumSignInfo>;
-pub type TrustedCertificate = TrustedEnvelope<SenderSignedData, AuthorityStrongQuorumSignInfo>;
+pub type VerifiedCertificate =
+    VerifiedEnvelope<SenderSignedTransaction, AuthorityStrongQuorumSignInfo>;
+pub type TrustedCertificate =
+    TrustedEnvelope<SenderSignedTransaction, AuthorityStrongQuorumSignInfo>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord, Hash)]
 pub enum InputObjectKind {

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -9,7 +9,9 @@ use iota_sdk_crypto::{
     Signer as _, ToFromBytes as _, ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey,
     secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair,
 };
-use iota_sdk_types::{Address, ObjectId, SimpleSignature, TransactionKind, crypto::Intent};
+use iota_sdk_types::{
+    Address, ObjectId, SenderSignedTransaction, SimpleSignature, TransactionKind, crypto::Intent,
+};
 use rand::{SeedableRng, rngs::StdRng};
 
 use crate::{
@@ -24,8 +26,7 @@ use crate::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     signature::UserSignature,
     transaction::{
-        SenderSignedData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER, Transaction, TransactionData,
-        TransactionDataAPI,
+        TEST_ONLY_GAS_UNIT_FOR_TRANSFER, Transaction, TransactionData, TransactionDataAPI,
     },
 };
 
@@ -196,7 +197,7 @@ pub fn make_upgraded_multisig_tx() -> Transaction {
 
     // Any 2 of 3 signatures verifies ok.
     let multi_sig1 = MultiSig::new(vec![sig1.into(), sig2.into()], multisig_pk).unwrap();
-    Transaction::new(SenderSignedData::new(
+    Transaction::new(SenderSignedTransaction::new(
         tx.transaction().clone(),
         vec![UserSignature::Multisig(multi_sig1)],
     ))
@@ -221,14 +222,14 @@ pub fn make_sponsored_regular_sig_tx() -> (Transaction, Address, Address) {
 
 mod move_authenticator {
     use fastcrypto::hash::HashFunction;
-    use iota_sdk_types::{Address, Digest, SharedObjectReference};
+    use iota_sdk_types::{Address, Digest, SenderSignedTransaction, SharedObjectReference};
 
     pub use crate::move_authenticator::{MoveAuthenticator, MoveAuthenticatorV1};
     use crate::{
         crypto::DefaultHash,
         object::OBJECT_START_VERSION,
         signature::UserSignature,
-        transaction::{SenderSignedData, Transaction},
+        transaction::Transaction,
         utils::{make_sponsored_transaction_data, make_transaction_data},
     };
 
@@ -236,7 +237,7 @@ mod move_authenticator {
     pub fn make_move_authenticator_tx(address: Address) -> Transaction {
         let data = make_transaction_data(address);
         let (authenticator, _) = make_move_authenticator_sig(address);
-        Transaction::new(SenderSignedData::new(data, vec![authenticator]))
+        Transaction::new(SenderSignedTransaction::new(data, vec![authenticator]))
     }
 
     /// Build a [`UserSignature::MoveAuthenticator`] and the underlying
@@ -270,7 +271,7 @@ mod move_authenticator {
         let (sender_sig, sender_auth) = make_move_authenticator_sig(sender_addr);
         let (sponsor_sig, sponsor_auth) = make_move_authenticator_sig(sponsor_addr);
         let tx_data = make_sponsored_transaction_data(sender_addr, sponsor_addr);
-        let tx = Transaction::new(SenderSignedData::new(
+        let tx = Transaction::new(SenderSignedTransaction::new(
             tx_data,
             vec![sender_sig, sponsor_sig],
         ));

--- a/crates/iota-vm-sdk/examples/authenticator_gas_profile.rs
+++ b/crates/iota-vm-sdk/examples/authenticator_gas_profile.rs
@@ -18,11 +18,12 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use fastcrypto::encoding::{Base64, Encoding};
+use iota_sdk_types::SenderSignedTransaction;
 use iota_types::{
     effects::TransactionEffectsAPI,
     object::Object,
     signature::UserSignature,
-    transaction::{SenderSignedData, TransactionData, TransactionDataAPI},
+    transaction::{TransactionData, TransactionDataAPI},
 };
 use iota_vm_sdk::{
     Chain, ChainContext, DebugConfig, ExecuteOptions, InMemoryStore, LocalVm, ProfileOutput,
@@ -102,7 +103,7 @@ fn fixture() -> Result<Value> {
 
 /// Build the example's signed transaction — PTB body plus its MoveAuthenticator
 /// signature — from the committed fixture.
-fn example_signed_transaction() -> Result<SenderSignedData> {
+fn example_signed_transaction() -> Result<SenderSignedTransaction> {
     let f = fixture()?;
     let tx: TransactionData =
         bcs::from_bytes(&Base64::decode(f["tx_b64"].as_str().unwrap()).unwrap())?;
@@ -116,5 +117,5 @@ fn example_signed_transaction() -> Result<SenderSignedData> {
             )?)
         })
         .collect::<Result<_>>()?;
-    Ok(SenderSignedData::new(tx, sigs))
+    Ok(SenderSignedTransaction::new(tx, sigs))
 }

--- a/crates/iota-vm-sdk/src/executor/local_vm.rs
+++ b/crates/iota-vm-sdk/src/executor/local_vm.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, OnceLock};
 
 use iota_execution::Executor;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::Address;
+use iota_sdk_types::{Address, SenderSignedTransaction};
 use iota_types::{
     effects::{TransactionEffectsAPI, TransactionEvents},
     gas::IotaGasStatus,
@@ -15,7 +15,7 @@ use iota_types::{
     move_authenticator::MoveAuthenticator,
     signature::VerifyParams,
     signature_verification::verify_sender_signed_data_message_signatures,
-    transaction::{SenderSignedData, TransactionData, TransactionDataAPI},
+    transaction::{TransactionData, TransactionDataAPI},
     transaction_executor::SimulateTransactionResult,
 };
 use move_bytecode_utils::{layout::TypeLayoutBuilder, module_cache::GetModule};
@@ -179,7 +179,7 @@ impl LocalVm {
     /// [`ExecutionResult::signature_status`], not as an error.
     pub fn execute_signed(
         &mut self,
-        signed: SenderSignedData,
+        signed: SenderSignedTransaction,
         opts: ExecuteOptions,
     ) -> Result<ExecutionResult, VmSdkError> {
         let env = ExecutionEnv::new(self, &opts.debug)?;
@@ -282,7 +282,7 @@ impl LocalVm {
     /// [`SignatureStatus::Failed`], not as an error.
     pub fn check_signing_authentication(
         &self,
-        signed: SenderSignedData,
+        signed: SenderSignedTransaction,
     ) -> Result<SignatureStatus, VmSdkError> {
         self.verify_standard_signatures(&signed)?;
 
@@ -403,7 +403,10 @@ impl LocalVm {
     }
 
     /// Verify the standard-scheme signatures on `signed`.
-    fn verify_standard_signatures(&self, signed: &SenderSignedData) -> Result<(), VmSdkError> {
+    fn verify_standard_signatures(
+        &self,
+        signed: &SenderSignedTransaction,
+    ) -> Result<(), VmSdkError> {
         // Match the node's verifier, which derives these from the protocol
         // config (see `AuthorityPerEpochStore`); `VerifyParams::default()` would
         // hardcode both off and diverge for passkey-in-multisig / additional
@@ -476,7 +479,7 @@ impl LocalVm {
 /// protocol enables `pre_consensus_sponsor_only_move_authentication`. Mirrors
 /// the node's `pre_consensus_move_authenticators`.
 fn pre_consensus_authenticator_addresses(
-    signed: &SenderSignedData,
+    signed: &SenderSignedTransaction,
     protocol_config: &ProtocolConfig,
 ) -> Vec<Address> {
     let selected: Vec<&MoveAuthenticator> = if protocol_config

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -103,7 +103,7 @@ pub(super) fn prepare_transaction(
     // shared/owned kind) that store loading does not change, so a denied
     // transaction is rejected without the intervening object I/O.
     //
-    // The node deny-checks `SenderSignedData::input_objects()`, which merges
+    // The node deny-checks `SenderSignedTransaction::input_objects()`, which merges
     // every `MoveAuthenticator`'s input objects into the transaction's; mirror
     // that merge so denied objects are also caught as authenticator inputs.
     let mut deny_check_input_kinds = raw_input_object_kinds.clone();

--- a/crates/iota-vm-sdk/src/lib.rs
+++ b/crates/iota-vm-sdk/src/lib.rs
@@ -58,11 +58,13 @@ pub use iota_config::transaction_deny_config::{
     TransactionDenyConfig, TransactionDenyConfigBuilder,
 };
 pub use iota_protocol_config::{Chain, ProtocolVersion};
-pub use iota_sdk_types::{Address, MoveAuthenticator, ObjectId, StructTag, TypeTag, Version};
+pub use iota_sdk_types::{
+    Address, MoveAuthenticator, ObjectId, SenderSignedTransaction, StructTag, TypeTag, Version,
+};
 pub use iota_types::{
     effects::{TransactionEffects, TransactionEvents},
     object::Object,
     signature::UserSignature,
-    transaction::{SenderSignedData, TransactionData},
+    transaction::TransactionData,
 };
 pub use store::{InMemoryStore, Store};

--- a/crates/iota-vm-sdk/src/wasm/simulate.rs
+++ b/crates/iota-vm-sdk/src/wasm/simulate.rs
@@ -6,12 +6,10 @@
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use iota_protocol_config::{Chain, ProtocolVersion};
-use iota_sdk_types::{ObjectReference, Owner as SdkOwner};
+use iota_sdk_types::{ObjectReference, Owner as SdkOwner, SenderSignedTransaction};
 use iota_types::{
-    effects::TransactionEffectsAPI,
-    object::Object,
-    signature::UserSignature,
-    transaction::{SenderSignedData, TransactionData},
+    effects::TransactionEffectsAPI, object::Object, signature::UserSignature,
+    transaction::TransactionData,
 };
 use wasm_bindgen::prelude::*;
 
@@ -90,7 +88,7 @@ pub fn simulate(req: JsValue, fetch_object: js_sys::Function) -> Result<JsValue,
                 .map_err(|e| JsError::new(&format!("signature[{i}] decode: {e}")))?;
             sigs.push(sig);
         }
-        let signed_data = SenderSignedData::new(tx, sigs);
+        let signed_data = SenderSignedTransaction::new(tx, sigs);
         vm.execute_signed(signed_data, opts).map_err(err_to_js)?
     } else {
         vm.execute(tx, opts).map_err(err_to_js)?

--- a/crates/iota-vm-sdk/tests/move_authenticator.rs
+++ b/crates/iota-vm-sdk/tests/move_authenticator.rs
@@ -17,10 +17,11 @@
 use std::{fs, path::PathBuf};
 
 use fastcrypto::encoding::{Base64, Encoding};
+use iota_sdk_types::SenderSignedTransaction;
 use iota_types::{
     object::Object,
     signature::UserSignature,
-    transaction::{SenderSignedData, TransactionData, TransactionDataAPI},
+    transaction::{TransactionData, TransactionDataAPI},
 };
 use iota_vm_sdk::{
     Chain, ChainContext, ExecuteOptions, ExecutionResult, InMemoryStore, LocalVm, ProtocolVersion,
@@ -58,8 +59,8 @@ impl Fixture {
             .collect()
     }
 
-    fn signed(&self) -> SenderSignedData {
-        SenderSignedData::new(self.transaction(), self.decoded_signatures())
+    fn signed(&self) -> SenderSignedTransaction {
+        SenderSignedTransaction::new(self.transaction(), self.decoded_signatures())
     }
 
     fn objects(&self) -> Vec<Object> {
@@ -220,7 +221,7 @@ fn move_authenticator_dev_inspect_rerun_ignores_zero_declared_budget() {
     // declared `0`.
     let first = vm
         .execute_signed(
-            SenderSignedData::new(tx.clone(), f.decoded_signatures()),
+            SenderSignedTransaction::new(tx.clone(), f.decoded_signatures()),
             ExecuteOptions::dev_inspect(),
         )
         .expect("first run returns Ok");
@@ -241,7 +242,7 @@ fn move_authenticator_dev_inspect_rerun_ignores_zero_declared_budget() {
     // metered at the declared `0` it would run out of gas and misreport.
     let second = vm
         .execute_signed(
-            SenderSignedData::new(tx, f.decoded_signatures()),
+            SenderSignedTransaction::new(tx, f.decoded_signatures()),
             ExecuteOptions::dev_inspect(),
         )
         .expect("second run returns Ok (the abort is carried in the status)");
@@ -289,7 +290,7 @@ fn sponsor_move_authenticator_is_executed_and_can_reject() {
         "tx must be sponsored (sender != sponsor)"
     );
 
-    let signed = SenderSignedData::new(tx, vec![sender_auth, sponsor_auth]);
+    let signed = SenderSignedTransaction::new(tx, vec![sender_auth, sponsor_auth]);
 
     // The store needs both accounts' objects (each authenticator resolves its
     // own `AuthenticatorFunctionRefV1` dynamic field).

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -48,8 +48,8 @@ use iota_sdk::{
     wallet_context::WalletContext,
 };
 use iota_sdk_types::{
-    Address, Identifier, ObjectId, ObjectReference, Owner, SharedObjectReference,
-    TransactionDigest, TransactionKind, TypeTag, Version,
+    Address, Identifier, ObjectId, ObjectReference, Owner, SenderSignedTransaction,
+    SharedObjectReference, TransactionDigest, TransactionKind, TypeTag, Version,
     crypto::{Intent, IntentMessage},
     gas::GasCostSummary,
     move_package::MovePackage,
@@ -77,8 +77,8 @@ use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType,
     signature::UserSignature,
     transaction::{
-        CallArg, InputObjectKind, SenderSignedData, Transaction, TransactionData,
-        TransactionDataAPI, TransactionKindExt,
+        CallArg, InputObjectKind, Transaction, TransactionData, TransactionDataAPI,
+        TransactionKindExt,
     },
 };
 use json_to_table::json_to_table;
@@ -214,7 +214,7 @@ pub enum IotaClientCommands {
         #[arg(long, num_args(1..), required = true)]
         signatures: Vec<String>,
     },
-    /// Execute a combined serialized SenderSignedData string.
+    /// Execute a combined serialized SenderSignedTransaction string.
     ExecuteCombinedSignedTx {
         /// BCS serialized sender signed data, as base64 encoded string. This is
         /// the output of iota client command using
@@ -665,7 +665,7 @@ pub struct TxProcessingArgs {
     #[arg(long)]
     pub serialize_unsigned_transaction: bool,
     /// Instead of executing the transaction, serialize the bcs bytes of the
-    /// signed transaction data (SenderSignedData) using base64 encoding,
+    /// signed transaction data (SenderSignedTransaction) using base64 encoding,
     /// and print out the string <SIGNED_TX_BYTES>. The string can be used
     /// to execute transaction with `iota client execute-combined-signed-tx
     /// --signed-tx-bytes <SIGNED_TX_BYTES>`.
@@ -1869,13 +1869,13 @@ impl IotaClientCommands {
                 IotaClientCommandResult::TransactionBlock(response)
             }
             IotaClientCommands::ExecuteCombinedSignedTx { signed_tx_bytes } => {
-                let data: SenderSignedData = bcs::from_bytes(
+                let data: SenderSignedTransaction = bcs::from_bytes(
                     &Base64::try_from(signed_tx_bytes)
                         .map_err(|_| anyhow!("Invalid Base64 encoding"))?
                         .to_vec()
                         .map_err(|_| anyhow!("Invalid Base64 encoding"))?
-                ).map_err(|_| anyhow!("Failed to parse SenderSignedData bytes, check if it matches the output of iota client commands with --serialize-signed-transaction"))?;
-                let transaction = Envelope::<SenderSignedData, EmptySignInfo>::new(data);
+                ).map_err(|_| anyhow!("Failed to parse SenderSignedTransaction bytes, check if it matches the output of iota client commands with --serialize-signed-transaction"))?;
+                let transaction = Envelope::<SenderSignedTransaction, EmptySignInfo>::new(data);
                 let response = context.execute_transaction_may_fail(transaction).await?;
                 IotaClientCommandResult::TransactionBlock(response)
             }
@@ -2991,7 +2991,7 @@ pub enum IotaClientCommandResult {
     Objects(Vec<IotaObjectResponse>),
     RawObject(IotaObjectResponse),
     RemoveAddress(Address),
-    SerializedSignedTransaction(SenderSignedData),
+    SerializedSignedTransaction(SenderSignedTransaction),
     SerializedUnsignedTransaction(TransactionData),
     Sign(SignData),
     Switch(SwitchResponse),
@@ -3504,7 +3504,7 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
             }
         }
 
-        let sender_signed_data = SenderSignedData::new(tx_data, signatures);
+        let sender_signed_data = SenderSignedTransaction::new(tx_data, signatures);
 
         if serialize_signed_transaction {
             Ok(IotaClientCommandResult::SerializedSignedTransaction(

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -51,7 +51,7 @@ use iota_types::{
     multisig::{MultiSig, MultiSigPublicKey, MultisigMember, ThresholdUnit, WeightUnit},
     passkey_authenticator::PasskeyAuthenticator,
     signature::{AuthenticatorTrait, VerifyParams},
-    transaction::{SenderSignedData, TransactionData, TransactionDataAPI},
+    transaction::{TransactionData, TransactionDataAPI},
 };
 use json_to_table::{Orientation, json_to_table};
 use serde::Serialize;
@@ -481,16 +481,17 @@ impl KeyToolCommand {
             }
             KeyToolCommand::DecodeSig { sig } => {
                 // Try to decode as UserSignature first, then fallback to
-                // SenderSignedData (which contains a SenderSignedTransaction)
+                // SenderSignedTransaction (which contains a SenderSignedTransaction)
                 let signature = match UserSignature::from_base64(&sig) {
                     Ok(sig) => sig,
                     Err(_) => {
-                        // Try decoding as SenderSignedData
+                        // Try decoding as SenderSignedTransaction
                         let tx_bytes = Base64::decode(&sig)
                             .map_err(|e| anyhow!("Invalid base64 encoding: {e}"))?;
-                        let tx = bcs::from_bytes::<SenderSignedData>(&tx_bytes).map_err(|e| {
-                            anyhow!("Failed to decode as signature or transaction: {e}")
-                        })?;
+                        let tx =
+                            bcs::from_bytes::<SenderSignedTransaction>(&tx_bytes).map_err(|e| {
+                                anyhow!("Failed to decode as signature or transaction: {e}")
+                            })?;
                         tx.0.signatures
                             .into_iter()
                             .next()

--- a/crates/iota/src/unit_tests/keytool_tests.rs
+++ b/crates/iota/src/unit_tests/keytool_tests.rs
@@ -878,9 +878,9 @@ async fn test_decode_sig() -> Result<(), anyhow::Error> {
         _ => panic!("Expected MoveAuthenticator variant"),
     }
 
-    // Test 3: Decode signature from a full SenderSignedData (transaction with
-    // signature) The fallback decodes the transaction and extracts the first
-    // signature
+    // Test 3: Decode signature from a full SenderSignedTransaction (transaction
+    // with signature) The fallback decodes the transaction and extracts the
+    // first signature
     let full_tx = "AQAAAAAAAgAIAMqaOwAAAAAAIBEREREVBOk1DmNdZc04zNLAKUNMajpIDYlHqbpqFbIVAgIAAQEAAAEBAwAAAAABAQARERERFQTpNQ5jXWXNOMzSwClDTGo6SA2JR6m6ahWyFQFODzG01xo0l0JIwq9SzbRyvRKR/9TvCUbh8lrerlLQWT9uOykAAAAAIBTjvmRbByY+0uGCBeTvSXQnUXonVSdJMuPOIwfGCZ/4ERERERUE6TUOY11lzTjM0sApQ0xqOkgNiUepumoVshXoAwAAAAAAAOBvPAAAAAAAAAFhAKFqV1NustAADKOOOfAZIA/9HrnmA9PqwAmOrqTs7OKjaEXylfywifj2XZyBmEJYodGE89xlkDOthe+bpBIrkwEoe8lptdiMUw3h3rcxQJf3bWp9zFLP4Eq3rpQOam52cw==";
     let output = KeyToolCommand::DecodeSig {
         sig: full_tx.to_string(),


### PR DESCRIPTION
Part of #11567.

- Remove the `pub use iota_sdk_types::SenderSignedTransaction as SenderSignedData` re-export from `iota-types` (the `TransactionData`/`TransactionDataV1` aliases on the same line stay; they are tracked separately).
- Adopt the SDK name at all call sites: `SenderSignedData` becomes `SenderSignedTransaction`, imported from `iota_sdk_types` directly. The in-repo struct was already replaced by the SDK type in #12331; this drops the transitional name.
- Deliberately unchanged: the GraphQL `rawTransaction` field description (public schema text) and the distinct SDK type `SenderSignedDataDigest`.

[run-ci]