### PR TITLE
refactor(iota-data-ingestion-core): make library checkpoint sync logs debug level

### DIFF
--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -25,7 +25,7 @@ use tokio::{
     time::timeout,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 #[cfg(not(target_os = "macos"))]
 use crate::reader::fetch::init_watcher;
@@ -408,7 +408,7 @@ impl CheckpointReaderActor {
                 Ok(_) => break,
                 Err(IngestionError::MaxCheckpointsCapacityReached) => break,
                 Err(IngestionError::CheckpointNotAvailableYet) => {
-                    break info!("historical reader does not have the requested checkpoint yet");
+                    break debug!("historical reader does not have the requested checkpoint yet");
                 }
                 Err(err) => match backoff.next_backoff() {
                     Some(duration) => {

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -510,7 +510,7 @@ impl CheckpointReaderActor {
             self.send_local_checkpoints_to_channel(checkpoints).await?;
         }
 
-        info!(
+        debug!(
             "Read from {remote_source}. Current checkpoint number: {}, pruning watermark: {}",
             self.current_checkpoint_number, self.last_pruned_watermark,
         );


### PR DESCRIPTION
# Description of change

This PR modifies checkpoint sync log from `info` to `debug` level. 

## Links to any relevant issues

fixes #12460 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This patch does not affect the normal ingestion operation of the `iota-indexer`, thus no further tests were conducted.


