### PR TITLE
fix(node): bind the validator gRPC server on the serving runtime

### DIFF
--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2434,19 +2434,25 @@ impl SpawnOnce {
     pub async fn start(self) -> Self {
         match self {
             Self::Unstarted(future, serving_rt_handle) => {
-                let server = future
-                    .into_inner()
-                    .await
-                    .unwrap_or_else(|err| panic!("Failed to start validator gRPC server: {err}"));
-                let handle = server.handle().clone();
-                // Serve client requests on the dedicated serving runtime so that
-                // request load never shares worker threads with the node core.
+                // bind() and serve() must execute on the serving runtime:
+                // iota_http::Builder::serve captures Handle::current() there for
+                // the accept loop and every request handler.
+                let (handle_tx, handle_rx) = tokio::sync::oneshot::channel();
                 serving_rt_handle.spawn(async move {
+                    let server = future.into_inner().await.unwrap_or_else(|err| {
+                        panic!("Failed to start validator gRPC server: {err}")
+                    });
+                    if handle_tx.send(server.handle().clone()).is_err() {
+                        return;
+                    }
                     if let Err(err) = server.serve().await {
                         info!("Server stopped: {err}");
                     }
                     info!("Server stopped");
                 });
+                let handle = handle_rx
+                    .await
+                    .expect("validator gRPC server exited before returning its handle");
                 Self::Started(handle)
             }
             Self::Started(_) => self,

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2750,3 +2750,103 @@ fn max_tx_per_checkpoint(protocol_config: &ProtocolConfig) -> usize {
 fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
     2
 }
+
+// Not msim: this test asserts routing across real OS worker-thread pools by
+// name, which the deterministic simulator collapses onto a single thread.
+#[cfg(all(test, not(msim)))]
+mod runtime_split_tests {
+    use std::{
+        sync::mpsc,
+        time::{Duration, Instant},
+    };
+
+    use anyhow::anyhow;
+
+    use super::SpawnOnce;
+
+    /// A single-worker-thread runtime whose worker thread carries `name`, so a
+    /// task can tell which runtime it is running on via `current_pool()`.
+    fn runtime(name: &'static str) -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name(name)
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    /// Name of the runtime whose worker thread is executing this code.
+    fn current_pool() -> String {
+        std::thread::current()
+            .name()
+            .unwrap_or("<unnamed>")
+            .to_string()
+    }
+
+    /// Regression guard for the runtime split. `SpawnOnce::start()` is invoked
+    /// on the node-core runtime (as `IotaNode::start_async` does), but it
+    /// must run the server *bind* on the serving runtime:
+    /// `iota_http::Builder::serve` captures `Handle::current()` there for
+    /// the accept loop and every request handler.
+    ///
+    /// The test records the runtime `start()` runs on and the runtime the bind
+    /// runs on, and asserts the former is node-core and the latter is
+    /// serving (so they differ). With the pre-fix inline bind the bind ran
+    /// on the caller (node-core) runtime, and this test fails.
+    #[test]
+    fn spawn_once_binds_on_serving_not_the_core_runtime() {
+        let node = runtime("node-core");
+        let serving = runtime("serving");
+        let (tx, rx) = mpsc::channel::<(&'static str, String)>();
+
+        // The "bind" future records where it runs, then binds a minimal real
+        // server (health service only) on an ephemeral port.
+        let bind_tx = tx.clone();
+        let bind_future = async move {
+            let _ = bind_tx.send(("bind", current_pool()));
+            let addr = "/ip4/127.0.0.1/tcp/0/http".parse().unwrap();
+            let server = iota_network_stack::config::Config::new()
+                .server_builder()
+                .bind(&addr, None)
+                .await
+                .map_err(|e| anyhow!("bind failed: {e}"))?;
+            Ok(server)
+        };
+        let once = SpawnOnce::new(bind_future, serving.handle().clone());
+
+        // Drive start() ON the node-core runtime and record the runtime it runs on.
+        let caller_tx = tx.clone();
+        node.spawn(async move {
+            let _ = caller_tx.send(("caller", current_pool()));
+            let _ = once.start().await;
+        });
+
+        // Collect both readings.
+        let (mut caller_pool, mut bind_pool) = (None, None);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while (caller_pool.is_none() || bind_pool.is_none()) && Instant::now() < deadline {
+            if let Ok((which, pool)) = rx.recv_timeout(Duration::from_millis(200)) {
+                match which {
+                    "caller" => caller_pool = Some(pool),
+                    "bind" => bind_pool = Some(pool),
+                    _ => {}
+                }
+            }
+        }
+        let caller_pool = caller_pool.expect("start() never ran");
+        let bind_pool = bind_pool.expect("bind future never ran");
+
+        assert!(
+            caller_pool.starts_with("node-core"),
+            "start() should run on the node-core runtime, ran on: {caller_pool}"
+        );
+        assert!(
+            bind_pool.starts_with("serving"),
+            "server bind must run on the serving runtime, ran on: {bind_pool}"
+        );
+        assert_ne!(
+            caller_pool, bind_pool,
+            "the fix must move the bind off the caller (node-core) runtime onto serving"
+        );
+    }
+}


### PR DESCRIPTION
# Description of change

Run the validator gRPC server's bind on the serving runtime so request handling stays off the node-core runtime.

`SpawnOnce::start()` is invoked on the node-core runtime (via `IotaNode::start_async`), but it awaited the server *bind* inline and moved only `serve()` to the serving runtime. `iota_http::Builder::serve` — invoked during bind — starts the accept loop and every per-request handler on `Handle::current()`, so binding on the node-core runtime pinned all validator request handling (and the work handlers spawn via `spawn_monitored_task!`, including transaction/authenticator verification) onto the node core. Under a `handle_transaction` flood this saturates the node-core workers and starves the checkpoint-signing task — the focal validator's `last_sent_checkpoint_signature` freezes while the serving runtime sits idle — defeating the runtime split this branch (#12046) introduces.

The fix performs the whole bind+serve inside the serving runtime and hands the server handle back to the caller via a `oneshot`, so the accept loop and handlers capture the serving runtime.

Measured on an AWS testbed (`aa-super-heavy` @ ~3000 TPS, m5d.8xlarge validators): before the fix the tokio runtime metrics showed the node-core runtime carrying ~3600 in-flight tasks with the serving runtime idle and `sig` frozen; after the fix the serving runtime carries the request load, the node core stays light, and `sig` tracks `cp`.

## Links to any relevant issues

Addresses a gap in #12046 — the runtime split did not actually move validator request handling to the serving runtime. No separate issue.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

Added `runtime_split_tests::spawn_once_binds_on_serving_not_the_core_runtime` (iota-node): it drives `SpawnOnce::start()` on a `node-core`-named runtime with a bind future that records the runtime it runs on, then asserts the bind runs on the serving runtime while `start()` itself runs on node-core (and that they differ). Verified it **fails** on the pre-fix inline bind (`ran on: node-core`) and **passes** with the fix. `cargo +nightly fmt` and `cargo test -p iota-node` pass locally; the full-workspace clippy/nextest gates were not run.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): validator gRPC request handling now runs on the dedicated serving runtime (as the runtime split intends), so client/request load can no longer starve consensus and checkpoint signing on the node core.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
