### PR TITLE
upstream: [move] Port bytecode verifier and abstract interpreter generalization (#10830)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8112,10 +8112,10 @@ dependencies = [
  "bcs",
  "iota-sdk-types",
  "iota-types",
- "move-abstract-interpreter",
  "move-abstract-stack",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
@@ -9166,10 +9166,6 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-dependencies = [
- "move-binary-format",
- "move-bytecode-verifier-meter",
-]
 
 [[package]]
 name = "move-abstract-stack"
@@ -9212,6 +9208,7 @@ version = "0.0.3"
 dependencies = [
  "anyhow",
  "indexmap 2.11.0",
+ "move-abstract-interpreter",
  "move-core-types",
  "ref-cast",
  "serde",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -326,6 +326,7 @@ name = "bytecode-verifier-tests"
 version = "0.1.0"
 dependencies = [
  "hex",
+ "itertools 0.10.5",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-verifier",
@@ -1826,11 +1827,6 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-dependencies = [
- "itertools 0.10.5",
- "move-binary-format",
- "move-bytecode-verifier-meter",
-]
 
 [[package]]
 name = "move-abstract-stack"
@@ -1877,6 +1873,7 @@ dependencies = [
  "arbitrary",
  "getrandom 0.2.16",
  "indexmap 2.11.0",
+ "move-abstract-interpreter",
  "move-core-types",
  "proptest",
  "proptest-derive",

--- a/external-crates/move/crates/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/crates/bytecode-verifier-tests/Cargo.toml
@@ -10,6 +10,7 @@ description = "Move bytecode verifier tests"
 [dev-dependencies]
 # external dependencies
 hex.workspace = true
+itertools.workspace = true
 petgraph.workspace = true
 
 # internal dependencies

--- a/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/control_flow_graph_tests.rs
+++ b/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/control_flow_graph_tests.rs
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::file_format::{
-    Bytecode, EnumDefinitionIndex, JumpTableInner, VariantJumpTable, VariantJumpTableIndex,
+    Bytecode, CodeOffset, EnumDefinitionIndex, JumpTableInner, VariantJumpTable,
+    VariantJumpTableIndex,
 };
-
-use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use move_bytecode_verifier::absint::VMControlFlowGraph;
 
 #[test]
 fn traversal_no_loops() {
@@ -232,8 +233,8 @@ fn out_of_order_blocks_variant_switch() {
 /// Return a vector containing the `BlockId`s from `cfg` in the order suggested
 /// by successively calling `ControlFlowGraph::next_block` starting from the
 /// entry block.
-fn traversal(cfg: &dyn ControlFlowGraph) -> Vec<BlockId> {
-    let mut order = Vec::with_capacity(cfg.num_blocks() as usize);
+fn traversal(cfg: &VMControlFlowGraph) -> Vec<CodeOffset> {
+    let mut order = Vec::with_capacity(cfg.num_blocks());
     let mut next = Some(cfg.entry_block_id());
 
     while let Some(block) = next {

--- a/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -13,6 +13,7 @@ pub mod binary_samples;
 pub mod bounds_tests;
 pub mod code_unit_tests;
 pub mod constants_tests;
+pub mod control_flow_graph_tests;
 pub mod control_flow_tests;
 pub mod duplication_tests;
 pub mod generic_ops_tests;

--- a/external-crates/move/crates/move-abstract-interpreter/Cargo.toml
+++ b/external-crates/move/crates/move-abstract-interpreter/Cargo.toml
@@ -7,12 +7,5 @@ license = "Apache-2.0"
 publish = false
 description = "Move abstract interpreter"
 
-[dependencies]
-move-binary-format.workspace = true
-move-bytecode-verifier-meter.workspace = true
-
-[dev-dependencies]
-itertools.workspace = true
-
 [features]
 default = []

--- a/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
@@ -1,44 +1,10 @@
-// Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
 
-use move_binary_format::{
-    CompiledModule,
-    errors::PartialVMResult,
-    file_format::{
-        AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,
-        Signature,
-    },
-};
-use move_bytecode_verifier_meter::{Meter, Scope};
-
-use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
-
-/// A `FunctionContext` holds all the information needed by the verifier for
-/// `FunctionDefinition`.` A control flow graph is built for a function when the
-/// `FunctionContext` is created.
-pub struct FunctionContext<'a> {
-    index: Option<FunctionDefinitionIndex>,
-    code: &'a CodeUnit,
-    parameters: &'a Signature,
-    return_: &'a Signature,
-    locals: &'a Signature,
-    type_parameters: &'a [AbilitySet],
-    cfg: VMControlFlowGraph,
-}
-
-/// Trait for finite-height abstract domains. Infinite height domains would
-/// require a more complex trait with widening and a partial order.
-pub trait AbstractDomain: Clone + Sized {
-    fn join(
-        &mut self,
-        other: &Self,
-        meter: &mut (impl Meter + ?Sized),
-    ) -> PartialVMResult<JoinResult>;
-}
+use crate::control_flow_graph::ControlFlowGraph;
 
 #[derive(Debug)]
 pub enum JoinResult {
@@ -46,35 +12,33 @@ pub enum JoinResult {
     Unchanged,
 }
 
-#[allow(dead_code)]
-#[derive(Clone)]
-pub struct BlockInvariant<State> {
-    /// Precondition of the block
-    pre: State,
-}
-
-/// A map from block id's to the pre/post of each block after a fixed point is
-/// reached.
-#[allow(dead_code)]
-pub type InvariantMap<State> = BTreeMap<BlockId, BlockInvariant<State>>;
-
-/// Costs for metered verification
-const ANALYZE_FUNCTION_BASE_COST: u128 = 10;
-const EXECUTE_BLOCK_BASE_COST: u128 = 10;
-const PER_BACKEDGE_COST: u128 = 10;
-const PER_SUCCESSOR_COST: u128 = 10;
-
-/// Take a pre-state + instruction and mutate it to produce a post-state
-/// Auxiliary data can be stored in self.
-pub trait TransferFunctions {
-    type State: AbstractDomain;
+pub trait AbstractInterpreter {
     type Error;
+    type BlockId: Copy + Ord;
+
+    type State: Clone;
+    type InstructionIndex: Copy + Ord;
+    type Instruction;
+
+    fn start(&mut self) -> Result<(), Self::Error>;
+    fn join(
+        &mut self,
+        pre: &mut Self::State,
+        post: &Self::State,
+    ) -> Result<JoinResult, Self::Error>;
+    fn visit_block_execution(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
+    fn visit_successor(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
+    fn visit_back_edge(
+        &mut self,
+        from: Self::BlockId,
+        to: Self::BlockId,
+    ) -> Result<(), Self::Error>;
 
     /// Execute local@instr found at index local@index in the current basic
     /// block from pre-state local@pre.
-    /// Should return an AnalysisError if executing the instruction is
-    /// unsuccessful, and () if the effects of successfully executing
-    /// local@instr have been reflected by mutatating local@pre.
+    /// Should return an Err if executing the instruction is unsuccessful, and
+    /// () if the effects of successfully executing local@instr have been
+    /// reflected by mutating local@pre.
     /// Auxiliary data from the analysis that is not part of the abstract state
     /// can be collected by mutating local@self.
     /// The last instruction index in the current block is local@last_index.
@@ -83,154 +47,107 @@ pub trait TransferFunctions {
     /// state before a join).
     fn execute(
         &mut self,
-        pre: &mut Self::State,
-        instr: &Bytecode,
-        index: CodeOffset,
-        last_index: CodeOffset,
-        meter: &mut (impl Meter + ?Sized),
-    ) -> PartialVMResult<()>;
+        state: &mut Self::State,
+        bounds: (Self::InstructionIndex, Self::InstructionIndex),
+        offset: Self::InstructionIndex,
+        instr: &Self::Instruction,
+    ) -> Result<(), Self::Error>;
 }
 
-pub trait AbstractInterpreter: TransferFunctions {
-    /// Analyze procedure local@function_context starting from pre-state
-    /// local@initial_state.
-    fn analyze_function(
-        &mut self,
-        initial_state: Self::State,
-        function_context: &FunctionContext,
-        meter: &mut (impl Meter + ?Sized),
-    ) -> PartialVMResult<()> {
-        meter.add(Scope::Function, ANALYZE_FUNCTION_BASE_COST)?;
-        let mut inv_map = InvariantMap::new();
-        let entry_block_id = function_context.cfg().entry_block_id();
-        let mut next_block = Some(entry_block_id);
-        inv_map.insert(entry_block_id, BlockInvariant { pre: initial_state });
+/// Analyze procedure local@function_context starting from pre-state
+/// local@initial_state.
+pub fn analyze_function<A, CFG>(
+    interpreter: &mut A,
+    cfg: &CFG,
+    code: &<CFG as ControlFlowGraph>::Instructions,
+    initial_state: A::State,
+) -> Result<(), A::Error>
+where
+    A: AbstractInterpreter,
+    CFG: ControlFlowGraph<
+            BlockId = A::BlockId,
+            InstructionIndex = A::InstructionIndex,
+            Instruction = A::Instruction,
+        >,
+{
+    interpreter.start()?;
+    let mut inv_map = BTreeMap::new();
+    let entry_block_id = cfg.entry_block_id();
+    let mut next_block = Some(entry_block_id);
+    inv_map.insert(entry_block_id, initial_state);
 
-        while let Some(block_id) = next_block {
-            let block_invariant = match inv_map.get_mut(&block_id) {
-                Some(invariant) => invariant,
-                None => {
-                    // This can only happen when all predecessors have errors,
-                    // so skip the block and move on to the next one
-                    next_block = function_context.cfg().next_block(block_id);
-                    continue;
-                }
-            };
+    while let Some(block_id) = next_block {
+        let block_invariant = match inv_map.get_mut(&block_id) {
+            Some(invariant) => invariant,
+            None => {
+                // This can only happen when all predecessors have errors,
+                // so skip the block and move on to the next one
+                next_block = cfg.next_block(block_id);
+                continue;
+            }
+        };
 
-            let pre_state = &block_invariant.pre;
-            // Note: this will stop analysis after the first error occurs, to avoid the risk
-            // of subsequent crashes
-            let post_state = self.execute_block(block_id, pre_state, function_context, meter)?;
+        let pre_state = &block_invariant;
+        // Note: this will stop analysis after the first error occurs, to avoid the risk
+        // of subsequent crashes
+        let post_state = execute_block(interpreter, cfg, code, block_id, pre_state)?;
 
-            let mut next_block_candidate = function_context.cfg().next_block(block_id);
-            // propagate postcondition of this block to successor blocks
-            for successor_block_id in function_context.cfg().successors(block_id) {
-                meter.add(Scope::Function, PER_SUCCESSOR_COST)?;
-                match inv_map.get_mut(successor_block_id) {
-                    Some(next_block_invariant) => {
-                        let join_result = {
-                            let old_pre = &mut next_block_invariant.pre;
-                            old_pre.join(&post_state, meter)
-                        }?;
-                        match join_result {
-                            JoinResult::Unchanged => {
-                                // Pre is the same after join. Reanalyzing this
-                                // block would produce
-                                // the same post
-                            }
-                            JoinResult::Changed => {
-                                // If the cur->successor is a back edge, jump back to the beginning
-                                // of the loop, instead of the normal next block
-                                if function_context
-                                    .cfg()
-                                    .is_back_edge(block_id, *successor_block_id)
-                                {
-                                    meter.add(Scope::Function, PER_BACKEDGE_COST)?;
-                                    next_block_candidate = Some(*successor_block_id);
-                                    break;
-                                }
+        let mut next_block_candidate = cfg.next_block(block_id);
+        // propagate postcondition of this block to successor blocks
+        for &successor_block_id in cfg.successors(block_id) {
+            interpreter.visit_successor(successor_block_id)?;
+            match inv_map.get_mut(&successor_block_id) {
+                Some(next_block_invariant) => {
+                    let join_result = interpreter.join(next_block_invariant, &post_state)?;
+                    match join_result {
+                        JoinResult::Unchanged => {
+                            // Pre is the same after join. Reanalyzing this
+                            // block would produce
+                            // the same post
+                        }
+                        JoinResult::Changed => {
+                            // If the cur->successor is a back edge, jump back to the beginning
+                            // of the loop, instead of the normal next block
+                            if cfg.is_back_edge(block_id, successor_block_id) {
+                                interpreter.visit_back_edge(block_id, successor_block_id)?;
+                                next_block_candidate = Some(successor_block_id);
+                                break;
                             }
                         }
                     }
-                    None => {
-                        // Haven't visited the next block yet. Use the post of the current block as
-                        // its pre
-                        inv_map.insert(
-                            *successor_block_id,
-                            BlockInvariant {
-                                pre: post_state.clone(),
-                            },
-                        );
-                    }
+                }
+                None => {
+                    // Haven't visited the next block yet. Use the post of the current block as
+                    // its pre
+                    inv_map.insert(successor_block_id, post_state.clone());
                 }
             }
-            next_block = next_block_candidate;
         }
-        Ok(())
+        next_block = next_block_candidate;
     }
-
-    fn execute_block(
-        &mut self,
-        block_id: BlockId,
-        pre_state: &Self::State,
-        function_context: &FunctionContext,
-        meter: &mut (impl Meter + ?Sized),
-    ) -> PartialVMResult<Self::State> {
-        meter.add(Scope::Function, EXECUTE_BLOCK_BASE_COST)?;
-        let mut state_acc = pre_state.clone();
-        let block_end = function_context.cfg().block_end(block_id);
-        for offset in function_context.cfg().instr_indexes(block_id) {
-            let instr = &function_context.code().code[offset as usize];
-            self.execute(&mut state_acc, instr, offset, block_end, meter)?
-        }
-        Ok(state_acc)
-    }
+    Ok(())
 }
 
-impl<'a> FunctionContext<'a> {
-    // Creates a `FunctionContext` for a module function.
-    pub fn new(
-        module: &'a CompiledModule,
-        index: FunctionDefinitionIndex,
-        code: &'a CodeUnit,
-        function_handle: &'a FunctionHandle,
-    ) -> Self {
-        Self {
-            index: Some(index),
-            code,
-            parameters: module.signature_at(function_handle.parameters),
-            return_: module.signature_at(function_handle.return_),
-            locals: module.signature_at(code.locals),
-            type_parameters: &function_handle.type_parameters,
-            cfg: VMControlFlowGraph::new(&code.code, &code.jump_tables),
-        }
+fn execute_block<A, CFG>(
+    interpreter: &mut A,
+    cfg: &CFG,
+    code: &<CFG as ControlFlowGraph>::Instructions,
+    block_id: A::BlockId,
+    pre_state: &A::State,
+) -> Result<A::State, A::Error>
+where
+    A: AbstractInterpreter,
+    CFG: ControlFlowGraph<
+            BlockId = A::BlockId,
+            InstructionIndex = A::InstructionIndex,
+            Instruction = A::Instruction,
+        >,
+{
+    interpreter.visit_block_execution(block_id)?;
+    let mut state_acc = pre_state.clone();
+    let bounds = (cfg.block_start(block_id), cfg.block_end(block_id));
+    for (offset, instr) in cfg.instructions(code, block_id) {
+        interpreter.execute(&mut state_acc, bounds, offset, instr)?
     }
-
-    pub fn index(&self) -> Option<FunctionDefinitionIndex> {
-        self.index
-    }
-
-    pub fn code(&self) -> &'a CodeUnit {
-        self.code
-    }
-
-    pub fn parameters(&self) -> &'a Signature {
-        self.parameters
-    }
-
-    pub fn return_(&self) -> &'a Signature {
-        self.return_
-    }
-
-    pub fn locals(&self) -> &'a Signature {
-        self.locals
-    }
-
-    pub fn type_parameters(&self) -> &'a [AbilitySet] {
-        self.type_parameters
-    }
-
-    pub fn cfg(&self) -> &VMControlFlowGraph {
-        &self.cfg
-    }
+    Ok(state_acc)
 }

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -6,69 +6,96 @@
 //! This module defines the control-flow graph uses for bytecode verification.
 use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 
-use move_binary_format::file_format::{Bytecode, CodeOffset, VariantJumpTable};
-
-// BTree/Hash agnostic type wrappers
-type Map<K, V> = BTreeMap<K, V>;
-type Set<V> = BTreeSet<V>;
-
-pub type BlockId = CodeOffset;
-
 /// A trait that specifies the basic requirements for a CFG
 pub trait ControlFlowGraph {
+    type BlockId: Copy + Ord;
+    type InstructionIndex: Copy + Ord;
+    type Instruction;
+    type Instructions: ?Sized;
+
     /// Start index of the block ID in the bytecode vector
-    fn block_start(&self, block_id: BlockId) -> CodeOffset;
+    fn block_start(&self, block_id: Self::BlockId) -> Self::InstructionIndex;
 
     /// End index of the block ID in the bytecode vector
-    fn block_end(&self, block_id: BlockId) -> CodeOffset;
+    fn block_end(&self, block_id: Self::BlockId) -> Self::InstructionIndex;
 
     /// Successors of the block ID in the bytecode vector
-    fn successors(&self, block_id: BlockId) -> &Vec<BlockId>;
+    fn successors(&self, block_id: Self::BlockId) -> &[Self::BlockId];
 
     /// Return the next block in traversal order
-    fn next_block(&self, block_id: BlockId) -> Option<BlockId>;
+    fn next_block(&self, block_id: Self::BlockId) -> Option<Self::BlockId>;
 
     /// Iterator over the indexes of instructions in this block
-    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>>;
+    fn instructions<'a>(
+        &self,
+        function_code: &'a Self::Instructions,
+        block_id: Self::BlockId,
+    ) -> impl IntoIterator<Item = (Self::InstructionIndex, &'a Self::Instruction)>
+    where
+        Self::Instruction: 'a;
 
     /// Return an iterator over the blocks of the CFG
-    fn blocks(&self) -> Vec<BlockId>;
+    fn blocks(&self) -> Vec<Self::BlockId>;
 
     /// Return the number of blocks (vertices) in the control flow graph
-    fn num_blocks(&self) -> u16;
+    fn num_blocks(&self) -> usize;
 
     /// Return the id of the entry block for this control-flow graph
     /// Note: even a CFG with no instructions has an (empty) entry block.
-    fn entry_block_id(&self) -> BlockId;
+    fn entry_block_id(&self) -> Self::BlockId;
 
     /// Checks if the block ID is a loop head
-    fn is_loop_head(&self, block_id: BlockId) -> bool;
+    fn is_loop_head(&self, block_id: Self::BlockId) -> bool;
 
     /// Checks if the edge from cur->next is a back edge
     /// returns false if the edge is not in the cfg
-    fn is_back_edge(&self, cur: BlockId, next: BlockId) -> bool;
+    fn is_back_edge(&self, cur: Self::BlockId, next: Self::BlockId) -> bool;
 
     /// Return the number of back edges in the cfg
     fn num_back_edges(&self) -> usize;
 }
 
-struct BasicBlock {
-    exit: CodeOffset,
-    successors: Vec<BlockId>,
+/// Used for the VM control flow graph
+pub trait Instruction: Sized {
+    type Index: Copy + Ord;
+    type VariantJumpTables: ?Sized;
+    const ENTRY_BLOCK_ID: Self::Index;
+
+    /// Return the successors of a given instruction
+    fn get_successors(
+        pc: Self::Index,
+        code: &[Self],
+        jump_tables: &Self::VariantJumpTables,
+    ) -> Vec<Self::Index>;
+
+    /// Return the offsets of jump targets for a given instruction
+    fn offsets(&self, jump_tables: &Self::VariantJumpTables) -> Vec<Self::Index>;
+
+    fn usize_as_index(i: usize) -> Self::Index;
+    fn index_as_usize(i: Self::Index) -> usize;
+
+    fn is_branch(&self) -> bool;
+}
+
+struct BasicBlock<InstructionIndex> {
+    exit: InstructionIndex,
+    successors: Vec<InstructionIndex>,
 }
 
 /// The control flow graph that we build from the bytecode.
-pub struct VMControlFlowGraph {
+/// Assumes a list of bytecode isntructions that satisfy the invariants
+/// specified in the VM's file format.
+pub struct VMControlFlowGraph<I: Instruction> {
     /// The basic blocks
-    blocks: Map<BlockId, BasicBlock>,
+    blocks: BTreeMap<I::Index, BasicBlock<I::Index>>,
     /// Basic block ordering for traversal
-    traversal_successors: Map<BlockId, BlockId>,
+    traversal_successors: BTreeMap<I::Index, I::Index>,
     /// Map of loop heads with all of their back edges
-    loop_heads: Map<BlockId, /* back edges */ Set<BlockId>>,
+    loop_heads: BTreeMap<I::Index, /* back edges */ BTreeSet<I::Index>>,
 }
 
-impl BasicBlock {
-    pub fn display(&self, entry: BlockId) {
+impl<InstructionIndex: std::fmt::Display + std::fmt::Debug> BasicBlock<InstructionIndex> {
+    pub fn display(&self, entry: InstructionIndex) {
         println!("+=======================+");
         println!("| Enter:  {}            |", entry);
         println!("+-----------------------+");
@@ -79,39 +106,34 @@ impl BasicBlock {
     }
 }
 
-const ENTRY_BLOCK_ID: BlockId = 0;
+impl<I: Instruction> VMControlFlowGraph<I> {
+    pub fn new(code: &[I], jump_tables: &I::VariantJumpTables) -> Self {
+        use std::collections::{BTreeMap as Map, BTreeSet as Set};
 
-impl VMControlFlowGraph {
-    pub fn new(code: &[Bytecode], jump_tables: &[VariantJumpTable]) -> Self {
-        let code_len = code.len() as CodeOffset;
+        let code_len = code.len();
         // First go through and collect block ids, i.e., offsets that begin basic
         // blocks. Need to do this first in order to handle backwards edges.
-        let mut block_ids = Set::new();
-        block_ids.insert(ENTRY_BLOCK_ID);
+        let mut block_ids = BTreeSet::new();
+        block_ids.insert(I::ENTRY_BLOCK_ID);
         for pc in 0..code.len() {
-            VMControlFlowGraph::record_block_ids(
-                pc as CodeOffset,
-                code,
-                jump_tables,
-                &mut block_ids,
-            );
+            VMControlFlowGraph::record_block_ids(pc, code, jump_tables, &mut block_ids);
         }
 
         // Create basic blocks
-        let mut blocks = Map::new();
+        let mut blocks: BTreeMap<I::Index, BasicBlock<I::Index>> = Map::new();
         let mut entry = 0;
         let mut exit_to_entry = Map::new();
         for pc in 0..code.len() {
-            let co_pc = pc as CodeOffset;
+            let co_pc = I::usize_as_index(pc);
 
             // Create a basic block
-            if Self::is_end_of_block(co_pc, code, &block_ids) {
+            if Self::is_end_of_block(pc, code, &block_ids) {
                 let exit = co_pc;
                 exit_to_entry.insert(exit, entry);
-                let successors = Bytecode::get_successors(co_pc, code, jump_tables);
+                let successors = I::get_successors(co_pc, code, jump_tables);
                 let bb = BasicBlock { exit, successors };
-                blocks.insert(entry, bb);
-                entry = co_pc + 1;
+                blocks.insert(I::usize_as_index(entry), bb);
+                entry = pc + 1;
             }
         }
         let blocks = blocks;
@@ -137,8 +159,8 @@ impl VMControlFlowGraph {
             Done,
         }
 
-        let mut exploration: Map<BlockId, Exploration> = Map::new();
-        let mut stack = vec![ENTRY_BLOCK_ID];
+        let mut exploration: Map<I::Index, Exploration> = Map::new();
+        let mut stack = vec![I::ENTRY_BLOCK_ID];
 
         // For every loop in the CFG that is reachable from the entry block, there is an
         // entry in `loop_heads` mapping to all the back edges pointing to it,
@@ -160,7 +182,7 @@ impl VMControlFlowGraph {
         //   loop (including `L`) will be visited while `F` is `InProgress`.
         // - Therefore, we will process the `L -> F` edge while `F` is `InProgress`.
         // - Therefore, we will record a back edge to it.
-        let mut loop_heads: Map<BlockId, Set<BlockId>> = Map::new();
+        let mut loop_heads: Map<I::Index, Set<I::Index>> = Map::new();
 
         // Blocks appear in `post_order` after all the blocks in their (non-reflexive)
         // sub-graph.
@@ -236,40 +258,43 @@ impl VMControlFlowGraph {
         }
     }
 
-    pub fn display(&self) {
+    pub fn display(&self)
+    where
+        I::Index: std::fmt::Debug + std::fmt::Display,
+    {
         for (entry, block) in &self.blocks {
             block.display(*entry);
         }
         println!("Traversal: {:#?}", self.traversal_successors);
     }
 
-    fn is_end_of_block(pc: CodeOffset, code: &[Bytecode], block_ids: &Set<BlockId>) -> bool {
-        pc + 1 == (code.len() as CodeOffset) || block_ids.contains(&(pc + 1))
+    fn is_end_of_block(pc: usize, code: &[I], block_ids: &BTreeSet<I::Index>) -> bool {
+        pc + 1 == code.len() || block_ids.contains(&I::usize_as_index(pc + 1))
     }
 
     fn record_block_ids(
-        pc: CodeOffset,
-        code: &[Bytecode],
-        jump_tables: &[VariantJumpTable],
-        block_ids: &mut Set<BlockId>,
+        pc: usize,
+        code: &[I],
+        jump_tables: &I::VariantJumpTables,
+        block_ids: &mut BTreeSet<I::Index>,
     ) {
-        let bytecode = &code[pc as usize];
+        let bytecode = &code[pc];
 
         block_ids.extend(bytecode.offsets(jump_tables));
 
-        if bytecode.is_branch() && pc + 1 < (code.len() as CodeOffset) {
-            block_ids.insert(pc + 1);
+        if bytecode.is_branch() && pc + 1 < code.len() {
+            block_ids.insert(I::usize_as_index(pc + 1));
         }
     }
 
     /// A utility function that implements BFS-reachability from block_id with
     /// respect to get_targets function
-    fn traverse_by(&self, block_id: BlockId) -> Vec<BlockId> {
+    fn traverse_by(&self, block_id: I::Index) -> Vec<I::Index> {
         let mut ret = Vec::new();
         // We use this index to keep track of our frontier.
         let mut index = 0;
         // Guard against cycles
-        let mut seen = Set::new();
+        let mut seen = BTreeSet::new();
 
         ret.push(block_id);
         seen.insert(&block_id);
@@ -289,12 +314,17 @@ impl VMControlFlowGraph {
         ret
     }
 
-    pub fn reachable_from(&self, block_id: BlockId) -> Vec<BlockId> {
+    pub fn reachable_from(&self, block_id: I::Index) -> Vec<I::Index> {
         self.traverse_by(block_id)
     }
 }
 
-impl ControlFlowGraph for VMControlFlowGraph {
+impl<I: Instruction> ControlFlowGraph for VMControlFlowGraph<I> {
+    type BlockId = I::Index;
+    type InstructionIndex = I::Index;
+    type Instruction = I;
+    type Instructions = [I];
+
     // Note: in the following procedures, it's safe not to check bounds because:
     // - Every CFG (even one with no instructions) has a block at ENTRY_BLOCK_ID
     // - The only way to acquire new BlockId's is via block_successors()
@@ -303,44 +333,53 @@ impl ControlFlowGraph for VMControlFlowGraph {
     // another CFG where it is not valid. The design does not attempt to prevent
     // this abuse of the API.
 
-    fn block_start(&self, block_id: BlockId) -> CodeOffset {
+    fn block_start(&self, block_id: Self::BlockId) -> I::Index {
         block_id
     }
 
-    fn block_end(&self, block_id: BlockId) -> CodeOffset {
+    fn block_end(&self, block_id: Self::BlockId) -> I::Index {
         self.blocks[&block_id].exit
     }
 
-    fn successors(&self, block_id: BlockId) -> &Vec<BlockId> {
+    fn successors(&self, block_id: Self::BlockId) -> &[Self::BlockId] {
         &self.blocks[&block_id].successors
     }
 
-    fn next_block(&self, block_id: BlockId) -> Option<CodeOffset> {
+    fn next_block(&self, block_id: Self::BlockId) -> Option<I::Index> {
         debug_assert!(self.blocks.contains_key(&block_id));
         self.traversal_successors.get(&block_id).copied()
     }
 
-    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>> {
-        Box::new(self.block_start(block_id)..=self.block_end(block_id))
+    fn instructions<'a>(
+        &self,
+        function_code: &'a [I],
+        block_id: Self::BlockId,
+    ) -> impl IntoIterator<Item = (Self::BlockId, &'a I)>
+    where
+        I: 'a,
+    {
+        let start = I::index_as_usize(self.block_start(block_id));
+        let end = I::index_as_usize(self.block_end(block_id));
+        (start..=end).map(|pc| (I::usize_as_index(pc), &function_code[pc]))
     }
 
-    fn blocks(&self) -> Vec<BlockId> {
+    fn blocks(&self) -> Vec<Self::BlockId> {
         self.blocks.keys().cloned().collect()
     }
 
-    fn num_blocks(&self) -> u16 {
-        self.blocks.len() as u16
+    fn num_blocks(&self) -> usize {
+        self.blocks.len()
     }
 
-    fn entry_block_id(&self) -> BlockId {
-        ENTRY_BLOCK_ID
+    fn entry_block_id(&self) -> Self::BlockId {
+        I::ENTRY_BLOCK_ID
     }
 
-    fn is_loop_head(&self, block_id: BlockId) -> bool {
+    fn is_loop_head(&self, block_id: Self::BlockId) -> bool {
         self.loop_heads.contains_key(&block_id)
     }
 
-    fn is_back_edge(&self, cur: BlockId, next: BlockId) -> bool {
+    fn is_back_edge(&self, cur: Self::BlockId, next: Self::BlockId) -> bool {
         self.loop_heads
             .get(&next)
             .is_some_and(|back_edges| back_edges.contains(&cur))

--- a/external-crates/move/crates/move-abstract-interpreter/src/lib.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/lib.rs
@@ -4,6 +4,3 @@
 
 pub mod absint;
 pub mod control_flow_graph;
-
-#[cfg(test)]
-mod unit_tests;

--- a/external-crates/move/crates/move-abstract-interpreter/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/unit_tests/mod.rs
@@ -1,5 +1,0 @@
-// Copyright (c) The Move Contributors
-// Modifications Copyright (c) 2025 IOTA Stiftung
-// SPDX-License-Identifier: Apache-2.0
-
-mod control_flow_graph_tests;

--- a/external-crates/move/crates/move-binary-format/Cargo.toml
+++ b/external-crates/move/crates/move-binary-format/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 variant_count.workspace = true
 
 # internal dependencies
+move-abstract-interpreter.workspace = true
 move-core-types.workspace = true
 
 [dev-dependencies]

--- a/external-crates/move/crates/move-binary-format/src/file_format.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format.rs
@@ -2366,6 +2366,37 @@ impl Bytecode {
     }
 }
 
+impl move_abstract_interpreter::control_flow_graph::Instruction for Bytecode {
+    type Index = CodeOffset;
+    type VariantJumpTables = [VariantJumpTable];
+
+    const ENTRY_BLOCK_ID: CodeOffset = 0;
+
+    fn get_successors(
+        pc: Self::Index,
+        code: &[Self],
+        jump_tables: &Self::VariantJumpTables,
+    ) -> Vec<Self::Index> {
+        Bytecode::get_successors(pc, code, jump_tables)
+    }
+
+    fn offsets(&self, jump_tables: &Self::VariantJumpTables) -> Vec<Self::Index> {
+        self.offsets(jump_tables)
+    }
+
+    fn usize_as_index(i: usize) -> Self::Index {
+        i as CodeOffset
+    }
+
+    fn index_as_usize(i: Self::Index) -> usize {
+        i as usize
+    }
+
+    fn is_branch(&self) -> bool {
+        self.is_branch()
+    }
+}
+
 /// A `CompiledModule` defines the structure of a module which is the unit of
 /// published code.
 ///

--- a/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
@@ -1,0 +1,194 @@
+// Copyright (c) The Move Contributors
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//**************************************************************************************************
+// New traits and public APIS
+//**************************************************************************************************
+pub use absint::JoinResult;
+use move_abstract_interpreter::{absint, control_flow_graph};
+use move_binary_format::{
+    CompiledModule,
+    errors::{PartialVMError, PartialVMResult},
+    file_format::{
+        AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,
+        Signature,
+    },
+};
+use move_bytecode_verifier_meter::{Meter, Scope};
+pub type VMControlFlowGraph = control_flow_graph::VMControlFlowGraph<Bytecode>;
+
+pub trait AbstractDomain: Clone + Sized {
+    fn join(
+        &mut self,
+        other: &Self,
+        meter: &mut (impl Meter + ?Sized),
+    ) -> PartialVMResult<JoinResult>;
+}
+
+pub trait TransferFunctions {
+    type State: AbstractDomain;
+
+    /// Execute local@instr found at index local@index in the current basic
+    /// block from pre-state local@pre.
+    /// Should return an Err if executing the instruction is unsuccessful, and
+    /// () if the effects of successfully executing local@instr have been
+    /// reflected by mutating local@pre.
+    /// Auxiliary data from the analysis that is not part of the abstract state
+    /// can be collected by mutating local@self.
+    /// The last instruction index in the current block is local@last_index.
+    /// Knowing this information allows clients to detect the end of a basic
+    /// block and special-case appropriately (e.g., normalizing the abstract
+    /// state before a join).
+    fn execute(
+        &mut self,
+        pre: &mut Self::State,
+        instr: &Bytecode,
+        index: CodeOffset,
+        bounds: (CodeOffset, CodeOffset),
+        meter: &mut (impl Meter + ?Sized),
+    ) -> PartialVMResult<()>;
+}
+
+pub fn analyze_function<TF: TransferFunctions, M: Meter + ?Sized>(
+    function_context: &FunctionContext,
+    meter: &mut M,
+    transfer_functions: &mut TF,
+    initial_state: TF::State,
+) -> Result<(), PartialVMError> {
+    let mut interpreter = AbstractInterpreter {
+        meter,
+        transfer_functions,
+    };
+    absint::analyze_function(
+        &mut interpreter,
+        &function_context.cfg,
+        &function_context.code.code,
+        initial_state,
+    )
+}
+
+/// A `FunctionContext` holds all the information needed by the verifier for
+/// `FunctionDefinition`.` A control flow graph is built for a function when the
+/// `FunctionContext` is created.
+pub struct FunctionContext<'a> {
+    index: Option<FunctionDefinitionIndex>,
+    code: &'a CodeUnit,
+    parameters: &'a Signature,
+    return_: &'a Signature,
+    locals: &'a Signature,
+    type_parameters: &'a [AbilitySet],
+    cfg: VMControlFlowGraph,
+}
+
+impl<'a> FunctionContext<'a> {
+    // Creates a `FunctionContext` for a module function.
+    pub fn new(
+        module: &'a CompiledModule,
+        index: FunctionDefinitionIndex,
+        code: &'a CodeUnit,
+        function_handle: &'a FunctionHandle,
+    ) -> Self {
+        Self {
+            index: Some(index),
+            code,
+            parameters: module.signature_at(function_handle.parameters),
+            return_: module.signature_at(function_handle.return_),
+            locals: module.signature_at(code.locals),
+            type_parameters: &function_handle.type_parameters,
+            cfg: VMControlFlowGraph::new(&code.code, &code.jump_tables),
+        }
+    }
+
+    pub fn index(&self) -> Option<FunctionDefinitionIndex> {
+        self.index
+    }
+
+    pub fn code(&self) -> &'a CodeUnit {
+        self.code
+    }
+
+    pub fn parameters(&self) -> &'a Signature {
+        self.parameters
+    }
+
+    pub fn return_(&self) -> &'a Signature {
+        self.return_
+    }
+
+    pub fn locals(&self) -> &'a Signature {
+        self.locals
+    }
+
+    pub fn type_parameters(&self) -> &'a [AbilitySet] {
+        self.type_parameters
+    }
+
+    pub fn cfg(&self) -> &VMControlFlowGraph {
+        &self.cfg
+    }
+}
+
+//**************************************************************************************************
+// Wrappers around shared absint and control flow graph implementations
+//**************************************************************************************************
+
+/// Costs for metered verification
+const ANALYZE_FUNCTION_BASE_COST: u128 = 10;
+const EXECUTE_BLOCK_BASE_COST: u128 = 10;
+const PER_BACKEDGE_COST: u128 = 10;
+const PER_SUCCESSOR_COST: u128 = 10;
+
+struct AbstractInterpreter<'a, M: Meter + ?Sized, TF: TransferFunctions> {
+    pub meter: &'a mut M,
+    pub transfer_functions: &'a mut TF,
+}
+
+impl<M: Meter + ?Sized, TF: TransferFunctions> absint::AbstractInterpreter
+    for AbstractInterpreter<'_, M, TF>
+{
+    type Error = PartialVMError;
+    type BlockId = CodeOffset;
+    type State = <TF as TransferFunctions>::State;
+    type InstructionIndex = CodeOffset;
+    type Instruction = Bytecode;
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        self.meter.add(Scope::Function, ANALYZE_FUNCTION_BASE_COST)
+    }
+
+    fn join(
+        &mut self,
+        pre: &mut Self::State,
+        post: &Self::State,
+    ) -> Result<absint::JoinResult, Self::Error> {
+        pre.join(post, self.meter)
+    }
+
+    fn visit_block_execution(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+        self.meter.add(Scope::Function, EXECUTE_BLOCK_BASE_COST)
+    }
+
+    fn visit_successor(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+        self.meter.add(Scope::Function, PER_SUCCESSOR_COST)
+    }
+
+    fn visit_back_edge(
+        &mut self,
+        _from: Self::BlockId,
+        _to: Self::BlockId,
+    ) -> Result<(), Self::Error> {
+        self.meter.add(Scope::Function, PER_BACKEDGE_COST)
+    }
+
+    fn execute(
+        &mut self,
+        state: &mut Self::State,
+        bounds: (Self::InstructionIndex, Self::InstructionIndex),
+        offset: Self::InstructionIndex,
+        instr: &Self::Instruction,
+    ) -> Result<(), Self::Error> {
+        self.transfer_functions
+            .execute(state, instr, offset, bounds, self.meter)
+    }
+}

--- a/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -103,7 +103,7 @@ fn verify_module_impl<'env>(
     Ok(())
 }
 
-fn verify_function<'env>(
+pub fn verify_function<'env>(
     verifier_config: &VerifierConfig,
     index: FunctionDefinitionIndex,
     function_definition: &'env FunctionDefinition,

--- a/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -9,7 +9,7 @@
 //! these two files.
 use std::collections::HashMap;
 
-use move_abstract_interpreter::{absint::FunctionContext, control_flow_graph::ControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
     IndexKind,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
@@ -22,8 +22,8 @@ use move_core_types::vm_status::StatusCode;
 use move_vm_config::verifier::VerifierConfig;
 
 use crate::{
-    ability_cache::AbilityCache, acquires_list_verifier::AcquiresVerifier, control_flow,
-    locals_safety, reference_safety, regex_reference_safety,
+    ability_cache::AbilityCache, absint::FunctionContext, acquires_list_verifier::AcquiresVerifier,
+    control_flow, locals_safety, reference_safety, regex_reference_safety,
     stack_usage_verifier::StackUsageVerifier, type_safety,
 };
 

--- a/external-crates/move/crates/move-bytecode-verifier/src/control_flow.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/control_flow.rs
@@ -15,7 +15,6 @@
 //! For bytecode versions 5 and below, delegates to `control_flow_v5`.
 use std::collections::BTreeSet;
 
-use move_abstract_interpreter::absint::FunctionContext;
 use move_binary_format::{
     CompiledModule,
     errors::{PartialVMError, PartialVMResult},
@@ -26,6 +25,7 @@ use move_core_types::vm_status::StatusCode;
 use move_vm_config::verifier::VerifierConfig;
 
 use crate::{
+    absint::FunctionContext,
     control_flow_v5,
     loop_summary::{LoopPartition, LoopSummary},
 };

--- a/external-crates/move/crates/move-bytecode-verifier/src/lib.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/lib.rs
@@ -10,6 +10,7 @@
 // Bounds checks are implemented in the `vm` crate.
 pub mod ability_cache;
 pub mod ability_field_requirements;
+pub mod absint;
 pub mod check_duplication;
 pub mod code_unit_verifier;
 pub mod constants;

--- a/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/abstract_state.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/abstract_state.rs
@@ -5,7 +5,6 @@
 
 //! This module defines the abstract state for the local safety analysis.
 
-use move_abstract_interpreter::absint::{AbstractDomain, FunctionContext, JoinResult};
 use move_binary_format::{
     CompiledModule,
     errors::{PartialVMError, PartialVMResult},
@@ -14,7 +13,10 @@ use move_binary_format::{
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
 
-use crate::ability_cache::AbilityCache;
+use crate::{
+    ability_cache::AbilityCache,
+    absint::{AbstractDomain, FunctionContext, JoinResult},
+};
 
 /// LocalState represents the current assignment state of a local
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -10,16 +10,18 @@
 mod abstract_state;
 
 use abstract_state::{AbstractState, LocalState, RET_COST, STEP_BASE_COST};
-use move_abstract_interpreter::absint::{AbstractInterpreter, FunctionContext, TransferFunctions};
 use move_binary_format::{
     CompiledModule,
-    errors::{PartialVMError, PartialVMResult},
+    errors::PartialVMResult,
     file_format::{Bytecode, CodeOffset},
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
 
-use crate::ability_cache::AbilityCache;
+use crate::{
+    ability_cache::AbilityCache,
+    absint::{FunctionContext, TransferFunctions, analyze_function},
+};
 
 pub(crate) fn verify<'a>(
     module: &CompiledModule,
@@ -28,7 +30,12 @@ pub(crate) fn verify<'a>(
     meter: &mut (impl Meter + ?Sized),
 ) -> PartialVMResult<()> {
     let initial_state = AbstractState::new(module, function_context, ability_cache, meter)?;
-    LocalsSafetyAnalysis().analyze_function(initial_state, function_context, meter)
+    analyze_function(
+        function_context,
+        meter,
+        &mut LocalsSafetyAnalysis(),
+        initial_state,
+    )
 }
 
 fn execute_inner(
@@ -178,18 +185,15 @@ struct LocalsSafetyAnalysis();
 
 impl TransferFunctions for LocalsSafetyAnalysis {
     type State = AbstractState;
-    type Error = PartialVMError;
 
     fn execute(
         &mut self,
         state: &mut Self::State,
         bytecode: &Bytecode,
         index: CodeOffset,
-        _last_index: CodeOffset,
+        _bounds: (CodeOffset, CodeOffset),
         meter: &mut (impl Meter + ?Sized),
     ) -> PartialVMResult<()> {
         execute_inner(state, bytecode, index, meter)
     }
 }
-
-impl AbstractInterpreter for LocalsSafetyAnalysis {}

--- a/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -4,9 +4,12 @@
 
 use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 
-use move_abstract_interpreter::control_flow_graph::{
-    BlockId, ControlFlowGraph, VMControlFlowGraph,
-};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
+use move_binary_format::file_format::CodeOffset;
+
+use crate::absint::VMControlFlowGraph;
+
+type BlockId = CodeOffset;
 
 /// Dense index into nodes in the same `LoopSummary`
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -81,7 +84,7 @@ impl LoopSummary {
             },
         }
 
-        let num_blocks = cfg.num_blocks() as usize;
+        let num_blocks = cfg.num_blocks();
 
         // Fields in LoopSummary that are filled via a depth-first traversal of `cfg`.
         let mut blocks = vec![0; num_blocks];

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -10,7 +10,6 @@ use std::{
     collections::{BTreeMap, BTreeSet},
 };
 
-use move_abstract_interpreter::absint::{AbstractDomain, FunctionContext, JoinResult};
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{
@@ -24,6 +23,8 @@ use move_borrow_graph::references::RefID;
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
 use move_vm_config::verifier::VerifierConfig;
+
+use crate::absint::{AbstractDomain, FunctionContext, JoinResult};
 
 type BorrowGraph = move_borrow_graph::graph::BorrowGraph<(), Label>;
 

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -17,7 +17,6 @@ use std::{
 };
 
 use abstract_state::{AbstractState, AbstractValue};
-use move_abstract_interpreter::absint::{AbstractInterpreter, FunctionContext, TransferFunctions};
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     CompiledModule,
@@ -33,7 +32,10 @@ use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
 use move_vm_config::verifier::VerifierConfig;
 
-use crate::reference_safety::abstract_state::STEP_BASE_COST;
+use crate::{
+    absint::{FunctionContext, TransferFunctions, analyze_function},
+    reference_safety::abstract_state::STEP_BASE_COST,
+};
 
 struct ReferenceSafetyAnalysis<'a> {
     config: &'a VerifierConfig,
@@ -80,7 +82,7 @@ pub(crate) fn verify<'a>(
     let initial_state = AbstractState::new(function_context);
 
     let mut verifier = ReferenceSafetyAnalysis::new(config, module, function_context, name_def_map);
-    verifier.analyze_function(initial_state, function_context, meter)
+    analyze_function(function_context, meter, &mut verifier, initial_state)
 }
 
 fn call(
@@ -567,14 +569,13 @@ fn execute_inner(
 
 impl TransferFunctions for ReferenceSafetyAnalysis<'_> {
     type State = AbstractState;
-    type Error = PartialVMError;
 
     fn execute(
         &mut self,
         state: &mut Self::State,
         bytecode: &Bytecode,
         index: CodeOffset,
-        last_index: CodeOffset,
+        (_first_index, last_index): (CodeOffset, CodeOffset),
         meter: &mut (impl Meter + ?Sized),
     ) -> PartialVMResult<()> {
         execute_inner(self, state, bytecode, index, meter)?;
@@ -585,5 +586,3 @@ impl TransferFunctions for ReferenceSafetyAnalysis<'_> {
         Ok(())
     }
 }
-
-impl AbstractInterpreter for ReferenceSafetyAnalysis<'_> {}

--- a/external-crates/move/crates/move-bytecode-verifier/src/regex_reference_safety/abstract_state.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/regex_reference_safety/abstract_state.rs
@@ -9,7 +9,6 @@ use std::{
     collections::{BTreeMap, BTreeSet},
 };
 
-use move_abstract_interpreter::absint::{AbstractDomain, FunctionContext, JoinResult};
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{
@@ -21,6 +20,8 @@ use move_binary_format::{
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
 use move_regex_borrow_graph::references::Ref;
+
+use crate::absint::{AbstractDomain, FunctionContext, JoinResult};
 
 type Graph = move_regex_borrow_graph::collections::Graph<(), Label>;
 type Paths = move_regex_borrow_graph::collections::Paths<(), Label>;

--- a/external-crates/move/crates/move-bytecode-verifier/src/regex_reference_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/regex_reference_safety/mod.rs
@@ -13,7 +13,6 @@ mod abstract_state;
 use std::num::NonZeroU64;
 
 use abstract_state::{AbstractState, AbstractValue};
-use move_abstract_interpreter::absint::{AbstractInterpreter, FunctionContext, TransferFunctions};
 use move_abstract_stack::{AbsStackError, AbstractStack};
 use move_binary_format::{
     CompiledModule,
@@ -28,7 +27,10 @@ use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
 
 use self::abstract_state::ValueKind;
-use crate::regex_reference_safety::abstract_state::STEP_BASE_COST;
+use crate::{
+    absint::{FunctionContext, TransferFunctions, analyze_function},
+    regex_reference_safety::abstract_state::STEP_BASE_COST,
+};
 
 struct ReferenceSafetyAnalysis<'a> {
     module: &'a CompiledModule,
@@ -68,7 +70,7 @@ pub fn verify(
     let initial_state = AbstractState::new(function_context)?;
 
     let mut verifier = ReferenceSafetyAnalysis::new(module, function_context);
-    verifier.analyze_function(initial_state, function_context, meter)
+    analyze_function(function_context, meter, &mut verifier, initial_state)
 }
 
 fn call(
@@ -532,14 +534,13 @@ fn execute_inner(
 
 impl TransferFunctions for ReferenceSafetyAnalysis<'_> {
     type State = AbstractState;
-    type Error = PartialVMError;
 
     fn execute(
         &mut self,
         state: &mut Self::State,
         bytecode: &Bytecode,
         index: CodeOffset,
-        last_index: CodeOffset,
+        (_first_index, last_index): (CodeOffset, CodeOffset),
         meter: &mut (impl Meter + ?Sized),
     ) -> PartialVMResult<()> {
         if self.needs_refresh {
@@ -558,5 +559,3 @@ impl TransferFunctions for ReferenceSafetyAnalysis<'_> {
         Ok(())
     }
 }
-
-impl AbstractInterpreter for ReferenceSafetyAnalysis<'_> {}

--- a/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -11,18 +11,21 @@
 //! the stack height by the number of values returned by the function as
 //! indicated in its signature. Additionally, the stack height must not dip
 //! below that at the beginning of the block for any basic block.
-use move_abstract_interpreter::{
-    absint::FunctionContext,
-    control_flow_graph::{BlockId, ControlFlowGraph},
-};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
     CompiledModule,
     errors::{PartialVMError, PartialVMResult},
-    file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation},
+    file_format::{
+        Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation,
+    },
 };
 use move_bytecode_verifier_meter::Meter;
 use move_core_types::vm_status::StatusCode;
 use move_vm_config::verifier::VerifierConfig;
+
+use crate::absint::{FunctionContext, VMControlFlowGraph};
+
+type BlockId = CodeOffset;
 
 pub(crate) struct StackUsageVerifier<'a> {
     module: &'a CompiledModule,
@@ -55,7 +58,7 @@ impl<'a> StackUsageVerifier<'a> {
         &self,
         config: &VerifierConfig,
         block_id: BlockId,
-        cfg: &dyn ControlFlowGraph,
+        cfg: &VMControlFlowGraph,
     ) -> PartialVMResult<()> {
         let code = &self.code.code;
         let mut stack_size_increment = 0;

--- a/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
@@ -9,7 +9,7 @@
 
 use std::{cmp::max, num::NonZeroU64};
 
-use move_abstract_interpreter::{absint::FunctionContext, control_flow_graph::ControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     CompiledModule,
@@ -25,7 +25,7 @@ use move_binary_format::{
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
 
-use crate::ability_cache::AbilityCache;
+use crate::{ability_cache::AbilityCache, absint::FunctionContext};
 
 struct Locals<'a> {
     param_count: usize,
@@ -157,12 +157,13 @@ pub(crate) fn verify<'env>(
 ) -> PartialVMResult<()> {
     let mut checker = TypeSafetyChecker::new(module, function_context, ability_cache);
     let verifier = &mut checker;
+    let jump_tables = &verifier.function_context.code().jump_tables;
 
     for block_id in function_context.cfg().blocks() {
-        for offset in function_context.cfg().instr_indexes(block_id) {
-            let code = &verifier.function_context.code();
-            let instr = &code.code[offset as usize];
-            let jump_tables = &code.jump_tables;
+        for (offset, instr) in function_context
+            .cfg()
+            .instructions(&function_context.code().code, block_id)
+        {
             verify_instr(verifier, instr, jump_tables, offset, meter)?
         }
     }

--- a/external-crates/move/crates/move-bytecode-verifier/src/verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/verifier.rs
@@ -87,6 +87,25 @@ pub fn verify_module_with_config_metered(
     meter: &mut (impl Meter + ?Sized),
 ) -> VMResult<()> {
     let ability_cache = &mut AbilityCache::new(module);
+    verify_module_with_config_metered_up_to_code_units(config, module, ability_cache, meter)?;
+    code_unit_verifier::verify_module(config, module, ability_cache, meter)?;
+
+    script_signature::verify_module(module, no_additional_script_signature_checks)
+}
+
+pub fn verify_module_with_config_unmetered(
+    config: &VerifierConfig,
+    module: &CompiledModule,
+) -> VMResult<()> {
+    verify_module_with_config_metered(config, module, &mut DummyMeter)
+}
+
+pub fn verify_module_with_config_metered_up_to_code_units<'env>(
+    config: &'env VerifierConfig,
+    module: &'env CompiledModule,
+    ability_cache: &mut AbilityCache<'env>,
+    meter: &mut (impl Meter + ?Sized),
+) -> VMResult<()> {
     BoundsChecker::verify_module(module).map_err(|e| {
         // We can't point the error at the module, because if bounds-checking
         // failed, we cannot safely index into module's handle to itself.
@@ -101,14 +120,5 @@ pub fn verify_module_with_config_metered(
     ability_field_requirements::verify_module(module, ability_cache, meter)?;
     RecursiveDataDefChecker::verify_module(module)?;
     InstantiationLoopChecker::verify_module(module)?;
-    code_unit_verifier::verify_module(config, module, ability_cache, meter)?;
-
-    script_signature::verify_module(module, no_additional_script_signature_checks)
-}
-
-pub fn verify_module_with_config_unmetered(
-    config: &VerifierConfig,
-    module: &CompiledModule,
-) -> VMResult<()> {
-    verify_module_with_config_metered(config, module, &mut DummyMeter)
+    Ok(())
 }

--- a/external-crates/move/crates/move-coverage/src/summary.rs
+++ b/external-crates/move/crates/move-coverage/src/summary.rs
@@ -10,9 +10,7 @@ use std::{
     io::{self, Write},
 };
 
-use move_abstract_interpreter::control_flow_graph::{
-    BlockId, ControlFlowGraph, VMControlFlowGraph,
-};
+use move_abstract_interpreter::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
 use move_binary_format::{
     CompiledModule,
     file_format::{Bytecode, CodeOffset},
@@ -24,6 +22,8 @@ use serde::{Deserialize, Serialize};
 use crate::coverage_map::{
     ExecCoverageMap, ExecCoverageMapWithModules, ModuleCoverageMap, TraceMap,
 };
+
+type BlockId = CodeOffset;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ModuleSummary {

--- a/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
@@ -3,8 +3,9 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use move_abstract_interpreter::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::file_format::{Bytecode, VariantJumpTable};
+use move_bytecode_verifier::absint::VMControlFlowGraph;
 
 use crate::unit_tests::testutils::compile_module_string;
 
@@ -277,7 +278,7 @@ fn cfg_compile_if_else_with_two_aborts() {
 #[test]
 fn cfg_compile_variant_switch_simple() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X has drop { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -291,7 +292,7 @@ fn cfg_compile_variant_switch_simple() {
                 return;
             label b1:
                 return;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
@@ -304,7 +305,7 @@ fn cfg_compile_variant_switch_simple() {
 #[test]
 fn cfg_compile_variant_switch_simple_unconditional_jump() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X has drop { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -315,13 +316,13 @@ fn cfg_compile_variant_switch_simple_unconditional_jump() {
                     V2 : b1,
                 };
             // This block is unreachable because `variant_switch` is an unconditional jump.
-            label fallthrough: 
+            label fallthrough:
                 return;
             label b0:
                 return;
             label b1:
                 return;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
@@ -334,7 +335,7 @@ fn cfg_compile_variant_switch_simple_unconditional_jump() {
 #[test]
 fn cfg_compile_variant_switch() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -354,10 +355,10 @@ fn cfg_compile_variant_switch() {
                 jump b3;
             label b3:
                 return;
-            label b4: 
+            label b4:
                 X.V2 {} = move(x);
                 jump b3;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
@@ -370,7 +371,7 @@ fn cfg_compile_variant_switch() {
 #[test]
 fn cfg_compile_variant_switch_with_two_aborts() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -390,10 +391,10 @@ fn cfg_compile_variant_switch_with_two_aborts() {
                 jump b3;
             label b3:
                 return;
-            label b4: 
+            label b4:
                 X.V2 {} = move(x);
                 abort 0;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
@@ -406,7 +407,7 @@ fn cfg_compile_variant_switch_with_two_aborts() {
 #[test]
 fn cfg_compile_variant_switch_with_return() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -432,10 +433,10 @@ fn cfg_compile_variant_switch_with_return() {
                 jump b3;
             label b3:
                 return;
-            label b4: 
+            label b4:
                 X.V2 {} = move(x);
                 abort 0;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);

--- a/iota-execution/latest/iota-verifier/Cargo.toml
+++ b/iota-execution/latest/iota-verifier/Cargo.toml
@@ -14,10 +14,10 @@ bcs.workspace = true
 # internal dependencies
 iota-sdk-types.workspace = true
 iota-types.workspace = true
-move-abstract-interpreter = { path = "../../../external-crates/move/crates/move-abstract-interpreter" }
 move-abstract-stack.workspace = true
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
+move-bytecode-verifier = { path = "../../../external-crates/move/crates/move-bytecode-verifier" }
 move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true

--- a/iota-execution/latest/iota-verifier/src/id_leak_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/id_leak_verifier.rs
@@ -19,9 +19,6 @@ use iota_types::{
     GENESIS_BRIDGE_ADDRESS, IOTA_FRAMEWORK_ADDRESS, IOTA_SYSTEM_ADDRESS,
     error::{ExecutionError, VMMVerifierErrorSubStatusCode},
 };
-use move_abstract_interpreter::absint::{
-    AbstractDomain, AbstractInterpreter, FunctionContext, JoinResult, TransferFunctions,
-};
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     errors::PartialVMError,
@@ -29,6 +26,9 @@ use move_binary_format::{
         Bytecode, CodeOffset, CompiledModule, FunctionDefinitionIndex, FunctionHandle, LocalIndex,
         StructDefinition, StructFieldInformation,
     },
+};
+use move_bytecode_verifier::absint::{
+    AbstractDomain, FunctionContext, JoinResult, TransferFunctions, analyze_function,
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::{
@@ -133,17 +133,16 @@ fn verify_id_leak(
             None => continue,
         };
         let handle = module.function_handle_at(func_def.function);
-        let func_view =
+        let function_context =
             FunctionContext::new(module, FunctionDefinitionIndex(index as u16), code, handle);
-        let initial_state = AbstractState::new(&func_view);
-        let mut verifier = IDLeakAnalysis::new(module, &func_view);
+        let initial_state = AbstractState::new(&function_context);
+        let mut verifier = IDLeakAnalysis::new(module, &function_context);
         let function_to_verify = verifier.cur_function();
         if FUNCTIONS_TO_SKIP.contains(&function_to_verify) {
             continue;
         }
-        verifier
-            .analyze_function(initial_state, &func_view, meter)
-            .map_err(|err| {
+        analyze_function(&function_context, meter, &mut verifier, initial_state).map_err(
+            |err| {
                 // Handle verification timeout specially
                 if check_for_verifier_timeout(&err.major_status()) {
                     to_verification_timeout_error(err.to_string())
@@ -157,7 +156,8 @@ fn verify_id_leak(
                 } else {
                     verification_failure(err.to_string())
                 }
-            })?;
+            },
+        )?;
     }
 
     Ok(())
@@ -266,7 +266,6 @@ impl<'a> IDLeakAnalysis<'a> {
 }
 
 impl TransferFunctions for IDLeakAnalysis<'_> {
-    type Error = ExecutionError;
     type State = AbstractState;
 
     fn execute(
@@ -274,7 +273,7 @@ impl TransferFunctions for IDLeakAnalysis<'_> {
         state: &mut Self::State,
         bytecode: &Bytecode,
         index: CodeOffset,
-        last_index: CodeOffset,
+        (_first_index, last_index): (u16, u16),
         meter: &mut (impl Meter + ?Sized),
     ) -> Result<(), PartialVMError> {
         execute_inner(self, state, bytecode, index, meter)?;
@@ -292,8 +291,6 @@ impl TransferFunctions for IDLeakAnalysis<'_> {
         Ok(())
     }
 }
-
-impl AbstractInterpreter for IDLeakAnalysis<'_> {}
 
 fn call(
     verifier: &mut IDLeakAnalysis,


### PR DESCRIPTION
# Description of change

Ports the upstream generalization of `move-abstract-interpreter` so the fixpoint engine no longer depends on the Move file format or the verifier's gas meter, plus the small verifier API opening that precedes it.

- `move-abstract-interpreter` drops all dependencies; its `ControlFlowGraph` trait gains associated types and a new `Instruction` trait abstracts the bytecode.
- `move-binary-format` implements `Instruction for Bytecode` (dependency direction inverted).
- New `move-bytecode-verifier/src/absint.rs` re-erects the verifier-facing API (`FunctionContext`, `AbstractDomain`, `TransferFunctions`, `analyze_function`) and owns the metering.
- No runtime or protocol behavior change.

## Upstream commits

| Commit | Upstream PR | Description |
|---|---|---|
| `7a0cdb27a710445d25dd51d375dc324a8241d8e9` | #21573 | [bytecode-verifier] Ready for internal analyzer tool in the nursery |
| `56dd0d68df0a891c615d462fa4ade923acd9fe2b` | #21574 | [move-abstract-interpreter] Make move-abstract-interpreter more general |

### Skipped

| Commit | Upstream PR | Reason |
|---|---|---|
| `73c7bd5936425952ddaace9f6fae12e65c8b85bc` | #21928 | Already ported downstream in `e4aae13611` (#11228), which brought in the whole `move-regex-borrow-graph` crate together with the later `regex_reference_safety` pass. All six source files match after normalizing comments, whitespace and import order; the only substantive differences are three pre-existing adaptations in `collections.rs` (`successors`/`predecessors`) forced by petgraph 0.5.1, which has no `GraphMap::edges_directed`. Workspace wiring is present in both `Cargo.toml`s. |

## Downstream adaptations

| File | Adaptation | Reason |
|---|---|---|
| `move-bytecode-verifier/src/regex_reference_safety/{mod,abstract_state}.rs` | Repointed to `crate::absint`; dropped `type Error` and the `AbstractInterpreter` marker impl; `last_index` → `bounds` tuple; free `analyze_function` | IOTA-only verifier pass (from #11228) that upstream did not have at #21574; same shape the patch applies to `reference_safety` |
| `bytecode-verifier-tests/src/unit_tests/control_flow_graph_tests.rs` | Import `move_bytecode_verifier::absint::VMControlFlowGraph` + the `ControlFlowGraph` trait; kept `VMControlFlowGraph::new` call sites; `fn traversal(cfg: &VMControlFlowGraph) -> Vec<CodeOffset>` | The patch's version cannot compile: it imports from `move_bytecode_verifier_meter::absint` (no such module) and leaves `&dyn ControlFlowGraph` / `BlockId` behind, while the trait is no longer object-safe and the alias is gone. Upstream never declares the module, so the file is dead there |
| `bytecode-verifier-tests/src/unit_tests/mod.rs`, `Cargo.toml` | Added `pub mod control_flow_graph_tests;` and the `itertools` dev-dep | Without it the moved tests are never compiled or run |
| `move-coverage/Cargo.toml` | Did **not** add `move-bytecode-verifier` | The patch adds it for `src/lcov.rs`, which IOTA does not have; `cargo machete` flags it as unused |
| `move-abstract-interpreter/Cargo.toml` | Removed the `itertools` dev-dep | Its only test file moved out; the crate now has no dependencies at all, which is the point of the change |
| `move-package-alt/src/mocks/mock-resolver-2.rs`, `move-package/tests/test_sources/test_symlinks/sources/M.move` | No change | The patch's `100644 => 120000` hunks are Slipstreamer artifacts; both are already symlinks with identical targets (verified by blob hash) |
| `Cargo.lock`, `external-crates/move/Cargo.lock` | Regenerated | Filtered out of the Slipstreamer patch |
| Copyright headers | New `move-bytecode-verifier/src/absint.rs` gets 2026; existing files keep their current year | Did not take Slipstreamer's 2024→2025 bumps, matching prior ports on this branch |

## Links to any relevant issues

Closes #10830

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

- `cargo check --all-targets --workspace` in `external-crates/move` and `cargo check -p iota-verifier-latest --all-targets` — clean
- `cargo nextest run` on `bytecode-verifier-tests`, `bytecode-verifier-transactional-tests`, `move-ir-compiler`, `move-coverage`, `move-abstract-interpreter`, `move-binary-format`, `move-bytecode-verifier` — 545 passed
- `cargo nextest run -p iota-verifier-latest -p iota-adapter-latest` — 21 passed
- The 7 revived `control_flow_graph_tests` pass, including `out_of_order_blocks_variant_switch` (2000 jump-table permutations through the now-generic CFG construction)
- `cargo +nightly fmt --all`, `cargo machete`, `cargo ci-license` — clean

`cargo ci-clippy` does not pass on this branch and did not before these commits (it fails first in `move-core-types/src/resolver.rs`, untouched here); every clippy finding in the crates touched by this PR is at a line it does not modify.
