### PR TITLE
chore(docs): document the restore feature for the indexer

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -136,6 +136,36 @@ When pruning is enabled, the following tables are subject to pruning:
 | **By transaction** (DELETE)                       | `event_*` (7 index tables), `tx_*` (10 index tables including `tx_global_order`) |
 | **By global sequence number** (DELETE with LIMIT) | `optimistic_transactions`                                                        |
 
+### Restore from a formal snapshot
+
+The indexer can initialize its database from a formal snapshot of the network instead of ingesting every checkpoint from genesis. A formal snapshot is a minimal, cryptographically verifiable capture of the end-of-epoch object state. Full nodes bootstrap from the same snapshots.
+
+For a target epoch, restoring the indexer involves downloading the snapshot, verifying it against the committee chain, and writing the live object state plus the epoch, protocol, and other data derived from it (display, packages, object-version mapping).
+
+The `restore` command exposes `run` and `available-epochs`:
+
+```sh
+iota-indexer restore --network <mainnet|testnet|devnet> run [OPTIONS]
+      --staging-path <STAGING_PATH>   Local directory to stage the downloaded MANIFEST and .ref files
+      --genesis-path <GENESIS_PATH>   Path to the genesis blob used to verify the snapshot
+      --epoch <EPOCH>                 Epoch to download [default: latest available]
+      --num-parallel-downloads <N>    Parallel downloads [default: host available parallelism]
+```
+
+`--genesis-path` is the network's genesis blob: the trusted resource the committee chain is verified against, and the snapshot is in turn verified against that committee chain.
+
+To list the epochs for which a formal snapshot is available:
+
+```sh
+# epochs are returned as a sorted JSON array, newest first
+iota-indexer restore --network <mainnet|testnet|devnet> available-epochs [| jq .[i] ] # i: 0,1,2,...
+```
+
+When the restore finishes it leaves the database at the target epoch's final checkpoint, and the prunable history tables only start populating from the checkpoints that follow the restore point. So, when configuring a retention policy, the restore epoch must sit at least a full retention window behind the tip. For example, to keep 30 epochs of data, restore from an epoch about 30 epochs behind the tip.
+
+> [!WARNING]
+> Like `--reset-db`, `restore` drops every table and re-applies all migrations before restoring. Run it only against a database you intend to rebuild or initialize, since it affects any reader sharing the same database.
+
 ### Backfilling of data
 
 Sometimes when the schema changes (e.g. adding a new table or column), backfilling may be required to populate historical data.

--- a/docs/content/operator/extended-data-services/iota-indexer.mdx
+++ b/docs/content/operator/extended-data-services/iota-indexer.mdx
@@ -9,6 +9,8 @@ teams:
   - iotaledger/infrastructure
 ---
 
+import IndexerRestorePicker from '@site/src/components/IndexerRestorePicker';
+
 The `iota-indexer` binary in writer mode ingests checkpoints from an IOTA checkpoint source, writes them into PostgreSQL tables, and maintains that database over time (migrations on start-up, pruning per retention policy). See the [Extended Data Services overview](./overview.mdx) for how it fits together with the JSON-RPC and GraphQL reader services.
 
 The `iota-indexer` binary also has a `run-backfill` subcommand — a one-off maintenance tool for filling specific tables over a historical range, typically after a schema change. Not part of normal operation.
@@ -260,41 +262,19 @@ iota-indexer restore --network <mainnet|testnet|devnet> available-epochs
 
 `--genesis-path` is the network's [genesis blob](../common/genesis.mdx). It is the trusted resource the committee chain is verified against. The snapshot is in turn verified against that committee chain.
 
-The formal snapshot store keeps a limited set of epochs: the latest epoch, plus the epoch at the start of every month back to genesis (the epoch that ended on the first day of that month). `available-epochs` returns them ordered newest first, so index `0` is the latest epoch, index `1` is the start of the current month, index `2` the month before, and so on back to genesis.
+One caveat when selecting the target epoch and configuring a retention policy is that the restore epoch must sit at least a full window behind the tip of the network. That is because all prunable history tables start populating from the checkpoints that follow the restore point. To keep the recommended [30 epochs of retention](#sizing-and-retention), restore from an epoch about 30 epochs behind the tip.
 
-One caveat when selecting the target epoch and configuring a retention policy is that the restore epoch must sit at least a full window behind the tip of the network. That is because all prunable history tables start populating from the checkpoints that follow the restore point. To keep the recommended [30 epochs of retention](#sizing-and-retention), restore from the start of the previous month (index `2`), roughly 30 to 60 days back.
-
-The following example selects that epoch, restores the database, and then starts the writer with pruning enabled to catch up. Omit `--epoch` to take the latest instead.
+List the epochs that currently have a snapshot with `available-epochs`:
 
 ```sh
-DATABASE_URL="postgres://iota_indexer:iota_indexer@localhost:5432/iota_indexer"
-NETWORK="mainnet"
-GENESIS_PATH="/path/to/genesis.blob"
-PRUNING_TOML_PATH="/path/to/pruning.toml"
-
-# available-epochs is ordered newest first:
-#     index 0 = latest epoch,
-#     index 1 = start of the current month,
-#     index 2 = the month before, ... back to genesis.
-#
-# Restore a month behind so catch-up covers the ~30-epoch retention window.
-EPOCH="$(iota-indexer restore --network "$NETWORK" available-epochs | jq '.[2]')"
-# Without jq:
-# EPOCH="$(iota-indexer restore --network "$NETWORK" available-epochs | python3 -c 'import json, sys; print(json.load(sys.stdin)[2])')"
-
-# 1. Bootstrap the database from the selected snapshot.
-iota-indexer --db-url "$DATABASE_URL" restore --network "$NETWORK" run \
-  --staging-path /tmp/indexer-restore \
-  --genesis-path "$GENESIS_PATH" \
-  --num-parallel-downloads 20 \
-  --epoch "$EPOCH"
-
-# 2. Catch up to the chain tip, with pruning enabled (see Pruning).
-iota-indexer --db-url "$DATABASE_URL" indexer \
-  --remote-store-url "https://checkpoints.$NETWORK.iota.cafe/ingestion/historical" \
-  --live-checkpoints-store-url "https://checkpoints.$NETWORK.iota.cafe/ingestion/live" \
-  --pruning-config-path "$PRUNING_TOML_PATH"
+iota-indexer restore --network mainnet available-epochs
 ```
+
+It prints the available epochs as a JSON array. Pass any of them to `--epoch` when restoring, or omit `--epoch` to take the latest.
+
+For convenience, the picker below generates the restore and catch-up commands. Leave the epoch on **Latest** for the most recent snapshot, and adjust the `DATABASE_URL`, `GENESIS_PATH`, and `PRUNING_TOML_PATH` values for your deployment.
+
+<IndexerRestorePicker />
 
 The snapshots are served from the public endpoints listed under [IOTA Foundation managed snapshots](../common/snapshots.mdx#iota-foundation-managed-snapshots).
 

--- a/docs/content/operator/extended-data-services/iota-indexer.mdx
+++ b/docs/content/operator/extended-data-services/iota-indexer.mdx
@@ -245,34 +245,29 @@ Several tables hold data that is retained for the full lifetime of the database.
 
 The IOTA Indexer has the ability to initialize the database from a [formal snapshot](../common/snapshots.mdx#formal-snapshots) of the network instead of ingesting every checkpoint from genesis. A formal snapshot is a minimal, cryptographically verifiable capture of the end-of-epoch object state. Full nodes bootstrap from the same snapshots (see [formal-snapshot restore](../common/snapshots.mdx#restoring-from-formal-snapshots)).
 
-For a target epoch, restoring the Indexer involves downloading the snapshot, verifying it against the committee chain, and writing the live object state plus the epoch, protocol, and other data derived from it (display, packages, object-version mapping). It leaves the database at that epoch's final checkpoint. Then the writer should be started to catch up to the chain tip.
+For a target epoch, restoring the Indexer involves downloading the snapshot, verifying it against the committee chain, and writing the live object state plus the epoch, protocol, and other data derived from it (display, packages, object-version mapping).
 
-This is feasible through the `restore` command that exposes two subcommands, `run` and `available-epochs`:
+The CLI command to manage the underlying operations is `restore`, which exposes `run` and `available-epochs`:
 
-```text
+```sh
 iota-indexer restore --network <mainnet|testnet|devnet> run [OPTIONS]
       --staging-path <STAGING_PATH>   Local directory to stage the downloaded MANIFEST and .ref files
       --genesis-path <GENESIS_PATH>   Path to the genesis blob used to verify the snapshot
       --epoch <EPOCH>                 Epoch to download [default: latest available]
       --num-parallel-downloads <N>    Parallel downloads [default: host available parallelism]
-
-iota-indexer restore --network <mainnet|testnet|devnet> available-epochs
-      Print the epochs for which a formal snapshot is available (no database needed)
 ```
+where `--genesis-path` is the network's [genesis blob](../common/genesis.mdx). It is the trusted resource the committee chain is verified against. The snapshot is in turn verified against that committee chain.
 
-`--genesis-path` is the network's [genesis blob](../common/genesis.mdx). It is the trusted resource the committee chain is verified against. The snapshot is in turn verified against that committee chain.
-
-One caveat when selecting the target epoch and configuring a retention policy is that the restore epoch must sit at least a full window behind the tip of the network. That is because all prunable history tables start populating from the checkpoints that follow the restore point. To keep the recommended [30 epochs of retention](#sizing-and-retention), restore from an epoch about 30 epochs behind the tip.
-
-List the epochs that currently have a snapshot with `available-epochs`:
+To get the epochs for which a formal snapshot is available use the following command:
 
 ```sh
-iota-indexer restore --network mainnet available-epochs
+# epochs are returned as a sorted JSON array, newest first
+iota-indexer restore --network <mainnet|testnet|devnet> available-epochs [| jq .[i] ] # i: 0,1,2,...
 ```
 
-It prints the available epochs as a JSON array. Pass any of them to `--epoch` when restoring, or omit `--epoch` to take the latest.
+When the restore finishes it leaves the database at the target epoch's final checkpoint. So, all prunable history tables start populating from the checkpoints that follow the restore point. Thus, one caveat when selecting the target epoch and configuring a retention policy is that the restore epoch must sit at least a full retention window behind the tip of the network. To keep the recommended [30 epochs of data](#sizing-and-retention), restore from an epoch about 30 epochs behind the tip.
 
-For convenience, the picker below generates the restore and catch-up commands. Leave the epoch on **Latest** for the most recent snapshot, and adjust the `DATABASE_URL`, `GENESIS_PATH`, and `PRUNING_TOML_PATH` values for your deployment.
+For convenience, the interactive picker below generates the restore command. Leave the epoch on **Latest** for the most recent snapshot, and adjust `DATABASE_URL` and `GENESIS_PATH`.
 
 <IndexerRestorePicker />
 

--- a/docs/content/operator/extended-data-services/iota-indexer.mdx
+++ b/docs/content/operator/extended-data-services/iota-indexer.mdx
@@ -13,6 +13,8 @@ The `iota-indexer` binary in writer mode ingests checkpoints from an IOTA checkp
 
 The `iota-indexer` binary also has a `run-backfill` subcommand — a one-off maintenance tool for filling specific tables over a historical range, typically after a schema change. Not part of normal operation.
 
+It also has a `restore` subcommand. This is a one-off tool that bootstraps the database from a formal snapshot instead of replaying every checkpoint from genesis. See [Restoring from a formal snapshot](#restoring-from-a-formal-snapshot).
+
 ## Scope
 
 The writer:
@@ -236,6 +238,71 @@ Tables not listed here are never pruned by the indexer.
 ### Non-prunable tables
 
 Several tables hold data that is retained for the full lifetime of the database. They are not affected by any retention setting and will not shrink when pruning is enabled. The largest contributors are `objects_version`, `objects_snapshot`, and `objects`.
+
+## Restoring from a formal snapshot
+
+The IOTA Indexer has the ability to initialize the database from a [formal snapshot](../common/snapshots.mdx#formal-snapshots) of the network instead of ingesting every checkpoint from genesis. A formal snapshot is a minimal, cryptographically verifiable capture of the end-of-epoch object state. Full nodes bootstrap from the same snapshots (see [formal-snapshot restore](../common/snapshots.mdx#restoring-from-formal-snapshots)).
+
+For a target epoch, restoring the Indexer involves downloading the snapshot, verifying it against the committee chain, and writing the live object state plus the epoch, protocol, and other data derived from it (display, packages, object-version mapping). It leaves the database at that epoch's final checkpoint. Then the writer should be started to catch up to the chain tip.
+
+This is feasible through the `restore` command that exposes two subcommands, `run` and `available-epochs`:
+
+```text
+iota-indexer restore --network <mainnet|testnet|devnet> run [OPTIONS]
+      --staging-path <STAGING_PATH>   Local directory to stage the downloaded MANIFEST and .ref files
+      --genesis-path <GENESIS_PATH>   Path to the genesis blob used to verify the snapshot
+      --epoch <EPOCH>                 Epoch to download [default: latest available]
+      --num-parallel-downloads <N>    Parallel downloads [default: host available parallelism]
+
+iota-indexer restore --network <mainnet|testnet|devnet> available-epochs
+      Print the epochs for which a formal snapshot is available (no database needed)
+```
+
+`--genesis-path` is the network's [genesis blob](../common/genesis.mdx). It is the trusted resource the committee chain is verified against. The snapshot is in turn verified against that committee chain.
+
+The formal snapshot store keeps a limited set of epochs: the latest epoch, plus the epoch at the start of every month back to genesis (the epoch that ended on the first day of that month). `available-epochs` returns them ordered newest first, so index `0` is the latest epoch, index `1` is the start of the current month, index `2` the month before, and so on back to genesis.
+
+One caveat when selecting the target epoch and configuring a retention policy is that the restore epoch must sit at least a full window behind the tip of the network. That is because all prunable history tables start populating from the checkpoints that follow the restore point. To keep the recommended [30 epochs of retention](#sizing-and-retention), restore from the start of the previous month (index `2`), roughly 30 to 60 days back.
+
+The following example selects that epoch, restores the database, and then starts the writer with pruning enabled to catch up. Omit `--epoch` to take the latest instead.
+
+```sh
+DATABASE_URL="postgres://iota_indexer:iota_indexer@localhost:5432/iota_indexer"
+NETWORK="mainnet"
+GENESIS_PATH="/path/to/genesis.blob"
+PRUNING_TOML_PATH="/path/to/pruning.toml"
+
+# available-epochs is ordered newest first:
+#     index 0 = latest epoch,
+#     index 1 = start of the current month,
+#     index 2 = the month before, ... back to genesis.
+#
+# Restore a month behind so catch-up covers the ~30-epoch retention window.
+EPOCH="$(iota-indexer restore --network "$NETWORK" available-epochs | jq '.[2]')"
+# Without jq:
+# EPOCH="$(iota-indexer restore --network "$NETWORK" available-epochs | python3 -c 'import json, sys; print(json.load(sys.stdin)[2])')"
+
+# 1. Bootstrap the database from the selected snapshot.
+iota-indexer --db-url "$DATABASE_URL" restore --network "$NETWORK" run \
+  --staging-path /tmp/indexer-restore \
+  --genesis-path "$GENESIS_PATH" \
+  --num-parallel-downloads 20 \
+  --epoch "$EPOCH"
+
+# 2. Catch up to the chain tip, with pruning enabled (see Pruning).
+iota-indexer --db-url "$DATABASE_URL" indexer \
+  --remote-store-url "https://checkpoints.$NETWORK.iota.cafe/ingestion/historical" \
+  --live-checkpoints-store-url "https://checkpoints.$NETWORK.iota.cafe/ingestion/live" \
+  --pruning-config-path "$PRUNING_TOML_PATH"
+```
+
+The snapshots are served from the public endpoints listed under [IOTA Foundation managed snapshots](../common/snapshots.mdx#iota-foundation-managed-snapshots).
+
+:::warning Destructive operation
+
+Like [`--reset-db`](#resetting-the-database), `restore` drops every table and re-applies all migrations before restoring. Run it only against a database you intend to rebuild or initialize, since it affects any reader sharing the same database.
+
+:::
 
 ## Appendix: PostgreSQL configuration
 

--- a/docs/site/src/components/FormalSnapshotPicker/index.tsx
+++ b/docs/site/src/components/FormalSnapshotPicker/index.tsx
@@ -1,38 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import BrowserOnly from '@docusaurus/BrowserOnly';
-import CodeBlock from '@theme/CodeBlock';
+import React, { useState } from 'react';
+import SnapshotEpochPicker, {
+    PickerField,
+    selectStyle,
+} from '@site/src/components/SnapshotEpochPicker';
+import { EpochSelection, Network } from '@site/src/hooks/useFormalSnapshotEpochs';
 
 const NETWORKS = ['mainnet', 'testnet'] as const;
-type Network = (typeof NETWORKS)[number];
 
 const SETUPS = ['binary', 'docker'] as const;
 type Setup = (typeof SETUPS)[number];
-
-type EpochSelection = number | 'latest';
-
-// Supports both the legacy schema (`available_epochs: number[]`) and the
-// current one (`available_epochs: [epoch, endTimestampMs | null][]`).
-interface Manifest {
-    available_epochs: Array<number | [number, number | null]>;
-}
-
-function normalizeEpochs(
-    raw: Manifest['available_epochs'] | undefined,
-): Array<[number, number | null]> {
-    return (raw ?? []).map((entry) =>
-        Array.isArray(entry) ? entry : [entry, null],
-    );
-}
-
-function formatTimestamp(ms: number): string {
-    if (ms == 0) return '';
-    const d = new Date(ms);
-    if (Number.isNaN(d.getTime())) return '';
-    return `${d.toISOString().slice(0, 16).replace('T', ' ')} UTC`;
-}
-
-const manifestUrl = (network: Network) =>
-    `https://formal-snapshot.${network}.iota.cafe/MANIFEST`;
 
 function buildCommand(
     setup: Setup,
@@ -72,78 +48,14 @@ function buildCommand(
     ].join('\n');
 }
 
-function Picker() {
+export default function FormalSnapshotPicker() {
     const [setup, setSetup] = useState<Setup>('binary');
-    const [network, setNetwork] = useState<Network>('mainnet');
-    const [epochs, setEpochs] = useState<Array<[number, number | null]>>([]);
-    const [epoch, setEpoch] = useState<EpochSelection>('latest');
-    const [loading, setLoading] = useState<boolean>(false);
-    const [error, setError] = useState<string | null>(null);
-
-    useEffect(() => {
-        let cancelled = false;
-        setLoading(true);
-        setError(null);
-        setEpochs([]);
-
-        fetch(manifestUrl(network))
-            .then((r) => {
-                if (!r.ok) throw new Error(`HTTP ${r.status}`);
-                return r.json();
-            })
-            .then((m: Manifest) => {
-                if (cancelled) return;
-                const sorted = normalizeEpochs(m.available_epochs).sort(
-                    ([a], [b]) => b - a,
-                );
-                setEpochs(sorted);
-            })
-            .catch((e) => {
-                if (!cancelled) setError(String(e?.message ?? e));
-            })
-            .finally(() => {
-                if (!cancelled) setLoading(false);
-            });
-
-        return () => {
-            cancelled = true;
-        };
-    }, [network]);
-
-    const selectStyle: React.CSSProperties = {
-        padding: '0.35rem 0.5rem',
-        borderRadius: '4px',
-        border: '1px solid var(--ifm-color-emphasis-300)',
-        background: 'var(--ifm-background-color)',
-        color: 'var(--ifm-font-color-base)',
-    };
-
-    const fieldStyle: React.CSSProperties = {
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '0.25rem',
-        fontSize: '0.9rem',
-    };
-
     return (
-        <div
-            style={{
-                border: '1px solid var(--ifm-color-emphasis-200)',
-                borderRadius: '6px',
-                padding: '1rem',
-                marginBottom: '1rem',
-            }}
-        >
-            <div
-                style={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: '1rem',
-                    marginBottom: '1rem',
-                }}
-            >
-                <label style={fieldStyle}>
-                    <span>Setup type</span>
+        <SnapshotEpochPicker
+            networks={NETWORKS}
+            fallback="Loading snapshot picker…"
+            extraFields={
+                <PickerField label="Setup type">
                     <select
                         style={selectStyle}
                         value={setup}
@@ -152,81 +64,9 @@ function Picker() {
                         <option value="binary">Binary</option>
                         <option value="docker">Docker</option>
                     </select>
-                </label>
-
-                <label style={fieldStyle}>
-                    <span>Network</span>
-                    <select
-                        style={selectStyle}
-                        value={network}
-                        onChange={(e) => {
-                            setNetwork(e.target.value as Network);
-                            setEpoch('latest');
-                        }}
-                    >
-                        {NETWORKS.map((n) => (
-                            <option key={n} value={n}>
-                                {n}
-                            </option>
-                        ))}
-                    </select>
-                </label>
-
-                <label style={fieldStyle}>
-                    <span>Snapshot epoch</span>
-                    <select
-                        style={selectStyle}
-                        value={String(epoch)}
-                        disabled={loading}
-                        onChange={(e) => {
-                            const v = e.target.value;
-                            setEpoch(v === 'latest' ? 'latest' : Number(v));
-                        }}
-                    >
-                        <option value="latest">
-                            {loading ? 'Loading…' : 'Latest'}
-                        </option>
-                        {epochs.map(([ep, ts], i) => {
-                            const label = ts
-                                ? `${ep} — ended at ${formatTimestamp(ts)}${
-                                    i === 0 ? ' [latest]' : ''
-                                }`
-                                : String(ep);
-                            return (
-                                <option key={ep} value={ep}>
-                                    {label}
-                                </option>
-                            );
-                        })}
-                    </select>
-                </label>
-            </div>
-
-            {error && (
-                <div
-                    style={{
-                        color: 'var(--ifm-color-danger)',
-                        marginBottom: '0.75rem',
-                        fontSize: '0.9rem',
-                    }}
-                >
-                    Could not load available epochs from {manifestUrl(network)}{' '}
-                    ({error}). You can still use the <code>--latest</code>{' '}
-                    option below.
-                </div>
-            )}
-
-            <CodeBlock language="bash">
-                {buildCommand(setup, network, epoch)}
-            </CodeBlock>
-        </div>
-    );
-}
-
-export default function FormalSnapshotPicker() {
-    return (
-        <BrowserOnly fallback={<div>Loading snapshot picker…</div>}>
-            {() => <Picker />}
-        </BrowserOnly>
+                </PickerField>
+            }
+            buildCommand={(network, epoch) => buildCommand(setup, network, epoch)}
+        />
     );
 }

--- a/docs/site/src/components/IndexerRestorePicker/index.tsx
+++ b/docs/site/src/components/IndexerRestorePicker/index.tsx
@@ -11,7 +11,6 @@ function buildCommand(network: Network, epoch: EpochSelection): string {
     const env = [
         'DATABASE_URL="postgres://iota_indexer:iota_indexer@localhost:5432/iota_indexer"',
         'GENESIS_PATH="/path/to/genesis.blob"',
-        'PRUNING_TOML_PATH="/path/to/pruning.toml"',
     ].join('\n');
 
     const restore = joinArgs([
@@ -21,21 +20,11 @@ function buildCommand(network: Network, epoch: EpochSelection): string {
         ...(epoch === 'latest' ? [] : [`  --epoch ${epoch}`]),
     ]);
 
-    const catchUp = joinArgs([
-        'iota-indexer --db-url "$DATABASE_URL" indexer',
-        `  --remote-store-url "https://checkpoints.${network}.iota.cafe/ingestion/historical"`,
-        `  --live-checkpoints-store-url "https://checkpoints.${network}.iota.cafe/ingestion/live"`,
-        '  --pruning-config-path "$PRUNING_TOML_PATH"',
-    ]);
-
     return [
         env,
         '',
-        '# 1. Bootstrap the database from the formal snapshot.',
+        '# Bootstrap the database from the formal snapshot.',
         restore,
-        '',
-        '# 2. Catch up to the chain tip, with pruning enabled.',
-        catchUp,
     ].join('\n');
 }
 

--- a/docs/site/src/components/IndexerRestorePicker/index.tsx
+++ b/docs/site/src/components/IndexerRestorePicker/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import SnapshotEpochPicker from '@site/src/components/SnapshotEpochPicker';
+import { EpochSelection, Network } from '@site/src/hooks/useFormalSnapshotEpochs';
+
+const NETWORKS = ['mainnet', 'testnet', 'devnet'] as const;
+
+/** Joins CLI argument lines into a shell command with line continuations. */
+const joinArgs = (args: string[]) => args.join(' \\\n');
+
+function buildCommand(network: Network, epoch: EpochSelection): string {
+    const env = [
+        'DATABASE_URL="postgres://iota_indexer:iota_indexer@localhost:5432/iota_indexer"',
+        'GENESIS_PATH="/path/to/genesis.blob"',
+        'PRUNING_TOML_PATH="/path/to/pruning.toml"',
+    ].join('\n');
+
+    const restore = joinArgs([
+        `iota-indexer --db-url "$DATABASE_URL" restore --network ${network} run`,
+        '  --staging-path /tmp/indexer-restore',
+        '  --genesis-path "$GENESIS_PATH"',
+        ...(epoch === 'latest' ? [] : [`  --epoch ${epoch}`]),
+    ]);
+
+    const catchUp = joinArgs([
+        'iota-indexer --db-url "$DATABASE_URL" indexer',
+        `  --remote-store-url "https://checkpoints.${network}.iota.cafe/ingestion/historical"`,
+        `  --live-checkpoints-store-url "https://checkpoints.${network}.iota.cafe/ingestion/live"`,
+        '  --pruning-config-path "$PRUNING_TOML_PATH"',
+    ]);
+
+    return [
+        env,
+        '',
+        '# 1. Bootstrap the database from the formal snapshot.',
+        restore,
+        '',
+        '# 2. Catch up to the chain tip, with pruning enabled.',
+        catchUp,
+    ].join('\n');
+}
+
+export default function IndexerRestorePicker() {
+    return (
+        <SnapshotEpochPicker
+            networks={NETWORKS}
+            fallback="Loading restore picker…"
+            buildCommand={buildCommand}
+            requireV2
+        />
+    );
+}

--- a/docs/site/src/components/SnapshotEpochPicker/index.tsx
+++ b/docs/site/src/components/SnapshotEpochPicker/index.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import CodeBlock from '@theme/CodeBlock';
+import {
+    EpochSelection,
+    Network,
+    formatTimestamp,
+    manifestUrl,
+    useFormalSnapshotEpochs,
+} from '@site/src/hooks/useFormalSnapshotEpochs';
+
+export const selectStyle: React.CSSProperties = {
+    padding: '0.35rem 0.5rem',
+    borderRadius: '4px',
+    border: '1px solid var(--ifm-color-emphasis-300)',
+    background: 'var(--ifm-background-color)',
+    color: 'var(--ifm-font-color-base)',
+};
+
+const fieldStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.25rem',
+    fontSize: '0.9rem',
+};
+
+/** A labeled control, styled to match the picker's other fields. */
+export function PickerField({
+    label,
+    children,
+}: {
+    label: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <label style={fieldStyle}>
+            <span>{label}</span>
+            {children}
+        </label>
+    );
+}
+
+export interface SnapshotEpochPickerProps {
+    /** Networks offered in the dropdown; the first is the default. */
+    networks: readonly Network[];
+    /** Builds the command shown for the selected network and epoch. */
+    buildCommand: (network: Network, epoch: EpochSelection) => string;
+    /** Extra controls rendered before the network select; own their own state. */
+    extraFields?: React.ReactNode;
+    /** Offer only V2 snapshots (those with an epoch-end timestamp). */
+    requireV2?: boolean;
+    /** Fallback text shown while the browser-only picker loads. */
+    fallback?: string;
+}
+
+function Picker({
+    networks,
+    buildCommand,
+    extraFields,
+    requireV2,
+}: SnapshotEpochPickerProps) {
+    const [network, setNetwork] = useState<Network>(networks[0]);
+    const [epoch, setEpoch] = useState<EpochSelection>('latest');
+    const { epochs, loading, error } = useFormalSnapshotEpochs(network);
+
+    const latestEpoch = epochs.length ? epochs[0][0] : null;
+
+    return (
+        <div
+            style={{
+                border: '1px solid var(--ifm-color-emphasis-200)',
+                borderRadius: '6px',
+                padding: '1rem',
+                marginBottom: '1rem',
+            }}
+        >
+            <div
+                style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '1rem',
+                    marginBottom: '1rem',
+                }}
+            >
+                {extraFields}
+
+                <PickerField label="Network">
+                    <select
+                        style={selectStyle}
+                        value={network}
+                        onChange={(e) => {
+                            setNetwork(e.target.value as Network);
+                            setEpoch('latest');
+                        }}
+                    >
+                        {networks.map((n) => (
+                            <option key={n} value={n}>
+                                {n}
+                            </option>
+                        ))}
+                    </select>
+                </PickerField>
+
+                <PickerField label="Snapshot epoch">
+                    <select
+                        style={selectStyle}
+                        value={String(epoch)}
+                        disabled={loading}
+                        onChange={(e) => {
+                            const v = e.target.value;
+                            setEpoch(v === 'latest' ? 'latest' : Number(v));
+                        }}
+                    >
+                        <option value="latest">
+                            {loading ? 'Loading…' : 'Latest'}
+                        </option>
+                        {epochs.map(([ep, ts]) => {
+                            // V1 snapshots have no usable timestamp; skip them
+                            // when only V2 is wanted.
+                            const date = formatTimestamp(ts);
+                            if (requireV2 && !date) return null;
+                            const label = date
+                                ? `${ep} — ended at ${date}${
+                                    ep === latestEpoch ? ' [latest]' : ''
+                                }`
+                                : String(ep);
+                            return (
+                                <option key={ep} value={ep}>
+                                    {label}
+                                </option>
+                            );
+                        })}
+                    </select>
+                </PickerField>
+            </div>
+
+            {error && (
+                <div
+                    style={{
+                        color: 'var(--ifm-color-danger)',
+                        marginBottom: '0.75rem',
+                        fontSize: '0.9rem',
+                    }}
+                >
+                    Could not load available epochs from {manifestUrl(network)}{' '}
+                    ({error}). You can still generate a command for the latest
+                    snapshot below.
+                </div>
+            )}
+
+            <CodeBlock language="bash">{buildCommand(network, epoch)}</CodeBlock>
+        </div>
+    );
+}
+
+export default function SnapshotEpochPicker(props: SnapshotEpochPickerProps) {
+    return (
+        <BrowserOnly fallback={<div>{props.fallback ?? 'Loading picker…'}</div>}>
+            {() => <Picker {...props} />}
+        </BrowserOnly>
+    );
+}

--- a/docs/site/src/hooks/useFormalSnapshotEpochs.ts
+++ b/docs/site/src/hooks/useFormalSnapshotEpochs.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+
+// Supports both the legacy schema (`available_epochs: number[]`) and the
+// current one (`available_epochs: [epoch, endTimestampMs | null][]`).
+interface Manifest {
+    available_epochs: Array<number | [number, number | null]>;
+}
+
+/** Networks that publish a formal snapshot. */
+export type Network = 'mainnet' | 'testnet' | 'devnet';
+
+/** A selected snapshot epoch, or the latest available one. */
+export type EpochSelection = number | 'latest';
+
+/** An available snapshot epoch and the epoch-end timestamp (ms), if known. */
+export type EpochEntry = [number, number | null];
+
+/**
+ * Formats an epoch-end timestamp (ms) as `YYYY-MM-DD HH:MM UTC`, or `''` when
+ * there is no usable timestamp. A missing (`null`) or `0` timestamp marks a V1
+ * snapshot; a non-empty result marks V2.
+ */
+export function formatTimestamp(ms: number | null): string {
+    if (!ms) return '';
+    const d = new Date(ms);
+    if (Number.isNaN(d.getTime())) return '';
+    return `${d.toISOString().slice(0, 16).replace('T', ' ')} UTC`;
+}
+
+/** URL of the formal snapshot MANIFEST for a network. */
+export const manifestUrl = (network: Network) =>
+    `https://formal-snapshot.${network}.iota.cafe/MANIFEST`;
+
+function normalizeEpochs(
+    raw: Manifest['available_epochs'] | undefined,
+): EpochEntry[] {
+    return (raw ?? []).map((entry) =>
+        Array.isArray(entry) ? entry : [entry, null],
+    );
+}
+
+export interface FormalSnapshotEpochs {
+    /** Available epochs, sorted newest first. */
+    epochs: EpochEntry[];
+    loading: boolean;
+    error: string | null;
+}
+
+/**
+ * Fetches the formal snapshot MANIFEST for `network` and returns the available
+ * epochs sorted newest first, along with loading and error state. Re-fetches
+ * whenever `network` changes.
+ */
+export function useFormalSnapshotEpochs(network: Network): FormalSnapshotEpochs {
+    const [epochs, setEpochs] = useState<EpochEntry[]>([]);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        setError(null);
+        setEpochs([]);
+
+        fetch(manifestUrl(network))
+            .then((r) => {
+                if (!r.ok) throw new Error(`HTTP ${r.status}`);
+                return r.json();
+            })
+            .then((m: Manifest) => {
+                if (cancelled) return;
+                const sorted = normalizeEpochs(m.available_epochs).sort(
+                    ([a], [b]) => b - a,
+                );
+                setEpochs(sorted);
+            })
+            .catch((e) => {
+                if (!cancelled) setError(String(e?.message ?? e));
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [network]);
+
+    return { epochs, loading, error };
+}


### PR DESCRIPTION
# Description of change

This patch updates the operator wiki pages to document the restore feature. The documentation is adapted and copied on the crate README as well.

It also reuses the custom command generator used in the respective full-node page, to provide a similar generator in the Indexer wiki. To this end:

* A new `SnapshotEpochPicker` component has been added that is reused across the full-node and indexer pages
* The option to filter out V1 snapshots from the picker was added (Indexer can only be restored from V2 snapshots)
* A new dedicated `IndexerSnapshotPicker` was added.

## Links to any relevant issues

Fixes #12060 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

Generated the wiki pages locally, and tested that the custom generators in the full-node page and the indexer page work as expected.