### PR TITLE
backport: refactor(authority): check_move_account has now a dedicated path for execution (#12375)

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1916,25 +1916,28 @@ impl AuthorityState {
                             auth_account_object_id,
                             auth_account_object_seq_number,
                             auth_account_object_digest,
-                        ) = move_authenticator.object_to_authenticate_components()?;
+                        ) = move_authenticator
+                            .object_to_authenticate_components()
+                            .expect("the object to authenticate is validated before consensus and cannot be invalid during execution");
 
                         let signer = move_authenticator.address();
 
-                        let authenticator_function_ref_for_execution = self.check_move_account(
-                            auth_account_object_id,
-                            auth_account_object_seq_number,
-                            auth_account_object_digest,
-                            account_object,
-                            &signer,
-                        )?;
+                        let authenticator_function_ref_for_execution = self
+                            .check_move_account_for_execution(
+                                auth_account_object_id,
+                                auth_account_object_seq_number,
+                                auth_account_object_digest,
+                                account_object,
+                                &signer,
+                            );
 
-                        Ok((
+                        (
                             authenticator_input_objects,
                             authenticator_function_ref_for_execution,
-                        ))
+                        )
                     },
                 )
-                .collect::<IotaResult<Vec<_>>>()?;
+                .collect::<Vec<_>>();
 
             let per_authenticator_input_objects = per_authenticator_inputs
                 .iter()
@@ -5622,9 +5625,36 @@ impl AuthorityState {
         Ok(new_epoch_store)
     }
 
-    /// Checks if `authenticator` unlocks a valid Move account and returns the
-    /// account-related `AuthenticatorFunctionRef` object.
-    fn check_move_account(
+    /// Resolves the account's `AuthenticatorFunctionRef` on the execution path,
+    /// where the certificate has already passed validation before consensus.
+    ///
+    /// A deleted or cancelled account object is not an error here: its version
+    /// is returned so execution can proceed and surface the proper effect
+    /// (e.g. `InputObjectDeleted` or a shared-object congestion cancellation).
+    /// Any other failure is a broken invariant and panics.
+    fn check_move_account_for_execution(
+        &self,
+        auth_account_object_id: ObjectId,
+        auth_account_object_seq_number: Option<Version>,
+        auth_account_object_digest: Option<ObjectDigest>,
+        account_object: ObjectReadResult,
+        signer: &Address,
+    ) -> AuthenticatorFunctionRefForExecution {
+        self.check_move_account(
+            auth_account_object_id,
+            auth_account_object_seq_number,
+            auth_account_object_digest,
+            account_object,
+            signer,
+            true,
+        )
+        .expect("move account checks cannot fail during execution")
+    }
+
+    /// Resolves the account's `AuthenticatorFunctionRef` on the validation
+    /// (signing) path, rejecting the transaction when the account object was
+    /// deleted or belongs to a cancelled transaction.
+    fn check_move_account_for_validation(
         &self,
         auth_account_object_id: ObjectId,
         auth_account_object_seq_number: Option<Version>,
@@ -5632,74 +5662,117 @@ impl AuthorityState {
         account_object: ObjectReadResult,
         signer: &Address,
     ) -> IotaResult<AuthenticatorFunctionRefForExecution> {
-        let account_object = match account_object.object {
-            ObjectReadResultKind::Object(object) => Ok(object),
-            ObjectReadResultKind::DeletedSharedObject(version, digest) => {
-                Err(UserInputError::AccountObjectDeleted {
-                    account_id: account_object.id(),
-                    account_version: version,
-                    transaction_digest: digest,
-                })
-            }
-            // It is impossible to check the account object because it is used in a canceled
-            // transaction and is not loaded.
-            ObjectReadResultKind::CancelledTransactionSharedObject(version) => {
-                Err(UserInputError::AccountObjectInCanceledTransaction {
-                    account_id: account_object.id(),
-                    account_version: version,
-                })
-            }
-        }?;
+        self.check_move_account(
+            auth_account_object_id,
+            auth_account_object_seq_number,
+            auth_account_object_digest,
+            account_object,
+            signer,
+            false,
+        )
+    }
 
-        let account_object_addr = Address::from(auth_account_object_id);
-
-        fp_ensure!(
-            signer == &account_object_addr,
-            UserInputError::IncorrectUserSignature {
-                error: format!("Move authenticator is trying to unlock {account_object_addr:?}, but given signer address is {signer:?}")
-            }
-            .into()
-        );
-
-        fp_ensure!(
-            account_object.is_shared() || account_object.is_immutable(),
-            UserInputError::AccountObjectNotSupported {
-                object_id: auth_account_object_id
-            }
-            .into()
-        );
-
-        let auth_account_object_seq_number =
-            if let Some(auth_account_object_seq_number) = auth_account_object_seq_number {
-                let account_object_version = account_object.version();
-
+    /// Checks whether `authenticator` unlocks a valid Move account and returns
+    /// the account-related `AuthenticatorFunctionRef`. When `is_execution` is
+    /// set, a deleted or cancelled account object yields its version instead of
+    /// an error, so execution can proceed to the proper effect. Prefer the
+    /// `check_move_account_for_execution` / `check_move_account_for_validation`
+    /// wrappers over calling this directly.
+    fn check_move_account(
+        &self,
+        auth_account_object_id: ObjectId,
+        auth_account_object_seq_number: Option<Version>,
+        auth_account_object_digest: Option<ObjectDigest>,
+        account_object: ObjectReadResult,
+        signer: &Address,
+        is_execution: bool,
+    ) -> IotaResult<AuthenticatorFunctionRefForExecution> {
+        let auth_account_object_seq_number = match (&account_object.object, is_execution) {
+            // In any case, if the account object is loaded, we can check its version and digest.
+            // Then we return the version of the account object to be used for reading the
+            // authenticator function ref dynamic field.
+            (ObjectReadResultKind::Object(object), _) => {
+                let account_object_addr = Address::from(auth_account_object_id);
                 fp_ensure!(
-                    account_object_version == auth_account_object_seq_number,
-                    UserInputError::AccountObjectVersionMismatch {
-                        object_id: auth_account_object_id,
-                        expected_version: auth_account_object_seq_number,
-                        actual_version: account_object_version,
+                    signer == &account_object_addr,
+                    UserInputError::IncorrectUserSignature {
+                        error: format!("Move authenticator is trying to unlock {account_object_addr:?}, but given signer address is {signer:?}")
                     }
                     .into()
                 );
 
-                auth_account_object_seq_number
-            } else {
-                account_object.version()
-            };
+                fp_ensure!(
+                    object.is_shared() || object.is_immutable(),
+                    UserInputError::AccountObjectNotSupported {
+                        object_id: auth_account_object_id
+                    }
+                    .into()
+                );
 
-        if let Some(auth_account_object_digest) = auth_account_object_digest {
-            let expected_digest = account_object.digest();
-            fp_ensure!(
-                expected_digest == auth_account_object_digest,
-                UserInputError::InvalidAccountObjectDigest {
-                    object_id: auth_account_object_id,
-                    expected_digest,
-                    actual_digest: auth_account_object_digest,
+                let auth_account_object_seq_number =
+                    if let Some(auth_account_object_seq_number) = auth_account_object_seq_number {
+                        let account_object_version = object.version();
+
+                        fp_ensure!(
+                            account_object_version == auth_account_object_seq_number,
+                            UserInputError::AccountObjectVersionMismatch {
+                                object_id: auth_account_object_id,
+                                expected_version: auth_account_object_seq_number,
+                                actual_version: account_object_version,
+                            }
+                            .into()
+                        );
+
+                        auth_account_object_seq_number
+                    } else {
+                        object.version()
+                    };
+
+                if let Some(auth_account_object_digest) = auth_account_object_digest {
+                    let expected_digest = object.digest();
+                    fp_ensure!(
+                        expected_digest == auth_account_object_digest,
+                        UserInputError::InvalidAccountObjectDigest {
+                            object_id: auth_account_object_id,
+                            expected_digest,
+                            actual_digest: auth_account_object_digest,
+                        }
+                        .into()
+                    );
                 }
-                .into()
-            );
-        }
+
+                Ok(auth_account_object_seq_number)
+            }
+            // If the account object is not loaded because it was deleted, we return the error in
+            // the case in which we are not executing the transaction right after.
+            (ObjectReadResultKind::DeletedSharedObject(version, digest), false) => {
+                Err(UserInputError::AccountObjectDeleted {
+                    account_id: account_object.id(),
+                    account_version: *version,
+                    transaction_digest: *digest,
+                })
+            }
+            // If the account object is not loaded because the transaction was canceled, we return
+            // the error in the case in which we are not executing the transaction right
+            // after.
+            (ObjectReadResultKind::CancelledTransactionSharedObject(version), false) => {
+                Err(UserInputError::AccountObjectInCanceledTransaction {
+                    account_id: account_object.id(),
+                    account_version: *version,
+                })
+            }
+            // If the account object is not loaded because it was deleted, we return the version in
+            // the case in which we are executing the transaction right after.
+            // This version is used to read the authenticator function ref dynamic field because it
+            // is greater than the version of the child dynamic field.
+            (ObjectReadResultKind::DeletedSharedObject(version, _), true) => Ok(*version),
+            // If the account object is not loaded because the transaction was canceled, we return
+            // the version in the case in which we are executing the transaction right
+            // after. This version is used to read the authenticator function ref
+            // dynamic field because it is greater than the version of the child dynamic
+            // field.
+            (ObjectReadResultKind::CancelledTransactionSharedObject(version), true) => Ok(*version),
+        }?;
 
         let authenticator_function_ref_field_id =
             derive_authenticator_function_ref_v1_dynamic_field_id(auth_account_object_id)?;
@@ -5801,7 +5874,7 @@ impl AuthorityState {
                     let AuthenticatorFunctionRefForExecution {
                         authenticator_function_ref,
                         ..
-                    } = self.check_move_account(
+                    } = self.check_move_account_for_validation(
                         auth_account_object_id,
                         auth_account_object_seq_number,
                         auth_account_object_digest,

--- a/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account.move
+++ b/crates/iota-e2e-tests/tests/abstract_account/abstract_account/sources/abstract_account.move
@@ -151,6 +151,18 @@ public fun rotate_auth_function_ref_v1(
     account::rotate_auth_function_ref_v1(self, authenticator)
 }
 
+/// Delete the account.
+///
+/// Only the account itself can call this function.
+public fun delete_account(self: AbstractAccount, ctx: &TxContext) {
+    // Check that the sender of this transaction is the account.
+    ensure_tx_sender_is_account(&self, ctx);
+
+    // Delete the account.
+    let AbstractAccount { id } = self;
+    object::delete(id);
+}
+
 // === Public-View Functions ===
 
 /// Return the account's address.

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -25,7 +25,7 @@ use iota_json_rpc_types::{
 };
 use iota_keys::keystore::AccountKeystore;
 use iota_macros::sim_test;
-use iota_protocol_config::ProtocolConfig;
+use iota_protocol_config::{PerObjectCongestionControlMode, ProtocolConfig};
 use iota_sdk_types::{
     Address, Argument, ExecutionError, Identifier, MoveLocation, ObjectId, ObjectReference, Owner,
     ProgrammableTransaction, SharedObjectReference, TypeTag, crypto::Intent,
@@ -476,6 +476,213 @@ async fn test_abstract_account_post_consensus_failure() -> Result<(), anyhow::Er
             && ErrorBitset::from_u64(*abort_code).unwrap().error_code() == Some(0)
         ),
         "Expected failure to be a MoveAuthenticationError wrapping a Move abort in basic_keyed_aa::authenticate_ed25519",
+    );
+
+    Ok(())
+}
+
+/// Test in 3 steps the failure of an Abstract Account transaction
+/// post-consensus:
+/// 1) Create a TX certificate signed by the validators where the authentication
+///    is successful
+/// 2) Tamper with the AA shared object state by creating a second TX altering
+///    the state by deleting the AA shared object
+/// 3) Submit the original certificate which should now fail during
+///    post-consensus, even though validators originally run the authenticate
+///    and it passed
+#[sim_test]
+async fn test_abstract_account_post_consensus_deletion_failure() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
+
+    // Build a test environment and create an abstract account
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_sender = aa_ref.object_id.into();
+
+    // Step 1: create an AA TX and ask the validators to sign it
+    // Create a simple transaction from the IOTA account
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+    let pt = test_env.craft_aa_simple_ptb(AA_MODULE_NAME)?;
+    let tx_data = test_env
+        .craft_tx_from_pt(
+            pt, aa_gas, aa_sender, None, // No sponsor
+        )
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+    // Create the MoveAuthenticator for the Ed25519 signature authenticator
+    let signatures = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest)?];
+    // Create the TX envelope and send it for validators signing
+    let aa_simple_tx = Transaction::from_user_sig_data(tx_data, signatures);
+    let cert = test_env
+        .test_cluster
+        .create_certificate(aa_simple_tx, Some(client_ip))
+        .await
+        .unwrap();
+
+    // Step 2: tamper with the AA shared object state by deleting it, so the
+    // original certificate becomes invalid post-consensus
+    let aa_gas2 = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+    let pt2 = test_env.craft_aa_delete_object_ptb()?;
+    let tx_data2 = test_env
+        .craft_tx_from_pt(
+            pt2, aa_gas2, aa_sender, None, // No sponsor
+        )
+        .await?;
+    let tx_digest2 = tx_data2.digest().into_inner();
+    // Create the MoveAuthenticator for the Ed25519 signature authenticator
+    let signatures2 = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest2)?];
+    // Create the TX envelope and send it for validators signing
+    let aa_delete_tx = Transaction::from_user_sig_data(tx_data2, signatures2);
+    // Should succeed
+    test_env
+        .execute_and_check_tx_correctness(aa_delete_tx)
+        .await?;
+
+    // Step 3: submit the original certificate which should now fail
+    let QuorumDriverResponse { effects_cert, .. } = test_env
+        .test_cluster
+        .authority_aggregator()
+        .process_certificate(
+            HandleCertificateRequestV1::new(cert).with_events(),
+            Some(client_ip),
+        )
+        .await
+        .unwrap();
+    let summary = effects_cert.summary_for_debug();
+
+    assert!(
+        summary.status.is_failure(),
+        "Expected the TX execution to fail"
+    );
+    assert!(
+        summary.gas_cost_summary.gas_used() == 1980400
+            && summary.mutated_object_count == 1
+            && summary.created_object_count == 0
+            && summary.unwrapped_object_count == 0
+            && summary.deleted_object_count == 0
+            && summary.wrapped_object_count == 0,
+        "Expected gas to be used in the failed transaction and that only the gas object was mutated",
+    );
+
+    let (error, command) = summary.status.unwrap_err();
+    assert!(
+        command.is_none(),
+        "Expected the authentication failure to carry no command index",
+    );
+    let ExecutionError::InputObjectDeleted = &error else {
+        panic!("Expected an InputObjectDeleted error, got: {error:?}");
+    };
+
+    Ok(())
+}
+
+/// Test that a certified Abstract Account transaction is cancelled
+/// post-consensus when the (shared) AA object it touches is congested.
+///
+/// Shared-object congestion control is forced on via protocol-config overrides:
+/// with `TotalGasBudget` accounting the transaction's gas budget alone
+/// overflows a per-object commit limit of 1, so it is deferred, and with zero
+/// allowed deferral rounds the first deferral is turned into a cancellation.
+/// Validators originally sign the transaction (authentication runs
+/// pre-consensus and passes), but post-consensus the AA object is read as a
+/// cancelled shared object and the transaction fails with
+/// `ExecutionCancelledDueToSharedObjectCongestionV2`.
+#[sim_test]
+async fn test_abstract_account_shared_object_congestion_cancellation() -> Result<(), anyhow::Error>
+{
+    telemetry_subscribers::init_for_testing();
+    let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
+
+    // Force shared-object congestion so any transaction touching a shared object
+    // is cancelled on the first deferral.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_per_object_congestion_control_mode_for_testing(
+            PerObjectCongestionControlMode::TotalGasBudget,
+        );
+        config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(1);
+        config.set_max_congestion_limit_overshoot_per_commit_for_testing(0);
+        config.set_max_deferral_rounds_for_congestion_control_for_testing(0);
+        // Selects the V2 error (carrying `suggested_gas_price`); enabled by
+        // default at the max protocol version, set explicitly for robustness.
+        config.set_congestion_control_gas_price_feedback_mechanism_for_testing(true);
+        config
+    });
+
+    // Build a test environment and create an abstract account
+    let mut test_env = TestEnvironment::new().await;
+    test_env
+        .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519)
+        .await?;
+    let aa_ref = test_env.aa_ref.unwrap();
+    let rgp = test_env.test_cluster.get_reference_gas_price().await;
+    let aa_sender = aa_ref.object_id.into();
+
+    // Create an AA TX that touches the (shared) AA object and ask the validators
+    // to sign it. Authentication runs and passes here, pre-consensus.
+    let aa_gas = test_env
+        .test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), aa_sender)
+        .await;
+    let pt = test_env.craft_aa_simple_ptb(AA_MODULE_NAME)?;
+    let tx_data = test_env
+        .craft_tx_from_pt(
+            pt, aa_gas, aa_sender, None, // No sponsor
+        )
+        .await?;
+    let tx_digest = tx_data.digest().into_inner();
+    // Create the MoveAuthenticator for the Ed25519 signature authenticator
+    let signatures = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest)?];
+    // Create the TX envelope and send it for validators signing
+    let aa_simple_tx = Transaction::from_user_sig_data(tx_data, signatures);
+    let cert = test_env
+        .test_cluster
+        .create_certificate(aa_simple_tx, Some(client_ip))
+        .await
+        .unwrap();
+
+    // Submit the certificate: consensus defers the congested transaction and,
+    // with zero deferral rounds allowed, cancels it.
+    let QuorumDriverResponse { effects_cert, .. } = test_env
+        .test_cluster
+        .authority_aggregator()
+        .process_certificate(
+            HandleCertificateRequestV1::new(cert).with_events(),
+            Some(client_ip),
+        )
+        .await
+        .unwrap();
+    let summary = effects_cert.summary_for_debug();
+
+    assert!(
+        summary.status.is_failure(),
+        "Expected the TX execution to fail"
+    );
+
+    let (error, command) = summary.status.unwrap_err();
+    assert!(
+        command.is_none(),
+        "Expected the congestion cancellation to carry no command index",
+    );
+    let ExecutionError::ExecutionCancelledDueToSharedObjectCongestionV2 {
+        congested_objects, ..
+    } = &error
+    else {
+        panic!("Expected an ExecutionCancelledDueToSharedObjectCongestionV2 error, got: {error:?}");
+    };
+    assert!(
+        congested_objects.contains(&aa_ref.object_id),
+        "Expected the AA shared object to be reported as congested, got: {congested_objects:?}",
     );
 
     Ok(())
@@ -2307,6 +2514,29 @@ impl TestEnvironment {
                 arguments,
             );
         }
+        Ok(builder.finish())
+    }
+
+    fn craft_aa_delete_object_ptb(&mut self) -> anyhow::Result<ProgrammableTransaction> {
+        let (Some(aa_ref), Some(aa_package_id)) = (self.aa_ref, self.aa_package_id) else {
+            anyhow::bail!("Abstract account not created yet");
+        };
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+
+        // Delete the abstract account shared object.
+        let arguments = vec![builder.obj(CallArg::Shared(SharedObjectReference::new(
+            aa_ref.object_id,
+            aa_ref.version,
+            true,
+        )))?];
+        builder.programmable_move_call(
+            aa_package_id,
+            Identifier::from_static(AA_MODULE_NAME),
+            Identifier::from_static("delete_account"),
+            vec![],
+            arguments,
+        );
         Ok(builder.finish())
     }
 

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -520,7 +520,7 @@ async fn test_abstract_account_post_consensus_deletion_failure() -> Result<(), a
     // Create the MoveAuthenticator for the Ed25519 signature authenticator
     let signatures = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest)?];
     // Create the TX envelope and send it for validators signing
-    let aa_simple_tx = Transaction::from_user_sig_data(tx_data, signatures);
+    let aa_simple_tx = Transaction::from_generic_sig_data(tx_data, signatures);
     let cert = test_env
         .test_cluster
         .create_certificate(aa_simple_tx, Some(client_ip))
@@ -543,7 +543,7 @@ async fn test_abstract_account_post_consensus_deletion_failure() -> Result<(), a
     // Create the MoveAuthenticator for the Ed25519 signature authenticator
     let signatures2 = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest2)?];
     // Create the TX envelope and send it for validators signing
-    let aa_delete_tx = Transaction::from_user_sig_data(tx_data2, signatures2);
+    let aa_delete_tx = Transaction::from_generic_sig_data(tx_data2, signatures2);
     // Should succeed
     test_env
         .execute_and_check_tx_correctness(aa_delete_tx)
@@ -644,7 +644,7 @@ async fn test_abstract_account_shared_object_congestion_cancellation() -> Result
     // Create the MoveAuthenticator for the Ed25519 signature authenticator
     let signatures = vec![test_env.create_move_authenticator_for_ed25519(&tx_digest)?];
     // Create the TX envelope and send it for validators signing
-    let aa_simple_tx = Transaction::from_user_sig_data(tx_data, signatures);
+    let aa_simple_tx = Transaction::from_generic_sig_data(tx_data, signatures);
     let cert = test_env
         .test_cluster
         .create_certificate(aa_simple_tx, Some(client_ip))

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -807,6 +807,7 @@ mod sim_only_tests {
         assert!(system_state.epoch_start_timestamp_ms() >= genesis_epoch_start_time + 20000);
 
         // We are getting out of safe mode soon.
+        test_cluster.wait_for_epoch_all_nodes(1).await;
         test_cluster.set_safe_mode_expected(false);
 
         // This epoch change should execute successfully without any upgrade and get us

--- a/scripts/ci_tests/rust_tests.py
+++ b/scripts/ci_tests/rust_tests.py
@@ -195,7 +195,7 @@ class RustTestOrchestrator:
             'manifest_path': get_arg_with_default('manifest_path', './Cargo.toml'),
             'manifest_path_external': get_arg_with_default('manifest_path_external', './external-crates/move/Cargo.toml'),
             'no_capture': get_arg_with_default('no_capture', False),
-            'simtest_timeout': get_arg_with_default('simtest_timeout', 180000),
+            'simtest_timeout': get_arg_with_default('simtest_timeout', 360000),
             'base_branch': get_arg_with_default('base_branch', 'origin/develop'),
             'dry_run': get_arg_with_default('dry_run', False),
             'no_fail_fast': get_arg_with_default('no_fail_fast', False),


### PR DESCRIPTION
# Description of change

Gives `check_move_account` a dedicated path for execution, so a certified Abstract Account transaction whose account object changed after signing executes to the proper effect instead of failing with a validation error.

Previously, executing a certificate re-ran the same account checks as pre-consensus validation: if the AA shared object had been deleted, or the transaction had been cancelled due to shared-object congestion, execution bailed out with `AccountObjectDeleted` / `AccountObjectInCanceledTransaction` instead of producing effects.

* `check_move_account_for_validation` (signing path): unchanged behavior — rejects a deleted or cancelled account object.
* `check_move_account_for_execution` (post-consensus path): a deleted or cancelled account object yields its version so execution proceeds and surfaces the correct failure effect (`InputObjectDeleted`, `ExecutionCancelledDueToSharedObjectCongestionV2`) with gas charged.
* New e2e tests certify an AA transaction and invalidate it before execution: deleting the AA object → `InputObjectDeleted`; forcing shared-object congestion cancellation →
`ExecutionCancelledDueToSharedObjectCongestionV2`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Nodes (Validators and Full nodes): A certified Abstract Account transaction whose account object was deleted or cancelled due to shared-object congestion now executes to the proper failure effect.
