### PR TITLE
chore(test-cluster,iota-core,iota-e2e-tests): cover both transaction flows in the tests

### DIFF
--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use iota_config::node::AuthorityOverloadConfig;
+use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{Owner, TransactionDigest};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
@@ -716,6 +717,13 @@ async fn test_txn_age_overload() {
 async fn test_authority_txn_signing_pushback() {
     telemetry_subscribers::init_for_testing();
 
+    // Load shedding at signing only applies to the pre-consensus flow, which
+    // `handle_transaction` serves.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(false);
+        config
+    });
+
     // Create one sender, two recipients addresses, and 2 gas objects.
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let (recipient1, _): (_, AccountKeyPair) = get_key_pair();
@@ -835,6 +843,13 @@ async fn test_authority_txn_signing_pushback() {
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_authority_txn_execution_pushback() {
     telemetry_subscribers::init_for_testing();
+
+    // Load shedding at execution only applies to the pre-consensus flow, which
+    // `handle_certificate` serves.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(false);
+        config
+    });
 
     // Create one sender, one recipient addresses, and 2 gas objects.
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -573,6 +573,11 @@ async fn test_v2_submit_tx_invalid_signature() {
 async fn test_v2_submit_tx_feature_flag_disabled() {
     telemetry_subscribers::init_for_testing();
 
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(false);
+        config
+    });
+
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let object_id = ObjectId::random();
     let gas_id = ObjectId::random();

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -9,7 +9,7 @@ use std::{
 
 use fastcrypto::traits::KeyPair;
 use iota_macros::sim_test;
-use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+use iota_protocol_config::{Chain, OverrideGuard, ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
     Address, ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, GenesisTransaction,
     Identifier, SharedObjectReference, TransactionKind, crypto::IntentScope,
@@ -344,6 +344,7 @@ async fn do_transaction_test_impl(
     err_check: impl Fn(&IotaError),
 ) {
     telemetry_subscribers::init_for_testing();
+    let _guard = disable_pcool_flow();
     let (sender1, sender_key1): (_, AccountKeyPair) = get_key_pair();
     let (sender2, sender_key2): (_, AccountKeyPair) = get_key_pair();
     let recipient = dbg_addr(2);
@@ -498,9 +499,20 @@ fn make_socket_addr() -> std::net::SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0)
 }
 
+/// The tests here drive the pre-consensus endpoints -- `handle_transaction`,
+/// `handle_certificate` and soft bundles -- which the P-COOL flow replaces
+/// with `submit_tx`, so they run against a protocol config with P-COOL off.
+fn disable_pcool_flow() -> OverrideGuard {
+    ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(false);
+        config
+    })
+}
+
 #[tokio::test]
 async fn test_oversized_txn() {
     telemetry_subscribers::init_for_testing();
+    let _guard = disable_pcool_flow();
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let recipient = dbg_addr(2);
     let object_id = ObjectId::random();
@@ -560,6 +572,7 @@ async fn test_oversized_txn() {
 #[tokio::test]
 async fn test_very_large_certificate() {
     telemetry_subscribers::init_for_testing();
+    let _guard = disable_pcool_flow();
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let recipient = dbg_addr(2);
     let object_id = ObjectId::random();
@@ -649,6 +662,7 @@ async fn test_very_large_certificate() {
 #[tokio::test]
 async fn test_handle_certificate_errors() {
     telemetry_subscribers::init_for_testing();
+    let _guard = disable_pcool_flow();
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let recipient = dbg_addr(2);
     let object_id = ObjectId::random();
@@ -814,6 +828,7 @@ async fn test_handle_soft_bundle_certificates() {
     let mut protocol_config =
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
     protocol_config.set_max_soft_bundle_size_for_testing(10);
+    protocol_config.set_enable_pcool_flow_for_testing(false);
 
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
@@ -990,6 +1005,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
     protocol_config.set_max_soft_bundle_size_for_testing(3);
     protocol_config.set_consensus_max_transactions_in_block_bytes_for_testing(10_000);
+    protocol_config.set_enable_pcool_flow_for_testing(false);
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
         .with_protocol_config(protocol_config)

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -507,8 +507,10 @@ async fn test_abstract_account_post_consensus_deletion_failure() -> Result<(), a
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
-    // Build a test environment and create an abstract account
-    let mut test_env = TestEnvironment::new().await;
+    // Build a test environment and create an abstract account. Step 2 below
+    // reads the response of the transaction that deletes the abstract account,
+    // so the fullnode has to keep the deleted object's previous version.
+    let mut test_env = TestEnvironment::new_with_unpruned_fullnode().await;
     test_env
         .setup_abstract_account(AA_AUTHENTICATE_FN_NAME_ED25519)
         .await?;
@@ -2051,8 +2053,25 @@ struct TestEnvironment {
 
 impl TestEnvironment {
     async fn new() -> Self {
-        let test_cluster = TestClusterBuilder::new().build().await;
+        Self::with_cluster(TestClusterBuilder::new().build().await)
+    }
 
+    /// Builds the environment on a cluster whose fullnode keeps every object
+    /// version.
+    ///
+    /// Reading a transaction response that carries balance or object changes
+    /// resolves the transaction's input objects at their previous version, and
+    /// the fullnode prunes those versions once their checkpoint is executed.
+    async fn new_with_unpruned_fullnode() -> Self {
+        Self::with_cluster(
+            TestClusterBuilder::new()
+                .disable_fullnode_pruning()
+                .build()
+                .await,
+        )
+    }
+
+    fn with_cluster(test_cluster: TestCluster) -> Self {
         Self {
             test_cluster,
             owner: None,
@@ -2847,7 +2866,7 @@ impl TestEnvironment {
 
         // The transaction must be successful
         assert!(confirmed_local_execution.unwrap());
-        assert!(errors.is_empty());
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
         Ok(())
     }
 

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -75,7 +75,18 @@ const AA_RECEIVE_OBJECT_FN_NAME_NO_SENDER_CHECK: &str = "receive_object_without_
 /// Test the creation of an Abstract Account and the issuance of a simple
 /// transaction from it using the Move-based Ed25519 signature authenticator.
 #[sim_test]
-async fn test_abstract_account_creation_and_issue_tx() -> Result<(), anyhow::Error> {
+async fn test_abstract_account_creation_and_issue_tx_pre_consensus_flow()
+-> Result<(), anyhow::Error> {
+    test_abstract_account_creation_and_issue_tx(false).await
+}
+
+#[sim_test]
+async fn test_abstract_account_creation_and_issue_tx_pcool_flow() -> Result<(), anyhow::Error> {
+    test_abstract_account_creation_and_issue_tx(true).await
+}
+
+async fn test_abstract_account_creation_and_issue_tx(pcool: bool) -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(pcool);
     telemetry_subscribers::init_for_testing();
 
     // Build a test environment and create an abstract account

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -48,7 +48,7 @@ use iota_types::{
     },
 };
 use move_command_line_common::error_bitset::ErrorBitset;
-use test_cluster::{TestCluster, TestClusterBuilder};
+use test_cluster::{TestCluster, TestClusterBuilder, override_pcool_flow};
 
 const AA_PACKAGE_PATH: &str = "tests/abstract_account/abstract_account";
 const AA_MODULE_NAME: &str = "abstract_account";
@@ -355,6 +355,7 @@ async fn test_receive_object_in_main_tx_succeeds() -> Result<(), anyhow::Error> 
 /// underlying abort and carries no command index.
 #[sim_test]
 async fn test_abstract_account_post_consensus_failure() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -491,6 +492,7 @@ async fn test_abstract_account_post_consensus_failure() -> Result<(), anyhow::Er
 ///    and it passed
 #[sim_test]
 async fn test_abstract_account_post_consensus_deletion_failure() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -600,6 +602,7 @@ async fn test_abstract_account_post_consensus_deletion_failure() -> Result<(), a
 #[sim_test]
 async fn test_abstract_account_shared_object_congestion_cancellation() -> Result<(), anyhow::Error>
 {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -695,6 +698,7 @@ async fn test_abstract_account_shared_object_congestion_cancellation() -> Result
 #[sim_test]
 async fn test_abstract_account_post_consensus_failure_without_report_flag()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -829,6 +833,7 @@ async fn test_abstract_account_post_consensus_failure_without_report_flag()
 /// authentication failure and carries no command index.
 #[sim_test]
 async fn test_pre_consensus_authentication_failure() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     let mut test_env = TestEnvironment::new().await;
@@ -878,6 +883,7 @@ async fn test_pre_consensus_authentication_failure() -> Result<(), anyhow::Error
 #[sim_test]
 async fn test_pre_consensus_authentication_failure_without_report_flag() -> Result<(), anyhow::Error>
 {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     // Disable reporting the authentication failure as a distinct error.
@@ -940,6 +946,7 @@ async fn test_pre_consensus_authentication_failure_without_report_flag() -> Resu
 ///   receiving object
 #[sim_test]
 async fn test_receiving_gas_executing_aa_tx_first() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -1048,6 +1055,7 @@ async fn test_receiving_gas_executing_aa_tx_first() -> Result<(), anyhow::Error>
 /// 4) Submit the original TX2 certificate. This should now succeed.
 #[sim_test]
 async fn test_receiving_gas_executing_aa_tx_later() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -1170,6 +1178,7 @@ async fn test_receiving_gas_executing_aa_tx_later() -> Result<(), anyhow::Error>
 /// 5) Submit the original TX2 certificate. This should now succeed.
 #[sim_test]
 async fn test_failing_receiving_gas_then_create_account() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -1301,6 +1310,7 @@ async fn test_failing_receiving_gas_then_create_account() -> Result<(), anyhow::
 ///    coin using the latest reference, this should now succeed.
 #[sim_test]
 async fn test_successful_receiving_gas_then_create_account() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -1414,6 +1424,7 @@ async fn test_successful_receiving_gas_then_create_account() -> Result<(), anyho
 #[sim_test]
 async fn test_aa_sender_and_aa_sponsor_succeeded_with_enabled_move_auth_for_sponsor()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     // Build the test environment and create the sender AA.
@@ -1518,6 +1529,7 @@ async fn test_sponsor_only_move_auth_succeeded_with_enabled_move_auth_for_sponso
 #[sim_test]
 async fn test_aa_sender_and_aa_sponsor_use_the_same_shared_object_succeeded_with_enabled_move_auth_for_sponsor()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     // Build the test environment and create the sender AA.
@@ -1566,6 +1578,7 @@ async fn test_aa_sender_and_aa_sponsor_use_the_same_shared_object_succeeded_with
 #[sim_test]
 async fn test_two_move_authenticators_rejected_with_disabled_move_auth_for_sponsor()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     // Disable Move authentication for the sponsor.
@@ -1628,6 +1641,7 @@ async fn test_two_move_authenticators_rejected_with_disabled_move_auth_for_spons
 #[sim_test]
 async fn test_sponsor_only_move_auth_rejected_with_disabled_move_auth_for_sponsor()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     // Disable Move authentication for the sponsor.
@@ -1708,6 +1722,7 @@ async fn test_sponsor_only_move_auth_rejected_with_disabled_move_auth_for_sponso
 #[sim_test]
 async fn test_wrong_signer_move_auth_rejected_with_enabled_move_auth_for_sponsor()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     // Build the test environment and create the sender AA.
@@ -1762,6 +1777,7 @@ async fn test_wrong_signer_move_auth_rejected_with_enabled_move_auth_for_sponsor
 #[sim_test]
 async fn test_aa_sender_and_aa_sponsor_rejected_when_sponsor_aa_fails_with_enabled_move_auth_for_sponsor()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     // Build the test environment and create the sender AA.
@@ -1821,6 +1837,7 @@ async fn test_aa_sender_and_aa_sponsor_rejected_when_sponsor_aa_fails_with_enabl
 #[sim_test]
 async fn test_sponsored_tx_sender_aa_fails_post_consensus_when_only_sponsor_runs_pre_consensus()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
@@ -1910,6 +1927,7 @@ async fn test_sponsored_tx_sender_aa_fails_post_consensus_when_only_sponsor_runs
 #[sim_test]
 async fn test_sponsored_tx_sender_aa_rejected_pre_consensus_without_sponsor_only_flag()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     // Disable the flag so ALL MAs run pre-consensus.
@@ -1966,6 +1984,7 @@ async fn test_sponsored_tx_sender_aa_rejected_pre_consensus_without_sponsor_only
 #[sim_test]
 async fn test_non_sponsored_tx_sender_aa_rejected_pre_consensus_with_sponsor_only_flag()
 -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
 
     let mut test_env = TestEnvironment::new().await;

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -46,7 +46,7 @@ use iota_types::{
 use jsonrpsee::{core::client::ClientT, rpc_params};
 use move_core_types::annotated_value::MoveStructLayout;
 use rand::rngs::OsRng;
-use test_cluster::TestClusterBuilder;
+use test_cluster::{TestClusterBuilder, override_pcool_flow};
 use tokio::{
     sync::RwLock,
     time::{Duration, sleep},
@@ -689,6 +689,7 @@ async fn test_full_node_event_query_by_module_ok() {
 
 #[sim_test]
 async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let fullnode = test_cluster.spawn_new_fullnode().await.iota_node;
     let metrics = KeyValueStoreMetrics::new_for_tests();
@@ -1141,6 +1142,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
 // Object fast path should be disabled and unused.
 #[sim_test]
 async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let fullnode = test_cluster.spawn_new_fullnode().await.iota_node;

--- a/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/state_service/list_owned_objects.rs
@@ -21,6 +21,7 @@ use iota_types::{
     transaction::CallArg,
 };
 use prost_types::FieldMask;
+use test_cluster::override_pcool_flow;
 
 use crate::utils::{
     NFT_PACKAGE, address_proto, assert_field_presence, assert_tonic_error,
@@ -611,7 +612,17 @@ fn object_id_set(response: &ListOwnedObjectsResponse) -> std::collections::HashS
 }
 
 #[sim_test]
-async fn list_owned_objects_filter_by_type() {
+async fn list_owned_objects_filter_by_type_pre_consensus_flow() {
+    list_owned_objects_filter_by_type(false).await;
+}
+
+#[sim_test]
+async fn list_owned_objects_filter_by_type_pcool_flow() {
+    list_owned_objects_filter_by_type(true).await;
+}
+
+async fn list_owned_objects_filter_by_type(pcool: bool) {
+    let _pcool_guard = override_pcool_flow(pcool);
     let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
     let mut state_client = client.state_service_client();
 

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/execute.rs
@@ -20,6 +20,7 @@ use iota_macros::sim_test;
 use iota_sdk_types::Address;
 use iota_test_transaction_builder::make_transfer_iota_transaction;
 use prost_types::FieldMask;
+use test_cluster::override_pcool_flow;
 
 use super::build_item;
 use crate::utils::{
@@ -600,36 +601,6 @@ async fn execute_transaction_batch_with_checkpoint_inclusion() {
     }
 }
 
-/// Drop-guard that restores the P-COOL env vars on scope exit so the
-/// process-wide flag does not leak into sibling tests sharing this process.
-#[must_use = "bind the guard for the lifetime of the test"]
-struct PcoolEnvGuard;
-
-impl Drop for PcoolEnvGuard {
-    fn drop(&mut self) {
-        // SAFETY: paired with `enable_pcool_env`; both run on the test
-        // thread before/after the cluster is alive.
-        unsafe {
-            std::env::remove_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE");
-            std::env::remove_var("IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW");
-        }
-    }
-}
-
-fn enable_pcool_env() -> PcoolEnvGuard {
-    // SAFETY: must be set before the test cluster starts spawning validator
-    // tasks; thread-local protocol-config overrides do not propagate across
-    // spawned tasks outside msim.
-    unsafe {
-        std::env::set_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE", "1");
-        std::env::set_var(
-            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW",
-            "true",
-        );
-    }
-    PcoolEnvGuard
-}
-
 /// Skip-effect-certification path through the gRPC handler. With the P-COOL
 /// flow enabled and `checkpoint_inclusion_timeout_ms` set, the handler must
 /// (1) drive the TD without a 2f+1 broadcast, (2) wait for local checkpoint
@@ -643,7 +614,7 @@ fn enable_pcool_env() -> PcoolEnvGuard {
 /// the handler rather than a successful response.
 #[sim_test]
 async fn execute_transaction_v1_skip_cert_rebuilds_from_cache() {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _proto_guard =
         iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_enable_pcool_flow_for_testing(true);
@@ -706,7 +677,7 @@ async fn execute_transaction_v1_skip_cert_rebuilds_from_cache() {
 /// "no successful response with uncertified data and no whole-RPC failure."
 #[sim_test]
 async fn execute_transaction_v1_skip_cert_no_quorum_yields_per_item_error() {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _proto_guard =
         iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_enable_pcool_flow_for_testing(true);

--- a/crates/iota-e2e-tests/tests/multisig_tests.rs
+++ b/crates/iota-e2e-tests/tests/multisig_tests.rs
@@ -36,7 +36,7 @@ use passkey_types::{
         PublicKeyCredentialUserEntity, UserVerificationRequirement,
     },
 };
-use test_cluster::{TestCluster, TestClusterBuilder};
+use test_cluster::{TestCluster, TestClusterBuilder, override_pcool_flow};
 use url::Url;
 
 async fn do_upgraded_multisig_test() -> IotaResult {
@@ -236,6 +236,7 @@ impl UserValidationMethod for MyUserValidationMethod {
 
 #[sim_test]
 async fn test_upgraded_multisig_feature_allow() {
+    let _pcool_guard = override_pcool_flow(false);
     let res = do_upgraded_multisig_test().await;
 
     // we didn't make a real transaction with a valid object, but we verify that we

--- a/crates/iota-e2e-tests/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/iota-e2e-tests/tests/onsite_reconfig_observer_tests.rs
@@ -9,11 +9,12 @@ use iota_core::{
 };
 use iota_macros::sim_test;
 use prometheus_filtered::Registry;
-use test_cluster::TestClusterBuilder;
+use test_cluster::{TestClusterBuilder, override_pcool_flow};
 use tracing::info;
 
 #[sim_test]
 async fn test_onsite_reconfig_observer_basic() {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(10000)

--- a/crates/iota-e2e-tests/tests/passkey_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/passkey_e2e_tests.rs
@@ -30,7 +30,7 @@ use passkey_types::{
         PublicKeyCredentialUserEntity, UserVerificationRequirement,
     },
 };
-use test_cluster::{TestCluster, TestClusterBuilder};
+use test_cluster::{TestCluster, TestClusterBuilder, override_pcool_flow};
 use url::Url;
 
 struct MyUserValidationMethod {}
@@ -227,6 +227,7 @@ fn make_good_passkey_tx(response: PasskeyResponse<TransactionData>) -> Transacti
 
 #[sim_test]
 async fn test_passkey_feature_deny() {
+    let _pcool_guard = override_pcool_flow(false);
     use iota_protocol_config::ProtocolConfig;
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_passkey_auth_for_testing(false);
@@ -246,6 +247,7 @@ async fn test_passkey_feature_deny() {
 
 #[sim_test]
 async fn test_passkey_authenticator_verifies() {
+    let _pcool_guard = override_pcool_flow(false);
     let test_cluster = TestClusterBuilder::new().build().await;
     let response = create_credential_and_sign_test_tx(&test_cluster, None, false, false).await;
     let tx = make_good_passkey_tx(response);
@@ -255,6 +257,7 @@ async fn test_passkey_authenticator_verifies() {
 
 #[sim_test]
 async fn test_passkey_fails_mismatched_challenge() {
+    let _pcool_guard = override_pcool_flow(false);
     let test_cluster = TestClusterBuilder::new().build().await;
 
     // Tweak intent in challenge that is sent to passkey.
@@ -300,6 +303,7 @@ async fn test_passkey_fails_mismatched_challenge() {
 
 #[sim_test]
 async fn test_passkey_fails_to_verify_sig() {
+    let _pcool_guard = override_pcool_flow(false);
     let test_cluster = TestClusterBuilder::new().build().await;
     let response = create_credential_and_sign_test_tx(&test_cluster, None, false, false).await;
     let mut modified_sig = response.user_sig_bytes.clone();
@@ -354,6 +358,7 @@ async fn test_passkey_fails_to_verify_sig() {
 
 #[sim_test]
 async fn test_passkey_fails_wrong_author() {
+    let _pcool_guard = override_pcool_flow(false);
     let test_cluster = TestClusterBuilder::new().build().await;
     // Modify sender that receives gas and construct test txn.
     let response =

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -44,7 +44,7 @@ use rand::{
     SeedableRng,
     rngs::{OsRng, StdRng},
 };
-use test_cluster::{TestCluster, TestClusterBuilder};
+use test_cluster::{TestCluster, TestClusterBuilder, override_pcool_flow};
 use tokio::time::sleep;
 
 #[sim_test]
@@ -143,6 +143,7 @@ async fn test_transaction_expiration() {
 // code path may not always be tested.
 #[sim_test]
 async fn reconfig_with_revert_end_to_end_test() {
+    let _pcool_guard = override_pcool_flow(false);
     let test_cluster = TestClusterBuilder::new().build().await;
     let authorities = test_cluster.swarm.validator_node_handles();
     let rgp = test_cluster.get_reference_gas_price().await;
@@ -327,6 +328,7 @@ async fn do_test_passive_reconfig(chain: Option<Chain>) {
 // Test that transaction locks from previously epochs could be overridden.
 #[sim_test]
 async fn test_expired_locks() {
+    let _pcool_guard = override_pcool_flow(false);
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(10000)
         .build()
@@ -497,6 +499,7 @@ async fn test_reconfig_with_failing_validator() {
 
 #[sim_test]
 async fn test_validator_resign_effects() {
+    let _pcool_guard = override_pcool_flow(false);
     // This test checks that validators are able to re-sign transaction effects that
     // were finalized in previous epochs. This allows authority aggregator to
     // form a new effects certificate in the new epoch.

--- a/crates/iota-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/iota-e2e-tests/tests/shared_objects_tests.rs
@@ -24,7 +24,7 @@ use iota_types::{
     transaction::CallArg,
 };
 use rand::distributions::Distribution;
-use test_cluster::TestClusterBuilder;
+use test_cluster::{TestClusterBuilder, override_pcool_flow};
 use tokio::time::sleep;
 
 /// Send a simple shared object transaction to IOTA and ensures the client gets
@@ -84,6 +84,7 @@ async fn shared_object_deletion() {
 
 #[sim_test]
 async fn shared_object_deletion_multiple_times() {
+    let _pcool_guard = override_pcool_flow(false);
     let num_deletions = 300;
     let mut test_cluster = TestClusterBuilder::new()
         .with_accounts(vec![AccountConfig {
@@ -146,6 +147,7 @@ async fn shared_object_deletion_multiple_times() {
 
 #[sim_test]
 async fn shared_object_deletion_multiple_times_cert_racing() {
+    let _pcool_guard = override_pcool_flow(false);
     let num_deletions = 10;
     let mut test_cluster = TestClusterBuilder::new()
         .with_accounts(vec![AccountConfig {
@@ -216,6 +218,7 @@ async fn shared_object_deletion_multiple_times_cert_racing() {
 /// regardless of the order. (checkpoint fork detection will also test this).
 #[sim_test]
 async fn shared_object_deletion_multi_certs() {
+    let _pcool_guard = override_pcool_flow(false);
     // cause random delay just before tx is executed
     register_fail_point_async("transaction_execution_delay", move || async move {
         let delay = {
@@ -549,6 +552,7 @@ async fn access_clock_object_test() {
 
 #[sim_test]
 async fn shared_object_sync() {
+    let _pcool_guard = override_pcool_flow(false);
     let test_cluster = TestClusterBuilder::new()
         // Set the threshold high enough so it won't be triggered.
         .with_authority_overload_config(AuthorityOverloadConfig {

--- a/crates/iota-e2e-tests/tests/shared_objects_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/shared_objects_version_tests.rs
@@ -15,17 +15,37 @@ use iota_types::{
     object::OBJECT_START_VERSION,
     transaction::CallArg,
 };
-use test_cluster::{TestCluster, TestClusterBuilder};
+use test_cluster::{TestCluster, TestClusterBuilder, override_pcool_flow};
 
 #[sim_test]
-async fn fresh_shared_object_initial_version_matches_current() {
+async fn fresh_shared_object_initial_version_matches_current_pre_consensus_flow() {
+    fresh_shared_object_initial_version_matches_current(false).await;
+}
+
+#[sim_test]
+async fn fresh_shared_object_initial_version_matches_current_pcool_flow() {
+    fresh_shared_object_initial_version_matches_current(true).await;
+}
+
+async fn fresh_shared_object_initial_version_matches_current(pcool: bool) {
+    let _pcool_guard = override_pcool_flow(pcool);
     let env = TestEnvironment::new().await;
     let (object_ref, owner) = env.create_shared_counter().await;
     assert!(is_shared_at(&owner, object_ref.version));
 }
 
 #[sim_test]
-async fn objects_transitioning_to_shared_remember_their_previous_version() {
+async fn objects_transitioning_to_shared_remember_their_previous_version_pre_consensus_flow() {
+    objects_transitioning_to_shared_remember_their_previous_version(false).await;
+}
+
+#[sim_test]
+async fn objects_transitioning_to_shared_remember_their_previous_version_pcool_flow() {
+    objects_transitioning_to_shared_remember_their_previous_version(true).await;
+}
+
+async fn objects_transitioning_to_shared_remember_their_previous_version(pcool: bool) {
+    let _pcool_guard = override_pcool_flow(pcool);
     let env = TestEnvironment::new().await;
     let (counter, _) = env.create_counter().await;
 

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -33,7 +33,7 @@ use iota_types::{
     },
     transaction::{Transaction, TransactionDataAPI},
 };
-use test_cluster::TestClusterBuilder;
+use test_cluster::{TestClusterBuilder, override_pcool_flow};
 use tokio::time::timeout;
 use tracing::info;
 
@@ -43,6 +43,7 @@ fn make_socket_addr() -> std::net::SocketAddr {
 
 #[sim_test]
 async fn test_blocking_execution() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
     let handle = &test_cluster.fullnode_handle.iota_node;
@@ -108,6 +109,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     #[cfg(msim)]
     {
         use iota_core::authority::{CheckpointTimeoutConfig, init_checkpoint_timeout_config};
@@ -192,6 +194,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_transaction_orchestrator_reconfig() {
+    let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
     let test_cluster = TestClusterBuilder::new().build().await;
     let epoch = test_cluster.fullnode_handle.iota_node.with(|node| {
@@ -314,7 +317,7 @@ async fn test_tx_across_epoch_boundaries() {
 #[sim_test]
 async fn test_wait_for_local_execution_across_epoch_boundary() {
     telemetry_subscribers::init_for_testing();
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -406,6 +409,7 @@ async fn execute_with_orchestrator(
 /// through the validators again — on every entry point.
 #[sim_test]
 async fn test_cached_response_for_executed_transaction() -> Result<(), anyhow::Error> {
+    let _pcool_guard = override_pcool_flow(false);
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
     let handle = &test_cluster.fullnode_handle.iota_node;
@@ -557,41 +561,9 @@ async fn execute_transaction_v1() -> Result<(), anyhow::Error> {
 /// being returned to the caller — otherwise the safety guard at the end of
 /// `execute_transaction_block` would reject the response as
 /// `QuorumDriverInternal`.
-/// Drop-guard that clears the P-COOL env vars on scope exit, so a test
-/// that enables the flow does not contaminate sibling tests sharing the same
-/// process (e.g. when run via `cargo nextest` with `--test-threads`).
-#[must_use = "drop the guard at the end of the test to restore env vars"]
-struct PcoolEnvGuard;
-
-impl Drop for PcoolEnvGuard {
-    fn drop(&mut self) {
-        // SAFETY: paired with `enable_pcool_env`; both calls run on the
-        // test thread before/after the cluster is alive.
-        unsafe {
-            std::env::remove_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE");
-            std::env::remove_var("IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW");
-        }
-    }
-}
-
-fn enable_pcool_env() -> PcoolEnvGuard {
-    // SAFETY: set before spawning the test cluster; env vars are the only
-    // reliable way to flip the P-COOL protocol flag inside validator
-    // tasks spawned by the cluster (thread-local `apply_overrides_for_testing`
-    // does not propagate to spawned tasks outside msim).
-    unsafe {
-        std::env::set_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE", "1");
-        std::env::set_var(
-            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW",
-            "true",
-        );
-    }
-    PcoolEnvGuard
-}
-
 #[sim_test]
 async fn test_skip_effect_cert_reconciles_to_checkpointed() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -656,7 +628,7 @@ async fn test_skip_effect_cert_reconciles_to_checkpointed() -> Result<(), anyhow
 /// `Checkpointed`).
 #[sim_test]
 async fn test_cached_response_for_executed_transaction_under_pcool() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -716,7 +688,7 @@ async fn test_cached_response_for_executed_transaction_under_pcool() -> Result<(
 /// or input/output objects must not receive them.
 #[sim_test]
 async fn test_skip_effect_cert_respects_request_flags() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -778,7 +750,7 @@ async fn test_skip_effect_cert_respects_request_flags() -> Result<(), anyhow::Er
 /// in-flight submissions in memory only.
 #[sim_test]
 async fn test_pcool_deduplicates_concurrent_submissions() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -853,7 +825,7 @@ async fn test_pcool_deduplicates_concurrent_submissions() -> Result<(), anyhow::
 /// a checkpoint inclusion that can never happen and timing out.
 #[sim_test]
 async fn test_pcool_duplicate_submission_inherits_failure() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -923,7 +895,7 @@ async fn test_pcool_duplicate_submission_inherits_failure() -> Result<(), anyhow
 #[sim_test]
 async fn test_pcool_duplicate_requiring_certification_returns_certified_effects()
 -> Result<(), anyhow::Error> {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -990,7 +962,7 @@ async fn test_pcool_duplicate_requiring_certification_returns_certified_effects(
 /// page on-call for a routine availability dip.
 #[sim_test]
 async fn test_skip_effect_cert_timeout_without_quorum() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -1066,7 +1038,7 @@ async fn test_skip_effect_cert_timeout_without_quorum() -> Result<(), anyhow::Er
 /// reconfiguration, since test infra polls its committee epoch.
 #[sim_test]
 async fn test_authority_aggregator_accessor_under_pcool() {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config
@@ -1227,7 +1199,7 @@ async fn test_orchestrator_rejects_expired_transaction() {
 /// the surviving submission instead of driving its own.
 #[sim_test]
 async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
-    let _env_guard = enable_pcool_env();
+    let _env_guard = override_pcool_flow(true);
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_enable_pcool_flow_for_testing(true);
         config

--- a/crates/iota-e2e-tests/tests/transfer_to_object_tests.rs
+++ b/crates/iota-e2e-tests/tests/transfer_to_object_tests.rs
@@ -13,17 +13,37 @@ use iota_types::{
     },
     transaction::{CallArg, Transaction},
 };
-use test_cluster::{TestCluster, TestClusterBuilder};
+use test_cluster::{TestCluster, TestClusterBuilder, override_pcool_flow};
 
 #[sim_test]
-async fn receive_of_object() {
+async fn receive_of_object_pre_consensus_flow() {
+    receive_of_object(false).await;
+}
+
+#[sim_test]
+async fn receive_of_object_pcool_flow() {
+    receive_of_object(true).await;
+}
+
+async fn receive_of_object(pcool: bool) {
+    let _pcool_guard = override_pcool_flow(pcool);
     let env = TestEnvironment::new().await;
     let (parent, child) = env.start().await;
     env.receive(parent, child).await.unwrap();
 }
 
 #[sim_test]
-async fn receive_of_object_with_reconfiguration() {
+async fn receive_of_object_with_reconfiguration_pre_consensus_flow() {
+    receive_of_object_with_reconfiguration(false).await;
+}
+
+#[sim_test]
+async fn receive_of_object_with_reconfiguration_pcool_flow() {
+    receive_of_object_with_reconfiguration(true).await;
+}
+
+async fn receive_of_object_with_reconfiguration(pcool: bool) {
+    let _pcool_guard = override_pcool_flow(pcool);
     let env = TestEnvironment::new().await;
     let (parent, child) = env.start().await;
     env.receive(parent, child).await.unwrap();

--- a/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
@@ -7,10 +7,11 @@ use std::time::Duration;
 use iota_macros::sim_test;
 use iota_test_transaction_builder::publish_basics_package_and_make_counter;
 use iota_types::base_types::dbg_addr;
-use test_cluster::TestClusterBuilder;
+use test_cluster::{TestClusterBuilder, override_pcool_flow};
 
 #[sim_test]
 async fn test_validator_tx_finalizer_fastpath_tx() {
+    let _pcool_guard = override_pcool_flow(false);
     let cluster = TestClusterBuilder::new()
         .with_num_validators(7)
         // Make epoch duration large enough so that reconfig is never triggered.
@@ -51,6 +52,7 @@ async fn test_validator_tx_finalizer_fastpath_tx() {
 
 #[sim_test]
 async fn test_validator_tx_finalizer_consensus_tx() {
+    let _pcool_guard = override_pcool_flow(false);
     let cluster = TestClusterBuilder::new()
         .with_num_validators(7)
         // Make epoch duration large enough so that reconfig is never triggered.
@@ -90,6 +92,7 @@ async fn test_validator_tx_finalizer_consensus_tx() {
 #[cfg(msim)]
 #[sim_test]
 async fn test_validator_tx_finalizer_equivocation() {
+    let _pcool_guard = override_pcool_flow(false);
     let cluster = TestClusterBuilder::new()
         .with_num_validators(7)
         // Make epoch duration large enough so that reconfig is never triggered.

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -64,7 +64,7 @@ use iota_types::{
     },
     messages_grpc::HandleCertificateRequestV1,
     object::Object,
-    quorum_driver_types::ExecuteTransactionRequestType,
+    quorum_driver_types::{ExecuteTransactionRequestType, ExecuteTransactionRequestV1},
     supported_protocol_versions::SupportedProtocolVersions,
     traffic_control::{PolicyConfig, RemoteFirewallConfig},
     transaction::{CertifiedTransaction, Transaction, TransactionData},
@@ -113,6 +113,39 @@ pub struct TestCluster {
     pub wallet: WalletContext,
     pub fullnode_handle: FullNodeHandle,
     faucet: Option<Faucet>,
+}
+
+/// Reverts the P-COOL protocol flag override when dropped.
+#[must_use = "the override only holds while the guard is alive"]
+pub struct PcoolFlowOverride;
+
+impl Drop for PcoolFlowOverride {
+    fn drop(&mut self) {
+        // SAFETY: paired with `override_pcool_flow`; both run on the test
+        // thread, outside the cluster's lifetime.
+        unsafe {
+            std::env::remove_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE");
+            std::env::remove_var("IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW");
+        }
+    }
+}
+
+/// Sets the P-COOL protocol flag for every node of a test cluster built while
+/// the returned guard is alive.
+///
+/// `ProtocolConfig::apply_overrides_for_testing` is thread-local and does not
+/// reach the tasks a cluster spawns, so the flag goes through the protocol
+/// config environment overrides instead.
+pub fn override_pcool_flow(enabled: bool) -> PcoolFlowOverride {
+    // SAFETY: called before the cluster is built, on the test thread.
+    unsafe {
+        std::env::set_var("IOTA_PROTOCOL_CONFIG_OVERRIDE_ENABLE", "1");
+        std::env::set_var(
+            "IOTA_PROTOCOL_CONFIG_FEATURE_FLAGS_OVERRIDE_ENABLE_PCOOL_FLOW",
+            enabled.to_string(),
+        );
+    }
+    PcoolFlowOverride
 }
 
 impl TestCluster {
@@ -626,11 +659,47 @@ impl TestCluster {
         &self,
         tx: Transaction,
     ) -> anyhow::Result<(TransactionEffects, TransactionEvents)> {
+        if self.protocol_config().enable_pcool_flow() {
+            return self.execute_transaction_via_orchestrator(tx).await;
+        }
         let results = self
             .submit_transaction_to_validators(tx.clone(), &self.get_validator_pubkeys())
             .await?;
         self.wallet.execute_transaction_may_fail(tx).await.unwrap();
         Ok(results)
+    }
+
+    /// Drives a transaction through the fullnode's transaction orchestrator
+    /// and returns the raw effects and events.
+    ///
+    /// The P-COOL flow has no certificate to hand to individual validators, so
+    /// this is the counterpart of `submit_transaction_to_validators` for
+    /// callers that only need the raw execution results.
+    async fn execute_transaction_via_orchestrator(
+        &self,
+        tx: Transaction,
+    ) -> anyhow::Result<(TransactionEffects, TransactionEvents)> {
+        let orchestrator = self.fullnode_handle.iota_node.with(|node| {
+            node.transaction_orchestrator()
+                .expect("fullnodes run a transaction orchestrator")
+        });
+        let (response, _executed_locally) = orchestrator
+            .execute_transaction_block(
+                ExecuteTransactionRequestV1 {
+                    transaction: tx,
+                    include_events: true,
+                    include_input_objects: false,
+                    include_output_objects: false,
+                    include_auxiliary_data: false,
+                },
+                ExecuteTransactionRequestType::WaitForLocalExecution,
+                None,
+            )
+            .await?;
+        Ok((
+            response.effects.effects,
+            response.events.unwrap_or_default(),
+        ))
     }
 
     pub fn authority_aggregator(&self) -> Arc<AuthorityAggregator<NetworkAuthorityClient>> {


### PR DESCRIPTION
# Description of change

Prepares the test suite for the P-COOL flow being enabled outside mainnet and testnet, so that flipping the protocol flag keeps both transaction flows covered in CI.

- `TestCluster::execute_transaction_return_raw_effects` drives the fullnode's transaction orchestrator when the P-COOL flow is on. That flow has no certificate to hand to individual validators, so the existing path through the authority aggregator does not apply.
- Adds `test_cluster::override_pcool_flow`, which sets the flag for every node of a cluster. Thread-local protocol config overrides do not reach the tasks a cluster spawns, so it goes through the protocol config environment overrides instead. It also replaces two copies of the same local helper in the e2e tests.
- Tests that drive `handle_transaction`, `handle_certificate`, soft bundles or the quorum driver only exist in the pre-consensus flow, so they now select that flow explicitly instead of relying on the default.
- Six tests that do not depend on the flow run once per setting, covering shared-object versioning, receiving objects, receiving across reconfiguration, gRPC owned-object indexing and abstract accounts. `sim_test` rewrites the test body into a zero-argument inner function, so rstest cannot parameterise these and each one gets a pair of wrappers instead.

## Links to any relevant issues

Related to #12433.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo simtest -p iota-e2e-tests`: 279 passed, 24 skipped. `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib`: 727 passed. `iota-json-rpc-tests`, `iota-cost` and `iota-source-validation`: 169 passed. Also verified with the protocol flag enabled, on top of #12457.
