### PR TITLE
feat(node): add node internal transaction builder client implementation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@
 /crates/iota-network-stack/ @iotaledger/node
 /crates/iota-node/ @iotaledger/node
 /crates/iota-node-storage/ @iotaledger/node
+/crates/iota-node-transaction-builder/ @iotaledger/node
 /crates/iota-open-rpc/ @iotaledger/infrastructure
 /crates/iota-open-rpc-macros/ @iotaledger/dev-tools
 /crates/iota-package-alt/ @iotaledger/vm-language

--- a/.github/crates-filters.yml
+++ b/.github/crates-filters.yml
@@ -106,6 +106,8 @@ iota-node:
   - "crates/iota-node/**"
 iota-node-storage:
   - "crates/iota-node-storage/**"
+iota-node-transaction-builder:
+  - "crates/iota-node-transaction-builder/**"
 iota-open-rpc:
   - "crates/iota-open-rpc/**"
 iota-open-rpc-macros:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6395,6 +6395,7 @@ dependencies = [
  "iota-config",
  "iota-metrics",
  "iota-node-storage",
+ "iota-node-transaction-builder",
  "iota-protocol-config",
  "iota-sdk-grpc-client",
  "iota-sdk-grpc-types",
@@ -7228,7 +7229,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node-transaction-builder"
-version = "1.29.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "bcs",
  "iota-node-storage",
@@ -7237,7 +7238,6 @@ dependencies = [
  "iota-sdk-types",
  "iota-types",
  "thiserror 1.0.64",
- "tokio",
  "tracing",
  "typed-store-error",
 ]
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7686,7 +7686,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6033,6 +6033,7 @@ dependencies = [
  "iota-sdk-crypto",
  "iota-sdk-grpc-client",
  "iota-sdk-grpc-types",
+ "iota-sdk-transaction-builder",
  "iota-sdk-types",
  "iota-simulator",
  "iota-snapshot",
@@ -7192,6 +7193,7 @@ dependencies = [
  "iota-names",
  "iota-network",
  "iota-network-stack",
+ "iota-node-transaction-builder",
  "iota-protocol-config",
  "iota-sdk-types",
  "iota-simulator",
@@ -7222,6 +7224,22 @@ dependencies = [
  "iota-sdk-types",
  "iota-types",
  "move-core-types",
+]
+
+[[package]]
+name = "iota-node-transaction-builder"
+version = "1.29.0-alpha"
+dependencies = [
+ "bcs",
+ "iota-node-storage",
+ "iota-protocol-config",
+ "iota-sdk-transaction-builder",
+ "iota-sdk-types",
+ "iota-types",
+ "thiserror 1.0.64",
+ "tokio",
+ "tracing",
+ "typed-store-error",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7686,7 +7686,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7686,7 +7686,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,9 +402,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "74fa61a4d97d77d364fd188102356c7661c10d79" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "74fa61a4d97d77d364fd188102356c7661c10d79" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -445,10 +445,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,9 +402,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "ee498b11862f0722f28289b6b44882649ce85ee6" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "ee498b11862f0722f28289b6b44882649ce85ee6" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -445,10 +445,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "ee498b11862f0722f28289b6b44882649ce85ee6", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "ee498b11862f0722f28289b6b44882649ce85ee6", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "ee498b11862f0722f28289b6b44882649ce85ee6", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "ee498b11862f0722f28289b6b44882649ce85ee6", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,9 +402,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "74fa61a4d97d77d364fd188102356c7661c10d79" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "74fa61a4d97d77d364fd188102356c7661c10d79" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -445,10 +445,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ members = [
   "crates/iota-network-stack",
   "crates/iota-node",
   "crates/iota-node-storage",
+  "crates/iota-node-transaction-builder",
   "crates/iota-open-rpc",
   "crates/iota-open-rpc-macros",
   "crates/iota-package-alt",
@@ -431,6 +432,7 @@ iota-network = { path = "crates/iota-network" }
 iota-network-stack = { path = "crates/iota-network-stack" }
 iota-node = { path = "crates/iota-node" }
 iota-node-storage = { path = "crates/iota-node-storage" }
+iota-node-transaction-builder = { path = "crates/iota-node-transaction-builder" }
 iota-open-rpc = { path = "crates/iota-open-rpc" }
 iota-open-rpc-macros = { path = "crates/iota-open-rpc-macros" }
 iota-package-dump = { path = "crates/iota-package-dump" }

--- a/crates/iota-e2e-tests/Cargo.toml
+++ b/crates/iota-e2e-tests/Cargo.toml
@@ -58,6 +58,7 @@ iota-node.workspace = true
 iota-protocol-config.workspace = true
 iota-sdk.workspace = true
 iota-sdk-crypto = { workspace = true, features = ["secp256r1"] }
+iota-sdk-transaction-builder.workspace = true
 iota-sdk-types.workspace = true
 iota-simulator.workspace = true
 iota-snapshot.workspace = true

--- a/crates/iota-e2e-tests/tests/node_transaction_builder_tests.rs
+++ b/crates/iota-e2e-tests/tests/node_transaction_builder_tests.rs
@@ -1,15 +1,13 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Tests for the node-internal [`TransactionBuilderResolveClient`]
+//! Tests for the node-internal [`TransactionBuilderLedgerClient`]
 //! implementation: the SDK `TransactionBuilder` resolves objects, gas, and
 //! protocol parameters directly from a fullnode's local state, without going
 //! through a public API.
 
 use iota_macros::sim_test;
-use iota_sdk_transaction_builder::{
-    TransactionBuilder, TransactionBuilderResolveClient, error::Error,
-};
+use iota_sdk_transaction_builder::{TransactionBuilder, TransactionBuilderLedgerClient};
 use iota_sdk_types::{StructTag, Transaction};
 use test_cluster::TestClusterBuilder;
 
@@ -25,7 +23,7 @@ async fn transaction_builder_via_node_internal_client() {
     let client = test_cluster
         .fullnode_handle
         .iota_node
-        .with(|node| node.transaction_builder_resolve_client());
+        .with(|node| node.transaction_builder_ledger_client());
 
     // Reads against local state.
     let reference_gas_price = client
@@ -73,21 +71,12 @@ async fn transaction_builder_via_node_internal_client() {
         .expect("listed object exists");
     assert_eq!(coin.id(), first_page.data[0].id());
 
-    // The client is read-only and cannot estimate the gas budget, so building
-    // without an explicit budget must fail.
-    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+    // The client is ledger-only, so `finish()` (which estimates the budget)
+    // does not exist for it; the budget is passed explicitly instead, and the
+    // builder resolves gas coins and the gas price through the client.
+    let mut builder = TransactionBuilder::new(sender).with_client(client);
     builder.send_iota(recipient, 1_000_000u64);
-    assert!(matches!(
-        builder.finish().await,
-        Err(Error::MissingGasBudget)
-    ));
-
-    // With an explicit budget, the builder resolves gas coins and the gas
-    // price through the client and produces a valid transaction.
-    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
-    builder.send_iota(recipient, 1_000_000u64);
-    builder.gas_budget(50_000_000);
-    let transaction = builder.finish().await.unwrap();
+    let transaction = builder.finish_with_budget(50_000_000).await.unwrap();
     let Transaction::V1(transaction_v1) = &transaction else {
         panic!("the builder produces V1 transactions");
     };

--- a/crates/iota-e2e-tests/tests/node_transaction_builder_tests.rs
+++ b/crates/iota-e2e-tests/tests/node_transaction_builder_tests.rs
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the node-internal [`TransactionBuilderClient`] implementation:
+//! the SDK `TransactionBuilder` resolves objects, gas, and protocol
+//! parameters directly from a fullnode's local state and executes through
+//! its transaction orchestrator, without going through a public API.
+
+use iota_macros::sim_test;
+use iota_sdk_transaction_builder::{TransactionBuilder, TransactionBuilderClient, WaitForTx};
+use iota_sdk_types::{ExecutionStatus, StructTag, Transaction};
+use iota_types::effects::TransactionEffectsAPI;
+use test_cluster::TestClusterBuilder;
+
+#[sim_test]
+async fn transaction_builder_via_node_internal_client() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .build()
+        .await;
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+
+    let client = test_cluster
+        .fullnode_handle
+        .iota_node
+        .with(|node| node.transaction_builder_client())
+        .expect("fullnodes run a transaction orchestrator");
+
+    // Reads against local state.
+    let reference_gas_price = client
+        .reference_gas_price(None)
+        .await
+        .unwrap()
+        .expect("current epoch always has a reference gas price");
+    assert!(reference_gas_price > 0);
+
+    let protocol_config = client.protocol_config().await.unwrap();
+    assert!(protocol_config.attributes.contains_key("max_tx_gas"));
+    assert!(
+        protocol_config
+            .attributes
+            .contains_key("max_gas_payment_objects")
+    );
+
+    // Owned-object listing with cursor pagination through the gRPC indexes.
+    let first_page = client
+        .objects(Some(StructTag::new_gas_coin()), sender, None, Some(1))
+        .await
+        .unwrap();
+    assert_eq!(first_page.data.len(), 1);
+    let cursor = first_page
+        .next_cursor
+        .clone()
+        .expect("test accounts start with multiple gas coins");
+    let second_page = client
+        .objects(
+            Some(StructTag::new_gas_coin()),
+            sender,
+            Some(cursor),
+            Some(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second_page.data.len(), 1);
+    assert_ne!(first_page.data[0].id(), second_page.data[0].id());
+
+    // Object lookup by id.
+    let coin = client
+        .object(first_page.data[0].id(), None)
+        .await
+        .unwrap()
+        .expect("listed object exists");
+    assert_eq!(coin.id(), first_page.data[0].id());
+
+    // Dry run through the builder; gas selection, gas price, and budget
+    // estimation all resolve through the node-internal client.
+    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+    builder.send_iota(recipient, 1_000_000u64);
+    let dry_run = builder.dry_run(true).await.unwrap();
+    assert!(matches!(dry_run.effects.status(), ExecutionStatus::Success));
+
+    // Build, sign, execute, and wait for finalization.
+    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+    builder.send_iota(recipient, 1_000_000u64);
+    let transaction = builder.finish().await.unwrap();
+    let Transaction::V1(transaction_v1) = &transaction else {
+        panic!("the builder produces V1 transactions");
+    };
+    assert!(transaction_v1.gas_payment.budget > 0);
+    assert!(!transaction_v1.gas_payment.objects.is_empty());
+
+    let signed = test_cluster.wallet.sign_transaction(&transaction);
+    let signatures = signed.signatures().to_vec();
+    let effects = client
+        .execute_tx(&signatures, &transaction, WaitForTx::Finalized)
+        .await
+        .unwrap();
+    assert!(matches!(effects.status(), ExecutionStatus::Success));
+
+    // The executed transaction and its effects are readable back from the
+    // node's stores.
+    let digest = transaction.digest();
+    client
+        .wait_for_tx(digest, WaitForTx::IndexedOnNode)
+        .await
+        .unwrap();
+    let stored_transaction = client
+        .transaction(digest)
+        .await
+        .unwrap()
+        .expect("executed transaction is stored");
+    assert_eq!(stored_transaction.transaction.digest(), digest);
+    let stored_effects = client
+        .transaction_effects(digest)
+        .await
+        .unwrap()
+        .expect("executed transaction effects are stored");
+    assert_eq!(
+        stored_effects.transaction_digest(),
+        effects.transaction_digest()
+    );
+}

--- a/crates/iota-e2e-tests/tests/node_transaction_builder_tests.rs
+++ b/crates/iota-e2e-tests/tests/node_transaction_builder_tests.rs
@@ -1,15 +1,16 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Tests for the node-internal [`TransactionBuilderClient`] implementation:
-//! the SDK `TransactionBuilder` resolves objects, gas, and protocol
-//! parameters directly from a fullnode's local state and executes through
-//! its transaction orchestrator, without going through a public API.
+//! Tests for the node-internal [`TransactionBuilderResolveClient`]
+//! implementation: the SDK `TransactionBuilder` resolves objects, gas, and
+//! protocol parameters directly from a fullnode's local state, without going
+//! through a public API.
 
 use iota_macros::sim_test;
-use iota_sdk_transaction_builder::{TransactionBuilder, TransactionBuilderClient, WaitForTx};
-use iota_sdk_types::{ExecutionStatus, StructTag, Transaction};
-use iota_types::effects::TransactionEffectsAPI;
+use iota_sdk_transaction_builder::{
+    TransactionBuilder, TransactionBuilderResolveClient, error::Error,
+};
+use iota_sdk_types::{StructTag, Transaction};
 use test_cluster::TestClusterBuilder;
 
 #[sim_test]
@@ -24,8 +25,7 @@ async fn transaction_builder_via_node_internal_client() {
     let client = test_cluster
         .fullnode_handle
         .iota_node
-        .with(|node| node.transaction_builder_client())
-        .expect("fullnodes run a transaction orchestrator");
+        .with(|node| node.transaction_builder_resolve_client());
 
     // Reads against local state.
     let reference_gas_price = client
@@ -73,51 +73,33 @@ async fn transaction_builder_via_node_internal_client() {
         .expect("listed object exists");
     assert_eq!(coin.id(), first_page.data[0].id());
 
-    // Dry run through the builder; gas selection, gas price, and budget
-    // estimation all resolve through the node-internal client.
+    // The client is read-only and cannot estimate the gas budget, so building
+    // without an explicit budget must fail.
     let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
     builder.send_iota(recipient, 1_000_000u64);
-    let dry_run = builder.dry_run(true).await.unwrap();
-    assert!(matches!(dry_run.effects.status(), ExecutionStatus::Success));
+    assert!(matches!(
+        builder.finish().await,
+        Err(Error::MissingGasBudget)
+    ));
 
-    // Build, sign, execute, and wait for finalization.
+    // With an explicit budget, the builder resolves gas coins and the gas
+    // price through the client and produces a valid transaction.
     let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
     builder.send_iota(recipient, 1_000_000u64);
+    builder.gas_budget(50_000_000);
     let transaction = builder.finish().await.unwrap();
     let Transaction::V1(transaction_v1) = &transaction else {
         panic!("the builder produces V1 transactions");
     };
-    assert!(transaction_v1.gas_payment.budget > 0);
+    assert_eq!(transaction_v1.gas_payment.budget, 50_000_000);
+    assert_eq!(transaction_v1.gas_payment.price, reference_gas_price);
     assert!(!transaction_v1.gas_payment.objects.is_empty());
 
+    // The built transaction is valid: signing and executing it through the
+    // wallet succeeds.
     let signed = test_cluster.wallet.sign_transaction(&transaction);
-    let signatures = signed.signatures().to_vec();
-    let effects = client
-        .execute_tx(&signatures, &transaction, WaitForTx::Finalized)
-        .await
-        .unwrap();
-    assert!(matches!(effects.status(), ExecutionStatus::Success));
-
-    // The executed transaction and its effects are readable back from the
-    // node's stores.
-    let digest = transaction.digest();
-    client
-        .wait_for_tx(digest, WaitForTx::IndexedOnNode)
-        .await
-        .unwrap();
-    let stored_transaction = client
-        .transaction(digest)
-        .await
-        .unwrap()
-        .expect("executed transaction is stored");
-    assert_eq!(stored_transaction.transaction.digest(), digest);
-    let stored_effects = client
-        .transaction_effects(digest)
-        .await
-        .unwrap()
-        .expect("executed transaction effects are stored");
-    assert_eq!(
-        stored_effects.transaction_digest(),
-        effects.transaction_digest()
-    );
+    test_cluster
+        .wallet
+        .execute_transaction_must_succeed(signed)
+        .await;
 }

--- a/crates/iota-grpc-server/Cargo.toml
+++ b/crates/iota-grpc-server/Cargo.toml
@@ -34,6 +34,7 @@ iota-config.workspace = true
 iota-grpc-types.workspace = true
 iota-metrics.workspace = true
 iota-node-storage.workspace = true
+iota-node-transaction-builder.workspace = true
 iota-protocol-config.workspace = true
 iota-sdk-types.workspace = true
 iota-traffic-controller.workspace = true

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -23,6 +23,7 @@ use iota_grpc_types::{
         },
     },
 };
+use iota_node_transaction_builder::NodeTransactionBuilderResolveClient;
 use iota_sdk_types::TransactionDigest;
 use iota_types::{
     effects::TransactionEffectsAPI,
@@ -39,6 +40,7 @@ pub struct TransactionExecutionGrpcService {
     pub config: iota_config::node::GrpcApiConfig,
     pub reader: Arc<GrpcReader>,
     pub executor: Arc<dyn TransactionExecutor>,
+    pub builder_client: NodeTransactionBuilderResolveClient,
 }
 
 impl TransactionExecutionGrpcService {
@@ -47,10 +49,12 @@ impl TransactionExecutionGrpcService {
         reader: Arc<GrpcReader>,
         executor: Arc<dyn TransactionExecutor>,
     ) -> Self {
+        let builder_client = NodeTransactionBuilderResolveClient::new(reader.state_reader());
         Self {
             config,
             reader,
             executor,
+            builder_client,
         }
     }
 }

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -23,7 +23,7 @@ use iota_grpc_types::{
         },
     },
 };
-use iota_node_transaction_builder::NodeTransactionBuilderResolveClient;
+use iota_node_transaction_builder::NodeTransactionBuilderLedgerClient;
 use iota_sdk_types::TransactionDigest;
 use iota_types::{
     effects::TransactionEffectsAPI,
@@ -40,7 +40,7 @@ pub struct TransactionExecutionGrpcService {
     pub config: iota_config::node::GrpcApiConfig,
     pub reader: Arc<GrpcReader>,
     pub executor: Arc<dyn TransactionExecutor>,
-    pub builder_client: NodeTransactionBuilderResolveClient,
+    pub builder_client: NodeTransactionBuilderLedgerClient,
 }
 
 impl TransactionExecutionGrpcService {
@@ -49,7 +49,7 @@ impl TransactionExecutionGrpcService {
         reader: Arc<GrpcReader>,
         executor: Arc<dyn TransactionExecutor>,
     ) -> Self {
-        let builder_client = NodeTransactionBuilderResolveClient::new(reader.state_reader());
+        let builder_client = NodeTransactionBuilderLedgerClient::new(reader.state_reader());
         Self {
             config,
             reader,

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -316,6 +316,10 @@ impl GrpcReader {
         self.server_version.clone()
     }
 
+    pub fn state_reader(&self) -> Arc<dyn iota_node_storage::GrpcStateReader> {
+        self.state_reader.clone()
+    }
+
     pub fn get_chain_identifier(&self) -> anyhow::Result<iota_types::digests::ChainIdentifier> {
         self.state_reader.get_chain_identifier().map_err(Into::into)
     }

--- a/crates/iota-node-transaction-builder/Cargo.toml
+++ b/crates/iota-node-transaction-builder/Cargo.toml
@@ -1,5 +1,3 @@
-# Copyright (c) 2026 IOTA Stiftung
-# SPDX-License-Identifier: Apache-2.0
 [package]
 name = "iota-node-transaction-builder"
 version.workspace = true

--- a/crates/iota-node-transaction-builder/Cargo.toml
+++ b/crates/iota-node-transaction-builder/Cargo.toml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name = "iota-node-transaction-builder"
+version.workspace = true
+authors = ["IOTA Foundation <info@iota.org>"]
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+# external dependencies
+bcs.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
+
+# internal dependencies
+iota-node-storage.workspace = true
+iota-protocol-config.workspace = true
+iota-sdk-transaction-builder.workspace = true
+iota-sdk-types.workspace = true
+iota-types.workspace = true
+typed-store-error.workspace = true

--- a/crates/iota-node-transaction-builder/Cargo.toml
+++ b/crates/iota-node-transaction-builder/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 # external dependencies
 bcs.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 
 # internal dependencies

--- a/crates/iota-node-transaction-builder/src/lib.rs
+++ b/crates/iota-node-transaction-builder/src/lib.rs
@@ -1,56 +1,46 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Node-internal implementation of the SDK's [`TransactionBuilderClient`].
+//! Node-internal implementation of the SDK's
+//! [`TransactionBuilderResolveClient`].
 //!
-//! [`NodeTransactionBuilderClient`] backs the SDK
+//! [`NodeTransactionBuilderResolveClient`] backs the SDK
 //! [`TransactionBuilder`](iota_sdk_transaction_builder::TransactionBuilder)
-//! with a node's local state instead of a remote gRPC or GraphQL endpoint:
-//! reads go through [`GrpcStateReader`] (the same interface the gRPC server
-//! uses) and execution / dry runs go through
-//! [`TransactionExecutor`] (implemented by the transaction orchestrator on a
-//! fullnode, and by simulacrum in tests).
+//! with a node's local state instead of a remote gRPC or GraphQL endpoint.
+//! All reads go through [`GrpcStateReader`] — the same interface the gRPC
+//! server uses — so the client is available wherever that store is
+//! (fullnodes via `GrpcReadStore`, simulacrum in tests).
+//!
+//! The client is read-only: it resolves objects, gas, and protocol
+//! parameters for [`TransactionBuilder::finish`], but does not simulate or
+//! execute. [`estimate_tx_budget`] uses the trait default and returns
+//! `None`, so the gas budget must be set explicitly on the builder.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use iota_node_storage::GrpcStateReader;
 use iota_protocol_config::{
     ProtocolConfig as NodeProtocolConfig, ProtocolConfigValue, ProtocolVersion,
 };
-use iota_sdk_transaction_builder::{
-    ObjectsPage, ProtocolConfig, TransactionBuilderClient, WaitForTx,
-};
-use iota_sdk_types::{
-    Address, Object, ObjectId, SignedTransaction, StructTag, Transaction, TransactionDigest,
-    TransactionEffects, UserSignature, Version,
-};
+use iota_sdk_transaction_builder::{ObjectsPage, ProtocolConfig, TransactionBuilderResolveClient};
+use iota_sdk_types::{Address, Object, ObjectId, StructTag, Version};
 use iota_types::{
-    effects::TransactionEffectsAPI,
     error::IotaError,
     iota_sdk_types_conversions::SdkTypeConversionError,
     iota_system_state::{IotaSystemStateTrait, get_iota_system_state},
-    quorum_driver_types::{ExecuteTransactionRequestV1, QuorumDriverError},
     storage::OwnedObjectCursor,
-    transaction::TransactionDataAPI,
-    transaction_executor::{SimulateTransactionResult, TransactionExecutor, VmChecks},
 };
 use typed_store_error::TypedStoreError;
 
 /// Default number of objects returned by
-/// [`TransactionBuilderClient::objects`] when no limit is given.
+/// [`TransactionBuilderResolveClient::objects`] when no limit is given.
 const DEFAULT_OBJECTS_PAGE_SIZE: usize = 50;
 
 /// Upper bound on the number of objects returned by
-/// [`TransactionBuilderClient::objects`].
+/// [`TransactionBuilderResolveClient::objects`].
 const MAX_OBJECTS_PAGE_SIZE: usize = 1000;
 
-/// How long [`TransactionBuilderClient::wait_for_tx`] waits before giving up.
-const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Interval between polls in [`TransactionBuilderClient::wait_for_tx`].
-const WAIT_FOR_TX_POLL_INTERVAL: Duration = Duration::from_millis(100);
-
-/// Error type for [`NodeTransactionBuilderClient`].
+/// Error type for [`NodeTransactionBuilderResolveClient`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
@@ -60,8 +50,6 @@ pub enum Error {
     #[error(transparent)]
     Conversion(#[from] SdkTypeConversionError),
     #[error(transparent)]
-    Execution(#[from] QuorumDriverError),
-    #[error(transparent)]
     Node(#[from] IotaError),
     #[error("invalid objects page cursor: {0}")]
     Cursor(bcs::Error),
@@ -69,20 +57,22 @@ pub enum Error {
     IndexesDisabled,
     #[error("protocol version {0} is not supported by this node")]
     UnsupportedProtocolVersion(u64),
-    #[error("timed out waiting for transaction {0}")]
-    WaitForTransactionTimeout(TransactionDigest),
 }
 
-/// A [`TransactionBuilderClient`] backed directly by a node's local state.
+/// A [`TransactionBuilderResolveClient`] backed directly by a node's local
+/// state.
+///
+/// [`objects`](TransactionBuilderResolveClient::objects) requires the gRPC
+/// indexes (the owned-object index) to be enabled and returns
+/// [`Error::IndexesDisabled`] otherwise.
 #[derive(Clone)]
-pub struct NodeTransactionBuilderClient {
+pub struct NodeTransactionBuilderResolveClient {
     reader: Arc<dyn GrpcStateReader>,
-    executor: Arc<dyn TransactionExecutor>,
 }
 
-impl NodeTransactionBuilderClient {
-    pub fn new(reader: Arc<dyn GrpcStateReader>, executor: Arc<dyn TransactionExecutor>) -> Self {
-        Self { reader, executor }
+impl NodeTransactionBuilderResolveClient {
+    pub fn new(reader: Arc<dyn GrpcStateReader>) -> Self {
+        Self { reader }
     }
 
     /// Protocol config of the current epoch.
@@ -96,18 +86,6 @@ impl NodeTransactionBuilderClient {
         )
         .ok_or(Error::UnsupportedProtocolVersion(protocol_version))
     }
-
-    /// Prepare a transaction for simulation: with a zero gas budget the dry
-    /// run would fail upfront, so run it with the maximum budget instead —
-    /// the effects then carry the actual cost. Mirrors the gRPC server's
-    /// handling of zero-budget simulations.
-    fn transaction_for_simulation(&self, tx: &Transaction) -> Result<Transaction, Error> {
-        let mut transaction = tx.clone();
-        if transaction.gas_data().budget == 0 {
-            transaction.gas_data_mut().budget = self.node_protocol_config()?.max_tx_gas();
-        }
-        Ok(transaction)
-    }
 }
 
 fn protocol_config_value_to_string(value: ProtocolConfigValue) -> String {
@@ -119,9 +97,8 @@ fn protocol_config_value_to_string(value: ProtocolConfigValue) -> String {
     }
 }
 
-impl TransactionBuilderClient for NodeTransactionBuilderClient {
+impl TransactionBuilderResolveClient for NodeTransactionBuilderResolveClient {
     type Error = Error;
-    type DryRunResult = SimulateTransactionResult;
 
     async fn object(
         &self,
@@ -151,7 +128,6 @@ impl TransactionBuilderClient for NodeTransactionBuilderClient {
             .map_err(Error::Cursor)?;
 
         let indexes = self.reader.grpc_indexes().ok_or(Error::IndexesDisabled)?;
-
         // The index iterator's cursor bound is inclusive, so skip the cursor
         // item itself to advance past the previous page.
         let skip = usize::from(cursor.is_some());
@@ -208,24 +184,6 @@ impl TransactionBuilderClient for NodeTransactionBuilderClient {
         Ok(ProtocolConfig { attributes })
     }
 
-    async fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<SignedTransaction>, Self::Error> {
-        let Some(transaction) = self.reader.try_get_transaction(&digest)? else {
-            return Ok(None);
-        };
-        let transaction = Arc::try_unwrap(transaction).unwrap_or_else(|arc| (*arc).clone());
-        Ok(Some(transaction.into_inner().into()))
-    }
-
-    async fn transaction_effects(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<TransactionEffects>, Self::Error> {
-        Ok(self.reader.try_get_transaction_effects(&digest)?)
-    }
-
     async fn reference_gas_price(
         &self,
         epoch: impl Into<Option<u64>>,
@@ -239,95 +197,6 @@ impl TransactionBuilderClient for NodeTransactionBuilderClient {
                 .reader
                 .get_epoch_info(epoch)?
                 .map(|info| info.reference_gas_price())),
-        }
-    }
-
-    async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
-        let transaction = self.transaction_for_simulation(tx)?;
-        let result = self
-            .executor
-            .simulate_transaction(transaction, VmChecks::Disabled)?;
-        Ok(Some(result.effects.gas_cost_summary().gas_used()))
-    }
-
-    async fn dry_run_tx(
-        &self,
-        tx: &Transaction,
-        skip_checks: bool,
-    ) -> Result<Self::DryRunResult, Self::Error> {
-        let checks = if skip_checks {
-            VmChecks::Disabled
-        } else {
-            VmChecks::Enabled
-        };
-        // Only apply the zero-budget replacement with checks disabled: with
-        // checks enabled the caller asked for full validation, and a zero
-        // budget should fail it.
-        let transaction = if checks.disabled() {
-            self.transaction_for_simulation(tx)?
-        } else {
-            tx.clone()
-        };
-        Ok(self.executor.simulate_transaction(transaction, checks)?)
-    }
-
-    async fn execute_tx(
-        &self,
-        signatures: &[UserSignature],
-        tx: &Transaction,
-        wait_for: impl Into<Option<WaitForTx>>,
-    ) -> Result<TransactionEffects, Self::Error> {
-        let signed_transaction = SignedTransaction {
-            transaction: tx.clone(),
-            signatures: signatures.to_vec(),
-        };
-        let request = ExecuteTransactionRequestV1::new(iota_types::transaction::Transaction::from(
-            signed_transaction,
-        ));
-        let response = self
-            .executor
-            .execute_transaction(request, false, None)
-            .await?;
-
-        if let Some(wait_for) = wait_for.into() {
-            self.wait_for_tx(tx.digest(), wait_for).await?;
-        }
-
-        Ok(response.effects.effects)
-    }
-
-    async fn wait_for_tx(
-        &self,
-        digest: TransactionDigest,
-        wait_for: WaitForTx,
-    ) -> Result<(), Self::Error> {
-        match wait_for {
-            WaitForTx::IndexedOnNode => {
-                let poll = async {
-                    let mut interval = tokio::time::interval(WAIT_FOR_TX_POLL_INTERVAL);
-                    loop {
-                        interval.tick().await;
-                        if self.reader.try_get_transaction_effects(&digest)?.is_some() {
-                            return Ok(());
-                        }
-                    }
-                };
-                tokio::time::timeout(WAIT_FOR_TX_TIMEOUT, poll)
-                    .await
-                    .map_err(|_| Error::WaitForTransactionTimeout(digest))?
-            }
-            WaitForTx::Finalized => {
-                let included = self
-                    .executor
-                    .wait_for_checkpoint_inclusion(&[digest], WAIT_FOR_TX_TIMEOUT)
-                    .await?;
-                if included.contains_key(&digest) {
-                    Ok(())
-                } else {
-                    Err(Error::WaitForTransactionTimeout(digest))
-                }
-            }
-            _ => unimplemented!("a new WaitForTx enum variant was added and needs to be handled"),
         }
     }
 }

--- a/crates/iota-node-transaction-builder/src/lib.rs
+++ b/crates/iota-node-transaction-builder/src/lib.rs
@@ -14,7 +14,7 @@
 //! The client is ledger-only: it resolves objects, gas, and protocol
 //! parameters, but does not simulate or execute, so transactions are built
 //! with an explicit gas budget via
-//! [`TransactionBuilder::finish_with_budget`].
+//! [`TransactionBuilder::finish_with_budget`](iota_sdk_transaction_builder::TransactionBuilder::finish_with_budget).
 
 use std::sync::Arc;
 

--- a/crates/iota-node-transaction-builder/src/lib.rs
+++ b/crates/iota-node-transaction-builder/src/lib.rs
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Node-internal implementation of the SDK's
-//! [`TransactionBuilderResolveClient`].
+//! [`TransactionBuilderLedgerClient`].
 //!
-//! [`NodeTransactionBuilderResolveClient`] backs the SDK
+//! [`NodeTransactionBuilderLedgerClient`] backs the SDK
 //! [`TransactionBuilder`](iota_sdk_transaction_builder::TransactionBuilder)
 //! with a node's local state instead of a remote gRPC or GraphQL endpoint.
 //! All reads go through [`GrpcStateReader`] — the same interface the gRPC
 //! server uses — so the client is available wherever that store is
 //! (fullnodes via `GrpcReadStore`, simulacrum in tests).
 //!
-//! The client is read-only: it resolves objects, gas, and protocol
-//! parameters for [`TransactionBuilder::finish`], but does not simulate or
-//! execute. [`estimate_tx_budget`] uses the trait default and returns
-//! `None`, so the gas budget must be set explicitly on the builder.
+//! The client is ledger-only: it resolves objects, gas, and protocol
+//! parameters, but does not simulate or execute, so transactions are built
+//! with an explicit gas budget via
+//! [`TransactionBuilder::finish_with_budget`].
 
 use std::sync::Arc;
 
@@ -22,7 +22,9 @@ use iota_node_storage::GrpcStateReader;
 use iota_protocol_config::{
     ProtocolConfig as NodeProtocolConfig, ProtocolConfigValue, ProtocolVersion,
 };
-use iota_sdk_transaction_builder::{ObjectsPage, ProtocolConfig, TransactionBuilderResolveClient};
+use iota_sdk_transaction_builder::{
+    ObjectsPage, ProtocolConfig, TransactionBuilderClientBase, TransactionBuilderLedgerClient,
+};
 use iota_sdk_types::{Address, Object, ObjectId, StructTag, Version};
 use iota_types::{
     error::IotaError,
@@ -33,14 +35,14 @@ use iota_types::{
 use typed_store_error::TypedStoreError;
 
 /// Default number of objects returned by
-/// [`TransactionBuilderResolveClient::objects`] when no limit is given.
+/// [`TransactionBuilderLedgerClient::objects`] when no limit is given.
 const DEFAULT_OBJECTS_PAGE_SIZE: usize = 50;
 
 /// Upper bound on the number of objects returned by
-/// [`TransactionBuilderResolveClient::objects`].
+/// [`TransactionBuilderLedgerClient::objects`].
 const MAX_OBJECTS_PAGE_SIZE: usize = 1000;
 
-/// Error type for [`NodeTransactionBuilderResolveClient`].
+/// Error type for [`NodeTransactionBuilderLedgerClient`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
@@ -59,18 +61,18 @@ pub enum Error {
     UnsupportedProtocolVersion(u64),
 }
 
-/// A [`TransactionBuilderResolveClient`] backed directly by a node's local
+/// A [`TransactionBuilderLedgerClient`] backed directly by a node's local
 /// state.
 ///
-/// [`objects`](TransactionBuilderResolveClient::objects) requires the gRPC
+/// [`objects`](TransactionBuilderLedgerClient::objects) requires the gRPC
 /// indexes (the owned-object index) to be enabled and returns
 /// [`Error::IndexesDisabled`] otherwise.
 #[derive(Clone)]
-pub struct NodeTransactionBuilderResolveClient {
+pub struct NodeTransactionBuilderLedgerClient {
     reader: Arc<dyn GrpcStateReader>,
 }
 
-impl NodeTransactionBuilderResolveClient {
+impl NodeTransactionBuilderLedgerClient {
     pub fn new(reader: Arc<dyn GrpcStateReader>) -> Self {
         Self { reader }
     }
@@ -97,9 +99,11 @@ fn protocol_config_value_to_string(value: ProtocolConfigValue) -> String {
     }
 }
 
-impl TransactionBuilderResolveClient for NodeTransactionBuilderResolveClient {
+impl TransactionBuilderClientBase for NodeTransactionBuilderLedgerClient {
     type Error = Error;
+}
 
+impl TransactionBuilderLedgerClient for NodeTransactionBuilderLedgerClient {
     async fn object(
         &self,
         object_id: ObjectId,

--- a/crates/iota-node-transaction-builder/src/lib.rs
+++ b/crates/iota-node-transaction-builder/src/lib.rs
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Node-internal implementation of the SDK's [`TransactionBuilderClient`].
+//!
+//! [`NodeTransactionBuilderClient`] backs the SDK
+//! [`TransactionBuilder`](iota_sdk_transaction_builder::TransactionBuilder)
+//! with a node's local state instead of a remote gRPC or GraphQL endpoint:
+//! reads go through [`GrpcStateReader`] (the same interface the gRPC server
+//! uses) and execution / dry runs go through
+//! [`TransactionExecutor`] (implemented by the transaction orchestrator on a
+//! fullnode, and by simulacrum in tests).
+
+use std::{sync::Arc, time::Duration};
+
+use iota_node_storage::GrpcStateReader;
+use iota_protocol_config::{
+    ProtocolConfig as NodeProtocolConfig, ProtocolConfigValue, ProtocolVersion,
+};
+use iota_sdk_transaction_builder::{
+    ObjectsPage, ProtocolConfig, TransactionBuilderClient, WaitForTx,
+};
+use iota_sdk_types::{
+    Address, Object, ObjectId, SignedTransaction, StructTag, Transaction, TransactionDigest,
+    TransactionEffects, UserSignature, Version,
+};
+use iota_types::{
+    effects::TransactionEffectsAPI,
+    error::IotaError,
+    iota_sdk_types_conversions::SdkTypeConversionError,
+    iota_system_state::{IotaSystemStateTrait, get_iota_system_state},
+    quorum_driver_types::{ExecuteTransactionRequestV1, QuorumDriverError},
+    storage::OwnedObjectCursor,
+    transaction::TransactionDataAPI,
+    transaction_executor::{SimulateTransactionResult, TransactionExecutor, VmChecks},
+};
+use typed_store_error::TypedStoreError;
+
+/// Default number of objects returned by
+/// [`TransactionBuilderClient::objects`] when no limit is given.
+const DEFAULT_OBJECTS_PAGE_SIZE: usize = 50;
+
+/// Upper bound on the number of objects returned by
+/// [`TransactionBuilderClient::objects`].
+const MAX_OBJECTS_PAGE_SIZE: usize = 1000;
+
+/// How long [`TransactionBuilderClient::wait_for_tx`] waits before giving up.
+const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Interval between polls in [`TransactionBuilderClient::wait_for_tx`].
+const WAIT_FOR_TX_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Error type for [`NodeTransactionBuilderClient`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Storage(#[from] iota_types::storage::error::Error),
+    #[error(transparent)]
+    Store(#[from] TypedStoreError),
+    #[error(transparent)]
+    Conversion(#[from] SdkTypeConversionError),
+    #[error(transparent)]
+    Execution(#[from] QuorumDriverError),
+    #[error(transparent)]
+    Node(#[from] IotaError),
+    #[error("invalid objects page cursor: {0}")]
+    Cursor(bcs::Error),
+    #[error("gRPC indexes are disabled on this node")]
+    IndexesDisabled,
+    #[error("protocol version {0} is not supported by this node")]
+    UnsupportedProtocolVersion(u64),
+    #[error("timed out waiting for transaction {0}")]
+    WaitForTransactionTimeout(TransactionDigest),
+}
+
+/// A [`TransactionBuilderClient`] backed directly by a node's local state.
+#[derive(Clone)]
+pub struct NodeTransactionBuilderClient {
+    reader: Arc<dyn GrpcStateReader>,
+    executor: Arc<dyn TransactionExecutor>,
+}
+
+impl NodeTransactionBuilderClient {
+    pub fn new(reader: Arc<dyn GrpcStateReader>, executor: Arc<dyn TransactionExecutor>) -> Self {
+        Self { reader, executor }
+    }
+
+    /// Protocol config of the current epoch.
+    fn node_protocol_config(&self) -> Result<NodeProtocolConfig, Error> {
+        let system_state = get_iota_system_state(self.reader.as_ref())?;
+        let chain = self.reader.get_chain_identifier()?.chain();
+        let protocol_version = system_state.protocol_version();
+        NodeProtocolConfig::get_for_version_if_supported(
+            ProtocolVersion::new(protocol_version),
+            chain,
+        )
+        .ok_or(Error::UnsupportedProtocolVersion(protocol_version))
+    }
+
+    /// Prepare a transaction for simulation: with a zero gas budget the dry
+    /// run would fail upfront, so run it with the maximum budget instead —
+    /// the effects then carry the actual cost. Mirrors the gRPC server's
+    /// handling of zero-budget simulations.
+    fn transaction_for_simulation(&self, tx: &Transaction) -> Result<Transaction, Error> {
+        let mut transaction = tx.clone();
+        if transaction.gas_data().budget == 0 {
+            transaction.gas_data_mut().budget = self.node_protocol_config()?.max_tx_gas();
+        }
+        Ok(transaction)
+    }
+}
+
+fn protocol_config_value_to_string(value: ProtocolConfigValue) -> String {
+    match value {
+        ProtocolConfigValue::u16(x) => x.to_string(),
+        ProtocolConfigValue::u32(x) => x.to_string(),
+        ProtocolConfigValue::u64(x) => x.to_string(),
+        ProtocolConfigValue::bool(x) => x.to_string(),
+    }
+}
+
+impl TransactionBuilderClient for NodeTransactionBuilderClient {
+    type Error = Error;
+    type DryRunResult = SimulateTransactionResult;
+
+    async fn object(
+        &self,
+        object_id: ObjectId,
+        version: impl Into<Option<Version>>,
+    ) -> Result<Option<Object>, Self::Error> {
+        let object = match version.into() {
+            Some(version) => self.reader.try_get_object_by_key(&object_id, version)?,
+            None => self.reader.try_get_object(&object_id)?,
+        };
+        object.map(Object::try_from).transpose().map_err(Into::into)
+    }
+
+    async fn objects(
+        &self,
+        struct_tag: Option<StructTag>,
+        owner: Address,
+        cursor: Option<Vec<u8>>,
+        limit: Option<usize>,
+    ) -> Result<ObjectsPage, Self::Error> {
+        let limit = limit
+            .unwrap_or(DEFAULT_OBJECTS_PAGE_SIZE)
+            .clamp(1, MAX_OBJECTS_PAGE_SIZE);
+        let cursor: Option<OwnedObjectCursor> = cursor
+            .map(|bytes| bcs::from_bytes(&bytes))
+            .transpose()
+            .map_err(Error::Cursor)?;
+
+        let indexes = self.reader.grpc_indexes().ok_or(Error::IndexesDisabled)?;
+
+        // The index iterator's cursor bound is inclusive, so skip the cursor
+        // item itself to advance past the previous page.
+        let skip = usize::from(cursor.is_some());
+        let mut iter = indexes
+            .account_owned_objects_info_iter(owner, cursor.as_ref(), struct_tag)?
+            .skip(skip);
+
+        let mut data = Vec::with_capacity(limit);
+        let mut last_cursor = None;
+        for item in iter.by_ref() {
+            let (info, item_cursor) = item?;
+            let Some(object) = self
+                .reader
+                .try_get_object_by_key(&info.object_id, info.version)?
+            else {
+                // The object is no longer at the indexed version (e.g. mutated
+                // between the index scan and the fetch).
+                tracing::debug!(
+                    object_id = %info.object_id,
+                    version = %info.version,
+                    "object not found while iterating owned objects, skipping",
+                );
+                continue;
+            };
+            data.push(Object::try_from(object)?);
+            last_cursor = Some(item_cursor);
+            if data.len() >= limit {
+                break;
+            }
+        }
+
+        let has_more = iter.next().transpose()?.is_some();
+        let next_cursor = if has_more {
+            last_cursor
+                .map(|cursor| bcs::to_bytes(&cursor))
+                .transpose()
+                .map_err(Error::Cursor)?
+        } else {
+            None
+        };
+
+        Ok(ObjectsPage { data, next_cursor })
+    }
+
+    async fn protocol_config(&self) -> Result<ProtocolConfig, Self::Error> {
+        let attributes = self
+            .node_protocol_config()?
+            .attr_map()
+            .into_iter()
+            .filter_map(|(name, value)| {
+                value.map(|value| (name, protocol_config_value_to_string(value)))
+            })
+            .collect();
+        Ok(ProtocolConfig { attributes })
+    }
+
+    async fn transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<SignedTransaction>, Self::Error> {
+        let Some(transaction) = self.reader.try_get_transaction(&digest)? else {
+            return Ok(None);
+        };
+        let transaction = Arc::try_unwrap(transaction).unwrap_or_else(|arc| (*arc).clone());
+        Ok(Some(transaction.into_inner().into()))
+    }
+
+    async fn transaction_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<TransactionEffects>, Self::Error> {
+        Ok(self.reader.try_get_transaction_effects(&digest)?)
+    }
+
+    async fn reference_gas_price(
+        &self,
+        epoch: impl Into<Option<u64>>,
+    ) -> Result<Option<u64>, Self::Error> {
+        match epoch.into() {
+            None => {
+                let system_state = get_iota_system_state(self.reader.as_ref())?;
+                Ok(Some(system_state.reference_gas_price()))
+            }
+            Some(epoch) => Ok(self
+                .reader
+                .get_epoch_info(epoch)?
+                .map(|info| info.reference_gas_price())),
+        }
+    }
+
+    async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
+        let transaction = self.transaction_for_simulation(tx)?;
+        let result = self
+            .executor
+            .simulate_transaction(transaction, VmChecks::Disabled)?;
+        Ok(Some(result.effects.gas_cost_summary().gas_used()))
+    }
+
+    async fn dry_run_tx(
+        &self,
+        tx: &Transaction,
+        skip_checks: bool,
+    ) -> Result<Self::DryRunResult, Self::Error> {
+        let checks = if skip_checks {
+            VmChecks::Disabled
+        } else {
+            VmChecks::Enabled
+        };
+        // Only apply the zero-budget replacement with checks disabled: with
+        // checks enabled the caller asked for full validation, and a zero
+        // budget should fail it.
+        let transaction = if checks.disabled() {
+            self.transaction_for_simulation(tx)?
+        } else {
+            tx.clone()
+        };
+        Ok(self.executor.simulate_transaction(transaction, checks)?)
+    }
+
+    async fn execute_tx(
+        &self,
+        signatures: &[UserSignature],
+        tx: &Transaction,
+        wait_for: impl Into<Option<WaitForTx>>,
+    ) -> Result<TransactionEffects, Self::Error> {
+        let signed_transaction = SignedTransaction {
+            transaction: tx.clone(),
+            signatures: signatures.to_vec(),
+        };
+        let request = ExecuteTransactionRequestV1::new(iota_types::transaction::Transaction::from(
+            signed_transaction,
+        ));
+        let response = self
+            .executor
+            .execute_transaction(request, false, None)
+            .await?;
+
+        if let Some(wait_for) = wait_for.into() {
+            self.wait_for_tx(tx.digest(), wait_for).await?;
+        }
+
+        Ok(response.effects.effects)
+    }
+
+    async fn wait_for_tx(
+        &self,
+        digest: TransactionDigest,
+        wait_for: WaitForTx,
+    ) -> Result<(), Self::Error> {
+        match wait_for {
+            WaitForTx::IndexedOnNode => {
+                let poll = async {
+                    let mut interval = tokio::time::interval(WAIT_FOR_TX_POLL_INTERVAL);
+                    loop {
+                        interval.tick().await;
+                        if self.reader.try_get_transaction_effects(&digest)?.is_some() {
+                            return Ok(());
+                        }
+                    }
+                };
+                tokio::time::timeout(WAIT_FOR_TX_TIMEOUT, poll)
+                    .await
+                    .map_err(|_| Error::WaitForTransactionTimeout(digest))?
+            }
+            WaitForTx::Finalized => {
+                let included = self
+                    .executor
+                    .wait_for_checkpoint_inclusion(&[digest], WAIT_FOR_TX_TIMEOUT)
+                    .await?;
+                if included.contains_key(&digest) {
+                    Ok(())
+                } else {
+                    Err(Error::WaitForTransactionTimeout(digest))
+                }
+            }
+            _ => unimplemented!("a new WaitForTx enum variant was added and needs to be handled"),
+        }
+    }
+}

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -52,6 +52,7 @@ iota-multiaddr.workspace = true
 iota-names.workspace = true
 iota-network.workspace = true
 iota-network-stack.workspace = true
+iota-node-transaction-builder.workspace = true
 iota-protocol-config.workspace = true
 iota-sdk-types.workspace = true
 iota-snapshot.workspace = true

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -98,6 +98,7 @@ use iota_network::{
     randomness, state_sync,
 };
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
+use iota_node_transaction_builder::NodeTransactionBuilderClient;
 use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
     RandomnessRound,
@@ -232,6 +233,7 @@ pub struct IotaNode {
     state_sync_handle: state_sync::Handle,
     randomness_handle: randomness::Handle,
     checkpoint_store: Arc<CheckpointStore>,
+    state_sync_store: RocksDbStore,
     global_state_hasher: Mutex<Option<Arc<GlobalStateHasher>>>,
     connection_monitor_status: Arc<ConnectionMonitorStatus>,
 
@@ -902,6 +904,7 @@ impl IotaNode {
             state_sync_handle,
             randomness_handle,
             checkpoint_store,
+            state_sync_store,
             global_state_hasher: Mutex::new(Some(global_state_hasher)),
             end_of_epoch_channel,
             connection_monitor_status,
@@ -1745,6 +1748,21 @@ impl IotaNode {
         &self,
     ) -> Option<Arc<TransactionOrchestrator<NetworkAuthorityClient>>> {
         self.transaction_orchestrator.clone()
+    }
+
+    /// Client for the SDK's `TransactionBuilder` backed by this node's local
+    /// state instead of a remote endpoint.
+    ///
+    /// Returns `None` when the node has no transaction orchestrator
+    /// (validators, or fullnodes started with `run_with_range`).
+    pub fn transaction_builder_client(&self) -> Option<NodeTransactionBuilderClient> {
+        let executor = self.transaction_orchestrator.clone()?
+            as Arc<dyn iota_types::transaction_executor::TransactionExecutor>;
+        let reader = Arc::new(GrpcReadStore::new(
+            self.state.clone(),
+            self.state_sync_store.clone(),
+        ));
+        Some(NodeTransactionBuilderClient::new(reader, executor))
     }
 
     /// Subscribe to the quorum driver's effects stream; errors while the

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -98,7 +98,7 @@ use iota_network::{
     randomness, state_sync,
 };
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
-use iota_node_transaction_builder::NodeTransactionBuilderResolveClient;
+use iota_node_transaction_builder::NodeTransactionBuilderLedgerClient;
 use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
     RandomnessRound,
@@ -1752,12 +1752,12 @@ impl IotaNode {
 
     /// Read-only client for the SDK's `TransactionBuilder` backed by this
     /// node's local state instead of a remote endpoint.
-    pub fn transaction_builder_resolve_client(&self) -> NodeTransactionBuilderResolveClient {
+    pub fn transaction_builder_ledger_client(&self) -> NodeTransactionBuilderLedgerClient {
         let reader = Arc::new(GrpcReadStore::new(
             self.state.clone(),
             self.state_sync_store.clone(),
         ));
-        NodeTransactionBuilderResolveClient::new(reader)
+        NodeTransactionBuilderLedgerClient::new(reader)
     }
 
     /// Subscribe to the quorum driver's effects stream; errors while the

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -98,7 +98,7 @@ use iota_network::{
     randomness, state_sync,
 };
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
-use iota_node_transaction_builder::NodeTransactionBuilderClient;
+use iota_node_transaction_builder::NodeTransactionBuilderResolveClient;
 use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
     RandomnessRound,
@@ -1750,19 +1750,14 @@ impl IotaNode {
         self.transaction_orchestrator.clone()
     }
 
-    /// Client for the SDK's `TransactionBuilder` backed by this node's local
-    /// state instead of a remote endpoint.
-    ///
-    /// Returns `None` when the node has no transaction orchestrator
-    /// (validators, or fullnodes started with `run_with_range`).
-    pub fn transaction_builder_client(&self) -> Option<NodeTransactionBuilderClient> {
-        let executor = self.transaction_orchestrator.clone()?
-            as Arc<dyn iota_types::transaction_executor::TransactionExecutor>;
+    /// Read-only client for the SDK's `TransactionBuilder` backed by this
+    /// node's local state instead of a remote endpoint.
+    pub fn transaction_builder_resolve_client(&self) -> NodeTransactionBuilderResolveClient {
         let reader = Arc::new(GrpcReadStore::new(
             self.state.clone(),
             self.state_sync_store.clone(),
         ));
-        Some(NodeTransactionBuilderClient::new(reader, executor))
+        NodeTransactionBuilderResolveClient::new(reader)
     }
 
     /// Subscribe to the quorum driver's effects stream; errors while the

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -52,7 +52,7 @@ use iota_sdk::{
     iota_client_config::{IotaClientConfig, IotaEnv},
     wallet_context::WalletContext,
 };
-use iota_sdk_transaction_builder::{TransactionBuilderClient, unresolved};
+use iota_sdk_transaction_builder::{TransactionBuilderResolveClient, unresolved};
 use iota_sdk_types::{
     Address, Identifier, MoveAuthenticatorV1, MovePackageData, ObjectId, ObjectReference, Owner,
     SenderSignedTransaction, SharedObjectReference, SignatureScheme, StructTag, Transaction,

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -52,7 +52,7 @@ use iota_sdk::{
     iota_client_config::{IotaClientConfig, IotaEnv},
     wallet_context::WalletContext,
 };
-use iota_sdk_transaction_builder::{TransactionBuilderResolveClient, unresolved};
+use iota_sdk_transaction_builder::{TransactionBuilderLedgerClient, unresolved};
 use iota_sdk_types::{
     Address, Identifier, MoveAuthenticatorV1, MovePackageData, ObjectId, ObjectReference, Owner,
     SenderSignedTransaction, SharedObjectReference, SignatureScheme, StructTag, Transaction,

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -12,7 +12,7 @@ use iota_json::{is_receiving_argument, primitive_type};
 use iota_move::manage_package::resolve_lock_file_path;
 use iota_move_build::CompiledPackage;
 use iota_sdk::wallet_context::WalletContext;
-use iota_sdk_transaction_builder::TransactionBuilderResolveClient;
+use iota_sdk_transaction_builder::TransactionBuilderLedgerClient;
 use iota_sdk_types::{
     Address, Argument, Command, Identifier, Object, ObjectData, ObjectId, Owner,
     ProgrammableTransaction, SharedObjectReference, TypeTag, move_package::MovePackage,

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -12,7 +12,7 @@ use iota_json::{is_receiving_argument, primitive_type};
 use iota_move::manage_package::resolve_lock_file_path;
 use iota_move_build::CompiledPackage;
 use iota_sdk::wallet_context::WalletContext;
-use iota_sdk_transaction_builder::TransactionBuilderClient;
+use iota_sdk_transaction_builder::TransactionBuilderResolveClient;
 use iota_sdk_types::{
     Address, Argument, Command, Identifier, Object, ObjectData, ObjectId, Owner,
     ProgrammableTransaction, SharedObjectReference, TypeTag, move_package::MovePackage,

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=74fa61a4d97d77d364fd188102356c7661c10d79#74fa61a4d97d77d364fd188102356c7661c10d79"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=ee498b11862f0722f28289b6b44882649ce85ee6#ee498b11862f0722f28289b6b44882649ce85ee6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7da31ee69e2de2f9271abdff4696a8e2b162321c#7da31ee69e2de2f9271abdff4696a8e2b162321c"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "ee498b11862f0722f28289b6b44882649ce85ee6" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "ee498b11862f0722f28289b6b44882649ce85ee6" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7da31ee69e2de2f9271abdff4696a8e2b162321c" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "74fa61a4d97d77d364fd188102356c7661c10d79" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
# Description of change

Allows using the SDK `TransactionBuilder` (from `iota-rust-sdk`) inside the node itself, backed by local state instead of a remote gRPC/GraphQL endpoint.

- New crate `iota-node-transaction-builder`: `NodeTransactionBuilderLedgerClient` implements the SDK's read-only `TransactionBuilderLedgerClient` trait over `GrpcStateReader` (`iota-node-storage`) — the same interface the gRPC server reads from. No dependency on `iota-core`, no executor handle.
- Resolves everything the builder needs from the node's stores: objects, owned-object listing (index-backed pagination with an opaque bcs cursor), reference gas price, and protocol config attributes.
- The client is ledger-only by design (the three-way trait split in iotaledger/iota-rust-sdk keeps simulation and execution in `TransactionBuilderSimulationClient`/`TransactionBuilderExecutionClient`): transactions are built with an explicit gas budget via `finish_with_budget` — calling `finish()`, which estimates the budget by simulating, does not compile for a ledger-only client. Execution stays with the existing `TransactionExecutor` paths.
- New `IotaNode::transaction_builder_ledger_client()` accessor returns a ready-made client; works on any node (only `objects()` requires the gRPC indexes to be enabled).
- gRPC server: `GrpcReader::state_reader()` exposes the underlying state reader, and `TransactionExecutionGrpcService` holds a `builder_client` built from it, for upcoming server-side transaction building.
- Bumps the `iota-rust-sdk` pin to the squash-merge commit of the trait split PR (iotaledger/iota-rust-sdk#1280) on the SDK's develop.

## Links to any relevant issues

None.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New e2e test `node_transaction_builder_tests` runs on a `TestCluster` fullnode: reads and cursor pagination from local state, and building with an explicit budget via `finish_with_budget` resolves gas coins and gas price locally and produces a transaction that executes successfully. Passes under both `cargo nextest` and `cargo simtest`. `cargo clippy --all-targets --all-features -- -D warnings` is clean on the touched crates.
