### PR TITLE
feat(node): Add progress bar to snapshot download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7654,6 +7654,7 @@ dependencies = [
  "object_store 0.13.1",
  "prometheus-filtered",
  "rand 0.8.6",
+ "reqwest",
  "serde",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7659,6 +7659,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7751,7 +7751,6 @@ dependencies = [
  "fastcrypto",
  "futures",
  "hyper",
- "indicatif",
  "integer-encoding",
  "iota-common",
  "iota-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7635,6 +7635,7 @@ name = "iota-snapshot"
 version = "1.30.0-alpha"
 dependencies = [
  "anyhow",
+ "async-trait",
  "backoff",
  "bcs",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7635,6 +7635,7 @@ name = "iota-snapshot"
 version = "1.30.0-alpha"
 dependencies = [
  "anyhow",
+ "backoff",
  "bcs",
  "byteorder",
  "bytes",

--- a/crates/iota-config/src/object_storage_config.rs
+++ b/crates/iota-config/src/object_storage_config.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, fs, path::PathBuf, sync::Arc};
+use std::{env, fs, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::*;
@@ -104,11 +104,20 @@ fn default_object_store_connection_limit() -> usize {
     20
 }
 
-fn no_timeout_options() -> ClientOptions {
+/// How long establishing a connection may take before it is abandoned.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// How long a transfer may go without receiving any bytes before it is
+/// abandoned.
+pub const TRANSFER_STALL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Client options with no overall request timeout, since a transfer takes as
+/// long as the object is large, but with the connect phase bounded.
+fn transfer_client_options() -> ClientOptions {
     ClientOptions::new()
         .with_timeout_disabled()
-        .with_connect_timeout_disabled()
-        .with_pool_idle_timeout(std::time::Duration::from_secs(300))
+        .with_connect_timeout(CONNECT_TIMEOUT)
+        .with_pool_idle_timeout(Duration::from_secs(300))
 }
 
 impl ObjectStoreConfig {
@@ -132,7 +141,7 @@ impl ObjectStoreConfig {
         info!(bucket=?self.bucket, object_store_type="S3", "Object Store");
 
         let mut builder = AmazonS3Builder::new()
-            .with_client_options(no_timeout_options())
+            .with_client_options(transfer_client_options())
             .with_imdsv1_fallback();
 
         if self.aws_virtual_hosted_style_request {
@@ -190,7 +199,7 @@ impl ObjectStoreConfig {
             builder = builder.with_service_account_path(account);
         }
 
-        let mut client_options = no_timeout_options();
+        let mut client_options = transfer_client_options();
         if let Some(google_project_id) = &self.google_project_id {
             let x_project_header = HeaderName::from_static("x-goog-user-project");
             let iam_req_header = HeaderName::from_static("userproject");
@@ -213,7 +222,8 @@ impl ObjectStoreConfig {
         info!(bucket=?self.bucket, account=?self.azure_storage_account,
           object_store_type="Azure", "Object Store");
 
-        let mut builder = MicrosoftAzureBuilder::new().with_client_options(no_timeout_options());
+        let mut builder =
+            MicrosoftAzureBuilder::new().with_client_options(transfer_client_options());
 
         if let Some(bucket) = &self.bucket {
             builder = builder.with_container_name(bucket);

--- a/crates/iota-indexer/src/restore/orchestration.rs
+++ b/crates/iota-indexer/src/restore/orchestration.rs
@@ -42,8 +42,12 @@ pub async fn start(
     num_parallel_downloads: NonZeroUsize,
     pg_indexer_store: PgIndexerStore,
 ) -> IndexerResult<()> {
-    let (mut reader, epoch, epoch_info) =
+    let (mut reader, epoch) =
         setup_reader(network, epoch, staging_path, num_parallel_downloads).await?;
+    let epoch_info = reader
+        .read_epoch_info()
+        .await
+        .map_err(|e| IndexerError::Restore(format!("failed to read epoch info: {e}")))?;
     let snapshot_chain_id = reader.chain_id();
     let genesis = Genesis::load(genesis_path)?;
 

--- a/crates/iota-indexer/src/restore/orchestration.rs
+++ b/crates/iota-indexer/src/restore/orchestration.rs
@@ -42,12 +42,8 @@ pub async fn start(
     num_parallel_downloads: NonZeroUsize,
     pg_indexer_store: PgIndexerStore,
 ) -> IndexerResult<()> {
-    let (mut reader, epoch) =
+    let (mut reader, epoch, epoch_info) =
         setup_reader(network, epoch, staging_path, num_parallel_downloads).await?;
-    let epoch_info = reader
-        .read_epoch_info()
-        .await
-        .map_err(|e| IndexerError::Restore(format!("failed to read epoch info: {e}")))?;
     let snapshot_chain_id = reader.chain_id();
     let genesis = Genesis::load(genesis_path)?;
 

--- a/crates/iota-indexer/src/restore/setup.rs
+++ b/crates/iota-indexer/src/restore/setup.rs
@@ -68,9 +68,10 @@ pub(crate) async fn setup_reader(
 
     // The chain id is read again from the same MANIFEST by the reader below,
     // which the caller uses.
-    let (_, epoch_info) = StateSnapshotReaderV1::read_epoch_info(epoch, &remote_store.config)
-        .await
-        .map_err(|e| IndexerError::Restore(format!("failed to read epoch info: {e}")))?;
+    let (_, epoch_info) =
+        StateSnapshotReaderV1::read_epoch_info(epoch, &remote_store.config, &MultiProgress::new())
+            .await
+            .map_err(|e| IndexerError::Restore(format!("failed to read epoch info: {e}")))?;
 
     info!(
         network = network.as_ref(),

--- a/crates/iota-indexer/src/restore/setup.rs
+++ b/crates/iota-indexer/src/restore/setup.rs
@@ -6,7 +6,7 @@ use std::{cmp::Reverse, num::NonZeroUsize, path::Path, sync::Arc, time::Duration
 use clap::ValueEnum;
 use indicatif::MultiProgress;
 use iota_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
-use iota_snapshot::reader::StateSnapshotReaderV1;
+use iota_snapshot::{EpochInfo, reader::StateSnapshotReaderV1};
 use iota_storage::object_store::{
     ObjectStoreGetExt,
     http::HttpDownloaderBuilder,
@@ -38,23 +38,25 @@ pub enum Network {
 /// 2. Resolves the target epoch: the given one, or the latest epoch available
 ///    in the bucket.
 /// 3. Verifies that the snapshot upload for that epoch has completed.
-/// 4. Instantiates the reader, which downloads the snapshot's MANIFEST and
+/// 4. Reads the snapshot's `EPOCH_INFO`, one small file, before anything large
+///    is downloaded.
+/// 5. Instantiates the reader, which downloads the snapshot's MANIFEST and
 ///    reference files into the staging directory.
 ///
-/// Returns the reader and the resolved epoch.
+/// Returns the reader, the resolved epoch, and the snapshot's epoch info.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 ///
 /// - The snapshot for the resolved epoch is incomplete.
-/// - Downloading the MANIFEST or reference files fails.
+/// - Downloading the MANIFEST, `EPOCH_INFO` or reference files fails.
 pub(crate) async fn setup_reader(
     network: Network,
     epoch: Option<u64>,
     staging_path: &Path,
     num_parallel_downloads: NonZeroUsize,
-) -> IndexerResult<(StateSnapshotReaderV1, u64)> {
+) -> IndexerResult<(StateSnapshotReaderV1, u64, EpochInfo)> {
     let remote_store = FormalSnapshotStore::new(network)?;
     let local_store_config = local_store_config(staging_path);
 
@@ -63,6 +65,12 @@ pub(crate) async fn setup_reader(
         None => remote_store.latest_available_epoch().await?,
     };
     remote_store.verify_completed_snapshot(epoch).await?;
+
+    // The chain id is read again from the same MANIFEST by the reader below,
+    // which the caller uses.
+    let (_, epoch_info) = StateSnapshotReaderV1::read_epoch_info(epoch, &remote_store.config)
+        .await
+        .map_err(|e| IndexerError::Restore(format!("failed to read epoch info: {e}")))?;
 
     info!(
         network = network.as_ref(),
@@ -85,7 +93,7 @@ pub(crate) async fn setup_reader(
         staging_path = %staging_path.display(),
         "formal snapshot reader ready; MANIFEST and reference files downloaded"
     );
-    Ok((reader, epoch))
+    Ok((reader, epoch, epoch_info))
 }
 
 /// Read client for a network's public formal snapshot store.

--- a/crates/iota-indexer/src/restore/setup.rs
+++ b/crates/iota-indexer/src/restore/setup.rs
@@ -6,7 +6,7 @@ use std::{cmp::Reverse, num::NonZeroUsize, path::Path, sync::Arc, time::Duration
 use clap::ValueEnum;
 use indicatif::MultiProgress;
 use iota_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
-use iota_snapshot::{EpochInfo, reader::StateSnapshotReaderV1};
+use iota_snapshot::reader::StateSnapshotReaderV1;
 use iota_storage::object_store::{
     ObjectStoreGetExt,
     http::HttpDownloaderBuilder,
@@ -38,25 +38,24 @@ pub enum Network {
 /// 2. Resolves the target epoch: the given one, or the latest epoch available
 ///    in the bucket.
 /// 3. Verifies that the snapshot upload for that epoch has completed.
-/// 4. Reads the snapshot's `EPOCH_INFO`, one small file, before anything large
-///    is downloaded.
-/// 5. Instantiates the reader, which downloads the snapshot's MANIFEST and
-///    reference files into the staging directory.
+/// 4. Instantiates the reader, which downloads the snapshot's MANIFEST into the
+///    staging directory. The reference and object files follow when the caller
+///    reads the snapshot.
 ///
-/// Returns the reader, the resolved epoch, and the snapshot's epoch info.
+/// Returns the reader and the resolved epoch.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 ///
 /// - The snapshot for the resolved epoch is incomplete.
-/// - Downloading the MANIFEST, `EPOCH_INFO` or reference files fails.
+/// - Downloading the MANIFEST fails.
 pub(crate) async fn setup_reader(
     network: Network,
     epoch: Option<u64>,
     staging_path: &Path,
     num_parallel_downloads: NonZeroUsize,
-) -> IndexerResult<(StateSnapshotReaderV1, u64, EpochInfo)> {
+) -> IndexerResult<(StateSnapshotReaderV1, u64)> {
     let remote_store = FormalSnapshotStore::new(network)?;
     let local_store_config = local_store_config(staging_path);
 
@@ -65,13 +64,6 @@ pub(crate) async fn setup_reader(
         None => remote_store.latest_available_epoch().await?,
     };
     remote_store.verify_completed_snapshot(epoch).await?;
-
-    // The chain id is read again from the same MANIFEST by the reader below,
-    // which the caller uses.
-    let (_, epoch_info) =
-        StateSnapshotReaderV1::read_epoch_info(epoch, &remote_store.config, &MultiProgress::new())
-            .await
-            .map_err(|e| IndexerError::Restore(format!("failed to read epoch info: {e}")))?;
 
     info!(
         network = network.as_ref(),
@@ -92,9 +84,9 @@ pub(crate) async fn setup_reader(
     info!(
         epoch,
         staging_path = %staging_path.display(),
-        "formal snapshot reader ready; MANIFEST and reference files downloaded"
+        "formal snapshot reader ready; MANIFEST downloaded"
     );
-    Ok((reader, epoch, epoch_info))
+    Ok((reader, epoch))
 }
 
 /// Read client for a network's public formal snapshot store.

--- a/crates/iota-snapshot/Cargo.toml
+++ b/crates/iota-snapshot/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 # external dependencies
 anyhow.workspace = true
+backoff.workspace = true
 bcs.workspace = true
 byteorder.workspace = true
 bytes.workspace = true

--- a/crates/iota-snapshot/Cargo.toml
+++ b/crates/iota-snapshot/Cargo.toml
@@ -35,6 +35,7 @@ iota-types.workspace = true
 prometheus-filtered.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 

--- a/crates/iota-snapshot/Cargo.toml
+++ b/crates/iota-snapshot/Cargo.toml
@@ -20,6 +20,7 @@ indicatif.workspace = true
 integer-encoding.workspace = true
 num_enum.workspace = true
 object_store.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "rt", "sync", "time"] }
 tokio-stream.workspace = true

--- a/crates/iota-snapshot/Cargo.toml
+++ b/crates/iota-snapshot/Cargo.toml
@@ -38,6 +38,8 @@ prometheus-filtered.workspace = true
 async-trait.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -20,7 +20,6 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::Duration,
 };
 
 use anyhow::Result;
@@ -57,9 +56,11 @@ use iota_types::{
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use object_store::path::Path;
 use serde::{Deserialize, Serialize};
-use tokio::time::Instant;
 
-use crate::restore::RestoreEpochInfo;
+use crate::{
+    progress::{ProgressTicker, ProgressUnit},
+    restore::RestoreEpochInfo,
+};
 
 /// The following describes the format of an object file (*.obj) used for
 /// persisting live iota objects. The maximum size per .obj file is 128MB. State
@@ -636,32 +637,23 @@ pub async fn accumulate_live_object_iter(
     m: MultiProgress,
     num_live_objects: u64,
 ) -> GlobalStateHash {
-    // Monitor progress of live object accumulation
-    let accum_progress_bar = m.add(ProgressBar::new(num_live_objects).with_style(
-        ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})").unwrap(),
-    ));
+    // Monitor progress of live object accumulation, whose position the ticker
+    // takes from the counter the loop below advances
     let accum_counter = Arc::new(AtomicU64::new(0));
-    let cloned_accum_counter = accum_counter.clone();
-    let cloned_progress_bar = accum_progress_bar.clone();
-    let handle = tokio::spawn(async move {
-        let a_instant = Instant::now();
-        loop {
-            if cloned_progress_bar.is_finished() {
-                break;
-            }
-            let num_accumulated = cloned_accum_counter.load(Ordering::Relaxed);
-            assert!(
-                num_accumulated <= num_live_objects,
-                "Accumulated more objects (at least {num_accumulated}) than expected ({num_live_objects})"
-            );
-            let accumulations_per_sec = num_accumulated as f64 / a_instant.elapsed().as_secs_f64();
-            cloned_progress_bar.set_position(num_accumulated);
-            cloned_progress_bar.set_message(format!(
-                "DB live obj accumulations per sec: {accumulations_per_sec}"
-            ));
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    });
+    let accum_ticker = ProgressTicker::spawn(
+        m.add(
+            ProgressBar::new(num_live_objects).with_style(
+                ProgressStyle::with_template(
+                    "[{elapsed_precise}] {wide_bar} Accumulating DB live objects: {pos}/{len} \
+                     ({per_sec}, ETA {eta})",
+                )
+                .unwrap(),
+            ),
+        ),
+        "Accumulating DB live objects",
+        ProgressUnit::Count("objects"),
+        Some(accum_counter.clone()),
+    );
 
     // Accumulate live objects
     let mut acc = GlobalStateHash::default();
@@ -669,9 +661,11 @@ pub async fn accumulate_live_object_iter(
         GlobalStateHasher::accumulate_live_object(&mut acc, &live_object);
         accum_counter.fetch_add(1, Ordering::Relaxed);
     }
-    accum_progress_bar.finish_with_message("DB live object accumulation completed");
-    handle
-        .await
-        .expect("Failed to join live object accumulation progress monitor");
+    let num_accumulated = accum_counter.load(Ordering::Relaxed);
+    assert!(
+        num_accumulated <= num_live_objects,
+        "Accumulated more objects ({num_accumulated}) than expected ({num_live_objects})"
+    );
+    accum_ticker.finish_with_message("DB live object accumulation completed");
     acc
 }

--- a/crates/iota-snapshot/src/lib.rs
+++ b/crates/iota-snapshot/src/lib.rs
@@ -7,6 +7,7 @@
 #[cfg(test)]
 mod tests;
 
+pub mod progress;
 pub mod reader;
 pub mod restore;
 pub mod uploader;

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Progress reporting for snapshot downloads.
+//!
+//! When the total byte size of a download is known — from a size sweep over
+//! the remote files with [`fetch_total_bytes`] — the bar is byte-denominated
+//! and indicatif renders the size totals, download speed, and ETA natively,
+//! while the file counts move to the bar message. When the sweep fails, the
+//! bar falls back to file counts.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use backoff::future::retry;
+use futures::{StreamExt, TryStreamExt};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use iota_storage::object_store::{
+    ObjectStoreGetExt, ObjectStorePutExt,
+    util::{get, put},
+};
+use object_store::path::Path;
+use tracing::warn;
+
+/// Fetch the combined size in bytes of every path in `paths` from the remote
+/// store with bounded concurrency, rendering a progress bar on `m` while the
+/// lookups run. Returns `None` after logging a warning if any lookup fails —
+/// a partial sum would misstate the total: progress reporting is best-effort
+/// and must never fail a download.
+pub async fn fetch_total_bytes(
+    remote_object_store: &Arc<dyn ObjectStoreGetExt>,
+    paths: Vec<Path>,
+    concurrency: usize,
+    m: &MultiProgress,
+) -> Option<u64> {
+    let bar = m.add(
+        ProgressBar::new(paths.len() as u64).with_style(
+            ProgressStyle::with_template(
+                "[{elapsed_precise}] {wide_bar} Fetching file sizes: {pos}/{len} (ETA {eta})",
+            )
+            .unwrap(),
+        ),
+    );
+    bar.enable_steady_tick(Duration::from_millis(100));
+    let mut stream = futures::stream::iter(paths)
+        .map(|path| {
+            let store = remote_object_store.clone();
+            let bar = bar.clone();
+            async move {
+                // Sizes are best-effort: retry briefly so a single transient
+                // error out of thousands of lookups doesn't hide the totals,
+                // but give up quickly rather than stall the restore.
+                let size = retry(size_lookup_backoff(), || async {
+                    store
+                        .object_size(&path)
+                        .await
+                        .map_err(backoff::Error::transient)
+                })
+                .await;
+                bar.inc(1);
+                (path, size)
+            }
+        })
+        .buffer_unordered(concurrency);
+    let mut total_bytes = 0u64;
+    while let Some((path, size)) = stream.next().await {
+        match size {
+            Ok(size) => total_bytes += size,
+            Err(err) => {
+                warn!("size lookup for {path} failed, download totals will not be shown: {err:?}");
+                // Dropping the stream cancels the remaining lookups rather
+                // than waiting for every one to finish first.
+                bar.finish_and_clear();
+                return None;
+            }
+        }
+    }
+    bar.finish_and_clear();
+    Some(total_bytes)
+}
+
+fn size_lookup_backoff() -> backoff::ExponentialBackoff {
+    backoff::ExponentialBackoff {
+        max_elapsed_time: Some(Duration::from_secs(3)),
+        ..Default::default()
+    }
+}
+
+/// A download progress bar added to `m`: byte-denominated when `total_bytes`
+/// is known (indicatif renders the size totals, download speed, and ETA; the
+/// file counts go to the message), file-count based otherwise.
+///
+/// `phase` is rendered verbatim at the start of the bar line, e.g.
+/// "Downloading .ref files".
+pub struct DownloadProgressBar {
+    bar: ProgressBar,
+    num_files: u64,
+    files_done: AtomicU64,
+    byte_denominated: bool,
+}
+
+impl DownloadProgressBar {
+    pub fn new(m: &MultiProgress, phase: &str, num_files: u64, total_bytes: Option<u64>) -> Self {
+        let bar = match total_bytes {
+            Some(total_bytes) => ProgressBar::new(total_bytes).with_style(
+                ProgressStyle::with_template(&format!(
+                    "[{{elapsed_precise}}] {{wide_bar}} {phase}: \
+                     {{binary_bytes}}/{{binary_total_bytes}} ({{binary_bytes_per_sec}}, \
+                     ETA {{eta}}) — {{msg}}"
+                ))
+                .unwrap(),
+            ),
+            None => ProgressBar::new(num_files).with_style(
+                ProgressStyle::with_template(&format!(
+                    "[{{elapsed_precise}}] {{wide_bar}} {phase}: {{pos}}/{{len}} files \
+                     (ETA {{eta}}) — {{msg}}"
+                ))
+                .unwrap(),
+            ),
+        };
+        let bar = m.add(bar);
+        // Render the bar on a timer so it stays visible while the first files
+        // are still in flight, rather than only repainting on completion.
+        bar.enable_steady_tick(Duration::from_millis(100));
+        Self {
+            bar,
+            num_files,
+            files_done: AtomicU64::new(0),
+            byte_denominated: total_bytes.is_some(),
+        }
+    }
+
+    /// Record one fully downloaded file of `bytes_len` bytes.
+    pub fn file_done(&self, bytes_len: u64) {
+        if self.byte_denominated {
+            let files_done = self.files_done.fetch_add(1, Ordering::Relaxed) + 1;
+            self.bar.inc(bytes_len);
+            self.bar
+                .set_message(format!("{files_done}/{} files", self.num_files));
+        } else {
+            self.bar.inc(1);
+        }
+    }
+
+    /// The underlying bar, e.g. to finish it with a message.
+    pub fn bar(&self) -> &ProgressBar {
+        &self.bar
+    }
+}
+
+/// Copy `src[i]` to `dest[i]` for all `i` in parallel, recording each
+/// completed file on `progress` and failing on the first copy that fails.
+pub async fn copy_files_with_progress<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
+    src: &[Path],
+    dest: &[Path],
+    src_store: &S,
+    dest_store: &D,
+    concurrency: usize,
+    progress: &DownloadProgressBar,
+) -> Result<()> {
+    futures::stream::iter(src.iter().zip(dest.iter()))
+        .map(|(path_in, path_out)| async move {
+            let bytes = get(src_store, path_in).await?;
+            let bytes_len = bytes.len() as u64;
+            put(dest_store, path_out, bytes).await?;
+            Ok::<_, anyhow::Error>(bytes_len)
+        })
+        .boxed()
+        .buffer_unordered(concurrency)
+        .try_for_each(|bytes_len| {
+            progress.file_done(bytes_len);
+            futures::future::ready(Ok(()))
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use indicatif::{MultiProgress, ProgressDrawTarget};
+    use iota_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
+    use iota_storage::object_store::{ObjectStoreGetExt, ObjectStorePutExt};
+    use object_store::{ObjectStore, memory::InMemory, path::Path};
+
+    use super::{DownloadProgressBar, copy_files_with_progress, fetch_total_bytes};
+
+    fn hidden_multi_progress() -> MultiProgress {
+        MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
+    }
+
+    #[tokio::test]
+    async fn test_copy_files_with_progress_advances_by_bytes() -> anyhow::Result<()> {
+        let src_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let dest_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        src_store
+            .put_bytes(&Path::from("a"), Bytes::from_static(b"12345"))
+            .await?;
+        src_store
+            .put_bytes(&Path::from("b"), Bytes::from_static(b"123"))
+            .await?;
+        let paths = [Path::from("a"), Path::from("b")];
+
+        let progress =
+            DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 2, Some(8));
+        copy_files_with_progress(&paths, &paths, &src_store, &dest_store, 2, &progress).await?;
+        assert_eq!(progress.bar().length(), Some(8));
+        assert_eq!(progress.bar().position(), 8);
+        assert_eq!(progress.bar().message(), "2/2 files");
+        assert_eq!(
+            dest_store.get_bytes(&Path::from("a")).await?.to_vec(),
+            b"12345"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_copy_files_with_progress_falls_back_to_file_counts() -> anyhow::Result<()> {
+        let src_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let dest_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        src_store
+            .put_bytes(&Path::from("a"), Bytes::from_static(b"12345"))
+            .await?;
+        src_store
+            .put_bytes(&Path::from("b"), Bytes::from_static(b"123"))
+            .await?;
+        let paths = [Path::from("a"), Path::from("b")];
+
+        // An unknown total byte size means the bar counts files instead.
+        let progress = DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 2, None);
+        copy_files_with_progress(&paths, &paths, &src_store, &dest_store, 2, &progress).await?;
+        assert_eq!(progress.bar().length(), Some(2));
+        assert_eq!(progress.bar().position(), 2);
+        Ok(())
+    }
+
+    /// A failed size lookup for any path in the batch means the download
+    /// totals will not be shown, rather than reporting a partial sum.
+    #[tokio::test]
+    async fn test_fetch_total_bytes_is_all_or_nothing() -> anyhow::Result<()> {
+        let tmp_dir = tempfile::tempdir()?;
+        std::fs::write(tmp_dir.path().join("present"), b"hello")?;
+        std::fs::write(tmp_dir.path().join("other"), b"abc")?;
+        let store_config = ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::File),
+            directory: Some(tmp_dir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let store: Arc<dyn ObjectStoreGetExt> = Arc::new(store_config.make()?);
+
+        let total = fetch_total_bytes(
+            &store,
+            vec![Path::from("present"), Path::from("other")],
+            2,
+            &hidden_multi_progress(),
+        )
+        .await;
+        assert_eq!(total, Some(8));
+
+        // Any failed lookup disables the displayed download totals entirely.
+        let total = fetch_total_bytes(
+            &store,
+            vec![Path::from("present"), Path::from("missing")],
+            2,
+            &hidden_multi_progress(),
+        )
+        .await;
+        assert!(total.is_none());
+        Ok(())
+    }
+}

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -97,7 +97,7 @@ fn size_lookup_backoff() -> backoff::ExponentialBackoff {
 /// file counts go to the message), file-count based otherwise.
 ///
 /// `phase` is rendered verbatim at the start of the bar line, e.g.
-/// "Downloading .ref files".
+/// "Downloading files".
 pub struct DownloadProgressBar {
     bar: ProgressBar,
     num_files: u64,

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -40,6 +40,19 @@ use tracing::{error, info, warn};
 /// which otherwise silences its logs can keep them.
 pub const LOG_TARGET_PROGRESS: &str = module_path!();
 
+/// Report `msg` on the progress display, or log it when the display is hidden
+/// — [`MultiProgress::println`] writes nothing at all there, so the phase
+/// announcements around the bars would otherwise be lost in exactly the runs
+/// that depend on the status lines.
+pub fn println_or_log(m: &MultiProgress, msg: impl AsRef<str>) -> std::io::Result<()> {
+    if m.is_hidden() {
+        info!(target: PROGRESS_LOG_TARGET, "{}", msg.as_ref());
+        Ok(())
+    } else {
+        m.println(msg)
+    }
+}
+
 /// The progress display for a restore: one that draws its bars on the
 /// terminal, or a hidden one — whose bars report through periodic status logs
 /// instead — when `disable_progress_bar` is set.
@@ -308,19 +321,22 @@ impl DownloadProgressBar {
         num_files: u64,
         total_bytes: Option<u64>,
     ) -> Self {
+        // A single-file download has no file counts to carry alongside its
+        // bytes, so it leaves the bar's message out entirely.
+        let msg = if num_files > 1 { " — {msg}" } else { "" };
         let bar = match total_bytes {
             Some(total_bytes) => ProgressBar::new(total_bytes).with_style(
                 ProgressStyle::with_template(&format!(
                     "[{{elapsed_precise}}] {{wide_bar}} {phase}: \
                      {{binary_bytes}}/{{binary_total_bytes}} ({{binary_bytes_per_sec}}, \
-                     ETA {{eta}}) — {{msg}}"
+                     ETA {{eta}}){msg}"
                 ))
                 .unwrap(),
             ),
             None => ProgressBar::new(num_files).with_style(
                 ProgressStyle::with_template(&format!(
                     "[{{elapsed_precise}}] {{wide_bar}} {phase}: {{pos}}/{{len}} files \
-                     (ETA {{eta}}) — {{msg}}"
+                     (ETA {{eta}}){msg}"
                 ))
                 .unwrap(),
             ),
@@ -407,6 +423,24 @@ pub async fn get_with_progress<S: ObjectStoreGetExt>(
     .await
 }
 
+/// Download the single file `src` from `store` with retries, reporting the
+/// bytes as they arrive on a bar of its own under `phase` — for a file big
+/// enough that a restore shouldn't sit silent while it downloads.
+pub async fn get_single_file_with_progress<S: ObjectStoreGetExt>(
+    store: &S,
+    src: &Path,
+    phase: &'static str,
+    m: &MultiProgress,
+) -> Result<Bytes> {
+    // The size only feeds the bar's totals, so a failed lookup costs the size
+    // and ETA rather than the download.
+    let total_bytes = store.object_size(src).await.ok();
+    let progress = DownloadProgressBar::new(m, phase, 1, total_bytes);
+    let bytes = get_with_progress(store, src, &progress).await?;
+    progress.finish_with_message("Download complete");
+    Ok(bytes)
+}
+
 /// Copy `src[i]` to `dest[i]` for all `i` in parallel, recording downloaded
 /// chunks and each completed file on `progress` and failing on the first copy
 /// that fails.
@@ -455,7 +489,7 @@ mod tests {
 
     use super::{
         DownloadProgressBar, ProgressTicker, ProgressUnit, copy_files_with_progress,
-        fetch_total_bytes, get_with_progress, status_line,
+        fetch_total_bytes, get_with_progress, println_or_log, status_line,
     };
 
     fn hidden_multi_progress() -> MultiProgress {
@@ -586,6 +620,24 @@ mod tests {
         assert!(logs.contains("Downloading files: 8 B/8 B"), "{logs}");
         assert!(logs.ends_with("— Download complete\n"), "{logs}");
         assert!(!logs.contains("ETA"), "{logs}");
+    }
+
+    /// A hidden display drops everything handed to `MultiProgress::println`,
+    /// so the phase announcements around the bars are logged there instead.
+    #[tokio::test]
+    async fn test_phase_announcements_are_logged_when_the_display_is_hidden() {
+        let hidden = hidden_multi_progress();
+        let logs = captured_logs(|| {
+            println_or_log(&hidden, "Loading genesis from genesis.blob").expect("hidden println");
+        });
+        assert!(logs.contains("Loading genesis from genesis.blob"), "{logs}");
+
+        // A drawn display prints them itself, with no log line.
+        let drawn = drawn_multi_progress();
+        let logs = captured_logs(|| {
+            println_or_log(&drawn, "Loading genesis from genesis.blob").expect("drawn println");
+        });
+        assert!(logs.is_empty(), "{logs}");
     }
 
     /// A bar the terminal can draw reports through the display, so it logs no

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -8,8 +8,14 @@
 //! and indicatif renders the size totals, download speed, and ETA natively,
 //! while the file counts move to the bar message. When the sweep fails, the
 //! bar falls back to file counts.
+//!
+//! Bars can only be drawn on a terminal. Whenever they can't be — output is
+//! piped or redirected, or `--disable-progress-bar` was passed — every bar's
+//! [`ProgressTicker`] logs the same information as a status line once per
+//! second instead.
 
 use std::{
+    borrow::Cow,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -21,10 +27,186 @@ use anyhow::Result;
 use backoff::future::retry;
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{
+    FormattedDuration, HumanBytes, HumanCount, HumanDuration, MultiProgress, ProgressBar,
+    ProgressDrawTarget, ProgressStyle,
+};
 use iota_storage::object_store::{ObjectStoreGetExt, ObjectStorePutExt, util::put};
 use object_store::path::Path;
-use tracing::{error, warn};
+use tokio::task::JoinHandle;
+use tracing::{error, info, warn};
+
+/// The `tracing` target every status line is logged under, so that a caller
+/// which otherwise silences its logs can keep them.
+pub const LOG_TARGET_PROGRESS: &str = module_path!();
+
+/// The progress display for a restore: one that draws its bars on the
+/// terminal, or a hidden one — whose bars report through periodic status logs
+/// instead — when `disable_progress_bar` is set.
+///
+/// A display bound to a non-terminal output stream is hidden either way, so
+/// callers get the status logs there without passing the flag.
+pub fn make_multi_progress(disable_progress_bar: bool) -> MultiProgress {
+    if disable_progress_bar {
+        MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
+    } else {
+        MultiProgress::new()
+    }
+}
+
+/// What a progress bar's position counts, used to render its status lines.
+#[derive(Clone, Copy)]
+pub enum ProgressUnit {
+    /// The position is a number of bytes.
+    Bytes,
+    /// The position counts items named by the given plural noun, e.g. "files".
+    Count(&'static str),
+}
+
+/// Reports a progress bar's state once per second for as long as it runs:
+/// mirrors `counter` into the bar's position if one was given, and logs a
+/// status line carrying the same totals, rate and ETA the bar shows whenever
+/// the bar itself can't be drawn.
+///
+/// Finish the bar through [`Self::finish_with_message`] or
+/// [`Self::finish_and_clear`] rather than on the bar itself, so the final
+/// status line is logged even when the bar finishes before the first second is
+/// up. Dropping the ticker stops the reporting.
+pub struct ProgressTicker {
+    bar: ProgressBar,
+    phase: &'static str,
+    unit: ProgressUnit,
+    task: Option<JoinHandle<()>>,
+}
+
+impl ProgressTicker {
+    /// Starts reporting `bar`, whose position counts `unit` and whose progress
+    /// is logged under `phase`, e.g. "Downloading files".
+    ///
+    /// When a `counter` is given, the bar's position is taken from it once per
+    /// second rather than being advanced by the caller.
+    pub fn spawn(
+        bar: ProgressBar,
+        phase: &'static str,
+        unit: ProgressUnit,
+        counter: Option<Arc<AtomicU64>>,
+    ) -> Self {
+        // A drawn bar renders its own totals, so there is only something to do
+        // once per second if the bar is hidden or its position has to be
+        // mirrored from a counter.
+        let log_status = bar.is_hidden();
+        let task = (log_status || counter.is_some()).then(|| {
+            let bar = bar.clone();
+            tokio::spawn(async move {
+                while !bar.is_finished() {
+                    if let Some(counter) = &counter {
+                        bar.set_position(counter.load(Ordering::Relaxed));
+                    }
+                    if log_status {
+                        info!(
+                            target: LOG_TARGET_PROGRESS,
+                            "{}",
+                            status_line(&bar, phase, &unit, None)
+                        );
+                    }
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            })
+        });
+        Self {
+            bar,
+            phase,
+            unit,
+            task,
+        }
+    }
+
+    /// Finishes the bar with `msg`, leaving it on screen.
+    pub fn finish_with_message(&self, msg: &'static str) {
+        self.finish(msg, false);
+    }
+
+    /// Finishes the bar with `msg` and removes it from the display, for a
+    /// phase whose completed bar isn't worth keeping.
+    pub fn finish_and_clear(&self, msg: &'static str) {
+        self.finish(msg, true);
+    }
+
+    /// The underlying bar, to advance it or set its message.
+    pub fn bar(&self) -> &ProgressBar {
+        &self.bar
+    }
+
+    fn finish(&self, msg: &'static str, clear: bool) {
+        // Stop the ticker first so it can't log a periodic line after the
+        // final one.
+        self.stop();
+        if clear {
+            self.bar.finish_and_clear();
+        } else {
+            self.bar.finish_with_message(msg);
+        }
+        if self.bar.is_hidden() {
+            info!(
+                target: LOG_TARGET_PROGRESS,
+                "{}",
+                status_line(&self.bar, self.phase, &self.unit, Some(msg))
+            );
+        }
+    }
+
+    fn stop(&self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for ProgressTicker {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Renders `bar`'s state as one log line: elapsed time, phase, how far it has
+/// got, its rate and ETA, and finally either `done_msg` or the bar's own
+/// message.
+///
+/// The rate and ETA are left out until the bar has moved far enough to
+/// estimate them, and the ETA also once the bar has finished.
+fn status_line(
+    bar: &ProgressBar,
+    phase: &str,
+    unit: &ProgressUnit,
+    done_msg: Option<&str>,
+) -> String {
+    let pos = bar.position();
+    // Every snapshot bar is created with a length; falling back to the
+    // position keeps a lengthless one from reporting a total of zero.
+    let len = bar.length().unwrap_or(pos);
+    let progress = match unit {
+        ProgressUnit::Bytes => format!("{}/{}", HumanBytes(pos), HumanBytes(len)),
+        ProgressUnit::Count(unit) => format!("{}/{} {unit}", HumanCount(pos), HumanCount(len)),
+    };
+    let mut line = format!("[{}] {phase}: {progress}", FormattedDuration(bar.elapsed()));
+    let rate = bar.per_sec();
+    if rate > 0.0 {
+        let rate = match unit {
+            ProgressUnit::Bytes => format!("{}/s", HumanBytes(rate as u64)),
+            ProgressUnit::Count(unit) => format!("{rate:.1} {unit}/s"),
+        };
+        if bar.is_finished() {
+            line.push_str(&format!(" ({rate})"));
+        } else {
+            line.push_str(&format!(" ({rate}, ETA {})", HumanDuration(bar.eta())));
+        }
+    }
+    let msg: Cow<'_, str> = done_msg.map_or_else(|| bar.message().into(), Into::into);
+    if !msg.is_empty() {
+        line.push_str(&format!(" — {msg}"));
+    }
+    line
+}
 
 /// Fetch the combined size in bytes of every path in `paths` from the remote
 /// store with bounded concurrency, rendering a progress bar on `m` while the
@@ -45,7 +227,13 @@ pub async fn fetch_total_bytes(
             .unwrap(),
         ),
     );
-    bar.enable_steady_tick(Duration::from_millis(100));
+    steady_tick_when_drawn(&bar);
+    let ticker = ProgressTicker::spawn(
+        bar.clone(),
+        "Fetching file sizes",
+        ProgressUnit::Count("files"),
+        None,
+    );
     let mut stream = futures::stream::iter(paths)
         .map(|path| {
             let store = remote_object_store.clone();
@@ -74,13 +262,22 @@ pub async fn fetch_total_bytes(
                 warn!("size lookup for {path} failed, download totals will not be shown: {err:?}");
                 // Dropping the stream cancels the remaining lookups rather
                 // than waiting for every one to finish first.
-                bar.finish_and_clear();
+                ticker.finish_and_clear("Size lookup failed");
                 return None;
             }
         }
     }
-    bar.finish_and_clear();
+    ticker.finish_and_clear("File sizes fetched");
     Some(total_bytes)
+}
+
+/// Repaints `bar` on a timer so it stays current while its work is in flight,
+/// rather than only when the caller advances it. A hidden bar is never
+/// repainted; its [`ProgressTicker`] reports it instead.
+fn steady_tick_when_drawn(bar: &ProgressBar) {
+    if !bar.is_hidden() {
+        bar.enable_steady_tick(Duration::from_millis(100));
+    }
 }
 
 fn size_lookup_backoff() -> backoff::ExponentialBackoff {
@@ -101,10 +298,16 @@ pub struct DownloadProgressBar {
     num_files: u64,
     files_done: AtomicU64,
     byte_denominated: bool,
+    ticker: ProgressTicker,
 }
 
 impl DownloadProgressBar {
-    pub fn new(m: &MultiProgress, phase: &str, num_files: u64, total_bytes: Option<u64>) -> Self {
+    pub fn new(
+        m: &MultiProgress,
+        phase: &'static str,
+        num_files: u64,
+        total_bytes: Option<u64>,
+    ) -> Self {
         let bar = match total_bytes {
             Some(total_bytes) => ProgressBar::new(total_bytes).with_style(
                 ProgressStyle::with_template(&format!(
@@ -123,14 +326,17 @@ impl DownloadProgressBar {
             ),
         };
         let bar = m.add(bar);
-        // Render the bar on a timer so it stays visible while the first files
-        // are still in flight, rather than only repainting on completion.
-        bar.enable_steady_tick(Duration::from_millis(100));
+        steady_tick_when_drawn(&bar);
+        let unit = match total_bytes {
+            Some(_) => ProgressUnit::Bytes,
+            None => ProgressUnit::Count("files"),
+        };
         Self {
-            bar,
+            bar: bar.clone(),
             num_files,
             files_done: AtomicU64::new(0),
             byte_denominated: total_bytes.is_some(),
+            ticker: ProgressTicker::spawn(bar, phase, unit, None),
         }
     }
 
@@ -165,7 +371,12 @@ impl DownloadProgressBar {
         }
     }
 
-    /// The underlying bar, e.g. to finish it with a message.
+    /// Records that both download phases are done, under the message `msg`.
+    pub fn finish_with_message(&self, msg: &'static str) {
+        self.ticker.finish_with_message(msg);
+    }
+
+    /// The underlying bar, e.g. to read its position in tests.
     pub fn bar(&self) -> &ProgressBar {
         &self.bar
     }
@@ -224,25 +435,186 @@ pub async fn copy_files_with_progress<S: ObjectStoreGetExt, D: ObjectStorePutExt
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
+    use std::{
+        io,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, AtomicU64, Ordering},
+        },
+        time::Duration,
     };
 
     use anyhow::Result;
     use async_trait::async_trait;
     use bytes::Bytes;
-    use indicatif::{MultiProgress, ProgressDrawTarget};
+    use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, TermLike};
     use iota_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
     use iota_storage::object_store::{ObjectStoreGetExt, ObjectStorePutExt};
     use object_store::{ObjectStore, memory::InMemory, path::Path};
+    use tracing_subscriber::fmt::MakeWriter;
 
     use super::{
-        DownloadProgressBar, copy_files_with_progress, fetch_total_bytes, get_with_progress,
+        DownloadProgressBar, ProgressTicker, ProgressUnit, copy_files_with_progress,
+        fetch_total_bytes, get_with_progress, status_line,
     };
 
     fn hidden_multi_progress() -> MultiProgress {
         MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
+    }
+
+    /// A terminal that accepts every write, so that bars added to the
+    /// resulting display count as drawn rather than hidden.
+    #[derive(Debug)]
+    struct DrawnTerm;
+
+    impl TermLike for DrawnTerm {
+        fn width(&self) -> u16 {
+            80
+        }
+
+        fn move_cursor_up(&self, _n: usize) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn move_cursor_down(&self, _n: usize) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn move_cursor_right(&self, _n: usize) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn move_cursor_left(&self, _n: usize) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn write_line(&self, _s: &str) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn write_str(&self, _s: &str) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn clear_line(&self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn flush(&self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn drawn_multi_progress() -> MultiProgress {
+        MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(DrawnTerm)))
+    }
+
+    /// Everything logged by `f` on the calling thread.
+    fn captured_logs(f: impl FnOnce()) -> String {
+        #[derive(Clone)]
+        struct Sink(Arc<Mutex<Vec<u8>>>);
+
+        impl io::Write for Sink {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl MakeWriter<'_> for Sink {
+            type Writer = Self;
+
+            fn make_writer(&self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(Sink(buf.clone()))
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        let logs = buf.lock().unwrap().clone();
+        String::from_utf8(logs).expect("log output is not valid UTF-8")
+    }
+
+    /// A status line carries the same totals, rate and ETA as the bar, and
+    /// leaves the rate and ETA out until there is progress to estimate from.
+    #[tokio::test]
+    async fn test_status_line_reports_totals_rate_and_eta() {
+        let bar = hidden_multi_progress().add(ProgressBar::new(100));
+
+        let line = status_line(&bar, "Downloading files", &ProgressUnit::Bytes, None);
+        assert!(line.ends_with("Downloading files: 0 B/100 B"), "{line}");
+
+        bar.inc(50);
+        bar.set_message("1/2 files");
+        let line = status_line(&bar, "Downloading files", &ProgressUnit::Bytes, None);
+        assert!(line.contains("Downloading files: 50 B/100 B ("), "{line}");
+        assert!(line.contains("B/s, ETA "), "{line}");
+        assert!(line.ends_with(" — 1/2 files"), "{line}");
+
+        // A counting bar names what it counts instead.
+        let line = status_line(
+            &bar,
+            "Checksumming ref files",
+            &ProgressUnit::Count("ref files"),
+            None,
+        );
+        assert!(
+            line.contains("Checksumming ref files: 50/100 ref files ("),
+            "{line}"
+        );
+        assert!(line.contains(" ref files/s, ETA "), "{line}");
+    }
+
+    /// The final line is logged whenever the phase ends, even if the bar
+    /// finished before the first second was up, and it reports the finishing
+    /// message rather than an ETA.
+    #[tokio::test]
+    async fn test_finish_logs_a_final_status_line_immediately() {
+        let progress =
+            DownloadProgressBar::new(&hidden_multi_progress(), "Downloading files", 2, Some(8));
+
+        let logs = captured_logs(|| progress.finish_with_message("Download complete"));
+        assert!(logs.contains("Downloading files: 8 B/8 B"), "{logs}");
+        assert!(logs.ends_with("— Download complete\n"), "{logs}");
+        assert!(!logs.contains("ETA"), "{logs}");
+    }
+
+    /// A bar the terminal can draw reports through the display, so it logs no
+    /// status lines at all.
+    #[tokio::test]
+    async fn test_a_drawn_bar_logs_no_status_lines() {
+        let bar = drawn_multi_progress().add(ProgressBar::new(1));
+        assert!(!bar.is_hidden());
+        let ticker = ProgressTicker::spawn(bar, "Downloading files", ProgressUnit::Bytes, None);
+
+        let logs = captured_logs(|| ticker.finish_with_message("Download complete"));
+        assert!(logs.is_empty(), "{logs}");
+    }
+
+    /// A bar handed a counter has its position taken from it, rather than
+    /// being advanced by the caller.
+    #[tokio::test(start_paused = true)]
+    async fn test_ticker_mirrors_the_counter_into_the_bar() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let ticker = ProgressTicker::spawn(
+            hidden_multi_progress().add(ProgressBar::new(100)),
+            "Accumulating ref files",
+            ProgressUnit::Count("ref files"),
+            Some(counter.clone()),
+        );
+
+        counter.store(7, Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert_eq!(ticker.bar().position(), 7);
     }
 
     #[tokio::test]

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -31,7 +31,9 @@ use indicatif::{
     FormattedDuration, HumanBytes, HumanCount, HumanDuration, MultiProgress, ProgressBar,
     ProgressDrawTarget, ProgressStyle,
 };
-use iota_storage::object_store::{ObjectStoreGetExt, ObjectStorePutExt, util::put};
+use iota_storage::object_store::{
+    ObjectStoreGetExt, ObjectStorePutExt, util::put,
+};
 use object_store::path::Path;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
@@ -256,10 +258,7 @@ pub async fn fetch_total_bytes(
                 // error out of thousands of lookups doesn't hide the totals,
                 // but give up quickly rather than stall the restore.
                 let size = retry(size_lookup_backoff(), || async {
-                    store
-                        .object_size(&path)
-                        .await
-                        .map_err(backoff::Error::transient)
+                    store.object_size(&path).await.map_err(classify_for_retry)
                 })
                 .await;
                 bar.inc(1);
@@ -290,6 +289,30 @@ pub async fn fetch_total_bytes(
 fn steady_tick_when_drawn(bar: &ProgressBar) {
     if !bar.is_hidden() {
         bar.enable_steady_tick(Duration::from_millis(100));
+    }
+}
+
+/// Wrap `err` for [`retry`]: an error retrying cannot fix — a missing object
+/// or denied access — gives up immediately, everything else is retried.
+fn classify_for_retry(err: anyhow::Error) -> backoff::Error<anyhow::Error> {
+    let is_permanent = err.chain().any(|cause| {
+        cause
+            .downcast_ref::<reqwest::Error>()
+            .and_then(reqwest::Error::status)
+            .is_some_and(|status| {
+                matches!(
+                    status,
+                    reqwest::StatusCode::NOT_FOUND
+                        | reqwest::StatusCode::FORBIDDEN
+                        | reqwest::StatusCode::UNAUTHORIZED
+                )
+            })
+    });
+
+    if is_permanent {
+        backoff::Error::permanent(err)
+    } else {
+        backoff::Error::transient(err)
     }
 }
 
@@ -417,7 +440,7 @@ pub async fn get_with_progress<S: ObjectStoreGetExt>(
             .map_err(|e| {
                 progress.remove_bytes(attempt_bytes.load(Ordering::Relaxed));
                 error!("Failed to read file {src} from object store with error: {e:?}");
-                backoff::Error::transient(e)
+                classify_for_retry(e)
             })
     })
     .await

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -31,9 +31,7 @@ use indicatif::{
     FormattedDuration, HumanBytes, HumanCount, HumanDuration, MultiProgress, ProgressBar,
     ProgressDrawTarget, ProgressStyle,
 };
-use iota_storage::object_store::{
-    ObjectStoreGetExt, ObjectStorePutExt, util::put,
-};
+use iota_storage::object_store::{ObjectStoreGetExt, ObjectStorePutExt, util::put};
 use object_store::path::Path;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
@@ -464,21 +462,20 @@ pub async fn get_single_file_with_progress<S: ObjectStoreGetExt>(
     Ok(bytes)
 }
 
-/// Copy `src[i]` to `dest[i]` for all `i` in parallel, recording downloaded
-/// chunks and each completed file on `progress` and failing on the first copy
-/// that fails.
+/// Copy every path in `paths` from `src_store` to `dest_store` in parallel,
+/// recording downloaded chunks and each completed file on `progress` and
+/// failing on the first copy that fails.
 pub async fn copy_files_with_progress<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
-    src: &[Path],
-    dest: &[Path],
+    paths: &[Path],
     src_store: &S,
     dest_store: &D,
     concurrency: usize,
     progress: &DownloadProgressBar,
 ) -> Result<()> {
-    futures::stream::iter(src.iter().zip(dest.iter()))
-        .map(|(path_in, path_out)| async move {
-            let bytes = get_with_progress(src_store, path_in, progress).await?;
-            put(dest_store, path_out, bytes).await?;
+    futures::stream::iter(paths)
+        .map(|path| async move {
+            let bytes = get_with_progress(src_store, path, progress).await?;
+            put(dest_store, path, bytes).await?;
             Ok::<_, anyhow::Error>(())
         })
         .boxed()
@@ -706,7 +703,7 @@ mod tests {
 
         let progress =
             DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 2, Some(8));
-        copy_files_with_progress(&paths, &paths, &src_store, &dest_store, 2, &progress).await?;
+        copy_files_with_progress(&paths, &src_store, &dest_store, 2, &progress).await?;
         assert_eq!(progress.bar().length(), Some(8));
         assert_eq!(progress.bar().position(), 8);
         assert_eq!(progress.bar().message(), "2/2 files");
@@ -731,7 +728,7 @@ mod tests {
 
         // An unknown total byte size means the bar counts files instead.
         let progress = DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 2, None);
-        copy_files_with_progress(&paths, &paths, &src_store, &dest_store, 2, &progress).await?;
+        copy_files_with_progress(&paths, &src_store, &dest_store, 2, &progress).await?;
         assert_eq!(progress.bar().length(), Some(2));
         assert_eq!(progress.bar().position(), 2);
         Ok(())

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -19,14 +19,12 @@ use std::{
 
 use anyhow::Result;
 use backoff::future::retry;
+use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use iota_storage::object_store::{
-    ObjectStoreGetExt, ObjectStorePutExt,
-    util::{get, put},
-};
+use iota_storage::object_store::{ObjectStoreGetExt, ObjectStorePutExt, util::put};
 use object_store::path::Path;
-use tracing::warn;
+use tracing::{error, warn};
 
 /// Fetch the combined size in bytes of every path in `paths` from the remote
 /// store with bounded concurrency, rendering a progress bar on `m` while the
@@ -136,11 +134,26 @@ impl DownloadProgressBar {
         }
     }
 
-    /// Record one fully downloaded file of `bytes_len` bytes.
-    pub fn file_done(&self, bytes_len: u64) {
+    /// Record `n` freshly received bytes of an in-flight download.
+    pub fn add_bytes(&self, n: u64) {
         if self.byte_denominated {
-            let files_done = self.files_done.fetch_add(1, Ordering::Relaxed) + 1;
-            self.bar.inc(bytes_len);
+            self.bar.inc(n);
+        }
+    }
+
+    /// Roll back bytes recorded by a failed download attempt, so the retry
+    /// doesn't count them twice.
+    pub fn remove_bytes(&self, n: u64) {
+        if self.byte_denominated {
+            self.bar.set_position(self.bar.position().saturating_sub(n));
+        }
+    }
+
+    /// Record one fully downloaded file, whose bytes were already recorded
+    /// with [`Self::add_bytes`] as they arrived.
+    pub fn file_done(&self) {
+        let files_done = self.files_done.fetch_add(1, Ordering::Relaxed) + 1;
+        if self.byte_denominated {
             self.bar
                 .set_message(format!("{files_done}/{} files", self.num_files));
         } else {
@@ -154,8 +167,34 @@ impl DownloadProgressBar {
     }
 }
 
-/// Copy `src[i]` to `dest[i]` for all `i` in parallel, recording each
-/// completed file on `progress` and failing on the first copy that fails.
+/// Download `src` from `store` with retries, recording received chunks on
+/// `progress` as they arrive. A failed attempt's bytes are rolled back so the
+/// retry doesn't count them twice.
+pub async fn get_with_progress<S: ObjectStoreGetExt>(
+    store: &S,
+    src: &Path,
+    progress: &DownloadProgressBar,
+) -> Result<Bytes> {
+    retry(backoff::ExponentialBackoff::default(), || async {
+        let attempt_bytes = AtomicU64::new(0);
+        store
+            .get_bytes_with_progress(src, &|n| {
+                attempt_bytes.fetch_add(n, Ordering::Relaxed);
+                progress.add_bytes(n);
+            })
+            .await
+            .map_err(|e| {
+                progress.remove_bytes(attempt_bytes.load(Ordering::Relaxed));
+                error!("Failed to read file {src} from object store with error: {e:?}");
+                backoff::Error::transient(e)
+            })
+    })
+    .await
+}
+
+/// Copy `src[i]` to `dest[i]` for all `i` in parallel, recording downloaded
+/// chunks and each completed file on `progress` and failing on the first copy
+/// that fails.
 pub async fn copy_files_with_progress<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
     src: &[Path],
     dest: &[Path],
@@ -166,15 +205,14 @@ pub async fn copy_files_with_progress<S: ObjectStoreGetExt, D: ObjectStorePutExt
 ) -> Result<()> {
     futures::stream::iter(src.iter().zip(dest.iter()))
         .map(|(path_in, path_out)| async move {
-            let bytes = get(src_store, path_in).await?;
-            let bytes_len = bytes.len() as u64;
+            let bytes = get_with_progress(src_store, path_in, progress).await?;
             put(dest_store, path_out, bytes).await?;
-            Ok::<_, anyhow::Error>(bytes_len)
+            Ok::<_, anyhow::Error>(())
         })
         .boxed()
         .buffer_unordered(concurrency)
-        .try_for_each(|bytes_len| {
-            progress.file_done(bytes_len);
+        .try_for_each(|()| {
+            progress.file_done();
             futures::future::ready(Ok(()))
         })
         .await
@@ -182,15 +220,22 @@ pub async fn copy_files_with_progress<S: ObjectStoreGetExt, D: ObjectStorePutExt
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
+    use anyhow::Result;
+    use async_trait::async_trait;
     use bytes::Bytes;
     use indicatif::{MultiProgress, ProgressDrawTarget};
     use iota_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
     use iota_storage::object_store::{ObjectStoreGetExt, ObjectStorePutExt};
     use object_store::{ObjectStore, memory::InMemory, path::Path};
 
-    use super::{DownloadProgressBar, copy_files_with_progress, fetch_total_bytes};
+    use super::{
+        DownloadProgressBar, copy_files_with_progress, fetch_total_bytes, get_with_progress,
+    };
 
     fn hidden_multi_progress() -> MultiProgress {
         MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
@@ -238,6 +283,64 @@ mod tests {
         copy_files_with_progress(&paths, &paths, &src_store, &dest_store, 2, &progress).await?;
         assert_eq!(progress.bar().length(), Some(2));
         assert_eq!(progress.bar().position(), 2);
+        Ok(())
+    }
+
+    /// Store whose first download attempt emits a partial chunk and then
+    /// fails; every later attempt succeeds.
+    struct FlakyStore {
+        payload: Bytes,
+        failed_once: AtomicBool,
+    }
+
+    impl std::fmt::Display for FlakyStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "flaky")
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStoreGetExt for FlakyStore {
+        async fn get_bytes(&self, src: &Path) -> Result<Bytes> {
+            self.get_bytes_with_progress(src, &|_| {}).await
+        }
+
+        async fn get_bytes_with_progress(
+            &self,
+            _src: &Path,
+            on_bytes: &(dyn Fn(u64) + Send + Sync),
+        ) -> Result<Bytes> {
+            if !self.failed_once.swap(true, Ordering::Relaxed) {
+                on_bytes(3);
+                anyhow::bail!("transient failure after a partial chunk");
+            }
+            on_bytes(self.payload.len() as u64);
+            Ok(self.payload.clone())
+        }
+
+        async fn exists(&self, _src: &Path) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn object_size(&self, _src: &Path) -> Result<u64> {
+            Ok(self.payload.len() as u64)
+        }
+    }
+
+    /// A failed attempt's partially counted bytes are rolled back, so the
+    /// retry's bytes aren't counted on top of them.
+    #[tokio::test]
+    async fn test_get_with_progress_rolls_back_failed_attempt() -> Result<()> {
+        let store = FlakyStore {
+            payload: Bytes::from_static(b"12345"),
+            failed_once: AtomicBool::new(false),
+        };
+        let progress =
+            DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 1, Some(5));
+
+        let bytes = get_with_progress(&store, &Path::from("a"), &progress).await?;
+        assert_eq!(bytes.to_vec(), b"12345");
+        assert_eq!(progress.bar().position(), 5);
         Ok(())
     }
 

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -46,7 +46,7 @@ pub const LOG_TARGET_PROGRESS: &str = module_path!();
 /// that depend on the status lines.
 pub fn println_or_log(m: &MultiProgress, msg: impl AsRef<str>) -> std::io::Result<()> {
     if m.is_hidden() {
-        info!(target: PROGRESS_LOG_TARGET, "{}", msg.as_ref());
+        info!(target: LOG_TARGET_PROGRESS, "{}", msg.as_ref());
         Ok(())
     } else {
         m.println(msg)

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -145,6 +145,10 @@ impl DownloadProgressBar {
     /// doesn't count them twice.
     pub fn remove_bytes(&self, n: u64) {
         if self.byte_denominated {
+            // The read-modify-write races with concurrent `add_bytes` calls
+            // from other in-flight downloads (indicatif has no atomic
+            // decrement); a lost increment only skews the displayed position
+            // slightly, which is acceptable for a progress bar.
             self.bar.set_position(self.bar.position().saturating_sub(n));
         }
     }

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -40,18 +40,17 @@ use iota_storage::{
 };
 use iota_types::{digests::ChainIdentifier, global_state_hash::GlobalStateHash};
 use object_store::path::Path;
-use tokio::{
-    sync::Mutex,
-    task::JoinHandle,
-    time::{Duration, Instant},
-};
+use tokio::{sync::Mutex, task::JoinHandle, time::Duration};
 use tracing::{error, info};
 
 use crate::{
     EPOCH_INFO_FILE_MAGIC, EpochInfo, FileMetadata, FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC,
     Manifest, OBJECT_FILE_MAGIC, OBJECT_ID_BYTES, OBJECT_REF_BYTES, REFERENCE_FILE_MAGIC,
     SEQUENCE_NUM_BYTES, SHA3_BYTES,
-    progress::{DownloadProgressBar, copy_files_with_progress, fetch_total_bytes},
+    progress::{
+        DownloadProgressBar, ProgressTicker, ProgressUnit, copy_files_with_progress,
+        fetch_total_bytes,
+    },
     restore::Restore,
 };
 
@@ -192,24 +191,17 @@ impl StateSnapshotReaderV1 {
             })
             .collect();
         let num_files = (files_to_download.len() + object_file_paths.len()) as u64;
-        // The size sweep only feeds the progress display; skip its HEAD
-        // requests entirely when the bars can't be seen (e.g. non-TTY
-        // output).
-        let total_bytes = if multi_progress_bar.is_hidden() {
-            None
-        } else {
-            fetch_total_bytes(
-                &remote_object_store,
-                files_to_download
-                    .iter()
-                    .cloned()
-                    .chain(object_file_paths)
-                    .collect(),
-                download_concurrency.get(),
-                &multi_progress_bar,
-            )
-            .await
-        };
+        let total_bytes = fetch_total_bytes(
+            &remote_object_store,
+            files_to_download
+                .iter()
+                .cloned()
+                .chain(object_file_paths)
+                .collect(),
+            download_concurrency.get(),
+            &multi_progress_bar,
+        )
+        .await;
         let download_progress = Arc::new(DownloadProgressBar::new(
             &multi_progress_bar,
             "Downloading files",
@@ -372,14 +364,21 @@ impl StateSnapshotReaderV1 {
 
         info!("Computing checksums");
         // Creates a progress bar for checksumming
-        let checksum_progress_bar = self.multi_progress_bar.add(
-            ProgressBar::new(num_part_files as u64).with_style(
-                ProgressStyle::with_template(
-                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files checksummed (ETA {eta}) ({msg})",
-                )
-                .unwrap(),
+        let checksum_ticker = ProgressTicker::spawn(
+            self.multi_progress_bar.add(
+                ProgressBar::new(num_part_files as u64).with_style(
+                    ProgressStyle::with_template(
+                        "[{elapsed_precise}] {wide_bar} Checksumming ref files: {pos}/{len} \
+                         ({per_sec}, ETA {eta}) — {msg}",
+                    )
+                    .unwrap(),
+                ),
             ),
+            "Checksumming ref files",
+            ProgressUnit::Count("ref files"),
+            None,
         );
+        let checksum_progress_bar = checksum_ticker.bar().clone();
 
         // Iterates over all FileMetadata in the ref files by partition and build up the
         // sha3 digests mapping: (bucket, (partition, sha3_digest))
@@ -430,7 +429,7 @@ impl StateSnapshotReaderV1 {
             })
             .await?;
 
-        checksum_progress_bar.finish_with_message("Checksumming complete");
+        checksum_ticker.finish_with_message("Checksumming complete");
 
         let accum_handle =
             sender.map(|sender| self.spawn_accumulation_tasks(sender, num_part_files));
@@ -453,36 +452,24 @@ impl StateSnapshotReaderV1 {
         sender: tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>,
         num_part_files: usize,
     ) -> JoinHandle<()> {
-        // Spawns accumulation progress bar
+        // Spawns accumulation progress bar, whose position the ticker takes
+        // from the counter the accumulation task below advances
         let concurrency = self.concurrency;
         let accum_counter = Arc::new(AtomicU64::new(0));
-        let cloned_accum_counter = accum_counter.clone();
-        let accum_progress_bar = self.multi_progress_bar.add(
-             ProgressBar::new(num_part_files as u64).with_style(
-                 ProgressStyle::with_template(
-                     "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files accumulated from snapshot (ETA {eta}) ({msg})",
-                 )
-                 .unwrap(),
-             ),
-         );
-        let cloned_accum_progress_bar = accum_progress_bar.clone();
-        // Spawns accumulation progress bar update task
-        tokio::spawn(async move {
-            let a_instant = Instant::now();
-            loop {
-                if cloned_accum_progress_bar.is_finished() {
-                    break;
-                }
-                let num_partitions = cloned_accum_counter.load(Ordering::Relaxed);
-                let total_partitions_per_sec =
-                    num_partitions as f64 / a_instant.elapsed().as_secs_f64();
-                cloned_accum_progress_bar.set_position(num_partitions);
-                cloned_accum_progress_bar.set_message(format!(
-                    "file partitions per sec: {total_partitions_per_sec}"
-                ));
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-        });
+        let accum_ticker = ProgressTicker::spawn(
+            self.multi_progress_bar.add(
+                ProgressBar::new(num_part_files as u64).with_style(
+                    ProgressStyle::with_template(
+                        "[{elapsed_precise}] {wide_bar} Accumulating ref files: {pos}/{len} \
+                         ({per_sec}, ETA {eta})",
+                    )
+                    .unwrap(),
+                ),
+            ),
+            "Accumulating ref files",
+            ProgressUnit::Count("ref files"),
+            Some(accum_counter.clone()),
+        );
 
         // spawns accumualation task
         let ref_files = self.ref_files.clone();
@@ -542,7 +529,7 @@ impl StateSnapshotReaderV1 {
                     })
                     .await;
             }
-            accum_progress_bar.finish_with_message("Accumulation complete");
+            accum_ticker.finish_with_message("Accumulation complete");
         })
     }
 
@@ -664,7 +651,7 @@ impl StateSnapshotReaderV1 {
             abort_registration,
         )
         .await?;
-        obj_progress.bar().finish_with_message("Download complete");
+        obj_progress.finish_with_message("Download complete");
         ret
     }
 

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -63,21 +63,27 @@ pub struct StateSnapshotReaderV1 {
     local_staging_dir_root: PathBuf,
     remote_object_store: Arc<dyn ObjectStoreGetExt>,
     local_object_store: Arc<dyn ObjectStorePutExt>,
+    local_object_store_list: Arc<dyn ObjectStoreListExt>,
     ref_files: BTreeMap<u32, BTreeMap<u32, FileMetadata>>,
     object_files: BTreeMap<u32, BTreeMap<u32, FileMetadata>>,
+    epoch_info_metadata: FileMetadata,
     /// Chain identifier recorded in the snapshot's `ManifestV2`.
     chain_id: ChainIdentifier,
     multi_progress_bar: MultiProgress,
-    /// Single download bar spanning both phases: the reference files
-    /// downloaded during construction and the object files downloaded during
-    /// [`Self::read`]. Its totals cover both file sets combined.
-    download_progress: Arc<DownloadProgressBar>,
     concurrency: NonZeroUsize,
+    /// When set, the staging directory is left as it is and any reference
+    /// files already in it are not downloaded again.
+    skip_reset_local_store: bool,
 }
 
 impl StateSnapshotReaderV1 {
-    /// Downloads the MANIFEST, FileMetadata of objects and references from the
-    /// remote store, then creates a StateSnapshotReaderV1 instance.
+    /// Reads the snapshot's MANIFEST — the metadata of its reference, object
+    /// and `EPOCH_INFO` files — and prepares the local staging directory.
+    ///
+    /// Only the MANIFEST is downloaded here. The reference and object files
+    /// both come down in [`Self::read`], so a caller can read and check
+    /// [`Self::read_epoch_info`] first and reject the snapshot before any of
+    /// it is transferred.
     pub async fn new(
         epoch: u64,
         remote_store_config: &ObjectStoreConfig,
@@ -160,9 +166,31 @@ impl StateSnapshotReaderV1 {
                 FileType::EpochInfo => epoch_info_files.push(file_metadata.clone()),
             }
         }
-        Self::single_epoch_info_metadata(epoch_info_files)?;
-        // Collects the path of all reference files
-        let files: Vec<Path> = ref_files
+        let epoch_info_metadata = Self::single_epoch_info_metadata(epoch_info_files)?;
+        Ok(StateSnapshotReaderV1 {
+            epoch,
+            local_staging_dir_root,
+            remote_object_store,
+            local_object_store,
+            local_object_store_list,
+            ref_files,
+            object_files,
+            epoch_info_metadata,
+            chain_id,
+            multi_progress_bar,
+            concurrency: download_concurrency,
+            skip_reset_local_store,
+        })
+    }
+
+    /// Downloads every reference file into the local staging directory, where
+    /// [`Self::ref_iter`] reads them from, and returns the bar it advanced —
+    /// whose totals also cover the object files that
+    /// [`Self::sync_live_objects`] downloads onto the same bar.
+    async fn download_reference_files(&self) -> Result<Arc<DownloadProgressBar>> {
+        let epoch_dir_path = self.epoch_dir();
+        let ref_file_paths: Vec<Path> = self
+            .ref_files
             .values()
             .flat_map(|entry| {
                 entry
@@ -171,8 +199,9 @@ impl StateSnapshotReaderV1 {
             })
             .collect();
 
-        let files_to_download = if skip_reset_local_store {
-            let mut list_stream = local_object_store_list
+        let files_to_download = if self.skip_reset_local_store {
+            let mut list_stream = self
+                .local_object_store_list
                 .list_objects(Some(&epoch_dir_path))
                 .await;
             let mut existing_files = std::collections::HashSet::new();
@@ -180,19 +209,18 @@ impl StateSnapshotReaderV1 {
                 existing_files.insert(meta.location);
             }
             let mut missing_files = Vec::new();
-            for file in &files {
+            for file in &ref_file_paths {
                 if !existing_files.contains(file) {
                     missing_files.push(file.clone());
                 }
             }
             missing_files
         } else {
-            files
+            ref_file_paths
         };
 
-        // The bar covers both download phases combined: the reference files
-        // downloaded here and the object files downloaded later in `read`.
-        let object_file_paths: Vec<Path> = object_files
+        let object_file_paths: Vec<Path> = self
+            .object_files
             .values()
             .flat_map(|entry| {
                 entry
@@ -202,45 +230,36 @@ impl StateSnapshotReaderV1 {
             .collect();
         let num_files = (files_to_download.len() + object_file_paths.len()) as u64;
         let total_bytes = fetch_total_bytes(
-            &remote_object_store,
+            &self.remote_object_store,
             files_to_download
                 .iter()
                 .cloned()
                 .chain(object_file_paths)
                 .collect(),
-            download_concurrency.get(),
-            &multi_progress_bar,
+            self.concurrency.get(),
+            &self.multi_progress_bar,
         )
         .await;
+
         let download_progress = Arc::new(DownloadProgressBar::new(
-            &multi_progress_bar,
+            &self.multi_progress_bar,
             "Downloading files",
             num_files,
             total_bytes,
         ));
+
         // Downloads all reference files from remote store to local store in parallel
         // and updates the progress bar accordingly
         copy_files_with_progress(
             &files_to_download,
             &files_to_download,
-            &remote_object_store,
-            &local_object_store,
-            download_concurrency.get(),
+            &self.remote_object_store,
+            &self.local_object_store,
+            self.concurrency.get(),
             &download_progress,
         )
         .await?;
-        Ok(StateSnapshotReaderV1 {
-            epoch,
-            local_staging_dir_root,
-            remote_object_store,
-            local_object_store,
-            ref_files,
-            object_files,
-            chain_id,
-            multi_progress_bar,
-            download_progress,
-            concurrency: download_concurrency,
-        })
+        Ok(download_progress)
     }
 
     pub async fn read(
@@ -284,44 +303,20 @@ impl StateSnapshotReaderV1 {
         }
     }
 
-    /// Downloads and decodes only the MANIFEST and `EPOCH_INFO` file for
-    /// `epoch`, never the large reference/object files.
-    ///
-    /// `EPOCH_INFO` carries a proof bundle per epoch since genesis, so for a
-    /// late epoch it is large enough to report on `m` while it downloads.
-    pub async fn read_epoch_info(
-        epoch: u64,
-        remote_store_config: &ObjectStoreConfig,
-        m: &MultiProgress,
-    ) -> anyhow::Result<(ChainIdentifier, EpochInfo)> {
-        let epoch_dir = Path::from(format!("epoch_{epoch}"));
-        let remote_object_store = make_remote_store(remote_store_config)?;
-
-        println_or_log(m, "Downloading the snapshot MANIFEST")?;
-        let manifest_bytes = remote_object_store
-            .get_bytes(&epoch_dir.child("MANIFEST"))
-            .await?;
-        let manifest = Self::read_manifest_from_bytes(&manifest_bytes)?;
-        let chain_id = Self::validate_v2_manifest(&manifest, epoch)?;
-
-        let epoch_info_files = manifest
-            .file_metadata()
-            .iter()
-            .filter(|metadata| matches!(metadata.file_type, FileType::EpochInfo))
-            .cloned()
-            .collect();
-        let epoch_info_metadata = Self::single_epoch_info_metadata(epoch_info_files)?;
-        let epoch_info_path = epoch_info_metadata.file_path(&epoch_dir);
+    /// Reads, verifies and decodes the snapshot's `EPOCH_INFO` file from the
+    /// remote store — one file, independent of the live-object restore in
+    /// [`Self::read`] and cheap enough to check before starting it.
+    pub async fn read_epoch_info(&self) -> anyhow::Result<EpochInfo> {
+        let epoch_info_path = self.epoch_info_metadata.file_path(&self.epoch_dir());
         let bytes = get_single_file_with_progress(
-            &remote_object_store,
+            &self.remote_object_store,
             &epoch_info_path,
             "Downloading EPOCH_INFO",
-            m,
+            &self.multi_progress_bar,
         )
         .await?;
-        println_or_log(m, "Checking and decoding EPOCH_INFO")?;
-        let epoch_info = Self::decode_epoch_info(bytes, &epoch_info_metadata)?;
-        Ok((chain_id, epoch_info))
+        println_or_log(&self.multi_progress_bar, "Checking and decoding EPOCH_INFO")?;
+        Self::decode_epoch_info(bytes, &self.epoch_info_metadata)
     }
 
     /// Verifies the sha3 digest against the manifest, strips the 4-byte magic
@@ -354,12 +349,14 @@ impl StateSnapshotReaderV1 {
     ///
     /// This method encapsulates the logic for several operations:
     ///
-    /// 1. Computing the partition checksums of the respective `*.ref` files.
-    /// 2. Computing the partition elliptic-curve multiset hash (ECMH) in the
+    /// 1. Downloading the snapshot's `*.ref` files into the local staging
+    ///    directory.
+    /// 2. Computing the partition checksums of the respective `*.ref` files.
+    /// 3. Computing the partition elliptic-curve multiset hash (ECMH) in the
     ///    background, and sending the result through the given `sender` to the
     ///    caller. This allows to compute and verify the root hash of the live
     ///    objects encoded in the snapshot. See [`GlobalStateHash`].
-    /// 3. Reading, inserting, and verifying all encoded live objects to the
+    /// 4. Reading, inserting, and verifying all encoded live objects to the
     ///    given `database`.
     pub async fn read_to_db(
         &mut self,
@@ -367,6 +364,11 @@ impl StateSnapshotReaderV1 {
         abort_registration: AbortRegistration,
         sender: Option<tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>>,
     ) -> Result<()> {
+        // The reference files have to be local before their checksums can be
+        // computed. Their download shares a bar with the object files, which
+        // `sync_live_objects` downloads onto it below.
+        let download_progress = self.download_reference_files().await?;
+
         // This computes and stores the sha3 digest of object references in REFERENCE
         // file for each bucket partition. When downloading objects, we will
         // compare sha3 digest of object references per *.obj file against this.
@@ -458,8 +460,13 @@ impl StateSnapshotReaderV1 {
 
         // Downloads all object files from remote in parallel and inserts the objects
         // into the database of choice
-        self.sync_live_objects(database, abort_registration, sha3_digests)
-            .await?;
+        self.sync_live_objects(
+            database,
+            abort_registration,
+            sha3_digests,
+            download_progress,
+        )
+        .await?;
 
         if let Some(handle) = accum_handle {
             handle.await?;
@@ -562,6 +569,7 @@ impl StateSnapshotReaderV1 {
         database: &impl Restore,
         abort_registration: AbortRegistration,
         sha3_digests: Arc<Mutex<DigestByBucketAndPartition>>,
+        download_progress: Arc<DownloadProgressBar>,
     ) -> Result<(), anyhow::Error> {
         let epoch_dir = self.epoch_dir();
         let concurrency = self.concurrency;
@@ -579,9 +587,9 @@ impl StateSnapshotReaderV1 {
                     .collect::<Vec<_>>()
             })
             .collect();
-        // Continues the shared download bar created in `new`, whose totals
-        // already include these object files.
-        let obj_progress = self.download_progress.clone();
+        // Continues the bar the reference files were downloaded on, whose
+        // totals already include these object files.
+        let obj_progress = download_progress;
         let obj_progress_clone = obj_progress.clone();
         let obj_progress_download = obj_progress.clone();
 

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -252,7 +252,6 @@ impl StateSnapshotReaderV1 {
         // and updates the progress bar accordingly
         copy_files_with_progress(
             &files_to_download,
-            &files_to_download,
             &self.remote_object_store,
             &self.local_object_store,
             self.concurrency.get(),

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -69,6 +69,10 @@ pub struct StateSnapshotReaderV1 {
     /// Chain identifier recorded in the snapshot's `ManifestV2`.
     chain_id: ChainIdentifier,
     multi_progress_bar: MultiProgress,
+    /// Single download bar spanning both phases: the reference files
+    /// downloaded during construction and the object files downloaded during
+    /// [`Self::read`]. Its totals cover both file sets combined.
+    download_progress: Arc<DownloadProgressBar>,
     concurrency: NonZeroUsize,
 }
 
@@ -177,19 +181,34 @@ impl StateSnapshotReaderV1 {
             files
         };
 
-        let ref_total_bytes = fetch_total_bytes(
+        // The bar covers both download phases combined: the reference files
+        // downloaded here and the object files downloaded later in `read`.
+        let object_file_paths: Vec<Path> = object_files
+            .values()
+            .flat_map(|entry| {
+                entry
+                    .values()
+                    .map(|file_metadata| file_metadata.file_path(&epoch_dir_path))
+            })
+            .collect();
+        let num_files = (files_to_download.len() + object_file_paths.len()) as u64;
+        let total_bytes = fetch_total_bytes(
             &remote_object_store,
-            files_to_download.clone(),
+            files_to_download
+                .iter()
+                .cloned()
+                .chain(object_file_paths)
+                .collect(),
             download_concurrency.get(),
             &multi_progress_bar,
         )
         .await;
-        let progress = DownloadProgressBar::new(
+        let download_progress = Arc::new(DownloadProgressBar::new(
             &multi_progress_bar,
-            "Downloading .ref files",
-            files_to_download.len() as u64,
-            ref_total_bytes,
-        );
+            "Downloading files",
+            num_files,
+            total_bytes,
+        ));
         // Downloads all reference files from remote store to local store in parallel
         // and updates the progress bar accordingly
         copy_files_with_progress(
@@ -198,12 +217,9 @@ impl StateSnapshotReaderV1 {
             &remote_object_store,
             &local_object_store,
             download_concurrency.get(),
-            &progress,
+            &download_progress,
         )
         .await?;
-        progress
-            .bar()
-            .finish_with_message("Missing ref files download complete");
         Ok(StateSnapshotReaderV1 {
             epoch,
             local_staging_dir_root,
@@ -213,6 +229,7 @@ impl StateSnapshotReaderV1 {
             object_files,
             chain_id,
             multi_progress_bar,
+            download_progress,
             concurrency: download_concurrency,
         })
     }
@@ -546,23 +563,9 @@ impl StateSnapshotReaderV1 {
                     .collect::<Vec<_>>()
             })
             .collect();
-        let obj_total_bytes = fetch_total_bytes(
-            &remote_object_store,
-            input_files
-                .iter()
-                .map(|(_, (_, file_metadata))| file_metadata.file_path(&epoch_dir))
-                .collect(),
-            concurrency.get(),
-            &self.multi_progress_bar,
-        )
-        .await;
-        // Creates a progress bar for object files
-        let obj_progress = Arc::new(DownloadProgressBar::new(
-            &self.multi_progress_bar,
-            "Downloading .obj files",
-            input_files.len() as u64,
-            obj_total_bytes,
-        ));
+        // Continues the shared download bar created in `new`, whose totals
+        // already include these object files.
+        let obj_progress = self.download_progress.clone();
         let obj_progress_clone = obj_progress.clone();
 
         let ret = Abortable::new(
@@ -644,9 +647,7 @@ impl StateSnapshotReaderV1 {
             abort_registration,
         )
         .await?;
-        obj_progress
-            .bar()
-            .finish_with_message("Objects download complete");
+        obj_progress.bar().finish_with_message("Download complete");
         ret
     }
 

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -49,7 +49,7 @@ use crate::{
     SEQUENCE_NUM_BYTES, SHA3_BYTES,
     progress::{
         DownloadProgressBar, ProgressTicker, ProgressUnit, copy_files_with_progress,
-        fetch_total_bytes,
+        fetch_total_bytes, get_single_file_with_progress, println_or_log,
     },
     restore::Restore,
 };
@@ -100,12 +100,22 @@ impl StateSnapshotReaderV1 {
         if !skip_reset_local_store {
             let local_epoch_dir_path = local_staging_dir_root.join(&epoch_dir);
             if local_epoch_dir_path.exists() {
+                // A previous run's staging files can be a whole snapshot's
+                // worth, so removing them is not always quick.
+                println_or_log(
+                    &multi_progress_bar,
+                    format!(
+                        "Removing the files a previous run staged in {}",
+                        local_epoch_dir_path.display()
+                    ),
+                )?;
                 fs::remove_dir_all(&local_epoch_dir_path)?;
             }
             fs::create_dir_all(&local_epoch_dir_path)?;
         }
         let epoch_dir_path = Path::from(epoch_dir);
         // Downloads MANIFEST from remote store
+        println_or_log(&multi_progress_bar, "Reading the snapshot MANIFEST")?;
         let manifest_file_path = epoch_dir_path.child("MANIFEST");
         copy_file(
             &manifest_file_path,
@@ -276,13 +286,18 @@ impl StateSnapshotReaderV1 {
 
     /// Downloads and decodes only the MANIFEST and `EPOCH_INFO` file for
     /// `epoch`, never the large reference/object files.
+    ///
+    /// `EPOCH_INFO` carries a proof bundle per epoch since genesis, so for a
+    /// late epoch it is large enough to report on `m` while it downloads.
     pub async fn read_epoch_info(
         epoch: u64,
         remote_store_config: &ObjectStoreConfig,
+        m: &MultiProgress,
     ) -> anyhow::Result<(ChainIdentifier, EpochInfo)> {
         let epoch_dir = Path::from(format!("epoch_{epoch}"));
         let remote_object_store = make_remote_store(remote_store_config)?;
 
+        println_or_log(m, "Downloading the snapshot MANIFEST")?;
         let manifest_bytes = remote_object_store
             .get_bytes(&epoch_dir.child("MANIFEST"))
             .await?;
@@ -297,7 +312,14 @@ impl StateSnapshotReaderV1 {
             .collect();
         let epoch_info_metadata = Self::single_epoch_info_metadata(epoch_info_files)?;
         let epoch_info_path = epoch_info_metadata.file_path(&epoch_dir);
-        let bytes = remote_object_store.get_bytes(&epoch_info_path).await?;
+        let bytes = get_single_file_with_progress(
+            &remote_object_store,
+            &epoch_info_path,
+            "Downloading EPOCH_INFO",
+            m,
+        )
+        .await?;
+        println_or_log(m, "Checking and decoding EPOCH_INFO")?;
         let epoch_info = Self::decode_epoch_info(bytes, &epoch_info_metadata)?;
         Ok((chain_id, epoch_info))
     }

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -567,7 +567,7 @@ impl StateSnapshotReaderV1 {
                 .iter()
                 .map(|(_, (_, file_metadata))| file_metadata.file_path(&epoch_dir))
                 .collect(),
-            concurrency,
+            concurrency.get(),
             &self.multi_progress_bar,
         )
         .await;

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -192,17 +192,24 @@ impl StateSnapshotReaderV1 {
             })
             .collect();
         let num_files = (files_to_download.len() + object_file_paths.len()) as u64;
-        let total_bytes = fetch_total_bytes(
-            &remote_object_store,
-            files_to_download
-                .iter()
-                .cloned()
-                .chain(object_file_paths)
-                .collect(),
-            download_concurrency.get(),
-            &multi_progress_bar,
-        )
-        .await;
+        // The size sweep only feeds the progress display; skip its HEAD
+        // requests entirely when the bars can't be seen (e.g. non-TTY
+        // output).
+        let total_bytes = if multi_progress_bar.is_hidden() {
+            None
+        } else {
+            fetch_total_bytes(
+                &remote_object_store,
+                files_to_download
+                    .iter()
+                    .cloned()
+                    .chain(object_file_paths)
+                    .collect(),
+                download_concurrency.get(),
+                &multi_progress_bar,
+            )
+            .await
+        };
         let download_progress = Arc::new(DownloadProgressBar::new(
             &multi_progress_bar,
             "Downloading files",
@@ -567,6 +574,7 @@ impl StateSnapshotReaderV1 {
         // already include these object files.
         let obj_progress = self.download_progress.clone();
         let obj_progress_clone = obj_progress.clone();
+        let obj_progress_download = obj_progress.clone();
 
         let ret = Abortable::new(
             async move {
@@ -578,6 +586,7 @@ impl StateSnapshotReaderV1 {
                         let file_path = file_metadata.file_path(&epoch_dir);
                         let remote_object_store = remote_object_store.clone();
                         let sha3_digests_cloned = sha3_digests.clone();
+                        let obj_progress = obj_progress_download.clone();
                         async move {
                             // Downloads object file with retries
                             let max_timeout = Duration::from_secs(60);
@@ -586,11 +595,20 @@ impl StateSnapshotReaderV1 {
                             timeout = std::cmp::min(max_timeout, timeout);
                             let mut attempts = 0usize;
                             let bytes = loop {
-                                match remote_object_store.get_bytes(&file_path).await {
+                                let attempt_bytes = AtomicU64::new(0);
+                                match remote_object_store
+                                    .get_bytes_with_progress(&file_path, &|n| {
+                                        attempt_bytes.fetch_add(n, Ordering::Relaxed);
+                                        obj_progress.add_bytes(n);
+                                    })
+                                    .await
+                                {
                                     Ok(bytes) => {
                                         break bytes;
                                     }
                                     Err(err) => {
+                                        obj_progress
+                                            .remove_bytes(attempt_bytes.load(Ordering::Relaxed));
                                         error!(
                                             "Obj {} .get failed (attempt {}): {}",
                                             file_metadata.file_path(&epoch_dir),
@@ -634,11 +652,10 @@ impl StateSnapshotReaderV1 {
                     .try_for_each(|(bytes, file_metadata, sha3_digest)| {
                         let obj_progress = &obj_progress_clone;
                         async move {
-                            let bytes_len = bytes.len() as u64;
                             database
                                 .insert_partition(file_metadata, bytes, &sha3_digest)
                                 .await?;
-                            obj_progress.file_done(bytes_len);
+                            obj_progress.file_done();
                             Ok(())
                         }
                     })

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -66,8 +66,6 @@ pub struct StateSnapshotReaderV1 {
     local_object_store: Arc<dyn ObjectStorePutExt>,
     ref_files: BTreeMap<u32, BTreeMap<u32, FileMetadata>>,
     object_files: BTreeMap<u32, BTreeMap<u32, FileMetadata>>,
-    epoch_info_metadata: FileMetadata,
-    epoch_info_path: Path,
     /// Chain identifier recorded in the snapshot's `ManifestV2`.
     chain_id: ChainIdentifier,
     multi_progress_bar: MultiProgress,
@@ -149,8 +147,7 @@ impl StateSnapshotReaderV1 {
                 FileType::EpochInfo => epoch_info_files.push(file_metadata.clone()),
             }
         }
-        let epoch_info_metadata = Self::single_epoch_info_metadata(epoch_info_files)?;
-        let epoch_info_path = epoch_info_metadata.file_path(&epoch_dir_path);
+        Self::single_epoch_info_metadata(epoch_info_files)?;
         // Collects the path of all reference files
         let files: Vec<Path> = ref_files
             .values()
@@ -214,8 +211,6 @@ impl StateSnapshotReaderV1 {
             local_object_store,
             ref_files,
             object_files,
-            epoch_info_metadata,
-            epoch_info_path,
             chain_id,
             multi_progress_bar,
             concurrency: download_concurrency,
@@ -230,16 +225,6 @@ impl StateSnapshotReaderV1 {
     ) -> Result<()> {
         self.read_to_db(perpetual_db, abort_registration, sender)
             .await
-    }
-
-    /// Reads, verifies, and decodes the snapshot's `EPOCH_INFO` file from the
-    /// remote store. Independent of the live-object restore in [`Self::read`].
-    pub async fn read_epoch_info(&self) -> anyhow::Result<EpochInfo> {
-        let bytes = self
-            .remote_object_store
-            .get_bytes(&self.epoch_info_path)
-            .await?;
-        Self::decode_epoch_info(bytes, &self.epoch_info_metadata)
     }
 
     /// Chain identifier recorded in this snapshot's manifest.
@@ -275,7 +260,7 @@ impl StateSnapshotReaderV1 {
 
     /// Downloads and decodes only the MANIFEST and `EPOCH_INFO` file for
     /// `epoch`, never the large reference/object files.
-    pub async fn read_epoch_info_only(
+    pub async fn read_epoch_info(
         epoch: u64,
         remote_store_config: &ObjectStoreConfig,
     ) -> anyhow::Result<(ChainIdentifier, EpochInfo)> {

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -40,8 +40,8 @@ use iota_storage::{
 };
 use iota_types::{digests::ChainIdentifier, global_state_hash::GlobalStateHash};
 use object_store::path::Path;
-use tokio::{sync::Mutex, task::JoinHandle, time::Duration};
-use tracing::{error, info};
+use tokio::{sync::Mutex, task::JoinHandle};
+use tracing::info;
 
 use crate::{
     EPOCH_INFO_FILE_MAGIC, EpochInfo, FileMetadata, FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC,
@@ -49,7 +49,7 @@ use crate::{
     SEQUENCE_NUM_BYTES, SHA3_BYTES,
     progress::{
         DownloadProgressBar, ProgressTicker, ProgressUnit, copy_files_with_progress,
-        fetch_total_bytes, get_single_file_with_progress, println_or_log,
+        fetch_total_bytes, get_single_file_with_progress, get_with_progress, println_or_log,
     },
     restore::Restore,
 };
@@ -606,47 +606,12 @@ impl StateSnapshotReaderV1 {
                         let obj_progress = obj_progress_download.clone();
                         async move {
                             // Downloads object file with retries
-                            let max_timeout = Duration::from_secs(60);
-                            let mut timeout = Duration::from_secs(2);
-                            timeout += timeout / 2;
-                            timeout = std::cmp::min(max_timeout, timeout);
-                            let mut attempts = 0usize;
-                            let bytes = loop {
-                                let attempt_bytes = AtomicU64::new(0);
-                                match remote_object_store
-                                    .get_bytes_with_progress(&file_path, &|n| {
-                                        attempt_bytes.fetch_add(n, Ordering::Relaxed);
-                                        obj_progress.add_bytes(n);
-                                    })
+                            let bytes =
+                                get_with_progress(&remote_object_store, &file_path, &obj_progress)
                                     .await
-                                {
-                                    Ok(bytes) => {
-                                        break bytes;
-                                    }
-                                    Err(err) => {
-                                        obj_progress
-                                            .remove_bytes(attempt_bytes.load(Ordering::Relaxed));
-                                        error!(
-                                            "Obj {} .get failed (attempt {}): {}",
-                                            file_metadata.file_path(&epoch_dir),
-                                            attempts,
-                                            err,
-                                        );
-                                        if timeout > max_timeout {
-                                            panic!(
-                                                "Failed to get obj file {} after {} attempts",
-                                                file_metadata.file_path(&epoch_dir),
-                                                attempts,
-                                            );
-                                        } else {
-                                            attempts += 1;
-                                            tokio::time::sleep(timeout).await;
-                                            timeout += timeout / 2;
-                                            continue;
-                                        }
-                                    }
-                                }
-                            };
+                                    .with_context(|| {
+                                        format!("Failed to download object file {file_path}")
+                                    })?;
 
                             // Gets the sha3 digest of the partition
                             let sha3_digest = sha3_digests_cloned.lock().await;

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -10,7 +10,7 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU64, Ordering},
     },
 };
 
@@ -35,9 +35,7 @@ use iota_storage::{
     object_store::{
         ObjectStoreGetExt, ObjectStoreListExt, ObjectStorePutExt,
         http::HttpDownloaderBuilder,
-        util::{
-            MANIFEST_FILENAME, RootManifest, copy_file, copy_files, get_path, path_to_filesystem,
-        },
+        util::{MANIFEST_FILENAME, RootManifest, copy_file, get_path, path_to_filesystem},
     },
 };
 use iota_types::{digests::ChainIdentifier, global_state_hash::GlobalStateHash};
@@ -52,7 +50,9 @@ use tracing::{error, info};
 use crate::{
     EPOCH_INFO_FILE_MAGIC, EpochInfo, FileMetadata, FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC,
     Manifest, OBJECT_FILE_MAGIC, OBJECT_ID_BYTES, OBJECT_REF_BYTES, REFERENCE_FILE_MAGIC,
-    SEQUENCE_NUM_BYTES, SHA3_BYTES, restore::Restore,
+    SEQUENCE_NUM_BYTES, SHA3_BYTES,
+    progress::{DownloadProgressBar, copy_files_with_progress, fetch_total_bytes},
+    restore::Restore,
 };
 
 pub type SnapshotChecksums = (DigestByBucketAndPartition, GlobalStateHash);
@@ -103,8 +103,9 @@ impl StateSnapshotReaderV1 {
             }
             fs::create_dir_all(&local_epoch_dir_path)?;
         }
+        let epoch_dir_path = Path::from(epoch_dir);
         // Downloads MANIFEST from remote store
-        let manifest_file_path = Path::from(epoch_dir.clone()).child("MANIFEST");
+        let manifest_file_path = epoch_dir_path.child("MANIFEST");
         copy_file(
             &manifest_file_path,
             &manifest_file_path,
@@ -149,17 +150,14 @@ impl StateSnapshotReaderV1 {
             }
         }
         let epoch_info_metadata = Self::single_epoch_info_metadata(epoch_info_files)?;
-        let epoch_dir_path = Path::from(epoch_dir);
         let epoch_info_path = epoch_info_metadata.file_path(&epoch_dir_path);
         // Collects the path of all reference files
         let files: Vec<Path> = ref_files
             .values()
             .flat_map(|entry| {
-                let files: Vec<_> = entry
+                entry
                     .values()
                     .map(|file_metadata| file_metadata.file_path(&epoch_dir_path))
-                    .collect();
-                files
             })
             .collect();
 
@@ -181,29 +179,34 @@ impl StateSnapshotReaderV1 {
         } else {
             files
         };
-        let progress_bar = multi_progress_bar.add(
-            ProgressBar::new(files_to_download.len() as u64).with_style(
-                ProgressStyle::with_template(
-                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} missing .ref files done ({msg})",
-                )
-                .unwrap(),
-            ),
+
+        let ref_total_bytes = fetch_total_bytes(
+            &remote_object_store,
+            files_to_download.clone(),
+            download_concurrency.get(),
+            &multi_progress_bar,
+        )
+        .await;
+        let progress = DownloadProgressBar::new(
+            &multi_progress_bar,
+            "Downloading .ref files",
+            files_to_download.len() as u64,
+            ref_total_bytes,
         );
-        // Render the bar on a timer so it stays visible while the first files are
-        // still in flight, rather than only repainting on completion.
-        progress_bar.enable_steady_tick(Duration::from_millis(100));
         // Downloads all reference files from remote store to local store in parallel
         // and updates the progress bar accordingly
-        copy_files(
+        copy_files_with_progress(
             &files_to_download,
             &files_to_download,
             &remote_object_store,
             &local_object_store,
-            download_concurrency,
-            Some(progress_bar.clone()),
+            download_concurrency.get(),
+            &progress,
         )
         .await?;
-        progress_bar.finish_with_message("Missing ref files download complete");
+        progress
+            .bar()
+            .finish_with_message("Missing ref files download complete");
         Ok(StateSnapshotReaderV1 {
             epoch,
             local_staging_dir_root,
@@ -363,7 +366,7 @@ impl StateSnapshotReaderV1 {
         let checksum_progress_bar = self.multi_progress_bar.add(
             ProgressBar::new(num_part_files as u64).with_style(
                 ProgressStyle::with_template(
-                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files checksummed ({msg})",
+                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files checksummed (ETA {eta}) ({msg})",
                 )
                 .unwrap(),
             ),
@@ -448,7 +451,7 @@ impl StateSnapshotReaderV1 {
         let accum_progress_bar = self.multi_progress_bar.add(
              ProgressBar::new(num_part_files as u64).with_style(
                  ProgressStyle::with_template(
-                     "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files accumulated from snapshot ({msg})",
+                     "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files accumulated from snapshot (ETA {eta}) ({msg})",
                  )
                  .unwrap(),
              ),
@@ -558,18 +561,24 @@ impl StateSnapshotReaderV1 {
                     .collect::<Vec<_>>()
             })
             .collect();
+        let obj_total_bytes = fetch_total_bytes(
+            &remote_object_store,
+            input_files
+                .iter()
+                .map(|(_, (_, file_metadata))| file_metadata.file_path(&epoch_dir))
+                .collect(),
+            concurrency,
+            &self.multi_progress_bar,
+        )
+        .await;
         // Creates a progress bar for object files
-        let obj_progress_bar = self.multi_progress_bar.add(
-            ProgressBar::new(input_files.len() as u64).with_style(
-                ProgressStyle::with_template(
-                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} .obj files done ({msg})",
-                )
-                .unwrap(),
-            ),
-        );
-        let obj_progress_bar_clone = obj_progress_bar.clone();
-        let instant = Instant::now();
-        let downloaded_bytes = AtomicUsize::new(0);
+        let obj_progress = Arc::new(DownloadProgressBar::new(
+            &self.multi_progress_bar,
+            "Downloading .obj files",
+            input_files.len() as u64,
+            obj_total_bytes,
+        ));
+        let obj_progress_clone = obj_progress.clone();
 
         let ret = Abortable::new(
             async move {
@@ -635,22 +644,13 @@ impl StateSnapshotReaderV1 {
                     .boxed()
                     .buffer_unordered(concurrency.into())
                     .try_for_each(|(bytes, file_metadata, sha3_digest)| {
-                        let downloaded_bytes = &downloaded_bytes;
-                        let obj_progress_bar = &obj_progress_bar_clone;
-                        let instant = &instant;
+                        let obj_progress = &obj_progress_clone;
                         async move {
-                            let bytes_len = bytes.len();
+                            let bytes_len = bytes.len() as u64;
                             database
                                 .insert_partition(file_metadata, bytes, &sha3_digest)
                                 .await?;
-                            downloaded_bytes.fetch_add(bytes_len, Ordering::Relaxed);
-                            obj_progress_bar.inc(1);
-                            obj_progress_bar.set_message(format!(
-                                "Download speed: {} MiB/s",
-                                downloaded_bytes.load(Ordering::Relaxed) as f64
-                                    / (1024 * 1024) as f64
-                                    / instant.elapsed().as_secs_f64(),
-                            ));
+                            obj_progress.file_done(bytes_len);
                             Ok(())
                         }
                     })
@@ -659,7 +659,9 @@ impl StateSnapshotReaderV1 {
             abort_registration,
         )
         .await?;
-        obj_progress_bar.finish_with_message("Objects download complete");
+        obj_progress
+            .bar()
+            .finish_with_message("Objects download complete");
         ret
     }
 

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -387,10 +387,10 @@ async fn snapshot_round_trip(
 
     // Snapshot is at epoch 0, so EPOCH_INFO has exactly one entry, which must
     // round-trip into an `EpochInfoV2`.
-    let (_, epoch_info) =
-        StateSnapshotReaderV1::read_epoch_info(0, &remote_store_config, &MultiProgress::new())
-            .await
-            .expect("read_epoch_info");
+    let epoch_info = snapshot_reader
+        .read_epoch_info()
+        .await
+        .expect("read_epoch_info");
     assert_eq!(
         epoch_info.entries().len(),
         1,
@@ -440,15 +440,25 @@ async fn epoch_info_round_trip(
         .await?;
 
     // 2. LOAD via `read_epoch_info` (the formal-snapshot restore's EPOCH_INFO-first
-    //    step): downloads only MANIFEST + EPOCH_INFO, verifies sha3 + magic.
-    let (chain_id, epoch_info) = StateSnapshotReaderV1::read_epoch_info(
+    //    step): the reader downloads only the MANIFEST, and `read_epoch_info` then
+    //    the one EPOCH_INFO file, verifying sha3 + magic.
+    let local_store_read_config = ObjectStoreConfig {
+        object_store: Some(ObjectStoreType::File),
+        directory: Some(tmp_dir.join("local_dir_read")),
+        ..Default::default()
+    };
+    let snapshot_reader = StateSnapshotReaderV1::new(
         snapshot_epoch,
         &remote_store_config,
-        &MultiProgress::new(),
+        &local_store_read_config,
+        NonZeroUsize::new(1).unwrap(),
+        MultiProgress::new(),
+        false, // skip_reset_local_store
     )
     .await?;
+    let epoch_info = snapshot_reader.read_epoch_info().await?;
     assert_eq!(
-        chain_id,
+        snapshot_reader.chain_id(),
         ChainIdentifier::default(),
         "manifest chain_id must round-trip through the snapshot"
     );

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -387,8 +387,7 @@ async fn snapshot_round_trip(
 
     // Snapshot is at epoch 0, so EPOCH_INFO has exactly one entry, which must
     // round-trip into an `EpochInfoV2`.
-    let epoch_info = snapshot_reader
-        .read_epoch_info()
+    let (_, epoch_info) = StateSnapshotReaderV1::read_epoch_info(0, &remote_store_config)
         .await
         .expect("read_epoch_info");
     assert_eq!(
@@ -439,11 +438,10 @@ async fn epoch_info_round_trip(
         .write_internal(snapshot_epoch, perpetual_db, root_accumulator)
         .await?;
 
-    // 2. LOAD via `read_epoch_info_only` (the formal-snapshot restore's
-    //    EPOCH_INFO-first step): downloads only MANIFEST + EPOCH_INFO, verifies
-    //    sha3 + magic.
+    // 2. LOAD via `read_epoch_info` (the formal-snapshot restore's EPOCH_INFO-first
+    //    step): downloads only MANIFEST + EPOCH_INFO, verifies sha3 + magic.
     let (chain_id, epoch_info) =
-        StateSnapshotReaderV1::read_epoch_info_only(snapshot_epoch, &remote_store_config).await?;
+        StateSnapshotReaderV1::read_epoch_info(snapshot_epoch, &remote_store_config).await?;
     assert_eq!(
         chain_id,
         ChainIdentifier::default(),

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -387,9 +387,10 @@ async fn snapshot_round_trip(
 
     // Snapshot is at epoch 0, so EPOCH_INFO has exactly one entry, which must
     // round-trip into an `EpochInfoV2`.
-    let (_, epoch_info) = StateSnapshotReaderV1::read_epoch_info(0, &remote_store_config)
-        .await
-        .expect("read_epoch_info");
+    let (_, epoch_info) =
+        StateSnapshotReaderV1::read_epoch_info(0, &remote_store_config, &MultiProgress::new())
+            .await
+            .expect("read_epoch_info");
     assert_eq!(
         epoch_info.entries().len(),
         1,
@@ -440,8 +441,12 @@ async fn epoch_info_round_trip(
 
     // 2. LOAD via `read_epoch_info` (the formal-snapshot restore's EPOCH_INFO-first
     //    step): downloads only MANIFEST + EPOCH_INFO, verifies sha3 + magic.
-    let (chain_id, epoch_info) =
-        StateSnapshotReaderV1::read_epoch_info(snapshot_epoch, &remote_store_config).await?;
+    let (chain_id, epoch_info) = StateSnapshotReaderV1::read_epoch_info(
+        snapshot_epoch,
+        &remote_store_config,
+        &MultiProgress::new(),
+    )
+    .await?;
     assert_eq!(
         chain_id,
         ChainIdentifier::default(),

--- a/crates/iota-storage/Cargo.toml
+++ b/crates/iota-storage/Cargo.toml
@@ -24,7 +24,6 @@ eyre.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
 hyper.workspace = true
-indicatif.workspace = true
 integer-encoding.workspace = true
 itertools.workspace = true
 lru.workspace = true

--- a/crates/iota-storage/src/object_store/http/gcs.rs
+++ b/crates/iota-storage/src/object_store/http/gcs.rs
@@ -12,7 +12,7 @@ use percent_encoding::{NON_ALPHANUMERIC, percent_encode, utf8_percent_encode};
 use reqwest::{Client, ClientBuilder};
 
 use crate::object_store::{
-    ObjectStoreGetExt,
+    ObjectStoreGetExt, collect_get_result_with_progress,
     http::{DEFAULT_USER_AGENT, exists, get, size},
 };
 
@@ -86,6 +86,15 @@ impl ObjectStoreGetExt for GoogleCloudStorage {
         let result = self.client.get(location).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)
+    }
+
+    async fn get_bytes_with_progress(
+        &self,
+        location: &Path,
+        on_bytes: &(dyn Fn(u64) + Send + Sync),
+    ) -> Result<Bytes> {
+        let result = self.client.get(location).await?;
+        collect_get_result_with_progress(result, location, on_bytes).await
     }
 
     async fn exists(&self, location: &Path) -> Result<bool> {

--- a/crates/iota-storage/src/object_store/http/gcs.rs
+++ b/crates/iota-storage/src/object_store/http/gcs.rs
@@ -7,6 +7,7 @@ use std::{fmt, sync::Arc};
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
+use iota_config::object_storage_config::{CONNECT_TIMEOUT, TRANSFER_STALL_TIMEOUT};
 use object_store::{GetResult, path::Path};
 use percent_encoding::{NON_ALPHANUMERIC, percent_encode, utf8_percent_encode};
 use reqwest::{Client, ClientBuilder};
@@ -25,7 +26,10 @@ struct GoogleCloudStorageClient {
 impl GoogleCloudStorageClient {
     pub fn new(bucket: &str) -> Result<Self> {
         let mut builder = ClientBuilder::new().pool_idle_timeout(None);
-        builder = builder.user_agent(DEFAULT_USER_AGENT);
+        builder = builder
+            .user_agent(DEFAULT_USER_AGENT)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .read_timeout(TRANSFER_STALL_TIMEOUT);
         let client = builder.https_only(false).build()?;
         let bucket_name_encoded = percent_encode(bucket.as_bytes(), NON_ALPHANUMERIC).to_string();
 

--- a/crates/iota-storage/src/object_store/http/gcs.rs
+++ b/crates/iota-storage/src/object_store/http/gcs.rs
@@ -13,7 +13,7 @@ use reqwest::{Client, ClientBuilder};
 
 use crate::object_store::{
     ObjectStoreGetExt,
-    http::{DEFAULT_USER_AGENT, exists, get},
+    http::{DEFAULT_USER_AGENT, exists, get, size},
 };
 
 #[derive(Debug)]
@@ -43,6 +43,11 @@ impl GoogleCloudStorageClient {
     async fn exists(&self, path: &Path) -> Result<bool> {
         let url = self.object_url(path);
         exists(&url, "gcs", path, &self.client).await
+    }
+
+    async fn size(&self, path: &Path) -> Result<u64> {
+        let url = self.object_url(path);
+        size(&url, "gcs", path, &self.client).await
     }
 
     fn object_url(&self, path: &Path) -> String {
@@ -85,5 +90,9 @@ impl ObjectStoreGetExt for GoogleCloudStorage {
 
     async fn exists(&self, location: &Path) -> Result<bool> {
         self.client.exists(location).await
+    }
+
+    async fn object_size(&self, location: &Path) -> Result<u64> {
+        self.client.size(location).await
     }
 }

--- a/crates/iota-storage/src/object_store/http/local.rs
+++ b/crates/iota-storage/src/object_store/http/local.rs
@@ -60,4 +60,19 @@ impl ObjectStoreGetExt for LocalStorage {
         .await??;
         Ok(exists)
     }
+
+    async fn object_size(&self, location: &Path) -> Result<u64> {
+        let path_to_filesystem = path_to_filesystem(self.root.clone(), location)?;
+        let handle = tokio::task::spawn_blocking(move || {
+            fs::metadata(&path_to_filesystem)
+                .map(|metadata| metadata.len())
+                .map_err(|e| {
+                    anyhow!(
+                        "Failed to get metadata for file {} with error: {e}",
+                        path_to_filesystem.display()
+                    )
+                })
+        });
+        handle.await?
+    }
 }

--- a/crates/iota-storage/src/object_store/http/mod.rs
+++ b/crates/iota-storage/src/object_store/http/mod.rs
@@ -114,6 +114,25 @@ async fn exists(url: &str, store: &'static str, location: &Path, client: &Client
     }
 }
 
+async fn size(url: &str, store: &'static str, location: &Path, client: &Client) -> Result<u64> {
+    let request = client.request(Method::HEAD, url);
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("failed to send HEAD request for {location} to {store}"))?
+        .error_for_status()
+        .with_context(|| format!("{store} returned an error status for {location}"))?;
+    let content_length = response
+        .headers()
+        .get(CONTENT_LENGTH)
+        .with_context(|| format!("{store} returned no content length for {location}"))?;
+    content_length
+        .to_str()
+        .context("bad content length header")?
+        .parse()
+        .context("invalid content length")
+}
+
 fn header_meta(location: &Path, headers: &HeaderMap) -> Result<ObjectMeta> {
     let last_modified = headers
         .get(LAST_MODIFIED)
@@ -193,6 +212,29 @@ mod tests {
 
         assert!(input_store.exists(&Path::from("file1")).await?);
         assert!(!input_store.exists(&Path::from("missing")).await?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_local_object_size() -> anyhow::Result<()> {
+        let input = TempDir::new()?;
+        let input_path = input.path();
+        fs::write(input_path.join("file1"), b"Lorem ipsum")?;
+
+        let input_store = ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::File),
+            directory: Some(input_path.to_path_buf()),
+            ..Default::default()
+        }
+        .make_http()?;
+
+        assert_eq!(input_store.object_size(&Path::from("file1")).await?, 11);
+        assert!(
+            input_store
+                .object_size(&Path::from("missing"))
+                .await
+                .is_err()
+        );
         Ok(())
     }
 }

--- a/crates/iota-storage/src/object_store/http/mod.rs
+++ b/crates/iota-storage/src/object_store/http/mod.rs
@@ -79,7 +79,12 @@ async fn get(
     client: &Client,
 ) -> Result<GetResult> {
     let request = client.request(Method::GET, url);
-    let response = request.send().await.context("failed to get")?;
+    let response = request
+        .send()
+        .await
+        .context("failed to get")?
+        .error_for_status()
+        .with_context(|| format!("{store} returned an error status for {location}"))?;
     let meta = header_meta(location, response.headers()).context("Failed to get header")?;
     let stream = response
         .bytes_stream()

--- a/crates/iota-storage/src/object_store/http/s3.rs
+++ b/crates/iota-storage/src/object_store/http/s3.rs
@@ -7,6 +7,7 @@ use std::{fmt, sync::Arc};
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
+use iota_config::object_storage_config::{CONNECT_TIMEOUT, TRANSFER_STALL_TIMEOUT};
 use object_store::{GetResult, path::Path};
 use percent_encoding::{PercentEncode, utf8_percent_encode};
 use reqwest::{Client, ClientBuilder};
@@ -27,7 +28,9 @@ impl S3Client {
         let mut builder = ClientBuilder::new();
         builder = builder
             .user_agent(DEFAULT_USER_AGENT)
-            .pool_idle_timeout(None);
+            .pool_idle_timeout(None)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .read_timeout(TRANSFER_STALL_TIMEOUT);
         let client = builder.https_only(false).build()?;
 
         Ok(Self {

--- a/crates/iota-storage/src/object_store/http/s3.rs
+++ b/crates/iota-storage/src/object_store/http/s3.rs
@@ -13,7 +13,7 @@ use reqwest::{Client, ClientBuilder};
 
 use crate::object_store::{
     ObjectStoreGetExt,
-    http::{DEFAULT_USER_AGENT, STRICT_PATH_ENCODE_SET, exists, get},
+    http::{DEFAULT_USER_AGENT, STRICT_PATH_ENCODE_SET, exists, get, size},
 };
 
 #[derive(Debug)]
@@ -42,6 +42,10 @@ impl S3Client {
     async fn exists(&self, location: &Path) -> Result<bool> {
         let url = self.path_url(location);
         exists(&url, "s3", location, &self.client).await
+    }
+    async fn size(&self, location: &Path) -> Result<u64> {
+        let url = self.path_url(location);
+        size(&url, "s3", location, &self.client).await
     }
     fn path_url(&self, path: &Path) -> String {
         format!("{}/{}", self.endpoint, Self::encode_path(path))
@@ -82,5 +86,9 @@ impl ObjectStoreGetExt for AmazonS3 {
 
     async fn exists(&self, location: &Path) -> Result<bool> {
         self.client.exists(location).await
+    }
+
+    async fn object_size(&self, location: &Path) -> Result<u64> {
+        self.client.size(location).await
     }
 }

--- a/crates/iota-storage/src/object_store/http/s3.rs
+++ b/crates/iota-storage/src/object_store/http/s3.rs
@@ -12,7 +12,7 @@ use percent_encoding::{PercentEncode, utf8_percent_encode};
 use reqwest::{Client, ClientBuilder};
 
 use crate::object_store::{
-    ObjectStoreGetExt,
+    ObjectStoreGetExt, collect_get_result_with_progress,
     http::{DEFAULT_USER_AGENT, STRICT_PATH_ENCODE_SET, exists, get, size},
 };
 
@@ -82,6 +82,15 @@ impl ObjectStoreGetExt for AmazonS3 {
         let result = self.client.get(location).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)
+    }
+
+    async fn get_bytes_with_progress(
+        &self,
+        location: &Path,
+        on_bytes: &(dyn Fn(u64) + Send + Sync),
+    ) -> Result<Bytes> {
+        let result = self.client.get(location).await?;
+        collect_get_result_with_progress(result, location, on_bytes).await
     }
 
     async fn exists(&self, location: &Path) -> Result<bool> {

--- a/crates/iota-storage/src/object_store/mod.rs
+++ b/crates/iota-storage/src/object_store/mod.rs
@@ -17,11 +17,45 @@ pub trait ObjectStoreGetExt: std::fmt::Display + Send + Sync + 'static {
     /// Return the bytes at given path in object store
     async fn get_bytes(&self, src: &Path) -> Result<Bytes>;
 
+    /// Like [`Self::get_bytes`], additionally invoking `on_bytes` with the
+    /// size of each received chunk while the download is in flight, so
+    /// callers can render live progress. The default implementation reports
+    /// the full size in one call once the download completes; stores that
+    /// stream their responses override it to report per chunk.
+    async fn get_bytes_with_progress(
+        &self,
+        src: &Path,
+        on_bytes: &(dyn Fn(u64) + Send + Sync),
+    ) -> Result<Bytes> {
+        let bytes = self.get_bytes(src).await?;
+        on_bytes(bytes.len() as u64);
+        Ok(bytes)
+    }
+
     /// Return whether an object exists at the given path.
     async fn exists(&self, src: &Path) -> Result<bool>;
 
     /// Return the size in bytes of the object at the given path.
     async fn object_size(&self, src: &Path) -> Result<u64>;
+}
+
+/// Collect a GET result's payload into contiguous bytes, invoking `on_bytes`
+/// with each chunk's size as it is received.
+pub(crate) async fn collect_get_result_with_progress(
+    result: object_store::GetResult,
+    src: &Path,
+    on_bytes: &(dyn Fn(u64) + Send + Sync),
+) -> Result<Bytes> {
+    use futures::StreamExt;
+    let mut stream = result.into_stream();
+    let mut buf = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk
+            .map_err(|e| anyhow!("Failed to stream GET result for file {src} with error: {e:?}"))?;
+        on_bytes(chunk.len() as u64);
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf.into())
 }
 
 macro_rules! as_ref_get_ext_impl {
@@ -30,6 +64,14 @@ macro_rules! as_ref_get_ext_impl {
         impl ObjectStoreGetExt for $type {
             async fn get_bytes(&self, src: &Path) -> Result<Bytes> {
                 self.as_ref().get_bytes(src).await
+            }
+
+            async fn get_bytes_with_progress(
+                &self,
+                src: &Path,
+                on_bytes: &(dyn Fn(u64) + Send + Sync),
+            ) -> Result<Bytes> {
+                self.as_ref().get_bytes_with_progress(src, on_bytes).await
             }
 
             async fn exists(&self, src: &Path) -> Result<bool> {
@@ -60,6 +102,18 @@ macro_rules! as_ref_get_impl {
                         anyhow!(
                             "Failed to collect GET result for file {src} into bytes with error: {e:?}")
                     })
+            }
+
+            async fn get_bytes_with_progress(
+                &self,
+                src: &Path,
+                on_bytes: &(dyn Fn(u64) + Send + Sync),
+            ) -> Result<Bytes> {
+                let result = self
+                    .get(src)
+                    .await
+                    .map_err(|e| anyhow!("Failed to get file {src} with error: {e:?}"))?;
+                collect_get_result_with_progress(result, src, on_bytes).await
             }
 
             async fn exists(&self, src: &Path) -> Result<bool> {

--- a/crates/iota-storage/src/object_store/mod.rs
+++ b/crates/iota-storage/src/object_store/mod.rs
@@ -19,6 +19,9 @@ pub trait ObjectStoreGetExt: std::fmt::Display + Send + Sync + 'static {
 
     /// Return whether an object exists at the given path.
     async fn exists(&self, src: &Path) -> Result<bool>;
+
+    /// Return the size in bytes of the object at the given path.
+    async fn object_size(&self, src: &Path) -> Result<u64>;
 }
 
 macro_rules! as_ref_get_ext_impl {
@@ -31,6 +34,10 @@ macro_rules! as_ref_get_ext_impl {
 
             async fn exists(&self, src: &Path) -> Result<bool> {
                 self.as_ref().exists(src).await
+            }
+
+            async fn object_size(&self, src: &Path) -> Result<u64> {
+                self.as_ref().object_size(src).await
             }
         }
     };
@@ -61,6 +68,13 @@ macro_rules! as_ref_get_impl {
                     Err(object_store::Error::NotFound { .. }) => Ok(false),
                     Err(e) => Err(anyhow!("Failed to check if file {src} exists with error: {e:?}")),
                 }
+            }
+
+            async fn object_size(&self, src: &Path) -> Result<u64> {
+                self.head(src)
+                    .await
+                    .map(|meta| meta.size)
+                    .map_err(|e| anyhow!("Failed to get size of file {src} with error: {e:?}"))
             }
         }
     };
@@ -180,6 +194,19 @@ mod tests {
 
         assert!(store.exists(&path).await?);
         assert!(!store.exists(&Path::from("missing")).await?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dyn_object_store_object_size() -> anyhow::Result<()> {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("file1");
+        store
+            .put_bytes(&path, bytes::Bytes::from_static(b"Lorem ipsum"))
+            .await?;
+
+        assert_eq!(store.object_size(&path).await?, 11);
+        assert!(store.object_size(&Path::from("missing")).await.is_err());
         Ok(())
     }
 }

--- a/crates/iota-storage/src/object_store/mod.rs
+++ b/crates/iota-storage/src/object_store/mod.rs
@@ -47,8 +47,8 @@ pub(crate) async fn collect_get_result_with_progress(
     on_bytes: &(dyn Fn(u64) + Send + Sync),
 ) -> Result<Bytes> {
     use futures::StreamExt;
+    let mut buf = Vec::with_capacity(result.meta.size as usize);
     let mut stream = result.into_stream();
-    let mut buf = Vec::new();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk
             .map_err(|e| anyhow!("Failed to stream GET result for file {src} with error: {e:?}"))?;

--- a/crates/iota-storage/src/object_store/mod.rs
+++ b/crates/iota-storage/src/object_store/mod.rs
@@ -2,12 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use iota_config::object_storage_config::TRANSFER_STALL_TIMEOUT;
 use object_store::{DynObjectStore, ObjectMeta, ObjectStore, ObjectStoreExt, path::Path};
 pub mod http;
 pub mod util;
@@ -39,6 +40,16 @@ pub trait ObjectStoreGetExt: std::fmt::Display + Send + Sync + 'static {
     async fn object_size(&self, src: &Path) -> Result<u64>;
 }
 
+/// Await `fut`, failing if it does not resolve within
+/// [`TRANSFER_STALL_TIMEOUT`].
+async fn with_stall_timeout<F: Future>(task_name: &str, src: &Path, fut: F) -> Result<F::Output> {
+    tokio::time::timeout(TRANSFER_STALL_TIMEOUT, fut)
+        .await
+        .map_err(|_| {
+            anyhow!("{task_name} for file {src} received nothing for {TRANSFER_STALL_TIMEOUT:?}")
+        })
+}
+
 /// Collect a GET result's payload into contiguous bytes, invoking `on_bytes`
 /// with each chunk's size as it is received.
 pub(crate) async fn collect_get_result_with_progress(
@@ -49,7 +60,8 @@ pub(crate) async fn collect_get_result_with_progress(
     use futures::StreamExt;
     let mut buf = Vec::with_capacity(result.meta.size as usize);
     let mut stream = result.into_stream();
-    while let Some(chunk) = stream.next().await {
+    // Fails once no chunk has arrived for `TRANSFER_STALL_TIMEOUT`.
+    while let Some(chunk) = with_stall_timeout("GET result stream", src, stream.next()).await? {
         let chunk = chunk
             .map_err(|e| anyhow!("Failed to stream GET result for file {src} with error: {e:?}"))?;
         on_bytes(chunk.len() as u64);
@@ -93,15 +105,9 @@ macro_rules! as_ref_get_impl {
         #[async_trait]
         impl ObjectStoreGetExt for $type {
             async fn get_bytes(&self, src: &Path) -> Result<Bytes> {
-                self.get(src)
-                    .await
-                    .map_err(|e| anyhow!("Failed to get file {src} with error: {e:?}"))?
-                    .bytes()
-                    .await
-                    .map_err(|e| {
-                        anyhow!(
-                            "Failed to collect GET result for file {src} into bytes with error: {e:?}")
-                    })
+                // Collected chunk by chunk rather than with `bytes()` so that a
+                // transfer that stalls part way through hits the stall timeout.
+                self.get_bytes_with_progress(src, &|_| {}).await
             }
 
             async fn get_bytes_with_progress(
@@ -109,24 +115,25 @@ macro_rules! as_ref_get_impl {
                 src: &Path,
                 on_bytes: &(dyn Fn(u64) + Send + Sync),
             ) -> Result<Bytes> {
-                let result = self
-                    .get(src)
-                    .await
+                let result = with_stall_timeout("GET request", src, self.get(src))
+                    .await?
                     .map_err(|e| anyhow!("Failed to get file {src} with error: {e:?}"))?;
                 collect_get_result_with_progress(result, src, on_bytes).await
             }
 
             async fn exists(&self, src: &Path) -> Result<bool> {
-                match self.head(src).await {
+                match with_stall_timeout("HEAD request", src, self.head(src)).await? {
                     Ok(_) => Ok(true),
                     Err(object_store::Error::NotFound { .. }) => Ok(false),
-                    Err(e) => Err(anyhow!("Failed to check if file {src} exists with error: {e:?}")),
+                    Err(e) => Err(anyhow!(
+                        "Failed to check if file {src} exists with error: {e:?}"
+                    )),
                 }
             }
 
             async fn object_size(&self, src: &Path) -> Result<u64> {
-                self.head(src)
-                    .await
+                with_stall_timeout("HEAD request", src, self.head(src))
+                    .await?
                     .map(|meta| meta.size)
                     .map_err(|e| anyhow!("Failed to get size of file {src} with error: {e:?}"))
             }
@@ -232,11 +239,72 @@ impl ObjectStoreDeleteExt for Arc<DynObjectStore> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    };
 
-    use object_store::{ObjectStore, memory::InMemory, path::Path};
+    use bytes::Bytes;
+    use futures::StreamExt;
+    use object_store::{
+        Attributes, GetResult, GetResultPayload, ObjectMeta, ObjectStore, memory::InMemory,
+        path::Path,
+    };
 
-    use crate::object_store::{ObjectStoreGetExt, ObjectStorePutExt};
+    use crate::object_store::{
+        ObjectStoreGetExt, ObjectStorePutExt, collect_get_result_with_progress,
+    };
+
+    #[tokio::test]
+    async fn test_dyn_object_store_get_bytes() -> anyhow::Result<()> {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("file1");
+        store
+            .put_bytes(&path, Bytes::from_static(b"Lorem ipsum"))
+            .await?;
+
+        assert_eq!(
+            store.get_bytes(&path).await?,
+            Bytes::from_static(b"Lorem ipsum")
+        );
+        assert!(store.get_bytes(&Path::from("missing")).await.is_err());
+        Ok(())
+    }
+
+    /// A transfer that goes quiet part way through fails rather than hanging.
+    /// Runs on a paused clock, so the stall timeout elapses without the test
+    /// waiting for it.
+    #[tokio::test(start_paused = true)]
+    async fn test_collect_get_result_with_progress_fails_on_a_stalled_stream() {
+        let src = Path::from("file1");
+        let payload = futures::stream::once(async {
+            Ok::<_, object_store::Error>(Bytes::from_static(b"Lorem"))
+        })
+        .chain(futures::stream::pending())
+        .boxed();
+        let result = GetResult {
+            range: 0..11,
+            payload: GetResultPayload::Stream(payload),
+            meta: ObjectMeta {
+                location: src.clone(),
+                last_modified: chrono::Utc::now(),
+                size: 11,
+                e_tag: None,
+                version: None,
+            },
+            attributes: Attributes::new(),
+        };
+
+        let received = AtomicU64::new(0);
+        let err = collect_get_result_with_progress(result, &src, &|n| {
+            received.fetch_add(n, Ordering::Relaxed);
+        })
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("received nothing"), "{err}");
+        assert_eq!(received.load(Ordering::Relaxed), 5);
+    }
 
     #[tokio::test]
     async fn test_dyn_object_store_exists() -> anyhow::Result<()> {

--- a/crates/iota-storage/src/object_store/util.rs
+++ b/crates/iota-storage/src/object_store/util.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use backoff::future::retry;
 use bytes::Bytes;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use itertools::Itertools;
 use object_store::{DynObjectStore, Error, ObjectStore, ObjectStoreExt, path::Path};
 use serde::{Deserialize, Serialize};
@@ -104,23 +104,6 @@ pub async fn copy_file<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
         warn!("Not copying empty file: {:?}", src);
         Ok(())
     }
-}
-
-/// Copy `src[i]` to `dest[i]` for all `i` in parallel, failing on the first
-/// copy that fails.
-pub async fn copy_files<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
-    src: &[Path],
-    dest: &[Path],
-    src_store: &S,
-    dest_store: &D,
-    concurrency: NonZeroUsize,
-) -> Result<()> {
-    futures::stream::iter(src.iter().zip(dest.iter()))
-        .map(|(path_in, path_out)| copy_file(path_in, path_out, src_store, dest_store))
-        .boxed()
-        .buffer_unordered(concurrency.get())
-        .try_for_each(|()| futures::future::ready(Ok(())))
-        .await
 }
 
 pub async fn delete_files<S: ObjectStoreDeleteExt>(

--- a/crates/iota-storage/src/object_store/util.rs
+++ b/crates/iota-storage/src/object_store/util.rs
@@ -10,11 +10,9 @@ use anyhow::{Context, Result, anyhow};
 use backoff::future::retry;
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
-use indicatif::ProgressBar;
 use itertools::Itertools;
 use object_store::{DynObjectStore, Error, ObjectStore, ObjectStoreExt, path::Path};
 use serde::{Deserialize, Serialize};
-use tokio::time::Instant;
 use tracing::{error, warn};
 use url::Url;
 
@@ -108,35 +106,21 @@ pub async fn copy_file<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
     }
 }
 
+/// Copy `src[i]` to `dest[i]` for all `i` in parallel, failing on the first
+/// copy that fails.
 pub async fn copy_files<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
     src: &[Path],
     dest: &[Path],
     src_store: &S,
     dest_store: &D,
     concurrency: NonZeroUsize,
-    progress_bar: Option<ProgressBar>,
-) -> Result<Vec<()>> {
-    let mut instant = Instant::now();
-    let progress_bar_clone = progress_bar.clone();
-    // Copies files from dest to src in parallel, and updates the progress bar if
-    // it's provided
-    let results = futures::stream::iter(src.iter().zip(dest.iter()))
-        .map(|(path_in, path_out)| async move {
-            let ret = copy_file(path_in, path_out, src_store, dest_store).await;
-            Ok((path_out.clone(), ret))
-        })
+) -> Result<()> {
+    futures::stream::iter(src.iter().zip(dest.iter()))
+        .map(|(path_in, path_out)| copy_file(path_in, path_out, src_store, dest_store))
         .boxed()
-        .buffer_unordered(concurrency.into())
-        .try_for_each(|(path, ret)| {
-            if let Some(progress_bar_clone) = &progress_bar_clone {
-                progress_bar_clone.inc(1);
-                progress_bar_clone.set_message(format!("file: {path}"));
-                instant = Instant::now();
-            }
-            futures::future::ready(ret)
-        })
-        .await;
-    Ok(results.into_iter().collect())
+        .buffer_unordered(concurrency.get())
+        .try_for_each(|()| futures::future::ready(Ok(())))
+        .await
 }
 
 pub async fn delete_files<S: ObjectStoreDeleteExt>(

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -20,6 +20,7 @@ use iota_protocol_config::Chain;
 use iota_replay::{ReplayToolCommand, execute_replay_command};
 use iota_sdk::{IotaClient, IotaClientBuilder, rpc_types::IotaTransactionBlockResponseOptions};
 use iota_sdk_types::{Address, ObjectId, TransactionDigest};
+use iota_snapshot::progress::LOG_TARGET_PROGRESS;
 use iota_types::{
     base_types::*,
     crypto::AuthorityPublicKeyBytes,
@@ -36,6 +37,13 @@ use crate::{
     download_formal_snapshot, get_latest_available_epoch, get_object, get_transaction_block,
     make_clients,
 };
+
+/// Log filter for the restore commands' non-verbose default: silence
+/// everything except the progress status lines, which are the only progress
+/// output left once the progress bars can't be drawn.
+fn progress_only_log_directives() -> String {
+    format!("off,{LOG_TARGET_PROGRESS}=info")
+}
 
 #[derive(Parser, Clone, ValueEnum)]
 pub enum Verbosity {
@@ -245,6 +253,10 @@ pub enum ToolCommand {
         #[arg(long)]
         verbose: bool,
 
+        /// Report progress as a status line logged once per second.
+        #[arg(long)]
+        disable_progress_bar: bool,
+
         /// Skip building the gRPC index store during the restore. By default
         /// it is built from the same object stream that restores the state,
         /// so a fullnode started with gRPC enabled opens it in place instead
@@ -284,6 +296,9 @@ pub enum ToolCommand {
         /// output will be reduced to necessary status information.
         #[arg(long)]
         verbose: bool,
+        /// Report progress as a status line logged once per second.
+        #[arg(long)]
+        disable_progress_bar: bool,
     },
 
     Replay {
@@ -583,11 +598,12 @@ impl ToolCommand {
                 no_sign_request,
                 latest,
                 verbose,
+                disable_progress_bar,
                 skip_grpc_indexes,
             } => {
                 if !verbose {
                     tracing_handle
-                        .update_log("off")
+                        .update_log(progress_only_log_directives())
                         .expect("Failed to update log level");
                 }
                 let num_parallel_downloads = num_parallel_downloads.unwrap_or_else(|| {
@@ -705,6 +721,7 @@ impl ToolCommand {
                     num_parallel_downloads,
                     verify,
                     skip_grpc_indexes,
+                    disable_progress_bar,
                 )
                 .await?;
             }
@@ -713,10 +730,11 @@ impl ToolCommand {
                 ingestion_url,
                 num_parallel_downloads,
                 verbose,
+                disable_progress_bar,
             } => {
                 if !verbose {
                     tracing_handle
-                        .update_log("off")
+                        .update_log(progress_only_log_directives())
                         .expect("Failed to update log level");
                 }
                 let num_parallel_downloads = NonZeroUsize::new(
@@ -724,7 +742,13 @@ impl ToolCommand {
                         .unwrap_or_else(|| num_cpus::get().saturating_sub(1).max(1)),
                 )
                 .expect("num-parallel-downloads must be non-zero");
-                backfill_checkpoint_summaries(&path, ingestion_url, num_parallel_downloads).await?;
+                backfill_checkpoint_summaries(
+                    &path,
+                    ingestion_url,
+                    num_parallel_downloads,
+                    disable_progress_bar,
+                )
+                .await?;
             }
             ToolCommand::Replay {
                 rpc_url,

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -48,7 +48,7 @@ use iota_sdk_types::{
 };
 use iota_snapshot::{
     VerifiedEpochInfo,
-    progress::{ProgressTicker, ProgressUnit, make_multi_progress},
+    progress::{ProgressTicker, ProgressUnit, make_multi_progress, println_or_log},
     reader::StateSnapshotReaderV1,
     restore::RestoreWithGrpcIndexes,
     setup_db_state,
@@ -626,7 +626,10 @@ pub(crate) async fn backfill_checkpoint_summaries(
         })?;
 
     if highest_synced == 0 {
-        m.println("Nothing to backfill: the node has only the genesis checkpoint.")?;
+        println_or_log(
+            m,
+            "Nothing to backfill: the node has only the genesis checkpoint.",
+        )?;
         return Ok(());
     }
 
@@ -643,13 +646,19 @@ pub(crate) async fn backfill_checkpoint_summaries(
     let archive_latest = reader.latest_available_checkpoint().await?;
     let target = highest_synced.min(archive_latest);
     if archive_latest < highest_synced {
-        m.println(format!(
-            "Checkpoint archive only reaches checkpoint {archive_latest}; filling summaries up to \
+        println_or_log(
+            m,
+            format!(
+                "Checkpoint archive only reaches checkpoint {archive_latest}; filling summaries up to \
              there (the node is synced to {highest_synced}). Re-run once the archive catches up."
-        ))?;
+            ),
+        )?;
     }
     if target == 0 {
-        m.println("Nothing to backfill: the checkpoint archive has nothing past genesis.")?;
+        println_or_log(
+            m,
+            "Nothing to backfill: the checkpoint archive has nothing past genesis.",
+        )?;
         return Ok(());
     }
 
@@ -686,9 +695,10 @@ pub(crate) async fn backfill_checkpoint_summaries(
         }
     }
     ticker.finish_with_message("Checkpoint summary backfill is complete");
-    m.println(format!(
-        "Successfully backfilled checkpoint summaries up to checkpoint {target}"
-    ))?;
+    println_or_log(
+        m,
+        format!("Successfully backfilled checkpoint summaries up to checkpoint {target}"),
+    )?;
     Ok(())
 }
 
@@ -800,14 +810,28 @@ pub async fn download_formal_snapshot(
     disable_progress_bar: bool,
 ) -> Result<(), anyhow::Error> {
     let m = make_multi_progress(disable_progress_bar);
-    m.println(format!(
-        "Beginning formal snapshot restore to end of epoch {epoch}, verification mode: {verify:?}",
-    ))?;
+    println_or_log(
+        &m,
+        format!(
+            "Beginning formal snapshot restore to end of epoch {epoch}, verification mode: \
+             {verify:?}",
+        ),
+    )?;
     let path = path.join("staging").to_path_buf();
     if path.exists() {
+        // A previous run's staging directory holds a whole restored database,
+        // so removing it can take a while.
+        println_or_log(
+            &m,
+            format!(
+                "Removing the previous staging directory at {}",
+                path.display()
+            ),
+        )?;
         fs::remove_dir_all(path.clone())?;
     }
     let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&path.join("store"), None));
+    println_or_log(&m, format!("Loading genesis from {}", genesis.display()))?;
     let genesis = Genesis::load(genesis).unwrap();
     let genesis_committee = genesis.committee()?;
     let expected_chain_id = ChainIdentifier::from(*genesis.checkpoint().digest());
@@ -819,7 +843,16 @@ pub async fn download_formal_snapshot(
     // and rejects a wrong-network or tampered snapshot before anything large is
     // downloaded.
     let (snapshot_chain_id, epoch_info) =
-        StateSnapshotReaderV1::read_epoch_info(epoch, &snapshot_store_config).await?;
+        StateSnapshotReaderV1::read_epoch_info(epoch, &snapshot_store_config, &m).await?;
+    // One signature check and one boundary proof per epoch since genesis, all
+    // before any of the snapshot proper is downloaded.
+    println_or_log(
+        &m,
+        format!(
+            "Verifying the epoch chain from genesis to the end of epoch {epoch} ({} epochs)",
+            epoch_info.entries().len()
+        ),
+    )?;
     let verified_epoch_info = iota_snapshot::verify_epoch_info_chain(
         epoch_info,
         genesis_committee.clone(),
@@ -839,6 +872,13 @@ pub async fn download_formal_snapshot(
     // chain-verified EPOCH_INFO — the restore needs no checkpoint archive. A
     // node that additionally wants the full intermediate summary history can
     // run `iota-tool backfill-checkpoint-summaries` afterwards.
+    println_or_log(
+        &m,
+        format!(
+            "Seeding the checkpoint store with {} end-of-epoch summaries and committees",
+            verified_epoch_info.entries().len()
+        ),
+    )?;
     sync_summaries_from_epoch_info(
         &checkpoint_store,
         &committee_store,
@@ -969,7 +1009,8 @@ pub async fn download_formal_snapshot(
             _ => unimplemented!("a new CheckpointCommitment variant was added and must be handled"),
         };
     } else {
-        m.println(
+        println_or_log(
+            &m,
             "WARNING: Skipping snapshot verification! \
             This is highly discouraged unless you fully trust the source of this snapshot and its contents.
             If this was unintentional, rerun with `--verify` set to `normal` or `strict`.",

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -821,7 +821,7 @@ pub async fn download_formal_snapshot(
     // and rejects a wrong-network or tampered snapshot before anything large is
     // downloaded.
     let (snapshot_chain_id, epoch_info) =
-        StateSnapshotReaderV1::read_epoch_info_only(epoch, &snapshot_store_config).await?;
+        StateSnapshotReaderV1::read_epoch_info(epoch, &snapshot_store_config).await?;
     let verified_epoch_info = iota_snapshot::verify_epoch_info_chain(
         epoch_info,
         genesis_committee.clone(),

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -23,7 +23,7 @@ use futures::{
     TryStreamExt,
     future::{AbortHandle, join_all},
 };
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressStyle};
 use iota_config::{
     genesis::Genesis,
     object_storage_config::{ObjectStoreConfig, ObjectStoreType},
@@ -47,7 +47,10 @@ use iota_sdk_types::{
     checkpoint::CheckpointCommitment,
 };
 use iota_snapshot::{
-    VerifiedEpochInfo, reader::StateSnapshotReaderV1, restore::RestoreWithGrpcIndexes,
+    VerifiedEpochInfo,
+    progress::{ProgressTicker, ProgressUnit, make_multi_progress},
+    reader::StateSnapshotReaderV1,
+    restore::RestoreWithGrpcIndexes,
     setup_db_state,
 };
 use iota_storage::object_store::{
@@ -597,8 +600,9 @@ pub(crate) async fn backfill_checkpoint_summaries(
     node_db_path: &Path,
     ingestion_url: String,
     num_parallel_downloads: NonZeroUsize,
+    disable_progress_bar: bool,
 ) -> anyhow::Result<()> {
-    let m = &MultiProgress::new();
+    let m = &make_multi_progress(disable_progress_bar);
 
     // Open the stopped node's existing stores in place. The committee store
     // already holds the genesis committee (from restore/sync), so it is opened
@@ -654,11 +658,21 @@ pub(crate) async fn backfill_checkpoint_summaries(
     // This fills in the missing historical summaries below the node's watermarks
     // without moving any of them.
     let range = 1..target + 1;
-    let bar = m.add(ProgressBar::new(target).with_style(
-        ProgressStyle::with_template("[{elapsed_precise}] {wide_bar} {pos}/{len} ({msg})").unwrap(),
-    ));
     let counter = Arc::new(AtomicU64::new(0));
-    spawn_rate_ticker(bar.clone(), counter.clone(), "checkpoints per sec");
+    let ticker = ProgressTicker::spawn(
+        m.add(
+            ProgressBar::new(target).with_style(
+                ProgressStyle::with_template(
+                    "[{elapsed_precise}] {wide_bar} Backfilling checkpoint summaries: {pos}/{len} \
+                     ({per_sec}, ETA {eta})",
+                )
+                .unwrap(),
+            ),
+        ),
+        "Backfilling checkpoint summaries",
+        ProgressUnit::Count("checkpoints"),
+        Some(counter.clone()),
+    );
 
     let mut blobs = reader.stream_blobs_for_range(range.clone()).await?;
     while let Some(blob) = blobs.try_next().await? {
@@ -671,7 +685,7 @@ pub(crate) async fn backfill_checkpoint_summaries(
             counter.fetch_add(1, Ordering::Relaxed);
         }
     }
-    bar.finish_with_message("Checkpoint summary backfill is complete");
+    ticker.finish_with_message("Checkpoint summary backfill is complete");
     m.println(format!(
         "Successfully backfilled checkpoint summaries up to checkpoint {target}"
     ))?;
@@ -697,23 +711,6 @@ fn checkpoint_archive_object_store_config(url: &str) -> ObjectStoreConfig {
             ..Default::default()
         }
     }
-}
-
-/// Spawn a background task that, once per second until `bar` finishes, mirrors
-/// `counter` into the bar's position and reports `{unit}: {rate}`.
-fn spawn_rate_ticker(bar: ProgressBar, counter: Arc<AtomicU64>, unit: &'static str) {
-    let start = Instant::now();
-    tokio::spawn(async move {
-        while !bar.is_finished() {
-            let count = counter.load(Ordering::Relaxed);
-            bar.set_position(count);
-            bar.set_message(format!(
-                "{unit}: {}",
-                count as f64 / start.elapsed().as_secs_f64()
-            ));
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    });
 }
 
 /// Seed the checkpoint store from the snapshot's chain-verified EPOCH_INFO —
@@ -800,8 +797,9 @@ pub async fn download_formal_snapshot(
     num_parallel_downloads: usize,
     verify: SnapshotVerifyMode,
     skip_grpc_indexes: bool,
+    disable_progress_bar: bool,
 ) -> Result<(), anyhow::Error> {
-    let m = MultiProgress::new();
+    let m = make_multi_progress(disable_progress_bar);
     m.println(format!(
         "Beginning formal snapshot restore to end of epoch {epoch}, verification mode: {verify:?}",
     ))?;

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -836,16 +836,37 @@ pub async fn download_formal_snapshot(
     let genesis_committee = genesis.committee()?;
     let expected_chain_id = ChainIdentifier::from(*genesis.checkpoint().digest());
 
-    // Download and chain-verify the snapshot's EPOCH_INFO up front (one small
-    // file): every entry's certified closing summary is checked against the
-    // committee chain walked from the operator's genesis. It drives the
-    // default (archive-free) summary sync and the checkpoint store's epoch seeding,
-    // and rejects a wrong-network or tampered snapshot before anything large is
-    // downloaded.
-    let (snapshot_chain_id, epoch_info) =
-        StateSnapshotReaderV1::read_epoch_info(epoch, &snapshot_store_config, &m).await?;
-    // One signature check and one boundary proof per epoch since genesis, all
-    // before any of the snapshot proper is downloaded.
+    // The reader reads the snapshot's MANIFEST and nothing else, so the
+    // EPOCH_INFO check below happens before any of the snapshot proper is
+    // transferred; the reference and object files come down in `read` at the
+    // end of this function.
+    let snapshot_dir = path.parent().unwrap().join("snapshot");
+    if snapshot_dir.exists() {
+        fs::remove_dir_all(snapshot_dir.clone())?;
+    }
+    let local_store_config = ObjectStoreConfig {
+        object_store: Some(ObjectStoreType::File),
+        directory: Some(snapshot_dir.to_path_buf()),
+        ..Default::default()
+    };
+    let mut reader = StateSnapshotReaderV1::new(
+        epoch,
+        &snapshot_store_config,
+        &local_store_config,
+        NonZeroUsize::new(num_parallel_downloads).unwrap(),
+        m.clone(),
+        false, // skip_reset_local_store
+    )
+    .await?;
+
+    // Chain-verify the snapshot's EPOCH_INFO up front: every entry's certified
+    // closing summary is checked against the committee chain walked from the
+    // operator's genesis. It drives the default (archive-free) summary sync and
+    // the checkpoint store's epoch seeding, and rejects a wrong-network or
+    // tampered snapshot before anything large is downloaded.
+    let snapshot_chain_id = reader.chain_id();
+    let epoch_info = reader.read_epoch_info().await?;
+    // One signature check and one boundary proof per epoch since genesis.
     println_or_log(
         &m,
         format!(
@@ -904,34 +925,13 @@ pub async fn download_formal_snapshot(
 
     let (_abort_handle, abort_registration) = AbortHandle::new_pair();
     let perpetual_db_clone = perpetual_db.clone();
-    let snapshot_dir = path.parent().unwrap().join("snapshot");
-    if snapshot_dir.exists() {
-        fs::remove_dir_all(snapshot_dir.clone())?;
-    }
-    let snapshot_dir_clone = snapshot_dir.clone();
 
     // TODO if verify is false, we should skip generating these and
     // not pass in a channel to the reader
     let (sender, mut receiver) = mpsc::channel(num_parallel_downloads);
-    let m_clone = m.clone();
     let grpc_indexes_clone = grpc_indexes.clone();
 
     let snapshot_handle = tokio::spawn(async move {
-        let local_store_config = ObjectStoreConfig {
-            object_store: Some(ObjectStoreType::File),
-            directory: Some(snapshot_dir_clone.to_path_buf()),
-            ..Default::default()
-        };
-        let mut reader = StateSnapshotReaderV1::new(
-            epoch,
-            &snapshot_store_config,
-            &local_store_config,
-            NonZeroUsize::new(num_parallel_downloads).unwrap(),
-            m_clone,
-            false, // skip_reset_local_store
-        )
-        .await
-        .unwrap_or_else(|err| panic!("Failed to create reader: {err}"));
         if let Some(grpc_indexes) = &grpc_indexes_clone {
             let grpc_restorer =
                 grpc_indexes.live_object_restorer(bulk_ingestion_options().batch_size_limit);

--- a/docs/content/operator/common/snapshots.mdx
+++ b/docs/content/operator/common/snapshots.mdx
@@ -125,7 +125,7 @@ To restore from a RocksDB snapshot, follow these steps:
       <TabItem label="Mainnet (Docker)" value="mainnet-docker">
       ```shell
       docker run --rm \
-         -v "<PATH-TO-NODE-DB>":/opt/iota/db \
+         -v "$PWD/data/db":/opt/iota/db \
          iotaledger/iota-tools:mainnet \
          /bin/sh -c "/usr/local/bin/iota-tool download-db-snapshot \
             --latest \
@@ -152,7 +152,7 @@ To restore from a RocksDB snapshot, follow these steps:
       <TabItem label="Testnet (Docker)" value="testnet-docker">
       ```shell
       docker run --rm \
-         -v "<PATH-TO-NODE-DB>":/opt/iota/db \
+         -v "$PWD/data/db":/opt/iota/db \
          iotaledger/iota-tools:testnet \
          /bin/sh -c "/usr/local/bin/iota-tool download-db-snapshot \
             --latest \

--- a/docs/content/operator/common/snapshots.mdx
+++ b/docs/content/operator/common/snapshots.mdx
@@ -203,6 +203,7 @@ The following steps can be used to restore a node from a Formal snapshot:
    - `--network`: Network to download snapshot for. Defaults to "mainnet".
    - `--path`: Path to snapshot directory on local filesystem.
    - `--skip-grpc-indexes`: Skips building the gRPC index store during the restore. By default it is built from the same object stream that restores the state, so a full node started with the gRPC API enabled opens it in place instead of re-indexing the whole restored state on first start. Skip it only if the node will never serve the gRPC API.
+   - `--disable-progress-bar`: Reports progress as a status line logged once per second instead of drawing progress bars.
 
 ### Backfilling the full checkpoint summary history
 
@@ -220,6 +221,7 @@ iota-tool backfill-checkpoint-summaries \
    - `--ingestion-url`: URL of the checkpoint archive to download summaries from — the same archive the node's state-sync fallback reads from (for example `https://checkpoints.<network>.iota.cafe/ingestion/historical`).
    - `--num-parallel-downloads`: Number of summaries to download in parallel. Defaults to a value based on the number of available cores.
    - `--verbose`: Enable verbose logging.
+   - `--disable-progress-bar`: Reports progress as a status line logged once per second instead of drawing a progress bar.
 
 Summaries are taken as-is from `--ingestion-url` without chain verification, so point it at the checkpoint archive you trust to serve this node's own chain. This only adds historical summaries below the node's existing watermarks — it never changes how far the node has synced or executed, and it never overwrites the summaries the node already has. It is safe to re-run.
 

--- a/docs/content/operator/common/snapshots.mdx
+++ b/docs/content/operator/common/snapshots.mdx
@@ -107,7 +107,7 @@ To restore from a RocksDB snapshot, follow these steps:
 
 1. Empty the snapshot directory specified by the `db-path` in your `fullnode.yaml`.
 2. Set the `AWS_SNAPSHOT_ENDPOINT` environment variable to the target snapshot URL. If not set, the default values are endpoints provided by the IOTA Foundation with public access:
-3. **Download the snapshot** for your target epoch to your local disk. Snapshots are stored per epoch in S3 buckets. For example, if you're restoring the latest epoch:
+3. **Download the snapshot** for your target epoch to your local disk. Snapshots are stored per epoch in S3 buckets. The Docker commands mount `$PWD/data/db`, the database directory used by the [Docker setup](../full-node/docker.mdx), so run them from that setup's directory or adjust the mount to your own `db-path`. For example, if you're restoring the latest epoch:
 
    <Tabs groupId="rocksdb-snapshot-command" queryString>
       <TabItem label="Mainnet (Binary)" value="mainnet-binary">
@@ -194,7 +194,7 @@ See [Install IOTA](../../developer/getting-started/install-iota.mdx#install-from
 The following steps can be used to restore a node from a Formal snapshot:
 
 1. If it's running, stop the node.
-2. Pick your setup, network, and a snapshot epoch. Copy the resulting command and run it:
+2. Pick your setup, network, and a snapshot epoch. Copy the resulting command and run it. The Docker command mounts `$PWD/data/db` and `$PWD/data/config/genesis.blob`, the layout used by the [Docker setup](../full-node/docker.mdx), so run it from that setup's directory or adjust the mounts to your own paths:
 
    <FormalSnapshotPicker />
 

--- a/docs/site/src/components/FormalSnapshotPicker/index.tsx
+++ b/docs/site/src/components/FormalSnapshotPicker/index.tsx
@@ -33,8 +33,8 @@ function buildCommand(
 
     return [
         'docker run --rm \\',
-        '  -v "<PATH-TO-NODE-DB>":/opt/iota/db \\',
-        '  -v "<PATH-TO-GENESIS-BLOB>":/opt/iota/config/genesis.blob \\',
+        '  -v "$PWD/data/db":/opt/iota/db \\',
+        '  -v "$PWD/data/config/genesis.blob":/opt/iota/config/genesis.blob \\',
         `  iotaledger/iota-tools:${network} \\`,
         '  /bin/sh -c "/usr/local/bin/iota-tool download-formal-snapshot \\',
         `    ${epochArg} \\`,


### PR DESCRIPTION
# Description of change

Improve progress reporting for `iota-tool download-formal-snapshot`:

- Add a byte-denominated progress bar for snapshot downloads: a size sweep over the remote files first fetches the total byte size (best-effort, with retries), so indicatif can natively render size totals, download speed, and ETA. Falls back to file counts when the sweep fails.
- New `iota-snapshot/src/progress.rs` module hosting the progress bar and size-sweep helpers, wired into formal snapshot download paths.
- Add `object_size` support to the object store HTTP backends (S3, GCS, local).
- Docs: replace the `<PATH-TO-NODE-DB>` / `<PATH-TO-GENESIS-BLOB>` placeholders in the snapshot restore commands with the concrete paths used by the standard docker-compose full node setup.

## Links to any relevant issues
Close #12357

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: `iota-tool download-formal-snapshot` now shows download progress with size totals, speed, and ETA.
- [ ] Rust SDK:
- [ ] gRPC:

