### PR TITLE
refactor(iota-core, iota-types): remove remaining `ConsensusTransactionKind` wildcard matches

### DIFF
--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -425,25 +425,21 @@ impl ConsensusAdapter {
         committee: &Committee,
         transactions: &[ConsensusTransaction],
     ) -> (impl Future<Output = ()>, usize, usize, usize) {
-        // Use the minimum digest to compute submit delay.
+        // Use the minimum digest to compute submit delay. P-COOL user
+        // transactions (`UserTransactionV1` / `UserTransactionV2`) are
+        // excluded: no submit delay needed (number of submitting validators
+        // controlled through another mechanism).
         let min_digest = transactions
             .iter()
-            .filter_map(|tx| match &tx.kind {
-                ConsensusTransactionKind::CertifiedTransaction(certificate) => {
-                    Some(certificate.digest())
-                }
-                ConsensusTransactionKind::UserTransactionV1(_)
-                | ConsensusTransactionKind::UserTransactionV2(_) => {
-                    // P-COOL: no submit delay needed (number of submitting validators
-                    // controlled through another mechanism)
-                    None
-                }
-                _ => None,
+            .filter_map(|tx| {
+                tx.is_user_certificate()
+                    .then(|| tx.kind.transaction_digest())
+                    .flatten()
             })
             .min();
 
         let (duration, position, positions_moved, preceding_disconnected) = match min_digest {
-            Some(digest) => self.await_submit_delay_user_transaction(committee, digest),
+            Some(digest) => self.await_submit_delay_user_transaction(committee, &digest),
             _ => (Duration::ZERO, 0, 0, 0),
         };
         (

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -52,7 +52,6 @@ use iota_sdk_types::{ObjectReference, TransactionDigest};
 use iota_types::{
     attestation::Attestation,
     error::{IotaError, IotaResult, UserInputError},
-    messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     transaction::{InputObjectKind, TransactionDataAPI, VerifiedTransaction},
 };
 use tracing::{debug, warn};
@@ -134,16 +133,13 @@ pub async fn validate_and_resolve_conflicts(
 
         // Only validate UserTransactionV1/V2; pass everything else through
         // unchanged.
-        let (transaction, attestation) = match &tx.0.transaction {
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV1(t),
-                ..
-            }) => (t.as_ref(), None),
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransactionV2(a),
-                ..
-            }) => (&a.transaction, Some(&a.attestation)),
-            _ => continue,
+        let Some((transaction, attestation)) = (match &tx.0.transaction {
+            SequencedConsensusTransactionKind::External(ext) => {
+                ext.kind.as_user_transaction_with_attestation()
+            }
+            SequencedConsensusTransactionKind::System(_) => None,
+        }) else {
+            continue;
         };
 
         let digest = *transaction.digest();

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::{
-    attestation::AttestedTransaction,
+    attestation::{Attestation, AttestedTransaction},
     base_types::{AuthorityName, ConciseableName},
     crypto::{AuthoritySignature, DefaultHash, default_hash},
     message_envelope::{Envelope, Message, VerifiedEnvelope},
@@ -302,13 +302,15 @@ impl ConsensusTransactionKind {
         self.map_cert_or_raw_user_tx(|c| *c.digest(), |t| *t.digest())
     }
 
-    /// Returns the raw, uncertified user transaction (`UserTransactionV1` or
-    /// `UserTransactionV2`) submitted directly to consensus, or `None` for any
+    /// Returns the raw, uncertified user transaction together with its
+    /// attestation (`Some` only for `UserTransactionV2`), or `None` for any
     /// other kind. Certified user transactions are not included here.
-    pub fn as_user_transaction(&self) -> Option<&Transaction> {
+    pub fn as_user_transaction_with_attestation(
+        &self,
+    ) -> Option<(&Transaction, Option<&Attestation>)> {
         match self {
-            Self::UserTransactionV1(tx) => Some(tx),
-            Self::UserTransactionV2(a) => Some(&a.transaction),
+            Self::UserTransactionV1(t) => Some((t, None)),
+            Self::UserTransactionV2(a) => Some((&a.transaction, Some(&a.attestation))),
             Self::CertifiedTransaction(_)
             | Self::CheckpointSignature(_)
             | Self::EndOfPublish(_)
@@ -321,6 +323,13 @@ impl ConsensusTransactionKind {
             #[allow(deprecated)]
             Self::NewJWKFetchedDeprecated => None,
         }
+    }
+
+    /// Returns the raw, uncertified user transaction (`UserTransactionV1` or
+    /// `UserTransactionV2`) submitted directly to consensus, or `None` for any
+    /// other kind. Certified user transactions are not included here.
+    pub fn as_user_transaction(&self) -> Option<&Transaction> {
+        self.as_user_transaction_with_attestation().map(|(t, _)| t)
     }
 
     /// Returns `true` only for a raw, uncertified user transaction


### PR DESCRIPTION
# Description of change

Follow-up to #12212 for the attestation feature branch: the branch adds `ConsensusTransactionKind::UserTransactionV2(Box<AttestedTransaction>)`, and two call sites still destructured the kind with a `_ =>` wildcard, which is precisely the silent-fallthrough pattern #12212 removed on develop.

This PR adds `ConsensusTransactionKind::as_user_transaction_with_attestation()`, an exhaustive-match accessor returning the raw user transaction together with its attestation (`Some` only for `UserTransactionV2`); `as_user_transaction()` now delegates to it. `validate_and_resolve_conflicts()` (post-consensus validation) now uses the new accessor instead of a local match ending in `_ => continue`.

Furthermore, `ConsensusAdapter::await_submit_delay()` now computes `min_digest` via `is_user_certificate()` + `transaction_digest()` instead of a local match ending in `_ => None`. No dedicated certificate accessor is added.

No behavior change: all wildcard arms mapped to the same skip/`None` outcome the accessors now produce.

## Links to any relevant issues

Follow-up to #12212.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes