### PR TITLE
fix(simtest): increase simtest timeout from 3 to 6 mins due to flaky migration test

### DIFF
--- a/scripts/ci_tests/rust_tests.py
+++ b/scripts/ci_tests/rust_tests.py
@@ -195,7 +195,7 @@ class RustTestOrchestrator:
             'manifest_path': get_arg_with_default('manifest_path', './Cargo.toml'),
             'manifest_path_external': get_arg_with_default('manifest_path_external', './external-crates/move/Cargo.toml'),
             'no_capture': get_arg_with_default('no_capture', False),
-            'simtest_timeout': get_arg_with_default('simtest_timeout', 180000),
+            'simtest_timeout': get_arg_with_default('simtest_timeout', 360000),
             'base_branch': get_arg_with_default('base_branch', 'origin/develop'),
             'dry_run': get_arg_with_default('dry_run', False),
             'no_fail_fast': get_arg_with_default('no_fail_fast', False),


### PR DESCRIPTION
`iota-e2e-tests::full_node_migration_tests test_full_node_load_migration_data_with_address_swap` was making the CI fail too often due to timeouts.