### PR TITLE
upstream(core): Promote error! logs to debug_fatal! and handle expected checkpoint builder errors gracefully

### DIFF
--- a/crates/iota-common/src/logging.rs
+++ b/crates/iota-common/src/logging.rs
@@ -23,19 +23,75 @@ pub fn crash_on_debug() -> bool {
     *CRASH_ON_DEBUG
 }
 
+#[cfg(msim)]
+pub mod intercept_debug_fatal {
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    pub struct DebugFatalCallback {
+        pub pattern: String,
+        pub callback: Arc<dyn Fn() + Send + Sync>,
+    }
+
+    thread_local! {
+        static INTERCEPT_DEBUG_FATAL: Mutex<Option<DebugFatalCallback>> = Mutex::new(None);
+    }
+
+    pub fn register_callback(message: &str, f: impl Fn() + Send + Sync + 'static) {
+        INTERCEPT_DEBUG_FATAL.with(|m| {
+            *m.lock().unwrap() = Some(DebugFatalCallback {
+                pattern: message.to_string(),
+                callback: Arc::new(f),
+            });
+        });
+    }
+
+    pub fn get_callback() -> Option<DebugFatalCallback> {
+        INTERCEPT_DEBUG_FATAL.with(|m| m.lock().unwrap().clone())
+    }
+}
+
+#[macro_export]
+macro_rules! register_debug_fatal_handler {
+    ($message:literal, $f:expr) => {
+        #[cfg(msim)]
+        $crate::logging::intercept_debug_fatal::register_callback($message, $f);
+
+        #[cfg(not(msim))]
+        {
+            // silence unused variable warnings from the body of the callback
+            let _ = $f;
+        }
+    };
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[macro_export]
 macro_rules! debug_fatal {
     ($($arg:tt)*) => {{
-        if $crate::logging::crash_on_debug() {
-            $crate::fatal!($($arg)*);
-        } else {
-            let stacktrace = std::backtrace::Backtrace::capture();
-            tracing::error!(debug_fatal = true, stacktrace = ?stacktrace, $($arg)*);
-            let location = concat!(file!(), ':', line!());
-            if let Some(metrics) = iota_metrics::get_metrics() {
-                metrics.system_invariant_violations.with_label_values(&[location]).inc();
+        loop {
+            #[cfg(msim)]
+            {
+                if let Some(cb) = $crate::logging::intercept_debug_fatal::get_callback() {
+                    let msg = format!($($arg)*);
+                    if msg.contains(&cb.pattern) {
+                        (cb.callback)();
+                    }
+                    break;
+                }
             }
+
+            if $crate::logging::crash_on_debug() {
+                $crate::fatal!($($arg)*);
+            } else {
+                let stacktrace = std::backtrace::Backtrace::capture();
+                tracing::error!(debug_fatal = true, stacktrace = ?stacktrace, $($arg)*);
+                let location = concat!(file!(), ':', line!());
+                if let Some(metrics) = iota_metrics::get_metrics() {
+                    metrics.system_invariant_violations.with_label_values(&[location]).inc();
+                }
+            }
+            break;
         }
     }};
 }

--- a/crates/iota-common/src/logging.rs
+++ b/crates/iota-common/src/logging.rs
@@ -73,6 +73,7 @@ macro_rules! debug_fatal {
             #[cfg(msim)]
             {
                 if let Some(cb) = $crate::logging::intercept_debug_fatal::get_callback() {
+                    tracing::error!($($arg)*);
                     let msg = format!($($arg)*);
                     if msg.contains(&cb.pattern) {
                         (cb.callback)();

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3798,11 +3798,7 @@ impl AuthorityState {
                 "Performing state consistency check for epoch {}",
                 cur_epoch_store.epoch()
             );
-            self.expensive_check_is_consistent_state(
-                state_hasher,
-                cur_epoch_store,
-                cfg!(debug_assertions), // panic in debug mode only
-            );
+            self.expensive_check_is_consistent_state(state_hasher, cur_epoch_store);
         }
 
         if expensive_safety_check_config.enable_secondary_index_checks() {
@@ -3819,7 +3815,6 @@ impl AuthorityState {
         &self,
         state_hasher: Arc<GlobalStateHasher>,
         cur_epoch_store: &AuthorityPerEpochStore,
-        panic: bool,
     ) {
         let live_object_set_hash = state_hasher.digest_live_object_set();
 
@@ -3834,23 +3829,16 @@ impl AuthorityState {
 
         let is_inconsistent = root_state_hash != live_object_set_hash;
         if is_inconsistent {
-            if panic {
-                panic!(
-                    "Inconsistent state detected: root state hash: {root_state_hash:?}, live object set hash: {live_object_set_hash:?}"
-                );
-            } else {
-                error!(
-                    "Inconsistent state detected: root state hash: {:?}, live object set hash: {:?}",
-                    root_state_hash, live_object_set_hash
-                );
-            }
+            debug_fatal!(
+                "Inconsistent state detected: root state hash: {:?}, live object set hash: {:?}",
+                root_state_hash,
+                live_object_set_hash
+            );
         } else {
             info!("State consistency check passed");
         }
 
-        if !panic {
-            state_hasher.set_inconsistent_state(is_inconsistent);
-        }
+        state_hasher.set_inconsistent_state(is_inconsistent);
     }
 
     pub fn current_epoch_for_testing(&self) -> EpochId {
@@ -4103,7 +4091,7 @@ impl AuthorityState {
         match self.read_object_at_version(object_id, obj_ref.version)? {
             Some((object, layout)) => Ok(PastObjectRead::VersionFound(obj_ref, object, layout)),
             None => {
-                error!(
+                debug_fatal!(
                     "Object with in parent_entry is missing from object store, datastore is \
                      inconsistent",
                 );
@@ -5127,7 +5115,7 @@ impl AuthorityState {
 
             let new_ref = new_object.object_ref();
             if new_ref != system_package_ref {
-                error!(
+                debug_fatal!(
                     "Framework mismatch -- binary: {new_ref:?}\n  upgrade: {system_package_ref:?}"
                 );
                 return None;
@@ -5371,7 +5359,7 @@ impl AuthorityState {
             .get_system_package_bytes(next_epoch_system_packages.clone(), &binary_config)
             .await
         else {
-            error!(
+            debug_fatal!(
                 "upgraded system packages {:?} are not locally available, cannot create \
                 ChangeEpochTx. validator binary must be upgraded to the correct version!",
                 next_epoch_system_packages

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -15,7 +15,6 @@ use std::{
     vec,
 };
 
-use anyhow::bail;
 use arc_swap::{ArcSwap, Guard};
 use async_trait::async_trait;
 use authority_per_epoch_store::TxLockGuard;
@@ -163,7 +162,7 @@ use crate::{
     },
     authority_client::NetworkAuthorityClient,
     checkpoint_progress_tracker::CheckpointProgressTracker,
-    checkpoints::CheckpointStore,
+    checkpoints::{CheckpointBuilderError, CheckpointBuilderResult, CheckpointStore},
     congestion_tracker::CongestionTracker,
     consensus_adapter::ConsensusAdapter,
     epoch::committee_store::CommitteeStore,
@@ -5326,7 +5325,7 @@ impl AuthorityState {
         checkpoint: CheckpointSequenceNumber,
         epoch_start_timestamp_ms: CheckpointTimestamp,
         scores: Vec<u64>,
-    ) -> anyhow::Result<(
+    ) -> CheckpointBuilderResult<(
         IotaSystemState,
         Option<SystemEpochInfoEvent>,
         TransactionEffects,
@@ -5373,7 +5372,7 @@ impl AuthorityState {
             //   packages, reconfigure, and most likely shut down in the new epoch (this
             //   validator likely doesn't support the new protocol version, or else it
             //   should have had the packages.)
-            bail!("missing system packages: cannot form ChangeEpochTx");
+            return Err(CheckpointBuilderError::SystemPackagesMissing);
         };
 
         // Use ChangeEpochV3 or ChangeEpochV4 when the feature flags are enabled and
@@ -5511,7 +5510,7 @@ impl AuthorityState {
             .try_is_tx_already_executed(tx_digest)?
         {
             warn!("change epoch tx has already been executed via state sync");
-            bail!("change epoch tx has already been executed via state sync",);
+            return Err(CheckpointBuilderError::ChangeEpochTxAlreadyExecuted);
         }
 
         let execution_guard = self.execution_lock_for_executable_transaction(&executable_tx)?;
@@ -5551,11 +5550,7 @@ impl AuthorityState {
         // able to deliver to the transaction to CheckpointExecutor after it is
         // included in a certified checkpoint.
         self.get_state_sync_store()
-            .try_insert_transaction_and_effects(&tx, &effects)
-            .map_err(|err| {
-                let err: anyhow::Error = err.into();
-                err
-            })?;
+            .try_insert_transaction_and_effects(&tx, &effects)?;
 
         info!(
             "Effects summary of the change epoch transaction: {:?}",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1370,10 +1370,14 @@ impl AuthorityPerEpochStore {
             .set(tokio::sync::Mutex::new(randomness_manager))
             .is_err()
         {
-            error!("BUG: `set_randomness_manager` called more than once; this should never happen");
+            debug_fatal!(
+                "BUG: `set_randomness_manager` called more than once; this should never happen"
+            );
         }
         if self.randomness_reporter.set(reporter).is_err() {
-            error!("BUG: `set_randomness_manager` called more than once; this should never happen");
+            debug_fatal!(
+                "BUG: `set_randomness_manager` called more than once; this should never happen"
+            );
         }
         result
     }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2191,7 +2191,7 @@ impl CheckpointAggregator {
         info!("Starting CheckpointAggregator");
         loop {
             if let Err(e) = self.run_and_notify().await {
-                debug_fatal!(
+                error!(
                     "Error while aggregating checkpoint, will retry in 1s: {:?}",
                     e
                 );

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1144,7 +1144,7 @@ impl CheckpointBuilder {
                     return;
                 }
                 Err(CheckpointBuilderError::Retry(inner)) => {
-                    let msg = format!("{:?}", inner);
+                    let msg = format!("{inner:?}");
                     debug_fatal!("Error while making checkpoint, will retry in 1s: {}", msg);
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     self.metrics.checkpoint_errors.inc();

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -23,7 +23,6 @@ use std::{
 
 use diffy::create_patch;
 use iota_common::{debug_fatal, fatal, random::get_rng, sync::notify_read::NotifyRead};
-use iota_macros::fail_point;
 use iota_metrics::{MonitoredFutureExt, monitored_future, monitored_scope};
 use iota_network::default_iota_network_config;
 use iota_sdk_types::{
@@ -1246,7 +1245,17 @@ impl CheckpointBuilder {
                     });
                 }
                 Err(e) => {
-                    error!("Error while making checkpoint, will retry in 1s: {:?}", e);
+                    let msg = format!("{:?}", e);
+                    // This particular error is expected to happen from time to time. Any other
+                    // error during checkpoint building is most likely a bug.
+                    if msg.contains("change epoch tx has already been executed via state sync") {
+                        info!(
+                            "change epoch tx has already been executed via state sync. Checkpoint builder will be shut down briefly"
+                        );
+                    } else {
+                        debug_fatal!("Error while making checkpoint, will retry in 1s: {}", msg);
+                    }
+
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     self.metrics.checkpoint_errors.inc();
                     return;
@@ -2182,7 +2191,7 @@ impl CheckpointAggregator {
         info!("Starting CheckpointAggregator");
         loop {
             if let Err(e) = self.run_and_notify().await {
-                error!(
+                debug_fatal!(
                     "Error while aggregating checkpoint, will retry in 1s: {:?}",
                     e
                 );
@@ -2399,9 +2408,9 @@ impl CheckpointSignatureAggregator {
                     format!("{digest} (total stake: {total_stake})")
                 })
                 .collect::<Vec<String>>();
-            error!(
-                checkpoint_seq = self.summary.sequence_number,
-                "Split brain detected in checkpoint signature aggregation! Remaining stake: {:?}, Digests by stake: {:?}",
+            debug_fatal!(
+                "Split brain detected in checkpoint signature aggregation for checkpoint {:?}. Remaining stake: {:?}, Digests by stake: {:?}",
+                self.summary.sequence_number,
                 self.signatures_by_digest.uncommitted_stake(),
                 digests_by_stake_messages,
             );
@@ -2594,8 +2603,6 @@ async fn diagnose_split_brain(
     let mut file = File::create(checkpoint_fork_file_path).unwrap();
     write!(file, "{fork_logs_text}").unwrap();
     debug!("{}", fork_logs_text);
-
-    fail_point!("split_brain_reached");
 }
 
 pub trait CheckpointServiceNotify {

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1028,6 +1028,23 @@ struct BuiltCheckpoint {
     full_contents: Option<FullCheckpointContents>,
 }
 
+#[derive(Debug)]
+pub enum CheckpointBuilderError {
+    ChangeEpochTxAlreadyExecuted,
+    SystemPackagesMissing,
+    Retry(anyhow::Error),
+}
+
+impl<IotaError: std::error::Error + Send + Sync + 'static> From<IotaError>
+    for CheckpointBuilderError
+{
+    fn from(e: IotaError) -> Self {
+        Self::Retry(e.into())
+    }
+}
+
+pub type CheckpointBuilderResult<T = ()> = Result<T, CheckpointBuilderError>;
+
 pub struct CheckpointBuilder {
     state: Arc<AuthorityState>,
     store: Arc<CheckpointStore>,
@@ -1117,13 +1134,29 @@ impl CheckpointBuilder {
         }
         info!("Starting CheckpointBuilder");
         loop {
-            self.maybe_build_checkpoints().await;
+            match self.maybe_build_checkpoints().await {
+                Ok(()) => {}
+                err @ Err(
+                    CheckpointBuilderError::ChangeEpochTxAlreadyExecuted
+                    | CheckpointBuilderError::SystemPackagesMissing,
+                ) => {
+                    info!("CheckpointBuilder stopping: {:?}", err);
+                    return;
+                }
+                Err(CheckpointBuilderError::Retry(inner)) => {
+                    let msg = format!("{:?}", inner);
+                    debug_fatal!("Error while making checkpoint, will retry in 1s: {}", msg);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    self.metrics.checkpoint_errors.inc();
+                    continue;
+                }
+            }
 
             self.notify.notified().await;
         }
     }
 
-    async fn maybe_build_checkpoints(&mut self) {
+    async fn maybe_build_checkpoints(&mut self) -> CheckpointBuilderResult {
         let _scope = monitored_scope("BuildCheckpoints");
 
         // Collect info about the most recently built checkpoint.
@@ -1221,46 +1254,28 @@ impl CheckpointBuilder {
                 "Making checkpoint with commit height range"
             );
 
-            match self
+            let seq = self
                 .make_checkpoint(std::mem::take(&mut grouped_pending_checkpoints))
-                .await
-            {
-                Ok(seq) => {
-                    // Count only on success; a failed build retries the same
-                    // group and would otherwise double-count it.
-                    self.metrics
-                        .commits_per_checkpoint
-                        .observe(commits_in_checkpoint as f64);
-                    // Advance the window anchor to the highest checkpoint just
-                    // built (a single call may emit several when chunked).
-                    last_seq = Some(seq);
-                    self.last_built.send_if_modified(|cur| {
-                        // when rebuilding checkpoints at startup, seq can be for an old checkpoint
-                        if seq > *cur {
-                            *cur = seq;
-                            true
-                        } else {
-                            false
-                        }
-                    });
-                }
-                Err(e) => {
-                    let msg = format!("{:?}", e);
-                    // This particular error is expected to happen from time to time. Any other
-                    // error during checkpoint building is most likely a bug.
-                    if msg.contains("change epoch tx has already been executed via state sync") {
-                        info!(
-                            "change epoch tx has already been executed via state sync. Checkpoint builder will be shut down briefly"
-                        );
-                    } else {
-                        debug_fatal!("Error while making checkpoint, will retry in 1s: {}", msg);
-                    }
+                .await?;
 
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    self.metrics.checkpoint_errors.inc();
-                    return;
+            // Count only on success; a failed build retries the same
+            // group and would otherwise double-count it.
+            self.metrics
+                .commits_per_checkpoint
+                .observe(commits_in_checkpoint as f64);
+            // Advance the window anchor to the highest checkpoint just
+            // built (a single call may emit several when chunked).
+            last_seq = Some(seq);
+            self.last_built.send_if_modified(|cur| {
+                // when rebuilding checkpoints at startup, seq can be for an old checkpoint
+                if seq > *cur {
+                    *cur = seq;
+                    true
+                } else {
+                    false
                 }
-            }
+            });
+
             // Ensure that the task can be cancelled at end of epoch, even if no other await
             // yields execution.
             tokio::task::yield_now().await;
@@ -1269,6 +1284,8 @@ impl CheckpointBuilder {
             "Waiting for more checkpoints from consensus after processing {last_height:?}; {} pending checkpoints left unprocessed until next interval",
             grouped_pending_checkpoints.len(),
         );
+
+        Ok(())
     }
 
     #[instrument(level = "debug", skip_all, fields(last_height = pendings.last().unwrap().details().checkpoint_height
@@ -1276,7 +1293,7 @@ impl CheckpointBuilder {
     async fn make_checkpoint(
         &self,
         pendings: Vec<PendingCheckpoint>,
-    ) -> anyhow::Result<CheckpointSequenceNumber> {
+    ) -> CheckpointBuilderResult<CheckpointSequenceNumber> {
         let _scope = monitored_scope("CheckpointBuilder::make_checkpoint");
         let last_details = pendings.last().unwrap().details().clone();
 
@@ -1568,7 +1585,8 @@ impl CheckpointBuilder {
         &self,
         transactions_effects_and_sizes: Vec<(Transaction, TransactionEffects, usize)>,
         signatures: Vec<Vec<UserSignature>>,
-    ) -> anyhow::Result<Vec<Vec<(Transaction, TransactionEffects, Vec<UserSignature>)>>> {
+    ) -> CheckpointBuilderResult<Vec<Vec<(Transaction, TransactionEffects, Vec<UserSignature>)>>>
+    {
         let _guard = monitored_scope("CheckpointBuilder::split_checkpoint_chunks");
         let mut chunks = Vec::new();
         let mut chunk = Vec::new();
@@ -1651,7 +1669,7 @@ impl CheckpointBuilder {
         all_effects: Vec<TransactionEffects>,
         details: &PendingCheckpointInfo,
         all_roots: &HashSet<TransactionDigest>,
-    ) -> anyhow::Result<NonEmpty<BuiltCheckpoint>> {
+    ) -> CheckpointBuilderResult<NonEmpty<BuiltCheckpoint>> {
         let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
 
         let total = all_effects.len();
@@ -1989,7 +2007,7 @@ impl CheckpointBuilder {
         signatures: &mut Vec<Vec<UserSignature>>,
         checkpoint: CheckpointSequenceNumber,
         scores: Vec<u64>,
-    ) -> anyhow::Result<(IotaSystemState, Option<SystemEpochInfoEvent>)> {
+    ) -> CheckpointBuilderResult<(IotaSystemState, Option<SystemEpochInfoEvent>)> {
         let (system_state, system_epoch_info_event, effects) = self
             .state
             .create_and_execute_advance_epoch_tx(

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -18,6 +18,7 @@ use fastcrypto::{
 };
 use fastcrypto_tbls::{dkg_v1, dkg_v1::Output, nodes, nodes::PartyId};
 use futures::{StreamExt, stream::FuturesUnordered};
+use iota_common::debug_fatal;
 use iota_macros::fail_point_if;
 use iota_network::randomness;
 use iota_sdk_types::RandomnessRound;
@@ -641,7 +642,9 @@ impl RandomnessManager {
             return Ok(());
         }
         let Some((_, party_id)) = self.authority_info.get(authority) else {
-            error!("random beacon: received DKG Message from unknown authority: {authority:?}");
+            debug_fatal!(
+                "random beacon: received DKG Message from unknown authority: {authority:?}"
+            );
             return Ok(());
         };
         if *party_id != msg.sender() {

--- a/crates/iota-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/iota-e2e-tests/tests/checkpoint_tests.rs
@@ -10,7 +10,8 @@ use std::{
     time::Duration,
 };
 
-use iota_macros::{register_fail_point, register_fail_point_if, sim_test};
+use iota_common::register_debug_fatal_handler;
+use iota_macros::{register_fail_point_if, sim_test};
 use iota_test_transaction_builder::make_transfer_iota_transaction;
 use iota_types::messages_checkpoint::CheckpointSummaryExt;
 use test_cluster::TestClusterBuilder;
@@ -59,14 +60,19 @@ async fn test_checkpoint_split_brain() {
             panic_timeout: None,
         });
     }
+
     let committee_size = 9;
     // count number of nodes that have reached split brain condition
     let count_split_brain_nodes: Arc<Mutex<AtomicUsize>> = Default::default();
     let count_clone = count_split_brain_nodes.clone();
-    register_fail_point("split_brain_reached", move || {
-        let counter = count_clone.lock().unwrap();
-        counter.fetch_add(1, Ordering::Relaxed);
-    });
+
+    register_debug_fatal_handler!(
+        "Split brain detected in checkpoint signature aggregation",
+        move || {
+            let counter = count_clone.lock().unwrap();
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+    );
 
     register_fail_point_if("cp_execution_nondeterminism", || true);
 

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -56,9 +56,16 @@ fn test_protocol_overrides_2() {
 #[cfg(msim)]
 mod sim_only_tests {
 
-    use std::{path::PathBuf, sync::Arc};
+    use std::{
+        path::PathBuf,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use fastcrypto::encoding::Base64;
+    use iota_common::register_debug_fatal_handler;
     use iota_core::authority::framework_injection;
     use iota_framework::BuiltInFramework;
     use iota_json_rpc_api::WriteApiClient;
@@ -697,6 +704,14 @@ mod sim_only_tests {
             .build()
             .await;
 
+        let framework_mismatch_counter = Arc::new(AtomicUsize::new(0));
+        register_debug_fatal_handler!("Framework mismatch -- ", {
+            let counter = framework_mismatch_counter.clone();
+            move || {
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
         // We must stop the validators before overriding the system modules, otherwise
         // the validators may start running before the override and hence send
         // capabilities indicating that they only support the genesis system
@@ -732,6 +747,9 @@ mod sim_only_tests {
             );
             assert_eq!(committee.epoch, 2);
         });
+
+        // The debug_fatal was hit
+        assert_eq!(framework_mismatch_counter.load(Ordering::Relaxed), 1);
     }
 
     // Test that protocol version upgrade does not complete when there is no quorum

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -464,6 +464,9 @@ async fn test_create_advance_epoch_tx_race() {
     // proceeded with reconfiguration.
     sleep(Duration::from_secs(1)).await;
     reconfig_delay_tx.send(()).unwrap();
+
+    // wait for reconfiguration to complete
+    test_cluster.wait_for_epoch(None).await;
 }
 
 #[sim_test]


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.52.3, v1.53.2)
- Port commit:
  - [MystenLabs/sui@9361992](https://github.com/MystenLabs/sui/commit/9361992e3ab95b8158d8d02c34d47b4051aeea88)
  - [MystenLabs/sui@32a7bc3](https://github.com/MystenLabs/sui/commit/32a7bc338ec05c4a075c0b88e12943fcdbd0f0f0)
  - [MystenLabs/sui@c70aa33](https://github.com/MystenLabs/sui/commit/c70aa33eeb09c20d9a83b2cecf8fc0524da61f53)
- Description:

Many `error!` logs that indicate invariant violations are replaced with `debug_fatal!` so that they trigger test failures. A new `register_debug_fatal_handler!` macro lets simulation tests intercept a `debug_fatal!` by message pattern instead of crashing; the split-brain checkpoint test and the framework-upgrade test now use it (the `split_brain_reached` fail point is removed).

The `debug_fatal!` in the checkpoint aggregator retry loop is reverted back to `error!`, since it can trigger harmlessly during end-of-epoch shutdown.

The checkpoint builder switches from `anyhow::Result` to a typed `CheckpointBuilderError` (`ChangeEpochTxAlreadyExecuted`, `SystemPackagesMissing`, `Retry`). The two expected end-of-epoch conditions now stop the builder cleanly at `info` level instead of string-matching the error message; only genuine errors hit `debug_fatal!` and retry.

Note:
- `CheckpointBuilderError`/`CheckpointBuilderResult` are `pub` instead of upstream's `pub(crate)`, because `reconfiguration_tests.rs` in `iota-e2e-tests` calls `AuthorityState::create_and_execute_advance_epoch_tx` directly.

## Links to any relevant issues

Part of #12269

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes