### PR TITLE
feat(graphql): expose checkpoint summary BCS on the Checkpoint type

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -359,6 +359,15 @@ type Checkpoint {
 	"""
 	digest: String!
 	"""
+	The Base64-encoded BCS serialization of this checkpoint's
+	`CheckpointSummary`.
+	
+	# Note
+	For older checkpoints, where this data was not recorded, `null` is
+	returned.
+	"""
+	bcs: Base64
+	"""
 	This checkpoint's position in the total order of finalized checkpoints,
 	agreed upon by consensus.
 	"""

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -12,7 +12,7 @@ use async_graphql::{
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{models::checkpoints::StoredCheckpoint, schema::checkpoints};
-use iota_sdk_types::CheckpointDigest;
+use iota_sdk_types::{CheckpointDigest, CheckpointSummary};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -96,6 +96,26 @@ impl Checkpoint {
     #[graphql(complexity = 0)]
     async fn digest(&self) -> Result<String> {
         Ok(self.digest_impl().extend()?.to_base58())
+    }
+
+    /// The Base64-encoded BCS serialization of this checkpoint's
+    /// `CheckpointSummary`.
+    ///
+    /// # Note
+    /// For older checkpoints, where this data was not recorded, `null` is
+    /// returned.
+    #[graphql(complexity = 0)]
+    async fn bcs(&self) -> Result<Option<Base64>> {
+        if self.stored.content_digest.is_none() || self.stored.version_specific_data.is_none() {
+            return Ok(None);
+        }
+        let summary = CheckpointSummary::try_from(self.stored.clone())
+            .map_err(|e| Error::Internal(format!("Failed to rebuild checkpoint summary: {e}")))
+            .extend()?;
+        let bytes = bcs::to_bytes(&summary)
+            .map_err(|e| Error::Internal(format!("Failed to serialize checkpoint summary: {e}")))
+            .extend()?;
+        Ok(Some(Base64::from(bytes)))
     }
 
     /// This checkpoint's position in the total order of finalized checkpoints,

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -363,6 +363,15 @@ type Checkpoint {
 	"""
 	digest: String!
 	"""
+	The Base64-encoded BCS serialization of this checkpoint's
+	`CheckpointSummary`.
+	
+	# Note
+	For older checkpoints, where this data was not recorded, `null` is
+	returned.
+	"""
+	bcs: Base64
+	"""
 	This checkpoint's position in the total order of finalized checkpoints,
 	agreed upon by consensus.
 	"""

--- a/crates/iota-indexer/migrations/pg/2026-06-23-100000_checkpoints_add_summary_fields/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-06-23-100000_checkpoints_add_summary_fields/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE checkpoints DROP COLUMN content_digest;
+ALTER TABLE checkpoints DROP COLUMN version_specific_data;

--- a/crates/iota-indexer/migrations/pg/2026-06-23-100000_checkpoints_add_summary_fields/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-06-23-100000_checkpoints_add_summary_fields/up.sql
@@ -1,0 +1,4 @@
+-- `CheckpointSummary` fields the other columns can't reproduce, needed to
+-- reconstruct the summary and recompute its canonical digest.
+ALTER TABLE checkpoints ADD COLUMN content_digest BYTEA;
+ALTER TABLE checkpoints ADD COLUMN version_specific_data BYTEA;

--- a/crates/iota-indexer/src/models/checkpoints.rs
+++ b/crates/iota-indexer/src/models/checkpoints.rs
@@ -223,8 +223,8 @@ impl TryFrom<StoredCheckpoint> for CheckpointSummary {
         let checkpoint_commitments =
             bcs::from_bytes(&checkpoint.checkpoint_commitments).map_err(|e| {
                 IndexerError::PersistentStorageDataCorruption(format!(
-                    "Failed to decode checkpoint commitments: {:?} with err: {:?}",
-                    checkpoint.checkpoint_commitments, e
+                    "Failed to decode checkpoint commitments: {:?} with err: {e:?}",
+                    checkpoint.checkpoint_commitments
                 ))
             })?;
 

--- a/crates/iota-indexer/src/models/checkpoints.rs
+++ b/crates/iota-indexer/src/models/checkpoints.rs
@@ -4,7 +4,10 @@
 
 use diesel::prelude::*;
 use iota_json_rpc_types::Checkpoint as RpcCheckpoint;
-use iota_sdk_types::{CheckpointDigest, TransactionDigest, gas::GasCostSummary};
+use iota_sdk_types::{
+    CheckpointContentsDigest, CheckpointDigest, CheckpointSummary, TransactionDigest,
+    gas::GasCostSummary,
+};
 
 use crate::{
     errors::IndexerError,
@@ -40,6 +43,8 @@ pub struct StoredCheckpoint {
     pub min_tx_sequence_number: Option<i64>,
     pub max_tx_sequence_number: Option<i64>,
     pub computation_cost_burned: Option<i64>,
+    pub content_digest: Option<Vec<u8>>,
+    pub version_specific_data: Option<Vec<u8>>,
 }
 
 impl StoredCheckpoint {
@@ -82,6 +87,8 @@ impl From<&IndexedCheckpoint> for StoredCheckpoint {
             end_of_epoch: c.end_of_epoch_data.is_some(),
             min_tx_sequence_number: Some(c.min_tx_sequence_number as i64),
             max_tx_sequence_number: Some(c.max_tx_sequence_number as i64),
+            content_digest: Some(c.content_digest.into_inner().to_vec()),
+            version_specific_data: Some(c.version_specific_data.clone()),
         }
     }
 }
@@ -178,6 +185,82 @@ impl TryFrom<StoredCheckpoint> for RpcCheckpoint {
     }
 }
 
+impl TryFrom<StoredCheckpoint> for CheckpointSummary {
+    type Error = IndexerError;
+
+    fn try_from(checkpoint: StoredCheckpoint) -> Result<CheckpointSummary, IndexerError> {
+        let computation_cost_burned = checkpoint.computation_cost_burned();
+
+        let content_digest_bytes = checkpoint.content_digest.ok_or_else(|| {
+            IndexerError::PersistentStorageDataCorruption(
+                "checkpoint content_digest is missing; re-index to populate it".to_string(),
+            )
+        })?;
+        let content_digest = CheckpointContentsDigest::from_bytes(content_digest_bytes.clone())
+            .map_err(|e| {
+                IndexerError::PersistentStorageDataCorruption(format!(
+                    "Failed to decode content digest: {content_digest_bytes:?} with err: {e:?}"
+                ))
+            })?;
+
+        let version_specific_data = checkpoint.version_specific_data.ok_or_else(|| {
+            IndexerError::PersistentStorageDataCorruption(
+                "checkpoint version_specific_data is missing; re-index to populate it".to_string(),
+            )
+        })?;
+
+        let previous_digest = checkpoint
+            .previous_checkpoint_digest
+            .map(|digest| {
+                CheckpointDigest::from_bytes(digest.clone()).map_err(|e| {
+                    IndexerError::PersistentStorageDataCorruption(format!(
+                        "Failed to decode previous checkpoint digest: {digest:?} with err: {e:?}"
+                    ))
+                })
+            })
+            .transpose()?;
+
+        let checkpoint_commitments =
+            bcs::from_bytes(&checkpoint.checkpoint_commitments).map_err(|e| {
+                IndexerError::PersistentStorageDataCorruption(format!(
+                    "Failed to decode checkpoint commitments: {:?} with err: {:?}",
+                    checkpoint.checkpoint_commitments, e
+                ))
+            })?;
+
+        let end_of_epoch_data = checkpoint
+            .end_of_epoch_data
+            .as_ref()
+            .map(|data| {
+                bcs::from_bytes(data).map_err(|e| {
+                    IndexerError::PersistentStorageDataCorruption(format!(
+                        "Failed to decode end of epoch data: {data:?} with err: {e:?}"
+                    ))
+                })
+            })
+            .transpose()?;
+
+        Ok(CheckpointSummary {
+            epoch: checkpoint.epoch as u64,
+            sequence_number: checkpoint.sequence_number as u64,
+            network_total_transactions: checkpoint.network_total_transactions as u64,
+            content_digest,
+            previous_digest,
+            epoch_rolling_gas_cost_summary: GasCostSummary {
+                computation_cost: checkpoint.computation_cost as u64,
+                computation_cost_burned,
+                storage_cost: checkpoint.storage_cost as u64,
+                storage_rebate: checkpoint.storage_rebate as u64,
+                non_refundable_storage_fee: checkpoint.non_refundable_storage_fee as u64,
+            },
+            timestamp_ms: checkpoint.timestamp_ms as u64,
+            checkpoint_commitments,
+            end_of_epoch_data,
+            version_specific_data,
+        })
+    }
+}
+
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = pruner_cp_watermark)]
 pub struct StoredCpTx {
@@ -193,5 +276,71 @@ impl From<&IndexedCheckpoint> for StoredCpTx {
             min_tx_sequence_number: c.min_tx_sequence_number as i64,
             max_tx_sequence_number: c.max_tx_sequence_number as i64,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn checkpoint_summary_rebuilds_from_stored_columns() {
+        let summary = CheckpointSummary {
+            epoch: 7,
+            sequence_number: 42,
+            network_total_transactions: 100,
+            content_digest: CheckpointContentsDigest::new([1u8; 32]),
+            previous_digest: Some(CheckpointDigest::new([2u8; 32])),
+            epoch_rolling_gas_cost_summary: GasCostSummary {
+                computation_cost: 10,
+                computation_cost_burned: 4,
+                storage_cost: 20,
+                storage_rebate: 5,
+                non_refundable_storage_fee: 1,
+            },
+            timestamp_ms: 1_700_000_000_000,
+            checkpoint_commitments: vec![],
+            end_of_epoch_data: None,
+            version_specific_data: vec![1, 2, 3, 4],
+        };
+
+        let stored = StoredCheckpoint {
+            sequence_number: summary.sequence_number as i64,
+            checkpoint_digest: summary.digest().into_inner().to_vec(),
+            epoch: summary.epoch as i64,
+            network_total_transactions: summary.network_total_transactions as i64,
+            previous_checkpoint_digest: summary.previous_digest.map(|d| d.into_inner().to_vec()),
+            end_of_epoch: summary.end_of_epoch_data.is_some(),
+            tx_digests: vec![],
+            timestamp_ms: summary.timestamp_ms as i64,
+            total_gas_cost: 0,
+            computation_cost: summary.epoch_rolling_gas_cost_summary.computation_cost as i64,
+            storage_cost: summary.epoch_rolling_gas_cost_summary.storage_cost as i64,
+            storage_rebate: summary.epoch_rolling_gas_cost_summary.storage_rebate as i64,
+            non_refundable_storage_fee: summary
+                .epoch_rolling_gas_cost_summary
+                .non_refundable_storage_fee as i64,
+            checkpoint_commitments: bcs::to_bytes(&summary.checkpoint_commitments).unwrap(),
+            validator_signature: vec![],
+            end_of_epoch_data: summary
+                .end_of_epoch_data
+                .as_ref()
+                .map(|d| bcs::to_bytes(d).unwrap()),
+            min_tx_sequence_number: None,
+            max_tx_sequence_number: None,
+            computation_cost_burned: Some(
+                summary
+                    .epoch_rolling_gas_cost_summary
+                    .computation_cost_burned as i64,
+            ),
+            content_digest: Some(summary.content_digest.into_inner().to_vec()),
+            version_specific_data: Some(summary.version_specific_data.clone()),
+        };
+
+        let rebuilt = CheckpointSummary::try_from(stored).unwrap();
+        assert_eq!(summary, rebuilt);
+        // The rebuilt summary must hash to the same canonical checkpoint digest.
+        assert_eq!(summary.digest(), rebuilt.digest());
     }
 }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -81,6 +81,8 @@ diesel::table! {
         min_tx_sequence_number -> Nullable<Int8>,
         max_tx_sequence_number -> Nullable<Int8>,
         computation_cost_burned -> Nullable<Int8>,
+        content_digest -> Nullable<Bytea>,
+        version_specific_data -> Nullable<Bytea>,
     }
 }
 

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -7,8 +7,8 @@ use iota_json_rpc_types::{
     IotaTransactionKind, ObjectChange,
 };
 use iota_sdk_types::{
-    Address, CheckpointDigest, ObjectDigest, ObjectId, Owner, StructTag, TransactionDigest,
-    TypeTag, Version, move_package::MovePackage,
+    Address, CheckpointContentsDigest, CheckpointDigest, ObjectDigest, ObjectId, Owner, StructTag,
+    TransactionDigest, TypeTag, Version, move_package::MovePackage,
 };
 use iota_types::{
     crypto::AggregateAuthoritySignature,
@@ -48,6 +48,8 @@ pub struct IndexedCheckpoint {
     pub non_refundable_storage_fee: u64,
     pub checkpoint_commitments: Vec<CheckpointCommitment>,
     pub validator_signature: AggregateAuthoritySignature,
+    pub content_digest: CheckpointContentsDigest,
+    pub version_specific_data: Vec<u8>,
     // Note: not used in StoredCheckpoint conversion and in code overall.
     pub successful_tx_num: usize,
     pub end_of_epoch_data: Option<EndOfEpochData>,
@@ -93,6 +95,8 @@ impl IndexedCheckpoint {
             timestamp_ms: checkpoint.timestamp_ms,
             validator_signature: auth_sig.clone(),
             checkpoint_commitments: checkpoint.checkpoint_commitments.clone(),
+            content_digest: checkpoint.content_digest,
+            version_specific_data: checkpoint.version_specific_data.clone(),
             min_tx_sequence_number,
             max_tx_sequence_number,
         }


### PR DESCRIPTION
# Description of change

This PR adds checkpoint summary BCS filed to Checkpoint type in graphql and adds the necessary changes to the iota-indexer side. 

For more in depth information check the description: https://github.com/iotaledger/iota/pull/12020

## Links to any relevant issues

Part of #12308 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

Relevant tests (synchronization, migration) are pending.