### PR TITLE
feat(iota-protocol-config): enable StarfishSpeed on testnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -187,6 +187,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 // Version 32: Move validator count limits (min/max validator count) and
 //             stake thresholds (joining stake, low/very low stake
 //             thresholds, grace period) into the protocol config.
+//             Enable the optimistic commit rule (StarfishSpeed) in Starfish
+//             consensus on testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3103,6 +3105,12 @@ impl ProtocolConfig {
                     cfg.validator_low_stake_threshold = Some(1_500_000_000_000_000);
                     cfg.validator_very_low_stake_threshold = Some(1_000_000_000_000_000);
                     cfg.validator_low_stake_grace_period = Some(7);
+
+                    if chain != Chain::Mainnet {
+                        // Enable the optimistic commit rule (StarfishSpeed) in
+                        // Starfish consensus.
+                        cfg.feature_flags.consensus_starfish_speed = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_32.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_32.snap
@@ -45,6 +45,7 @@ feature_flags:
   move_native_tx_context: true
   additional_borrow_checks: true
   pre_consensus_sponsor_only_move_authentication: true
+  consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
   validator_metadata_verify_v2: true
   report_move_authentication_error: true


### PR DESCRIPTION
# Description of change

Enable the optimistic commit rule (StarfishSpeed) in Starfish consensus on testnet.

## Links to any relevant issues

fixes #12427

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable the optimistic commit rule (StarfishSpeed) in Starfish consensus on testnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
