### PR TITLE
feat(ci): run split cluster checks in parallel with rust tests

### DIFF
--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -3,6 +3,10 @@ name: Split Cluster Check
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: split-cluster-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -40,6 +44,16 @@ jobs:
           retention-days: 5
           if-no-files-found: warn
 
+  validate-mainnet-cancel:
+    needs: [validate-mainnet]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   validate-testnet:
     runs-on: self-hosted-x64
     if: (!cancelled() && !failure())
@@ -64,3 +78,13 @@ jobs:
           path: /tmp/testnet-split-cluster-${{ github.run_id }}/logs/
           retention-days: 5
           if-no-files-found: warn
+
+  validate-testnet-cancel:
+    needs: [validate-testnet]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_split_cluster_sync_check.yml
+++ b/.github/workflows/_split_cluster_sync_check.yml
@@ -3,6 +3,10 @@ name: Split Cluster Synchronization Check
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      isNightly:
+        type: boolean
+        default: false
 
 concurrency:
   group: split-cluster-sync-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -45,6 +49,17 @@ jobs:
           path: /tmp/mainnet-split-cluster-sync-${{ github.run_id }}/metrics/
           retention-days: 5
           if-no-files-found: warn
+
+  validate-mainnet-cancel:
+    needs: [validate-mainnet]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   validate-testnet:
     runs-on: self-hosted-x64
     if: (!cancelled() && !failure())
@@ -75,3 +90,13 @@ jobs:
           path: /tmp/testnet-split-cluster-sync-${{ github.run_id }}/metrics/
           retention-days: 5
           if-no-files-found: warn
+
+  validate-testnet-cancel:
+    needs: [validate-testnet]
+    if: failure() && !inputs.isNightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflow run
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -132,7 +132,6 @@ jobs:
       - dprint-format
       - license-check
       - typos
-      - rust
     if: (!cancelled() && !failure() && github.event_name != 'pull_request' && needs.diff.outputs.isRust == 'true')
     uses: ./.github/workflows/_split_cluster.yml
 
@@ -141,7 +140,6 @@ jobs:
   split-cluster-sync-check:
     needs:
       - diff
-      - rust
     if: (!cancelled() && !failure() && github.event_name != 'pull_request' && needs.diff.outputs.isStarfishSynchronization == 'true')
     uses: ./.github/workflows/_split_cluster_sync_check.yml
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -102,10 +102,14 @@ jobs:
   split-cluster:
     if: ${{ !inputs.rustTestsOnly && !inputs.simTestsOnly }}
     uses: ./.github/workflows/_split_cluster.yml
+    with:
+      isNightly: true
 
   split-cluster-sync-check:
     if: ${{ !inputs.rustTestsOnly && !inputs.simTestsOnly }}
     uses: ./.github/workflows/_split_cluster_sync_check.yml
+    with:
+      isNightly: true
 
   simtest:
     if: ${{ inputs.simTestsOnly || !inputs.rustTestsOnly }}


### PR DESCRIPTION
## Summary
- `split-cluster` / `split-cluster-sync-check` no longer wait on `rust` in `hierarchy.yml` — they build and check out independently, so with less contention on CI runners since the merge queue rollout, they can run alongside `rust` instead of after it.
- Added `validate-mainnet-cancel` / `validate-testnet-cancel` jobs to `_split_cluster.yml` and `_split_cluster_sync_check.yml`, mirroring the existing `*-cancel` pattern elsewhere, so a failure there now cancels the whole run instead of letting the now-concurrent `rust-tests`/`rust-simtests` keep burning `self-hosted-x64` capacity.
- Threaded an `isNightly` input through both workflows (default `false`) and set it to `true` from `nightly.yml`, so nightly runs aren't cancelled by a single failing check.