### PR TITLE
fix(docs): import SignatureScheme and UserSignature from the SDK in Rust examples

### DIFF
--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3248,6 +3248,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-names",
+ "iota-protocol-config",
  "iota-sdk-types",
  "iota-types",
  "move-vm-config",

--- a/docs/examples/rust/abstract_account/authenticator-inputs-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-inputs-cryptographic-protection.rs
@@ -20,16 +20,16 @@ use iota_sdk::{
     IotaClient, IotaClientBuilder,
     rpc_types::{IotaTransactionBlockEffectsAPI, ObjectChange},
     types::{
-        crypto::SignatureScheme, programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::Transaction,
+        programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::Transaction,
     },
 };
 use iota_sdk_types::{
-    Address, Argument, Identifier, ObjectId, ObjectReference, Owner, SharedObjectReference, TypeTag,
+    Address, Argument, Identifier, ObjectId, ObjectReference, Owner, SharedObjectReference,
+    SignatureScheme, TypeTag, UserSignature,
 };
 use iota_types::{
-    crypto::PublicKey, move_authenticator::MoveAuthenticatorExt, signature::UserSignature,
-    transaction::CallArg, utils::MoveAuthenticatorV1,
+    crypto::PublicKey, move_authenticator::MoveAuthenticatorExt, transaction::CallArg,
+    utils::MoveAuthenticatorV1,
 };
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/abstract_account/authenticator-shared-object-swap.rs
+++ b/docs/examples/rust/abstract_account/authenticator-shared-object-swap.rs
@@ -17,16 +17,16 @@ use iota_sdk::{
     IotaClient, IotaClientBuilder,
     rpc_types::{IotaTransactionBlockEffectsAPI, ObjectChange},
     types::{
-        crypto::SignatureScheme, programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::Transaction,
+        programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::Transaction,
     },
 };
 use iota_sdk_types::{
-    Address, Argument, Identifier, ObjectId, ObjectReference, Owner, SharedObjectReference, TypeTag,
+    Address, Argument, Identifier, ObjectId, ObjectReference, Owner, SharedObjectReference,
+    SignatureScheme, TypeTag, UserSignature,
 };
 use iota_types::{
-    crypto::PublicKey, move_authenticator::MoveAuthenticatorExt, signature::UserSignature,
-    transaction::CallArg, utils::MoveAuthenticatorV1,
+    crypto::PublicKey, move_authenticator::MoveAuthenticatorExt, transaction::CallArg,
+    utils::MoveAuthenticatorV1,
 };
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
@@ -12,16 +12,13 @@ use docs_examples::utils::{
     request_tokens_from_faucet,
 };
 use iota_keys::keystore::{AccountKeystore, InMemKeystore};
-use iota_sdk::{
-    IotaClient, IotaClientBuilder, rpc_types::ObjectChange, types::crypto::SignatureScheme,
-};
+use iota_sdk::{IotaClient, IotaClientBuilder, rpc_types::ObjectChange};
 use iota_sdk_types::{
     Address, Argument, Identifier, ObjectId, ObjectReference, Owner, SharedObjectReference,
-    TransactionKind, TypeTag,
+    SignatureScheme, TransactionKind, TypeTag, UserSignature,
 };
 use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    signature::UserSignature,
     transaction::{CallArg, Transaction, TransactionData},
     utils::MoveAuthenticatorV1,
 };

--- a/docs/examples/rust/src/utils.rs
+++ b/docs/examples/rust/src/utils.rs
@@ -20,13 +20,14 @@ use iota_sdk::{
         IotaTransactionBlockResponseOptions, ObjectChange,
     },
     types::{
-        crypto::SignatureScheme,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
         transaction::{Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Address, ObjectId, ObjectReference, ProgrammableTransaction, crypto::Intent};
+use iota_sdk_types::{
+    Address, ObjectId, ObjectReference, ProgrammableTransaction, SignatureScheme, crypto::Intent,
+};
 use iota_types::{move_package, transaction::TransactionDataAPI};
 use reqwest::Client;
 use serde::Deserialize;

--- a/docs/examples/rust/stardust/address-unlock-condition.rs
+++ b/docs/examples/rust/stardust/address-unlock-condition.rs
@@ -18,7 +18,6 @@ use iota_sdk::{
         IotaTransactionBlockResponseOptions,
     },
     types::{
-        crypto::SignatureScheme,
         dynamic_field::DynamicFieldName,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -27,7 +26,7 @@ use iota_sdk::{
         transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, SignatureScheme, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs

--- a/docs/examples/rust/stardust/alias-migration.rs
+++ b/docs/examples/rust/stardust/alias-migration.rs
@@ -15,7 +15,6 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaData, IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        crypto::SignatureScheme,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
@@ -23,7 +22,7 @@ use iota_sdk::{
         transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, SignatureScheme, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/alias-output-claim.rs
+++ b/docs/examples/rust/stardust/alias-output-claim.rs
@@ -14,7 +14,6 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaData, IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        crypto::SignatureScheme,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
@@ -22,7 +21,7 @@ use iota_sdk::{
         transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, SignatureScheme, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/basic-output-claim.rs
+++ b/docs/examples/rust/stardust/basic-output-claim.rs
@@ -14,7 +14,6 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaData, IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        crypto::SignatureScheme,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
@@ -22,7 +21,7 @@ use iota_sdk::{
         transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, SignatureScheme, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/foundry-output-claim.rs
+++ b/docs/examples/rust/stardust/foundry-output-claim.rs
@@ -15,7 +15,6 @@ use iota_sdk::{
     },
     types::{
         coin_manager::CoinManagerTreasuryCap,
-        crypto::SignatureScheme,
         dynamic_field::DynamicFieldName,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -23,7 +22,9 @@ use iota_sdk::{
         transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, StructTag, TypeTag, crypto::Intent};
+use iota_sdk_types::{
+    Argument, Identifier, ObjectId, SignatureScheme, StructTag, TypeTag, crypto::Intent,
+};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs

--- a/docs/examples/rust/stardust/iota-self-sponsor.rs
+++ b/docs/examples/rust/stardust/iota-self-sponsor.rs
@@ -15,14 +15,13 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        crypto::SignatureScheme,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
         transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, SignatureScheme, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 pub const IOTA_COIN_TYPE: u32 = 4218;

--- a/docs/examples/rust/stardust/nft-migration.rs
+++ b/docs/examples/rust/stardust/nft-migration.rs
@@ -12,14 +12,13 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        crypto::SignatureScheme,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
         transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, SignatureScheme, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs

--- a/docs/examples/rust/stardust/nft-output-claim.rs
+++ b/docs/examples/rust/stardust/nft-output-claim.rs
@@ -14,7 +14,6 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::{IotaData, IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
     types::{
-        crypto::SignatureScheme,
         gas_coin::GAS,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         quorum_driver_types::ExecuteTransactionRequestType,
@@ -22,7 +21,7 @@ use iota_sdk::{
         transaction::{CallArg, Transaction, TransactionData},
     },
 };
-use iota_sdk_types::{Argument, Identifier, ObjectId, TypeTag, crypto::Intent};
+use iota_sdk_types::{Argument, Identifier, ObjectId, SignatureScheme, TypeTag, crypto::Intent};
 use iota_types::transaction::TransactionDataAPI;
 
 /// Got from iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs


### PR DESCRIPTION
# Description of change

Follow-up to #12342 and #12277: the Rust docs examples still imported `SignatureScheme` and `UserSignature` from `iota_types` / `iota_sdk::types::crypto`. Import them from `iota_sdk_types` instead, and update the examples' `Cargo.lock`.

## Links to any relevant issues

None.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)