### PR TITLE
feat(iota-core,iota-types): suppress duplicate resubmissions via soft locks

### DIFF
--- a/crates/iota-core/src/authority_server/metrics.rs
+++ b/crates/iota-core/src/authority_server/metrics.rs
@@ -38,6 +38,8 @@ pub struct ValidatorServiceMetrics {
     pub x_forwarded_for_num_hops: Gauge,
     pub num_rejected_tx_soft_lock_conflict: IntCounter,
     pub soft_lock_table_size: IntGauge,
+    pub num_rejected_tx_recently_resubmitted: IntCounter,
+    pub recently_resubmitted_interval: Histogram,
 }
 
 impl ValidatorServiceMetrics {
@@ -203,6 +205,19 @@ impl ValidatorServiceMetrics {
             num_rejected_tx_soft_lock_conflict: register_int_counter_with_registry!(
                 "validator_service_num_rejected_tx_soft_lock_conflict",
                 "Number of transactions rejected due to pre-consensus soft lock conflict on owned objects",
+                registry,
+            )
+                .unwrap(),
+            num_rejected_tx_recently_resubmitted: register_int_counter_with_registry!(
+                "validator_service_num_rejected_tx_recently_resubmitted",
+                "Number of transactions rejected as duplicate resubmissions of a transaction whose soft locks are still held",
+                registry,
+            )
+                .unwrap(),
+            recently_resubmitted_interval: register_histogram_with_registry!(
+                "validator_service_recently_resubmitted_interval_seconds",
+                "Time between a transaction acquiring its soft locks and a duplicate resubmission of it being suppressed",
+                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
                 .unwrap(),

--- a/crates/iota-core/src/authority_server/metrics.rs
+++ b/crates/iota-core/src/authority_server/metrics.rs
@@ -39,7 +39,6 @@ pub struct ValidatorServiceMetrics {
     pub num_rejected_tx_soft_lock_conflict: IntCounter,
     pub soft_lock_table_size: IntGauge,
     pub num_rejected_tx_recently_resubmitted: IntCounter,
-    pub recently_resubmitted_interval: Histogram,
 }
 
 impl ValidatorServiceMetrics {
@@ -211,13 +210,6 @@ impl ValidatorServiceMetrics {
             num_rejected_tx_recently_resubmitted: register_int_counter_with_registry!(
                 "validator_service_num_rejected_tx_recently_resubmitted",
                 "Number of transactions rejected as duplicate resubmissions of a transaction whose soft locks are still held",
-                registry,
-            )
-                .unwrap(),
-            recently_resubmitted_interval: register_histogram_with_registry!(
-                "validator_service_recently_resubmitted_interval_seconds",
-                "Time between a transaction acquiring its soft locks and a duplicate resubmission of it being suppressed",
-                iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
                 .unwrap(),

--- a/crates/iota-core/src/authority_server/soft_lock.rs
+++ b/crates/iota-core/src/authority_server/soft_lock.rs
@@ -164,7 +164,7 @@ impl PreConsensusSoftLocks {
         // again. Locks are released once consensus processes or drops the
         // transaction (or on submit failure), which is exactly when
         // resubmission becomes meaningful.
-        if Self::in_flight_elapsed(&inner, &tx_digest, now, ttl).is_some() {
+        if Self::is_in_flight(&inner, &tx_digest, now, ttl) {
             return Err(IotaError::RecentlyResubmitted { digest: tx_digest });
         }
 
@@ -310,7 +310,7 @@ impl PreConsensusSoftLocks {
             return false;
         }
         let inner = self.inner.lock();
-        Self::in_flight_elapsed(&inner, tx_digest, Instant::now(), self.lock_ttl).is_some()
+        Self::is_in_flight(&inner, tx_digest, Instant::now(), self.lock_ttl)
     }
 
     /// Drops all entries.  Called at epoch boundary.
@@ -365,29 +365,25 @@ impl PreConsensusSoftLocks {
 
     // -- private helpers -----------------------------------------------------
 
-    /// Returns the elapsed time since `tx_digest` acquired its locks if at
-    /// least one of them is still held by this digest and unexpired.
+    /// Returns whether `tx_digest` still holds at least one unexpired lock —
+    /// i.e. the transaction is in flight on this validator.
     ///
     /// Operates on the `Inner` already borrowed from the outer mutex so
     /// callers can combine the check with a mutation in one critical section.
-    fn in_flight_elapsed(
+    fn is_in_flight(
         inner: &Inner,
         tx_digest: &TransactionDigest,
         now: Instant,
         lock_ttl: Duration,
-    ) -> Option<Duration> {
-        inner
-            .tx_to_objects
-            .get(tx_digest)?
-            .iter()
-            .find_map(|obj_ref| {
-                let record = inner.locks.get(obj_ref)?;
-                if record.digest != *tx_digest {
-                    return None;
-                }
-                let elapsed = now.duration_since(record.acquired_at);
-                (elapsed < lock_ttl).then_some(elapsed)
+    ) -> bool {
+        let Some(obj_refs) = inner.tx_to_objects.get(tx_digest) else {
+            return false;
+        };
+        obj_refs.iter().any(|obj_ref| {
+            inner.locks.get(obj_ref).is_some_and(|record| {
+                record.digest == *tx_digest && now.duration_since(record.acquired_at) < lock_ttl
             })
+        })
     }
 
     /// Test-and-set a single object lock in the forward index.

--- a/crates/iota-core/src/authority_server/soft_lock.rs
+++ b/crates/iota-core/src/authority_server/soft_lock.rs
@@ -5,15 +5,22 @@
 //!
 //! This module provides an in-memory, defense-in-depth mechanism that prevents
 //! a validator from accepting two transactions that conflict on the same owned
-//! objects at pre-submission time. The authoritative conflict resolution
-//! remains in post-consensus validation (`post_consensus_validation.rs`); this
-//! layer merely reduces wasted consensus bandwidth and client-visible latency.
+//! objects at pre-submission time, and from forwarding duplicate resubmissions
+//! of a transaction that is already in flight (its locks are still held). The
+//! authoritative conflict resolution remains in post-consensus validation
+//! (`post_consensus_validation.rs`); this layer merely reduces wasted
+//! consensus bandwidth and client-visible latency.
+//!
+//! Every user transaction holds at least one owned object (its gas coin), so
+//! the lock table sees every transaction and duplicate suppression covers
+//! shared-object transactions too.
 //!
 //! # Edge cases
 //!
 //! | Case                            | Behavior                                                              |
 //! |---------------------------------|-----------------------------------------------------------------------|
-//! | Same tx digest resubmitted      | `try_acquire` is idempotent for same digest — passes through          |
+//! | Same tx digest, locks held      | Rejected with `RecentlyResubmitted` until released or expired         |
+//! | Same tx digest, locks released/expired | Re-acquired; passes through                                    |
 //! | Different tx, same owned objects | Soft lock conflict → `ObjectLockConflict` error                       |
 //! | Tx processed by consensus        | Released in `authority_per_epoch_store` after quarantine               |
 //! | Tx dropped in post-consensus     | Released in `authority_per_epoch_store` after quarantine               |
@@ -107,7 +114,9 @@ impl PreConsensusSoftLocks {
 
     /// Creates a disabled instance: every operation is a no-op and
     /// `try_acquire` never reports a conflict, so post-consensus validation is
-    /// the sole conflict resolver.
+    /// the sole conflict resolver. Disabling also disables duplicate
+    /// resubmission suppression — consensus-level dedup remains the only
+    /// defense against same-digest resubmission storms.
     pub fn disabled() -> Self {
         Self::new_inner(DEFAULT_SOFT_LOCK_TTL, false)
     }
@@ -124,8 +133,11 @@ impl PreConsensusSoftLocks {
     /// Attempts to soft-lock every `ObjectReference` in `owned_objects` for
     /// `tx_digest`.
     ///
-    /// - **Same digest**: idempotent — the lock is refreshed but no error is
-    ///   returned. This allows the same transaction to be resubmitted freely.
+    /// - **Same digest, locks held**: returns `RecentlyResubmitted` — the
+    ///   transaction is already in flight on this validator and forwarding it
+    ///   again would only duplicate it in consensus.
+    /// - **Same digest, locks released or expired**: re-acquired with a fresh
+    ///   timestamp, so retrying a consensus-forgotten transaction works.
     /// - **Different digest, unexpired**: returns `ObjectLockConflict`.
     /// - **Expired lock**: silently overwritten by the new transaction.
     ///
@@ -144,6 +156,16 @@ impl PreConsensusSoftLocks {
         let now = Instant::now();
         let ttl = self.lock_ttl;
         let mut inner = self.inner.lock();
+
+        // A digest whose locks are still held is already in flight on this
+        // validator — suppress the duplicate before it reaches consensus
+        // again. Locks are released once consensus processes or drops the
+        // transaction (or on submit failure), which is exactly when
+        // resubmission becomes meaningful.
+        if Self::in_flight_elapsed(&inner, &tx_digest, now, ttl).is_some() {
+            return Err(IotaError::RecentlyResubmitted { digest: tx_digest });
+        }
+
         let mut acquired: Vec<ObjectReference> = Vec::with_capacity(owned_objects.len());
 
         for obj_ref in owned_objects {
@@ -278,6 +300,18 @@ impl PreConsensusSoftLocks {
         self.lock_count.load(Ordering::Relaxed)
     }
 
+    /// Returns the elapsed time since `tx_digest` soft-locked its objects, if
+    /// the transaction is still in flight on this validator (locks held and
+    /// unexpired). Returns `None` for unknown, released, or expired digests,
+    /// and always `None` when disabled.
+    pub fn check_in_flight(&self, tx_digest: &TransactionDigest) -> Option<Duration> {
+        if !self.enabled {
+            return None;
+        }
+        let inner = self.inner.lock();
+        Self::in_flight_elapsed(&inner, tx_digest, Instant::now(), self.lock_ttl)
+    }
+
     /// Drops all entries.  Called at epoch boundary.
     pub fn clear(&self) {
         if !self.enabled {
@@ -329,6 +363,31 @@ impl PreConsensusSoftLocks {
     }
 
     // -- private helpers -----------------------------------------------------
+
+    /// Returns the elapsed time since `tx_digest` acquired its locks if at
+    /// least one of them is still held by this digest and unexpired.
+    ///
+    /// Operates on the `Inner` already borrowed from the outer mutex so
+    /// callers can combine the check with a mutation in one critical section.
+    fn in_flight_elapsed(
+        inner: &Inner,
+        tx_digest: &TransactionDigest,
+        now: Instant,
+        lock_ttl: Duration,
+    ) -> Option<Duration> {
+        inner
+            .tx_to_objects
+            .get(tx_digest)?
+            .iter()
+            .find_map(|obj_ref| {
+                let record = inner.locks.get(obj_ref)?;
+                if record.digest != *tx_digest {
+                    return None;
+                }
+                let elapsed = now.duration_since(record.acquired_at);
+                (elapsed < lock_ttl).then_some(elapsed)
+            })
+    }
 
     /// Test-and-set a single object lock in the forward index.
     ///
@@ -428,15 +487,73 @@ mod tests {
     }
 
     #[test]
-    fn test_same_digest_idempotent() {
+    fn test_same_digest_in_flight_rejected() {
         let table = PreConsensusSoftLocks::with_ttl(Duration::from_secs(60));
         let obj = obj_ref(1, 1);
         let tx = digest(1);
 
         table.try_acquire(tx, &[obj]).unwrap();
-        // Same digest again — should succeed.
+        // Same digest while its locks are held — suppressed as a duplicate.
+        let err = table.try_acquire(tx, &[obj]).unwrap_err();
+        assert!(
+            matches!(err, IotaError::RecentlyResubmitted { digest } if digest == tx),
+            "expected RecentlyResubmitted, got {err:?}"
+        );
+        assert!(
+            err.is_retryable().0,
+            "suppression must be retryable so clients back off instead of failing hard"
+        );
+        assert_eq!(table.lock_count(), 1);
+    }
+
+    #[test]
+    fn test_same_digest_after_release_passes() {
+        let table = PreConsensusSoftLocks::with_ttl(Duration::from_secs(60));
+        let obj = obj_ref(1, 1);
+        let tx = digest(1);
+
+        table.try_acquire(tx, &[obj]).unwrap();
+        table.release(&tx);
+        // Locks released (consensus processed/dropped the tx) — resubmission
+        // is meaningful again and must pass.
         table.try_acquire(tx, &[obj]).unwrap();
         assert_eq!(table.lock_count(), 1);
+    }
+
+    #[test]
+    fn test_check_in_flight_lifecycle() {
+        let table = PreConsensusSoftLocks::with_ttl(Duration::from_secs(60));
+        let obj = obj_ref(1, 1);
+        let tx = digest(1);
+
+        assert!(table.check_in_flight(&tx).is_none());
+        table.try_acquire(tx, &[obj]).unwrap();
+        assert!(
+            table.check_in_flight(&tx).is_some(),
+            "digest with held locks must be reported in flight"
+        );
+        table.release(&tx);
+        assert!(table.check_in_flight(&tx).is_none());
+    }
+
+    #[test]
+    fn test_check_in_flight_expired_lock_is_not_in_flight() {
+        let table = PreConsensusSoftLocks::with_ttl(Duration::ZERO);
+        let tx = digest(1);
+        table.try_acquire(tx, &[obj_ref(1, 1)]).unwrap();
+        assert!(
+            table.check_in_flight(&tx).is_none(),
+            "expired locks must not count as in flight"
+        );
+    }
+
+    #[test]
+    fn test_disabled_allows_same_digest_resubmission() {
+        let table = PreConsensusSoftLocks::disabled();
+        let tx = digest(1);
+        table.try_acquire(tx, &[obj_ref(1, 1)]).unwrap();
+        table.try_acquire(tx, &[obj_ref(1, 1)]).unwrap();
+        assert!(table.check_in_flight(&tx).is_none());
     }
 
     #[test]
@@ -484,13 +601,12 @@ mod tests {
         );
     }
 
-    /// The idempotent same-digest path must refresh the lock's timestamp so a
-    /// legitimately-retrying client doesn't see its own lock expire mid-flight.
-    /// We inspect the stored `Instant` directly rather than race the wall
-    /// clock.
+    /// Re-acquiring after expiry (e.g. a client retrying a transaction that
+    /// consensus forgot) must pass and refresh the lock's timestamp. We
+    /// inspect the stored `Instant` directly rather than race the wall clock.
     #[test]
-    fn test_same_digest_refreshes_timestamp() {
-        let table = PreConsensusSoftLocks::with_ttl(Duration::from_secs(60));
+    fn test_same_digest_after_expiry_reacquires_with_fresh_timestamp() {
+        let table = PreConsensusSoftLocks::with_ttl(Duration::ZERO);
         let obj = obj_ref(1, 1);
         let tx = digest(1);
 

--- a/crates/iota-core/src/authority_server/soft_lock.rs
+++ b/crates/iota-core/src/authority_server/soft_lock.rs
@@ -76,7 +76,9 @@ struct Inner {
     tx_to_objects: HashMap<TransactionDigest, Vec<ObjectReference>>,
 }
 
-/// In-memory soft locks for pre-consensus owned-object conflict detection.
+/// In-memory soft locks that detect pre-consensus owned-object conflicts and
+/// suppress duplicate resubmissions of a transaction whose locks are still
+/// held.
 ///
 /// Not persisted — crash recovery starts with a clean table.
 /// Post-consensus validation is the authoritative conflict resolver.
@@ -300,16 +302,15 @@ impl PreConsensusSoftLocks {
         self.lock_count.load(Ordering::Relaxed)
     }
 
-    /// Returns the elapsed time since `tx_digest` soft-locked its objects, if
-    /// the transaction is still in flight on this validator (locks held and
-    /// unexpired). Returns `None` for unknown, released, or expired digests,
-    /// and always `None` when disabled.
-    pub fn check_in_flight(&self, tx_digest: &TransactionDigest) -> Option<Duration> {
+    /// Returns whether `tx_digest` is still in flight on this validator — its
+    /// soft locks are held and unexpired. `false` for unknown, released, or
+    /// expired digests, and always `false` when disabled.
+    pub fn check_in_flight(&self, tx_digest: &TransactionDigest) -> bool {
         if !self.enabled {
-            return None;
+            return false;
         }
         let inner = self.inner.lock();
-        Self::in_flight_elapsed(&inner, tx_digest, Instant::now(), self.lock_ttl)
+        Self::in_flight_elapsed(&inner, tx_digest, Instant::now(), self.lock_ttl).is_some()
     }
 
     /// Drops all entries.  Called at epoch boundary.
@@ -526,14 +527,14 @@ mod tests {
         let obj = obj_ref(1, 1);
         let tx = digest(1);
 
-        assert!(table.check_in_flight(&tx).is_none());
+        assert!(!table.check_in_flight(&tx));
         table.try_acquire(tx, &[obj]).unwrap();
         assert!(
-            table.check_in_flight(&tx).is_some(),
+            table.check_in_flight(&tx),
             "digest with held locks must be reported in flight"
         );
         table.release(&tx);
-        assert!(table.check_in_flight(&tx).is_none());
+        assert!(!table.check_in_flight(&tx));
     }
 
     #[test]
@@ -542,7 +543,7 @@ mod tests {
         let tx = digest(1);
         table.try_acquire(tx, &[obj_ref(1, 1)]).unwrap();
         assert!(
-            table.check_in_flight(&tx).is_none(),
+            !table.check_in_flight(&tx),
             "expired locks must not count as in flight"
         );
     }
@@ -553,7 +554,7 @@ mod tests {
         let tx = digest(1);
         table.try_acquire(tx, &[obj_ref(1, 1)]).unwrap();
         table.try_acquire(tx, &[obj_ref(1, 1)]).unwrap();
-        assert!(table.check_in_flight(&tx).is_none());
+        assert!(!table.check_in_flight(&tx));
     }
 
     #[test]

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -201,11 +201,8 @@ impl ValidatorService {
         // signature verification so resubmission storms are short-circuited
         // cheaply; the soft-lock acquisition below remains the authoritative,
         // atomic gate for duplicates racing past this probe.
-        if let Some(elapsed) = soft_locks.check_in_flight(&tx_digest) {
+        if soft_locks.check_in_flight(&tx_digest) {
             metrics.num_rejected_tx_recently_resubmitted.inc();
-            metrics
-                .recently_resubmitted_interval
-                .observe(elapsed.as_secs_f64());
             let error = IotaError::RecentlyResubmitted { digest: tx_digest };
             let weight = normalize(&error);
             return (TxStatusUpdate::Rejected { error }, weight);

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -196,6 +196,21 @@ impl ValidatorService {
             return (build_executed(effects), Weight::one());
         }
 
+        // Suppress duplicate resubmissions of a transaction that is still in
+        // flight on this validator (its soft locks are held). Checked before
+        // signature verification so resubmission storms are short-circuited
+        // cheaply; the soft-lock acquisition below remains the authoritative,
+        // atomic gate for duplicates racing past this probe.
+        if let Some(elapsed) = soft_locks.check_in_flight(&tx_digest) {
+            metrics.num_rejected_tx_recently_resubmitted.inc();
+            metrics
+                .recently_resubmitted_interval
+                .observe(elapsed.as_secs_f64());
+            let error = IotaError::RecentlyResubmitted { digest: tx_digest };
+            let weight = normalize(&error);
+            return (TxStatusUpdate::Rejected { error }, weight);
+        }
+
         // Verify user signature.
         let tx_verif_guard = metrics.tx_verification_latency.start_timer();
         let verified_tx = match epoch_store.verify_transaction(transaction) {
@@ -265,12 +280,16 @@ impl ValidatorService {
         }
 
         // Soft-lock owned objects to prevent conflicting transactions.
-        // Same-digest resubmission passes through (idempotent).
+        // Same-digest resubmission while in flight → rejected (duplicate).
         // Different-digest conflict on same objects → rejected.
         // Placed after the reconfig check so we never acquire locks that would
         // need releasing on the epoch-halt path.
         if let Err(error) = soft_locks.try_acquire(tx_digest, &owned_objects) {
-            metrics.num_rejected_tx_soft_lock_conflict.inc();
+            if matches!(error, IotaError::RecentlyResubmitted { .. }) {
+                metrics.num_rejected_tx_recently_resubmitted.inc();
+            } else {
+                metrics.num_rejected_tx_soft_lock_conflict.inc();
+            }
             let weight = normalize(&error);
             return (TxStatusUpdate::Rejected { error }, weight);
         }

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -7,7 +7,7 @@ use iota_network::api::{
     GetCheckpointRequest, GetTxStatusRequest, NotifyCapabilitiesRequest, SubmitTxRequest,
     TxStatusQuery, ValidatorPeer, ValidatorV2,
 };
-use iota_protocol_config::{Chain, ProtocolConfig};
+use iota_protocol_config::{Chain, OverrideGuard, ProtocolConfig};
 // Additional imports for P-COOL tests
 use iota_sdk_types::{
     Address, Argument, Command, Identifier, ObjectId, SplitCoins,
@@ -388,73 +388,19 @@ async fn collect_v2_stream(
         .collect()
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn test_v2_submit_tx_success() {
+/// Builds a P-COOL-enabled validator service backed by a single owned object
+/// and a gas coin, plus a signed transfer transaction spending them. The
+/// returned [`OverrideGuard`] enables the P-COOL flow and must be kept alive
+/// for the duration of the test.
+async fn setup_v2_transfer_tx() -> (
+    OverrideGuard,
+    Arc<ValidatorService>,
+    Transaction,
+    TransactionDigest,
+) {
     telemetry_subscribers::init_for_testing();
 
-    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_enable_pcool_flow_for_testing(true);
-        config
-    });
-
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let object_id = ObjectId::random();
-    let gas_id = ObjectId::random();
-
-    let authority_state = TestAuthorityBuilder::new()
-        .with_starting_objects(&[
-            Object::with_id_owner_for_testing(object_id, sender),
-            Object::with_id_owner_for_testing(gas_id, sender),
-        ])
-        .build()
-        .await;
-
-    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
-        authority_state.name,
-    ));
-
-    let validator_service = Arc::new(ValidatorService::new_for_tests(
-        authority_state.clone(),
-        consensus_adapter,
-        Arc::new(ValidatorServiceMetrics::new_for_tests()),
-    ));
-
-    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).unwrap();
-    let gas = authority_state.get_object(&gas_id).unwrap();
-    let recipient = dbg_addr(2);
-
-    let tx_data = TransactionData::new_transfer(
-        recipient,
-        object.object_ref(),
-        sender,
-        gas.object_ref(),
-        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
-        rgp,
-    );
-    let tx = to_sender_signed_transaction(tx_data, &sender_key);
-    let expected_digest = *tx.digest();
-
-    let response = validator_service
-        .submit_tx(make_v2_submit_request(vec![tx]))
-        .await
-        .expect("submit_tx should succeed");
-
-    let results = collect_v2_stream(response).await;
-    assert_eq!(results.len(), 1);
-    let (digest, result) = &results[0];
-    assert_eq!(*digest, expected_digest);
-    assert!(
-        matches!(result, TxStatusUpdate::Submitted),
-        "Expected Submitted, got {result:?}"
-    );
-}
-
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn test_v2_submit_tx_resubmission_suppressed() {
-    telemetry_subscribers::init_for_testing();
-
-    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+    let guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
     });
@@ -495,6 +441,32 @@ async fn test_v2_submit_tx_resubmission_suppressed() {
     );
     let tx = to_sender_signed_transaction(tx_data, &sender_key);
     let expected_digest = *tx.digest();
+
+    (guard, validator_service, tx, expected_digest)
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_success() {
+    let (_guard, validator_service, tx, expected_digest) = setup_v2_transfer_tx().await;
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(vec![tx]))
+        .await
+        .expect("submit_tx should succeed");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    let (digest, result) = &results[0];
+    assert_eq!(*digest, expected_digest);
+    assert!(
+        matches!(result, TxStatusUpdate::Submitted),
+        "Expected Submitted, got {result:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_resubmission_suppressed() {
+    let (_guard, validator_service, tx, expected_digest) = setup_v2_transfer_tx().await;
 
     // First submission goes through.
     let response = validator_service

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -451,6 +451,87 @@ async fn test_v2_submit_tx_success() {
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_resubmission_suppressed() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
+        authority_state.name,
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
+
+    let tx_data = TransactionData::new_transfer(
+        dbg_addr(2),
+        object.object_ref(),
+        sender,
+        gas.object_ref(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx_data, &sender_key);
+    let expected_digest = *tx.digest();
+
+    // First submission goes through.
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(vec![tx.clone()]))
+        .await
+        .expect("submit_tx stream should open successfully");
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    assert!(
+        matches!(results[0].1, TxStatusUpdate::Submitted),
+        "Expected Submitted, got {:?}",
+        results[0].1
+    );
+
+    // Resubmitting the same digest while it is still in flight (soft locks
+    // held, not yet processed by consensus) must be suppressed.
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(vec![tx]))
+        .await
+        .expect("submit_tx stream should open successfully");
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    match &results[0].1 {
+        TxStatusUpdate::Rejected { error } => {
+            assert!(
+                matches!(
+                    error,
+                    IotaError::RecentlyResubmitted { digest } if *digest == expected_digest
+                ),
+                "Expected RecentlyResubmitted, got {error:?}"
+            );
+        }
+        other => panic!("Expected Rejected, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_v2_submit_tx_invalid_signature() {
     telemetry_subscribers::init_for_testing();
 

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -517,7 +517,7 @@ pub enum IotaError {
         new_epoch: EpochId,
         locked_by_tx: TransactionDigest,
     },
-    #[error("Transaction {digest:?} was recently submitted; duplicate resubmission suppressed.")]
+    #[error("Transaction {digest:?} was recently submitted; duplicate resubmission suppressed")]
     RecentlyResubmitted { digest: TransactionDigest },
     #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{digest}]")]
     TransactionNotFound { digest: TransactionDigest },

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -517,6 +517,8 @@ pub enum IotaError {
         new_epoch: EpochId,
         locked_by_tx: TransactionDigest,
     },
+    #[error("Transaction {digest:?} was recently submitted; duplicate resubmission suppressed.")]
+    RecentlyResubmitted { digest: TransactionDigest },
     #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{digest}]")]
     TransactionNotFound { digest: TransactionDigest },
     #[error("{TRANSACTIONS_NOT_FOUND_MSG_PREFIX} [{digests:?}]")]
@@ -860,6 +862,10 @@ impl IotaError {
 
             // Transient consensus failure — other validators likely unaffected
             IotaError::FailedToSubmitToConsensus(..) => true,
+
+            // Same digest already in flight — client should wait for the
+            // original to land or retry once the soft locks are released.
+            IotaError::RecentlyResubmitted { .. } => true,
 
             // Non retryable error
             IotaError::Execution(..) => false,


### PR DESCRIPTION
# Description of change

Reject a resubmission of a transaction whose pre-consensus soft locks are still held instead of passing it through, cutting duplicate consensus traffic for in-flight transactions.

- Reuses the existing pre-consensus soft locks and adds a digest-keyed in-flight check, so a same-digest resubmission is suppressed while the original is still in flight — this also covers shared-object and gasless transactions that hold no owned-object lock (the object-keyed locks are idempotent on the same digest and let those through).
- A cheap `check_in_flight` probe runs before signature verification so resubmission storms are short-circuited without paying for verification; the authoritative gate stays the soft-lock acquisition below it.
- New retriable error `IotaError::RecentlyResubmitted` so clients back off and wait for the original to land instead of treating it as a hard failure.
- Soft-lock TTL is 12s (derived from `gc_depth`), released earlier when the transaction commits.

Replaces #12152, which suppressed the same duplicates with a separate digest-keyed cache; this instead reuses the soft-lock machinery already on the validator rather than adding a parallel component.

## Links to any relevant issues

Related: iotaledger/iota-private#466

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes