### PR TITLE
fix(indexer): restore available epochs returns epochs with v2 snapshots

### DIFF
--- a/crates/iota-indexer/src/restore/setup.rs
+++ b/crates/iota-indexer/src/restore/setup.rs
@@ -134,8 +134,9 @@ impl FormalSnapshotStore {
         let root_manifest = RootManifest::from_bytes(&manifest_contents)?;
         let mut epochs: Vec<_> = root_manifest
             .available_epochs
-            .iter()
-            .map(|(epoch, _)| *epoch)
+            .into_iter()
+            // epochs with V2 snapshots have a positive timestamp
+            .filter_map(|(epoch, timestamp)| (timestamp > 0).then_some(epoch))
             .collect();
         epochs.sort_by_key(|&epoch| Reverse(epoch));
         Ok(epochs)


### PR DESCRIPTION
# Description of change

This patch ensures that the epochs returned via `iota-indexer restore --network <network> available-epochs` contain a V2 snapshot. The restore cannot go through with V1 snapshots.

## Links to any relevant issues

Part of #12061

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Built and ran `iota-indexer restore --network mainnet available-epochs`. Epoch 428 for which there is a V1 snapshot is no longer returned.