### PR TITLE
fix(iota-core,iota-e2e-tests): make the checkpoint-inclusion wait survive epoch boundaries

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3961,9 +3961,8 @@ impl AuthorityState {
     /// already checkpointed.
     ///
     /// The wait survives epoch boundaries: a transaction in flight at a
-    /// boundary is checkpointed in the next epoch (executed-but-not-
-    /// checkpointed transactions are reverted at epoch end and resubmitted),
-    /// and still resolves here under the original deadline.
+    /// boundary may only be checkpointed in the next epoch, and still resolves
+    /// here under the original deadline.
     pub async fn wait_for_checkpoint_inclusion(
         &self,
         digests: &[TransactionDigest],
@@ -4003,7 +4002,7 @@ impl AuthorityState {
             }
 
             // The epoch ended mid-wait, and this epoch store's notifications
-            // can no longer fire: transactions executed near the boundary are
+            // can no longer fire: whatever is still uncheckpointed here is
             // checkpointed in the next epoch, on the next store. Cancelling
             // the wait may also have dropped notifications it had already
             // received, but the table write precedes each notification, so

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3959,35 +3959,111 @@ impl AuthorityState {
     /// `(checkpoint_sequence_number, checkpoint_timestamp_ms)`.
     /// On timeout, returns partial results for any transactions that were
     /// already checkpointed.
+    ///
+    /// The wait survives epoch boundaries: a transaction in flight at a
+    /// boundary is checkpointed in the next epoch (executed-but-not-
+    /// checkpointed transactions are reverted at epoch end and resubmitted),
+    /// and still resolves here under the original deadline.
     pub async fn wait_for_checkpoint_inclusion(
         &self,
         digests: &[TransactionDigest],
         timeout: Duration,
     ) -> IotaResult<BTreeMap<TransactionDigest, (CheckpointSequenceNumber, u64)>> {
-        let epoch_store = self.load_epoch_store_one_call_per_task();
+        // There is no notification for the epoch-store swap, and termination
+        // and swap can come in either order (`reconfigure` terminates the old
+        // epoch first, `reconfigure_for_testing` swaps first), so after epoch
+        // termination the swap is polled at this interval.
+        const EPOCH_STORE_SWAP_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-        // Local cache so multiple transactions in the same checkpoint only
-        // trigger a single checkpoint summary lookup.
+        let deadline = tokio::time::Instant::now() + timeout;
         let mut checkpoint_timestamp_cache = HashMap::<CheckpointSequenceNumber, u64>::new();
+        let mut results = BTreeMap::new();
+        let mut remaining = digests.to_vec();
+        // Deliberately re-loaded after each epoch termination below; the
+        // one-call-per-task rule guards against *unaware* mixing of epoch
+        // stores within a task.
+        let mut epoch_store = self.load_epoch_store_one_call_per_task().clone();
 
-        let results = epoch_store
-            .wait_for_transactions_in_checkpoint_with_timeout(digests, timeout, |seq| {
-                *checkpoint_timestamp_cache.entry(seq).or_insert_with(|| {
-                    self.get_checkpoint_by_sequence_number(seq)
-                        .ok()
-                        .flatten()
-                        .map(|c| c.timestamp_ms)
-                        .unwrap_or(0)
+        loop {
+            let wait = epoch_store.wait_for_transactions_in_checkpoint_with_timeout(
+                &remaining,
+                deadline.saturating_duration_since(tokio::time::Instant::now()),
+                |seq| self.checkpoint_timestamp_ms_cached(seq, &mut checkpoint_timestamp_cache),
+            );
+            tokio::select! {
+                wait_results = wait => {
+                    for (digest, seq_and_ts) in remaining.iter().zip(wait_results?) {
+                        if let Some(seq_and_ts) = seq_and_ts {
+                            results.insert(*digest, seq_and_ts);
+                        }
+                    }
+                    return Ok(results);
+                }
+                _ = epoch_store.wait_epoch_terminated() => {}
+            }
+
+            // The epoch ended mid-wait, and this epoch store's notifications
+            // can no longer fire: transactions executed near the boundary are
+            // checkpointed in the next epoch, on the next store. Cancelling
+            // the wait may also have dropped notifications it had already
+            // received, but the table write precedes each notification, so
+            // re-reading the table recovers them.
+            let found = match epoch_store.multi_get_transaction_checkpoint(&remaining) {
+                Ok(found) => found,
+                // The table handles were already released. They are released
+                // long after the epoch's checkpoints are executed, so nothing
+                // waited on here can still be checkpointed in the old epoch;
+                // move on to the next store.
+                Err(IotaError::EpochEnded(_)) => vec![None; remaining.len()],
+                Err(err) => return Err(err),
+            };
+            remaining = remaining
+                .iter()
+                .zip(found)
+                .filter_map(|(digest, found_seq)| match found_seq {
+                    Some(seq) => {
+                        let ts = self
+                            .checkpoint_timestamp_ms_cached(seq, &mut checkpoint_timestamp_cache);
+                        results.insert(*digest, (seq, ts));
+                        None
+                    }
+                    None => Some(*digest),
                 })
-            })
-            .await?;
+                .collect();
+            if remaining.is_empty() {
+                return Ok(results);
+            }
 
-        Ok(digests
-            .iter()
-            .copied()
-            .zip(results)
-            .filter_map(|(digest, opt)| opt.map(|seq_and_ts| (digest, seq_and_ts)))
-            .collect())
+            // Hop to the next epoch's store, bounded by the caller's deadline.
+            let prev_epoch = epoch_store.epoch();
+            epoch_store = loop {
+                let current = self.load_epoch_store_one_call_per_task().clone();
+                if current.epoch() > prev_epoch {
+                    break current;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    return Ok(results);
+                }
+                tokio::time::sleep(EPOCH_STORE_SWAP_POLL_INTERVAL).await;
+            };
+        }
+    }
+
+    /// Resolve a checkpoint's timestamp, memoizing lookups in `cache` so
+    /// multiple transactions in the same checkpoint trigger a single
+    /// checkpoint summary lookup.
+    fn checkpoint_timestamp_ms_cached(
+        &self,
+        seq: CheckpointSequenceNumber,
+        cache: &mut HashMap<CheckpointSequenceNumber, u64>,
+    ) -> u64 {
+        *cache.entry(seq).or_insert_with(|| {
+            self.get_checkpoint_by_sequence_number(seq)
+                .ok()
+                .flatten()
+                .map(|c| c.timestamp_ms)
+                .unwrap_or(0)
+        })
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3968,19 +3968,10 @@ impl AuthorityState {
         digests: &[TransactionDigest],
         timeout: Duration,
     ) -> IotaResult<BTreeMap<TransactionDigest, (CheckpointSequenceNumber, u64)>> {
-        // There is no notification for the epoch-store swap, and termination
-        // and swap can come in either order (`reconfigure` terminates the old
-        // epoch first, `reconfigure_for_testing` swaps first), so after epoch
-        // termination the swap is polled at this interval.
-        const EPOCH_STORE_SWAP_POLL_INTERVAL: Duration = Duration::from_millis(100);
-
         let deadline = tokio::time::Instant::now() + timeout;
         let mut checkpoint_timestamp_cache = HashMap::<CheckpointSequenceNumber, u64>::new();
         let mut results = BTreeMap::new();
         let mut remaining = digests.to_vec();
-        // Deliberately re-loaded after each epoch termination below; the
-        // one-call-per-task rule guards against *unaware* mixing of epoch
-        // stores within a task.
         let mut epoch_store = self.load_epoch_store_one_call_per_task().clone();
 
         loop {
@@ -4016,35 +4007,56 @@ impl AuthorityState {
                 Err(IotaError::EpochEnded(_)) => vec![None; remaining.len()],
                 Err(err) => return Err(err),
             };
-            remaining = remaining
-                .iter()
-                .zip(found)
-                .filter_map(|(digest, found_seq)| match found_seq {
+            let mut still_uncheckpointed = Vec::new();
+            for (digest, found_seq) in remaining.iter().zip(found) {
+                match found_seq {
                     Some(seq) => {
                         let ts = self
                             .checkpoint_timestamp_ms_cached(seq, &mut checkpoint_timestamp_cache);
                         results.insert(*digest, (seq, ts));
-                        None
                     }
-                    None => Some(*digest),
-                })
-                .collect();
+                    None => still_uncheckpointed.push(*digest),
+                }
+            }
+            remaining = still_uncheckpointed;
             if remaining.is_empty() {
                 return Ok(results);
             }
 
-            // Hop to the next epoch's store, bounded by the caller's deadline.
-            let prev_epoch = epoch_store.epoch();
-            epoch_store = loop {
-                let current = self.load_epoch_store_one_call_per_task().clone();
-                if current.epoch() > prev_epoch {
-                    break current;
-                }
-                if tokio::time::Instant::now() >= deadline {
-                    return Ok(results);
-                }
-                tokio::time::sleep(EPOCH_STORE_SWAP_POLL_INTERVAL).await;
-            };
+            match self
+                .wait_for_next_epoch_store(epoch_store.epoch(), deadline)
+                .await
+            {
+                Some(next) => epoch_store = next,
+                None => return Ok(results),
+            }
+        }
+    }
+
+    /// Wait for the epoch store to be swapped to an epoch later than
+    /// `prev_epoch`, returning `None` if `deadline` passes first.
+    async fn wait_for_next_epoch_store(
+        &self,
+        prev_epoch: EpochId,
+        deadline: tokio::time::Instant,
+    ) -> Option<Arc<AuthorityPerEpochStore>> {
+        // There is no notification for the epoch-store swap, and termination
+        // and swap can come in either order (`reconfigure` terminates the old
+        // epoch first, `reconfigure_for_testing` swaps first), so the swap is
+        // polled at this interval.
+        const EPOCH_STORE_SWAP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+        loop {
+            // Deliberately re-loaded on each poll; the one-call-per-task rule
+            // guards against *unaware* mixing of epoch stores within a task.
+            let current = self.load_epoch_store_one_call_per_task().clone();
+            if current.epoch() > prev_epoch {
+                return Some(current);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(EPOCH_STORE_SWAP_POLL_INTERVAL).await;
         }
     }
 

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -181,6 +181,89 @@ async fn wait_for_transactions_in_checkpoint_times_out_without_notify() {
     );
 }
 
+#[tokio::test]
+async fn wait_for_checkpoint_inclusion_resolves_across_reconfiguration() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let digest = TransactionDigest::random();
+    let seq = 5;
+    let ts = 1_700_000_000_000;
+
+    let state = authority_state.clone();
+    let waiter = tokio::spawn(async move {
+        state
+            .wait_for_checkpoint_inclusion(&[digest], Duration::from_secs(30))
+            .await
+    });
+    // Let the waiter register on the current (soon-to-be-old) epoch store.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    authority_state.reconfigure_for_testing().await;
+    // Let the waiter hop to the new epoch store and register there, so the
+    // mapping below is delivered through the notification path (which carries
+    // the timestamp; the DB-read path would fall back to a checkpoint summary
+    // lookup that has nothing to find in this test).
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // The mapping lands in the next epoch's store, as happens for transactions
+    // executed near the boundary (reverted at epoch end and resubmitted into
+    // the next epoch).
+    authority_state
+        .epoch_store_for_testing()
+        .insert_finalized_transactions(&[digest], seq, ts)
+        .expect("insert_finalized_transactions should succeed");
+
+    let results = timeout(Duration::from_secs(5), waiter)
+        .await
+        .expect("wait did not resolve promptly after reconfiguration")
+        .expect("waiter task panicked")
+        .expect("wait_for_checkpoint_inclusion returned error");
+    assert_eq!(results.get(&digest), Some(&(seq, ts)));
+}
+
+#[tokio::test]
+async fn wait_for_checkpoint_inclusion_recovers_mapping_from_old_epoch_store() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let old_store = authority_state.epoch_store_for_testing().clone();
+    let digest = TransactionDigest::random();
+    let seq = 5;
+
+    let state = authority_state.clone();
+    let waiter = tokio::spawn(async move {
+        state
+            .wait_for_checkpoint_inclusion(&[digest], Duration::from_secs(30))
+            .await
+    });
+    // Let the waiter register on the current (soon-to-be-old) epoch store.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Write the mapping directly to the old store's table without firing the
+    // notification, modeling a notification the waiter raced with at the
+    // boundary. The waiter must recover it by re-reading the old store's
+    // table after epoch termination.
+    let mut batch = old_store.db_batch_for_test();
+    batch
+        .insert_batch(
+            &old_store
+                .tables()
+                .expect("old epoch store tables should still be open")
+                .executed_transactions_to_checkpoint,
+            [(digest, seq)],
+        )
+        .expect("insert_batch should succeed");
+    batch.write().expect("batch write should succeed");
+
+    authority_state.reconfigure_for_testing().await;
+
+    let results = timeout(Duration::from_secs(5), waiter)
+        .await
+        .expect("wait did not resolve promptly after reconfiguration")
+        .expect("waiter task panicked")
+        .expect("wait_for_checkpoint_inclusion returned error");
+    // No checkpoint summary exists in this test, so the timestamp resolves
+    // to the 0 fallback.
+    assert_eq!(results.get(&digest), Some(&(seq, 0)));
+}
+
 /// Persisted overload notifications must round-trip through
 /// `ConsensusCommitOutput::record_overload_notification` (flushed via
 /// `write_to_batch`) -> `load_overload_notifications`. Re-recording in a

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -204,9 +204,8 @@ async fn wait_for_checkpoint_inclusion_resolves_across_reconfiguration() {
     // lookup that has nothing to find in this test).
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    // The mapping lands in the next epoch's store, as happens for transactions
-    // executed near the boundary (reverted at epoch end and resubmitted into
-    // the next epoch).
+    // The mapping lands in the next epoch's store, as happens for a transaction
+    // that is still uncheckpointed when the epoch ends.
     authority_state
         .epoch_store_for_testing()
         .insert_finalized_transactions(&[digest], seq, ts)

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -309,8 +309,8 @@ async fn test_tx_across_epoch_boundaries() {
 /// not burn the full 30s finality timeout: its checkpoint-inclusion wait
 /// registers on the old epoch's store, while the transaction is checkpointed
 /// on the next epoch's store (here because submission is rejected until the
-/// epoch changes; in production also when an executed-but-not-checkpointed
-/// transaction is reverted at the boundary and resubmitted).
+/// epoch changes; in the certificate mode also when an executed-but-not-
+/// checkpointed transaction is reverted at the boundary and resubmitted).
 #[sim_test]
 async fn test_wait_for_local_execution_across_epoch_boundary() {
     telemetry_subscribers::init_for_testing();

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -304,6 +304,75 @@ async fn test_tx_across_epoch_boundaries() {
     info!("test completed in {:?}", start.elapsed());
 }
 
+/// A `WaitForLocalExecution` request in flight at an epoch boundary must
+/// resolve shortly after the transaction is checkpointed in the next epoch,
+/// not burn the full 30s finality timeout: its checkpoint-inclusion wait
+/// registers on the old epoch's store, while the transaction (reverted at
+/// epoch end and resubmitted) is checkpointed on the next epoch's store.
+#[sim_test]
+async fn test_wait_for_local_execution_across_epoch_boundary() {
+    telemetry_subscribers::init_for_testing();
+    let _env_guard = enable_pcool_env();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel(1);
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
+    let authorities = test_cluster.swarm.validator_node_handles();
+
+    // Stop 2 of the 4 validators from accepting user transactions, so the
+    // submission cannot finalize until the epoch changes.
+    for handle in authorities.iter().take(2) {
+        handle
+            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
+            .await;
+    }
+
+    let to = test_cluster
+        .fullnode_handle
+        .iota_node
+        .with(|node| node.transaction_orchestrator().unwrap());
+    let tx_digest = *tx.digest();
+    info!(?tx_digest, "Submitting WaitForLocalExecution tx");
+    tokio::task::spawn(async move {
+        let result = to
+            .execute_transaction_block(
+                ExecuteTransactionRequestV1::new(tx),
+                ExecuteTransactionRequestType::WaitForLocalExecution,
+                None,
+            )
+            .await;
+        result_tx.send(result).await.unwrap();
+    });
+
+    info!("Asking remaining validators to change epoch");
+    for handle in authorities.iter().skip(2) {
+        handle
+            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
+            .await;
+    }
+    test_cluster.wait_for_epoch(Some(1)).await;
+
+    // The transaction is checkpointed early in epoch 1 and the request must
+    // resolve shortly after — well under the 30s finality timeout it used to
+    // burn before returning `TimeoutBeforeFinality`.
+    let result = match tokio::time::timeout(Duration::from_secs(15), result_rx.recv()).await {
+        Ok(Some(result)) => result,
+        Ok(None) => panic!("submission task dropped the result channel"),
+        Err(_) => panic!("WaitForLocalExecution did not resolve within 15s of the epoch change"),
+    };
+    let (response, executed_locally) = result
+        .unwrap_or_else(|e| panic!("WaitForLocalExecution failed across the boundary: {e:?}"));
+    assert!(executed_locally, "tx should be executed locally");
+    match response.effects.finality_info {
+        EffectsFinalityInfo::Checkpointed(epoch, _seq) => assert_eq!(epoch, 1),
+        other => panic!("expected Checkpointed finality, got {other:?}"),
+    }
+}
+
 async fn execute_with_orchestrator(
     orchestrator: &TransactionOrchestrator<NetworkAuthorityClient>,
     txn: Transaction,

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -307,8 +307,10 @@ async fn test_tx_across_epoch_boundaries() {
 /// A `WaitForLocalExecution` request in flight at an epoch boundary must
 /// resolve shortly after the transaction is checkpointed in the next epoch,
 /// not burn the full 30s finality timeout: its checkpoint-inclusion wait
-/// registers on the old epoch's store, while the transaction (reverted at
-/// epoch end and resubmitted) is checkpointed on the next epoch's store.
+/// registers on the old epoch's store, while the transaction is checkpointed
+/// on the next epoch's store (here because submission is rejected until the
+/// epoch changes; in production also when an executed-but-not-checkpointed
+/// transaction is reverted at the boundary and resubmitted).
 #[sim_test]
 async fn test_wait_for_local_execution_across_epoch_boundary() {
     telemetry_subscribers::init_for_testing();
@@ -323,9 +325,15 @@ async fn test_wait_for_local_execution_across_epoch_boundary() {
     let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
     let authorities = test_cluster.swarm.validator_node_handles();
 
-    // Stop 2 of the 4 validators from accepting user transactions, so the
-    // submission cannot finalize until the epoch changes.
-    for handle in authorities.iter().take(2) {
+    // Stop every validator from accepting user transactions before
+    // submitting. Admission is the only way a user transaction enters
+    // consensus, so the transaction deterministically cannot be sequenced in
+    // epoch 0 — the driver keeps retrying the rejected submissions
+    // (`ValidatorHaltedAtEpochEnd` is retriable) until epoch 1 opens. The
+    // validators stay up and keep running consensus; the epoch changes once
+    // the 2f+1 `EndOfPublish` quorum is collected.
+    info!("Asking all validators to change epoch");
+    for handle in authorities.iter() {
         handle
             .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
             .await;
@@ -348,21 +356,31 @@ async fn test_wait_for_local_execution_across_epoch_boundary() {
         result_tx.send(result).await.unwrap();
     });
 
-    info!("Asking remaining validators to change epoch");
-    for handle in authorities.iter().skip(2) {
-        handle
-            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
-            .await;
-    }
+    // Tripwire: the request's checkpoint-inclusion wait must register on the
+    // epoch-0 store for the test to exercise the boundary crossing.
+    // Reconfiguration needs several consensus commits plus checkpoint
+    // execution, which cannot complete in the spawn gap above; if this ever
+    // trips, the test has gone degenerate (passing without covering the
+    // boundary) rather than flaky.
+    assert_eq!(
+        test_cluster
+            .fullnode_handle
+            .iota_node
+            .with(|node| node.state().epoch_store_for_testing().epoch()),
+        0,
+        "reconfiguration outran the submission; the wait no longer starts in epoch 0"
+    );
+
     test_cluster.wait_for_epoch(Some(1)).await;
 
     // The transaction is checkpointed early in epoch 1 and the request must
     // resolve shortly after — well under the 30s finality timeout it used to
-    // burn before returning `TimeoutBeforeFinality`.
-    let result = match tokio::time::timeout(Duration::from_secs(15), result_rx.recv()).await {
+    // burn before returning `TimeoutBeforeFinality`. The window leaves room
+    // for the driver's retry backoff, which is capped at 10s.
+    let result = match tokio::time::timeout(Duration::from_secs(20), result_rx.recv()).await {
         Ok(Some(result)) => result,
         Ok(None) => panic!("submission task dropped the result channel"),
-        Err(_) => panic!("WaitForLocalExecution did not resolve within 15s of the epoch change"),
+        Err(_) => panic!("WaitForLocalExecution did not resolve within 20s of the epoch change"),
     };
     let (response, executed_locally) = result
         .unwrap_or_else(|e| panic!("WaitForLocalExecution failed across the boundary: {e:?}"));


### PR DESCRIPTION
# Description of change

`AuthorityState::wait_for_checkpoint_inclusion` registered on the current epoch store's `executed_transactions_to_checkpoint` notification, and nothing wakes those waiters at reconfiguration — so every `WaitForLocalExecution` (skip-effect-certification) request in flight at an epoch boundary burned the full 30s finality timeout and returned `TimeoutBeforeFinality`, even though the transaction executed and a client retry succeeded instantly from cache.

The wait is now epoch-aware, keeping its signature so all callers (both transaction-orchestrator call sites and the gRPC execution service) benefit:

- race the per-epoch wait against `wait_epoch_terminated()`;
- on termination, re-read the old store's table — safe because the table write precedes each notification and the checkpoint executor completes the epoch before `reconfigure` — recovering results the cancelled wait may have dropped;
- hop to the next epoch's store with a short bounded poll (there is no notification for the store swap, and termination and swap come in either order between `reconfigure` and `reconfigure_for_testing`) and re-register there, all under the caller's original deadline.

The certified-effects path is unaffected by the bug: its effects wait lives on the cross-epoch writeback cache and is wrapped in `within_alive_epoch` with a resubmission on epoch end.

## Links to any relevant issues

fixes #12412

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Unit tests (`authority_per_epoch_store_tests`): a wait started before `reconfigure_for_testing` resolves promptly when the mapping lands in the next epoch's store, and recovers a mapping written to the old store's table without a notification. e2e simtest (`test_wait_for_local_execution_across_epoch_boundary`): a `WaitForLocalExecution` request submitted while all validators are closing the epoch resolves well under the 30s timeout with `Checkpointed` finality in epoch 1. Every validator is closed before the submission, so the transaction deterministically cannot finalize in epoch 0, and a tripwire assertion checks the wait starts in epoch 0; verified across msim seeds 1-5. All new tests fail on `develop` without the fix (verified by reverting `authority.rs` and re-running).

### Local network benchmark

Docker private network (4 validators + 1 fullnode, Starfish, P-COOL flow enabled, 60s epochs) driven by the `stress` tool from network-benchmark #48 at 100 QPS, 50% owned-object transfers / 50% shared counters, with `--wait-for-local-execution`. Two node images built from the same Dockerfile: this branch, and its merge-base (develop without the fix).

JSON-RPC `WaitForLocalExecution` (transaction-orchestrator caller), 360s per arm:

|                                         | merge-base | this branch |
| --------------------------------------- | ---------: | ----------: |
| epoch boundaries crossed                |          6 |           6 |
| finality timeouts (`-32050`)            |        281 |           0 |
| `tx_orchestrator_early_cached_response` |        281 |           0 |
| TPS                                     |         98 |          99 |
| latency p50 / p99 (ms)                  | 338 / 1299 |  332 / 1298 |

On the merge-base the failures arrive in one burst per epoch, each ~29s after the fullnode's `Reconfiguration finished` (49/60/36/48/48/40 across the six boundaries) — the 30s timeout expiring on waits registered against the closing epoch's store. `tx_orchestrator_early_cached_response` matching the timeout count exactly is the same event server-side: every timed-out transaction had executed, and the client retry was answered from cache. On this branch all six boundaries pass with no timeout, at unchanged throughput and latency.

The same pair over gRPC `ExecuteTransactions` with a checkpoint-inclusion timeout (300s, 5 boundaries) shows no timeouts on either image, so it is a regression check rather than a second reproduction: that caller registers the wait only after the effects are known, when the transaction is already committed in the closing epoch and is nearly always checkpointed there, giving it a much narrower exposure window than the orchestrator's pre-consensus wait.
