### PR TITLE
fix(iota-indexer): index correctly display events

### DIFF
--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -37,7 +37,9 @@ use crate::{
     },
     metrics::IndexerMetrics,
     models::{
-        display::{StoredDisplay, display_type_and_id_from_event},
+        display::{
+            StoredDisplay, display_id_from_created_event, displayed_type_from_created_event,
+        },
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate, extract_epoch_info_event},
         obj_indices::StoredObjectVersion,
         objects::StoredBackwardHistoryObject,
@@ -412,15 +414,21 @@ impl PrimaryWorker {
         // `display::new` only emits a `DisplayCreated` event with no fields. If an
         // author creates a `Display<T>` but never calls `update_version`, it wouldn't
         // get indexed normally. To prevent this, we fall back to the contents of the
-        // created object itself, while ensuring `VersionUpdated` events still take
-        // precedence.
-        for (object_type, display_id) in events.iter().filter_map(display_type_and_id_from_event) {
+        // created object itself for types with no `VersionUpdated` event in this
+        // transaction.
+        for event in events.iter() {
+            let Some(object_type) = displayed_type_from_created_event(event) else {
+                continue;
+            };
             if db_displays.contains_key(&object_type) {
                 continue;
             }
-            if let Some(display) = output_objects
-                .iter()
-                .find(|object| object.id() == display_id)
+            if let Some(display) = display_id_from_created_event(event)
+                .and_then(|display_id| {
+                    output_objects
+                        .iter()
+                        .find(|object| object.id() == display_id)
+                })
                 .and_then(StoredDisplay::try_from_object)
             {
                 db_displays.insert(object_type, display);

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     metrics::IndexerMetrics,
     models::{
-        display::{StoredDisplay, display_id_from_event},
+        display::{StoredDisplay, display_type_and_id_from_event},
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate, extract_epoch_info_event},
         obj_indices::StoredObjectVersion,
         objects::StoredBackwardHistoryObject,
@@ -414,15 +414,17 @@ impl PrimaryWorker {
         // get indexed normally. To prevent this, we fall back to the contents of the
         // created object itself, while ensuring `VersionUpdated` events still take
         // precedence.
-        for display in events
-            .iter()
-            .filter_map(display_id_from_event)
-            .filter_map(|id| output_objects.iter().find(|object| object.id() == id))
-            .filter_map(StoredDisplay::try_from_object)
-        {
-            db_displays
-                .entry(display.object_type.clone())
-                .or_insert(display);
+        for (object_type, display_id) in events.iter().filter_map(display_type_and_id_from_event) {
+            if db_displays.contains_key(&object_type) {
+                continue;
+            }
+            if let Some(display) = output_objects
+                .iter()
+                .find(|object| object.id() == display_id)
+                .and_then(StoredDisplay::try_from_object)
+            {
+                db_displays.insert(object_type, display);
+            }
         }
 
         // Input Objects

--- a/crates/iota-indexer/src/ingestion/primary/prepare.rs
+++ b/crates/iota-indexer/src/ingestion/primary/prepare.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     metrics::IndexerMetrics,
     models::{
-        display::StoredDisplay,
+        display::{StoredDisplay, display_id_from_event},
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate, extract_epoch_info_event},
         obj_indices::StoredObjectVersion,
         objects::StoredBackwardHistoryObject,
@@ -372,6 +372,7 @@ impl PrimaryWorker {
             transaction: sender_signed_data,
             effects: fx,
             events,
+            output_objects,
             ..
         } = tx;
 
@@ -402,11 +403,27 @@ impl PrimaryWorker {
             .map(|(idx, event)| EventIndex::from_event(tx_sequence_number, idx as u64, event))
             .collect();
 
-        let db_displays = events
+        let mut db_displays: BTreeMap<String, StoredDisplay> = events
             .iter()
             .flat_map(StoredDisplay::try_from_event)
             .map(|display| (display.object_type.clone(), display))
             .collect();
+
+        // `display::new` only emits a `DisplayCreated` event with no fields. If an
+        // author creates a `Display<T>` but never calls `update_version`, it wouldn't
+        // get indexed normally. To prevent this, we fall back to the contents of the
+        // created object itself, while ensuring `VersionUpdated` events still take
+        // precedence.
+        for display in events
+            .iter()
+            .filter_map(display_id_from_event)
+            .filter_map(|id| output_objects.iter().find(|object| object.id() == id))
+            .filter_map(StoredDisplay::try_from_object)
+        {
+            db_displays
+                .entry(display.object_type.clone())
+                .or_insert(display);
+        }
 
         // Input Objects
         let input_objects = tx

--- a/crates/iota-indexer/src/models/display.rs
+++ b/crates/iota-indexer/src/models/display.rs
@@ -110,16 +110,23 @@ impl StoredDisplay {
     }
 }
 
-/// Extracts the unique `ObjectId` of the `Display<T>` object from a
-/// `0x2::display::DisplayCreated` event.
+/// Extracts, from a `0x2::display::DisplayCreated<T>` event, the canonical
+/// name of `T` together with the `ObjectId` of the created `Display<T>`
+/// object.
 ///
 /// Returns `None` if the provided event is of a different type.
-pub fn display_id_from_event(event: &Event) -> Option<ObjectId> {
+pub fn display_type_and_id_from_event(event: &Event) -> Option<(String, ObjectId)> {
     if !event.type_.is_display_created() {
         return None;
     }
+    let [TypeTag::Struct(displayed_type)] = event.type_.type_params() else {
+        return None;
+    };
     let created_event: ID = bcs::from_bytes(&event.contents).ok()?;
-    Some(created_event.bytes)
+    Some((
+        displayed_type.to_canonical_string(/* with_prefix */ true),
+        created_event.bytes,
+    ))
 }
 
 /// Returns whether `struct_tag` is of `0x2::display::Display` type.
@@ -154,21 +161,26 @@ mod tests {
     }
 
     #[test]
-    fn display_id_from_event_extracts_id_from_display_created_event() {
+    fn parse_display_created_event_extracts_type_and_id() {
+        let displayed_type = displayed_type();
         let display_id = ObjectId::random();
         let event = display_event(
-            StructTag::new_display_created(displayed_type()),
+            StructTag::new_display_created(displayed_type.clone()),
             bcs::to_bytes(&ID::new(display_id)).unwrap(),
         );
-        assert_eq!(display_id_from_event(&event), Some(display_id));
+
+        assert_eq!(
+            display_type_and_id_from_event(&event),
+            Some((displayed_type.to_canonical_string(true), display_id))
+        );
     }
 
     #[test]
-    fn display_id_from_event_ignores_other_events() {
+    fn parse_display_created_event_ignores_other_events() {
         let event = display_event(
             StructTag::new_display_version_updated(displayed_type()),
             vec![],
         );
-        assert_eq!(display_id_from_event(&event), None);
+        assert_eq!(display_type_and_id_from_event(&event), None);
     }
 }

--- a/crates/iota-indexer/src/models/display.rs
+++ b/crates/iota-indexer/src/models/display.rs
@@ -110,23 +110,31 @@ impl StoredDisplay {
     }
 }
 
-/// Extracts, from a `0x2::display::DisplayCreated<T>` event, the canonical
-/// name of `T` together with the `ObjectId` of the created `Display<T>`
-/// object.
+/// Extracts the canonical name of `T` from the type of a
+/// `0x2::display::DisplayCreated<T>` event, without touching the event
+/// contents.
 ///
 /// Returns `None` if the provided event is of a different type.
-pub fn display_type_and_id_from_event(event: &Event) -> Option<(String, ObjectId)> {
+pub fn displayed_type_from_created_event(event: &Event) -> Option<String> {
     if !event.type_.is_display_created() {
         return None;
     }
     let [TypeTag::Struct(displayed_type)] = event.type_.type_params() else {
         return None;
     };
+    Some(displayed_type.to_canonical_string(/* with_prefix */ true))
+}
+
+/// Extracts the `ObjectId` of the created `Display<T>` object from the
+/// contents of a `0x2::display::DisplayCreated<T>` event.
+///
+/// Returns `None` if the provided event is of a different type.
+pub fn display_id_from_created_event(event: &Event) -> Option<ObjectId> {
+    if !event.type_.is_display_created() {
+        return None;
+    }
     let created_event: ID = bcs::from_bytes(&event.contents).ok()?;
-    Some((
-        displayed_type.to_canonical_string(/* with_prefix */ true),
-        created_event.bytes,
-    ))
+    Some(created_event.bytes)
 }
 
 /// Returns whether `struct_tag` is of `0x2::display::Display` type.
@@ -161,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_display_created_event_extracts_type_and_id() {
+    fn display_created_event_helpers_extract_type_and_id() {
         let displayed_type = displayed_type();
         let display_id = ObjectId::random();
         let event = display_event(
@@ -170,17 +178,19 @@ mod tests {
         );
 
         assert_eq!(
-            display_type_and_id_from_event(&event),
-            Some((displayed_type.to_canonical_string(true), display_id))
+            displayed_type_from_created_event(&event),
+            Some(displayed_type.to_canonical_string(true))
         );
+        assert_eq!(display_id_from_created_event(&event), Some(display_id));
     }
 
     #[test]
-    fn parse_display_created_event_ignores_other_events() {
+    fn display_created_event_helpers_ignore_other_events() {
         let event = display_event(
             StructTag::new_display_version_updated(displayed_type()),
             vec![],
         );
-        assert_eq!(display_type_and_id_from_event(&event), None);
+        assert_eq!(displayed_type_from_created_event(&event), None);
+        assert_eq!(display_id_from_created_event(&event), None);
     }
 }

--- a/crates/iota-indexer/src/models/display.rs
+++ b/crates/iota-indexer/src/models/display.rs
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::prelude::*;
-use iota_sdk_types::{Address, Event, Identifier, StructTag, TypeTag};
+use iota_sdk_types::{Address, Event, Identifier, ObjectId, StructTag, TypeTag};
 use iota_types::{
     collection_types::VecMap,
     display::{DisplayObject, DisplayVersionUpdatedEvent},
+    id::ID,
     object::Object,
 };
 
@@ -109,9 +110,65 @@ impl StoredDisplay {
     }
 }
 
+/// Extracts the unique `ObjectId` of the `Display<T>` object from a
+/// `0x2::display::DisplayCreated` event.
+///
+/// Returns `None` if the provided event is of a different type.
+pub fn display_id_from_event(event: &Event) -> Option<ObjectId> {
+    if !event.type_.is_display_created() {
+        return None;
+    }
+    let created_event: ID = bcs::from_bytes(&event.contents).ok()?;
+    Some(created_event.bytes)
+}
+
 /// Returns whether `struct_tag` is of `0x2::display::Display` type.
 fn is_display(struct_tag: &StructTag) -> bool {
     struct_tag.address() == Address::FRAMEWORK
         && struct_tag.module() == &Identifier::DISPLAY_MODULE
         && struct_tag.name() == &DISPLAY_STRUCT_NAME
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn display_event(type_: StructTag, contents: Vec<u8>) -> Event {
+        Event {
+            package_id: ObjectId::random(),
+            module: Identifier::DISPLAY_MODULE,
+            sender: Address::random(),
+            type_,
+            contents,
+        }
+    }
+
+    /// The type `T` a `Display<T>` refers to.
+    fn displayed_type() -> StructTag {
+        StructTag::new(
+            Address::random(),
+            Identifier::from_static("test"),
+            Identifier::from_static("Test"),
+            vec![],
+        )
+    }
+
+    #[test]
+    fn display_id_from_event_extracts_id_from_display_created_event() {
+        let display_id = ObjectId::random();
+        let event = display_event(
+            StructTag::new_display_created(displayed_type()),
+            bcs::to_bytes(&ID::new(display_id)).unwrap(),
+        );
+        assert_eq!(display_id_from_event(&event), Some(display_id));
+    }
+
+    #[test]
+    fn display_id_from_event_ignores_other_events() {
+        let event = display_event(
+            StructTag::new_display_version_updated(displayed_type()),
+            vec![],
+        );
+        assert_eq!(display_id_from_event(&event), None);
+    }
 }

--- a/crates/iota-indexer/tests/data/display_no_version_update/Move.toml
+++ b/crates/iota-indexer/tests/data/display_no_version_update/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "display_no_version_update"
+edition = "2024.beta"
+
+[dependencies]
+Iota = { local = "../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+display_no_version_update = "0x0"

--- a/crates/iota-indexer/tests/data/display_no_version_update/sources/display_no_version_update.move
+++ b/crates/iota-indexer/tests/data/display_no_version_update/sources/display_no_version_update.move
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Test module that creates a `Display<Nft>` on publish without ever calling
+/// `display::update_version`, so the publish transaction emits only a
+/// `DisplayCreated` event and the display fields exist solely in the
+/// `Display` object.
+module display_no_version_update::display_no_version_update {
+    use std::string::String;
+    use iota::display;
+    use iota::package;
+
+    public struct DISPLAY_NO_VERSION_UPDATE has drop {}
+
+    public struct Nft has key, store {
+        id: UID,
+        name: String,
+    }
+
+    fun init(otw: DISPLAY_NO_VERSION_UPDATE, ctx: &mut TxContext) {
+        let publisher = package::claim(otw, ctx);
+        let display = display::new_with_fields<Nft>(
+            &publisher,
+            vector[b"name".to_string(), b"description".to_string()],
+            vector[b"{name}".to_string(), b"An NFT with display".to_string()],
+            ctx,
+        );
+        transfer::public_transfer(display, ctx.sender());
+        transfer::public_transfer(publisher, ctx.sender());
+    }
+
+    public entry fun mint(name: String, ctx: &mut TxContext) {
+        transfer::public_transfer(Nft { id: object::new(ctx), name }, ctx.sender());
+    }
+}

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -994,6 +994,116 @@ fn test_repeatedly_update_display() {
     });
 }
 
+/// The display info of an object type must be indexed even when the package
+/// author never calls `display::update_version`, in which case no
+/// `VersionUpdated` event exists and the fields can only be read from the
+/// `Display` object created on publish.
+#[test]
+fn test_display_indexed_without_version_update() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.object_id, gas_ref.version).await;
+
+        let (_, _, nft_id) =
+            deploy_display_no_version_update_pkg_and_mint_nft(sender, &sender_kp, client, "gift")
+                .await
+                .unwrap();
+
+        let res = client
+            .get_object(nft_id, Some(IotaObjectDataOptions::new().with_display()))
+            .await
+            .unwrap();
+        let display_fields = res.data.unwrap().display.unwrap().data.unwrap();
+
+        assert_eq!(display_fields["name"], "gift");
+        assert_eq!(display_fields["description"], "An NFT with display");
+    });
+}
+
+/// A later `VersionUpdated` event must take precedence over the display info
+/// previously indexed from the `Display` object.
+#[test]
+fn test_version_update_overrides_display_indexed_from_object() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.object_id, gas_ref.version).await;
+
+        let (package_id, display_obj_id, nft_id) =
+            deploy_display_no_version_update_pkg_and_mint_nft(sender, &sender_kp, client, "gift")
+                .await
+                .unwrap();
+
+        let nft_type_tag = TypeTag::Struct(Box::new(StructTag::new(
+            package_id,
+            Identifier::from_static("display_no_version_update"),
+            Identifier::from_static("Nft"),
+            Vec::new(),
+        )));
+
+        let res = update_display_object(
+            sender,
+            &sender_kp,
+            client,
+            &display_obj_id,
+            nft_type_tag.clone(),
+            "description",
+            "An updated NFT with display",
+        )
+        .await
+        .unwrap();
+        assert_transaction_success(&res);
+
+        let res =
+            bump_display_object_version(sender, &sender_kp, client, &display_obj_id, nft_type_tag)
+                .await
+                .unwrap();
+        assert_transaction_success(&res);
+
+        let res = client
+            .get_object(nft_id, Some(IotaObjectDataOptions::new().with_display()))
+            .await
+            .unwrap();
+        let display_fields = res.data.unwrap().display.unwrap().data.unwrap();
+
+        assert_eq!(display_fields["description"], "An updated NFT with display");
+        assert_eq!(display_fields["name"], "gift");
+    });
+}
+
 #[tokio::test]
 async fn test_optimistic_tables_pruning() -> IndexerResult<()> {
     let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
@@ -1327,6 +1437,64 @@ async fn deploy_bear_pkg(
         "../../examples/trading/contracts/demo",
     )
     .await
+}
+
+/// Deploys the test package under `tests/data/display_no_version_update`,
+/// whose `init` creates a `Display<Nft>` with fields but never calls
+/// `display::update_version`, and mints an `Nft` with the given `name`.
+///
+/// Returns the package id, the `Display<Nft>` object id and the `Nft` id.
+async fn deploy_display_no_version_update_pkg_and_mint_nft(
+    address: Address,
+    address_kp: &AccountKeyPair,
+    client: &HttpClient,
+    name: &str,
+) -> Result<(ObjectId, ObjectId, ObjectId), anyhow::Error> {
+    let (publish_res, package_id) = deploy_package(
+        address,
+        address_kp,
+        client,
+        "tests/data/display_no_version_update",
+    )
+    .await;
+
+    // The only event emitted by the publish transaction is `DisplayCreated`,
+    // which carries the id of the created `Display<Nft>` object.
+    let display_obj_id = ObjectId::from_prefixed_short_hex(
+        publish_res.events.unwrap().data[0]
+            .parsed_json
+            .as_object()
+            .unwrap()["id"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+
+    let res = execute_move_call(
+        client,
+        address,
+        address_kp,
+        package_id,
+        "display_no_version_update".to_string(),
+        "mint".to_string(),
+        type_args![]?,
+        call_args!(name.to_string())?,
+        None,
+    )
+    .await?;
+    assert_transaction_success(&res);
+
+    let nft_id = res
+        .effects
+        .as_ref()
+        .unwrap()
+        .created()
+        .iter()
+        .exactly_one()
+        .unwrap()
+        .object_id();
+
+    Ok((package_id, display_obj_id, nft_id))
 }
 
 async fn deploy_package(


### PR DESCRIPTION
# Description of change

The indexer populated the `display` table only from `VersionUpdated` events, which the framework emits solely when a package author calls `display::update_version`. Authors that create and fill a `Display<T>` without ever calling it (nothing forces them to) emit only a `DisplayCreated` event, which carries no fields, so their display info was never indexed and object queries returned no display data.

Changes:

- during ingestion, for every `DisplayCreated` event, index the display fields directly from the created `Display<T>` object found in the transaction's output objects, reusing `StoredDisplay::try_from_object` and the `bcs_kind` schema introduced for the formal-snapshot restore (hence the PR targets `feat/indexer-formal-snapshot`).
- `VersionUpdated` events keep precedence over object-derived rows, so a later `update_version` still overwrites the fallback data, never the reverse.
- the optimistic indexing path shares `index_transaction_components`, so it gets the same behavior with no extra changes.
- added the `tests/data/display_no_version_update` test package (creates a populated `Display<Nft>` in `init` and deliberately never calls `update_version`) with two integration tests: display served from the object alone, and a later `update_version` overriding the object-derived row; plus unit tests for the new `display_id_from_event` helper.

## Links to any relevant issues

fixes #12292 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Ran the the indexer tests which includes the newly added test cases
```shell
cargo test -p iota-indexer --profile simulator --features shared_test_runtime
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch even tough touches the iota-indexer directly the changes to the ingestion are non breaking thus the ingestion pipeline is not affected.


