### PR TITLE
feat(core+network): state sync improvements

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1110,8 +1110,12 @@ pub struct MetricsConfig {
     pub groups: Option<MetricGroups>,
 }
 
-fn default_checkpoint_archive_download_concurrency() -> usize {
-    10
+fn default_checkpoint_archive_download_concurrency() -> NonZeroUsize {
+    NonZeroUsize::new(10).unwrap()
+}
+
+fn default_checkpoint_archive_verify_concurrency() -> NonZeroUsize {
+    std::thread::available_parallelism().unwrap_or(NonZeroUsize::new(4).unwrap())
 }
 
 /// Configuration for backfilling checkpoint contents from the
@@ -1123,7 +1127,11 @@ pub struct CheckpointArchiveConfig {
     pub url: String,
     /// Non-zero number of checkpoints to download in parallel.
     #[serde(default = "default_checkpoint_archive_download_concurrency")]
-    pub download_concurrency: usize,
+    pub download_concurrency: NonZeroUsize,
+    /// Non-zero number of downloaded checkpoints to verify in parallel.
+    /// Defaults to the number of CPU cores.
+    #[serde(default = "default_checkpoint_archive_verify_concurrency")]
+    pub verify_concurrency: NonZeroUsize,
 }
 
 /// Configuration for the per-epoch state-snapshot publisher.

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1118,6 +1118,10 @@ fn default_checkpoint_archive_verify_concurrency() -> NonZeroUsize {
     std::thread::available_parallelism().unwrap_or(NonZeroUsize::new(4).unwrap())
 }
 
+fn default_checkpoint_archive_max_checkpoints_ahead_of_execution() -> NonZeroUsize {
+    NonZeroUsize::new(100_000).unwrap()
+}
+
 /// Configuration for backfilling checkpoint contents from the
 /// checkpoint archive when peers no longer serve the required range.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1132,6 +1136,13 @@ pub struct CheckpointArchiveConfig {
     /// Defaults to the number of CPU cores.
     #[serde(default = "default_checkpoint_archive_verify_concurrency")]
     pub verify_concurrency: NonZeroUsize,
+    /// Pause downloading from the archive while the synced watermark is this
+    /// many checkpoints ahead of the executed watermark, and resume once
+    /// execution catches up. Bounds the disk space held by checkpoints that
+    /// are synced but not yet executed, since only executed checkpoints can
+    /// be pruned.
+    #[serde(default = "default_checkpoint_archive_max_checkpoints_ahead_of_execution")]
+    pub max_checkpoints_ahead_of_execution: NonZeroUsize,
 }
 
 /// Configuration for the per-epoch state-snapshot publisher.

--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -9,10 +9,12 @@ use std::{
     time::Duration,
 };
 
-use tracing::info;
+use strum::{EnumCount, IntoEnumIterator};
+use tracing::{debug, info};
 
 use crate::{
-    authority::authority_store_tables::AuthorityPerpetualTables, checkpoints::CheckpointStore,
+    authority::authority_store_tables::AuthorityPerpetualTables,
+    checkpoints::{CheckpointStore, checkpoint_executor::utils::PipelineStage},
 };
 
 /// Shared progress tracker for checkpoint operations. Updated by the
@@ -25,6 +27,11 @@ use crate::{
 pub struct CheckpointProgressTracker {
     /// Accumulated checkpoint execution time in nanoseconds.
     execution_time_ns: AtomicU64,
+    /// Accumulated time spent working in each checkpoint pipeline stage, in
+    /// nanoseconds, indexed by [`PipelineStage`]. Since every stage admits
+    /// one checkpoint at a time, a stage accumulating close to one second
+    /// per second is the throughput bottleneck.
+    stage_time_ns: [AtomicU64; PipelineStage::COUNT],
     /// Accumulated object pruning time in nanoseconds.
     object_pruning_time_ns: AtomicU64,
     /// Accumulated checkpoint/effects pruning time in nanoseconds.
@@ -35,6 +42,7 @@ impl CheckpointProgressTracker {
     pub fn new() -> Self {
         Self {
             execution_time_ns: AtomicU64::new(0),
+            stage_time_ns: std::array::from_fn(|_| AtomicU64::new(0)),
             object_pruning_time_ns: AtomicU64::new(0),
             checkpoint_pruning_time_ns: AtomicU64::new(0),
         }
@@ -43,6 +51,10 @@ impl CheckpointProgressTracker {
     pub fn add_execution_time(&self, duration: Duration) {
         self.execution_time_ns
             .fetch_add(duration.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    pub(crate) fn add_stage_time(&self, stage: PipelineStage, duration: Duration) {
+        self.stage_time_ns[stage as usize].fetch_add(duration.as_nanos() as u64, Ordering::Relaxed);
     }
 
     pub fn add_object_pruning_time(&self, duration: Duration) {
@@ -134,6 +146,29 @@ impl CheckpointProgressTracker {
                          objects pruned {object_pruned_seq_number} (+{object_prune_delta}, {object_prune_time_delta:.2?}), \
                          checkpoints pruned {checkpoint_pruned_seq_number} (+{checkpoint_prune_delta}, {checkpoint_prune_time_delta:.2?})",
                     );
+
+                    // Every pipeline stage admits one checkpoint at a time,
+                    // so the stage whose time approaches one second per tick
+                    // is the execution throughput bottleneck.
+                    let stage_times: Vec<String> = PipelineStage::iter()
+                        .filter_map(|stage| {
+                            let stage_time_ns =
+                                tracker.stage_time_ns[stage as usize].swap(0, Ordering::Relaxed);
+                            (stage_time_ns > 0).then(|| {
+                                format!(
+                                    "{} {:.2?}",
+                                    stage.as_str(),
+                                    Duration::from_nanos(stage_time_ns)
+                                )
+                            })
+                        })
+                        .collect();
+                    if !stage_times.is_empty() {
+                        debug!(
+                            "checkpoint pipeline stage times [epoch {epoch}]: {}",
+                            stage_times.join(", ")
+                        );
+                    }
 
                     prev_executed = highest_executed_seq_number;
                     prev_total_tx = total_tx;

--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -78,6 +78,7 @@ impl CheckpointProgressTracker {
         tokio::task::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
             let mut prev_executed: u64 = 0;
+            let mut prev_synced: u64 = 0;
             let mut prev_total_tx: u64 = 0;
             let mut prev_obj_pruned: u64 = 0;
             let mut prev_ckpt_pruned: u64 = 0;
@@ -118,12 +119,14 @@ impl CheckpointProgressTracker {
                     .unwrap_or(0);
 
                 let exec_delta = highest_executed_seq_number.saturating_sub(prev_executed);
+                let synced_delta = synced_seq_number.saturating_sub(prev_synced);
                 let tx_delta = total_tx.saturating_sub(prev_total_tx);
                 let object_prune_delta = object_pruned_seq_number.saturating_sub(prev_obj_pruned);
                 let checkpoint_prune_delta =
                     checkpoint_pruned_seq_number.saturating_sub(prev_ckpt_pruned);
 
                 if exec_delta > 0
+                    || synced_delta > 0
                     || tx_delta > 0
                     || object_prune_delta > 0
                     || checkpoint_prune_delta > 0
@@ -142,7 +145,7 @@ impl CheckpointProgressTracker {
                         Duration::from_nanos(checkpoint_prune_time_delta_ns);
 
                     info!(
-                        "checkpoint progress [epoch {epoch}]: executed {highest_executed_seq_number}/{synced_seq_number} (+{exec_delta}, {tx_delta} tx/s, {exec_time_delta:.2?}), \
+                        "checkpoint progress [epoch {epoch}]: executed {highest_executed_seq_number}/{synced_seq_number} (+{exec_delta}/+{synced_delta}, {tx_delta} tx/s, {exec_time_delta:.2?}), \
                          objects pruned {object_pruned_seq_number} (+{object_prune_delta}, {object_prune_time_delta:.2?}), \
                          checkpoints pruned {checkpoint_pruned_seq_number} (+{checkpoint_prune_delta}, {checkpoint_prune_time_delta:.2?})",
                     );
@@ -171,6 +174,7 @@ impl CheckpointProgressTracker {
                     }
 
                     prev_executed = highest_executed_seq_number;
+                    prev_synced = synced_seq_number;
                     prev_total_tx = total_tx;
                     prev_obj_pruned = object_pruned_seq_number;
                     prev_ckpt_pruned = checkpoint_pruned_seq_number;

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -260,7 +260,11 @@ impl CheckpointExecutor {
             .and_then(|s| s.parse().ok())
             .unwrap_or(this.config.checkpoint_execution_max_concurrency);
 
-        let pipeline_stages = PipelineStages::new(next_to_schedule, this.metrics.clone());
+        let pipeline_stages = PipelineStages::new(
+            next_to_schedule,
+            this.metrics.clone(),
+            this.checkpoint_progress_tracker.clone(),
+        );
 
         let final_checkpoint_executed = stream_synced_checkpoints(
             this.checkpoint_store.clone(),

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -21,7 +21,7 @@
 //! successfully, we have reached the end of epoch. This allows us to use it as
 //! a signal for reconfig.
 
-use std::{sync::Arc, time::Instant};
+use std::{future::Future, sync::Arc, time::Instant};
 
 use futures::StreamExt;
 use iota_common::{debug_fatal, fatal};
@@ -90,7 +90,6 @@ pub(crate) struct CheckpointExecutionData {
 pub(crate) struct CheckpointTransactionData {
     pub transactions: Vec<VerifiedExecutableTransaction>,
     pub effects: Vec<TransactionEffects>,
-    pub executed_fx_digests: Vec<Option<TransactionEffectsDigest>>,
 }
 
 pub(crate) struct CheckpointExecutionState {
@@ -271,12 +270,15 @@ impl CheckpointExecutor {
             next_to_schedule,
             run_with_range.and_then(|rwr| rwr.into_checkpoint_bound()),
         )
-        // Checkpoint loading and execution is parallelized
+        // Checkpoint loading and execution is parallelized: each
+        // checkpoint's task loads its transaction data before awaiting
+        // admission to the ordered pipeline stages.
         .map(|checkpoint| {
             let this = this.clone();
-            let pipeline_handle = pipeline_stages.handle(checkpoint.sequence_number());
+            let pipeline_stages = pipeline_stages.clone();
             async move {
-                let pipeline_handle = pipeline_handle.await;
+                let seq = checkpoint.sequence_number();
+                let pipeline_handle = async move { pipeline_stages.handle(seq).await };
                 tokio::spawn(this.execute_checkpoint(checkpoint, pipeline_handle))
                     .await
                     .unwrap()
@@ -305,16 +307,33 @@ impl CheckpointExecutor {
     async fn execute_checkpoint(
         self: Arc<Self>,
         checkpoint: VerifiedCheckpoint,
-        mut pipeline_handle: PipelineHandle,
+        pipeline_handle: impl Future<Output = PipelineHandle> + Send,
     ) -> bool /* is final checkpoint */ {
         debug!("executing checkpoint");
         let sequence_number = checkpoint.sequence_number;
+        let is_last_checkpoint_of_epoch = checkpoint.is_last_checkpoint_of_epoch();
 
         checkpoint.report_checkpoint_age(&self.metrics.checkpoint_contents_age);
         self.backpressure_manager
             .update_highest_certified_checkpoint(sequence_number);
 
-        if checkpoint.is_last_checkpoint_of_epoch() && sequence_number > 0 {
+        // Load the transaction data before awaiting admission to the
+        // pipeline: it reads only state-sync-written data (contents,
+        // transactions, and expected effects), so it can run in parallel
+        // across the buffered checkpoints instead of inside the ordered
+        // ExecuteTransactions stage. The clone is needed because the
+        // locally-built-checkpoint path below wants the checkpoint too.
+        let loaded = (self.state.is_fullnode(&self.epoch_store) || is_last_checkpoint_of_epoch)
+            .then(|| {
+                let _scope = iota_metrics::monitored_scope(
+                    "CheckpointExecutor::load_checkpoint_transactions",
+                );
+                self.load_checkpoint_transactions(checkpoint.clone())
+            });
+
+        let mut pipeline_handle = pipeline_handle.await;
+
+        if is_last_checkpoint_of_epoch && sequence_number > 0 {
             let _wait_for_previous_checkpoints_guard =
                 iota_metrics::monitored_scope("CheckpointExecutor::wait_for_previous_checkpoints");
 
@@ -332,14 +351,19 @@ impl CheckpointExecutor {
         // Note: only `execute_transactions_from_synced_checkpoint` has end-of-epoch
         // logic.
         let exec_start = Instant::now();
-        let ckpt_state = if self.state.is_fullnode(&self.epoch_store)
-            || checkpoint.is_last_checkpoint_of_epoch()
-        {
-            self.execute_transactions_from_synced_checkpoint(checkpoint, &mut pipeline_handle)
+        let ckpt_state = match loaded {
+            Some((ckpt_state, tx_data)) => {
+                self.execute_transactions_from_synced_checkpoint(
+                    ckpt_state,
+                    tx_data,
+                    &mut pipeline_handle,
+                )
                 .await
-        } else {
-            self.verify_locally_built_checkpoint(checkpoint, &mut pipeline_handle)
-                .await
+            }
+            None => {
+                self.verify_locally_built_checkpoint(checkpoint, &mut pipeline_handle)
+                    .await
+            }
         };
 
         let tps = self.tps_estimator.lock().update(
@@ -502,8 +526,9 @@ impl CheckpointExecutor {
 
         let Some(locally_built_checkpoint) = locally_built_checkpoint else {
             // fall back to tx-by-tx execution path if we are catching up.
+            let (ckpt_state, tx_data) = self.load_checkpoint_transactions(checkpoint);
             return self
-                .execute_transactions_from_synced_checkpoint(checkpoint, pipeline_handle)
+                .execute_transactions_from_synced_checkpoint(ckpt_state, tx_data, pipeline_handle)
                 .await;
         };
 
@@ -568,16 +593,15 @@ impl CheckpointExecutor {
     #[instrument(level = "info", skip_all)]
     async fn execute_transactions_from_synced_checkpoint(
         &self,
-        checkpoint: VerifiedCheckpoint,
+        mut ckpt_state: CheckpointExecutionState,
+        tx_data: CheckpointTransactionData,
         pipeline_handle: &mut PipelineHandle,
     ) -> CheckpointExecutionState {
-        let sequence_number = checkpoint.sequence_number;
+        let sequence_number = ckpt_state.data.checkpoint.sequence_number;
 
-        let (mut ckpt_state, tx_data, unexecuted_tx_digests) = {
+        let unexecuted_tx_digests = {
             let _scope = iota_metrics::monitored_scope("CheckpointExecutor::execute_transactions");
-            let (ckpt_state, tx_data) = self.load_checkpoint_transactions(checkpoint);
-            let unexecuted_tx_digests = self.schedule_transaction_execution(&ckpt_state, &tx_data);
-            (ckpt_state, tx_data, unexecuted_tx_digests)
+            self.schedule_transaction_execution(&ckpt_state, &tx_data)
         };
 
         finish_stage!(pipeline_handle, ExecuteTransactions);
@@ -764,10 +788,6 @@ impl CheckpointExecutor {
                     fx_digests.push(fx_digest);
                 });
 
-            let executed_fx_digests = self
-                .transaction_cache_reader
-                .multi_get_executed_effects_digests(&tx_digests);
-
             (
                 CheckpointExecutionState::new(CheckpointExecutionData {
                     checkpoint,
@@ -778,7 +798,6 @@ impl CheckpointExecutor {
                 CheckpointTransactionData {
                     transactions,
                     effects,
-                    executed_fx_digests,
                 },
             )
         } else {
@@ -843,10 +862,6 @@ impl CheckpointExecutor {
                 .map(|tx| VerifiedExecutableTransaction::new_from_checkpoint(tx, epoch, seq))
                 .collect();
 
-            let executed_fx_digests = self
-                .transaction_cache_reader
-                .multi_get_executed_effects_digests(&tx_digests);
-
             (
                 CheckpointExecutionState::new(CheckpointExecutionData {
                     checkpoint,
@@ -857,7 +872,6 @@ impl CheckpointExecutor {
                 CheckpointTransactionData {
                     transactions,
                     effects,
-                    executed_fx_digests,
                 },
             )
         }
@@ -870,6 +884,14 @@ impl CheckpointExecutor {
         ckpt_state: &CheckpointExecutionState,
         tx_data: &CheckpointTransactionData,
     ) -> Vec<TransactionDigest> {
+        // Which transactions have already been executed must be read here, in
+        // the ordered pipeline stage, and not when the checkpoint data is
+        // loaded: execution progresses in between, and a stale answer would
+        // skip the fork check for a transaction that executed since loading.
+        let executed_fx_digests = self
+            .transaction_cache_reader
+            .multi_get_executed_effects_digests(&ckpt_state.data.tx_digests);
+
         // Find unexecuted transactions and their expected effects digests
         let (unexecuted_tx_digests, unexecuted_txns, unexecuted_effects): (Vec<_>, Vec<_>, Vec<_>) =
             itertools::multiunzip(
@@ -878,7 +900,7 @@ impl CheckpointExecutor {
                     ckpt_state.data.tx_digests.iter(),
                     ckpt_state.data.fx_digests.iter(),
                     tx_data.effects.iter(),
-                    tx_data.executed_fx_digests.iter()
+                    executed_fx_digests.iter()
                 )
                 .filter_map(
                     |(txn, tx_digest, expected_fx_digest, effects, executed_fx_digest)| {

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/utils.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/utils.rs
@@ -18,7 +18,10 @@ use tokio::sync::watch;
 use tracing::{debug, error, instrument, warn};
 
 use super::metrics::CheckpointExecutorMetrics;
-use crate::{checkpoints::CheckpointStore, execution_cache::TransactionCacheRead};
+use crate::{
+    checkpoint_progress_tracker::CheckpointProgressTracker, checkpoints::CheckpointStore,
+    execution_cache::TransactionCacheRead,
+};
 
 #[instrument(level = "debug", skip_all)]
 pub(super) fn stream_synced_checkpoints(
@@ -367,7 +370,7 @@ impl PipelineStage {
         Self::from_repr((self as usize) + 1).unwrap()
     }
 
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         Self::VARIANTS[self as usize]
     }
 }
@@ -406,6 +409,9 @@ impl PipelineHandle {
             .stage_active_duration_ns
             .with_label_values(&[self.cur_stage.as_str()])
             .inc_by(duration.as_nanos() as u64);
+        if let Some(tracker) = &self.stages.tracker {
+            tracker.add_stage_time(self.cur_stage, duration);
+        }
         assert_eq!(finished, self.cur_stage, "cannot skip stages");
 
         self.stages.end(self.cur_stage, self.seq);
@@ -414,6 +420,10 @@ impl PipelineHandle {
         if self.cur_stage != PipelineStage::End {
             self.stages.begin(self.cur_stage, self.seq).await;
         }
+        // Restart the timer only after being admitted to the next stage, so
+        // each stage's reported time covers its own work, not the wait for
+        // the previous checkpoint to clear the stage.
+        self.timer = Instant::now();
     }
 
     /// Skip to a given stage.
@@ -430,16 +440,19 @@ impl PipelineHandle {
 pub(super) struct PipelineStages {
     stages: [SequenceWatch; PipelineStage::End as usize],
     metrics: Arc<CheckpointExecutorMetrics>,
+    tracker: Option<Arc<CheckpointProgressTracker>>,
 }
 
 impl PipelineStages {
     pub fn new(
         starting_seq: CheckpointSequenceNumber,
         metrics: Arc<CheckpointExecutorMetrics>,
+        tracker: Option<Arc<CheckpointProgressTracker>>,
     ) -> Arc<Self> {
         Arc::new(Self {
             stages: std::array::from_fn(|_| SequenceWatch::new(starting_seq)),
             metrics,
+            tracker,
         })
     }
 
@@ -507,7 +520,7 @@ mod test {
     #[tokio::test]
     #[should_panic(expected = "cannot skip stages")]
     async fn test_skip_pipeline_stages() {
-        let stages = PipelineStages::new(0, CheckpointExecutorMetrics::new_for_tests());
+        let stages = PipelineStages::new(0, CheckpointExecutorMetrics::new_for_tests(), None);
         let mut handle = stages.handle(0).await;
         handle
             .finish_stage(PipelineStage::WaitForTransactions)
@@ -516,7 +529,7 @@ mod test {
 
     #[sim_test]
     async fn test_pipeline_stages() {
-        let stages = PipelineStages::new(0, CheckpointExecutorMetrics::new_for_tests());
+        let stages = PipelineStages::new(0, CheckpointExecutorMetrics::new_for_tests(), None);
 
         let output_by_stage = Arc::new(Mutex::new(HashMap::new()));
         let output_by_order = Arc::new(Mutex::new(Vec::new()));

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -594,34 +594,54 @@ impl CheckpointStore {
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), TypedStoreError> {
+        self.multi_insert_certified_checkpoints(std::slice::from_ref(checkpoint))
+    }
+
+    /// Inserts a batch of certified checkpoints in a single write, like
+    /// [`Self::insert_certified_checkpoint`] for each of them.
+    pub fn multi_insert_certified_checkpoints(
+        &self,
+        checkpoints: &[VerifiedCheckpoint],
+    ) -> Result<(), TypedStoreError> {
+        let Some(last) = checkpoints.last() else {
+            return Ok(());
+        };
         debug!(
-            checkpoint_seq = checkpoint.sequence_number(),
-            "Inserting certified checkpoint",
+            checkpoint_seq = last.sequence_number(),
+            count = checkpoints.len(),
+            "Inserting certified checkpoints",
         );
         let mut batch = self.tables.certified_checkpoints.batch();
         batch
             .insert_batch(
                 &self.tables.certified_checkpoints,
-                [(checkpoint.sequence_number(), checkpoint.serializable_ref())],
+                checkpoints
+                    .iter()
+                    .map(|c| (c.sequence_number(), c.serializable_ref())),
             )?
             .insert_batch(
                 &self.tables.checkpoint_by_digest,
-                [(checkpoint.digest(), checkpoint.serializable_ref())],
-            )?;
-        if checkpoint.next_epoch_committee().is_some() {
-            batch.insert_batch(
+                checkpoints
+                    .iter()
+                    .map(|c| (c.digest(), c.serializable_ref())),
+            )?
+            .insert_batch(
                 &self.tables.epoch_last_checkpoint_map,
-                [(&checkpoint.epoch(), checkpoint.sequence_number())],
+                checkpoints
+                    .iter()
+                    .filter(|c| c.next_epoch_committee().is_some())
+                    .map(|c| (c.epoch(), c.sequence_number())),
             )?;
-        }
         batch.write()?;
 
-        if let Some(local_checkpoint) = self
-            .tables
-            .locally_computed_checkpoints
-            .get(&checkpoint.sequence_number())?
-        {
-            self.check_for_checkpoint_fork(&local_checkpoint, checkpoint);
+        for checkpoint in checkpoints {
+            if let Some(local_checkpoint) = self
+                .tables
+                .locally_computed_checkpoints
+                .get(&checkpoint.sequence_number())?
+            {
+                self.check_for_checkpoint_fork(&local_checkpoint, checkpoint);
+            }
         }
 
         Ok(())
@@ -664,13 +684,31 @@ impl CheckpointStore {
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), TypedStoreError> {
-        let seq = checkpoint.sequence_number();
-        debug!(checkpoint_seq = seq, "Updating highest synced checkpoint",);
+        self.multi_update_highest_synced_checkpoint(std::slice::from_ref(checkpoint))
+    }
+
+    /// Marks a consecutive run of checkpoints as synced: writes the watermark
+    /// once, for the last checkpoint, but notifies waiters of every
+    /// checkpoint in the run.
+    pub fn multi_update_highest_synced_checkpoint(
+        &self,
+        checkpoints: &[VerifiedCheckpoint],
+    ) -> Result<(), TypedStoreError> {
+        let Some(last) = checkpoints.last() else {
+            return Ok(());
+        };
+        debug!(
+            checkpoint_seq = last.sequence_number(),
+            "Updating highest synced checkpoint",
+        );
         self.tables.watermarks.insert(
             &CheckpointWatermark::HighestSynced,
-            &(seq, *checkpoint.digest()),
+            &(last.sequence_number(), *last.digest()),
         )?;
-        self.synced_checkpoint_notify_read.notify(&seq, checkpoint);
+        for checkpoint in checkpoints {
+            self.synced_checkpoint_notify_read
+                .notify(&checkpoint.sequence_number(), checkpoint);
+        }
         Ok(())
     }
 
@@ -804,19 +842,41 @@ impl CheckpointStore {
         checkpoint: &VerifiedCheckpoint,
         full_contents: VerifiedCheckpointContents,
     ) -> Result<(), TypedStoreError> {
-        let full_contents = full_contents.into_inner();
-        let contents = full_contents.checkpoint_contents();
-        assert_eq!(checkpoint.contents_digest, contents.digest());
+        self.multi_insert_verified_checkpoint_contents(vec![(checkpoint.clone(), full_contents)])
+    }
 
-        self.tables
-            .checkpoint_content
-            .insert(&contents.digest(), &contents)?;
+    /// Batch variant of [`Self::insert_verified_checkpoint_contents`]:
+    /// persists all contents rows in a single write, then caches the full
+    /// contents.
+    ///
+    /// INVARIANT: See [`Self::cache_full_checkpoint_contents`].
+    pub fn multi_insert_verified_checkpoint_contents(
+        &self,
+        checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
+    ) -> Result<(), TypedStoreError> {
+        let checkpoints: Vec<_> = checkpoints
+            .into_iter()
+            .map(|(checkpoint, full_contents)| (checkpoint, full_contents.into_inner()))
+            .collect();
 
-        self.cache_full_checkpoint_contents(
-            checkpoint.sequence_number(),
-            checkpoint.contents_digest,
-            full_contents,
-        );
+        let mut batch = self.tables.checkpoint_content.batch();
+        for (checkpoint, full_contents) in &checkpoints {
+            let contents = full_contents.checkpoint_contents();
+            assert_eq!(checkpoint.contents_digest, contents.digest());
+            batch.insert_batch(
+                &self.tables.checkpoint_content,
+                [(contents.digest(), contents)],
+            )?;
+        }
+        batch.write()?;
+
+        for (checkpoint, full_contents) in checkpoints {
+            self.cache_full_checkpoint_contents(
+                checkpoint.sequence_number(),
+                checkpoint.contents_digest,
+                full_contents,
+            );
+        }
         Ok(())
     }
 

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -368,6 +368,12 @@ impl WriteStore for RocksDbStore {
             .map_err(Into::into)
     }
 
+    async fn wait_for_executed_checkpoint(&self, sequence_number: CheckpointSequenceNumber) {
+        self.checkpoint_store
+            .notify_read_executed_checkpoint(sequence_number)
+            .await;
+    }
+
     fn try_insert_synced_checkpoints(
         &self,
         checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -68,6 +68,26 @@ impl RocksDbStore {
     pub fn get_last_executed_checkpoint(&self) -> Result<Option<VerifiedCheckpoint>, IotaError> {
         Ok(self.checkpoint_store.get_highest_executed_checkpoint()?)
     }
+
+    /// Marks a consecutive run of checkpoints as synced, writing the watermark
+    /// once for the last one but notifying waiters of every checkpoint.
+    fn update_highest_synced_checkpoints(
+        &self,
+        checkpoints: &[VerifiedCheckpoint],
+    ) -> Result<(), iota_types::storage::error::Error> {
+        let Some(last) = checkpoints.last() else {
+            return Ok(());
+        };
+        let mut locked = self.highest_synced_checkpoint.lock();
+        if locked.is_some_and(|seq| seq >= last.sequence_number) {
+            return Ok(());
+        }
+        self.checkpoint_store
+            .multi_update_highest_synced_checkpoint(checkpoints)
+            .map_err(iota_types::storage::error::Error::custom)?;
+        *locked = Some(last.sequence_number);
+        Ok(())
+    }
 }
 
 impl ReadStore for RocksDbStore {
@@ -298,15 +318,7 @@ impl WriteStore for RocksDbStore {
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), iota_types::storage::error::Error> {
-        let mut locked = self.highest_synced_checkpoint.lock();
-        if locked.is_some() && locked.unwrap() >= checkpoint.sequence_number {
-            return Ok(());
-        }
-        self.checkpoint_store
-            .update_highest_synced_checkpoint(checkpoint)
-            .map_err(iota_types::storage::error::Error::custom)?;
-        *locked = Some(checkpoint.sequence_number);
-        Ok(())
+        self.update_highest_synced_checkpoints(std::slice::from_ref(checkpoint))
     }
 
     fn try_update_highest_verified_checkpoint(
@@ -397,14 +409,7 @@ impl WriteStore for RocksDbStore {
         self.checkpoint_store
             .multi_insert_verified_checkpoint_contents(checkpoints)?;
 
-        let mut locked = self.highest_synced_checkpoint.lock();
-        if locked.is_none_or(|seq| seq < last.sequence_number) {
-            self.checkpoint_store
-                .multi_update_highest_synced_checkpoint(&summaries)
-                .map_err(iota_types::storage::error::Error::custom)?;
-            *locked = Some(last.sequence_number);
-        }
-        Ok(())
+        self.update_highest_synced_checkpoints(&summaries)
     }
 }
 

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -348,6 +348,14 @@ impl WriteStore for RocksDbStore {
         Ok(())
     }
 
+    fn try_get_highest_executed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, iota_types::storage::error::Error> {
+        self.checkpoint_store
+            .get_highest_executed_checkpoint_seq_number()
+            .map_err(Into::into)
+    }
+
     fn try_insert_synced_checkpoints(
         &self,
         checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -347,6 +347,57 @@ impl WriteStore for RocksDbStore {
             .unwrap();
         Ok(())
     }
+
+    fn try_insert_synced_checkpoints(
+        &self,
+        checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
+    ) -> Result<(), iota_types::storage::error::Error> {
+        let summaries: Vec<VerifiedCheckpoint> = checkpoints
+            .iter()
+            .map(|(checkpoint, _)| checkpoint.clone())
+            .collect();
+        let Some(last) = summaries.last() else {
+            return Ok(());
+        };
+
+        for checkpoint in &summaries {
+            if let Some(EndOfEpochData {
+                next_epoch_committee,
+                ..
+            }) = checkpoint.end_of_epoch_data.as_ref()
+            {
+                let committee = Committee::from_committee_members(
+                    checkpoint.epoch().checked_add(1).unwrap(),
+                    next_epoch_committee,
+                );
+                self.try_insert_committee(committee)?;
+            }
+        }
+
+        self.checkpoint_store
+            .multi_insert_certified_checkpoints(&summaries)?;
+        self.try_update_highest_verified_checkpoint(last)?;
+
+        // Transactions and effects must be durable before their contents
+        // rows (see `CheckpointStore::cache_full_checkpoint_contents`).
+        for (_, contents) in &checkpoints {
+            self.cache_traits
+                .state_sync_store
+                .try_multi_insert_transaction_and_effects(contents.transactions())
+                .map_err(iota_types::storage::error::Error::custom)?;
+        }
+        self.checkpoint_store
+            .multi_insert_verified_checkpoint_contents(checkpoints)?;
+
+        let mut locked = self.highest_synced_checkpoint.lock();
+        if locked.is_none_or(|seq| seq < last.sequence_number) {
+            self.checkpoint_store
+                .multi_update_highest_synced_checkpoint(&summaries)
+                .map_err(iota_types::storage::error::Error::custom)?;
+            *locked = Some(last.sequence_number);
+        }
+        Ok(())
+    }
 }
 
 pub struct GrpcReadStore {

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1384,11 +1384,7 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             "data_ingestion_executor".to_string(),
             checkpoint_archive_config.verify_concurrency.get(),
             Default::default(),
-            StateSyncReducer {
-                store,
-                metrics,
-                verify_concurrency: checkpoint_archive_config.verify_concurrency,
-            },
+            StateSyncReducer { store, metrics },
         );
         let setup_result = setup_data_ingestion_executor(
             worker_pool,

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -115,7 +115,7 @@ use server::CheckpointContentsDownloadLimitLayer;
 pub use server::{
     GetCheckpointAvailabilityResponse, GetCheckpointSummaryRequest, StateSyncHandshake,
 };
-use worker::StateSyncWorker;
+use worker::{StateSyncReducer, StateSyncWorker};
 
 const PEER_BALANCER_SELECTION_WINDOW: usize = 10;
 
@@ -1249,10 +1249,9 @@ where
 }
 
 async fn setup_data_ingestion_executor<W: Worker + 'static>(
-    worker: W,
+    worker_pool: WorkerPool<W>,
     remote_store_url: RemoteUrl,
     initial_checkpoint_number: CheckpointSequenceNumber,
-    concurrency: usize,
     reader_options: Option<ReaderOptions>,
     ingestion_limit: Option<IngestionLimit>,
 ) -> IngestionResult<(
@@ -1263,12 +1262,6 @@ async fn setup_data_ingestion_executor<W: Worker + 'static>(
     let progress_store = ShimProgressStore(initial_checkpoint_number);
     let token = CancellationToken::new();
     let mut executor = IndexerExecutor::new(progress_store, 1, metrics, token.child_token());
-    let worker_pool = WorkerPool::new(
-        worker,
-        "data_ingestion_executor".to_string(),
-        concurrency,
-        Default::default(),
-    );
     executor.register(worker_pool).await?;
     if let Some(limit) = ingestion_limit {
         executor.with_ingestion_limit(limit);
@@ -1364,16 +1357,24 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             batch_size: checkpoint_archive_config.download_concurrency,
             ..Default::default()
         };
-        // Keep a clone for the final log; the original is moved into StateSyncWorker.
+        // Keep a clone for the final log; the original is moved into the reducer.
         let store_for_log = store.clone();
+        // Workers verify signatures and content digests in parallel; the
+        // reducer chain-checks and inserts the results in sequence order.
+        let worker_pool = WorkerPool::new_with_reducer(
+            StateSyncWorker(store.clone()),
+            "data_ingestion_executor".to_string(),
+            checkpoint_archive_config.verify_concurrency,
+            Default::default(),
+            StateSyncReducer(store, metrics),
+        );
         let setup_result = setup_data_ingestion_executor(
-            StateSyncWorker(store, metrics),
+            worker_pool,
             RemoteUrl::HybridHistoricalStore {
                 historical_url: checkpoint_archive_config.url.clone(),
                 live_url: None,
             },
             start,
-            1,
             Some(reader_options),
             ingestion_limit,
         )

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -123,6 +123,12 @@ const PEER_BALANCER_SELECTION_WINDOW: usize = 10;
 // entire sync range.
 const PEER_HEIGHTS_CLEANUP_CHECKPOINT_INTERVAL: u64 = 10_000;
 
+/// Caps the memory the archive reader may hold in downloaded checkpoints that
+/// have not been inserted yet. Without it the reader keeps downloading until it
+/// is `MAX_CHECKPOINTS_IN_PROGRESS` checkpoints ahead, which is a lot of memory
+/// while the reducer waits for execution to catch up.
+const CHECKPOINT_ARCHIVE_DATA_LIMIT: usize = 256 * 1024 * 1024;
+
 /// A handle to the StateSync subsystem.
 ///
 /// This handle can be cloned and shared. Once all copies of a StateSync
@@ -1347,32 +1353,21 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             return;
         };
         // The archive should cover [start, end); we want everything up to end-1
-        // and leave `end` onward to normal p2p sync. The end of the window is
-        // additionally bounded relative to the executed watermark: synced
-        // contents can only be pruned once executed, so letting sync run
-        // unboundedly ahead of execution grows disk usage without bound. This
-        // function runs periodically, so a paused or shortened window resumes
-        // once execution catches up. `MaxCheckpoint(last)` makes the executor
-        // shut down on its own once it has processed that range.
-        let highest_executed = store.get_highest_executed_checkpoint_seq_number();
+        // and leave `end` onward to normal p2p sync. `MaxCheckpoint(last)`
+        // makes the executor shut down on its own once it has processed that
+        // range.
         let Some(last) = checkpoint_archive_sync_end(
             start,
             lowest_checkpoint_on_peers.expect("checked by sync_from_checkpoint_archive"),
-            highest_executed,
-            checkpoint_archive_config
-                .max_checkpoints_ahead_of_execution
-                .get() as u64,
         ) else {
-            debug!(
-                "Checkpoint archive sync paused: synced checkpoint {highest_synced} is more than \
-                 {} checkpoints ahead of executed checkpoint {highest_executed:?}",
-                checkpoint_archive_config.max_checkpoints_ahead_of_execution
-            );
             return;
         };
         let ingestion_limit = Some(IngestionLimit::MaxCheckpoint(last));
         let reader_options = ReaderOptions {
             batch_size: checkpoint_archive_config.download_concurrency.get(),
+            // The reducer waits for execution before inserting, and downloaded
+            // checkpoints pile up in memory while it does.
+            data_limit: CHECKPOINT_ARCHIVE_DATA_LIMIT,
             ..Default::default()
         };
         // Keep a clone for the final log; the original is moved into the reducer.
@@ -1384,7 +1379,13 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             "data_ingestion_executor".to_string(),
             checkpoint_archive_config.verify_concurrency.get(),
             Default::default(),
-            StateSyncReducer { store, metrics },
+            StateSyncReducer {
+                store,
+                metrics,
+                max_checkpoints_ahead_of_execution: checkpoint_archive_config
+                    .max_checkpoints_ahead_of_execution
+                    .get() as u64,
+            },
         );
         let setup_result = setup_data_ingestion_executor(
             worker_pool,
@@ -1418,21 +1419,14 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
     }
 }
 
-/// The last checkpoint an archive sync window may cover: below the peers'
-/// lowest available checkpoint (everything from there on comes from normal
-/// p2p sync), and at most `max_ahead_of_execution` checkpoints ahead of the
-/// executed watermark. `None` when the window is empty and sync should pause.
+/// The last checkpoint an archive sync run covers: the one below the peers'
+/// lowest available checkpoint, since everything from there on comes from
+/// normal p2p sync. `None` when the range is empty.
 fn checkpoint_archive_sync_end(
     start: CheckpointSequenceNumber,
     lowest_checkpoint_on_peers: CheckpointSequenceNumber,
-    highest_executed: Option<CheckpointSequenceNumber>,
-    max_ahead_of_execution: u64,
 ) -> Option<CheckpointSequenceNumber> {
-    let below_peers = lowest_checkpoint_on_peers.checked_sub(1)?;
-    let cap = highest_executed
-        .unwrap_or(0)
-        .saturating_add(max_ahead_of_execution);
-    let last = below_peers.min(cap);
+    let last = lowest_checkpoint_on_peers.checked_sub(1)?;
     (start <= last).then_some(last)
 }
 

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1384,7 +1384,11 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             "data_ingestion_executor".to_string(),
             checkpoint_archive_config.verify_concurrency.get(),
             Default::default(),
-            StateSyncReducer(store, metrics),
+            StateSyncReducer {
+                store,
+                metrics,
+                verify_concurrency: checkpoint_archive_config.verify_concurrency,
+            },
         );
         let setup_result = setup_data_ingestion_executor(
             worker_pool,

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1347,14 +1347,32 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             return;
         };
         // The archive should cover [start, end); we want everything up to end-1
-        // and leave `end` onward to normal p2p sync. `MaxCheckpoint(end-1)` makes
-        // the executor shut down on its own once it has processed that range.
-        //
-        // `MaxCheckpoint` only fires once the reader delivers checkpoint `end`.
-        let ingestion_limit =
-            lowest_checkpoint_on_peers.map(|end| IngestionLimit::MaxCheckpoint(end - 1));
+        // and leave `end` onward to normal p2p sync. The end of the window is
+        // additionally bounded relative to the executed watermark: synced
+        // contents can only be pruned once executed, so letting sync run
+        // unboundedly ahead of execution grows disk usage without bound. This
+        // function runs periodically, so a paused or shortened window resumes
+        // once execution catches up. `MaxCheckpoint(last)` makes the executor
+        // shut down on its own once it has processed that range.
+        let highest_executed = store.get_highest_executed_checkpoint_seq_number();
+        let Some(last) = checkpoint_archive_sync_end(
+            start,
+            lowest_checkpoint_on_peers.expect("checked by sync_from_checkpoint_archive"),
+            highest_executed,
+            checkpoint_archive_config
+                .max_checkpoints_ahead_of_execution
+                .get() as u64,
+        ) else {
+            debug!(
+                "Checkpoint archive sync paused: synced checkpoint {highest_synced} is more than \
+                 {} checkpoints ahead of executed checkpoint {highest_executed:?}",
+                checkpoint_archive_config.max_checkpoints_ahead_of_execution
+            );
+            return;
+        };
+        let ingestion_limit = Some(IngestionLimit::MaxCheckpoint(last));
         let reader_options = ReaderOptions {
-            batch_size: checkpoint_archive_config.download_concurrency,
+            batch_size: checkpoint_archive_config.download_concurrency.get(),
             ..Default::default()
         };
         // Keep a clone for the final log; the original is moved into the reducer.
@@ -1364,7 +1382,7 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
         let worker_pool = WorkerPool::new_with_reducer(
             StateSyncWorker(store.clone()),
             "data_ingestion_executor".to_string(),
-            checkpoint_archive_config.verify_concurrency,
+            checkpoint_archive_config.verify_concurrency.get(),
             Default::default(),
             StateSyncReducer(store, metrics),
         );
@@ -1398,6 +1416,24 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             Err(err) => warn!("State sync from archive failed with error: {:?}", err),
         }
     }
+}
+
+/// The last checkpoint an archive sync window may cover: below the peers'
+/// lowest available checkpoint (everything from there on comes from normal
+/// p2p sync), and at most `max_ahead_of_execution` checkpoints ahead of the
+/// executed watermark. `None` when the window is empty and sync should pause.
+fn checkpoint_archive_sync_end(
+    start: CheckpointSequenceNumber,
+    lowest_checkpoint_on_peers: CheckpointSequenceNumber,
+    highest_executed: Option<CheckpointSequenceNumber>,
+    max_ahead_of_execution: u64,
+) -> Option<CheckpointSequenceNumber> {
+    let below_peers = lowest_checkpoint_on_peers.checked_sub(1)?;
+    let cap = highest_executed
+        .unwrap_or(0)
+        .saturating_add(max_ahead_of_execution);
+    let last = below_peers.min(cap);
+    (start <= last).then_some(last)
 }
 
 /// Syncs checkpoint contents from peers if the target sequence cursor, which is

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -1081,22 +1081,24 @@ async fn sync_with_checkpoints_gap() -> anyhow::Result<()> {
 fn test_checkpoint_archive_sync_end() {
     use crate::state_sync::checkpoint_archive_sync_end;
 
-    // No cap in play: the window ends just below the peers' lowest checkpoint.
-    assert_eq!(
-        checkpoint_archive_sync_end(1, 100, Some(90), 1000),
-        Some(99)
-    );
-
-    // The execution cap shortens the window.
-    assert_eq!(checkpoint_archive_sync_end(1, 100, Some(20), 30), Some(50));
-
-    // Nothing executed yet: the cap is anchored at checkpoint 0.
-    assert_eq!(checkpoint_archive_sync_end(1, 100, None, 30), Some(30));
-
-    // Sync is already at the cap: pause until execution catches up.
-    assert_eq!(checkpoint_archive_sync_end(61, 100, Some(20), 40), None);
+    // The run ends just below the peers' lowest checkpoint.
+    assert_eq!(checkpoint_archive_sync_end(1, 100), Some(99));
 
     // Peers already cover everything from checkpoint 1 on.
-    assert_eq!(checkpoint_archive_sync_end(1, 1, Some(0), 1000), None);
-    assert_eq!(checkpoint_archive_sync_end(1, 0, Some(0), 1000), None);
+    assert_eq!(checkpoint_archive_sync_end(1, 1), None);
+    assert_eq!(checkpoint_archive_sync_end(1, 0), None);
+}
+
+#[test]
+fn test_required_executed_checkpoint() {
+    use crate::state_sync::worker::required_executed_checkpoint;
+
+    // Within the cap of checkpoint 0: nothing to wait for.
+    assert_eq!(required_executed_checkpoint(30, 30), 0);
+    assert_eq!(required_executed_checkpoint(50, 1000), 0);
+
+    // Past the cap: execution has to reach the checkpoint the cap is anchored
+    // to, so that inserting stays exactly at the cap.
+    assert_eq!(required_executed_checkpoint(31, 30), 1);
+    assert_eq!(required_executed_checkpoint(51, 30), 21);
 }

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, num::NonZeroUsize, time::Duration};
 
 use anemo::{PeerId, Request};
 use anyhow::anyhow;
@@ -335,7 +335,8 @@ async fn test_state_sync_using_checkpoint_archive() -> anyhow::Result<()> {
         std::fs::write(temp_dir.path().join("MANIFEST"), &manifest_bytes[..])?;
     }
     let checkpoint_archive_config = CheckpointArchiveConfig {
-        download_concurrency: 1,
+        download_concurrency: NonZeroUsize::new(1).unwrap(),
+        verify_concurrency: NonZeroUsize::new(2).unwrap(),
         url: format!("file://{}", temp_dir.path().display()),
     };
     // Build and connect two nodes where Node 1 will be given access to an archive

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -337,6 +337,7 @@ async fn test_state_sync_using_checkpoint_archive() -> anyhow::Result<()> {
     let checkpoint_archive_config = CheckpointArchiveConfig {
         download_concurrency: NonZeroUsize::new(1).unwrap(),
         verify_concurrency: NonZeroUsize::new(2).unwrap(),
+        max_checkpoints_ahead_of_execution: NonZeroUsize::new(1_000_000).unwrap(),
         url: format!("file://{}", temp_dir.path().display()),
     };
     // Build and connect two nodes where Node 1 will be given access to an archive
@@ -1074,4 +1075,28 @@ async fn sync_with_checkpoints_gap() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_checkpoint_archive_sync_end() {
+    use crate::state_sync::checkpoint_archive_sync_end;
+
+    // No cap in play: the window ends just below the peers' lowest checkpoint.
+    assert_eq!(
+        checkpoint_archive_sync_end(1, 100, Some(90), 1000),
+        Some(99)
+    );
+
+    // The execution cap shortens the window.
+    assert_eq!(checkpoint_archive_sync_end(1, 100, Some(20), 30), Some(50));
+
+    // Nothing executed yet: the cap is anchored at checkpoint 0.
+    assert_eq!(checkpoint_archive_sync_end(1, 100, None, 30), Some(30));
+
+    // Sync is already at the cap: pause until execution catches up.
+    assert_eq!(checkpoint_archive_sync_end(61, 100, Some(20), 40), None);
+
+    // Peers already cover everything from checkpoint 1 on.
+    assert_eq!(checkpoint_archive_sync_end(1, 1, Some(0), 1000), None);
+    assert_eq!(checkpoint_archive_sync_end(1, 0, Some(0), 1000), None);
 }

--- a/crates/iota-network/src/state_sync/worker.rs
+++ b/crates/iota-network/src/state_sync/worker.rs
@@ -12,11 +12,12 @@ use iota_types::{
     committee::{Committee, EpochId},
     full_checkpoint_content::CheckpointData,
     messages_checkpoint::{
-        CertifiedCheckpointSummary, FullCheckpointContents, VerifiedCheckpoint,
-        VerifiedCheckpointContents,
+        CertifiedCheckpointSummary, CheckpointSequenceNumber, FullCheckpointContents,
+        VerifiedCheckpoint, VerifiedCheckpointContents,
     },
     storage::WriteStore,
 };
+use tracing::debug;
 
 use crate::state_sync::metrics::Metrics;
 
@@ -94,6 +95,9 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Worker for StateSyncWorker<S
 pub(crate) struct StateSyncReducer<S> {
     pub(crate) store: S,
     pub(crate) metrics: Metrics,
+    /// How far the synced watermark may run ahead of the executed one before
+    /// insertion waits for execution to catch up.
+    pub(crate) max_checkpoints_ahead_of_execution: u64,
 }
 
 /// How many checkpoints the reducer commits per store insertion at most,
@@ -106,6 +110,7 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
 {
     async fn commit(&self, batch: &[VerifiedArchiveCheckpoint]) -> anyhow::Result<()> {
         self.verify_deferred_signatures(batch).await?;
+        self.wait_for_execution_to_catch_up(batch).await;
 
         let mut to_insert = Vec::with_capacity(batch.len());
         let mut prev_checkpoint = None;
@@ -147,6 +152,40 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
 }
 
 impl<S: WriteStore + Clone> StateSyncReducer<S> {
+    /// Waits until the whole batch fits within
+    /// `max_checkpoints_ahead_of_execution` of the executed watermark.
+    ///
+    /// Synced contents can only be pruned once executed, so inserting far
+    /// ahead of execution grows disk usage without bound. Waiting here rather
+    /// than bounding what the workers download keeps the disk bound while
+    /// leaving the run's range untouched; execution advances from the
+    /// checkpoints already in the store, so it makes progress in the meantime.
+    async fn wait_for_execution_to_catch_up(&self, batch: &[VerifiedArchiveCheckpoint]) {
+        let (Some(first), Some(last)) = (batch.first(), batch.last()) else {
+            return;
+        };
+        let required = required_executed_checkpoint(
+            last.summary.sequence_number,
+            self.max_checkpoints_ahead_of_execution,
+        )
+        // Execution can only reach checkpoints that are inserted, so never
+        // wait past the batch's predecessor: a cap below the batch size would
+        // otherwise wait for a checkpoint this very batch has to insert.
+        .min(first.summary.sequence_number.saturating_sub(1));
+
+        let highest_executed = self.store.get_highest_executed_checkpoint_seq_number();
+        if highest_executed.unwrap_or(0) >= required {
+            return;
+        }
+        debug!(
+            "checkpoint archive sync paused: inserting checkpoint {} needs executed checkpoint \
+             {required}, which is at {highest_executed:?}",
+            last.summary.sequence_number
+        );
+        self.store.wait_for_executed_checkpoint(required).await;
+        debug!("checkpoint archive sync resumed at executed checkpoint {required}");
+    }
+
     /// Verifies the authority signatures the workers had to defer, batched per
     /// epoch. The deferred checkpoints sit at the head of an epoch, so by
     /// commit time the previous epoch's last checkpoint — which carries their
@@ -215,6 +254,15 @@ impl<S: WriteStore + Clone> StateSyncReducer<S> {
             .map(VerifiedCheckpoint::new_unchecked)
             .map_err(|_| anyhow!("checkpoint linkage verification failed"))
     }
+}
+
+/// The executed checkpoint that inserting `sequence_number` waits for, so that
+/// insertion stays within `max_ahead_of_execution` checkpoints of execution.
+pub(crate) fn required_executed_checkpoint(
+    sequence_number: CheckpointSequenceNumber,
+    max_ahead_of_execution: u64,
+) -> CheckpointSequenceNumber {
+    sequence_number.saturating_sub(max_ahead_of_execution)
 }
 
 /// Verifies the authority signatures of `summaries`, all certified by

--- a/crates/iota-network/src/state_sync/worker.rs
+++ b/crates/iota-network/src/state_sync/worker.rs
@@ -2,10 +2,11 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use anemo::async_trait;
 use anyhow::{Context, anyhow, ensure};
+use futures::{StreamExt, TryStreamExt};
 use iota_data_ingestion_core::{Reducer, Worker};
 use iota_storage::verify_checkpoint_linkage;
 use iota_types::{
@@ -82,7 +83,13 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Worker for StateSyncWorker<S
 /// verifies the signatures the workers had to defer — the checkpoints at the
 /// head of an epoch whose committee only becomes available here, once the
 /// previous epoch's last checkpoint is committed.
-pub(crate) struct StateSyncReducer<S>(pub(crate) S, pub(crate) Metrics);
+pub(crate) struct StateSyncReducer<S> {
+    pub(crate) store: S,
+    pub(crate) metrics: Metrics,
+    /// How many deferred signature verifications to run in parallel; the
+    /// workers use the same bound for their own verification.
+    pub(crate) verify_concurrency: NonZeroUsize,
+}
 
 /// How many checkpoints the reducer commits per store insertion at most,
 /// bounding the size of the underlying write batches.
@@ -104,12 +111,13 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
             to_insert.push((verified_checkpoint, message.contents.clone()));
         }
 
-        self.0
+        self.store
             .try_insert_synced_checkpoints(to_insert)
             .map_err(|e| anyhow!("failed to insert synced checkpoints: {e}"))?;
 
         for _ in batch {
-            self.1.update_checkpoints_synced_from_checkpoint_archive();
+            self.metrics
+                .update_checkpoints_synced_from_checkpoint_archive();
         }
         Ok(())
     }
@@ -134,35 +142,43 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
 }
 
 impl<S: WriteStore + Clone> StateSyncReducer<S> {
-    /// Verifies the authority signatures the workers had to
-    /// defer in parallel. The deferred checkpoints sit at the head of an epoch,
-    /// so by commit time the previous epoch's last checkpoint — which
-    /// carries their committee — is committed and the committee is in the
-    /// store.
+    /// Verifies in parallel the authority signatures the workers had to defer.
+    /// The deferred checkpoints sit at the head of an epoch, so by commit time
+    /// the previous epoch's last checkpoint — which carries their committee —
+    /// is committed and the committee is in the store.
     async fn verify_deferred_signatures(
         &self,
         batch: &[VerifiedArchiveCheckpoint],
     ) -> anyhow::Result<()> {
-        let tasks: Vec<_> = batch
+        let deferred = batch
             .iter()
             .filter(|message| !message.signatures_verified)
             .map(|message| {
                 let summary = message.summary.clone();
-                let committee = self.0.get_committee(summary.epoch()).context(format!(
+                let committee = self.store.get_committee(summary.epoch()).context(format!(
                     "missing committee for epoch {} in store",
                     summary.epoch()
                 ))?;
-                Ok(tokio::task::spawn_blocking(move || {
-                    summary
-                        .verify_authority_signatures(&committee)
-                        .map_err(|e| anyhow!("checkpoint signature verification failed: {e}"))
-                }))
+                Ok((summary, committee))
             })
-            .collect::<anyhow::Result<_>>()?;
-        for task in tasks {
-            task.await??;
-        }
-        Ok(())
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        futures::stream::iter(deferred.into_iter().map(|(summary, committee)| async move {
+            tokio::task::spawn_blocking(move || {
+                summary
+                    .verify_authority_signatures(&committee)
+                    .map_err(|e| {
+                        anyhow!(
+                            "signature verification failed for checkpoint {}: {e}",
+                            summary.sequence_number
+                        )
+                    })
+            })
+            .await?
+        }))
+        .buffer_unordered(self.verify_concurrency.get())
+        .try_collect()
+        .await
     }
 
     /// Chain-checks one checkpoint against its predecessor — the previous
@@ -174,7 +190,10 @@ impl<S: WriteStore + Clone> StateSyncReducer<S> {
         prev_in_batch: Option<&VerifiedCheckpoint>,
     ) -> anyhow::Result<VerifiedCheckpoint> {
         let sequence_number = message.summary.sequence_number;
-        if let Some(existing) = self.0.get_checkpoint_by_sequence_number(sequence_number) {
+        if let Some(existing) = self
+            .store
+            .get_checkpoint_by_sequence_number(sequence_number)
+        {
             // The contents will be inserted under the stored summary, and
             // mismatched contents would only panic after the transactions are
             // written, so reject archive data that diverges from the store
@@ -192,7 +211,7 @@ impl<S: WriteStore + Clone> StateSyncReducer<S> {
         let prev_checkpoint = match prev_in_batch {
             Some(prev) if prev.sequence_number == prev_checkpoint_seq_num => prev.clone(),
             _ => self
-                .0
+                .store
                 .get_checkpoint_by_sequence_number(prev_checkpoint_seq_num)
                 .context(format!(
                     "missing previous checkpoint {prev_checkpoint_seq_num} in store"

--- a/crates/iota-network/src/state_sync/worker.rs
+++ b/crates/iota-network/src/state_sync/worker.rs
@@ -84,27 +84,61 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Worker for StateSyncWorker<S
 /// previous epoch's last checkpoint is committed.
 pub(crate) struct StateSyncReducer<S>(pub(crate) S, pub(crate) Metrics);
 
+/// How many checkpoints the reducer commits per store insertion at most,
+/// bounding the size of the underlying write batches.
+const MAX_CHECKPOINTS_PER_COMMIT: usize = 500;
+
 #[async_trait]
 impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
     for StateSyncReducer<S>
 {
     async fn commit(&self, batch: &[VerifiedArchiveCheckpoint]) -> anyhow::Result<()> {
+        let mut to_insert = Vec::with_capacity(batch.len());
+        let mut prev_checkpoint = None;
         for message in batch {
-            let verified_checkpoint = self.get_or_insert_verified_checkpoint(message)?;
-            self.0
-                .insert_checkpoint_contents(&verified_checkpoint, message.contents.clone());
-            self.0
-                .update_highest_synced_checkpoint(&verified_checkpoint);
+            let verified_checkpoint =
+                self.verify_against_previous(message, prev_checkpoint.as_ref())?;
+            prev_checkpoint = Some(verified_checkpoint.clone());
+            to_insert.push((verified_checkpoint, message.contents.clone()));
+        }
+
+        self.0
+            .try_insert_synced_checkpoints(to_insert)
+            .map_err(|e| anyhow!("failed to insert synced checkpoints: {e}"))?;
+
+        for _ in batch {
             self.1.update_checkpoints_synced_from_checkpoint_archive();
         }
         Ok(())
     }
+
+    /// Closes a batch at the size cap, and at epoch boundaries so that an
+    /// epoch's last checkpoint — which carries the next committee — is
+    /// committed before any checkpoint of the next epoch needs that committee
+    /// for its deferred signature verification.
+    fn should_close_batch(
+        &self,
+        batch: &[VerifiedArchiveCheckpoint],
+        next_item: Option<&VerifiedArchiveCheckpoint>,
+    ) -> bool {
+        let Some(next) = next_item else {
+            return true;
+        };
+        batch.len() >= MAX_CHECKPOINTS_PER_COMMIT
+            || batch
+                .last()
+                .is_some_and(|last| last.summary.epoch() != next.summary.epoch())
+    }
 }
 
 impl<S: WriteStore + Clone> StateSyncReducer<S> {
-    fn get_or_insert_verified_checkpoint(
+    /// Chain-checks one checkpoint against its predecessor — the previous
+    /// checkpoint of the batch being committed, or the store's copy at the
+    /// start of a batch — and finishes any verification the workers deferred.
+    fn verify_against_previous(
         &self,
         message: &VerifiedArchiveCheckpoint,
+        prev_in_batch: Option<&VerifiedCheckpoint>,
     ) -> anyhow::Result<VerifiedCheckpoint> {
         let sequence_number = message.summary.sequence_number;
         if let Some(existing) = self.0.get_checkpoint_by_sequence_number(sequence_number) {
@@ -114,25 +148,23 @@ impl<S: WriteStore + Clone> StateSyncReducer<S> {
         let prev_checkpoint_seq_num = sequence_number
             .checked_sub(1)
             .context("checkpoint seq num underflow")?;
-        let prev_checkpoint = self
-            .0
-            .get_checkpoint_by_sequence_number(prev_checkpoint_seq_num)
-            .context(format!(
-                "missing previous checkpoint {prev_checkpoint_seq_num} in store"
-            ))?;
-
-        let verified_checkpoint = if message.signatures_verified {
-            verify_checkpoint_linkage(&prev_checkpoint, message.summary.clone())
-                .map(VerifiedCheckpoint::new_unchecked)
-                .map_err(|_| anyhow!("checkpoint linkage verification failed"))?
-        } else {
-            verify_checkpoint(&prev_checkpoint, &self.0, message.summary.clone())
-                .map_err(|_| anyhow!("checkpoint verification failed"))?
+        let prev_checkpoint = match prev_in_batch {
+            Some(prev) if prev.sequence_number == prev_checkpoint_seq_num => prev.clone(),
+            _ => self
+                .0
+                .get_checkpoint_by_sequence_number(prev_checkpoint_seq_num)
+                .context(format!(
+                    "missing previous checkpoint {prev_checkpoint_seq_num} in store"
+                ))?,
         };
 
-        self.0.insert_checkpoint(&verified_checkpoint);
-        self.0
-            .update_highest_verified_checkpoint(&verified_checkpoint);
-        Ok(verified_checkpoint)
+        if message.signatures_verified {
+            verify_checkpoint_linkage(&prev_checkpoint, message.summary.clone())
+                .map(VerifiedCheckpoint::new_unchecked)
+                .map_err(|_| anyhow!("checkpoint linkage verification failed"))
+        } else {
+            verify_checkpoint(&prev_checkpoint, &self.0, message.summary.clone())
+                .map_err(|_| anyhow!("checkpoint verification failed"))
+        }
     }
 }

--- a/crates/iota-network/src/state_sync/worker.rs
+++ b/crates/iota-network/src/state_sync/worker.rs
@@ -54,7 +54,9 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Worker for StateSyncWorker<S
         let summary = checkpoint.checkpoint_summary.clone();
         let committee = self.0.get_committee(summary.epoch());
         // As many workers run as there are cores, so keep their CPU-bound
-        // verification off the runtime's worker threads.
+        // verification off the runtime's worker threads, where it would hold up
+        // checkpoint execution — which in turn gates how far sync may run
+        // ahead.
         tokio::task::spawn_blocking(move || {
             let signatures_verified = match committee {
                 Some(committee) => {

--- a/crates/iota-network/src/state_sync/worker.rs
+++ b/crates/iota-network/src/state_sync/worker.rs
@@ -2,14 +2,14 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use anemo::async_trait;
 use anyhow::{Context, anyhow, ensure};
-use futures::{StreamExt, TryStreamExt};
 use iota_data_ingestion_core::{Reducer, Worker};
 use iota_storage::verify_checkpoint_linkage;
 use iota_types::{
+    committee::{Committee, EpochId},
     full_checkpoint_content::CheckpointData,
     messages_checkpoint::{
         CertifiedCheckpointSummary, FullCheckpointContents, VerifiedCheckpoint,
@@ -92,9 +92,6 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Worker for StateSyncWorker<S
 pub(crate) struct StateSyncReducer<S> {
     pub(crate) store: S,
     pub(crate) metrics: Metrics,
-    /// How many deferred signature verifications to run in parallel; the
-    /// workers use the same bound for their own verification.
-    pub(crate) verify_concurrency: NonZeroUsize,
 }
 
 /// How many checkpoints the reducer commits per store insertion at most,
@@ -148,43 +145,31 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
 }
 
 impl<S: WriteStore + Clone> StateSyncReducer<S> {
-    /// Verifies in parallel the authority signatures the workers had to defer.
-    /// The deferred checkpoints sit at the head of an epoch, so by commit time
-    /// the previous epoch's last checkpoint — which carries their committee —
-    /// is committed and the committee is in the store.
+    /// Verifies the authority signatures the workers had to defer, batched per
+    /// epoch. The deferred checkpoints sit at the head of an epoch, so by
+    /// commit time the previous epoch's last checkpoint — which carries their
+    /// committee — is committed and the committee is in the store.
     async fn verify_deferred_signatures(
         &self,
         batch: &[VerifiedArchiveCheckpoint],
     ) -> anyhow::Result<()> {
-        let deferred = batch
-            .iter()
-            .filter(|message| !message.signatures_verified)
-            .map(|message| {
-                let summary = message.summary.clone();
-                let committee = self.store.get_committee(summary.epoch()).context(format!(
-                    "missing committee for epoch {} in store",
-                    summary.epoch()
-                ))?;
-                Ok((summary, committee))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
+        let mut deferred: BTreeMap<EpochId, Vec<CertifiedCheckpointSummary>> = BTreeMap::new();
+        for message in batch.iter().filter(|message| !message.signatures_verified) {
+            deferred
+                .entry(message.summary.epoch())
+                .or_default()
+                .push(message.summary.clone());
+        }
 
-        futures::stream::iter(deferred.into_iter().map(|(summary, committee)| async move {
-            tokio::task::spawn_blocking(move || {
-                summary
-                    .verify_authority_signatures(&committee)
-                    .map_err(|e| {
-                        anyhow!(
-                            "signature verification failed for checkpoint {}: {e}",
-                            summary.sequence_number
-                        )
-                    })
-            })
-            .await?
-        }))
-        .buffer_unordered(self.verify_concurrency.get())
-        .try_collect()
-        .await
+        for (epoch, summaries) in deferred {
+            let committee = self
+                .store
+                .get_committee(epoch)
+                .context(format!("missing committee for epoch {epoch} in store"))?;
+            tokio::task::spawn_blocking(move || batch_verify_signatures(&summaries, &committee))
+                .await??;
+        }
+        Ok(())
     }
 
     /// Chain-checks one checkpoint against its predecessor — the previous
@@ -228,4 +213,32 @@ impl<S: WriteStore + Clone> StateSyncReducer<S> {
             .map(VerifiedCheckpoint::new_unchecked)
             .map_err(|_| anyhow!("checkpoint linkage verification failed"))
     }
+}
+
+/// Verifies the authority signatures of `summaries`, all certified by
+/// `committee`, in one batched signature verification. On failure the
+/// summaries are verified one by one, so that the error names the offending
+/// checkpoint.
+fn batch_verify_signatures(
+    summaries: &[CertifiedCheckpointSummary],
+    committee: &Committee,
+) -> anyhow::Result<()> {
+    let Err(batch_error) =
+        CertifiedCheckpointSummary::batch_verify_authority_signatures(summaries, committee)
+    else {
+        return Ok(());
+    };
+    for summary in summaries {
+        summary
+            .verify_authority_signatures(committee)
+            .map_err(|e| {
+                anyhow!(
+                    "checkpoint {} signature verification failed: {e}",
+                    summary.sequence_number
+                )
+            })?;
+    }
+    Err(anyhow!(
+        "checkpoint signature batch verification failed: {batch_error}"
+    ))
 }

--- a/crates/iota-network/src/state_sync/worker.rs
+++ b/crates/iota-network/src/state_sync/worker.rs
@@ -5,9 +5,9 @@
 use std::sync::Arc;
 
 use anemo::async_trait;
-use anyhow::{Context, anyhow};
+use anyhow::{Context, anyhow, ensure};
 use iota_data_ingestion_core::{Reducer, Worker};
-use iota_storage::{verify_checkpoint, verify_checkpoint_linkage};
+use iota_storage::verify_checkpoint_linkage;
 use iota_types::{
     full_checkpoint_content::CheckpointData,
     messages_checkpoint::{
@@ -93,6 +93,8 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
     for StateSyncReducer<S>
 {
     async fn commit(&self, batch: &[VerifiedArchiveCheckpoint]) -> anyhow::Result<()> {
+        self.verify_deferred_signatures(batch).await?;
+
         let mut to_insert = Vec::with_capacity(batch.len());
         let mut prev_checkpoint = None;
         for message in batch {
@@ -132,9 +134,40 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
 }
 
 impl<S: WriteStore + Clone> StateSyncReducer<S> {
+    /// Verifies the authority signatures the workers had to
+    /// defer in parallel. The deferred checkpoints sit at the head of an epoch,
+    /// so by commit time the previous epoch's last checkpoint — which
+    /// carries their committee — is committed and the committee is in the
+    /// store.
+    async fn verify_deferred_signatures(
+        &self,
+        batch: &[VerifiedArchiveCheckpoint],
+    ) -> anyhow::Result<()> {
+        let tasks: Vec<_> = batch
+            .iter()
+            .filter(|message| !message.signatures_verified)
+            .map(|message| {
+                let summary = message.summary.clone();
+                let committee = self.0.get_committee(summary.epoch()).context(format!(
+                    "missing committee for epoch {} in store",
+                    summary.epoch()
+                ))?;
+                Ok(tokio::task::spawn_blocking(move || {
+                    summary
+                        .verify_authority_signatures(&committee)
+                        .map_err(|e| anyhow!("checkpoint signature verification failed: {e}"))
+                }))
+            })
+            .collect::<anyhow::Result<_>>()?;
+        for task in tasks {
+            task.await??;
+        }
+        Ok(())
+    }
+
     /// Chain-checks one checkpoint against its predecessor — the previous
     /// checkpoint of the batch being committed, or the store's copy at the
-    /// start of a batch — and finishes any verification the workers deferred.
+    /// start of a batch.
     fn verify_against_previous(
         &self,
         message: &VerifiedArchiveCheckpoint,
@@ -142,6 +175,14 @@ impl<S: WriteStore + Clone> StateSyncReducer<S> {
     ) -> anyhow::Result<VerifiedCheckpoint> {
         let sequence_number = message.summary.sequence_number;
         if let Some(existing) = self.0.get_checkpoint_by_sequence_number(sequence_number) {
+            // The contents will be inserted under the stored summary, and
+            // mismatched contents would only panic after the transactions are
+            // written, so reject archive data that diverges from the store
+            // before any write.
+            ensure!(
+                existing.digest() == message.summary.digest(),
+                "archive checkpoint {sequence_number} does not match the checkpoint already in the store"
+            );
             return Ok(existing);
         }
 
@@ -158,13 +199,8 @@ impl<S: WriteStore + Clone> StateSyncReducer<S> {
                 ))?,
         };
 
-        if message.signatures_verified {
-            verify_checkpoint_linkage(&prev_checkpoint, message.summary.clone())
-                .map(VerifiedCheckpoint::new_unchecked)
-                .map_err(|_| anyhow!("checkpoint linkage verification failed"))
-        } else {
-            verify_checkpoint(&prev_checkpoint, &self.0, message.summary.clone())
-                .map_err(|_| anyhow!("checkpoint verification failed"))
-        }
+        verify_checkpoint_linkage(&prev_checkpoint, message.summary.clone())
+            .map(VerifiedCheckpoint::new_unchecked)
+            .map_err(|_| anyhow!("checkpoint linkage verification failed"))
     }
 }

--- a/crates/iota-network/src/state_sync/worker.rs
+++ b/crates/iota-network/src/state_sync/worker.rs
@@ -52,26 +52,32 @@ impl<S: WriteStore + Clone + Send + Sync + 'static> Worker for StateSyncWorker<S
         checkpoint: Arc<CheckpointData>,
     ) -> anyhow::Result<Self::Message> {
         let summary = checkpoint.checkpoint_summary.clone();
-        let signatures_verified = match self.0.get_committee(summary.epoch()) {
-            Some(committee) => {
-                summary
-                    .verify_authority_signatures(&committee)
-                    .map_err(|e| anyhow!("checkpoint signature verification failed: {e}"))?;
-                true
-            }
-            None => false,
-        };
-        let full_contents = FullCheckpointContents::from_contents_and_execution_data(
-            checkpoint.checkpoint_contents.clone(),
-            checkpoint.transactions.iter().map(|t| t.execution_data()),
-        );
-        full_contents.verify_digests(summary.contents_digest)?;
-        let contents = VerifiedCheckpointContents::new_unchecked(full_contents);
-        Ok(VerifiedArchiveCheckpoint {
-            summary,
-            contents,
-            signatures_verified,
+        let committee = self.0.get_committee(summary.epoch());
+        // As many workers run as there are cores, so keep their CPU-bound
+        // verification off the runtime's worker threads.
+        tokio::task::spawn_blocking(move || {
+            let signatures_verified = match committee {
+                Some(committee) => {
+                    summary
+                        .verify_authority_signatures(&committee)
+                        .map_err(|e| anyhow!("checkpoint signature verification failed: {e}"))?;
+                    true
+                }
+                None => false,
+            };
+            let full_contents = FullCheckpointContents::from_contents_and_execution_data(
+                checkpoint.checkpoint_contents.clone(),
+                checkpoint.transactions.iter().map(|t| t.execution_data()),
+            );
+            full_contents.verify_digests(summary.contents_digest)?;
+            let contents = VerifiedCheckpointContents::new_unchecked(full_contents);
+            Ok(VerifiedArchiveCheckpoint {
+                summary,
+                contents,
+                signatures_verified,
+            })
         })
+        .await?
     }
 }
 

--- a/crates/iota-network/src/state_sync/worker.rs
+++ b/crates/iota-network/src/state_sync/worker.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use anemo::async_trait;
 use anyhow::{Context, anyhow};
-use iota_data_ingestion_core::Worker;
-use iota_storage::verify_checkpoint;
+use iota_data_ingestion_core::{Reducer, Worker};
+use iota_storage::{verify_checkpoint, verify_checkpoint_linkage};
 use iota_types::{
     full_checkpoint_content::CheckpointData,
     messages_checkpoint::{
@@ -19,68 +19,120 @@ use iota_types::{
 
 use crate::state_sync::metrics::Metrics;
 
-pub(crate) struct StateSyncWorker<S>(pub(crate) S, pub(crate) Metrics);
+/// A checkpoint downloaded from the archive whose content digests — and,
+/// unless deferred, authority signatures — have been verified by a
+/// [`StateSyncWorker`], pending the chain-linkage check and insertion in the
+/// [`StateSyncReducer`].
+pub(crate) struct VerifiedArchiveCheckpoint {
+    summary: CertifiedCheckpointSummary,
+    contents: VerifiedCheckpointContents,
+    /// False when the committee for the checkpoint's epoch was not yet in the
+    /// store, because the previous epoch's last checkpoint had not been
+    /// committed; the reducer verifies the signatures for those instead.
+    signatures_verified: bool,
+}
+
+/// Verifies checkpoints downloaded from the archive.
+///
+/// Multiple workers run concurrently, so this performs only the CPU-heavy
+/// per-checkpoint verification that doesn't depend on the previous checkpoint:
+/// authority signatures and content digests. The [`StateSyncReducer`] receives
+/// the results ordered by sequence number and performs the chain-linkage check
+/// and the store insertion.
+pub(crate) struct StateSyncWorker<S>(pub(crate) S);
 
 #[async_trait]
 impl<S: WriteStore + Clone + Send + Sync + 'static> Worker for StateSyncWorker<S> {
     type Error = anyhow::Error;
-    type Message = ();
+    type Message = VerifiedArchiveCheckpoint;
 
-    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> anyhow::Result<()> {
-        let verified_checkpoint = get_or_insert_verified_checkpoint(
-            &self.0,
-            checkpoint.checkpoint_summary.clone(),
-            true,
-        )?;
+    async fn process_checkpoint(
+        &self,
+        checkpoint: Arc<CheckpointData>,
+    ) -> anyhow::Result<Self::Message> {
+        let summary = checkpoint.checkpoint_summary.clone();
+        let signatures_verified = match self.0.get_committee(summary.epoch()) {
+            Some(committee) => {
+                summary
+                    .verify_authority_signatures(&committee)
+                    .map_err(|e| anyhow!("checkpoint signature verification failed: {e}"))?;
+                true
+            }
+            None => false,
+        };
         let full_contents = FullCheckpointContents::from_contents_and_execution_data(
             checkpoint.checkpoint_contents.clone(),
             checkpoint.transactions.iter().map(|t| t.execution_data()),
         );
-        full_contents.verify_digests(verified_checkpoint.contents_digest)?;
-        let verified_contents = VerifiedCheckpointContents::new_unchecked(full_contents);
-        self.0
-            .insert_checkpoint_contents(&verified_checkpoint, verified_contents);
-        self.0
-            .update_highest_synced_checkpoint(&verified_checkpoint);
-        self.1.update_checkpoints_synced_from_checkpoint_archive();
+        full_contents.verify_digests(summary.contents_digest)?;
+        let contents = VerifiedCheckpointContents::new_unchecked(full_contents);
+        Ok(VerifiedArchiveCheckpoint {
+            summary,
+            contents,
+            signatures_verified,
+        })
+    }
+}
+
+/// Chain-checks and commits checkpoints verified by [`StateSyncWorker`]s.
+///
+/// This is the single sequential stage of archive sync: batches arrive
+/// ordered by sequence number, and each checkpoint is linked to the previous
+/// one before its summary and contents are inserted into the store. It also
+/// verifies the signatures the workers had to defer — the checkpoints at the
+/// head of an epoch whose committee only becomes available here, once the
+/// previous epoch's last checkpoint is committed.
+pub(crate) struct StateSyncReducer<S>(pub(crate) S, pub(crate) Metrics);
+
+#[async_trait]
+impl<S: WriteStore + Clone + Send + Sync + 'static> Reducer<StateSyncWorker<S>>
+    for StateSyncReducer<S>
+{
+    async fn commit(&self, batch: &[VerifiedArchiveCheckpoint]) -> anyhow::Result<()> {
+        for message in batch {
+            let verified_checkpoint = self.get_or_insert_verified_checkpoint(message)?;
+            self.0
+                .insert_checkpoint_contents(&verified_checkpoint, message.contents.clone());
+            self.0
+                .update_highest_synced_checkpoint(&verified_checkpoint);
+            self.1.update_checkpoints_synced_from_checkpoint_archive();
+        }
         Ok(())
     }
 }
 
-fn get_or_insert_verified_checkpoint<S>(
-    store: &S,
-    certified_checkpoint: CertifiedCheckpointSummary,
-    verify: bool,
-) -> anyhow::Result<VerifiedCheckpoint>
-where
-    S: WriteStore + Clone,
-{
-    store
-        .get_checkpoint_by_sequence_number(certified_checkpoint.sequence_number)
-        .map(Ok::<VerifiedCheckpoint, anyhow::Error>)
-        .unwrap_or_else(|| {
-            let verified_checkpoint = if verify {
-                // Verify checkpoint summary
-                let prev_checkpoint_seq_num = certified_checkpoint
-                    .sequence_number
-                    .checked_sub(1)
-                    .context("Checkpoint seq num underflow")?;
-                let prev_checkpoint = store
-                    .get_checkpoint_by_sequence_number(prev_checkpoint_seq_num)
-                    .context(format!(
-                        "Missing previous checkpoint {prev_checkpoint_seq_num} in store",
-                    ))?;
+impl<S: WriteStore + Clone> StateSyncReducer<S> {
+    fn get_or_insert_verified_checkpoint(
+        &self,
+        message: &VerifiedArchiveCheckpoint,
+    ) -> anyhow::Result<VerifiedCheckpoint> {
+        let sequence_number = message.summary.sequence_number;
+        if let Some(existing) = self.0.get_checkpoint_by_sequence_number(sequence_number) {
+            return Ok(existing);
+        }
 
-                verify_checkpoint(&prev_checkpoint, store, certified_checkpoint)
-                    .map_err(|_| anyhow!("Checkpoint verification failed"))?
-            } else {
-                VerifiedCheckpoint::new_unchecked(certified_checkpoint)
-            };
-            // Insert checkpoint summary
-            store.insert_checkpoint(&verified_checkpoint);
-            // Update highest verified checkpoint watermark
-            store.update_highest_verified_checkpoint(&verified_checkpoint);
-            Ok::<VerifiedCheckpoint, anyhow::Error>(verified_checkpoint)
-        })
-        .map_err(|e| anyhow!("Failed to get verified checkpoint: {e:?}"))
+        let prev_checkpoint_seq_num = sequence_number
+            .checked_sub(1)
+            .context("checkpoint seq num underflow")?;
+        let prev_checkpoint = self
+            .0
+            .get_checkpoint_by_sequence_number(prev_checkpoint_seq_num)
+            .context(format!(
+                "missing previous checkpoint {prev_checkpoint_seq_num} in store"
+            ))?;
+
+        let verified_checkpoint = if message.signatures_verified {
+            verify_checkpoint_linkage(&prev_checkpoint, message.summary.clone())
+                .map(VerifiedCheckpoint::new_unchecked)
+                .map_err(|_| anyhow!("checkpoint linkage verification failed"))?
+        } else {
+            verify_checkpoint(&prev_checkpoint, &self.0, message.summary.clone())
+                .map_err(|_| anyhow!("checkpoint verification failed"))?
+        };
+
+        self.0.insert_checkpoint(&verified_checkpoint);
+        self.0
+            .update_highest_verified_checkpoint(&verified_checkpoint);
+        Ok(verified_checkpoint)
+    }
 }

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -158,12 +158,19 @@ pub fn make_iterator<T: DeserializeOwned, R: Read + 'static>(
     }
 }
 
+/// The chain-linkage part of checkpoint verification: checks that
+/// `checkpoint` directly extends `current` (matching previous digest and a
+/// valid epoch transition). Does not verify authority signatures; returns the
+/// summary unchanged on success so the caller can finish verification.
+///
+/// # Panics
+///
+/// Panics if `checkpoint`'s sequence number is not `current`'s plus one.
 #[expect(clippy::result_large_err)]
-pub fn verify_checkpoint_with_committee(
-    committee: Arc<Committee>,
+pub fn verify_checkpoint_linkage(
     current: &VerifiedCheckpoint,
     checkpoint: CertifiedCheckpointSummary,
-) -> Result<VerifiedCheckpoint, CertifiedCheckpointSummary> {
+) -> Result<CertifiedCheckpointSummary, CertifiedCheckpointSummary> {
     assert_eq!(
         checkpoint.sequence_number(),
         current.sequence_number().checked_add(1).unwrap()
@@ -208,6 +215,17 @@ pub fn verify_checkpoint_with_committee(
         );
         return Err(checkpoint);
     }
+
+    Ok(checkpoint)
+}
+
+#[expect(clippy::result_large_err)]
+pub fn verify_checkpoint_with_committee(
+    committee: Arc<Committee>,
+    current: &VerifiedCheckpoint,
+    checkpoint: CertifiedCheckpointSummary,
+) -> Result<VerifiedCheckpoint, CertifiedCheckpointSummary> {
+    let checkpoint = verify_checkpoint_linkage(current, checkpoint)?;
 
     checkpoint
         .verify_authority_signatures(&committee)

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -33,7 +33,7 @@ use crate::{
     committee::{Committee, EpochId},
     crypto::{
         AccountKeyPair, AggregateAuthoritySignature, AuthoritySignInfo, AuthoritySignInfoTrait,
-        AuthorityStrongQuorumSignInfo, default_hash, get_key_pair,
+        AuthorityStrongQuorumSignInfo, VerificationObligation, default_hash, get_key_pair,
     },
     effects::{TestEffectsBuilder, TransactionEffectsAPI},
     error::{IotaError, IotaResult},
@@ -258,6 +258,31 @@ impl CertifiedCheckpointSummary {
             Intent::iota_app(IntentScope::CheckpointSummary),
             committee,
         )
+    }
+
+    /// Verifies the authority signatures of `summaries`, all certified by
+    /// `committee`, in a single batched signature verification. Cheaper than
+    /// verifying each summary on its own, at the cost of not saying which
+    /// summary failed; callers that need that can fall back to
+    /// [`Self::verify_authority_signatures`] per summary.
+    #[instrument(level = "trace", skip_all)]
+    pub fn batch_verify_authority_signatures(
+        summaries: &[Self],
+        committee: &Committee,
+    ) -> IotaResult {
+        let mut obligation = VerificationObligation::default();
+        for summary in summaries {
+            summary.data().verify_epoch(summary.auth_sig().epoch)?;
+            let idx = obligation.add_message(
+                summary.data(),
+                summary.auth_sig().epoch,
+                Intent::iota_app(IntentScope::CheckpointSummary),
+            );
+            summary
+                .auth_sig()
+                .add_to_verification_obligation(committee, &mut obligation, idx)?;
+        }
+        obligation.verify_all()
     }
 
     pub fn try_into_verified(self, committee: &Committee) -> IotaResult<VerifiedCheckpoint> {
@@ -840,6 +865,70 @@ mod tests {
                 .verify_authority_signatures(&committee)
                 .is_err()
         )
+    }
+
+    #[test]
+    fn test_batch_verify_certified_checkpoints() {
+        let mut rng = StdRng::from_seed(RNG_SEED);
+        let (keys, committee) = make_committee_key(&mut rng);
+
+        let summary_for_sequence_number = |sequence_number| {
+            let set =
+                CheckpointContents::new_with_digests_only_for_tests([ExecutionDigests::random()]);
+            CheckpointSummary::new_with_protocol_config(
+                &ProtocolConfig::get_for_max_version_UNSAFE(),
+                committee.epoch,
+                sequence_number,
+                0,
+                &set,
+                None,
+                GasCostSummary::default(),
+                None,
+                0,
+                Vec::new(),
+            )
+        };
+        let certify = |summary: CheckpointSummary| {
+            let sign_infos = keys
+                .iter()
+                .map(|k| {
+                    SignedCheckpointSummary::sign(committee.epoch, &summary, k, k.public().into())
+                })
+                .collect();
+            CertifiedCheckpointSummary::new(summary, sign_infos, &committee).expect("cert is OK")
+        };
+
+        let summaries: Vec<_> = (1..=3)
+            .map(|seq| certify(summary_for_sequence_number(seq)))
+            .collect();
+        CertifiedCheckpointSummary::batch_verify_authority_signatures(&summaries, &committee)
+            .expect("signatures ok");
+
+        // A certificate whose signatures were made over a different summary
+        // fails the batch.
+        let mismatched = {
+            let summary = summary_for_sequence_number(4);
+            let sign_infos = keys
+                .iter()
+                .map(|k| {
+                    SignedCheckpointSummary::sign(
+                        committee.epoch,
+                        &summary_for_sequence_number(4),
+                        k,
+                        k.public().into(),
+                    )
+                })
+                .collect();
+            CertifiedCheckpointSummary::new(summary, sign_infos, &committee).expect("cert is OK")
+        };
+        let with_mismatched: Vec<_> = summaries.into_iter().chain([mismatched]).collect();
+        assert!(
+            CertifiedCheckpointSummary::batch_verify_authority_signatures(
+                &with_mismatched,
+                &committee
+            )
+            .is_err()
+        );
     }
 
     // Generate a CheckpointSummary from the input transaction digest. All the other

--- a/crates/iota-types/src/storage/write_store.rs
+++ b/crates/iota-types/src/storage/write_store.rs
@@ -60,6 +60,25 @@ pub trait WriteStore: ReadStore {
         self.try_insert_committee(new_committee)
             .expect("storage access failed")
     }
+
+    /// Inserts a consecutive run of verified checkpoints with their full
+    /// contents and advances the verified and synced watermarks past the
+    /// last one.
+    ///
+    /// The default implementation inserts the checkpoints one at a time;
+    /// implementations can override it to batch the writes.
+    fn try_insert_synced_checkpoints(
+        &self,
+        checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
+    ) -> Result<()> {
+        for (checkpoint, contents) in checkpoints {
+            self.try_insert_checkpoint(&checkpoint)?;
+            self.try_update_highest_verified_checkpoint(&checkpoint)?;
+            self.try_insert_checkpoint_contents(&checkpoint, contents)?;
+            self.try_update_highest_synced_checkpoint(&checkpoint)?;
+        }
+        Ok(())
+    }
 }
 
 impl<T: WriteStore + ?Sized> WriteStore for &T {
@@ -88,6 +107,13 @@ impl<T: WriteStore + ?Sized> WriteStore for &T {
 
     fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
         (*self).try_insert_committee(new_committee)
+    }
+
+    fn try_insert_synced_checkpoints(
+        &self,
+        checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
+    ) -> Result<()> {
+        (*self).try_insert_synced_checkpoints(checkpoints)
     }
 }
 
@@ -118,6 +144,13 @@ impl<T: WriteStore + ?Sized> WriteStore for Box<T> {
     fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
         (**self).try_insert_committee(new_committee)
     }
+
+    fn try_insert_synced_checkpoints(
+        &self,
+        checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
+    ) -> Result<()> {
+        (**self).try_insert_synced_checkpoints(checkpoints)
+    }
 }
 
 impl<T: WriteStore + ?Sized> WriteStore for Arc<T> {
@@ -146,5 +179,12 @@ impl<T: WriteStore + ?Sized> WriteStore for Arc<T> {
 
     fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
         (**self).try_insert_committee(new_committee)
+    }
+
+    fn try_insert_synced_checkpoints(
+        &self,
+        checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
+    ) -> Result<()> {
+        (**self).try_insert_synced_checkpoints(checkpoints)
     }
 }

--- a/crates/iota-types/src/storage/write_store.rs
+++ b/crates/iota-types/src/storage/write_store.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use super::error::Result;
 use crate::{
     committee::Committee,
-    messages_checkpoint::{VerifiedCheckpoint, VerifiedCheckpointContents},
+    messages_checkpoint::{
+        CheckpointSequenceNumber, VerifiedCheckpoint, VerifiedCheckpointContents,
+    },
     storage::ReadStore,
 };
 
@@ -61,6 +63,22 @@ pub trait WriteStore: ReadStore {
             .expect("storage access failed")
     }
 
+    /// The highest checkpoint whose transactions have been executed, when the
+    /// store tracks execution progress. `None` when nothing has been executed
+    /// yet or the store does not track execution (the default).
+    fn try_get_highest_executed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>> {
+        Ok(None)
+    }
+
+    /// Non-fallible version of
+    /// `try_get_highest_executed_checkpoint_seq_number`.
+    fn get_highest_executed_checkpoint_seq_number(&self) -> Option<CheckpointSequenceNumber> {
+        self.try_get_highest_executed_checkpoint_seq_number()
+            .expect("storage access failed")
+    }
+
     /// Inserts a consecutive run of verified checkpoints with their full
     /// contents and advances the verified and synced watermarks past the
     /// last one.
@@ -109,6 +127,12 @@ impl<T: WriteStore + ?Sized> WriteStore for &T {
         (*self).try_insert_committee(new_committee)
     }
 
+    fn try_get_highest_executed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>> {
+        (*self).try_get_highest_executed_checkpoint_seq_number()
+    }
+
     fn try_insert_synced_checkpoints(
         &self,
         checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
@@ -145,6 +169,12 @@ impl<T: WriteStore + ?Sized> WriteStore for Box<T> {
         (**self).try_insert_committee(new_committee)
     }
 
+    fn try_get_highest_executed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>> {
+        (**self).try_get_highest_executed_checkpoint_seq_number()
+    }
+
     fn try_insert_synced_checkpoints(
         &self,
         checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
@@ -179,6 +209,12 @@ impl<T: WriteStore + ?Sized> WriteStore for Arc<T> {
 
     fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
         (**self).try_insert_committee(new_committee)
+    }
+
+    fn try_get_highest_executed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>> {
+        (**self).try_get_highest_executed_checkpoint_seq_number()
     }
 
     fn try_insert_synced_checkpoints(

--- a/crates/iota-types/src/storage/write_store.rs
+++ b/crates/iota-types/src/storage/write_store.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use super::error::Result;
 use crate::{
@@ -79,6 +79,16 @@ pub trait WriteStore: ReadStore {
             .expect("storage access failed")
     }
 
+    /// Resolves once the store's executed watermark has reached the given
+    /// sequence number. Returns right away for stores that don't track
+    /// execution (the default), since their watermark never advances.
+    fn wait_for_executed_checkpoint(
+        &self,
+        _sequence_number: CheckpointSequenceNumber,
+    ) -> impl Future<Output = ()> + Send {
+        std::future::ready(())
+    }
+
     /// Inserts a consecutive run of verified checkpoints with their full
     /// contents and advances the verified and synced watermarks past the
     /// last one.
@@ -139,6 +149,13 @@ impl<T: WriteStore + ?Sized> WriteStore for &T {
     ) -> Result<()> {
         (*self).try_insert_synced_checkpoints(checkpoints)
     }
+
+    fn wait_for_executed_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> impl Future<Output = ()> + Send {
+        (*self).wait_for_executed_checkpoint(sequence_number)
+    }
 }
 
 impl<T: WriteStore + ?Sized> WriteStore for Box<T> {
@@ -181,6 +198,13 @@ impl<T: WriteStore + ?Sized> WriteStore for Box<T> {
     ) -> Result<()> {
         (**self).try_insert_synced_checkpoints(checkpoints)
     }
+
+    fn wait_for_executed_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> impl Future<Output = ()> + Send {
+        (**self).wait_for_executed_checkpoint(sequence_number)
+    }
 }
 
 impl<T: WriteStore + ?Sized> WriteStore for Arc<T> {
@@ -222,5 +246,12 @@ impl<T: WriteStore + ?Sized> WriteStore for Arc<T> {
         checkpoints: Vec<(VerifiedCheckpoint, VerifiedCheckpointContents)>,
     ) -> Result<()> {
         (**self).try_insert_synced_checkpoints(checkpoints)
+    }
+
+    fn wait_for_executed_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> impl Future<Output = ()> + Send {
+        (**self).wait_for_executed_checkpoint(sequence_number)
     }
 }


### PR DESCRIPTION
# Description of change

Speeds up catch-up from the checkpoint archive, bounds the disk it can take up while doing so, and makes the checkpoint execution pipeline's bottleneck visible. Six independent changes:

**Archive sync: verify in parallel, insert in batches** (`iota-network`, `iota-storage`, `iota-types`, `iota-core`)

- The archive sync worker pool ran a single worker that verified authority signatures, verified content digests, and inserted each checkpoint sequentially — capping sync at roughly one core. Workers now run in parallel (new `verify-concurrency` config, default: CPU cores) and do only the order-independent verification; a new reducer receives the results in sequence order, chain-checks each against its predecessor, and inserts them.
- Checkpoints at the head of an epoch can reach a worker before the previous epoch's last checkpoint is committed, so their committee isn't in the store yet. Signature verification for those is deferred to the reducer, where the committee is guaranteed to be available, and runs as one batched signature verification per epoch (new `CertifiedCheckpointSummary::batch_verify_authority_signatures`, which falls back to verifying one by one so a failure still names the checkpoint).
- A worker's signature and digest verification runs in `spawn_blocking`: with one worker per core it would otherwise hold up checkpoint execution on the same runtime, and execution progress gates how far sync may run ahead.
- The reducer commits up to 500 checkpoints per store insertion via a new `WriteStore::try_insert_synced_checkpoints`. The `RocksDbStore` override writes all summaries in one batch, all contents rows in one batch, and the synced watermark once per batch — still notifying waiters of every checkpoint, which the checkpoint executor relies on. The default trait implementation keeps the one-at-a-time behaviour for other stores.
- Batches close at epoch boundaries, so an epoch's last checkpoint — which carries the next committee — is committed before any deferred verification of the next epoch needs it.
- `verify_checkpoint_with_committee` is split so the reducer can run the chain-linkage part (`verify_checkpoint_linkage`) on its own; the signatures are always verified separately, by the worker or by the reducer's batch.
- A checkpoint that is already in the store is only reused if its summary matches the archive's, so divergent archive data is rejected before anything is written rather than asserting after the transactions are written.

**Archive sync: pause when too far ahead of execution** (`iota-network`, `iota-types`, `iota-core`)

- Synced checkpoint contents can only be pruned once executed, so sync running unboundedly ahead of execution — which parallel verification makes much easier to do — grows disk usage without bound. The reducer now waits before inserting a batch that would put the synced watermark more than `max_checkpoints_ahead_of_execution` (new config, default: 100 000) past the executed watermark. The run's range is unaffected: it still covers everything up to the peers' lowest available checkpoint, so sync is uninterrupted on a node whose execution keeps up.
- Waiting on insertion rather than shortening the run keeps the disk bound without splitting archive sync into repeated runs, at the cost of holding downloaded checkpoints in memory while paused. Nothing is written before the wait, and the reader stops fetching once it is `MAX_CHECKPOINTS_IN_PROGRESS` checkpoints or `data_limit` bytes ahead of what has been inserted; archive sync now sets `data_limit` (256 MiB) to bound that memory.
- The wait is event-driven, not polled: a new `WriteStore::wait_for_executed_checkpoint` resolves once the executed watermark reaches the checkpoint the cap is anchored to. `RocksDbStore` implements it with `CheckpointStore::notify_read_executed_checkpoint`, and the default resolves immediately for stores that don't track execution. The wait target is clamped to the batch's predecessor, so a cap below the batch size cannot wait for a checkpoint the batch itself has to insert.
- Reading the executed watermark for the fast path goes through a new `WriteStore::try_get_highest_executed_checkpoint_seq_number`, which defaults to `None` for stores that don't track execution and is implemented by `RocksDbStore`.

**Checkpoint execution: load transaction data outside the ordered pipeline** (`iota-core`)

- The `ExecuteTransactions` pipeline stage admits one checkpoint at a time, and loading a checkpoint's transaction data was its dominant cost — making it the execution throughput ceiling during catch-up. Loading only reads state-sync-written data (contents, transactions, expected effects), so each checkpoint's task now loads before awaiting pipeline admission, in parallel across the buffered checkpoints; the ordered stage keeps just the scheduler enqueue.
- The already-executed check (`multi_get_executed_effects_digests`) moves out of loading and into the ordered stage: execution progresses between loading and scheduling, and a stale answer would skip the fork check for a transaction that executed in between.

**Progress logging** (`iota-core`)

- Per-stage pipeline times are accumulated in the progress tracker and logged once a second. Since every stage admits one checkpoint at a time, the stage approaching one second per tick is the bottleneck. A stage's timer restarts only after admission, so its reported time covers its own work rather than the wait for the previous checkpoint to clear it.
- The progress line now also shows the synced-checkpoint delta (`+executed/+synced`), which tells apart "execution is behind" from "sync is behind".

## Links to any relevant issues

None.

## How the change has been tested

- `test_checkpoint_archive_sync_end` covers the run's range against the peers' lowest available checkpoint, and `test_required_executed_checkpoint` the executed checkpoint the insertion wait targets.
- `test_batch_verify_certified_checkpoints` covers the batched summary signature verification, including a certificate whose signatures were made over a different summary.
- The rest of the changes reorganise existing verification, insertion, and loading work rather than add behaviour, and are covered by `test_state_sync_using_checkpoint_archive` (archive sync end to end) and the existing `iota-core` checkpoint executor pipeline tests.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Faster catch-up from the checkpoint archive — downloaded checkpoints are now verified in parallel (new `checkpoint-archive.verify-concurrency` config, default: CPU cores) and inserted in batches, and archive sync pauses while it is more than `checkpoint-archive.max-checkpoints-ahead-of-execution` checkpoints (default: 100 000) ahead of execution; checkpoint execution loads transaction data outside the ordered pipeline. Node logs gain per-stage checkpoint pipeline times and the synced-checkpoint rate.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

