### PR TITLE
feat(iota-data-ingestion-core): support local buckets in `RemoteStore` via `file://` prefix

### DIFF
--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -115,17 +115,27 @@ impl RemoteStore {
                 historical_url,
                 live_url,
             } => {
-                let config = ArchiveReaderConfig {
-                    download_concurrency: NonZeroUsize::new(batch_size)
-                        .expect("batch size must be greater than zero"),
-                    remote_store_config: ObjectStoreConfig {
+                let remote_store_config = if let Some(dir) = historical_url.strip_prefix("file://")
+                {
+                    ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::File),
+                        directory: Some(PathBuf::from(dir)),
+                        ..Default::default()
+                    }
+                } else {
+                    ObjectStoreConfig {
                         object_store: Some(ObjectStoreType::S3),
                         object_store_connection_limit: 20,
                         aws_endpoint: Some(historical_url),
                         aws_virtual_hosted_style_request: true,
                         no_sign_request: true,
                         ..Default::default()
-                    },
+                    }
+                };
+                let config = ArchiveReaderConfig {
+                    download_concurrency: NonZeroUsize::new(batch_size)
+                        .expect("batch size must be greater than zero"),
+                    remote_store_config,
                     use_for_pruning_watermark: false,
                 };
                 let historical = HistoricalReader::new(config)


### PR DESCRIPTION
# Description of change

This PR adds the possibility to specify a `File` based object store for the `RemoteStore`, via `file://` prefix, so it can be used in tests.

## Links to any relevant issues

#12416 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes