### PR TITLE
feat(iota-protocol-config): enable the P-COOL flow on devnet

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3143,7 +3143,14 @@ impl AuthorityPerEpochStore {
             .user_signatures_for_checkpoints
             .lock()
             .insert(digest, signatures);
-        let key = ConsensusTransactionKey::Certificate(digest);
+        // Match the key the checkpoint builder waits on: in the P-COOL flow
+        // user transactions are submitted as UserTransaction, not as
+        // Certificate.
+        let key = if self.protocol_config().enable_pcool_flow() {
+            ConsensusTransactionKey::UserTransaction(digest)
+        } else {
+            ConsensusTransactionKey::Certificate(digest)
+        };
         let key = SequencedConsensusTransactionKey::External(key);
 
         let mut output = ConsensusCommitOutput::default();

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4638,11 +4638,12 @@ async fn test_consensus_commit_prologue_generation(#[values(false, true)] pcool:
 
     telemetry_subscribers::init_for_testing();
 
-    let _guard = pcool.then(|| {
-        ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_enable_pcool_flow_for_testing(true);
-            config
-        })
+    // Pin the flag in both cases: the default for `Chain::Unknown` enables the
+    // P-COOL flow, so leaving it unset would run the certificate case against a
+    // protocol config that disagrees with the submission path under test.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(move |_, mut config| {
+        config.set_enable_pcool_flow_for_testing(pcool);
+        config
     });
 
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();

--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -34,7 +34,7 @@ use iota_types::{
     transaction::SenderSignedTransactionAPI,
 };
 use jsonrpsee::{core::client::ClientT, rpc_params};
-use test_cluster::{TestCluster, TestClusterBuilder};
+use test_cluster::{TestCluster, TestClusterBuilder, override_pcool_flow};
 
 #[tokio::test]
 async fn test_validator_traffic_control_noop() -> Result<(), anyhow::Error> {
@@ -234,6 +234,9 @@ async fn test_fullnode_traffic_control_dry_run() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_validator_traffic_control_error_blocked() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
+    // Under the P-COOL flow `handle_transaction` is rejected before signature
+    // verification, so the errors this policy counts never reach the tally.
+    let _pcool_guard = override_pcool_flow(false);
     let n = 5;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
@@ -293,6 +296,9 @@ async fn test_validator_traffic_control_error_blocked() -> Result<(), anyhow::Er
 async fn test_validator_traffic_control_error_blocked_with_policy_reconfig()
 -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
+    // Under the P-COOL flow `handle_transaction` is rejected before signature
+    // verification, so the errors this policy counts never reach the tally.
+    let _pcool_guard = override_pcool_flow(false);
     let n = 5;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 100,
@@ -510,6 +516,9 @@ async fn test_fullnode_traffic_control_error_blocked() -> Result<(), anyhow::Err
 #[tokio::test]
 async fn test_validator_traffic_control_error_delegated() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
+    // Under the P-COOL flow `handle_transaction` is rejected before signature
+    // verification, so the errors this policy counts never reach the tally.
+    let _pcool_guard = override_pcool_flow(false);
     let n = 5;
     let port = 65000;
     let policy_config = PolicyConfig {

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -243,6 +243,11 @@ async fn test_transaction_orchestrator_reconfig() {
 #[sim_test]
 async fn test_tx_across_epoch_boundaries() {
     telemetry_subscribers::init_for_testing();
+    // Halting 2 of 4 validators only withholds certification quorum. Under the
+    // P-COOL flow a single accepting validator carries the transaction into
+    // consensus, so it can be sequenced before the epoch changes;
+    // `test_wait_for_local_execution_across_epoch_boundary` covers that flow.
+    let _pcool_guard = override_pcool_flow(false);
     let total_tx_cnt = 1;
     let (result_tx, mut result_rx) = tokio::sync::mpsc::channel::<FinalizedEffects>(total_tx_cnt);
 

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1328,7 +1328,7 @@
                 "enable_group_ops_native_function_msm": true,
                 "enable_move_authentication": true,
                 "enable_move_authentication_for_sponsor": true,
-                "enable_pcool_flow": false,
+                "enable_pcool_flow": true,
                 "enable_poseidon": true,
                 "enable_vdf": true,
                 "hardened_otw_check": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -199,6 +199,7 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             Enable Move-based sponsor account authentication on mainnet.
 //             Only sponsor Move authentication is performed pre-consensus on
 //             mainnet.
+//             Enable the P-COOL flow on devnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3197,6 +3198,10 @@ impl ProtocolConfig {
                             .consensus_enable_sliding_window_leader_schedule = true;
                         cfg.feature_flags
                             .consensus_enable_absolute_score_leader_schedule = true;
+                        // Enable the P-COOL flow: transactions skip
+                        // pre-consensus certification and owned-object locking,
+                        // and conflicts are resolved after consensus.
+                        cfg.feature_flags.enable_pcool_flow = true;
                     }
                 }
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_32.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_32.snap
@@ -54,6 +54,7 @@ feature_flags:
   pre_consensus_sponsor_only_move_authentication: true
   consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
+  enable_pcool_flow: true
   validator_metadata_verify_v2: true
   package_metadata_with_dynamic_module_metadata: true
   report_move_authentication_error: true

--- a/crates/iota-single-node-benchmark/Cargo.toml
+++ b/crates/iota-single-node-benchmark/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 iota-config.workspace = true
 iota-core = { workspace = true, features = ["test-utils"] }
 iota-move-build.workspace = true
+iota-protocol-config.workspace = true
 iota-sdk-types.workspace = true
 iota-storage.workspace = true
 iota-test-transaction-builder.workspace = true
@@ -37,7 +38,6 @@ telemetry-subscribers.workspace = true
 [dev-dependencies]
 iota-macros.workspace = true
 iota-metrics.workspace = true
-iota-protocol-config.workspace = true
 iota-simulator.workspace = true
 
 [lints]

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -20,6 +20,7 @@ use iota_core::{
     global_state_hasher::GlobalStateHasher,
     mock_consensus::{ConsensusMode, MockConsensusClient},
 };
+use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{Address, ObjectReference, TransactionDigest};
 use iota_test_transaction_builder::{PublishData, TestTransactionBuilder};
 use iota_types::{
@@ -48,7 +49,14 @@ pub struct SingleValidator {
 
 impl SingleValidator {
     pub(crate) async fn new(genesis_objects: &[Object], component: Component) -> Self {
+        // Every component certifies its transactions first, and the validator
+        // entry points measured here (`handle_transaction`,
+        // `handle_certificate_v1`) reject requests once the P-COOL flow is on,
+        // so the benchmark runs the certified flow.
+        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        protocol_config.set_enable_pcool_flow_for_testing(false);
         let validator = TestAuthorityBuilder::new()
+            .with_protocol_config(protocol_config)
             .disable_indexer()
             .with_starting_objects(genesis_objects)
             // This is needed to properly run checkpoint executor.


### PR DESCRIPTION
# Description of change

Enables the P-COOL flow on every chain other than mainnet and testnet, which is devnet and local networks.

Protocol version 32 is not part of any release branch and no network runs it yet — mainnet is on 30, testnet and devnet on 31, and the latest release branch `releases/iota-v1.28.0-release` caps at 31 — so the flag goes into that version rather than a new one. The mainnet and testnet snapshots for version 32 are unchanged, which confirms the guard.

Also pins the three traffic-control error tests to the certified flow. They drive errors through `handle_transaction`, which the P-COOL flow rejects before it verifies signatures, so the errors these policies count never reach the tally and the blocklist stays empty. `validator_v2` tallies through the same `normalize()`, so this is a gap in test coverage rather than in behaviour — #12500 tracks moving these tests onto `submit_tx` along with the rest of the suite still pinned to the certified flow.

Stacked on #12456, which keeps both transaction flows covered in the tests.

## Links to any relevant issues

fixes #12433

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo simtest -p iota-e2e-tests`: 282 passed, 22 skipped. `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-e2e-tests -p iota-core`: 1009 passed. `iota-protocol-config` and `iota-swarm-config`: 13 passed.

`rust / rust-tests` only runs on `merge_group`, so the traffic-control failures first appeared when the PR was queued rather than on the branch.

### Release Notes

- [x] Protocol: The P-COOL flow is enabled on devnet from protocol version 32.
