### PR TITLE
feat: reorder attestation checks

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -6145,34 +6145,6 @@ impl AuthorityState {
         })
     }
 
-    /// Re-runs the sender-side coin deny-list check for an attested
-    /// (`UserTransactionV2`) transaction in the post-consensus phase.
-    ///
-    /// An honest attestor performs this check at attestation time, but the deny
-    /// list is a Move object whose state may change between attestation and
-    /// execution. Running the check at execution time would crash the
-    /// validator, so we run it during post-consensus validation where the
-    /// transaction can still be dropped.
-    pub(crate) fn check_coin_deny_list_for_attested_tx(
-        &self,
-        transaction: &VerifiedTransaction,
-        epoch: EpochId,
-    ) -> IotaResult<()> {
-        let (tx_input_objects, tx_receiving_objects, per_authenticator_inputs) =
-            self.read_objects_for_validation(transaction, epoch)?;
-        let per_authenticator_input_objects: Vec<&InputObjects> =
-            per_authenticator_inputs.iter().map(|(io, _)| io).collect();
-        check_coin_deny_list_v1(
-            transaction.data().transaction().sender(),
-            &tx_input_objects,
-            &tx_receiving_objects,
-            &per_authenticator_input_objects,
-            &self.get_object_store(),
-            Some(epoch),
-        )?;
-        Ok(())
-    }
-
     /// Re-runs the `TransactionDenyConfig` deny checks (disabled features,
     /// denied signers, denied input/receiving objects, denied package
     /// dependencies) for an attested (`UserTransactionV2`) transaction in the

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -35,11 +35,14 @@
 //!   tx's own prior-round lock), which is exempt. Cheap; performed before
 //!   expensive checks.
 //! - Check #6: `handle_transaction_validation_checks()` for
-//!   `UserTransactionV1`, or the deny-list and coin deny-list re-checks for
-//!   attested `UserTransactionV2`
-//!   (`check_transaction_deny_list_for_attested_tx()` then
-//!   `check_coin_deny_list_for_attested_tx()`). Drop with error. Only reached
-//!   when all locks are free.
+//!   `UserTransactionV1`, or for attested `UserTransactionV2` a payload-only
+//!   gas-bounds check (`check_gas_bounds()`, #8a) followed by the
+//!   `TransactionDenyConfig` re-check
+//!   (`check_transaction_deny_list_for_attested_tx()`). Drop with error. Only
+//!   reached when all locks are free. The coin deny-list check (#10) is no
+//!   longer run here for attested transactions; it is enforced during execution
+//!   (fail-to-effects), so a stale-attestation view resolves to a failed effect
+//!   rather than a drop.
 //! - All passed — acquire locks in the local tracking map, keep transaction.
 
 use std::{
@@ -51,7 +54,8 @@ use iota_common::fatal;
 use iota_sdk_types::{ObjectReference, TransactionDigest};
 use iota_types::{
     attestation::Attestation,
-    error::{IotaError, IotaResult, UserInputError},
+    error::{IotaError, IotaResult},
+    gas::check_gas_bounds,
     transaction::{
         InputObjectKind, SenderSignedTransactionAPI, TransactionDataAPI, VerifiedTransaction,
     },
@@ -328,11 +332,12 @@ pub async fn validate_and_resolve_conflicts(
         // `UserTransactionV1` runs the full
         // `handle_transaction_validation_checks` (which includes the
         // `TransactionDenyConfig` deny-list check). For `UserTransactionV2`
-        // (attested transactions) two checks are re-run individually — the
-        // deny-list check and the coin deny-list check (see below). The rest
-        // of `handle_transaction_validation_checks` is skipped for V2 because
-        // it is either re-applied during execution or is not safety-critical
-        // to run post-consensus:
+        // (attested transactions) a payload-only gas-bounds check (#8a) and the
+        // `TransactionDenyConfig` deny-list check are run individually (see
+        // below); the coin deny-list check (#10) is enforced during execution
+        // instead of here. The rest of `handle_transaction_validation_checks`
+        // is skipped for V2 because it is either re-applied during execution or
+        // is not safety-critical to run post-consensus:
         //   - Receiving-object validity: the Move runtime fails the `receive()` call
         //     when the ref doesn't match current state.
         //   - Move bytecode verifier on publish: the Move VM re-verifies every newly
@@ -350,11 +355,6 @@ pub async fn validate_and_resolve_conflicts(
         // lists, feature kill-switches): this is a LOCAL check, sourced from
         // each validator's `NodeConfig`. TODO: source the deny config from
         // consensus-agreed state instead of the local `NodeConfig`.
-        //
-        // Coin deny list v1 MUST be re-checked here for attested
-        // transactions: the attestor's view may be stale if a deny-list
-        // update tx was sequenced between attestation and consensus, and
-        // running this check at execution time would crash the validator.
         if attestation.is_none() {
             let verified_tx = VerifiedTransaction::new_from_verified(transaction.clone());
             if let Err(e) = authority_state
@@ -381,6 +381,26 @@ pub async fn validate_and_resolve_conflicts(
                 continue;
             }
         } else {
+            // Check #8a: payload-only gas bounds/price. Deterministic drop
+            // before version assignment; balance (#8b) is still checked at
+            // execution.
+            let txn = transaction.data().transaction();
+            if let Err(e) = check_gas_bounds(
+                epoch_store.protocol_config(),
+                epoch_store.reference_gas_price(),
+                txn.gas_price(),
+                txn.gas_budget(),
+            ) {
+                let e: IotaError = e.into();
+                warn!(
+                    ?digest,
+                    error = ?e,
+                    "UserTransactionV2 failed post-consensus gas bounds check, dropping"
+                );
+                dropped.push((digest, e));
+                keep[i] = false;
+                continue;
+            }
             let verified_tx = VerifiedTransaction::new_from_verified(transaction.clone());
             // Deny-list check (placeholder using the local deny config — see
             // the `TransactionDenyConfig` note in the Check #6 doc above).
@@ -394,32 +414,6 @@ pub async fn validate_and_resolve_conflicts(
                     ?digest,
                     error = ?e,
                     "UserTransactionV2 failed post-consensus deny-list check, dropping"
-                );
-                dropped.push((digest, e));
-                keep[i] = false;
-                continue;
-            }
-            if let Err(e) = authority_state
-                .check_coin_deny_list_for_attested_tx(&verified_tx, epoch_store.epoch())
-            {
-                if e.is_storage_or_epoch_error() {
-                    return Err(e);
-                }
-                // The helper performs two distinct steps; surface which one
-                // failed so triage doesn't mistake a stale-attestation input
-                // for an actual deny-list violation.
-                let reason = match &e {
-                    IotaError::UserInput {
-                        error:
-                            UserInputError::CoinTypeGlobalPause { .. }
-                            | UserInputError::AddressDeniedForCoin { .. },
-                    } => "coin deny-list re-check",
-                    _ => "input load (likely stale attestation)",
-                };
-                warn!(
-                    ?digest,
-                    error = ?e,
-                    "UserTransactionV2 failed post-consensus {reason}, dropping"
                 );
                 dropped.push((digest, e));
                 keep[i] = false;

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -8,7 +8,9 @@
 //!
 //! 1. **Semantic validation** — deduplication, already-executed check,
 //!    structural validity, attestor verification, and deny checks (deny lists,
-//!    gas, ownership, coin deny list, Move authenticator).
+//!    gas, ownership, coin deny list, Move authenticator) — the full set for
+//!    `UserTransactionV1`, a payload-only subset for `UserTransactionV2`; see
+//!    Check #6.
 //! 2. **Owned-object conflict resolution** (white-flag) — three-tier lock check
 //!    and lock acquisition.
 //!
@@ -76,7 +78,9 @@ use crate::{
 /// For each `UserTransactionV1` or `UserTransactionV2` in consensus order:
 /// - Runs deduplication, already-executed check, structural validity, attestor
 ///   verification (V2 only), lock conflict check, and deny checks (deny list,
-///   gas, ownership, coin deny list, Move authenticator).
+///   gas, ownership, coin deny list, Move authenticator) — the last group in
+///   full for `UserTransactionV1`, as a payload-only subset for
+///   `UserTransactionV2`.
 /// - If all checks pass, acquires owned-object locks in a local tracking map.
 /// - Drops the transaction (with an error) on any failure.
 /// - An already-executed transaction is **retained** (not dropped): it
@@ -275,10 +279,12 @@ pub async fn validate_and_resolve_conflicts(
         // expensive deny checks so conflicting transactions are filtered first.
         //
         // Locks are keyed by full ObjectReference (id + version + digest), not just
-        // ObjectID. Two transactions referencing the same object at different
-        // versions will NOT conflict here — version freshness is validated
-        // later in Check #6 (deny checks load objects from DB and verify
-        // that the transaction's input refs match the current state).
+        // ObjectID, so two transactions referencing the same object at different
+        // versions do NOT conflict here. Version freshness is validated elsewhere:
+        // in Check #6 for `UserTransactionV1`, whose deny checks load objects from
+        // DB and verify the input refs against current state, and at execution
+        // (`check_certificate_input`) for `UserTransactionV2`, whose Check #6 is
+        // payload-only.
         //
         // Tier 1: Local HashMap (current commit).
         // Tier 2: Consensus quarantine (previous uncommitted commits).
@@ -338,9 +344,14 @@ pub async fn validate_and_resolve_conflicts(
         //   - Move bytecode verifier on publish: the Move VM re-verifies every newly
         //     published package; the signing-time variant only adds a stricter meter as
         //     a DoS gate.
-        //   - Gas, ownership, `MoveAuthenticator` execution: re-applied in the
+        //   - Gas balance, ownership, `MoveAuthenticator` execution: re-applied in the
         //     execution pipeline (`check_certificate_input` and
-        //     `authenticate_then_execute_transaction_to_effects`).
+        //     `authenticate_then_execute_transaction_to_effects`). Only the balance is
+        //     left to execution; the payload-only gas bounds are checked below.
+        //   - Coin deny list: enforced during execution
+        //     (`TemporaryStore::check_input_coin_deny_list`), so a stale attestation
+        //     view resolves to a failed effect charged to the issuer instead of a
+        //     free drop.
         //
         // The user signature is verified pre-consensus in the block verifier
         // (`IotaTxValidator::validate_transactions`) for both `UserTransactionV1`
@@ -376,8 +387,12 @@ pub async fn validate_and_resolve_conflicts(
                 continue;
             }
         } else {
-            // Payload-only gas bounds/price. Deterministic drop before version assignment;
-            // balance is still checked at execution.
+            // Payload-only gas bounds/price: a pure function of the transaction and
+            // epoch constants, so the drop is deterministic before version assignment.
+            // The balance is checked at execution instead — it depends on the gas coins'
+            // values at the versions this commit assigns, which are not applied yet, so
+            // a read here would follow this validator's execution progress rather than
+            // the state the transaction executes against.
             let txn = transaction.data().transaction();
             if let Err(e) = check_gas_bounds(
                 epoch_store.protocol_config(),

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -350,8 +350,8 @@ pub async fn validate_and_resolve_conflicts(
         //     left to execution; the payload-only gas bounds are checked below.
         //   - Coin deny list: enforced during execution
         //     (`TemporaryStore::check_input_coin_deny_list`), so a stale attestation
-        //     view resolves to a failed effect charged to the issuer instead of a
-        //     free drop.
+        //     view resolves to a failed effect charged to the issuer instead of a free
+        //     drop.
         //
         // The user signature is verified pre-consensus in the block verifier
         // (`IotaTxValidator::validate_transactions`) for both `UserTransactionV1`

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -36,13 +36,10 @@
 //!   expensive checks.
 //! - Check #6: `handle_transaction_validation_checks()` for
 //!   `UserTransactionV1`, or for attested `UserTransactionV2` a payload-only
-//!   gas-bounds check (`check_gas_bounds()`, #8a) followed by the
+//!   gas-bounds check (`check_gas_bounds()`) followed by the
 //!   `TransactionDenyConfig` re-check
 //!   (`check_transaction_deny_list_for_attested_tx()`). Drop with error. Only
-//!   reached when all locks are free. The coin deny-list check (#10) is no
-//!   longer run here for attested transactions; it is enforced during execution
-//!   (fail-to-effects), so a stale-attestation view resolves to a failed effect
-//!   rather than a drop.
+//!   reached when all locks are free.
 //! - All passed — acquire locks in the local tracking map, keep transaction.
 
 use std::{
@@ -324,18 +321,16 @@ pub async fn validate_and_resolve_conflicts(
             continue;
         }
 
-        // Check #6: Deny list, gas, ownership, coin deny list, Move
-        // authenticator. Only reached if all locks are free — skips the
-        // expensive object loading for transactions that would be dropped
-        // by the lock conflict check.
+        // Check #6: Validation and deny checks. Only reached when all locks are
+        // free, so the expensive object loading is skipped for transactions the
+        // lock conflict check would drop. The `UserTransactionV1` and attested
+        // `UserTransactionV2` paths diverge; the detail follows.
         //
         // `UserTransactionV1` runs the full
-        // `handle_transaction_validation_checks` (which includes the
-        // `TransactionDenyConfig` deny-list check). For `UserTransactionV2`
-        // (attested transactions) a payload-only gas-bounds check (#8a) and the
+        // `handle_transaction_validation_checks`. For `UserTransactionV2`
+        // (attested transactions) a payload-only gas-bounds check and the
         // `TransactionDenyConfig` deny-list check are run individually (see
-        // below); the coin deny-list check (#10) is enforced during execution
-        // instead of here. The rest of `handle_transaction_validation_checks`
+        // below). The rest of `handle_transaction_validation_checks`
         // is skipped for V2 because it is either re-applied during execution or
         // is not safety-critical to run post-consensus:
         //   - Receiving-object validity: the Move runtime fails the `receive()` call
@@ -381,9 +376,8 @@ pub async fn validate_and_resolve_conflicts(
                 continue;
             }
         } else {
-            // Check #8a: payload-only gas bounds/price. Deterministic drop
-            // before version assignment; balance (#8b) is still checked at
-            // execution.
+            // Payload-only gas bounds/price. Deterministic drop before version assignment;
+            // balance is still checked at execution.
             let txn = transaction.data().transaction();
             if let Err(e) = check_gas_bounds(
                 epoch_store.protocol_config(),

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -18,7 +18,7 @@ use iota_types::{
         get_per_type_coin_deny_list_v1,
     },
     effects::{TransactionEffects, TransactionEffectsAPI},
-    error::{IotaError, IotaResult, UserInputError},
+    error::{ExecutionErrorKind, IotaError, IotaResult, UserInputError},
     executable_transaction::VerifiedExecutableTransaction,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     object::Object,
@@ -451,7 +451,7 @@ async fn test_execution_fails_spending_denied_coin_under_attestation() {
     let executable =
         VerifiedExecutableTransaction::new_from_checkpoint(verified_tx, epoch_store.epoch(), 1);
 
-    let (effects, _execution_error) = env
+    let (effects, execution_error) = env
         .env
         .authority
         .try_execute_immediately(&executable.into(), None, &epoch_store)
@@ -463,6 +463,13 @@ async fn test_execution_fails_spending_denied_coin_under_attestation() {
     assert!(
         matches!(error, ExecutionError::AddressDeniedForCoin { .. }),
         "expected AddressDeniedForCoin, got {error:?}"
+    );
+    assert!(
+        matches!(
+            execution_error.as_ref().map(|e| e.kind()),
+            Some(ExecutionErrorKind::AddressDeniedForCoin { .. })
+        ),
+        "expected AddressDeniedForCoin from the executor, got {execution_error:?}"
     );
     assert!(
         effects.gas_cost_summary().gas_used() > 0,

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
-    Address, Identifier, ObjectId, ObjectReference, SharedObjectReference, StructTag,
-    TransactionDigest, TypeTag, Version,
+    Address, ExecutionError, ExecutionStatus, Identifier, ObjectId, ObjectReference,
+    SharedObjectReference, StructTag, TransactionDigest, TypeTag, Version,
 };
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
@@ -19,6 +19,7 @@ use iota_types::{
     },
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::{IotaError, IotaResult, UserInputError},
+    executable_transaction::VerifiedExecutableTransaction,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     object::Object,
     transaction::{CallArg, TEST_ONLY_GAS_UNIT_FOR_PUBLISH, Transaction, VerifiedTransaction},
@@ -412,6 +413,62 @@ async fn test_post_consensus_drops_tx_spending_coin_unpaused_this_epoch() {
         ),
         "unexpected drop reason: {:?}",
         dropped[0].1
+    );
+}
+
+// The #10 reorder moved the coin deny-list check for attested transactions from
+// a post-consensus drop to an execution-time failure. This exercises that
+// execution-time path: a transaction spending a regulated coin whose sender is
+// denied must fail to effects with `AddressDeniedForCoin` (issuer charged), not
+// crash the validator. The transaction is executed directly, bypassing the
+// signing-time deny check, to reproduce a stale or lying attestor whose
+// transaction reaches execution.
+#[tokio::test]
+async fn test_execution_fails_spending_denied_coin_under_attestation() {
+    let guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config.set_enable_validator_attestation_for_testing(true);
+        config
+    });
+
+    let env = RegulatedCoinEnv::new().await;
+
+    // Deny the sender; the entry (written in epoch 0) activates in epoch 1.
+    env.deny_sender().await;
+
+    // `reconfigure_for_testing` installs its own config override (carrying the
+    // flags set above into the next epoch) and panics if another override is
+    // still installed.
+    drop(guard);
+    env.reconfigure().await;
+    assert_eq!(env.epoch(), 1);
+
+    // Build the transfer in the denied epoch and execute it directly. Signing
+    // (`handle_transaction`) would reject a denied-coin spend up front, so this
+    // goes through `verify_transaction` (signature only) + direct execution,
+    // reproducing a transaction that reached execution despite being denied.
+    let transfer = env.build_transfer().await;
+    let epoch_store = env.env.authority.epoch_store_for_testing();
+    let verified_tx = epoch_store.verify_transaction(transfer).unwrap();
+    let executable =
+        VerifiedExecutableTransaction::new_from_checkpoint(verified_tx, epoch_store.epoch(), 1);
+
+    let (effects, _execution_error) = env
+        .env
+        .authority
+        .try_execute_immediately(&executable.into(), None, &epoch_store)
+        .unwrap();
+
+    let ExecutionStatus::Failure { error, .. } = effects.status() else {
+        panic!("expected an execution failure, got {:?}", effects.status());
+    };
+    assert!(
+        matches!(error, ExecutionError::AddressDeniedForCoin { .. }),
+        "expected AddressDeniedForCoin, got {error:?}"
+    );
+    assert!(
+        effects.gas_cost_summary().gas_used() > 0,
+        "the issuer must be charged gas for the failed execution"
     );
 }
 

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Address, ExecutionError, ExecutionStatus, Identifier, ObjectId, ObjectReference,
-    SharedObjectReference, StructTag, TransactionDigest, TypeTag, Version,
+    SharedObjectReference, StructTag, TransactionDigest, TypeTag, UnchangedSharedKind, Version,
 };
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
@@ -467,6 +467,15 @@ async fn test_execution_fails_spending_denied_coin_under_attestation() {
     assert!(
         effects.gas_cost_summary().gas_used() > 0,
         "the issuer must be charged gas for the failed execution"
+    );
+    // The check read the deny list to decide the failure, so the effects must
+    // report that read even though the transaction failed.
+    assert!(
+        effects
+            .unchanged_shared_objects()
+            .contains(&(ObjectId::DENY_LIST, UnchangedSharedKind::PerEpochConfig)),
+        "expected the deny list recorded as a per-epoch config read, got {:?}",
+        effects.unchanged_shared_objects()
     );
 }
 

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -416,13 +416,11 @@ async fn test_post_consensus_drops_tx_spending_coin_unpaused_this_epoch() {
     );
 }
 
-// The #10 reorder moved the coin deny-list check for attested transactions from
-// a post-consensus drop to an execution-time failure. This exercises that
-// execution-time path: a transaction spending a regulated coin whose sender is
-// denied must fail to effects with `AddressDeniedForCoin` (issuer charged), not
-// crash the validator. The transaction is executed directly, bypassing the
-// signing-time deny check, to reproduce a stale or lying attestor whose
-// transaction reaches execution.
+// A transaction spending a regulated coin whose sender is denied must fail to
+// effects with `AddressDeniedForCoin` (issuer charged), not crash the
+// validator. The transaction is executed directly, bypassing the signing-time
+// deny check, to reproduce a stale or lying attestor whose transaction reaches
+// execution.
 #[tokio::test]
 async fn test_execution_fails_spending_denied_coin_under_attestation() {
     let guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -2064,7 +2064,24 @@ async fn test_v2_gas_bounds_out_of_range_dropped() {
         &sender_key,
     );
 
-    for tx in [price_under_rgp, budget_too_high] {
+    // Each transaction is paired with the error it must be dropped for; a matcher
+    // accepting either would pass even if both tripped the same bound.
+    for (tx, expected_error) in [
+        (
+            price_under_rgp,
+            UserInputError::GasPriceUnderRGP {
+                gas_price: rgp - 1,
+                reference_gas_price: rgp,
+            },
+        ),
+        (
+            budget_too_high,
+            UserInputError::GasBudgetTooHigh {
+                gas_budget: max_tx_gas + 1,
+                max_budget: max_tx_gas,
+            },
+        ),
+    ] {
         let digest = *tx.digest();
         let mut transactions = vec![make_user_tx_v2(
             tx,
@@ -2086,16 +2103,12 @@ async fn test_v2_gas_bounds_out_of_range_dropped() {
             "out-of-bounds-gas V2 should be dropped"
         );
         assert_eq!(dropped.len(), 1, "one dropped entry expected");
-        assert!(
-            matches!(
-                dropped[0].1,
-                IotaError::UserInput {
-                    error: UserInputError::GasPriceUnderRGP { .. }
-                        | UserInputError::GasBudgetTooHigh { .. }
-                }
-            ),
-            "expected a gas-bounds UserInputError, got {:?}",
+        assert_eq!(
             dropped[0].1,
+            IotaError::UserInput {
+                error: expected_error
+            },
+            "unexpected drop reason",
         );
         assert!(
             locks.is_empty(),

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -2014,9 +2014,9 @@ async fn test_v2_cost_out_of_bounds() {
 
 /// A `UserTransactionV2` whose declared gas price or budget is out of the
 /// protocol bounds is dropped post-consensus by the payload-only gas-bounds
-/// check (#8a), before version assignment. The balance check (#8b) still runs
-/// at execution. Two representative cases: gas price below the reference gas
-/// price, and gas budget above the protocol maximum.
+/// check, before version assignment. The balance check still runs at execution.
+/// Two representative cases: gas price below the reference gas price, and gas
+/// budget above the protocol maximum.
 #[sim_test]
 async fn test_v2_gas_bounds_out_of_range_dropped() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
@@ -2041,10 +2041,6 @@ async fn test_v2_gas_bounds_out_of_range_dropped() {
     assert!(rgp > 0, "test requires a non-zero reference gas price");
 
     let protocol_config = epoch_store.protocol_config();
-    // attestor_index 0 == certificate_author_index 0 set by new_test → matches,
-    // so each transaction reaches the gas-bounds check rather than being caught
-    // by the attestor verification (Check #3). `min_units` keeps the attested
-    // computation within the valid range for Check #3.
     let min_units = protocol_config
         .base_tx_cost_fixed()
         .min(protocol_config.gas_rounding_step());

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -16,7 +16,8 @@ use iota_types::{
     executable_transaction::VerifiedExecutableTransaction,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     object::Object,
-    transaction::{TransactionDataAPI, TransactionKey, VerifiedTransaction},
+    transaction::{TransactionData, TransactionDataAPI, TransactionKey, VerifiedTransaction},
+    utils::to_sender_signed_transaction,
 };
 
 use crate::{
@@ -2008,5 +2009,102 @@ async fn test_v2_cost_out_of_bounds() {
             vec![digest],
             "digest must be collected before Check #3 for soft-lock release",
         );
+    }
+}
+
+/// A `UserTransactionV2` whose declared gas price or budget is out of the
+/// protocol bounds is dropped post-consensus by the payload-only gas-bounds
+/// check (#8a), before version assignment. The balance check (#8b) still runs
+/// at execution. Two representative cases: gas price below the reference gas
+/// price, and gas budget above the protocol maximum.
+#[sim_test]
+async fn test_v2_gas_bounds_out_of_range_dropped() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (Address, AccountKeyPair) = get_key_pair();
+    let recipient = get_key_pair::<AccountKeyPair>().0;
+
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+
+    let (authority, _) = init_state_with_objects_and_object_basics(vec![
+        Object::with_id_owner_for_testing(object_id, sender),
+        Object::with_id_owner_for_testing(gas_id, sender),
+    ])
+    .await;
+
+    let epoch_store = authority.epoch_store_for_testing();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    assert!(rgp > 0, "test requires a non-zero reference gas price");
+
+    let protocol_config = epoch_store.protocol_config();
+    // attestor_index 0 == certificate_author_index 0 set by new_test → matches,
+    // so each transaction reaches the gas-bounds check rather than being caught
+    // by the attestor verification (Check #3). `min_units` keeps the attested
+    // computation within the valid range for Check #3.
+    let min_units = protocol_config
+        .base_tx_cost_fixed()
+        .min(protocol_config.gas_rounding_step());
+    let max_tx_gas = protocol_config.max_tx_gas();
+
+    let object_ref = authority.get_object(&object_id).unwrap().object_ref();
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
+
+    // Gas price below the reference gas price → `GasPriceUnderRGP`.
+    let price_under_rgp = make_transfer_object_transaction(
+        object_ref,
+        gas_ref,
+        sender,
+        &sender_key,
+        recipient,
+        rgp - 1,
+    );
+    // Gas budget above the protocol maximum → `GasBudgetTooHigh`.
+    let budget_too_high = to_sender_signed_transaction(
+        TransactionData::new_transfer(recipient, object_ref, sender, gas_ref, max_tx_gas + 1, rgp),
+        &sender_key,
+    );
+
+    for tx in [price_under_rgp, budget_too_high] {
+        let digest = *tx.digest();
+        let mut transactions = vec![make_user_tx_v2(
+            tx,
+            starfish_config::AuthorityIndex::new_for_test(0),
+            min_units,
+        )];
+
+        let (dropped, locks, user_tx_digests) =
+            post_consensus_validation::validate_and_resolve_conflicts(
+                &authority,
+                &epoch_store,
+                &mut transactions,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            transactions.is_empty(),
+            "out-of-bounds-gas V2 should be dropped"
+        );
+        assert_eq!(dropped.len(), 1, "one dropped entry expected");
+        assert!(
+            matches!(
+                dropped[0].1,
+                IotaError::UserInput {
+                    error: UserInputError::GasPriceUnderRGP { .. }
+                        | UserInputError::GasBudgetTooHigh { .. }
+                }
+            ),
+            "expected a gas-bounds UserInputError, got {:?}",
+            dropped[0].1,
+        );
+        assert!(
+            locks.is_empty(),
+            "no locks should be acquired for a dropped transaction"
+        );
+        assert_eq!(user_tx_digests, vec![digest]);
     }
 }

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -124,6 +124,61 @@ pub fn check_coin_deny_list_v1(
     Ok(())
 }
 
+/// Checks `sender` against the deny list of every non-gas coin type among
+/// `objects` while returning an [`ExecutionError`] that folds into
+/// `ExecutionStatus::Failure`.
+///
+/// The read is epoch-gated, so the verdict is the same on every validator.
+pub fn check_coin_deny_list_v1_for_sender_during_execution(
+    sender: Address,
+    objects: &BTreeMap<ObjectId, Object>,
+    cur_epoch: EpochId,
+    object_store: &dyn ObjectStore,
+) -> DenyListResult {
+    let coin_types = objects
+        .values()
+        .filter(|obj| !obj.is_gas_coin())
+        .filter_map(|obj| {
+            obj.coin_type_opt()
+                .map(|coin_type| coin_type.to_canonical_string(false))
+        })
+        .collect::<BTreeSet<_>>();
+    let num_non_gas_coin_owners = coin_types.len() as u64;
+    DenyListResult {
+        result: check_sender_against_coin_types(sender, coin_types, cur_epoch, object_store),
+        num_non_gas_coin_owners,
+    }
+}
+
+fn check_sender_against_coin_types(
+    sender: Address,
+    coin_types: BTreeSet<String>,
+    cur_epoch: EpochId,
+    object_store: &dyn ObjectStore,
+) -> Result<(), ExecutionError> {
+    for coin_type in coin_types {
+        let Some(deny_list) = get_per_type_coin_deny_list_v1(&coin_type, object_store) else {
+            continue;
+        };
+        if check_global_pause(&deny_list, object_store, Some(cur_epoch)) {
+            return Err(ExecutionError::new(
+                ExecutionErrorKind::CoinTypeGlobalPause { coin_type },
+                None,
+            ));
+        }
+        if check_address_denied_by_config(&deny_list, sender, object_store, Some(cur_epoch)) {
+            return Err(ExecutionError::new(
+                ExecutionErrorKind::AddressDeniedForCoin {
+                    address: sender,
+                    coin_type,
+                },
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Returns 1) whether the coin deny list check passed,
 ///         2) the deny lists checked
 ///         2) the number of regulated coin owners checked.

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -7,7 +7,7 @@ use std::{
     fmt,
 };
 
-use iota_sdk_types::{Address, Identifier, ObjectId, StructTag, TypeTag, Version};
+use iota_sdk_types::{Address, Identifier, ObjectId, ObjectReference, StructTag, TypeTag, Version};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tracing::{error, instrument};
 
@@ -125,16 +125,22 @@ pub fn check_coin_deny_list_v1(
 }
 
 /// Checks `sender` against the deny list of every non-gas coin type among
-/// `objects` while returning an [`ExecutionError`] that folds into
-/// `ExecutionStatus::Failure`.
+/// `objects` and the declared `receiving_objects`, while returning an
+/// [`ExecutionError`] that folds into `ExecutionStatus::Failure`.
 ///
 /// The read is epoch-gated, so the verdict is the same on every validator.
 pub fn check_coin_deny_list_v1_for_sender_during_execution(
     sender: Address,
     objects: &BTreeMap<ObjectId, Object>,
+    receiving_objects: &[ObjectReference],
     cur_epoch: EpochId,
     object_store: &dyn ObjectStore,
 ) -> DenyListResult {
+    // A receiving object absent from the store cannot be received (`receive`
+    // aborts), so it is skipped rather than failing the check.
+    let receiving = receiving_objects
+        .iter()
+        .filter_map(|objref| object_store.get_object(&objref.object_id));
     let coin_types = objects
         .values()
         .filter(|obj| !obj.is_gas_coin())
@@ -142,6 +148,13 @@ pub fn check_coin_deny_list_v1_for_sender_during_execution(
             obj.coin_type_opt()
                 .map(|coin_type| coin_type.to_canonical_string(false))
         })
+        .chain(receiving.filter_map(|obj| {
+            if obj.is_gas_coin() {
+                return None;
+            }
+            obj.coin_type_opt()
+                .map(|coin_type| coin_type.to_canonical_string(false))
+        }))
         .collect::<BTreeSet<_>>();
     let num_non_gas_coin_owners = coin_types.len() as u64;
     DenyListResult {

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -116,6 +116,50 @@ pub mod checked {
         }
     }
 
+    /// Validates the transaction's declared gas price and budget against the
+    /// epoch reference gas price and the protocol config bounds.
+    ///
+    /// Payload-only: reads no objects and no frontier state, so it is safe to
+    /// run post-consensus before version assignment. Mirrors the price checks
+    /// in [`IotaGasStatus::check_gas_preconditions`] and the budget-bound
+    /// checks in `IotaGasStatusV1::check_gas_balance`, without touching gas
+    /// coins.
+    pub fn check_gas_bounds(
+        config: &ProtocolConfig,
+        reference_gas_price: u64,
+        gas_price: u64,
+        gas_budget: u64,
+    ) -> UserInputResult<()> {
+        if gas_price < reference_gas_price {
+            return Err(UserInputError::GasPriceUnderRGP {
+                gas_price,
+                reference_gas_price,
+            });
+        }
+        if gas_price > config.max_gas_price() {
+            return Err(UserInputError::GasPriceTooHigh {
+                max_gas_price: config.max_gas_price(),
+            });
+        }
+        let max_gas_budget = config.max_tx_gas();
+        // Uses the transaction `gas_price`, not the reference gas price, to match
+        // `IotaCostTable::new`.
+        let min_transaction_cost = config.base_tx_cost_fixed() * gas_price;
+        if gas_budget > max_gas_budget {
+            return Err(UserInputError::GasBudgetTooHigh {
+                gas_budget,
+                max_budget: max_gas_budget,
+            });
+        }
+        if gas_budget < min_transaction_cost {
+            return Err(UserInputError::GasBudgetTooLow {
+                gas_budget,
+                min_budget: min_transaction_cost,
+            });
+        }
+        Ok(())
+    }
+
     // Helper functions to deal with gas coins operations.
 
     pub fn deduct_gas(gas_object: &mut Object, charge_or_rebate: i64) {

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -15,7 +15,10 @@ pub mod checked {
     use crate::{
         ObjectId,
         error::{ExecutionError, IotaResult, UserInputError, UserInputResult},
-        gas_model::{gas_v1::IotaGasStatus as IotaGasStatusV1, tables::GasStatus},
+        gas_model::{
+            gas_v1::{IotaGasStatus as IotaGasStatusV1, min_transaction_cost},
+            tables::GasStatus,
+        },
         object::{MoveStructExt, Object},
         transaction::ObjectReadResult,
     };
@@ -142,9 +145,7 @@ pub mod checked {
             });
         }
         let max_gas_budget = config.max_tx_gas();
-        // Uses the transaction `gas_price`, not the reference gas price, to match
-        // `IotaCostTable::new`.
-        let min_transaction_cost = config.base_tx_cost_fixed() * gas_price;
+        let min_transaction_cost = min_transaction_cost(config, gas_price);
         if gas_budget > max_gas_budget {
             return Err(UserInputError::GasBudgetTooHigh {
                 gas_budget,

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -121,7 +121,7 @@ pub mod checked {
     ///
     /// Payload-only: reads no objects and no frontier state, so it is safe to
     /// run post-consensus before version assignment. Mirrors the price checks
-    /// in [`IotaGasStatus::check_gas_preconditions`] and the budget-bound
+    /// in `IotaGasStatus::check_gas_preconditions` and the budget-bound
     /// checks in `IotaGasStatusV1::check_gas_balance`, without touching gas
     /// coins.
     pub fn check_gas_bounds(

--- a/crates/iota-types/src/gas_model/gas_v1.rs
+++ b/crates/iota-types/src/gas_model/gas_v1.rs
@@ -119,13 +119,15 @@ mod checked {
         }
     }
 
+    /// The flat fee charged for every transaction.
+    pub(crate) fn min_transaction_cost(config: &ProtocolConfig, gas_price: u64) -> u64 {
+        config.base_tx_cost_fixed() * gas_price
+    }
+
     impl IotaCostTable {
         pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
-            // gas_price here is the Reference Gas Price, however we may decide
-            // to change it to be the price passed in the transaction
-            let min_transaction_cost = c.base_tx_cost_fixed() * gas_price;
             Self {
-                min_transaction_cost,
+                min_transaction_cost: min_transaction_cost(c, gas_price),
                 max_gas_budget: c.max_tx_gas(),
                 package_publish_per_byte_cost: c.package_publish_cost_per_byte(),
                 object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -850,18 +850,21 @@ mod checked {
                 cancelled_objects,
             )?;
 
-            // Coin deny-list check over the input objects for attested
-            // transactions. Enforced here (fail-to-effects, issuer pays) rather
-            // than post-consensus, so a stale-attestation view resolves to an
-            // execution failure instead of being dropped. Gated on the
-            // attestation flag so V1 and historical replay are byte-identical.
-            if protocol_config.enable_validator_attestation() {
-                temporary_store.check_input_coin_deny_list()?;
-            }
-
-            // If the pre-execution succeeded, proceed with the main execution loop
-            // else propagate the pre-execution error
+            // If the pre-execution (Move authentication) succeeded, proceed with
+            // the main execution loop; else propagate the pre-execution error.
             let mut execution_result = pre_execution_result_opt.unwrap_or(Ok(())).and_then(|_| {
+                // Coin deny-list check over the input objects for attested
+                // transactions. Runs only after Move authentication has
+                // succeeded, so an authentication failure — which is not
+                // attributable to the issuer — is never masked by a coin-deny
+                // failure that would charge the issuer. Enforced here
+                // (fail-to-effects, issuer pays) rather than post-consensus, so a
+                // stale-attestation view resolves to an execution failure instead
+                // of being dropped. Gated on the attestation flag so V1 and
+                // historical replay are byte-identical.
+                if protocol_config.enable_validator_attestation() {
+                    temporary_store.check_input_coin_deny_list()?;
+                }
                 execution_loop::<Mode>(
                     temporary_store,
                     transaction_kind,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -857,7 +857,8 @@ mod checked {
             // If the pre-execution (Move authentication) succeeded, proceed with
             // the main execution loop; else propagate the pre-execution error.
             let mut execution_result = pre_execution_result_opt.unwrap_or(Ok(())).and_then(|_| {
-                // Coin deny-list check over the input objects for attested transactions. Runs
+                // Coin deny-list check over the input and declared receiving
+                // objects for attested transactions. Runs
                 // only after Move authentication has succeeded, so an authentication failure —
                 // which is not attributable to the issuer — is never masked by a coin-deny
                 // failure that would charge the issuer. Enforced here so a stale-attestation

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -48,7 +48,7 @@ mod checked {
         object::{OBJECT_START_VERSION, Object, ObjectInner},
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         randomness_state::RANDOMNESS_STATE_UPDATE_FUNCTION_NAME,
-        storage::{BackingStore, Storage},
+        storage::{BackingStore, DenyListResult, Storage},
         transaction::{CallArg, CheckedInputObjects, InputObjects, TransactionKindExt},
     };
     use move_binary_format::CompiledModule;
@@ -834,6 +834,10 @@ mod checked {
         let is_genesis_or_epoch_change_tx = matches!(transaction_kind, TransactionKind::Genesis(_))
             || transaction_kind.is_end_of_epoch();
 
+        let is_system_tx = transaction_kind.is_system();
+
+        let sender = tx_ctx.borrow().sender();
+
         let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
 
         let tx_digest = tx_ctx.borrow().digest();
@@ -853,17 +857,24 @@ mod checked {
             // If the pre-execution (Move authentication) succeeded, proceed with
             // the main execution loop; else propagate the pre-execution error.
             let mut execution_result = pre_execution_result_opt.unwrap_or(Ok(())).and_then(|_| {
-                // Coin deny-list check over the input objects for attested
-                // transactions. Runs only after Move authentication has
-                // succeeded, so an authentication failure — which is not
-                // attributable to the issuer — is never masked by a coin-deny
-                // failure that would charge the issuer. Enforced here
-                // (fail-to-effects, issuer pays) rather than post-consensus, so a
-                // stale-attestation view resolves to an execution failure instead
-                // of being dropped. Gated on the attestation flag so V1 and
-                // historical replay are byte-identical.
-                if protocol_config.enable_validator_attestation() {
-                    temporary_store.check_input_coin_deny_list()?;
+                // Coin deny-list check over the input objects for attested transactions. Runs
+                // only after Move authentication has succeeded, so an authentication failure —
+                // which is not attributable to the issuer — is never masked by a coin-deny
+                // failure that would charge the issuer. Enforced here so a stale-attestation
+                // view resolves to an execution failure instead of being dropped.
+                //
+                // Gated on the attestation flag. `UserTransactionV1` is rejected by the
+                // consensus verifier once the flag is on, so every user transaction reaching
+                // this point is attested; epochs before the flag flips are unaffected. System
+                // transactions are never attested and hold no address-owned coin inputs, so
+                // they are excluded.
+                if protocol_config.enable_validator_attestation() && !is_system_tx {
+                    let DenyListResult {
+                        result,
+                        num_non_gas_coin_owners,
+                    } = temporary_store.check_input_coin_deny_list(sender);
+                    gas_charger.charge_coin_transfers(protocol_config, num_non_gas_coin_owners)?;
+                    result?;
                 }
                 execution_loop::<Mode>(
                     temporary_store,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -850,6 +850,15 @@ mod checked {
                 cancelled_objects,
             )?;
 
+            // Coin deny-list check over the input objects for attested
+            // transactions. Enforced here (fail-to-effects, issuer pays) rather
+            // than post-consensus, so a stale-attestation view resolves to an
+            // execution failure instead of being dropped. Gated on the
+            // attestation flag so V1 and historical replay are byte-identical.
+            if protocol_config.enable_validator_attestation() {
+                temporary_store.check_input_coin_deny_list()?;
+            }
+
             // If the pre-execution succeeded, proceed with the main execution loop
             // else propagate the pre-execution error
             let mut execution_result = pre_execution_result_opt.unwrap_or(Ok(())).and_then(|_| {

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -850,13 +850,14 @@ type ModifiedObjectInfo<'a> = (
 );
 
 impl TemporaryStore<'_> {
-    /// Coin deny-list check over the transaction's input objects, run during
-    /// execution of attested transactions. Checks `sender` against every
-    /// non-gas input coin type.
+    /// Coin deny-list check over the transaction's input and declared
+    /// receiving objects, run during execution of attested transactions.
+    /// Checks `sender` against every non-gas coin type among them.
     pub(crate) fn check_input_coin_deny_list(&self, sender: Address) -> DenyListResult {
         let result = check_coin_deny_list_v1_for_sender_during_execution(
             sender,
             &self.input_objects,
+            &self.receiving_objects,
             self.cur_epoch,
             self.store.as_object_store(),
         );

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -19,7 +19,10 @@ use iota_types::{
     auth_context::AuthContext,
     base_types::VersionDigest,
     committee::EpochId,
-    deny_list_v1::check_coin_deny_list_v1_during_execution,
+    deny_list_v1::{
+        check_coin_deny_list_v1_during_execution,
+        check_coin_deny_list_v1_for_sender_during_execution,
+    },
     effects::{
         EffectsObjectChange, IDOperation, ObjectIn, ObjectOut, TransactionEffects,
         TransactionEffectsExt, TransactionEvents,
@@ -847,22 +850,31 @@ type ModifiedObjectInfo<'a> = (
 );
 
 impl TemporaryStore<'_> {
-    /// Sender-side coin deny-list check over the transaction's input objects,
-    /// run during execution of attested transactions.
-    ///
-    /// Reuses [`check_coin_deny_list_v1_during_execution`], which checks
-    /// whether each coin's owner is denied for its type — for an owned
-    /// input coin that owner is the sender, so this reproduces the
-    /// sender-side check while returning an [`ExecutionError`] that folds
-    /// into `ExecutionStatus::Failure` rather than aborting a must-execute
-    /// certificate.
-    pub(crate) fn check_input_coin_deny_list(&self) -> Result<(), ExecutionError> {
-        check_coin_deny_list_v1_during_execution(
+    /// Coin deny-list check over the transaction's input objects, run during
+    /// execution of attested transactions. Checks `sender` against every
+    /// non-gas input coin type.
+    pub(crate) fn check_input_coin_deny_list(&self, sender: Address) -> DenyListResult {
+        let result = check_coin_deny_list_v1_for_sender_during_execution(
+            sender,
             &self.input_objects,
             self.cur_epoch,
             self.store.as_object_store(),
-        )
-        .result
+        );
+        self.record_deny_list_read(result.num_non_gas_coin_owners);
+        result
+    }
+
+    /// Records the deny-list object as a per-epoch config read in the effects
+    /// when the check examined at least one coin.
+    fn record_deny_list_read(&self, num_non_gas_coin_owners: u64) {
+        // The denylist object is only loaded if there are regulated transfers.
+        // And also if we already have it in the input there is no need to commit it
+        // again in the effects.
+        if num_non_gas_coin_owners > 0 && !self.input_objects.contains_key(&ObjectId::DENY_LIST) {
+            self.loaded_per_epoch_config_objects
+                .write()
+                .insert(ObjectId::DENY_LIST);
+        }
     }
 
     fn get_input_iota(
@@ -1159,16 +1171,7 @@ impl Storage for TemporaryStore<'_> {
             self.cur_epoch,
             self.store.as_object_store(),
         );
-        // The denylist object is only loaded if there are regulated transfers.
-        // And also if we already have it in the input there is no need to commit it
-        // again in the effects.
-        if result.num_non_gas_coin_owners > 0
-            && !self.input_objects.contains_key(&ObjectId::DENY_LIST)
-        {
-            self.loaded_per_epoch_config_objects
-                .write()
-                .insert(ObjectId::DENY_LIST);
-        }
+        self.record_deny_list_read(result.num_non_gas_coin_owners);
         result
     }
 

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -847,6 +847,24 @@ type ModifiedObjectInfo<'a> = (
 );
 
 impl TemporaryStore<'_> {
+    /// Sender-side coin deny-list check over the transaction's input objects,
+    /// run during execution of attested transactions.
+    ///
+    /// Reuses [`check_coin_deny_list_v1_during_execution`], which checks
+    /// whether each coin's owner is denied for its type — for an owned
+    /// input coin that owner is the sender, so this reproduces the
+    /// sender-side check while returning an [`ExecutionError`] that folds
+    /// into `ExecutionStatus::Failure` rather than aborting a must-execute
+    /// certificate.
+    pub(crate) fn check_input_coin_deny_list(&self) -> Result<(), ExecutionError> {
+        check_coin_deny_list_v1_during_execution(
+            &self.input_objects,
+            self.cur_epoch,
+            self.store.as_object_store(),
+        )
+        .result
+    }
+
     fn get_input_iota(
         &self,
         id: &ObjectId,


### PR DESCRIPTION
# Description of change

Phase 1 of the [attestation check reordering](https://github.com/iotaledger/iota-private/issues/438#issuecomment-4939701267): move pre-execution checks to the pipeline stage where their verdict is deterministic across validators, for attested `UserTransactionV2` transactions. All changes are gated behind `enable_validator_attestation` / `enable_pcool_flow` flags, so no released network behavior changes and no protocol-version bump / snapshot regeneration is required.

- **# 8a gas bounds/price** → post-consensus. New payload-only `check_gas_bounds` (`iota-types/gas.rs`) runs as a deterministic drop before version assignment; the balance check (# 8b) still runs at execution, where it depends on state this commit has not applied yet.
- **# 10 coin deny list** → execution. Removed the post-consensus re-check for attested txns (`check_coin_deny_list_for_attested_tx`); enforced during execution via `TemporaryStore::check_input_coin_deny_list`, which checks the sender against every non-gas input coin type (`check_coin_deny_list_v1_for_sender_during_execution`) — the same predicate the pre-execution `check_coin_deny_list_v1` applies, so moving the check does not change which transactions are denied. A denied coin now fails to effects with the existing `AddressDeniedForCoin` / `CoinTypeGlobalPause` status (issuer pays gas). The check charges `charge_coin_transfers` for the settings it reads and records the deny-list object as a per-epoch config read, matching the written-objects check; system transactions are excluded, as they are never attested.
- **# 9c duplicate object refs** — no change; already enforced post-consensus via `validity_check` (Check # 2) for both V1 and V2.

Also included: `min_transaction_cost` is extracted in `iota-types/gas_model/gas_v1.rs` so `check_gas_bounds` and `IotaCostTable::new` no longer duplicate the formula.

With validator attestation enabled, the coin deny-list check runs twice per user transaction and each run charges gas:
- pre-execution: one deny-list read charged per distinct non-gas coin type among the transaction inputs, Move-authenticator inputs, and declared receiving objects — whether or not the type is regulated;
- after execution (pre-existing): one read charged per new owner of each written non-gas coin.
Net effect: a transaction that spends a coin and writes one back pays both charges; without attestation only the write-time charge applies.

This PR only addresses check placement. Deferred to a follow-up PR:

- Authentication-failure who-pays: at real execution (`prepare_certificate`) the `authentication_failed` bit is currently ignored, so a transaction that reaches execution with a failed Move authentication is still committed as a gas-charged failure effect. Under an honest attestor this never happens (auth-failed txns are dropped at attestation); under a Byzantine attestor it charges an author who never authenticated the transaction. Phase 2 (#12465) surfaces that bit and routes it to an attestor-attributable (`InvalidAttestation`) effect.
- Coin deny list over receiving objects: the removed post-consensus check tested the sender against coin types from inputs **and** receiving objects; the execution-side check sees input objects only, since receiving objects are resolved lazily by `receive()`. A denied sender spending a regulated coin received into an object they own is therefore no longer blocked for attested transactions — an honest attestor still catches it at attestation time, so this only matters against a stale or lying attestor. Belongs to the coin deny-list rework.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota-private/issues/438.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Added `test_v2_gas_bounds_out_of_range_dropped` (# 8a) and `test_execution_fails_spending_denied_coin_under_attestation` (# 10), the latter asserting the failure status, the executor's error, gas charged to the issuer, and the deny-list per-epoch config entry in the effects. Not covered, since the coin deny-list check is being revisited: an attested transaction surviving post-consensus validation (rather than being dropped), and the sender-vs-owner predicate — both need a V2 fixture with a Move authenticator. Regression: `gas_tests`, `coin_deny_list_tests`, `post_consensus_validation_tests`, `validator_v2_tests` pass; `cargo +nightly fmt` and clippy clean.

### Release Notes

- [x] Protocol: with validator attestation enabled, transactions additionally pay one deny-list read per non-gas input/receiving coin type (on top of the existing per-new-owner charge after execution).
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---
