### PR TITLE
feat(iota): build transfer and pay transactions over gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5499,6 +5499,8 @@ dependencies = [
  "iota-protocol-config",
  "iota-sdk",
  "iota-sdk-crypto",
+ "iota-sdk-grpc-client",
+ "iota-sdk-transaction-builder",
  "iota-sdk-types",
  "iota-simulator",
  "iota-source-validation",
@@ -7514,7 +7516,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "bech32 0.11.1",
  "bip32",
@@ -7539,7 +7541,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7568,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7576,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7595,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7611,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7630,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,9 +400,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "475b0de92e4b9e3115367382e1bba56630b785b9" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "475b0de92e4b9e3115367382e1bba56630b785b9" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -441,10 +441,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 iota-grpc-client = { workspace = true, optional = true }
 iota-grpc-types = { workspace = true, optional = true }
 iota-sdk-crypto = { workspace = true, optional = true }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", optional = true }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false, optional = true }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda", optional = true }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda", default-features = false, optional = true }
 iota-sdk-types = { workspace = true, optional = true }
 
 [features]

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -52,6 +52,7 @@ iota-common.workspace = true
 iota-config.workspace = true
 iota-execution.workspace = true
 iota-genesis-builder.workspace = true
+iota-grpc-client.workspace = true
 iota-json.workspace = true
 iota-json-rpc-types.workspace = true
 iota-keys.workspace = true
@@ -64,6 +65,7 @@ iota-package-management.workspace = true
 iota-protocol-config.workspace = true
 iota-sdk.workspace = true
 iota-sdk-crypto = { workspace = true, features = ["ed25519"] }
+iota-sdk-transaction-builder.workspace = true
 iota-sdk-types.workspace = true
 iota-source-validation.workspace = true
 iota-types.workspace = true
@@ -100,6 +102,9 @@ toml.workspace = true
 iota-faucet.workspace = true
 iota-macros.workspace = true
 iota-metrics.workspace = true
+# `test-client` provides the in-memory `TestClient` the transaction-building
+# unit tests resolve their object inputs against.
+iota-sdk-transaction-builder = { workspace = true, features = ["test-client"] }
 iota-simulator.workspace = true
 iota-swarm-config.workspace = true
 iota-test-transaction-builder.workspace = true

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -47,6 +47,7 @@ use iota_sdk::{
     iota_client_config::{IotaClientConfig, IotaEnv},
     wallet_context::WalletContext,
 };
+use iota_sdk_transaction_builder::TransactionBuilder;
 use iota_sdk_types::{
     Address, Identifier, MoveAuthenticatorV1, ObjectId, ObjectReference, Owner,
     SharedObjectReference, SignatureScheme, TransactionDigest, TransactionKind, TypeTag,
@@ -107,6 +108,7 @@ use crate::{
     clever_error_rendering::render_clever_error_opt,
     client_ptb::ptb::{PTB, PTBCommandResult},
     displays::Pretty,
+    grpc_transaction_builder::{TransactionBuilderExt, input_refs},
     key_identity::{KeyIdentity, get_identity_address, get_identity_address_from_keystore},
     keytool::Key,
     signing::{SignData, get_shared_object_version, sign_secure, sign_transaction},
@@ -1362,16 +1364,12 @@ impl IotaClientCommands {
             } => {
                 let signer = context.get_object_owner(&object_id).await?;
                 let to = get_identity_address(Some(to), context).await?;
-                let client = context.get_client().await?;
-                let tx_kind = client
-                    .transaction_builder()
-                    .transfer_object_tx_kind(object_id, to)
-                    .await?;
+                let grpc_client = context.get_grpc_client().await?;
+                let mut builder = TransactionBuilder::new(signer).with_client(&grpc_client);
+                builder.transfer_objects(to, vec![object_id]);
+                let tx_kind = builder.finish_kind().await?;
 
-                let gas_payment = client
-                    .transaction_builder()
-                    .input_refs(&payment.gas)
-                    .await?;
+                let gas_payment = input_refs(&grpc_client, &payment.gas).await?;
 
                 dry_run_or_execute_or_serialize(
                     signer,
@@ -1412,21 +1410,17 @@ impl IotaClientCommands {
                     .try_collect::<Vec<Address>>()
                     .await?;
                 let signer = context.get_object_owner(&input_coins[0]).await?;
-                let client = context.get_client().await?;
-                let tx_kind = client
-                    .transaction_builder()
-                    .pay_tx_kind(input_coins.clone(), recipients.clone(), amounts.clone())
-                    .await?;
+                let grpc_client = context.get_grpc_client().await?;
+                let mut builder = TransactionBuilder::new(signer).with_client(&grpc_client);
+                builder.pay(&input_coins, &recipients, &amounts)?;
+                let tx_kind = builder.finish_kind().await?;
 
                 ensure!(
                     !payment.gas.iter().any(|gas| input_coins.contains(gas)),
                     "Gas coin is in input coins of `pay` command, use `pay-iota` instead!"
                 );
 
-                let gas_payment = client
-                    .transaction_builder()
-                    .input_refs(&payment.gas)
-                    .await?;
+                let gas_payment = input_refs(&grpc_client, &payment.gas).await?;
 
                 dry_run_or_execute_or_serialize(
                     signer,
@@ -1468,10 +1462,10 @@ impl IotaClientCommands {
                     .await?;
                 let signer =
                     get_identity_address(processing.sender.map(Into::into), context).await?;
-                let client = context.get_client().await?;
-                let tx_kind = client
-                    .transaction_builder()
-                    .pay_iota_tx_kind(recipients, amounts.clone())?;
+                let grpc_client = context.get_grpc_client().await?;
+                let mut builder = TransactionBuilder::new(signer).with_client(&grpc_client);
+                builder.pay_iota(&recipients, &amounts)?;
+                let tx_kind = builder.finish_kind().await?;
 
                 let input_coins = if let Some(coins) = input_coins {
                     coins
@@ -1501,10 +1495,7 @@ impl IotaClientCommands {
                     .await?
                 };
 
-                let gas_payment = client
-                    .transaction_builder()
-                    .input_refs(&input_coins)
-                    .await?;
+                let gas_payment = input_refs(&grpc_client, &input_coins).await?;
 
                 dry_run_or_execute_or_serialize(
                     signer,
@@ -1528,13 +1519,12 @@ impl IotaClientCommands {
                 );
                 let recipient = get_identity_address(Some(recipient), context).await?;
                 let signer = context.get_object_owner(&input_coins[0]).await?;
-                let client = context.get_client().await?;
-                let tx_kind = client.transaction_builder().pay_all_iota_tx_kind(recipient);
+                let grpc_client = context.get_grpc_client().await?;
+                let mut builder = TransactionBuilder::new(signer).with_client(&grpc_client);
+                builder.pay_all_iota(recipient);
+                let tx_kind = builder.finish_kind().await?;
 
-                let gas_payment = client
-                    .transaction_builder()
-                    .input_refs(&input_coins)
-                    .await?;
+                let gas_payment = input_refs(&grpc_client, &input_coins).await?;
 
                 dry_run_or_execute_or_serialize(
                     signer,

--- a/crates/iota/src/grpc_transaction_builder.rs
+++ b/crates/iota/src/grpc_transaction_builder.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transaction building for the client commands over the gRPC client.
+//!
+//! [`TransactionBuilderExt`] adds the transaction shapes the client commands
+//! need to the SDK [`TransactionBuilder`], mirroring the `*_tx_kind` helpers of
+//! the JSON-RPC [`iota_transaction_builder::TransactionBuilder`]. The builder
+//! resolves the object inputs itself; finish it with
+//! [`finish_kind`](TransactionBuilder::finish_kind), which leaves the gas alone
+//! because the client commands select it themselves.
+
+#[cfg(test)]
+#[path = "unit_tests/grpc_transaction_builder_tests.rs"]
+mod grpc_transaction_builder_tests;
+
+use anyhow::{bail, ensure};
+use iota_grpc_client::{Client, ReadMask, read_mask_fields::ObjectField};
+use iota_sdk_transaction_builder::{
+    TransactionBuilder, TransactionBuilderClient, unresolved::Argument,
+};
+use iota_sdk_types::{Address, ObjectId, ObjectReference};
+
+/// Resolve `object_ids` to the [`ObjectReference`]s of their current versions,
+/// keeping the given order.
+///
+/// The client commands need these for the gas payment, which they pass to
+/// `dry_run_or_execute_or_serialize` rather than to the builder.
+pub(crate) async fn input_refs(
+    client: &Client,
+    object_ids: &[ObjectId],
+) -> Result<Vec<ObjectReference>, anyhow::Error> {
+    if object_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let requests: Vec<_> = object_ids.iter().map(|id| (*id, None)).collect();
+    let objects = client
+        .get_objects(&requests, Some(ReadMask::from(ObjectField::REFERENCE)))
+        .await?
+        .into_inner();
+    objects
+        .iter()
+        .map(|object| object.object_reference().map_err(anyhow::Error::from))
+        .collect()
+}
+
+/// The transaction shapes the client commands build, as an extension of the SDK
+/// [`TransactionBuilder`].
+pub(crate) trait TransactionBuilderExt {
+    /// Merge `input_coins` into the first of them and pay `amounts` to
+    /// `recipients` out of it.
+    ///
+    /// Errors if `input_coins` is empty, or if `recipients` and `amounts` are
+    /// empty or differ in length.
+    fn pay(
+        &mut self,
+        input_coins: &[ObjectId],
+        recipients: &[Address],
+        amounts: &[u64],
+    ) -> Result<&mut Self, anyhow::Error>;
+
+    /// Pay `amounts` to `recipients` out of the gas coin.
+    ///
+    /// Errors if `recipients` and `amounts` are empty or differ in length.
+    fn pay_iota(
+        &mut self,
+        recipients: &[Address],
+        amounts: &[u64],
+    ) -> Result<&mut Self, anyhow::Error>;
+
+    /// Transfer the whole gas coin to `recipient`.
+    fn pay_all_iota(&mut self, recipient: Address) -> &mut Self;
+}
+
+impl<C: TransactionBuilderClient> TransactionBuilderExt for TransactionBuilder<C> {
+    fn pay(
+        &mut self,
+        input_coins: &[ObjectId],
+        recipients: &[Address],
+        amounts: &[u64],
+    ) -> Result<&mut Self, anyhow::Error> {
+        let coin_args = self.apply_arguments(input_coins.to_vec());
+        let Some((&primary_coin, coins_to_merge)) = coin_args.split_first() else {
+            bail!("Pay transaction requires a non-empty list of input coins");
+        };
+        if !coins_to_merge.is_empty() {
+            self.merge_coins(primary_coin, coins_to_merge.to_vec());
+        }
+        pay_from(self, primary_coin, recipients, amounts)
+    }
+
+    fn pay_iota(
+        &mut self,
+        recipients: &[Address],
+        amounts: &[u64],
+    ) -> Result<&mut Self, anyhow::Error> {
+        pay_from(self, Argument::Gas, recipients, amounts)
+    }
+
+    fn pay_all_iota(&mut self, recipient: Address) -> &mut Self {
+        self.transfer_objects(recipient, vec![Argument::Gas])
+    }
+}
+
+/// Split `amounts` off `coin` and transfer each split coin to the recipient at
+/// the same index. Repeated recipients are transferred to in a single command.
+fn pay_from<'b, C: TransactionBuilderClient>(
+    builder: &'b mut TransactionBuilder<C>,
+    coin: Argument,
+    recipients: &[Address],
+    amounts: &[u64],
+) -> Result<&'b mut TransactionBuilder<C>, anyhow::Error> {
+    ensure!(
+        recipients.len() == amounts.len(),
+        "Found {} recipient addresses, but {} recipient amounts",
+        recipients.len(),
+        amounts.len(),
+    );
+    ensure!(!amounts.is_empty(), "No amounts to pay");
+
+    let Argument::Result(split) = builder.split_coins(coin, amounts.to_vec()).arg() else {
+        unreachable!("`split_coins` adds a command, so its argument is a command result");
+    };
+
+    let mut per_recipient: Vec<(Address, Vec<Argument>)> = Vec::new();
+    for (i, recipient) in recipients.iter().enumerate() {
+        let split_coin = Argument::NestedResult(split, i as u16);
+        match per_recipient.iter_mut().find(|(r, _)| r == recipient) {
+            Some((_, coins)) => coins.push(split_coin),
+            None => per_recipient.push((*recipient, vec![split_coin])),
+        }
+    }
+    for (recipient, coins) in per_recipient {
+        builder.transfer_objects(recipient, coins);
+    }
+    Ok(builder)
+}

--- a/crates/iota/src/lib.rs
+++ b/crates/iota/src/lib.rs
@@ -10,6 +10,7 @@ mod clever_error_rendering;
 #[cfg(feature = "gen-completions")]
 mod completions;
 pub mod displays;
+mod grpc_transaction_builder;
 pub mod iota_commands;
 pub mod key_identity;
 pub mod keytool;

--- a/crates/iota/src/unit_tests/grpc_transaction_builder_tests.rs
+++ b/crates/iota/src/unit_tests/grpc_transaction_builder_tests.rs
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! The transaction kinds built by this module have to stay identical to the
+//! ones the JSON-RPC `iota_transaction_builder::TransactionBuilder` produces.
+//! Its `*_tx_kind` helpers all delegate to [`ProgrammableTransactionBuilder`]
+//! once the object references are resolved, so these tests rebuild the expected
+//! programmable transaction with it and compare.
+//!
+//! Object inputs resolve against [`TestClient`], which fabricates an
+//! address-owned coin per id, so the expected references are read back from
+//! that same client.
+
+use iota_sdk_transaction_builder::TestClient;
+use iota_sdk_types::TransactionKind;
+use iota_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+
+use super::*;
+
+fn address(byte: u8) -> Address {
+    Address::new([byte; Address::LENGTH])
+}
+
+fn object_id(byte: u8) -> ObjectId {
+    ObjectId::new([byte; ObjectId::LENGTH])
+}
+
+fn builder() -> TransactionBuilder<TestClient> {
+    TransactionBuilder::new(address(1)).with_client(TestClient)
+}
+
+/// The reference [`TestClient`] resolves `object_id` to.
+async fn object_ref(object_id: ObjectId) -> ObjectReference {
+    let object = TestClient
+        .object(object_id, None)
+        .await
+        .expect("the test client fabricates every object")
+        .expect("the test client never reports an object as missing");
+    ObjectReference::new(object_id, object.version(), object.digest())
+}
+
+#[tokio::test]
+async fn pay_matches_json_rpc_builder() {
+    let coins = [object_id(3), object_id(4), object_id(5)];
+    // A repeated recipient has to end up in a single transfer command, and a
+    // repeated amount in a single pure input.
+    let recipients = [address(6), address(7), address(6)];
+    let amounts = [100, 200, 100];
+
+    let mut coin_refs = Vec::new();
+    for coin in coins {
+        coin_refs.push(object_ref(coin).await);
+    }
+    let mut expected = ProgrammableTransactionBuilder::new();
+    expected
+        .pay(coin_refs, recipients.to_vec(), amounts.to_vec())
+        .unwrap();
+
+    let mut builder = builder();
+    builder.pay(&coins, &recipients, &amounts).unwrap();
+
+    assert_eq!(
+        builder.finish_kind().await.unwrap(),
+        TransactionKind::new_programmable(expected.finish()),
+    );
+}
+
+#[tokio::test]
+async fn pay_with_a_single_coin_matches_json_rpc_builder() {
+    let coins = [object_id(3)];
+    let recipients = [address(6)];
+    let amounts = [100];
+
+    let mut expected = ProgrammableTransactionBuilder::new();
+    expected
+        .pay(
+            vec![object_ref(coins[0]).await],
+            recipients.to_vec(),
+            amounts.to_vec(),
+        )
+        .unwrap();
+
+    let mut builder = builder();
+    builder.pay(&coins, &recipients, &amounts).unwrap();
+
+    assert_eq!(
+        builder.finish_kind().await.unwrap(),
+        TransactionKind::new_programmable(expected.finish()),
+    );
+}
+
+#[tokio::test]
+async fn pay_iota_matches_json_rpc_builder() {
+    let recipients = [address(6), address(7), address(6)];
+    let amounts = [100, 200, 100];
+
+    let mut expected = ProgrammableTransactionBuilder::new();
+    expected
+        .pay_iota(recipients.to_vec(), amounts.to_vec())
+        .unwrap();
+
+    let mut builder = builder();
+    builder.pay_iota(&recipients, &amounts).unwrap();
+
+    assert_eq!(
+        builder.finish_kind().await.unwrap(),
+        TransactionKind::new_programmable(expected.finish()),
+    );
+}
+
+#[tokio::test]
+async fn pay_all_iota_matches_json_rpc_builder() {
+    let recipient = address(6);
+
+    let mut expected = ProgrammableTransactionBuilder::new();
+    expected.pay_all_iota(recipient);
+
+    let mut builder = builder();
+    builder.pay_all_iota(recipient);
+
+    assert_eq!(
+        builder.finish_kind().await.unwrap(),
+        TransactionKind::new_programmable(expected.finish()),
+    );
+}
+
+/// `finish_kind` must not pull gas coins into the transaction: the client
+/// commands select the gas payment themselves.
+#[tokio::test]
+async fn finish_kind_leaves_the_gas_payment_empty() {
+    let mut builder = builder();
+    builder.pay_iota(&[address(6)], &[100]).unwrap();
+
+    let TransactionKind::Programmable(ptb) = builder.finish_kind().await.unwrap() else {
+        panic!("expected a programmable transaction");
+    };
+    // Only the amount and the recipient, no gas coin the builder picked itself.
+    assert_eq!(ptb.inputs.len(), 2);
+}
+
+#[test]
+fn pay_rejects_mismatched_recipients_and_amounts() {
+    assert!(builder().pay_iota(&[address(6)], &[100, 200]).is_err());
+}
+
+#[test]
+fn pay_rejects_an_empty_coin_list() {
+    assert!(builder().pay(&[], &[address(6)], &[100]).is_err());
+}

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "iota-metrics",
  "iota-names",
  "iota-protocol-config",
+ "iota-sdk-crypto",
  "iota-sdk-types",
  "iota-types",
  "move-vm-config",
@@ -3428,6 +3429,7 @@ dependencies = [
  "anyhow",
  "bip32",
  "fastcrypto",
+ "iota-sdk-crypto",
  "iota-sdk-types",
  "iota-types",
  "rand 0.8.6",
@@ -3687,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "fastcrypto",
  "iota-sdk-types",
@@ -3701,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3720,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3736,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3755,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=61b8fc3a68da76184d8e171a65b8d633022b4dda#61b8fc3a68da76184d8e171a65b8d633022b4dda"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "61b8fc3a68da76184d8e171a65b8d633022b4dda" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
> **Blocked on iotaledger/iota-rust-sdk#1289.** The pinned SDK rev points at that PR's branch head for `finish_kind`; it needs re-pointing at the merge commit before this lands.

# Description of change

Phase 3 of the gRPC transaction-building migration, first command family. `transfer`, `pay`, `pay-iota` and `pay-all-iota` build their transaction with the SDK `TransactionBuilder` driven by `WalletContext::get_grpc_client()` instead of the JSON-RPC client's `transaction_builder()`.

`pay`, `pay-iota` and `pay-all-iota` need a shape the SDK builder has no single method for — merge into the first coin, split per amount, group the transfers of repeated recipients — so those three live in a `TransactionBuilderExt` trait in a new `grpc_transaction_builder` module, ready for the remaining families. `transfer` maps straight onto `transfer_objects` and calls it directly. `finish_kind` returns the bare `TransactionKind` these commands need; gas payment, price and budget stay where they were, in `dry_run_or_execute_or_serialize`.

Still on the JSON-RPC client, by design: JSON-arg `move_call` (the SDK builder takes typed arguments), split/merge, publish/upgrade, and the PTB command.

## Two behaviour notes

**`transfer` serializes differently.** The SDK builder registers the object before the recipient; the JSON-RPC one did the reverse. Same command, same object reference, same input count and sizes, same gas cost — but the two inputs swap positions, so `--serialize-unsigned-transaction` bytes and the transaction digest differ. Nothing depends on either being stable (the digest already varies per run, since it commits to gas coin versions and the budget). `pay`, `pay-iota` and `pay-all-iota` are unchanged byte-for-byte.

**These commands now need a `grpc` URL in the active env.** Freshly created configs have one — the first-run wizard, `with_default_envs` and `IotaEnv::localnet()` all populate it — but a `client.yaml` written before #12097, or an env created from a custom URL without `--grpc`, will fail with `gRPC is not configured for environment [X]`. Affected users need `iota client new-env --grpc <URL>` or a manual `client.yaml` edit.

## Links to any relevant issues

Part of #12099 (first of four command families; the issue stays open). Depends on #12097.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

The `pay` family is the part with real logic, and its unit tests assert the built `TransactionKind` is **equal** to what `ProgrammableTransactionBuilder` produces via the JSON-RPC helpers — same commands, same input order, same pure-input deduplication, same grouping of repeated recipients. Object inputs resolve against the SDK's `TestClient`, so no network is needed.

- `cargo nextest run -p iota --lib grpc_transaction_builder` — 7 passing.
- `cargo nextest run -p iota --test cli_tests` — 86 passing. `test_move_authenticator` overflows its stack, which reproduces on a clean `develop`, so it is unrelated.
- `cargo clippy -p iota --all-targets --all-features -- -D warnings`, `cargo +nightly fmt`, `dprint fmt` all clean.
- `cargo check --all-targets` for every crate depending on the SDK builder (`test-cluster`, `iota-test-transaction-builder`, `iota-cluster-test`, `iota-indexer`, `iota-rust-sdk`, `iota-source-validation`) — the rev bump adds exactly one upstream commit, which is additive.

### Release Notes

- [x] CLI: `transfer`, `pay`, `pay-iota` and `pay-all-iota` build their transactions over gRPC and now require a `grpc` URL in the active environment; environments created before gRPC support need one added with `iota client new-env --grpc <URL>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)