### PR TITLE
fix(ci): do not run hierarchy tests on pushes to develop

### DIFF
--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -3,7 +3,6 @@ name: Hierarchy
 on:
   push:
     branches:
-      - "develop"
       - "devnet"
       - "testnet"
       - "mainnet"


### PR DESCRIPTION
# Description of change

We enabled the `merge-queue` so we don't need to test again on pushes to develop.