### PR TITLE
feat(consensus): select leader-schedule bad nodes by absolute performance

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -580,8 +580,8 @@ struct FeatureFlags {
     consensus_enable_sliding_window_leader_schedule: bool,
 
     // If true, Starfish selects "bad" leader-schedule nodes by absolute
-    // normalized distributed-vote performance (below a low threshold), bounded
-    // by a stake overflow clamp, with a minimum-stake floor on the good
+    // normalized reputation score: exclude validators below a low threshold,
+    // capped at a maximum number of validators, and keep a minimum-size good
     // (swap-in) pool; when false, the fixed stake cut by rank is used.
     #[serde(skip_serializing_if = "is_false")]
     consensus_enable_absolute_score_bad_nodes: bool,
@@ -1474,15 +1474,15 @@ pub struct ProtocolConfig {
     consensus_leader_schedule_window_size: Option<u32>,
 
     /// High threshold (percent) for the absolute leader-schedule selection: an
-    /// authority whose distributed-vote score, normalized to the window's
-    /// theoretical maximum, is at or above this is a "good" (swap-in) node.
+    /// authority whose reputation score, normalized to the window's theoretical
+    /// maximum, is at or above this is a "good" (swap-in) node.
     /// When unset, defaults to 90. Consulted only when
     /// `consensus_enable_absolute_score_bad_nodes` is set.
     consensus_good_nodes_normalized_score_threshold: Option<u64>,
 
     /// Low threshold (percent) for the absolute leader-schedule selection: an
-    /// authority whose normalized distributed-vote score is strictly below this
-    /// is a "bad" node. When unset, defaults to 50. Consulted only when
+    /// authority whose normalized reputation score is strictly below this is a
+    /// "bad" node. When unset, defaults to 50. Consulted only when
     /// `consensus_enable_absolute_score_bad_nodes` is set.
     consensus_bad_nodes_normalized_score_threshold: Option<u64>,
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -584,7 +584,7 @@ struct FeatureFlags {
     // capped at a maximum number of validators, and keep a minimum-size good
     // (swap-in) pool; when false, the fixed stake cut by rank is used.
     #[serde(skip_serializing_if = "is_false")]
-    consensus_enable_absolute_score_bad_nodes: bool,
+    consensus_enable_absolute_score_leader_schedule: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1888,8 +1888,9 @@ impl ProtocolConfig {
         res
     }
 
-    pub fn consensus_enable_absolute_score_bad_nodes(&self) -> bool {
-        self.feature_flags.consensus_enable_absolute_score_bad_nodes
+    pub fn consensus_enable_absolute_score_leader_schedule(&self) -> bool {
+        self.feature_flags
+            .consensus_enable_absolute_score_leader_schedule
     }
 
     pub fn deny_rule_governance(&self) -> bool {
@@ -3375,8 +3376,9 @@ impl ProtocolConfig {
             .consensus_enable_sliding_window_leader_schedule = val;
     }
 
-    pub fn set_consensus_enable_absolute_score_bad_nodes_for_testing(&mut self, val: bool) {
-        self.feature_flags.consensus_enable_absolute_score_bad_nodes = val;
+    pub fn set_consensus_enable_absolute_score_leader_schedule_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .consensus_enable_absolute_score_leader_schedule = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1474,16 +1474,17 @@ pub struct ProtocolConfig {
     consensus_leader_schedule_window_size: Option<u32>,
 
     /// High threshold (percent) for the absolute leader-schedule selection: an
-    /// authority whose reputation score, normalized to the window's theoretical
-    /// maximum, is at or above this is a "good" (swap-in) node.
+    /// authority whose reputation score, normalized to the highest score in the
+    /// window, is at or above this is a "good" (swap-in) node.
     /// When unset, defaults to 90. Consulted only when
     /// `consensus_enable_absolute_score_bad_nodes` is set.
     consensus_good_nodes_normalized_score_threshold: Option<u64>,
 
     /// Low threshold (percent) for the absolute leader-schedule selection: an
-    /// authority whose normalized reputation score is strictly below this is a
-    /// "bad" node. When unset, defaults to 50. Consulted only when
-    /// `consensus_enable_absolute_score_bad_nodes` is set.
+    /// authority whose reputation score, normalized to the highest score in the
+    /// window, is strictly below this is a "bad" node. When unset, defaults to
+    /// 50. Consulted only when `consensus_enable_absolute_score_bad_nodes` is
+    /// set.
     consensus_bad_nodes_normalized_score_threshold: Option<u64>,
 
     /// Minimum size of the "good" (swap-in) pool, as a percent of the validator
@@ -1912,17 +1913,6 @@ impl ProtocolConfig {
             "consensus_enable_sliding_window_leader_schedule requires window_size >= commits_per_schedule"
         );
         res
-    }
-
-    /// Number of committed subdags the leader-schedule reputation scores are
-    /// aggregated over: the sliding window when enabled, otherwise the rotation
-    /// interval (V2 accumulates one interval's worth of commits per schedule).
-    pub fn scoring_window_commits(&self) -> u32 {
-        if self.consensus_enable_sliding_window_leader_schedule() {
-            self.leader_schedule_window_size()
-        } else {
-            self.commits_per_schedule()
-        }
     }
 
     pub fn consensus_enable_absolute_score_bad_nodes(&self) -> bool {

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1917,11 +1917,21 @@ impl ProtocolConfig {
 
     pub fn consensus_enable_absolute_score_bad_nodes(&self) -> bool {
         let res = self.feature_flags.consensus_enable_absolute_score_bad_nodes;
-        assert!(
-            !res || self.good_nodes_normalized_score_threshold()
-                > self.bad_nodes_normalized_score_threshold(),
-            "consensus_enable_absolute_score_bad_nodes requires good threshold > bad threshold"
-        );
+        if res {
+            assert!(
+                self.good_nodes_normalized_score_threshold()
+                    > self.bad_nodes_normalized_score_threshold(),
+                "consensus_enable_absolute_score_bad_nodes requires good threshold > bad threshold"
+            );
+            assert!(
+                self.min_good_nodes_percent() >= 1,
+                "consensus_enable_absolute_score_bad_nodes requires min_good_nodes_percent >= 1 so the good pool is non-empty"
+            );
+            assert!(
+                self.min_good_nodes_percent() + self.max_bad_nodes_percent() < 70,
+                "consensus_enable_absolute_score_bad_nodes requires min_good_nodes_percent + max_bad_nodes_percent < 70"
+            );
+        }
         res
     }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1919,6 +1919,14 @@ impl ProtocolConfig {
         let res = self.feature_flags.consensus_enable_absolute_score_bad_nodes;
         if res {
             assert!(
+                self.good_nodes_normalized_score_threshold() <= 100,
+                "consensus_enable_absolute_score_bad_nodes requires good_nodes_normalized_score_threshold <= 100"
+            );
+            assert!(
+                self.bad_nodes_normalized_score_threshold() <= 100,
+                "consensus_enable_absolute_score_bad_nodes requires bad_nodes_normalized_score_threshold <= 100"
+            );
+            assert!(
                 self.good_nodes_normalized_score_threshold()
                     > self.bad_nodes_normalized_score_threshold(),
                 "consensus_enable_absolute_score_bad_nodes requires good threshold > bad threshold"

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1914,6 +1914,17 @@ impl ProtocolConfig {
         res
     }
 
+    /// Number of committed subdags the leader-schedule reputation scores are
+    /// aggregated over: the sliding window when enabled, otherwise the rotation
+    /// interval (V2 accumulates one interval's worth of commits per schedule).
+    pub fn scoring_window_commits(&self) -> u32 {
+        if self.consensus_enable_sliding_window_leader_schedule() {
+            self.leader_schedule_window_size()
+        } else {
+            self.commits_per_schedule()
+        }
+    }
+
     pub fn consensus_enable_absolute_score_bad_nodes(&self) -> bool {
         let res = self.feature_flags.consensus_enable_absolute_score_bad_nodes;
         assert!(

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1472,33 +1472,6 @@ pub struct ProtocolConfig {
     /// over (the scoring depth). When unset, defaults to 600. Consulted only
     /// when `consensus_enable_sliding_window_leader_schedule` is set.
     consensus_leader_schedule_window_size: Option<u32>,
-
-    /// High threshold (percent) for the absolute leader-schedule selection: an
-    /// authority whose reputation score, normalized to the highest score in the
-    /// window, is at or above this is a "good" (swap-in) node.
-    /// When unset, defaults to 90. Consulted only when
-    /// `consensus_enable_absolute_score_bad_nodes` is set.
-    consensus_good_nodes_normalized_score_threshold: Option<u64>,
-
-    /// Low threshold (percent) for the absolute leader-schedule selection: an
-    /// authority whose reputation score, normalized to the highest score in the
-    /// window, is strictly below this is a "bad" node. When unset, defaults to
-    /// 50. Consulted only when `consensus_enable_absolute_score_bad_nodes` is
-    /// set.
-    consensus_bad_nodes_normalized_score_threshold: Option<u64>,
-
-    /// Minimum size of the "good" (swap-in) pool, as a percent of the validator
-    /// count. When fewer nodes clear the high threshold, the pool extends to
-    /// the next-best scorers until it holds this many validators, so it is
-    /// never a single node. When unset, defaults to 20. Consulted only when
-    /// `consensus_enable_absolute_score_bad_nodes` is set.
-    consensus_min_good_nodes_percent: Option<u64>,
-
-    /// Maximum number of "bad" validators that may be excluded, as a percent of
-    /// the validator count. When more validators score below the low threshold,
-    /// only the worst up to this cap are excluded. When unset, defaults to 33.
-    /// Consulted only when `consensus_enable_absolute_score_bad_nodes` is set.
-    consensus_max_bad_nodes_percent: Option<u64>,
 }
 
 // feature flags
@@ -1916,49 +1889,7 @@ impl ProtocolConfig {
     }
 
     pub fn consensus_enable_absolute_score_bad_nodes(&self) -> bool {
-        let res = self.feature_flags.consensus_enable_absolute_score_bad_nodes;
-        if res {
-            assert!(
-                self.good_nodes_normalized_score_threshold() <= 100,
-                "consensus_enable_absolute_score_bad_nodes requires good_nodes_normalized_score_threshold <= 100"
-            );
-            assert!(
-                self.bad_nodes_normalized_score_threshold() <= 100,
-                "consensus_enable_absolute_score_bad_nodes requires bad_nodes_normalized_score_threshold <= 100"
-            );
-            assert!(
-                self.good_nodes_normalized_score_threshold()
-                    > self.bad_nodes_normalized_score_threshold(),
-                "consensus_enable_absolute_score_bad_nodes requires good threshold > bad threshold"
-            );
-            assert!(
-                self.min_good_nodes_percent() >= 1,
-                "consensus_enable_absolute_score_bad_nodes requires min_good_nodes_percent >= 1 so the good pool is non-empty"
-            );
-            assert!(
-                self.min_good_nodes_percent() + self.max_bad_nodes_percent() < 70,
-                "consensus_enable_absolute_score_bad_nodes requires min_good_nodes_percent + max_bad_nodes_percent < 70"
-            );
-        }
-        res
-    }
-
-    pub fn good_nodes_normalized_score_threshold(&self) -> u64 {
-        self.consensus_good_nodes_normalized_score_threshold
-            .unwrap_or(90)
-    }
-
-    pub fn bad_nodes_normalized_score_threshold(&self) -> u64 {
-        self.consensus_bad_nodes_normalized_score_threshold
-            .unwrap_or(50)
-    }
-
-    pub fn min_good_nodes_percent(&self) -> u64 {
-        self.consensus_min_good_nodes_percent.unwrap_or(20)
-    }
-
-    pub fn max_bad_nodes_percent(&self) -> u64 {
-        self.consensus_max_bad_nodes_percent.unwrap_or(33)
+        self.feature_flags.consensus_enable_absolute_score_bad_nodes
     }
 
     pub fn deny_rule_governance(&self) -> bool {
@@ -2588,10 +2519,6 @@ impl ProtocolConfig {
             auth_context_authenticator_function_info_v1_cost_base: None,
             consensus_commits_per_schedule: None,
             consensus_leader_schedule_window_size: None,
-            consensus_good_nodes_normalized_score_threshold: None,
-            consensus_bad_nodes_normalized_score_threshold: None,
-            consensus_min_good_nodes_percent: None,
-            consensus_max_bad_nodes_percent: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -3450,22 +3377,6 @@ impl ProtocolConfig {
 
     pub fn set_consensus_enable_absolute_score_bad_nodes_for_testing(&mut self, val: bool) {
         self.feature_flags.consensus_enable_absolute_score_bad_nodes = val;
-    }
-
-    pub fn set_good_nodes_normalized_score_threshold_for_testing(&mut self, val: u64) {
-        self.consensus_good_nodes_normalized_score_threshold = Some(val);
-    }
-
-    pub fn set_bad_nodes_normalized_score_threshold_for_testing(&mut self, val: u64) {
-        self.consensus_bad_nodes_normalized_score_threshold = Some(val);
-    }
-
-    pub fn set_min_good_nodes_percent_for_testing(&mut self, val: u64) {
-        self.consensus_min_good_nodes_percent = Some(val);
-    }
-
-    pub fn set_max_bad_nodes_percent_for_testing(&mut self, val: u64) {
-        self.consensus_max_bad_nodes_percent = Some(val);
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -578,6 +578,13 @@ struct FeatureFlags {
     // stake-weighted base election is used.
     #[serde(skip_serializing_if = "is_false")]
     consensus_enable_sliding_window_leader_schedule: bool,
+
+    // If true, Starfish selects "bad" leader-schedule nodes by absolute
+    // normalized distributed-vote performance (below a low threshold), bounded
+    // by a stake overflow clamp, with a minimum-stake floor on the good
+    // (swap-in) pool; when false, the fixed stake cut by rank is used.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_enable_absolute_score_bad_nodes: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1465,6 +1472,32 @@ pub struct ProtocolConfig {
     /// over (the scoring depth). When unset, defaults to 600. Consulted only
     /// when `consensus_enable_sliding_window_leader_schedule` is set.
     consensus_leader_schedule_window_size: Option<u32>,
+
+    /// High threshold (percent) for the absolute leader-schedule selection: an
+    /// authority whose distributed-vote score, normalized to the window's
+    /// theoretical maximum, is at or above this is a "good" (swap-in) node.
+    /// When unset, defaults to 90. Consulted only when
+    /// `consensus_enable_absolute_score_bad_nodes` is set.
+    consensus_good_nodes_normalized_score_threshold: Option<u64>,
+
+    /// Low threshold (percent) for the absolute leader-schedule selection: an
+    /// authority whose normalized distributed-vote score is strictly below this
+    /// is a "bad" node. When unset, defaults to 50. Consulted only when
+    /// `consensus_enable_absolute_score_bad_nodes` is set.
+    consensus_bad_nodes_normalized_score_threshold: Option<u64>,
+
+    /// Minimum size of the "good" (swap-in) pool, as a percent of the validator
+    /// count. When fewer nodes clear the high threshold, the pool extends to
+    /// the next-best scorers until it holds this many validators, so it is
+    /// never a single node. When unset, defaults to 20. Consulted only when
+    /// `consensus_enable_absolute_score_bad_nodes` is set.
+    consensus_min_good_nodes_percent: Option<u64>,
+
+    /// Maximum number of "bad" validators that may be excluded, as a percent of
+    /// the validator count. When more validators score below the low threshold,
+    /// only the worst up to this cap are excluded. When unset, defaults to 33.
+    /// Consulted only when `consensus_enable_absolute_score_bad_nodes` is set.
+    consensus_max_bad_nodes_percent: Option<u64>,
 }
 
 // feature flags
@@ -1879,6 +1912,34 @@ impl ProtocolConfig {
             "consensus_enable_sliding_window_leader_schedule requires window_size >= commits_per_schedule"
         );
         res
+    }
+
+    pub fn consensus_enable_absolute_score_bad_nodes(&self) -> bool {
+        let res = self.feature_flags.consensus_enable_absolute_score_bad_nodes;
+        assert!(
+            !res || self.good_nodes_normalized_score_threshold()
+                > self.bad_nodes_normalized_score_threshold(),
+            "consensus_enable_absolute_score_bad_nodes requires good threshold > bad threshold"
+        );
+        res
+    }
+
+    pub fn good_nodes_normalized_score_threshold(&self) -> u64 {
+        self.consensus_good_nodes_normalized_score_threshold
+            .unwrap_or(90)
+    }
+
+    pub fn bad_nodes_normalized_score_threshold(&self) -> u64 {
+        self.consensus_bad_nodes_normalized_score_threshold
+            .unwrap_or(50)
+    }
+
+    pub fn min_good_nodes_percent(&self) -> u64 {
+        self.consensus_min_good_nodes_percent.unwrap_or(20)
+    }
+
+    pub fn max_bad_nodes_percent(&self) -> u64 {
+        self.consensus_max_bad_nodes_percent.unwrap_or(33)
     }
 
     pub fn deny_rule_governance(&self) -> bool {
@@ -2508,6 +2569,10 @@ impl ProtocolConfig {
             auth_context_authenticator_function_info_v1_cost_base: None,
             consensus_commits_per_schedule: None,
             consensus_leader_schedule_window_size: None,
+            consensus_good_nodes_normalized_score_threshold: None,
+            consensus_bad_nodes_normalized_score_threshold: None,
+            consensus_min_good_nodes_percent: None,
+            consensus_max_bad_nodes_percent: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -3362,6 +3427,26 @@ impl ProtocolConfig {
     pub fn set_consensus_enable_sliding_window_leader_schedule_for_testing(&mut self, val: bool) {
         self.feature_flags
             .consensus_enable_sliding_window_leader_schedule = val;
+    }
+
+    pub fn set_consensus_enable_absolute_score_bad_nodes_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_enable_absolute_score_bad_nodes = val;
+    }
+
+    pub fn set_good_nodes_normalized_score_threshold_for_testing(&mut self, val: u64) {
+        self.consensus_good_nodes_normalized_score_threshold = Some(val);
+    }
+
+    pub fn set_bad_nodes_normalized_score_threshold_for_testing(&mut self, val: u64) {
+        self.consensus_bad_nodes_normalized_score_threshold = Some(val);
+    }
+
+    pub fn set_min_good_nodes_percent_for_testing(&mut self, val: u64) {
+        self.consensus_min_good_nodes_percent = Some(val);
+    }
+
+    pub fn set_max_bad_nodes_percent_for_testing(&mut self, val: u64) {
+        self.consensus_max_bad_nodes_percent = Some(val);
     }
 }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3022,7 +3022,7 @@ mod test {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_leader_schedule_restart_invariant_rotation(
         #[case] enable_sliding_window: bool,
-        #[case] enable_absolute_score_bad_nodes: bool,
+        #[case] enable_absolute_score_leader_schedule: bool,
     ) {
         telemetry_subscribers::init_for_testing();
         let default_params = Parameters::default();
@@ -3032,10 +3032,10 @@ mod test {
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(false);
-        if enable_absolute_score_bad_nodes {
+        if enable_absolute_score_leader_schedule {
             context
                 .protocol_config
-                .set_consensus_enable_absolute_score_bad_nodes_for_testing(true);
+                .set_consensus_enable_absolute_score_leader_schedule_for_testing(true);
         }
         if enable_sliding_window {
             context

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3015,10 +3015,15 @@ mod test {
     /// the lagging frontier. The assertions compare live vs. restarted directly
     /// (no hard-coded count) and run for both the sliding-window and V2 paths.
     #[rstest]
-    #[case::sliding_window(true)]
-    #[case::v2(false)]
+    #[case::v2(false, false)]
+    #[case::v2_absolute_scores(false, true)]
+    #[case::sliding_window(true, false)]
+    #[case::sliding_window_absolute_scores(true, true)]
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_leader_schedule_restart_invariant_rotation(#[case] enable_sliding_window: bool) {
+    async fn test_leader_schedule_restart_invariant_rotation(
+        #[case] enable_sliding_window: bool,
+        #[case] enable_absolute_score_bad_nodes: bool,
+    ) {
         telemetry_subscribers::init_for_testing();
         let default_params = Parameters::default();
 
@@ -3027,6 +3032,11 @@ mod test {
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(false);
+        if enable_absolute_score_bad_nodes {
+            context
+                .protocol_config
+                .set_consensus_enable_absolute_score_bad_nodes_for_testing(true);
+        }
         if enable_sliding_window {
             context
                 .protocol_config

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -751,11 +751,8 @@ impl LeaderSwapTable {
     /// performers both normalize to 100%. A node below the low threshold is
     /// bad; a node at or above the high threshold is good. The good pool
     /// extends down the ranking until it holds at least the minimum number
-    /// of validators, even past the low threshold if needed — spreading
-    /// swap-in duty across more validators matters more than excluding
-    /// every low scorer, since a low score reflects unreliability rather
-    /// than Byzantine behavior. The bad set is capped at the maximum
-    /// bad-node count. All thresholds come from the protocol config.
+    /// of validators; the bad set is capped at the maximum bad-node count.
+    /// All thresholds come from the protocol config.
     fn select_by_absolute_score(
         context: &Arc<Context>,
         authorities_by_score: &[(AuthorityIndex, u64)],
@@ -791,10 +788,8 @@ impl LeaderSwapTable {
         let committee_size = context.committee.size() as u64;
 
         // Good pool: the top scorers, extended past the high threshold until it
-        // holds at least the minimum number of validators. This can pull in a
-        // node below the low (bad) threshold rather than leave the pool too
-        // small to swap into; for small committees the minimum itself can
-        // still be a single validator.
+        // holds at least the minimum number of validators, enforced even if
+        // that requires including a node below the low (bad) threshold.
         let min_good =
             (protocol_config.min_good_nodes_percent() * committee_size).div_ceil(100) as usize;
         let mut good_nodes = Vec::new();

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -742,6 +742,24 @@ impl LeaderSwapTable {
         (good_nodes, bad_nodes)
     }
 
+    /// High threshold (percent) for the absolute leader-schedule selection: a
+    /// validator whose reputation score, normalized to the highest score in
+    /// the window, is at or above this is a "good" (swap-in) node.
+    const GOOD_NODES_NORMALIZED_SCORE_THRESHOLD: u64 = 90;
+
+    /// Low threshold (percent) for the absolute leader-schedule selection: a
+    /// validator whose reputation score, normalized to the highest score in
+    /// the window, is strictly below this is a "bad" node.
+    const BAD_NODES_NORMALIZED_SCORE_THRESHOLD: u64 = 50;
+
+    /// Minimum size of the "good" (swap-in) pool, as a percent of the
+    /// validator count.
+    const MIN_GOOD_NODES_PERCENT: u64 = 20;
+
+    /// Maximum number of "bad" validators that may be excluded, as a percent
+    /// of the validator count.
+    const MAX_BAD_NODES_PERCENT: u64 = 33;
+
     /// Splits the score-descending `authorities_by_score` into the good
     /// (swap-in) and bad sets by performance relative to the top scorer. Each
     /// score is normalized against the highest score in the window, so the
@@ -752,7 +770,6 @@ impl LeaderSwapTable {
     /// bad; a node at or above the high threshold is good. The good pool
     /// extends down the ranking until it holds at least the minimum number
     /// of validators; the bad set is capped at the maximum bad-node count.
-    /// All thresholds come from the protocol config.
     fn select_by_absolute_score(
         context: &Arc<Context>,
         authorities_by_score: &[(AuthorityIndex, u64)],
@@ -760,9 +777,8 @@ impl LeaderSwapTable {
         Vec<(AuthorityIndex, String, Stake)>,
         BTreeMap<AuthorityIndex, (String, Stake)>,
     ) {
-        let protocol_config = &context.protocol_config;
-        let good_threshold = protocol_config.good_nodes_normalized_score_threshold() as u128;
-        let bad_threshold = protocol_config.bad_nodes_normalized_score_threshold() as u128;
+        let good_threshold = Self::GOOD_NODES_NORMALIZED_SCORE_THRESHOLD as u128;
+        let bad_threshold = Self::BAD_NODES_NORMALIZED_SCORE_THRESHOLD as u128;
 
         // Normalize against the highest score in this window (the top
         // performer). `authorities_by_score` is score descending, so the first
@@ -790,8 +806,7 @@ impl LeaderSwapTable {
         // Good pool: the top scorers, extended past the high threshold until it
         // holds at least the minimum number of validators, enforced even if
         // that requires including a node below the low (bad) threshold.
-        let min_good =
-            (protocol_config.min_good_nodes_percent() * committee_size).div_ceil(100) as usize;
+        let min_good = (Self::MIN_GOOD_NODES_PERCENT * committee_size).div_ceil(100) as usize;
         let mut good_nodes = Vec::new();
         for &(authority_idx, score) in authorities_by_score.iter() {
             if !is_good(score) && good_nodes.len() >= min_good {
@@ -803,7 +818,7 @@ impl LeaderSwapTable {
 
         // Bad set: the lowest scorers below the threshold, excluding any node
         // already claimed by the good pool, capped at the maximum bad-node count.
-        let max_bad = (protocol_config.max_bad_nodes_percent() * committee_size / 100) as usize;
+        let max_bad = (Self::MAX_BAD_NODES_PERCENT * committee_size / 100) as usize;
         let good_indexes = good_nodes
             .iter()
             .map(|(idx, _, _)| *idx)
@@ -822,6 +837,28 @@ impl LeaderSwapTable {
         (good_nodes, bad_nodes)
     }
 }
+
+const _: () = assert!(
+    LeaderSwapTable::GOOD_NODES_NORMALIZED_SCORE_THRESHOLD <= 100,
+    "GOOD_NODES_NORMALIZED_SCORE_THRESHOLD must be <= 100"
+);
+const _: () = assert!(
+    LeaderSwapTable::BAD_NODES_NORMALIZED_SCORE_THRESHOLD <= 100,
+    "BAD_NODES_NORMALIZED_SCORE_THRESHOLD must be <= 100"
+);
+const _: () = assert!(
+    LeaderSwapTable::GOOD_NODES_NORMALIZED_SCORE_THRESHOLD
+        > LeaderSwapTable::BAD_NODES_NORMALIZED_SCORE_THRESHOLD,
+    "GOOD_NODES_NORMALIZED_SCORE_THRESHOLD must be > BAD_NODES_NORMALIZED_SCORE_THRESHOLD"
+);
+const _: () = assert!(
+    LeaderSwapTable::MIN_GOOD_NODES_PERCENT >= 1,
+    "MIN_GOOD_NODES_PERCENT must be >= 1 so the good pool is non-empty"
+);
+const _: () = assert!(
+    LeaderSwapTable::MIN_GOOD_NODES_PERCENT + LeaderSwapTable::MAX_BAD_NODES_PERCENT < 70,
+    "MIN_GOOD_NODES_PERCENT + MAX_BAD_NODES_PERCENT must be < 70"
+);
 
 impl Debug for LeaderSwapTable {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -751,9 +751,11 @@ impl LeaderSwapTable {
     /// performers both normalize to 100%. A node below the low threshold is
     /// bad; a node at or above the high threshold is good. The good pool
     /// extends down the ranking until it holds at least the minimum number
-    /// of validators (never a single node); the bad set is capped at the
-    /// maximum bad-node count. All thresholds come from the protocol
-    /// config.
+    /// of validators, even past the low threshold if needed — spreading
+    /// swap-in duty across more validators matters more than excluding
+    /// every low scorer, since a low score reflects unreliability rather
+    /// than Byzantine behavior. The bad set is capped at the maximum
+    /// bad-node count. All thresholds come from the protocol config.
     fn select_by_absolute_score(
         context: &Arc<Context>,
         authorities_by_score: &[(AuthorityIndex, u64)],
@@ -789,8 +791,10 @@ impl LeaderSwapTable {
         let committee_size = context.committee.size() as u64;
 
         // Good pool: the top scorers, extended past the high threshold until it
-        // holds at least the minimum number of validators, so it is never a
-        // single node.
+        // holds at least the minimum number of validators. This can pull in a
+        // node below the low (bad) threshold rather than leave the pool too
+        // small to swap into; for small committees the minimum itself can
+        // still be a single validator.
         let min_good =
             (protocol_config.min_good_nodes_percent() * committee_size).div_ceil(100) as usize;
         let mut good_nodes = Vec::new();

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Formatter},
     sync::Arc,
 };
@@ -599,26 +599,14 @@ impl LeaderSwapTable {
         // the same score is preserved.
         authorities_by_score.sort_by_key(|a2| std::cmp::Reverse(a2.1));
 
-        // Calculating the good nodes
-        let good_nodes = Self::retrieve_first_nodes(
-            context.clone(),
-            authorities_by_score.iter(),
-            swap_stake_threshold,
-        )
-        .into_iter()
-        .collect::<Vec<(AuthorityIndex, String, Stake)>>();
-
-        // Calculating the bad nodes
-        // Reverse the sorted authorities to score ascending so we get the first
-        // low scorers up to the provided stake threshold.
-        let bad_nodes = Self::retrieve_first_nodes(
-            context,
-            authorities_by_score.iter().rev(),
-            swap_stake_threshold,
-        )
-        .into_iter()
-        .map(|(idx, hostname, stake)| (idx, (hostname, stake)))
-        .collect::<BTreeMap<AuthorityIndex, (String, Stake)>>();
+        let (good_nodes, bad_nodes) = if context
+            .protocol_config
+            .consensus_enable_absolute_score_bad_nodes()
+        {
+            Self::select_by_absolute_score(&context, &authorities_by_score, &reputation_scores)
+        } else {
+            Self::select_by_stake_rank(&context, &authorities_by_score, swap_stake_threshold)
+        };
 
         good_nodes.iter().for_each(|(idx, hostname, stake)| {
             tracing::debug!(
@@ -720,6 +708,112 @@ impl LeaderSwapTable {
         }
 
         filtered_authorities
+    }
+
+    /// Splits the score-descending `authorities_by_score` into the good
+    /// (swap-in) and bad sets using the fixed stake cut: the top scorers up to
+    /// `swap_stake_threshold`% of stake are good, the lowest scorers up to the
+    /// same stake are bad.
+    fn select_by_stake_rank(
+        context: &Arc<Context>,
+        authorities_by_score: &[(AuthorityIndex, u64)],
+        swap_stake_threshold: u64,
+    ) -> (
+        Vec<(AuthorityIndex, String, Stake)>,
+        BTreeMap<AuthorityIndex, (String, Stake)>,
+    ) {
+        let good_nodes = Self::retrieve_first_nodes(
+            context.clone(),
+            authorities_by_score.iter(),
+            swap_stake_threshold,
+        );
+
+        // Reverse to score ascending so we take the lowest scorers up to the
+        // stake threshold.
+        let bad_nodes = Self::retrieve_first_nodes(
+            context.clone(),
+            authorities_by_score.iter().rev(),
+            swap_stake_threshold,
+        )
+        .into_iter()
+        .map(|(idx, hostname, stake)| (idx, (hostname, stake)))
+        .collect::<BTreeMap<AuthorityIndex, (String, Stake)>>();
+
+        (good_nodes, bad_nodes)
+    }
+
+    /// Splits the score-descending `authorities_by_score` into the good
+    /// (swap-in) and bad sets by absolute performance. Each score is compared
+    /// against the window's theoretical maximum
+    /// (`commit_range.size() * total_stake`): a node below the low threshold is
+    /// bad, a node at or above the high threshold is good. The good pool
+    /// extends down the ranking until it holds at least the minimum number
+    /// of validators (never a single node); the bad set is capped at the
+    /// maximum bad-node count. All thresholds come from the protocol
+    /// config.
+    fn select_by_absolute_score(
+        context: &Arc<Context>,
+        authorities_by_score: &[(AuthorityIndex, u64)],
+        reputation_scores: &ReputationScores,
+    ) -> (
+        Vec<(AuthorityIndex, String, Stake)>,
+        BTreeMap<AuthorityIndex, (String, Stake)>,
+    ) {
+        let protocol_config = &context.protocol_config;
+        let good_threshold = protocol_config.good_nodes_normalized_score_threshold() as u128;
+        let bad_threshold = protocol_config.bad_nodes_normalized_score_threshold() as u128;
+
+        let total_stake = context.committee.total_stake();
+        // Theoretical maximum distributed-vote score for one authority over the
+        // window: one vote per committed leader, each witnessed by all stake.
+        let max_possible = reputation_scores.commit_range.size() as u128 * total_stake as u128;
+
+        // Nothing to normalize against, so make no swaps.
+        if max_possible == 0 {
+            return (Vec::new(), BTreeMap::new());
+        }
+
+        // Integer-only comparisons against `score / max_possible`:
+        //   good: score * 100 >= good_threshold * max_possible
+        //   bad:  score * 100 <  bad_threshold  * max_possible
+        let is_good = |score: u64| (score as u128) * 100 >= good_threshold * max_possible;
+        let is_bad = |score: u64| (score as u128) * 100 < bad_threshold * max_possible;
+
+        let committee_size = context.committee.size() as u64;
+
+        // Good pool: the top scorers, extended past the high threshold until it
+        // holds at least the minimum number of validators, so it is never a
+        // single node.
+        let min_good =
+            (protocol_config.min_good_nodes_percent() * committee_size).div_ceil(100) as usize;
+        let mut good_nodes = Vec::new();
+        for &(authority_idx, score) in authorities_by_score.iter() {
+            if !is_good(score) && good_nodes.len() >= min_good {
+                break;
+            }
+            let authority = context.committee.authority(authority_idx);
+            good_nodes.push((authority_idx, authority.hostname.clone(), authority.stake));
+        }
+
+        // Bad set: the lowest scorers below the threshold, excluding any node
+        // already claimed by the good pool, capped at the maximum bad-node count.
+        let max_bad = (protocol_config.max_bad_nodes_percent() * committee_size / 100) as usize;
+        let good_indexes = good_nodes
+            .iter()
+            .map(|(idx, _, _)| *idx)
+            .collect::<BTreeSet<AuthorityIndex>>();
+        let bad_nodes = authorities_by_score
+            .iter()
+            .rev()
+            .filter(|entry| is_bad(entry.1) && !good_indexes.contains(&entry.0))
+            .take(max_bad)
+            .map(|&(idx, _)| {
+                let authority = context.committee.authority(idx);
+                (idx, (authority.hostname.clone(), authority.stake))
+            })
+            .collect::<BTreeMap<AuthorityIndex, (String, Stake)>>();
+
+        (good_nodes, bad_nodes)
     }
 }
 
@@ -1387,6 +1481,114 @@ mod tests {
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         LeaderSwapTable::new_inner(context, swap_stake_threshold, 0, reputation_scores);
+    }
+
+    fn context_with_absolute_selection(committee_size: usize) -> Arc<Context> {
+        let mut context = Context::new_for_test(committee_size).0;
+        context
+            .protocol_config
+            .set_consensus_enable_absolute_score_bad_nodes_for_testing(true);
+        Arc::new(context)
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_classifies_by_threshold() {
+        telemetry_subscribers::init_for_testing();
+        // 4 authorities, even stake (total 4), window size 11 => max score 44.
+        // Good is score >= 90% (>= 40), bad is score < 50% (< 22).
+        let context = context_with_absolute_selection(4);
+        let reputation_scores = ReputationScores::new((0..=10).into(), vec![0, 30, 40, 44]);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        let good: Vec<_> = table.good_nodes.iter().map(|(idx, _, _)| *idx).collect();
+        assert_eq!(good.len(), 2);
+        assert!(good.contains(&AuthorityIndex::new_for_test(2)));
+        assert!(good.contains(&AuthorityIndex::new_for_test(3)));
+        // The middle node (score 30) is neither good nor bad.
+        assert!(!good.contains(&AuthorityIndex::new_for_test(1)));
+        assert_eq!(table.bad_nodes.len(), 1);
+        assert!(
+            table
+                .bad_nodes
+                .contains_key(&AuthorityIndex::new_for_test(0))
+        );
+        assert!(
+            !table
+                .bad_nodes
+                .contains_key(&AuthorityIndex::new_for_test(1))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_good_pool_respects_count_floor() {
+        telemetry_subscribers::init_for_testing();
+        // 10 authorities, so the 20%-of-validators good-pool floor is 2 nodes.
+        // Only one authority clears the 90% threshold; the pool must extend to
+        // the next-best scorer to meet the floor, so it is never one node.
+        let context = context_with_absolute_selection(10);
+        let mut scores = vec![60u64; 10];
+        scores[9] = 110;
+        let reputation_scores = ReputationScores::new((0..=10).into(), scores);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        assert_eq!(table.good_nodes.len(), 2);
+        let good: Vec<_> = table.good_nodes.iter().map(|(idx, _, _)| *idx).collect();
+        assert!(good.contains(&AuthorityIndex::new_for_test(9)));
+        // Every authority scores above 50%, so none are bad.
+        assert!(table.bad_nodes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_caps_bad_set_by_count() {
+        telemetry_subscribers::init_for_testing();
+        // 10 authorities. Five score 0 (bad), five clear the high threshold. The
+        // five below-threshold nodes exceed the 33%-of-validators cap (3), so
+        // only the worst three may be excluded.
+        let context = context_with_absolute_selection(10);
+        let mut scores = vec![0u64; 10];
+        for s in scores.iter_mut().skip(5) {
+            *s = 110;
+        }
+        let reputation_scores = ReputationScores::new((0..=10).into(), scores);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        assert_eq!(table.good_nodes.len(), 5);
+        assert_eq!(table.bad_nodes.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_all_bad_keeps_good_pool() {
+        telemetry_subscribers::init_for_testing();
+        // Every authority scores 0. The good pool must still be non-empty (so
+        // swapping never panics) while the worst nodes are still excluded.
+        let context = context_with_absolute_selection(10);
+        let reputation_scores = ReputationScores::new((0..=10).into(), vec![0; 10]);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        assert!(!table.good_nodes.is_empty());
+        assert!(!table.bad_nodes.is_empty());
+        // A bad leader is swapped for a good node rather than panicking.
+        let bad_leader = *table.bad_nodes.keys().next().unwrap();
+        assert!(table.swap(bad_leader, 1, 0).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_deterministic_and_differs_from_stake_rank() {
+        telemetry_subscribers::init_for_testing();
+        let scores = || ReputationScores::new((0..=10).into(), vec![0, 30, 40, 44]);
+
+        let absolute_context = context_with_absolute_selection(4);
+        let first = LeaderSwapTable::new_inner(absolute_context.clone(), 33, 0, scores());
+        let second = LeaderSwapTable::new_inner(absolute_context, 33, 0, scores());
+        assert_eq!(first.good_nodes, second.good_nodes);
+        assert_eq!(first.bad_nodes, second.bad_nodes);
+
+        // The stake-rank path (flag off) admits only the single top scorer as
+        // good; the absolute path admits both authorities above the threshold.
+        let stake_rank_context = Arc::new(Context::new_for_test(4).0);
+        let stake_rank = LeaderSwapTable::new_inner(stake_rank_context, 33, 0, scores());
+        assert_eq!(stake_rank.good_nodes.len(), 1);
+        assert_eq!(first.good_nodes.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -603,7 +603,7 @@ impl LeaderSwapTable {
             .protocol_config
             .consensus_enable_absolute_score_bad_nodes()
         {
-            Self::select_by_absolute_score(&context, &authorities_by_score, &reputation_scores)
+            Self::select_by_absolute_score(&context, &authorities_by_score)
         } else {
             Self::select_by_stake_rank(&context, &authorities_by_score, swap_stake_threshold)
         };
@@ -743,10 +743,10 @@ impl LeaderSwapTable {
     }
 
     /// Splits the score-descending `authorities_by_score` into the good
-    /// (swap-in) and bad sets by absolute performance. Each score is compared
-    /// against the window's theoretical maximum
-    /// (`commit_range.size() * total_stake`): a node below the low threshold is
-    /// bad, a node at or above the high threshold is good. The good pool
+    /// (swap-in) and bad sets by absolute performance. Each score is normalized
+    /// against the most a validator could score over the scoring window, i.e.
+    /// its commit count times the total stake. A node below the low threshold
+    /// is bad; a node at or above the high threshold is good. The good pool
     /// extends down the ranking until it holds at least the minimum number
     /// of validators (never a single node); the bad set is capped at the
     /// maximum bad-node count. All thresholds come from the protocol
@@ -754,7 +754,6 @@ impl LeaderSwapTable {
     fn select_by_absolute_score(
         context: &Arc<Context>,
         authorities_by_score: &[(AuthorityIndex, u64)],
-        reputation_scores: &ReputationScores,
     ) -> (
         Vec<(AuthorityIndex, String, Stake)>,
         BTreeMap<AuthorityIndex, (String, Stake)>,
@@ -763,12 +762,12 @@ impl LeaderSwapTable {
         let good_threshold = protocol_config.good_nodes_normalized_score_threshold() as u128;
         let bad_threshold = protocol_config.bad_nodes_normalized_score_threshold() as u128;
 
-        let total_stake = context.committee.total_stake();
-        // Theoretical maximum score for one authority over the window: at most
+        // Theoretical maximum score for one authority over the scoring window:
         // one vote per committed leader, each witnessed by all stake.
-        let max_possible = reputation_scores.commit_range.size() as u128 * total_stake as u128;
+        let max_possible = protocol_config.scoring_window_commits() as u128
+            * context.committee.total_stake() as u128;
 
-        // Nothing to normalize against, so make no swaps.
+        // No window to normalize against, so make no swaps.
         if max_possible == 0 {
             return (Vec::new(), BTreeMap::new());
         }
@@ -1488,6 +1487,11 @@ mod tests {
         context
             .protocol_config
             .set_consensus_enable_absolute_score_bad_nodes_for_testing(true);
+        // Pin the V2 scoring window so the normalized scores below are measured
+        // against a fixed maximum (window commits * total stake).
+        context
+            .protocol_config
+            .set_commits_per_schedule_for_testing(11);
         Arc::new(context)
     }
 
@@ -1557,19 +1561,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_leader_swap_table_absolute_score_all_bad_keeps_good_pool() {
+    async fn test_leader_swap_table_absolute_score_swaps_bad_leaders() {
         telemetry_subscribers::init_for_testing();
-        // Every authority scores 0. The good pool must still be non-empty (so
-        // swapping never panics) while the worst nodes are still excluded.
+        // One clear top scorer, everyone else far below it. The good pool is
+        // non-empty and the low scorers are excluded, so a bad leader is swapped
+        // for a good node rather than panicking.
         let context = context_with_absolute_selection(10);
-        let reputation_scores = ReputationScores::new((0..=10).into(), vec![0; 10]);
+        let mut scores = vec![0u64; 10];
+        scores[0] = 100;
+        let reputation_scores = ReputationScores::new((0..=10).into(), scores);
         let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
 
         assert!(!table.good_nodes.is_empty());
         assert!(!table.bad_nodes.is_empty());
-        // A bad leader is swapped for a good node rather than panicking.
         let bad_leader = *table.bad_nodes.keys().next().unwrap();
         assert!(table.swap(bad_leader, 1, 0).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_normalizes_by_sliding_window_size() {
+        telemetry_subscribers::init_for_testing();
+        // In sliding-window mode scores are summed over `window_size` commits,
+        // but the stamped commit_range is only the (smaller) rotation interval.
+        // Normalization must use window_size: here it is 10 (max score 10 * 4 =
+        // 40), so node 1 at 26 is 0.65 and must be middle. Using the 5-commit
+        // rotation interval would make its max 20 and wrongly mark node 1 good.
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_enable_absolute_score_bad_nodes_for_testing(true);
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        context
+            .protocol_config
+            .set_commits_per_schedule_for_testing(5);
+        context
+            .protocol_config
+            .set_leader_schedule_window_size_for_testing(10);
+        let context = Arc::new(context);
+
+        let reputation_scores = ReputationScores::new((0..=4).into(), vec![40, 26, 12, 2]);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        let good: Vec<_> = table.good_nodes.iter().map(|(idx, _, _)| *idx).collect();
+        assert_eq!(good, vec![AuthorityIndex::new_for_test(0)]);
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -764,8 +764,8 @@ impl LeaderSwapTable {
         let bad_threshold = protocol_config.bad_nodes_normalized_score_threshold() as u128;
 
         let total_stake = context.committee.total_stake();
-        // Theoretical maximum distributed-vote score for one authority over the
-        // window: one vote per committed leader, each witnessed by all stake.
+        // Theoretical maximum score for one authority over the window: at most
+        // one vote per committed leader, each witnessed by all stake.
         let max_possible = reputation_scores.commit_range.size() as u128 * total_stake as u128;
 
         // Nothing to normalize against, so make no swaps.

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -601,7 +601,7 @@ impl LeaderSwapTable {
 
         let (good_nodes, bad_nodes) = if context
             .protocol_config
-            .consensus_enable_absolute_score_bad_nodes()
+            .consensus_enable_absolute_score_leader_schedule()
         {
             Self::select_by_absolute_score(&context, &authorities_by_score)
         } else {
@@ -1530,7 +1530,7 @@ mod tests {
         let mut context = Context::new_for_test(committee_size).0;
         context
             .protocol_config
-            .set_consensus_enable_absolute_score_bad_nodes_for_testing(true);
+            .set_consensus_enable_absolute_score_leader_schedule_for_testing(true);
         Arc::new(context)
     }
 

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -743,10 +743,13 @@ impl LeaderSwapTable {
     }
 
     /// Splits the score-descending `authorities_by_score` into the good
-    /// (swap-in) and bad sets by absolute performance. Each score is normalized
-    /// against the most a validator could score over the scoring window, i.e.
-    /// its commit count times the total stake. A node below the low threshold
-    /// is bad; a node at or above the high threshold is good. The good pool
+    /// (swap-in) and bad sets by performance relative to the top scorer. Each
+    /// score is normalized against the highest score in the window, so the
+    /// thresholds mean the same thing regardless of how close the scoring
+    /// strategy gets to its theoretical ceiling — V2 batch and sliding-window
+    /// reach very different absolute levels for the same network, but their top
+    /// performers both normalize to 100%. A node below the low threshold is
+    /// bad; a node at or above the high threshold is good. The good pool
     /// extends down the ranking until it holds at least the minimum number
     /// of validators (never a single node); the bad set is capped at the
     /// maximum bad-node count. All thresholds come from the protocol
@@ -762,21 +765,26 @@ impl LeaderSwapTable {
         let good_threshold = protocol_config.good_nodes_normalized_score_threshold() as u128;
         let bad_threshold = protocol_config.bad_nodes_normalized_score_threshold() as u128;
 
-        // Theoretical maximum score for one authority over the scoring window:
-        // one vote per committed leader, each witnessed by all stake.
-        let max_possible = protocol_config.scoring_window_commits() as u128
-            * context.committee.total_stake() as u128;
+        // Normalize against the highest score in this window (the top
+        // performer). `authorities_by_score` is score descending, so the first
+        // entry is the maximum. It is derived from the same committed subdags on
+        // every authority, so the normalization is deterministic and reproduces
+        // identically on recovery.
+        let top_score = authorities_by_score
+            .first()
+            .map(|&(_, score)| score as u128)
+            .unwrap_or(0);
 
-        // No window to normalize against, so make no swaps.
-        if max_possible == 0 {
+        // No positive score to normalize against, so make no swaps.
+        if top_score == 0 {
             return (Vec::new(), BTreeMap::new());
         }
 
-        // Integer-only comparisons against `score / max_possible`:
-        //   good: score * 100 >= good_threshold * max_possible
-        //   bad:  score * 100 <  bad_threshold  * max_possible
-        let is_good = |score: u64| (score as u128) * 100 >= good_threshold * max_possible;
-        let is_bad = |score: u64| (score as u128) * 100 < bad_threshold * max_possible;
+        // Integer-only comparisons against `score / top_score`:
+        //   good: score * 100 >= good_threshold * top_score
+        //   bad:  score * 100 <  bad_threshold  * top_score
+        let is_good = |score: u64| (score as u128) * 100 >= good_threshold * top_score;
+        let is_bad = |score: u64| (score as u128) * 100 < bad_threshold * top_score;
 
         let committee_size = context.committee.size() as u64;
 
@@ -1487,19 +1495,14 @@ mod tests {
         context
             .protocol_config
             .set_consensus_enable_absolute_score_bad_nodes_for_testing(true);
-        // Pin the V2 scoring window so the normalized scores below are measured
-        // against a fixed maximum (window commits * total stake).
-        context
-            .protocol_config
-            .set_commits_per_schedule_for_testing(11);
         Arc::new(context)
     }
 
     #[tokio::test]
     async fn test_leader_swap_table_absolute_score_classifies_by_threshold() {
         telemetry_subscribers::init_for_testing();
-        // 4 authorities, even stake (total 4), window size 11 => max score 44.
-        // Good is score >= 90% (>= 40), bad is score < 50% (< 22).
+        // 4 authorities. The top scorer has 44, so good is >= 90% of 44
+        // (>= 40) and bad is < 50% of 44 (< 22).
         let context = context_with_absolute_selection(4);
         let reputation_scores = ReputationScores::new((0..=10).into(), vec![0, 30, 40, 44]);
         let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
@@ -1579,33 +1582,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_leader_swap_table_absolute_score_normalizes_by_sliding_window_size() {
+    async fn test_leader_swap_table_absolute_score_normalizes_by_top_scorer() {
         telemetry_subscribers::init_for_testing();
-        // In sliding-window mode scores are summed over `window_size` commits,
-        // but the stamped commit_range is only the (smaller) rotation interval.
-        // Normalization must use window_size: here it is 10 (max score 10 * 4 =
-        // 40), so node 1 at 26 is 0.65 and must be middle. Using the 5-commit
-        // rotation interval would make its max 20 and wrongly mark node 1 good.
-        let mut context = Context::new_for_test(4).0;
-        context
-            .protocol_config
-            .set_consensus_enable_absolute_score_bad_nodes_for_testing(true);
-        context
-            .protocol_config
-            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
-        context
-            .protocol_config
-            .set_commits_per_schedule_for_testing(5);
-        context
-            .protocol_config
-            .set_leader_schedule_window_size_for_testing(10);
-        let context = Arc::new(context);
-
-        let reputation_scores = ReputationScores::new((0..=4).into(), vec![40, 26, 12, 2]);
+        // Selection normalizes against the top score in the window (20 here),
+        // not against the scoring strategy's theoretical ceiling. Node 1 at 18
+        // is 90% of the best, so it is good; the same score of 18 measured
+        // against a much higher theoretical ceiling would instead fall below
+        // every threshold.
+        let context = context_with_absolute_selection(4);
+        let reputation_scores = ReputationScores::new((0..=10).into(), vec![20, 18, 10, 4]);
         let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
 
         let good: Vec<_> = table.good_nodes.iter().map(|(idx, _, _)| *idx).collect();
-        assert_eq!(good, vec![AuthorityIndex::new_for_test(0)]);
+        assert_eq!(good.len(), 2);
+        assert!(good.contains(&AuthorityIndex::new_for_test(0)));
+        assert!(good.contains(&AuthorityIndex::new_for_test(1)));
+        // Node 2 (10 = 50% of the top) is neither good nor bad.
+        assert!(!good.contains(&AuthorityIndex::new_for_test(2)));
+        assert!(
+            !table
+                .bad_nodes
+                .contains_key(&AuthorityIndex::new_for_test(2))
+        );
+        // Node 3 (4 = 20% of the top) is below the low threshold.
+        assert_eq!(table.bad_nodes.len(), 1);
+        assert!(
+            table
+                .bad_nodes
+                .contains_key(&AuthorityIndex::new_for_test(3))
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description of change

Adds a way to select the "bad" validators that the leader schedule excludes from leadership by **absolute performance** instead of a fixed stake quantile. Wired behind a new default-off protocol flag (`consensus_enable_absolute_score_leader_schedule`).

## Motivation

The leader schedule swaps low-reputation validators out of leadership so their slots go to better performers. Today the "bad" set is a fixed cut by rank: walk validators from the lowest distributed-vote score and take them until their cumulative stake reaches `consensus_bad_nodes_stake_threshold` (20%). This mismatches the actual score distribution in both directions.

Measuring `consensus_reputation_scores` on testnet and mainnet over a day (per leader-schedule window, normalized so 1.0 = the window's top scorer), the distribution is strongly **bimodal** — a dense cluster of healthy nodes near the top, a thin middle, and a distinct low tail:

- **Testnet** (55 authorities): 33 at ≥ 0.95, ~9 in the 0.5–0.95 middle, 13 below 0.5 (12 of those effectively dead, < 0.1). Median 0.99, mean 0.74.
- **Mainnet** (64 authorities): 32 at ≥ 0.95, ~14 middle, 18 below 0.5 (6 near-zero). Median 0.95, mean 0.72.

The score is a liveness/propagation signal, not a stake signal: it correlates with stake at ~0 (Spearman 0.05–0.09), and the low tail is stable across a week and across restarts.

A fixed-quantile cut is wrong for this shape in both directions:

- **It excludes good nodes.** It always removes ~20%-stake worth regardless of whether anyone is actually underperforming, so in healthy windows the cut reaches up into the top cluster. On testnet the highest-scoring excluded node is at 0.49 median, but reaches 0.65 at p90 and 0.91 in some windows — nodes performing at 65–91% of the best get swapped out purely for ranking slightly lower.
- **It keeps bad nodes.** The stake budget fills before covering the whole low tail, so a higher-stake weak node is spared while lower-stake nodes scoring the same are cut. On mainnet a ~5%-stake validator scoring ~0.37 stays in the schedule because adding it would exceed the 20% budget.

## What this PR does

Behind the flag, classify each validator by its distributed-vote score normalized to the highest score in the window (the top performer), so the thresholds are relative to the best validator and mean the same thing regardless of scoring path or window length:

- **bad** = below the low threshold (default 50%) — excluded, but never more than the maximum bad-node count (a percent of the validator count, default 33%); if more validators score low, only the worst up to that cap are excluded.
- **good** (swap-in pool) = at or above the high threshold (default 90%), extended down to the next-best scorers until the pool holds the minimum number of validators (a percent of the validator count, default 20%) — even past the low threshold if needed, so swap-in duty isn't concentrated on very few validators. The pool is never empty, though for small committees this minimum can still be a single validator.
- the middle band stays as normal leaders.

The two size bounds count validators rather than stake, because they are per-node properties: the good-pool floor spreads the uniformly-random swapped leadership across several distinct nodes, and the bad-set cap limits how aggressively low scores prune the schedule. The score thresholds and both count bounds are plain constants, not protocol-config fields: no protocol version has ever set them to anything but their defaults, so there's nothing that needs to move in lockstep across a rolling upgrade. Only the enable flag is a protocol parameter, since flipping it does need to activate at the same protocol version for every validator. The bound invariants between the constants (e.g. good threshold > bad threshold) are checked at compile time. Comparisons are integer-only.

The existing rank-based stake cut is unchanged: it remains the flag-off path. Raw scores, their persistence in commits, and the `reputation_scores` metric are untouched.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
