### PR TITLE
chore(iota-core): guard P-COOL randomness transactions categorization invariant

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -20,7 +20,7 @@ use futures::{
     stream::FuturesUnordered,
 };
 use iota_common::{
-    fatal, in_test_configuration,
+    debug_fatal, fatal, in_test_configuration,
     sync::{notify_once::NotifyOnce, notify_read::NotifyRead},
 };
 use iota_config::node::ExpensiveSafetyCheckConfig;
@@ -3697,25 +3697,17 @@ impl AuthorityPerEpochStore {
             // `sequenced_randomness_transactions` empty until the partition after
             // conflict resolution. If it is non-empty here, the partition below
             // overwrites it and those transactions are silently ignored and never
-            // conflict-resolved, which is a logic bug. Log error in release, panic
-            // in debug/test.
+            // conflict-resolved, which is a logic bug.
             if !sequenced_randomness_transactions.is_empty() {
-                error!(
-                    round = consensus_commit_info.round,
-                    count = sequenced_randomness_transactions.len(),
-                    "BUG: P-COOL flow's sequenced_randomness_transactions is non-empty before \
-                        conflict resolution; these transactions will be silently ignored and \
-                        never conflict-resolved"
+                debug_fatal!(
+                    "P-COOL flow categorization must keep all user transactions (regular + \
+                        randomness) in sequenced_transactions until validate_and_resolve_conflicts \
+                        and the subsequent partition; got {} transactions in \
+                        sequenced_randomness_transactions at round {}",
+                    sequenced_randomness_transactions.len(),
+                    consensus_commit_info.round,
                 );
             }
-            debug_assert!(
-                sequenced_randomness_transactions.is_empty(),
-                "P-COOL flow categorization must keep all user transactions (regular + \
-                    randomness) in sequenced_transactions until validate_and_resolve_conflicts \
-                    and the subsequent partition; sequenced_randomness_transactions should be \
-                    empty here, got {} transactions",
-                sequenced_randomness_transactions.len(),
-            );
 
             let (dropped, owned_object_locks, soft_lock_digests) =
                 post_consensus_validation::validate_and_resolve_conflicts(

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3692,6 +3692,31 @@ impl AuthorityPerEpochStore {
         // after the consensus output is quarantined.
         let mut soft_lock_release_tx_digests = Vec::new();
         if enable_pcool {
+            // Invariant: P-COOL flow categorization funnels all user transactions
+            // (regular + randomness) into `sequenced_transactions`, leaving
+            // `sequenced_randomness_transactions` empty until the partition after
+            // conflict resolution. If it is non-empty here, the partition below
+            // overwrites it and those transactions are silently ignored and never
+            // conflict-resolved, which is a logic bug. Log error in release, panic
+            // in debug/test.
+            if !sequenced_randomness_transactions.is_empty() {
+                error!(
+                    round = consensus_commit_info.round,
+                    count = sequenced_randomness_transactions.len(),
+                    "BUG: P-COOL flow's sequenced_randomness_transactions is non-empty before \
+                        conflict resolution; these transactions will be silently ignored and \
+                        never conflict-resolved"
+                );
+            }
+            debug_assert!(
+                sequenced_randomness_transactions.is_empty(),
+                "P-COOL flow categorization must keep all user transactions (regular + \
+                    randomness) in sequenced_transactions until validate_and_resolve_conflicts \
+                    and the subsequent partition; sequenced_randomness_transactions should be \
+                    empty here, got {} transactions",
+                sequenced_randomness_transactions.len(),
+            );
+
             let (dropped, owned_object_locks, soft_lock_digests) =
                 post_consensus_validation::validate_and_resolve_conflicts(
                     authority_state,


### PR DESCRIPTION
# Description of change

This PR adds a guard just before post-consensus conflict resolution in the P-COOL flow: a `debug_fatal!` asserting `sequenced_randomness_transactions` is empty at that point. It panics in debug and simtest builds (including release-built simtests, where a plain `debug_assert!` would compile out); in production release builds, it logs an error with a captured backtrace and increments the `system_invariant_violations` metric.

**Rationale:** In the P-COOL flow, categorization funnels all user transactions—regular and randomness—into `sequenced_transactions`, and only splits randomness transactions back out by partitioning *after* `validate_and_resolve_conflicts()`, so "`sequenced_randomness_transactions` is empty before conflict resolution" is the property that keeps #10764 fixed. The split that follows is a plain assignment (`sequenced_randomness_transactions = randomness`), so it assumes the vector is empty going in. Nothing currently enforces that assumption. If the vector
were non-empty going in, those transactions would be silently overwritten and lost, on top of having skipped conflict resolution—with no log and no metric. This PR's guard turns that silent failure into a loud one.

These changes are preventive hardening, not a bug fix—the invariant holds today. No behavior change.

## Links to any relevant issues

- Issue #10764 - the actual correctness requirement.
- PR #11301 - the demonstrated near-miss (see [comment](https://github.com/iotaledger/iota/pull/11301#discussion_r3272352548)).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes