### PR TITLE
feat(consensus): leader schedule redesign

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1310,6 +1310,7 @@
                 "consensus_block_restrictions": true,
                 "consensus_commit_transactions_only_for_traversed_headers": true,
                 "consensus_distributed_vote_scoring_strategy": true,
+                "consensus_enable_sliding_window_leader_schedule": false,
                 "consensus_fast_commit_sync": true,
                 "consensus_linearize_subdag_v2": true,
                 "consensus_median_timestamp_with_checkpoint_enforcement": true,
@@ -1502,6 +1503,7 @@
                 "consensus_gc_depth": {
                   "u32": "60"
                 },
+                "consensus_leader_schedule_window_size": null,
                 "consensus_max_acknowledgments_per_block": null,
                 "consensus_max_num_transactions_in_block": {
                   "u64": "512"

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1310,6 +1310,7 @@
                 "consensus_block_restrictions": true,
                 "consensus_commit_transactions_only_for_traversed_headers": true,
                 "consensus_distributed_vote_scoring_strategy": true,
+                "consensus_enable_absolute_score_leader_schedule": false,
                 "consensus_enable_sliding_window_leader_schedule": false,
                 "consensus_fast_commit_sync": true,
                 "consensus_linearize_subdag_v2": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -578,6 +578,13 @@ struct FeatureFlags {
     // `MoveAuthenticationError` execution error.
     #[serde(skip_serializing_if = "is_false")]
     report_move_authentication_error: bool,
+
+    // If true, the Starfish leader schedule scores reputation over a sliding
+    // window and rebuilds the swap table every `consensus_commits_per_schedule`
+    // commits with a uniform base election; when false, V2 snapshot scoring +
+    // stake-weighted base election is used.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_enable_sliding_window_leader_schedule: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1490,6 +1497,11 @@ pub struct ProtocolConfig {
     /// `validator_low_stake_threshold` before being removed.
     /// Supersedes `SystemParametersV1::validator_low_stake_grace_period`.
     validator_low_stake_grace_period: Option<u64>,
+
+    /// Number of committed subdags the sliding-window leader scorer aggregates
+    /// over (the scoring depth). When unset, defaults to 600. Consulted only
+    /// when `consensus_enable_sliding_window_leader_schedule` is set.
+    consensus_leader_schedule_window_size: Option<u32>,
 }
 
 // feature flags
@@ -1878,12 +1890,32 @@ impl ProtocolConfig {
     }
 
     pub fn commits_per_schedule(&self) -> u32 {
-        if cfg!(msim) {
+        let commits_per_schedule = if cfg!(msim) {
             // Exercise faster leader-schedule rotation in simtests.
             min(10, self.consensus_commits_per_schedule.unwrap_or(300))
         } else {
             self.consensus_commits_per_schedule.unwrap_or(300)
-        }
+        };
+        assert!(
+            commits_per_schedule > 0,
+            "consensus_commits_per_schedule must be greater than 0"
+        );
+        commits_per_schedule
+    }
+
+    pub fn leader_schedule_window_size(&self) -> u32 {
+        self.consensus_leader_schedule_window_size.unwrap_or(600)
+    }
+
+    pub fn consensus_enable_sliding_window_leader_schedule(&self) -> bool {
+        let res = self
+            .feature_flags
+            .consensus_enable_sliding_window_leader_schedule;
+        assert!(
+            !res || self.leader_schedule_window_size() >= self.commits_per_schedule(),
+            "consensus_enable_sliding_window_leader_schedule requires window_size >= commits_per_schedule"
+        );
+        res
     }
 
     pub fn deny_rule_governance(&self) -> bool {
@@ -2518,6 +2550,7 @@ impl ProtocolConfig {
             validator_low_stake_threshold: None,
             validator_very_low_stake_threshold: None,
             validator_low_stake_grace_period: None,
+            consensus_leader_schedule_window_size: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -3383,6 +3416,15 @@ impl ProtocolConfig {
 
     pub fn set_report_move_authentication_error_for_testing(&mut self, val: bool) {
         self.feature_flags.report_move_authentication_error = val;
+    }
+
+    pub fn set_leader_schedule_window_size_for_testing(&mut self, val: u32) {
+        self.consensus_leader_schedule_window_size = Some(val);
+    }
+
+    pub fn set_consensus_enable_sliding_window_leader_schedule_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .consensus_enable_sliding_window_leader_schedule = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -585,6 +585,13 @@ struct FeatureFlags {
     // stake-weighted base election is used.
     #[serde(skip_serializing_if = "is_false")]
     consensus_enable_sliding_window_leader_schedule: bool,
+
+    // If true, Starfish selects "bad" leader-schedule nodes by absolute
+    // normalized reputation score: exclude validators below a low threshold,
+    // capped at a maximum number of validators, and keep a minimum-size good
+    // (swap-in) pool; when false, the fixed stake cut by rank is used.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_enable_absolute_score_leader_schedule: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1916,6 +1923,11 @@ impl ProtocolConfig {
             "consensus_enable_sliding_window_leader_schedule requires window_size >= commits_per_schedule"
         );
         res
+    }
+
+    pub fn consensus_enable_absolute_score_leader_schedule(&self) -> bool {
+        self.feature_flags
+            .consensus_enable_absolute_score_leader_schedule
     }
 
     pub fn deny_rule_governance(&self) -> bool {
@@ -3425,6 +3437,11 @@ impl ProtocolConfig {
     pub fn set_consensus_enable_sliding_window_leader_schedule_for_testing(&mut self, val: bool) {
         self.feature_flags
             .consensus_enable_sliding_window_leader_schedule = val;
+    }
+
+    pub fn set_consensus_enable_absolute_score_leader_schedule_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .consensus_enable_absolute_score_leader_schedule = val;
     }
 }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -934,6 +934,23 @@ pub(crate) enum Decision {
 
 /// The status of a leader slot from the direct and indirect commit rules.
 ///
+/// A leader slot advances through three nested levels — every finalized leader
+/// is resolved, and every resolved leader is decided:
+///
+/// - **Decided** — commit-vs-skip is answered: `Skip`, or `Commit` with any
+///   metastate (including `Pending`). Convertible to a `DecidedLeader`.
+/// - **Resolved** — the outcome is fully pinned: `Skip`, or `Commit` with a
+///   settled (non-`Pending`) metastate, so sequencing can proceed past it
+///   (`is_resolved`). `Commit(Pending)` is decided but not resolved — the
+///   indirect rule upgrades its metastate on a later commit pass.
+/// - **Finalized** — a resolved leader the committer has processed as part of a
+///   contiguous, rotation-boundary-respecting prefix (its `last_finalized`
+///   boundary has advanced past the leader). Permanent; Decided and Resolved
+///   are provisional and recomputed on every commit pass — before finalization
+///   a slot's outcome can still flip between `Commit` and `Skip`.
+///
+/// `Undecided` is none of these: the slot has no commit-vs-skip decision yet.
+///
 /// `Commit(_, Some(Optimistic), strong_voters)` carries the r+1 authorities
 /// whose strong votes attest data availability for the leader and its
 /// acknowledgments; the linearizer feeds them to the per-ref ack tracker.
@@ -966,9 +983,11 @@ impl LeaderStatus {
         }
     }
 
-    /// True when sequencing can proceed past this leader. `Commit(Pending)`
-    /// and `Undecided` are non-final.
-    pub(crate) fn is_final(&self) -> bool {
+    /// True when this leader is resolved: its outcome is fully pinned -- a
+    /// `Skip`, or a `Commit` with a settled (non-`Pending`) metastate -- so
+    /// sequencing can proceed past it. `Commit(Pending)` is decided but not
+    /// yet resolved; `Undecided` is neither.
+    pub(crate) fn is_resolved(&self) -> bool {
         match self {
             Self::Commit(_, Some(CommitMetastate::Pending), _) => false,
             Self::Commit(..) | Self::Skip(_) => true,

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -39,6 +39,7 @@ use crate::{
     header_synchronizer::HeaderSynchronizerHandle,
     misbehavior_store::MisbehaviorStore,
     network::{NetworkClient, SerializedTransactionsV2},
+    sliding_window_schedule::SlidingWindowSchedule,
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
 
@@ -729,6 +730,25 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 commits_since_schedule_update,
                 max(leader_schedule_window, max(cached_rounds, gc_depth * 2)),
             );
+            // When the sliding-window leader schedule is enabled, recovery replays
+            // the scorer over `replay_start..=last`; fetch enough commits to cover
+            // that range so the replayed window matches a fully-synced node
+            let num_commits = if inner
+                .context
+                .protocol_config
+                .consensus_enable_sliding_window_leader_schedule()
+            {
+                let window = inner.context.protocol_config.leader_schedule_window_size();
+                let replay_start = SlidingWindowSchedule::replay_start(last_commit_index, window);
+                max(
+                    num_commits,
+                    last_commit_index
+                        .saturating_sub(replay_start)
+                        .saturating_add(1),
+                )
+            } else {
+                num_commits
+            };
             let block_refs = dag_state.get_block_refs_for_recent_commits(num_commits);
             (commits_since_schedule_update, block_refs)
         };

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -86,9 +86,9 @@ pub(crate) struct Core {
     /// to note that this does not signify that the leader has been
     /// persisted yet as it still has to go through CommitObserver and
     /// persist the commit in store. On recovery/restart
-    /// the last_decided_leader will be set to the last_commit leader in dag
+    /// the last_finalized_leader will be set to the last_commit leader in dag
     /// state.
-    last_decided_leader: Slot,
+    last_finalized_leader: Slot,
     /// The consensus leader schedule to be used to resolve the leader for a
     /// given round.
     leader_schedule: Arc<LeaderSchedule>,
@@ -218,7 +218,7 @@ impl Core {
         sync_last_known_own_block: bool,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
     ) -> Self {
-        let last_decided_leader = dag_state.read().last_commit_leader();
+        let last_finalized_leader = dag_state.read().last_commit_leader();
         let committer = UniversalCommitterBuilder::new(
             context.clone(),
             leader_schedule.clone(),
@@ -275,7 +275,7 @@ impl Core {
             context,
             last_signaled_round,
             last_included_ancestors,
-            last_decided_leader,
+            last_finalized_leader,
             leader_schedule,
             transaction_consumer,
             block_manager,
@@ -738,8 +738,8 @@ impl Core {
         // 6. Reinitialize BlockManager
         self.block_manager.reinitialize();
 
-        // 7. Update last_decided_leader to match the new DAG state
-        self.last_decided_leader = last_commit_leader;
+        // 7. Update last_finalized_leader to match the new DAG state
+        self.last_finalized_leader = last_commit_leader;
 
         // 8. Reinitialize CommitObserver with recovery (uses recover_and_send_commits)
         self.commit_observer.reinitialize(last_commit_index).await?;
@@ -1283,19 +1283,21 @@ impl Core {
             // Always try to process the synced commits first. If there are certified
             // commits to process then the decided leaders and the commits will be returned.
 
-            let mut decided_leaders = self.committer.try_decide(self.last_decided_leader);
+            let mut decided_leaders = self.committer.try_decide(self.last_finalized_leader);
 
-            // Truncate the decided leaders to fit the commit schedule limit.
+            // Drop leaders past the next rotation boundary; they are re-decided next
+            // pass under the new schedule. This pins each committed leader to the
+            // schedule at its position — the dropped tail stays provisional.
             if decided_leaders.len() >= commits_until_update {
                 let _ = decided_leaders.split_off(commits_until_update);
             }
 
             // If the decided leaders list is empty then just break the loop.
-            let Some(last_decided) = decided_leaders.last().cloned() else {
+            let Some(last_finalized) = decided_leaders.last().cloned() else {
                 break;
             };
 
-            self.last_decided_leader = last_decided.slot();
+            self.last_finalized_leader = last_finalized.slot();
 
             // Emit skip events for the DAG visualizer before filtering.
             #[cfg(feature = "dag-visualizer")]
@@ -1319,7 +1321,7 @@ impl Core {
                 .metrics
                 .node_metrics
                 .last_decided_leader_round
-                .set(self.last_decided_leader.round as i64);
+                .set(self.last_finalized_leader.round as i64);
 
             // It's possible to reach this point as the decided leaders might all of them be
             // "Skip" decisions. In this case there is no leader to commit and
@@ -1364,6 +1366,8 @@ impl Core {
                 );
                 dag_state.add_scoring_subdags(subdags.iter().map(|s| s.base.clone()).collect());
             }
+            self.leader_schedule
+                .feed_committed_subdags(subdags.iter().map(|s| s.base.clone()));
 
             committed_sub_dags.extend(subdags);
 
@@ -1821,17 +1825,18 @@ impl CoreSignalsReceivers {
 pub(crate) async fn create_cores(
     context: Context,
     authorities: Vec<Stake>,
-) -> Vec<CoreTextFixture> {
+) -> Vec<CoreTestFixture> {
     let mut cores = Vec::new();
 
     for index in 0..authorities.len() {
         let own_index = AuthorityIndex::new_for_test(index as u8);
-        let core = CoreTextFixture::new(
+        let core = CoreTestFixture::new(
             context.clone(),
             authorities.clone(),
             own_index,
             false,
             false,
+            None,
         )
         .await;
         cores.push(core);
@@ -1840,7 +1845,7 @@ pub(crate) async fn create_cores(
 }
 
 #[cfg(test)]
-pub(crate) struct CoreTextFixture {
+pub(crate) struct CoreTestFixture {
     pub core: Core,
     pub signal_receivers: CoreSignalsReceivers,
     pub block_receiver: broadcast::Receiver<VerifiedBlock>,
@@ -1849,13 +1854,14 @@ pub(crate) struct CoreTextFixture {
 }
 
 #[cfg(test)]
-impl CoreTextFixture {
+impl CoreTestFixture {
     async fn new(
         context: Context,
         authorities: Vec<Stake>,
         own_index: AuthorityIndex,
         sync_last_known_own_block: bool,
         with_rocksdb: bool,
+        store: Option<Arc<dyn Store>>,
     ) -> Self {
         let (committee, mut signers) = local_committee_and_keys(0, authorities);
         let mut context = context;
@@ -1867,11 +1873,15 @@ impl CoreTextFixture {
             .set_consensus_bad_nodes_stake_threshold_for_testing(33);
 
         let context = Arc::new(context);
-        let store: Arc<dyn Store> = if !with_rocksdb {
-            Arc::new(MemStore::new())
-        } else {
-            let store_path = context.parameters.db_path.as_path().to_str().unwrap();
-            Arc::new(RocksDBStore::new(store_path))
+        // Reuse an existing store to model a restart (recovery from persisted
+        // state); otherwise start from a fresh one.
+        let store: Arc<dyn Store> = match store {
+            Some(store) => store,
+            None if !with_rocksdb => Arc::new(MemStore::new()),
+            None => {
+                let store_path = context.parameters.db_path.as_path().to_str().unwrap();
+                Arc::new(RocksDBStore::new(store_path))
+            }
         };
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
@@ -1933,6 +1943,7 @@ mod test {
     use futures::{StreamExt, stream::FuturesUnordered};
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use iota_protocol_config::ProtocolConfig;
+    use rstest::rstest;
     use serial_test::serial;
     use starfish_config::{AuthorityIndex, Parameters};
     use tokio::time::sleep;
@@ -1944,7 +1955,7 @@ mod test {
             BlockHeaderDigest, TestBlockHeader, TransactionsCommitment, genesis_block_headers,
             genesis_blocks,
         },
-        commit::CommitAPI,
+        commit::{CommitAPI, CommitRange},
         leader_scoring::ReputationScores,
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
@@ -2484,12 +2495,13 @@ mod test {
         let (context, _) = Context::new_for_test(4);
         let gc_depth = context.protocol_config.gc_depth();
 
-        let fixture = CoreTextFixture::new(
+        let fixture = CoreTestFixture::new(
             context.clone(),
             vec![1; 4],
             AuthorityIndex::new_for_test(0),
             false,
             false,
+            None,
         )
         .await;
         let core = &fixture.core;
@@ -2822,69 +2834,17 @@ mod test {
         // create the cores and their signals for all the authorities
         let mut cores = create_cores(context, vec![1, 1, 1, 1]).await;
 
-        // Now iterate over a few rounds and ensure the corresponding signals are
-        // created while network advances
+        // Advance the gossip network round by round; `gossip_one_round` asserts
+        // each round is healthy and fully connected.
         let mut last_round_block_headers = Vec::new();
         for round in 1..=30 {
-            let mut this_round_block_headers = Vec::new();
-
-            // Wait for min block delay to allow blocks to be proposed.
-            sleep(default_params.min_block_delay).await;
-
-            for core_fixture in &mut cores {
-                // add the blocks from last round
-                // this will trigger a block creation for the round and a signal should be
-                // emitted
-                core_fixture
-                    .core
-                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
-                    .unwrap();
-
-                // A "new round" signal should be received given that all the blocks of previous
-                // round have been processed
-                let new_round = receive(
-                    Duration::from_secs(1),
-                    core_fixture.signal_receivers.new_round_receiver(),
-                )
-                .await;
-                assert_eq!(new_round, round);
-
-                // Check that a new block has been proposed.
-                let verified_block = tokio::time::timeout(
-                    Duration::from_secs(1),
-                    core_fixture.block_receiver.recv(),
-                )
-                .await
-                .unwrap()
-                .unwrap();
-                assert_eq!(verified_block.round(), round);
-                assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
-
-                // append the new block to this round blocks
-                this_round_block_headers
-                    .push(core_fixture.core.last_proposed_block_header().clone());
-
-                let block_header = core_fixture.core.last_proposed_block_header();
-
-                // ensure that produced block is referring to the blocks of last_round
-                assert_eq!(
-                    block_header.ancestors().len(),
-                    core_fixture.core.context.committee.size()
-                );
-                for ancestor in block_header.ancestors() {
-                    if block_header.round() > 1 {
-                        // don't bother with round 1 block which just contains the genesis blocks.
-                        assert!(
-                            last_round_block_headers
-                                .iter()
-                                .any(|block_header| block_header.reference() == *ancestor),
-                            "Reference from previous round should be added"
-                        );
-                    }
-                }
-            }
-
-            last_round_block_headers = this_round_block_headers;
+            last_round_block_headers = gossip_one_round(
+                &mut cores,
+                round,
+                &last_round_block_headers,
+                default_params.min_block_delay,
+            )
+            .await;
         }
 
         for core_fixture in cores {
@@ -2937,6 +2897,204 @@ mod test {
         }
     }
 
+    /// Drives a fully-connected gossip network forward by one block-round:
+    /// feeds the previous round's proposed headers to every core (which
+    /// runs the real `try_commit`) and returns the headers proposed this
+    /// round, to be used as ancestors for the next round. A uniform,
+    /// fully-connected DAG keeps the reputation scores equal across all
+    /// authorities, so the resulting leader schedule is independent of RNG
+    /// seed and topology.
+    async fn gossip_one_round(
+        cores: &mut [CoreTestFixture],
+        round: u32,
+        last_round_block_headers: &[VerifiedBlockHeader],
+        min_block_delay: Duration,
+    ) -> Vec<VerifiedBlockHeader> {
+        let mut this_round_block_headers = Vec::new();
+        // Wait for min block delay to allow blocks to be proposed.
+        sleep(min_block_delay).await;
+        for core_fixture in cores.iter_mut() {
+            core_fixture
+                .core
+                .add_block_headers(last_round_block_headers.to_vec(), DataSource::Test)
+                .unwrap();
+            // Feeding the previous round's blocks advances this core a round and
+            // triggers a proposal; assert the round signal and a healthy,
+            // fully-connected proposed block.
+            let new_round = receive(
+                Duration::from_secs(1),
+                core_fixture.signal_receivers.new_round_receiver(),
+            )
+            .await;
+            assert_eq!(new_round, round);
+            let proposed_block =
+                tokio::time::timeout(Duration::from_secs(1), core_fixture.block_receiver.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(proposed_block.round(), round);
+            assert_eq!(proposed_block.author(), core_fixture.core.context.own_index);
+            let block_header = core_fixture.core.last_proposed_block_header().clone();
+            assert_eq!(
+                block_header.ancestors().len(),
+                core_fixture.core.context.committee.size()
+            );
+            if round > 1 {
+                for ancestor in block_header.ancestors() {
+                    assert!(
+                        last_round_block_headers
+                            .iter()
+                            .any(|bh| bh.reference() == *ancestor),
+                        "reference from previous round should be added"
+                    );
+                }
+            }
+            this_round_block_headers.push(block_header);
+        }
+        this_round_block_headers
+    }
+
+    /// Drives the gossip network until `cores[0]` has performed at least one
+    /// leader-schedule rotation and then sits mid-interval: its scoring-subdag
+    /// count is strictly between 0 and `num_commits_per_schedule` (10 here,
+    /// matching `CoreTestFixture`'s `with_num_commits_per_schedule(10)`). It
+    /// loops until that state holds rather than running a fixed number of
+    /// gossip rounds, because the number of commits per round is not fixed.
+    async fn drive_to_post_rotation_mid_interval(
+        cores: &mut [CoreTestFixture],
+        min_block_delay: Duration,
+    ) {
+        const NUM_COMMITS_PER_SCHEDULE: u64 = 10;
+        // Generous safety ceiling; the loop actually breaks dynamically below.
+        const MAX_ROUNDS: u32 = 6 * NUM_COMMITS_PER_SCHEDULE as u32;
+        let mut round = 0u32;
+        let mut last_round_block_headers = Vec::new();
+        let mut rotated = false;
+        loop {
+            round += 1;
+            assert!(
+                round <= MAX_ROUNDS,
+                "network did not reach a post-rotation mid-interval state within {MAX_ROUNDS} rounds"
+            );
+            last_round_block_headers =
+                gossip_one_round(cores, round, &last_round_block_headers, min_block_delay).await;
+
+            // A rotation has occurred once the in-effect swap table carries
+            // persisted reputation scores (a non-empty commit range).
+            if cores[0]
+                .core
+                .leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range
+                != CommitRange::default()
+            {
+                rotated = true;
+            }
+
+            let count = cores[0].core.dag_state.read().scoring_subdags_count() as u64;
+            if rotated && count > 0 && count < NUM_COMMITS_PER_SCHEDULE {
+                break;
+            }
+        }
+    }
+
+    /// Drives a real 4-core network past one leader-schedule rotation to a
+    /// mid-interval commit, flushes, then rebuilds authority 0 from the same
+    /// store via the real recovery path (`DagState::new` +
+    /// `LeaderSchedule::from_store`) and asserts the rotation count is
+    /// restart-invariant: a recovered node resumes with the same
+    /// commits-until-next-rotation as one that never restarted.
+    ///
+    /// On the sliding-window path the scorer's scored frontier lags the
+    /// rotation boundary by `MAX_PENDING_COMMITS = 3`, while recovery rebuilds
+    /// the rotation-counting scoring subdag from the persisted
+    /// `commit_range.end() + 1`. The count stays invariant because the
+    /// persisted end is the rotation boundary (the last committed index), not
+    /// the lagging frontier. The assertions compare live vs. restarted directly
+    /// (no hard-coded count) and run for both the sliding-window and V2 paths.
+    #[rstest]
+    #[case::sliding_window(true)]
+    #[case::v2(false)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_leader_schedule_restart_invariant_rotation(#[case] enable_sliding_window: bool) {
+        telemetry_subscribers::init_for_testing();
+        let default_params = Parameters::default();
+
+        let (mut context, _) = Context::new_for_test(4);
+        // Test blocks carry no strong votes; run with StarfishSpeed off.
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(false);
+        if enable_sliding_window {
+            context
+                .protocol_config
+                .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+            // Pin the rotation interval small and keep `window_size >=
+            // commits_per_schedule` (a protocol-config invariant the flag
+            // getter asserts).
+            context
+                .protocol_config
+                .set_commits_per_schedule_for_testing(10);
+            context
+                .protocol_config
+                .set_leader_schedule_window_size_for_testing(20);
+        }
+
+        // Drive a real 4-core network until it has done >= 1 rotation and sits
+        // mid-interval, persisting a real `CommitInfo`.
+        let mut cores = create_cores(context.clone(), vec![1, 1, 1, 1]).await;
+        drive_to_post_rotation_mid_interval(&mut cores, default_params.min_block_delay).await;
+
+        // Flush so the persisted `CommitInfo` reaches the store, then restart the
+        // node by rebuilding it from the same store via the real recovery path.
+        cores[0].core.dag_state.write().flush();
+        let restarted = CoreTestFixture::new(
+            context,
+            vec![1, 1, 1, 1],
+            AuthorityIndex::new_for_test(0),
+            false,
+            false,
+            Some(cores[0].store.clone()),
+        )
+        .await;
+
+        // Root cause: the rotation count is restart-invariant.
+        assert_eq!(
+            restarted.core.dag_state.read().scoring_subdags_count(),
+            cores[0].core.dag_state.read().scoring_subdags_count(),
+            "scoring_subdags_count must be restart-invariant"
+        );
+        // The same fact, as commits-until-next-rotation.
+        assert_eq!(
+            restarted
+                .core
+                .leader_schedule
+                .commits_until_leader_schedule_update(restarted.core.dag_state.clone()),
+            cores[0]
+                .core
+                .leader_schedule
+                .commits_until_leader_schedule_update(cores[0].core.dag_state.clone()),
+            "commits_until_leader_schedule_update must be restart-invariant"
+        );
+
+        // The recovered swap table must match the live one exactly, not just
+        // the rotation count. It is rebuilt with the rotation boundary as its
+        // seed, so equal-scoring authorities shuffle into the same good/bad
+        // split on both sides.
+        let restarted_table = restarted.core.leader_schedule.leader_swap_table.read();
+        let live_table = cores[0].core.leader_schedule.leader_swap_table.read();
+        assert_eq!(
+            restarted_table.good_nodes, live_table.good_nodes,
+            "recovered good_nodes must match the live node"
+        );
+        assert_eq!(
+            restarted_table.bad_nodes, live_table.bad_nodes,
+            "recovered bad_nodes must match the live node"
+        );
+    }
+
     #[tokio::test]
     #[serial]
     async fn test_sequenced_transactions_no_headers() {
@@ -2969,12 +3127,13 @@ mod test {
         // fast commit sync requires committing only for traversed headers.
         assert!(context.protocol_config.consensus_fast_commit_sync());
         let own_index = AuthorityIndex::new_for_test(0);
-        let core_fixture_own = CoreTextFixture::new(
+        let core_fixture_own = CoreTestFixture::new(
             context.clone(),
             vec![1; committee_size],
             own_index,
             true,
             false,
+            None,
         )
         .await;
         // create a DAG of 2*gc_depth rounds
@@ -2987,12 +3146,13 @@ mod test {
             .dag_state_cached_rounds;
         // One authority will try to catch up, so it does not create any block
         let catch_up_index = AuthorityIndex::new_for_test((committee_size - 1) as u8);
-        let core_fixture_catch_up = CoreTextFixture::new(
+        let core_fixture_catch_up = CoreTestFixture::new(
             context.clone(),
             vec![1; committee_size],
             catch_up_index,
             true,
             true,
+            None,
         )
         .await;
         let active_authorities = (0..(committee_size - 1) as u8)
@@ -3190,8 +3350,15 @@ mod test {
         });
 
         let authority_index = AuthorityIndex::new_for_test(0);
-        let core =
-            CoreTextFixture::new(context, vec![1, 1, 1, 1], authority_index, true, false).await;
+        let core = CoreTestFixture::new(
+            context,
+            vec![1, 1, 1, 1],
+            authority_index,
+            true,
+            false,
+            None,
+        )
+        .await;
         let store = core.store.clone();
         let mut core = core.core;
 
@@ -3815,12 +3982,13 @@ mod test {
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(true);
-        let fixture = CoreTextFixture::new(
+        let fixture = CoreTestFixture::new(
             context,
             vec![1; 4],
             AuthorityIndex::new_for_test(0),
             false,
             false,
+            None,
         )
         .await;
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -3015,10 +3015,15 @@ mod test {
     /// the lagging frontier. The assertions compare live vs. restarted directly
     /// (no hard-coded count) and run for both the sliding-window and V2 paths.
     #[rstest]
-    #[case::sliding_window(true)]
-    #[case::v2(false)]
+    #[case::v2(false, false)]
+    #[case::v2_absolute_scores(false, true)]
+    #[case::sliding_window(true, false)]
+    #[case::sliding_window_absolute_scores(true, true)]
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_leader_schedule_restart_invariant_rotation(#[case] enable_sliding_window: bool) {
+    async fn test_leader_schedule_restart_invariant_rotation(
+        #[case] enable_sliding_window: bool,
+        #[case] enable_absolute_score_leader_schedule: bool,
+    ) {
         telemetry_subscribers::init_for_testing();
         let default_params = Parameters::default();
 
@@ -3027,6 +3032,11 @@ mod test {
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(false);
+        if enable_absolute_score_leader_schedule {
+            context
+                .protocol_config
+                .set_consensus_enable_absolute_score_leader_schedule_for_testing(true);
+        }
         if enable_sliding_window {
             context
                 .protocol_config

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1320,7 +1320,7 @@ impl Core {
             self.context
                 .metrics
                 .node_metrics
-                .last_decided_leader_round
+                .last_finalized_leader_round
                 .set(self.last_finalized_leader.round as i64);
 
             // It's possible to reach this point as the decided leaders might all of them be

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -271,8 +271,14 @@ pub(crate) struct DagState {
     /// Rounds for latest blocks traversed by linearizer per authority.
     last_committed_rounds: Vec<Round>,
 
-    /// The committed subdags that have been scored but scores have not been
-    /// used for leader schedule yet.
+    /// Committed subdags scored since the last leader-schedule rotation, not
+    /// yet applied to the schedule. The V2 path computes its reputation
+    /// scores from these; the sliding-window path takes scores from the
+    /// window scorer instead, so there this serves only as the rotation
+    /// counter (`scoring_subdags_count`) and the just-rotated edge
+    /// (`is_scoring_subdag_empty`). Once V2 is removed it can be dropped
+    /// entirely, both roles replaced by a single recovered `u32` holding the
+    /// last rotation boundary index.
     scoring_subdag: ScoringSubdag,
 
     /// Commit votes pending to be included in new blocks. Ordered by
@@ -304,9 +310,8 @@ pub(crate) struct DagState {
     /// the next dag state flush. This is okay because we can recover
     /// reputation scores & last_committed_rounds from the commits as
     /// needed.
-    /// The index in CommitRef correspond to the first index of the next
-    /// scheduler window, while the reputation scores in CommitInfoare for
-    /// the previous window.
+    /// The `CommitRef` is the boundary commit — the last commit of the window
+    /// that just closed — so recovery resumes from its index + 1.
     commit_info_to_write: Vec<(CommitRef, CommitInfo)>,
 
     /// Misbehavior scoring metrics (in-memory + persisted buckets).
@@ -639,10 +644,9 @@ impl DagState {
     }
 
     fn rebuild_scoring_subdag_from_store(&mut self) {
-        let Some(last_commit) = self.last_commit.as_ref() else {
+        let Some(last_commit_index) = self.last_commit.as_ref().map(|c| c.index()) else {
             return;
         };
-        let last_commit_index = last_commit.index();
 
         let commit_recovery_start_index = self.last_commit_info_index().saturating_add(1);
 

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -8,17 +8,18 @@ use std::{
     sync::Arc,
 };
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 use starfish_config::{AuthorityIndex, Stake};
 
 use crate::{
     CommitIndex, Round,
-    commit::{CommitInfo, CommitRange, CommitRef, GENESIS_COMMIT_INDEX},
+    commit::{CommitInfo, CommitRange, CommitRef, GENESIS_COMMIT_INDEX, SubDagBase},
     context::Context,
     dag_state::DagState,
     error::ConsensusResult,
     leader_scoring::{ReputationScores, ScoringSubdag},
+    sliding_window_schedule::SlidingWindowSchedule,
 };
 
 /// Calculates the seed index for leader swap table initialization.
@@ -60,15 +61,30 @@ pub(crate) struct LeaderSchedule {
     pub leader_swap_table: Arc<RwLock<LeaderSwapTable>>,
     context: Arc<Context>,
     num_commits_per_schedule: u32,
+    /// When set (the `consensus_enable_sliding_window_leader_schedule` flag is
+    /// on), reputation scores are sourced from this sliding-window scorer
+    /// instead of the `ScoringSubdag` snapshot, and the base election is
+    /// uniform. `None` runs the V2 path.
+    sliding_window: Option<Arc<Mutex<SlidingWindowSchedule>>>,
 }
 
 impl LeaderSchedule {
     pub(crate) fn new(context: Arc<Context>, leader_swap_table: LeaderSwapTable) -> Self {
         let num_commits_per_schedule = context.protocol_config.commits_per_schedule();
+        let sliding_window = context
+            .protocol_config
+            .consensus_enable_sliding_window_leader_schedule()
+            .then(|| {
+                Arc::new(Mutex::new(SlidingWindowSchedule::new(
+                    context.clone(),
+                    context.protocol_config.leader_schedule_window_size(),
+                )))
+            });
         Self {
             context,
             num_commits_per_schedule,
             leader_swap_table: Arc::new(RwLock::new(leader_swap_table)),
+            sliding_window,
         }
     }
 
@@ -90,7 +106,9 @@ impl LeaderSchedule {
         );
 
         // create the schedule
-        Self::new(context, leader_swap_table)
+        let schedule = Self::new(context, leader_swap_table);
+        schedule.recover_sliding_window(&dag_state);
+        schedule
     }
 
     /// Reinitializes the leader schedule from stored commit info.
@@ -104,8 +122,11 @@ impl LeaderSchedule {
             dag_state.read().scoring_subdags_count(),
         );
 
-        let mut write = self.leader_swap_table.write();
-        *write = leader_swap_table;
+        {
+            let mut write = self.leader_swap_table.write();
+            *write = leader_swap_table;
+        }
+        self.recover_sliding_window(dag_state);
     }
 
     pub(crate) fn commits_until_leader_schedule_update(
@@ -164,13 +185,19 @@ impl LeaderSchedule {
                 let table = self.leader_swap_table.read();
                 table.swap(leader, round, leader_offset).unwrap_or(leader)
             } else {
-                let leader = self.elect_leader_stake_based(round, leader_offset);
+                let leader = if self.sliding_window.is_some() {
+                    self.elect_leader_uniform(round, leader_offset)
+                } else {
+                    self.elect_leader_stake_based(round, leader_offset)
+                };
                 let table = self.leader_swap_table.read();
                 table.swap(leader, round, leader_offset).unwrap_or(leader)
             }
         }
     }
 
+    /// Stake-weighted base election. `offset` selects among multiple leaders in
+    /// a round; with one leader per round today it is always 0.
     pub(crate) fn elect_leader_stake_based(&self, round: u32, offset: u32) -> AuthorityIndex {
         assert!((offset as usize) < self.context.committee.size());
 
@@ -205,9 +232,8 @@ impl LeaderSchedule {
         let new_commit_range = &new_table.reputation_scores.commit_range;
 
         // Unless LeaderSchedule is brand new and using the default commit range
-        // of CommitRange(0..0) all future LeaderSwapTables should be calculated
-        // from a CommitRange of equal length and immediately following the
-        // preceding commit range of the old swap table.
+        // of CommitRange(0..0), every LeaderSwapTable should carry a CommitRange
+        // of equal length, immediately following the old table's range.
         if *old_commit_range != CommitRange::default() {
             assert!(
                 old_commit_range.is_next_range(new_commit_range)
@@ -267,21 +293,38 @@ impl LeaderSchedule {
             return;
         }
 
-        let (reputation_scores, last_commit_index) = {
+        // Both paths feed the same swap table and go through range_validation and
+        // persist below; they differ only in where the scores and commit_range
+        // come from.
+        //
+        // Sliding-window: scores are the running-window aggregate; commit_range is
+        // the committed interval ending at the boundary L — the same shape V2
+        // produces, so it satisfies the shared range_validation. Its end (L) is
+        // where a restarted node resumes the scoring subdag (from L+1). The
+        // window's scored frontier lags L by MAX_PENDING_COMMITS.
+        //
+        // V2: scores and commit_range both come from the ScoringSubdag snapshot.
+        let (reputation_scores, boundary) = if let Some(sliding_window) = &self.sliding_window {
+            let scores = sliding_window
+                .lock()
+                .reputation_scores()
+                .scores_per_authority;
+            let boundary = dag_state_write_lock.last_commit_index();
+            let interval = self.num_commits_per_schedule;
+            let start = boundary.saturating_sub(interval).saturating_add(1);
+            (
+                ReputationScores::new(CommitRange::new(start..=boundary), scores),
+                boundary,
+            )
+        } else {
             let reputation_scores = dag_state_write_lock.calculate_scoring_subdag_scores();
-            let last_commit_index = dag_state_write_lock.scoring_subdag_commit_range().end();
-            (reputation_scores, last_commit_index)
+            let boundary = dag_state_write_lock.scoring_subdag_commit_range().end();
+            (reputation_scores, boundary)
         };
-        let table = LeaderSwapTable::new(
-            self.context.clone(),
-            last_commit_index,
-            reputation_scores.clone(),
-        );
+        let table = LeaderSwapTable::new(self.context.clone(), boundary, reputation_scores.clone());
         self.persist_scores(dag_state_write_lock, reputation_scores);
-        {
-            self.range_validation(&table, &self.leader_swap_table.read());
-            self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
-        }
+        self.range_validation(&table, &self.leader_swap_table.read());
+        self.apply_reputation_scores_inner(&mut self.leader_swap_table.write(), table);
     }
 
     /// Updates the leader schedule from reputation scores stored in a commit.
@@ -301,10 +344,9 @@ impl LeaderSchedule {
         commit_index: CommitIndex,
         reputation_scores_desc: &[(AuthorityIndex, u64)],
     ) -> ConsensusResult<()> {
-        // Determine the commit range for these scores.
         // Reputation scores are attached to the *first* commit after a schedule
-        // update, so the scores correspond to the previous window ending at
-        // commit_index - 1.
+        // update, so commit_index - 1 is the last commit of the window that just
+        // closed; the commit_range below is the committed interval ending there.
         let range_end = commit_index.saturating_sub(1);
         if range_end == GENESIS_COMMIT_INDEX {
             return Ok(());
@@ -409,6 +451,61 @@ impl LeaderSchedule {
         let mut old = self.leader_swap_table.write();
         self.range_validation(&table, &old);
         self.apply_reputation_scores_inner(&mut old, table);
+    }
+
+    /// Uniform (non-stake-weighted) base election, used when the sliding-window
+    /// leader schedule is enabled. Round-seeded so all authorities draw the
+    /// same candidate for a given round. `offset` selects among multiple
+    /// leaders in a round; with one leader per round today it is always 0.
+    pub(crate) fn elect_leader_uniform(&self, round: u32, offset: u32) -> AuthorityIndex {
+        assert!((offset as usize) < self.context.committee.size());
+        let mut seed_bytes = [0u8; 32];
+        seed_bytes[32 - 4..].copy_from_slice(&round.to_le_bytes());
+        let mut rng = StdRng::from_seed(seed_bytes);
+        let choices = self
+            .context
+            .committee
+            .authorities()
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        *choices
+            .choose_multiple(&mut rng, self.context.committee.size())
+            .nth(offset as usize)
+            .unwrap()
+    }
+
+    /// Feeds newly committed subdags to the sliding-window scorer when enabled.
+    /// Called on every commit; returns without effect on the V2 path (no
+    /// scorer).
+    pub(crate) fn feed_committed_subdags(&self, subdags: impl IntoIterator<Item = SubDagBase>) {
+        if let Some(sliding_window) = &self.sliding_window {
+            let mut scorer = sliding_window.lock();
+            for subdag in subdags {
+                scorer.add_commit(subdag);
+            }
+        }
+    }
+
+    /// Rebuilds the sliding-window scorer (when enabled) by replaying the last
+    /// `window_size` committed subdags from storage, so the running aggregate
+    /// is current after a restart or fast-sync. Does not recover the in-effect
+    /// swap table. Returns without effect on the V2 path (no scorer).
+    fn recover_sliding_window(&self, dag_state: &RwLock<DagState>) {
+        let Some(sliding_window) = &self.sliding_window else {
+            return;
+        };
+        let window_size = self.context.protocol_config.leader_schedule_window_size();
+        let subdags = {
+            let dag_state = dag_state.read();
+            let last_commit_index = dag_state.last_commit_index();
+            let start = SlidingWindowSchedule::replay_start(last_commit_index, window_size);
+            dag_state.load_scoring_subdags_from_store((start..=last_commit_index).into())
+        };
+        let mut fresh = SlidingWindowSchedule::new(self.context.clone(), window_size);
+        for subdag in subdags {
+            fresh.add_commit(subdag);
+        }
+        *sliding_window.lock() = fresh;
     }
 }
 
@@ -700,6 +797,29 @@ mod tests {
         assert_ne!(
             leader_schedule.elect_leader_stake_based(1, 1),
             leader_schedule.elect_leader_stake_based(1, 2)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_elect_leader_uniform() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
+        let size = context.committee.size();
+
+        // For a fixed round, varying the offset across the whole committee yields
+        // a permutation of all authorities — the uniform draw covers everyone.
+        let round = 7;
+        let mut leaders = (0..size as u32)
+            .map(|offset| leader_schedule.elect_leader_uniform(round, offset))
+            .collect::<Vec<_>>();
+        leaders.sort();
+        leaders.dedup();
+        assert_eq!(leaders.len(), size);
+
+        // Deterministic: same (round, offset) always elects the same leader.
+        assert_eq!(
+            leader_schedule.elect_leader_uniform(round, 0),
+            leader_schedule.elect_leader_uniform(round, 0)
         );
     }
 
@@ -1032,6 +1152,64 @@ mod tests {
             leader_schedule.elect_leader(4, 0),
             AuthorityIndex::new_for_test(2)
         );
+    }
+
+    #[tokio::test]
+    async fn test_update_leader_schedule_sliding_window() {
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
+            .with_num_commits_per_schedule(3);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=9).build();
+        let commits = dag_builder
+            .get_sub_dag_and_commits(1..=9)
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        // Feed the first 6 commits, then rebuild: scores come from the sliding
+        // window (commits 1..=3 are scored, given the 3-commit lookback), not a
+        // ScoringSubdag snapshot. commit_range is the committed interval ending at
+        // the boundary — with num_commits_per_schedule = 3 and last committed
+        // index 6, that is 4..=6.
+        leader_schedule.feed_committed_subdags(commits[..6].iter().map(|(s, _)| s.base.clone()));
+        {
+            let mut ds = dag_state.write();
+            ds.set_last_commit(commits[5].1.clone());
+            leader_schedule.update_leader_schedule(&mut ds);
+        }
+        let range = leader_schedule
+            .leader_swap_table
+            .read()
+            .reputation_scores
+            .commit_range
+            .clone();
+        assert_eq!(range, (4..=6).into());
+
+        // Feed 3 more and rebuild again. The committed-interval ranges are
+        // contiguous and equal-size (4..=6 then 7..=9), so range_validation — now
+        // shared with the V2 path — accepts them.
+        leader_schedule.feed_committed_subdags(commits[6..].iter().map(|(s, _)| s.base.clone()));
+        {
+            let mut ds = dag_state.write();
+            ds.set_last_commit(commits[8].1.clone());
+            leader_schedule.update_leader_schedule(&mut ds);
+        }
+        let range = leader_schedule
+            .leader_swap_table
+            .read()
+            .reputation_scores
+            .commit_range
+            .clone();
+        assert_eq!(range, (7..=9).into());
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -408,12 +408,12 @@ impl LeaderSchedule {
     /// window becomes the live scoring subdag.
     fn update_leader_schedule_from_backlog(&self, dag_state_write_lock: &mut DagState) {
         let backlog_range = dag_state_write_lock.scoring_subdag_commit_range();
-        let window_size = self.num_commits_per_schedule;
-        // The caller only routes here when the backlog exceeds one window, so
-        // there is at least one full window.
-        let full_windows = backlog_range.size() as u32 / window_size;
-        let window_start = backlog_range.start() + (full_windows - 1) * window_size;
-        let window_end = window_start + (window_size - 1);
+        let commits_per_schedule = self.num_commits_per_schedule;
+        // The caller only routes here when the backlog exceeds
+        // `commits_per_schedule`, so there is at least one full window.
+        let full_windows = backlog_range.size() as u32 / commits_per_schedule;
+        let window_start = backlog_range.start() + (full_windows - 1) * commits_per_schedule;
+        let window_end = window_start + (commits_per_schedule - 1);
 
         tracing::info!(
             "Rebuilding leader schedule from the last full window \
@@ -422,12 +422,31 @@ impl LeaderSchedule {
 
         dag_state_write_lock.clear_scoring_subdag();
 
-        let mut scoring_subdag = ScoringSubdag::new(self.context.clone());
-        scoring_subdag.add_subdags(
-            dag_state_write_lock
-                .load_scoring_subdags_from_store((window_start..=window_end).into()),
-        );
-        let reputation_scores = scoring_subdag.calculate_distributed_vote_scores();
+        let reputation_scores = if self.sliding_window.is_some() {
+            // Rebuild the window aggregate a continuously running node had when
+            // it rotated at window_end. The live scorer stays as recovered —
+            // current up to the last commit — for the rotations that follow.
+            let scorer_window_size = self.context.protocol_config.leader_schedule_window_size();
+            let replay_start = SlidingWindowSchedule::replay_start(window_end, scorer_window_size);
+            let mut scorer = SlidingWindowSchedule::new(self.context.clone(), scorer_window_size);
+            for subdag in dag_state_write_lock
+                .load_scoring_subdags_from_store((replay_start..=window_end).into())
+            {
+                scorer.add_commit(subdag);
+            }
+            let scores = scorer.reputation_scores().scores_per_authority;
+            // The recorded range is the span between the previous schedule
+            // update and this one: recovery resumes the commit count after
+            // its end, and the next update's range must directly follow it.
+            ReputationScores::new(CommitRange::new(window_start..=window_end), scores)
+        } else {
+            let mut scoring_subdag = ScoringSubdag::new(self.context.clone());
+            scoring_subdag.add_subdags(
+                dag_state_write_lock
+                    .load_scoring_subdags_from_store((window_start..=window_end).into()),
+            );
+            scoring_subdag.calculate_distributed_vote_scores()
+        };
         // The window is interval-wide and lands on the rotation boundaries by
         // construction, so the steady-state range validation is not repeated.
         let table =
@@ -1955,5 +1974,215 @@ mod tests {
                 );
             }
         }
+    }
+
+    // Recovers a sliding-window schedule from a store whose last CommitInfo
+    // lags the last commit by more than one rotation interval, and checks that
+    // the schedule is rebuilt onto the same rotation boundaries a continuously
+    // running node used.
+    async fn run_sliding_window_update_after_recovery_backlog(restart: bool) {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+
+        const INTERVAL: u32 = 3;
+
+        // Persist commits 1..=11 but only one CommitInfo, covering (1..=3):
+        // recovery rebuilds a backlog of 8 commits — two full windows (4..=6)
+        // and (7..=9) plus the partial window (10..=11).
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=12).build();
+        let first_window = dag_builder.get_sub_dag_and_commits(1..=INTERVAL);
+        let committed_rounds = dag_builder.last_committed_rounds.clone();
+        let rest = dag_builder.get_sub_dag_and_commits(INTERVAL + 1..=12);
+
+        let mut headers_to_write = vec![];
+        let mut commits_to_write = vec![];
+        for (sub_dag, commit) in first_window.iter().chain(&rest[..8]) {
+            headers_to_write.extend(sub_dag.headers.iter().cloned());
+            commits_to_write.push(commit.clone());
+        }
+        let commit_info = CommitInfo {
+            reputation_scores: ReputationScores::new((1..=INTERVAL).into(), vec![1, 2, 4, 3]),
+            committed_rounds,
+        };
+        let commit_ref = first_window.last().unwrap().1.reference();
+        store
+            .write(
+                WriteBatch::default()
+                    .commit_info(vec![(commit_ref, commit_info)])
+                    .block_headers(headers_to_write)
+                    .commits(commits_to_write),
+            )
+            .unwrap();
+
+        let mut dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        assert_eq!(dag_state.read().scoring_subdags_count(), 8);
+
+        let mut leader_schedule = LeaderSchedule::from_store(context.clone(), dag_state.clone())
+            .with_num_commits_per_schedule(INTERVAL);
+        assert_eq!(
+            leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range,
+            (1..=3).into()
+        );
+
+        // The backlog forces an immediate schedule update.
+        assert_eq!(
+            leader_schedule.commits_until_leader_schedule_update(dag_state.clone()),
+            0
+        );
+
+        // The rebuilt table lands on the end of the backlog's last full
+        // window; the partial window stays live.
+        leader_schedule.update_leader_schedule(&mut dag_state.write());
+        {
+            let table = leader_schedule.leader_swap_table.read();
+            assert_eq!(table.reputation_scores.commit_range, (7..=9).into());
+            assert_eq!(table.good_nodes.len(), 1);
+            assert_eq!(table.bad_nodes.len(), 1);
+        }
+        assert_eq!(dag_state.read().scoring_subdags_count(), 2);
+
+        if restart {
+            dag_state.write().flush();
+            assert_eq!(dag_state.read().last_commit_info_index(), 9);
+            dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            assert_eq!(dag_state.read().scoring_subdags_count(), 2);
+            leader_schedule = LeaderSchedule::from_store(context, dag_state.clone())
+                .with_num_commits_per_schedule(INTERVAL);
+            assert_eq!(
+                leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .reputation_scores
+                    .commit_range,
+                (7..=9).into()
+            );
+        }
+
+        // The next rotation triggers after commit 12 and validates strictly:
+        // (10..=12) continues on the same window boundaries.
+        let (sub_dag, commit) = &rest[8];
+        leader_schedule.feed_committed_subdags([sub_dag.base.clone()]);
+        {
+            let mut write = dag_state.write();
+            write.add_commit(commit.clone());
+            write.add_scoring_subdags(vec![sub_dag.base.clone()]);
+        }
+        assert_eq!(
+            leader_schedule.commits_until_leader_schedule_update(dag_state.clone()),
+            0
+        );
+        leader_schedule.update_leader_schedule(&mut dag_state.write());
+        assert_eq!(
+            leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .commit_range,
+            (10..=12).into()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sliding_window_update_after_recovery_backlog() {
+        run_sliding_window_update_after_recovery_backlog(false).await;
+    }
+
+    #[tokio::test]
+    async fn test_sliding_window_update_after_recovery_backlog_with_restart() {
+        run_sliding_window_update_after_recovery_backlog(true).await;
+    }
+
+    /// Verifies that rebuilding the schedule from an oversized recovered
+    /// backlog produces the exact same `LeaderSwapTable` as a node that never
+    /// crashed and rotated its schedule incrementally over the same commits.
+    #[tokio::test]
+    async fn test_sliding_window_backlog_rebuild_matches_live_schedule() {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold_for_testing(33);
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+
+        // Two full 5-commit rotation windows, built once and shared by both
+        // scenarios so both operate on identical committed subdags.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=10).build();
+        let sub_dags_and_commits = dag_builder.get_sub_dag_and_commits(1..=10);
+
+        // Live scenario: commits are fed one at a time and the schedule is
+        // rotated as soon as each 5-commit window fills up.
+        let dag_state_live = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let leader_schedule_live = LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
+            .with_num_commits_per_schedule(5);
+        for (index, (sub_dag, commit)) in sub_dags_and_commits.iter().enumerate() {
+            leader_schedule_live.feed_committed_subdags([sub_dag.base.clone()]);
+            let mut dag_state_write = dag_state_live.write();
+            dag_state_write.set_last_commit(commit.clone());
+            dag_state_write.add_scoring_subdags(vec![sub_dag.base.clone()]);
+            if (index + 1) % 5 == 0 {
+                leader_schedule_live.update_leader_schedule(&mut dag_state_write);
+            }
+        }
+        let live_table_window_2 = leader_schedule_live.leader_swap_table.read().clone();
+
+        // Recovered scenario: the same 10 commits are persisted with no
+        // CommitInfo at all, so DagState recovers them as a single 10-commit
+        // backlog exceeding the 5-commit rotation interval.
+        let store = Arc::new(MemStore::new());
+        let mut headers_to_write = vec![];
+        let mut commits_to_write = vec![];
+        for (sub_dag, commit) in &sub_dags_and_commits {
+            headers_to_write.extend(sub_dag.headers.iter().cloned());
+            commits_to_write.push(commit.clone());
+        }
+        store
+            .write(
+                WriteBatch::default()
+                    .block_headers(headers_to_write)
+                    .commits(commits_to_write),
+            )
+            .unwrap();
+
+        let dag_state_recovered = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        assert_eq!(dag_state_recovered.read().scoring_subdags_count(), 10);
+
+        let leader_schedule_recovered =
+            LeaderSchedule::from_store(context, dag_state_recovered.clone())
+                .with_num_commits_per_schedule(5);
+        leader_schedule_recovered.update_leader_schedule(&mut dag_state_recovered.write());
+        let recovered_table = leader_schedule_recovered.leader_swap_table.read().clone();
+
+        // The backlog is an exact multiple of the interval, so nothing stays
+        // live after the rebuild.
+        assert_eq!(dag_state_recovered.read().scoring_subdags_count(), 0);
+
+        // The table rebuilt from the backlog (last full window) must match the
+        // live node's window-2 table exactly.
+        assert_eq!(
+            recovered_table.reputation_scores,
+            live_table_window_2.reputation_scores
+        );
+        assert_eq!(recovered_table.good_nodes, live_table_window_2.good_nodes);
+        assert_eq!(recovered_table.bad_nodes, live_table_window_2.bad_nodes);
     }
 }

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Formatter},
     sync::Arc,
 };
@@ -599,26 +599,14 @@ impl LeaderSwapTable {
         // the same score is preserved.
         authorities_by_score.sort_by_key(|a2| std::cmp::Reverse(a2.1));
 
-        // Calculating the good nodes
-        let good_nodes = Self::retrieve_first_nodes(
-            context.clone(),
-            authorities_by_score.iter(),
-            swap_stake_threshold,
-        )
-        .into_iter()
-        .collect::<Vec<(AuthorityIndex, String, Stake)>>();
-
-        // Calculating the bad nodes
-        // Reverse the sorted authorities to score ascending so we get the first
-        // low scorers up to the provided stake threshold.
-        let bad_nodes = Self::retrieve_first_nodes(
-            context,
-            authorities_by_score.iter().rev(),
-            swap_stake_threshold,
-        )
-        .into_iter()
-        .map(|(idx, hostname, stake)| (idx, (hostname, stake)))
-        .collect::<BTreeMap<AuthorityIndex, (String, Stake)>>();
+        let (good_nodes, bad_nodes) = if context
+            .protocol_config
+            .consensus_enable_absolute_score_leader_schedule()
+        {
+            Self::select_by_absolute_score(&context, &authorities_by_score)
+        } else {
+            Self::select_by_stake_rank(&context, &authorities_by_score, swap_stake_threshold)
+        };
 
         good_nodes.iter().for_each(|(idx, hostname, stake)| {
             tracing::debug!(
@@ -721,7 +709,156 @@ impl LeaderSwapTable {
 
         filtered_authorities
     }
+
+    /// Splits the score-descending `authorities_by_score` into the good
+    /// (swap-in) and bad sets using the fixed stake cut: the top scorers up to
+    /// `swap_stake_threshold`% of stake are good, the lowest scorers up to the
+    /// same stake are bad.
+    fn select_by_stake_rank(
+        context: &Arc<Context>,
+        authorities_by_score: &[(AuthorityIndex, u64)],
+        swap_stake_threshold: u64,
+    ) -> (
+        Vec<(AuthorityIndex, String, Stake)>,
+        BTreeMap<AuthorityIndex, (String, Stake)>,
+    ) {
+        let good_nodes = Self::retrieve_first_nodes(
+            context.clone(),
+            authorities_by_score.iter(),
+            swap_stake_threshold,
+        );
+
+        // Reverse to score ascending so we take the lowest scorers up to the
+        // stake threshold.
+        let bad_nodes = Self::retrieve_first_nodes(
+            context.clone(),
+            authorities_by_score.iter().rev(),
+            swap_stake_threshold,
+        )
+        .into_iter()
+        .map(|(idx, hostname, stake)| (idx, (hostname, stake)))
+        .collect::<BTreeMap<AuthorityIndex, (String, Stake)>>();
+
+        (good_nodes, bad_nodes)
+    }
+
+    /// High threshold (percent) for the absolute leader-schedule selection: a
+    /// validator whose reputation score, normalized to the highest score in
+    /// the window, is at or above this is a "good" (swap-in) node.
+    const GOOD_NODES_NORMALIZED_SCORE_THRESHOLD: u64 = 90;
+
+    /// Low threshold (percent) for the absolute leader-schedule selection: a
+    /// validator whose reputation score, normalized to the highest score in
+    /// the window, is strictly below this is a "bad" node.
+    const BAD_NODES_NORMALIZED_SCORE_THRESHOLD: u64 = 50;
+
+    /// Minimum size of the "good" (swap-in) pool, as a percent of the
+    /// validator count.
+    const MIN_GOOD_NODES_PERCENT: u64 = 20;
+
+    /// Maximum number of "bad" validators that may be excluded, as a percent
+    /// of the validator count.
+    const MAX_BAD_NODES_PERCENT: u64 = 33;
+
+    /// Splits the score-descending `authorities_by_score` into the good
+    /// (swap-in) and bad sets by performance relative to the top scorer. Each
+    /// score is normalized against the highest score in the window, so the
+    /// thresholds mean the same thing regardless of how close the scoring
+    /// strategy gets to its theoretical ceiling — V2 batch and sliding-window
+    /// reach very different absolute levels for the same network, but their top
+    /// performers both normalize to 100%. A node below the low threshold is
+    /// bad; a node at or above the high threshold is good. The good pool
+    /// extends down the ranking until it holds at least the minimum number
+    /// of validators; the bad set is capped at the maximum bad-node count.
+    fn select_by_absolute_score(
+        context: &Arc<Context>,
+        authorities_by_score: &[(AuthorityIndex, u64)],
+    ) -> (
+        Vec<(AuthorityIndex, String, Stake)>,
+        BTreeMap<AuthorityIndex, (String, Stake)>,
+    ) {
+        let good_threshold = Self::GOOD_NODES_NORMALIZED_SCORE_THRESHOLD as u128;
+        let bad_threshold = Self::BAD_NODES_NORMALIZED_SCORE_THRESHOLD as u128;
+
+        // Normalize against the highest score in this window (the top
+        // performer). `authorities_by_score` is score descending, so the first
+        // entry is the maximum. It is derived from the same committed subdags on
+        // every authority, so the normalization is deterministic and reproduces
+        // identically on recovery.
+        let top_score = authorities_by_score
+            .first()
+            .map(|&(_, score)| score as u128)
+            .unwrap_or(0);
+
+        // No positive score to normalize against, so make no swaps.
+        if top_score == 0 {
+            return (Vec::new(), BTreeMap::new());
+        }
+
+        // Integer-only comparisons against `score / top_score`:
+        //   good: score * 100 >= good_threshold * top_score
+        //   bad:  score * 100 <  bad_threshold  * top_score
+        let is_good = |score: u64| (score as u128) * 100 >= good_threshold * top_score;
+        let is_bad = |score: u64| (score as u128) * 100 < bad_threshold * top_score;
+
+        let committee_size = context.committee.size() as u64;
+
+        // Good pool: the top scorers, extended past the high threshold until it
+        // holds at least the minimum number of validators, enforced even if
+        // that requires including a node below the low (bad) threshold.
+        let min_good = (Self::MIN_GOOD_NODES_PERCENT * committee_size).div_ceil(100) as usize;
+        let mut good_nodes = Vec::new();
+        for &(authority_idx, score) in authorities_by_score.iter() {
+            if !is_good(score) && good_nodes.len() >= min_good {
+                break;
+            }
+            let authority = context.committee.authority(authority_idx);
+            good_nodes.push((authority_idx, authority.hostname.clone(), authority.stake));
+        }
+
+        // Bad set: the lowest scorers below the threshold, excluding any node
+        // already claimed by the good pool, capped at the maximum bad-node count.
+        let max_bad = (Self::MAX_BAD_NODES_PERCENT * committee_size / 100) as usize;
+        let good_indexes = good_nodes
+            .iter()
+            .map(|(idx, _, _)| *idx)
+            .collect::<BTreeSet<AuthorityIndex>>();
+        let bad_nodes = authorities_by_score
+            .iter()
+            .rev()
+            .filter(|entry| is_bad(entry.1) && !good_indexes.contains(&entry.0))
+            .take(max_bad)
+            .map(|&(idx, _)| {
+                let authority = context.committee.authority(idx);
+                (idx, (authority.hostname.clone(), authority.stake))
+            })
+            .collect::<BTreeMap<AuthorityIndex, (String, Stake)>>();
+
+        (good_nodes, bad_nodes)
+    }
 }
+
+const _: () = assert!(
+    LeaderSwapTable::GOOD_NODES_NORMALIZED_SCORE_THRESHOLD <= 100,
+    "GOOD_NODES_NORMALIZED_SCORE_THRESHOLD must be <= 100"
+);
+const _: () = assert!(
+    LeaderSwapTable::BAD_NODES_NORMALIZED_SCORE_THRESHOLD <= 100,
+    "BAD_NODES_NORMALIZED_SCORE_THRESHOLD must be <= 100"
+);
+const _: () = assert!(
+    LeaderSwapTable::GOOD_NODES_NORMALIZED_SCORE_THRESHOLD
+        > LeaderSwapTable::BAD_NODES_NORMALIZED_SCORE_THRESHOLD,
+    "GOOD_NODES_NORMALIZED_SCORE_THRESHOLD must be > BAD_NODES_NORMALIZED_SCORE_THRESHOLD"
+);
+const _: () = assert!(
+    LeaderSwapTable::MIN_GOOD_NODES_PERCENT >= 1,
+    "MIN_GOOD_NODES_PERCENT must be >= 1 so the good pool is non-empty"
+);
+const _: () = assert!(
+    LeaderSwapTable::MIN_GOOD_NODES_PERCENT + LeaderSwapTable::MAX_BAD_NODES_PERCENT < 70,
+    "MIN_GOOD_NODES_PERCENT + MAX_BAD_NODES_PERCENT must be < 70"
+);
 
 impl Debug for LeaderSwapTable {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -1387,6 +1524,148 @@ mod tests {
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         LeaderSwapTable::new_inner(context, swap_stake_threshold, 0, reputation_scores);
+    }
+
+    fn context_with_absolute_selection(committee_size: usize) -> Arc<Context> {
+        let mut context = Context::new_for_test(committee_size).0;
+        context
+            .protocol_config
+            .set_consensus_enable_absolute_score_leader_schedule_for_testing(true);
+        Arc::new(context)
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_classifies_by_threshold() {
+        telemetry_subscribers::init_for_testing();
+        // 4 authorities. The top scorer has 44, so good is >= 90% of 44
+        // (>= 40) and bad is < 50% of 44 (< 22).
+        let context = context_with_absolute_selection(4);
+        let reputation_scores = ReputationScores::new((0..=10).into(), vec![0, 30, 40, 44]);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        let good: Vec<_> = table.good_nodes.iter().map(|(idx, _, _)| *idx).collect();
+        assert_eq!(good.len(), 2);
+        assert!(good.contains(&AuthorityIndex::new_for_test(2)));
+        assert!(good.contains(&AuthorityIndex::new_for_test(3)));
+        // The middle node (score 30) is neither good nor bad.
+        assert!(!good.contains(&AuthorityIndex::new_for_test(1)));
+        assert_eq!(table.bad_nodes.len(), 1);
+        assert!(
+            table
+                .bad_nodes
+                .contains_key(&AuthorityIndex::new_for_test(0))
+        );
+        assert!(
+            !table
+                .bad_nodes
+                .contains_key(&AuthorityIndex::new_for_test(1))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_good_pool_respects_count_floor() {
+        telemetry_subscribers::init_for_testing();
+        // 10 authorities, so the 20%-of-validators good-pool floor is 2 nodes.
+        // Only one authority clears the 90% threshold; the pool must extend to
+        // the next-best scorer to meet the floor, so it is never one node.
+        let context = context_with_absolute_selection(10);
+        let mut scores = vec![60u64; 10];
+        scores[9] = 110;
+        let reputation_scores = ReputationScores::new((0..=10).into(), scores);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        assert_eq!(table.good_nodes.len(), 2);
+        let good: Vec<_> = table.good_nodes.iter().map(|(idx, _, _)| *idx).collect();
+        assert!(good.contains(&AuthorityIndex::new_for_test(9)));
+        // Every authority scores above 50%, so none are bad.
+        assert!(table.bad_nodes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_caps_bad_set_by_count() {
+        telemetry_subscribers::init_for_testing();
+        // 10 authorities. Five score 0 (bad), five clear the high threshold. The
+        // five below-threshold nodes exceed the 33%-of-validators cap (3), so
+        // only the worst three may be excluded.
+        let context = context_with_absolute_selection(10);
+        let mut scores = vec![0u64; 10];
+        for s in scores.iter_mut().skip(5) {
+            *s = 110;
+        }
+        let reputation_scores = ReputationScores::new((0..=10).into(), scores);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        assert_eq!(table.good_nodes.len(), 5);
+        assert_eq!(table.bad_nodes.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_swaps_bad_leaders() {
+        telemetry_subscribers::init_for_testing();
+        // One clear top scorer, everyone else far below it. The good pool is
+        // non-empty and the low scorers are excluded, so a bad leader is swapped
+        // for a good node rather than panicking.
+        let context = context_with_absolute_selection(10);
+        let mut scores = vec![0u64; 10];
+        scores[0] = 100;
+        let reputation_scores = ReputationScores::new((0..=10).into(), scores);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        assert!(!table.good_nodes.is_empty());
+        assert!(!table.bad_nodes.is_empty());
+        let bad_leader = *table.bad_nodes.keys().next().unwrap();
+        assert!(table.swap(bad_leader, 1, 0).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_normalizes_by_top_scorer() {
+        telemetry_subscribers::init_for_testing();
+        // Selection normalizes against the top score in the window (20 here),
+        // not against the scoring strategy's theoretical ceiling. Node 1 at 18
+        // is 90% of the best, so it is good; the same score of 18 measured
+        // against a much higher theoretical ceiling would instead fall below
+        // every threshold.
+        let context = context_with_absolute_selection(4);
+        let reputation_scores = ReputationScores::new((0..=10).into(), vec![20, 18, 10, 4]);
+        let table = LeaderSwapTable::new_inner(context, 33, 0, reputation_scores);
+
+        let good: Vec<_> = table.good_nodes.iter().map(|(idx, _, _)| *idx).collect();
+        assert_eq!(good.len(), 2);
+        assert!(good.contains(&AuthorityIndex::new_for_test(0)));
+        assert!(good.contains(&AuthorityIndex::new_for_test(1)));
+        // Node 2 (10 = 50% of the top) is neither good nor bad.
+        assert!(!good.contains(&AuthorityIndex::new_for_test(2)));
+        assert!(
+            !table
+                .bad_nodes
+                .contains_key(&AuthorityIndex::new_for_test(2))
+        );
+        // Node 3 (4 = 20% of the top) is below the low threshold.
+        assert_eq!(table.bad_nodes.len(), 1);
+        assert!(
+            table
+                .bad_nodes
+                .contains_key(&AuthorityIndex::new_for_test(3))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_leader_swap_table_absolute_score_deterministic_and_differs_from_stake_rank() {
+        telemetry_subscribers::init_for_testing();
+        let scores = || ReputationScores::new((0..=10).into(), vec![0, 30, 40, 44]);
+
+        let absolute_context = context_with_absolute_selection(4);
+        let first = LeaderSwapTable::new_inner(absolute_context.clone(), 33, 0, scores());
+        let second = LeaderSwapTable::new_inner(absolute_context, 33, 0, scores());
+        assert_eq!(first.good_nodes, second.good_nodes);
+        assert_eq!(first.bad_nodes, second.bad_nodes);
+
+        // The stake-rank path (flag off) admits only the single top scorer as
+        // good; the absolute path admits both authorities above the threshold.
+        let stake_rank_context = Arc::new(Context::new_for_test(4).0);
+        let stake_rank = LeaderSwapTable::new_inner(stake_rank_context, 33, 0, scores());
+        assert_eq!(stake_rank.good_nodes.len(), 1);
+        assert_eq!(first.good_nodes.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -488,12 +488,20 @@ impl LeaderSchedule {
 
     /// Rebuilds the sliding-window scorer (when enabled) by replaying the last
     /// `window_size` committed subdags from storage, so the running aggregate
-    /// is current after a restart or fast-sync. Does not recover the in-effect
-    /// swap table. Returns without effect on the V2 path (no scorer).
+    /// is current after a restart or fast-sync. No-op while fast sync is
+    /// ongoing; `reinitialize` rebuilds the window once fast sync completes.
+    /// Does not recover the in-effect swap table. Returns without effect on
+    /// the V2 path (no scorer).
     fn recover_sliding_window(&self, dag_state: &RwLock<DagState>) {
         let Some(sliding_window) = &self.sliding_window else {
             return;
         };
+        // Skip if fast sync is ongoing - committed block headers may not be
+        // available and the window is rebuilt on reinitialize anyway
+        if dag_state.read().fast_sync_ongoing() {
+            tracing::info!("Skipping sliding window recovery - fast sync ongoing");
+            return;
+        }
         let window_size = self.context.protocol_config.leader_schedule_window_size();
         let subdags = {
             let dag_state = dag_state.read();
@@ -994,6 +1002,67 @@ mod tests {
         let leader_swap_table = leader_schedule.leader_swap_table.read();
         assert_eq!(leader_swap_table.good_nodes.len(), 0);
         assert_eq!(leader_swap_table.bad_nodes.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_leader_schedule_from_store_during_fast_sync() {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=6).build();
+
+        let mut headers = vec![];
+        let mut commits = vec![];
+        for (sub_dag, commit) in dag_builder.get_sub_dag_and_commits(1..=6) {
+            headers.extend(sub_dag.headers.iter().cloned());
+            commits.push(commit);
+        }
+
+        // Persist the fast-sync intermediate state: commits and the fast-sync
+        // flag, but no committed block headers.
+        store
+            .write(
+                WriteBatch {
+                    fast_commit_sync_flag: Some(true),
+                    ..Default::default()
+                }
+                .commits(commits),
+            )
+            .unwrap();
+
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        // Recovery must not replay subdags (their headers are absent) and is
+        // deferred until fast sync completes.
+        let leader_schedule = LeaderSchedule::from_store(context, dag_state.clone());
+        let sliding_window = leader_schedule.sliding_window.as_ref().unwrap();
+        assert_eq!(
+            sliding_window.lock().reputation_scores().commit_range,
+            CommitRange::default()
+        );
+
+        // Once fast sync completes (headers stored, flag cleared), reinitialize
+        // rebuilds the window.
+        store
+            .write(
+                WriteBatch {
+                    fast_commit_sync_flag: Some(false),
+                    ..Default::default()
+                }
+                .block_headers(headers),
+            )
+            .unwrap();
+        leader_schedule.reinitialize(&dag_state);
+        assert_eq!(
+            sliding_window.lock().reputation_scores().commit_range,
+            (1..=3).into()
+        );
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -1657,4 +1657,24 @@ mod tests {
         assert_eq!(recovered_table.good_nodes, live_table_window_2.good_nodes);
         assert_eq!(recovered_table.bad_nodes, live_table_window_2.bad_nodes);
     }
+
+    #[test]
+    fn test_leader_schedule_window_invariant_for_all_protocol_configs() {
+        use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+
+        // The getter assert enforcing this only fires once consensus starts at
+        // the adopting epoch; check every defined config here so that a
+        // misconfigured version fails CI, which runs this without msim and so
+        // compares the real, unclamped values.
+        for chain in [Chain::Unknown, Chain::Mainnet, Chain::Testnet] {
+            for version in ProtocolVersion::MIN.as_u64()..=ProtocolVersion::MAX.as_u64() {
+                let config = ProtocolConfig::get_for_version(ProtocolVersion::new(version), chain);
+                assert!(
+                    !config.consensus_enable_sliding_window_leader_schedule()
+                        || config.leader_schedule_window_size() >= config.commits_per_schedule(),
+                    "{chain:?} v{version}: leader_schedule_window_size must be >= commits_per_schedule"
+                );
+            }
+        }
+    }
 }

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 use tracing::instrument;
 
 use crate::{
-    block_header::{BlockHeaderAPI, BlockRef},
+    block_header::{BlockHeaderAPI, BlockRef, Round},
     commit::{CommitRange, SubDagBase},
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -252,11 +252,115 @@ impl ScoringSubdag {
     }
 }
 
+/// Walks `[c_minus_2, c_minus_1, c]` in order, returning every commit up to and
+/// **including** the first whose leader round is strictly greater than `upper`.
+/// Callers pass strictly increasing leader rounds, so the scan always stops on
+/// a commit above `upper` rather than running off the end.
+fn scan_until_leader_round_above<'a>(
+    c_minus_2: &'a SubDagBase,
+    c_minus_1: &'a SubDagBase,
+    c: &'a SubDagBase,
+    upper: Round,
+) -> Vec<&'a SubDagBase> {
+    let mut out = Vec::with_capacity(3);
+    for cmt in [c_minus_2, c_minus_1, c] {
+        out.push(cmt);
+        if cmt.leader.round > upper {
+            break;
+        }
+    }
+    out
+}
+
+/// Compute the per-commit score contribution for the new commit `c`, scoring
+/// the oldest of the 3 pending commits (`c_minus_3`). Returns per-authority
+/// score deltas indexed by `AuthorityIndex`.
+///
+/// V2's distributed-vote semantics with propagation lookahead bounded at r+2:
+/// for each authority A, `contribution[A]` is the sum of stake of authorities
+/// whose round-(r+2) blocks strongly link to A's round-(r+1) voting block,
+/// where A's voting block strongly links to `c_minus_3`'s leader block (round
+/// r).
+///
+/// Equivocation: if A has multiple voting blocks at r+1 within the lookback
+/// window, `contribution[A] = 0`.
+///
+/// Assumes consecutive commits have strictly increasing leader rounds
+/// (`c_minus_3 < c_minus_2 < c_minus_1 < c`), which the driving schedule
+/// maintains by construction.
+pub(crate) fn compute_per_commit_contribution(
+    context: &Context,
+    c_minus_3: &SubDagBase,
+    c_minus_2: &SubDagBase,
+    c_minus_1: &SubDagBase,
+    c: &SubDagBase,
+) -> Vec<u64> {
+    let committee = &context.committee;
+    let leader_ref = c_minus_3.leader;
+    let r = leader_ref.round;
+    let vote_round = r + 1;
+    let certify_round = r + 2;
+
+    // Voting blocks at round r+1 that strongly link to the leader block, grouped by
+    // author. Multiple blocks per author indicates equivocation in the lookback
+    // window.
+    let voting_commits = scan_until_leader_round_above(c_minus_2, c_minus_1, c, vote_round);
+    let mut voting_blocks_by_author: BTreeMap<AuthorityIndex, Vec<BlockRef>> = BTreeMap::new();
+    for commit in &voting_commits {
+        for header in &commit.headers {
+            if header.round() != vote_round {
+                continue;
+            }
+            if !header.ancestors().contains(&leader_ref) {
+                continue;
+            }
+            voting_blocks_by_author
+                .entry(header.author())
+                .or_default()
+                .push(header.reference());
+        }
+    }
+
+    // Round-(r+2) certifying blocks, with their ancestor lists.
+    let certifying_commits = scan_until_leader_round_above(c_minus_2, c_minus_1, c, certify_round);
+    let mut certifying_blocks: Vec<(AuthorityIndex, &[BlockRef])> = Vec::new();
+    for commit in &certifying_commits {
+        for header in &commit.headers {
+            if header.round() == certify_round {
+                certifying_blocks.push((header.author(), header.ancestors()));
+            }
+        }
+    }
+
+    let mut scores = vec![0u64; committee.size()];
+    for (author, voting_refs) in &voting_blocks_by_author {
+        // Equivocation in the lookback window → zero contribution.
+        if voting_refs.len() != 1 {
+            continue;
+        }
+        let voting_ref = voting_refs[0];
+        // Dedup by certifier so an equivocating certifier's stake counts once.
+        let mut certifying_stake = StakeAggregator::<QuorumThreshold>::new();
+        for (cert_author, cert_ancestors) in &certifying_blocks {
+            if cert_ancestors.contains(&voting_ref) {
+                certifying_stake.add(*cert_author, committee);
+            }
+        }
+        scores[author.value()] = certifying_stake.stake();
+    }
+
+    scores
+}
+
 #[cfg(test)]
 mod tests {
 
     use super::*;
-    use crate::test_dag_builder::DagBuilder;
+    use crate::{
+        block_header::{BlockHeaderDigest, TestBlockHeader, VerifiedBlockHeader},
+        commit::{CommitDigest, CommitRef},
+        test_dag_builder::DagBuilder,
+    };
 
     #[test]
     fn test_from_scores_desc_converts_to_per_authority_scores() {
@@ -359,5 +463,107 @@ mod tests {
         let scores = scoring_subdag.calculate_distributed_vote_scores();
         assert_eq!(scores.scores_per_authority, vec![5, 5, 5, 5]);
         assert_eq!(scores.commit_range, (1..=4).into());
+    }
+
+    /// Helper: build 4 fully-connected commits using `DagBuilder` and return
+    /// their `SubDagBase`s in order [commit_1, commit_2, commit_3, commit_4].
+    fn build_four_commits(context: Arc<Context>) -> Vec<SubDagBase> {
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=4).build();
+        dag_builder
+            .get_sub_dag_and_commits(1..=4)
+            .into_iter()
+            .map(|(sub_dag, _)| sub_dag.base)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_compute_per_commit_contribution_full_connectivity() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let subdags = build_four_commits(context.clone());
+        assert_eq!(subdags.len(), 4);
+
+        let contribution = compute_per_commit_contribution(
+            &context,
+            &subdags[0],
+            &subdags[1],
+            &subdags[2],
+            &subdags[3],
+        );
+
+        // In a fully-connected DAG, every authority votes for commit-1's leader and
+        // every round-(r+2) block certifies every voting block. So every authority's
+        // contribution equals the full committee stake.
+        let expected_per_authority: u64 = context.committee.total_stake();
+        assert_eq!(
+            contribution,
+            vec![expected_per_authority; context.committee.size()],
+            "expected each authority to get full committee stake as contribution"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compute_per_commit_contribution_dedups_equivocating_certifier() {
+        // An equivocating certifier — two round-(r+2) blocks from one author,
+        // both linking the same voting block — contributes its stake once, not
+        // once per block.
+        let context = Arc::new(Context::new_for_test(4).0);
+        let committee = &context.committee;
+        let r: Round = 10;
+
+        // Minimal subdag: the scorer reads only the leader round and the
+        // headers' ancestor links.
+        let subdag = |leader_round: Round, headers: Vec<VerifiedBlockHeader>| SubDagBase {
+            leader: BlockRef::new(
+                leader_round,
+                AuthorityIndex::new_for_test(0),
+                BlockHeaderDigest::MIN,
+            ),
+            headers,
+            committed_header_refs: vec![],
+            timestamp_ms: 0,
+            commit_ref: CommitRef::new(0, CommitDigest::MIN),
+            reputation_scores_desc: vec![],
+        };
+
+        let c_minus_3 = subdag(r, vec![]);
+
+        // Authority 0 casts a single vote for the leader at round r+1.
+        let voting_block = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 1, 0)
+                .set_ancestors(vec![c_minus_3.leader])
+                .build(),
+        );
+        let voting_ref = voting_block.reference();
+
+        // Authority 1 equivocates at round r+2 with two distinct blocks, each
+        // certifying the voting block.
+        let cert_a = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 2, 1)
+                .set_ancestors(vec![voting_ref])
+                .set_timestamp_ms(1)
+                .build(),
+        );
+        let cert_b = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 2, 1)
+                .set_ancestors(vec![voting_ref])
+                .set_timestamp_ms(2)
+                .build(),
+        );
+
+        let c_minus_2 = subdag(r + 1, vec![voting_block]);
+        let c_minus_1 = subdag(r + 2, vec![cert_a, cert_b]);
+        let c = subdag(r + 3, vec![]);
+
+        let scores =
+            compute_per_commit_contribution(&context, &c_minus_3, &c_minus_2, &c_minus_1, &c);
+
+        let mut expected = vec![0u64; committee.size()];
+        expected[0] = committee.stake(AuthorityIndex::new_for_test(1));
+        assert_eq!(
+            scores, expected,
+            "equivocating certifier's stake must be counted once, not per block"
+        );
     }
 }

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -142,6 +142,16 @@ impl ScoringSubdag {
             .scope_processing_time
             .with_label_values(&["ScoringSubdag::add_unscored_committed_subdags"])
             .start_timer();
+
+        // The vote traversal below feeds only the V2 boundary score computation;
+        // the sliding-window path scores from its running window aggregate
+        // instead. There only `commit_range` is needed (it drives rotation
+        // timing), so skip the per-commit traversal.
+        let sliding_window_enabled = self
+            .context
+            .protocol_config
+            .consensus_enable_sliding_window_leader_schedule();
+
         for subdag in committed_subdags {
             if let Some(commit_range) = self.commit_range.as_mut() {
                 commit_range.extend_to(subdag.commit_ref.index);
@@ -152,6 +162,11 @@ impl ScoringSubdag {
                     subdag.commit_ref.index..=subdag.commit_ref.index,
                 ));
             }
+
+            if sliding_window_enabled {
+                continue;
+            }
+
             // Add the committed leader to the list of leaders we will be scoring.
             tracing::trace!("Adding new committed leader {} for scoring", subdag.leader);
             self.leaders.insert(subdag.leader);
@@ -544,5 +559,34 @@ mod tests {
             scores, expected,
             "equivocating certifier's stake must be counted once, not per block"
         );
+    }
+
+    #[tokio::test]
+    async fn test_add_subdags_skips_vote_scoring_when_sliding_window_enabled() {
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_enable_sliding_window_leader_schedule_for_testing(true);
+        let context = Arc::new(context);
+
+        // A fully-connected DAG that would produce non-zero votes on the V2 path.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=4).build();
+
+        let mut scoring_subdag = ScoringSubdag::new(context);
+        for (sub_dag, _commit) in dag_builder.get_sub_dag_and_commits(1..=4) {
+            scoring_subdag.add_subdags(vec![sub_dag.base]);
+        }
+
+        // The commit range is still maintained — it is what drives rotation
+        // timing (`scored_subdags_count` / `is_empty`) on the sliding-window path.
+        assert_eq!(scoring_subdag.scored_subdags_count(), 4);
+        assert_eq!(scoring_subdag.commit_range, Some(CommitRange::new(1..=4)));
+        assert!(!scoring_subdag.is_empty());
+
+        // But the per-commit vote traversal was skipped: no leaders or votes
+        // accumulated, so the V2 boundary score computation is never fed.
+        assert!(scoring_subdag.leaders.is_empty());
+        assert!(scoring_subdag.votes.is_empty());
     }
 }

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 use tracing::instrument;
 
 use crate::{
-    block_header::{BlockHeaderAPI, BlockRef, Round},
+    block_header::{BlockHeaderAPI, BlockRef},
     commit::{CommitRange, SubDagBase},
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -24,7 +24,11 @@ use crate::{
 pub(crate) struct ReputationScores {
     /// Score per authority. Vec index is the `AuthorityIndex`.
     pub(crate) scores_per_authority: Vec<u64>,
-    // The range of commits these scores were calculated from.
+    /// The range of commits these scores were calculated from. Exception: on
+    /// the sliding-window path the *persisted* range is the committed
+    /// interval ending at the rotation boundary,
+    /// whereas the scores are aggregated over a deeper window ending
+    /// `MAX_PENDING_COMMITS` commits earlier.
     pub(crate) commit_range: CommitRange,
 }
 
@@ -252,26 +256,6 @@ impl ScoringSubdag {
     }
 }
 
-/// Walks `[c_minus_2, c_minus_1, c]` in order, returning every commit up to and
-/// **including** the first whose leader round is strictly greater than `upper`.
-/// Callers pass strictly increasing leader rounds, so the scan always stops on
-/// a commit above `upper` rather than running off the end.
-fn scan_until_leader_round_above<'a>(
-    c_minus_2: &'a SubDagBase,
-    c_minus_1: &'a SubDagBase,
-    c: &'a SubDagBase,
-    upper: Round,
-) -> Vec<&'a SubDagBase> {
-    let mut out = Vec::with_capacity(3);
-    for cmt in [c_minus_2, c_minus_1, c] {
-        out.push(cmt);
-        if cmt.leader.round > upper {
-            break;
-        }
-    }
-    out
-}
-
 /// Compute the per-commit score contribution for the new commit `c`, scoring
 /// the oldest of the 3 pending commits (`c_minus_3`). Returns per-authority
 /// score deltas indexed by `AuthorityIndex`.
@@ -280,14 +264,11 @@ fn scan_until_leader_round_above<'a>(
 /// for each authority A, `contribution[A]` is the sum of stake of authorities
 /// whose round-(r+2) blocks strongly link to A's round-(r+1) voting block,
 /// where A's voting block strongly links to `c_minus_3`'s leader block (round
-/// r).
+/// r). The round-(r+1) and round-(r+2) blocks are collected from all three
+/// commits following `c_minus_3` (`c_minus_2`, `c_minus_1`, `c`).
 ///
-/// Equivocation: if A has multiple voting blocks at r+1 within the lookback
-/// window, `contribution[A] = 0`.
-///
-/// Assumes consecutive commits have strictly increasing leader rounds
-/// (`c_minus_3 < c_minus_2 < c_minus_1 < c`), which the driving schedule
-/// maintains by construction.
+/// Equivocation: if A has multiple voting blocks at r+1 within that window,
+/// `contribution[A] = 0`.
 pub(crate) fn compute_per_commit_contribution(
     context: &Context,
     c_minus_3: &SubDagBase,
@@ -304,9 +285,8 @@ pub(crate) fn compute_per_commit_contribution(
     // Voting blocks at round r+1 that strongly link to the leader block, grouped by
     // author. Multiple blocks per author indicates equivocation in the lookback
     // window.
-    let voting_commits = scan_until_leader_round_above(c_minus_2, c_minus_1, c, vote_round);
     let mut voting_blocks_by_author: BTreeMap<AuthorityIndex, Vec<BlockRef>> = BTreeMap::new();
-    for commit in &voting_commits {
+    for commit in [c_minus_2, c_minus_1, c] {
         for header in &commit.headers {
             if header.round() != vote_round {
                 continue;
@@ -322,9 +302,8 @@ pub(crate) fn compute_per_commit_contribution(
     }
 
     // Round-(r+2) certifying blocks, with their ancestor lists.
-    let certifying_commits = scan_until_leader_round_above(c_minus_2, c_minus_1, c, certify_round);
     let mut certifying_blocks: Vec<(AuthorityIndex, &[BlockRef])> = Vec::new();
-    for commit in &certifying_commits {
+    for commit in [c_minus_2, c_minus_1, c] {
         for header in &commit.headers {
             if header.round() == certify_round {
                 certifying_blocks.push((header.author(), header.ancestors()));
@@ -357,7 +336,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_header::{BlockHeaderDigest, TestBlockHeader, VerifiedBlockHeader},
+        block_header::{BlockHeaderDigest, Round, TestBlockHeader, VerifiedBlockHeader},
         commit::{CommitDigest, CommitRef},
         test_dag_builder::DagBuilder,
     };

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
     sync::Arc,
 };
@@ -316,34 +316,34 @@ pub(crate) fn compute_per_commit_contribution(
         }
     }
 
-    // Round-(r+2) certifying blocks, with their ancestor lists.
-    let mut certifying_blocks: Vec<(AuthorityIndex, &[BlockRef])> = Vec::new();
+    // Voting-block ref → author, for authors with exactly one voting block.
+    // Equivocation in the lookback window → excluded, zero contribution.
+    let mut voting_author_by_ref: HashMap<BlockRef, AuthorityIndex> = HashMap::new();
+    for (author, voting_refs) in &voting_blocks_by_author {
+        if let [voting_ref] = voting_refs.as_slice() {
+            voting_author_by_ref.insert(*voting_ref, *author);
+        }
+    }
+
+    // One pass over the round-(r+2) blocks' ancestors. The aggregator dedups
+    // by certifier so an equivocating certifier's stake counts once per author.
+    let mut certifying_stake: Vec<StakeAggregator<QuorumThreshold>> = (0..committee.size())
+        .map(|_| StakeAggregator::new())
+        .collect();
     for commit in [c_minus_2, c_minus_1, c] {
         for header in &commit.headers {
-            if header.round() == certify_round {
-                certifying_blocks.push((header.author(), header.ancestors()));
+            if header.round() != certify_round {
+                continue;
+            }
+            for ancestor in header.ancestors() {
+                if let Some(author) = voting_author_by_ref.get(ancestor) {
+                    certifying_stake[author.value()].add(header.author(), committee);
+                }
             }
         }
     }
 
-    let mut scores = vec![0u64; committee.size()];
-    for (author, voting_refs) in &voting_blocks_by_author {
-        // Equivocation in the lookback window → zero contribution.
-        if voting_refs.len() != 1 {
-            continue;
-        }
-        let voting_ref = voting_refs[0];
-        // Dedup by certifier so an equivocating certifier's stake counts once.
-        let mut certifying_stake = StakeAggregator::<QuorumThreshold>::new();
-        for (cert_author, cert_ancestors) in &certifying_blocks {
-            if cert_ancestors.contains(&voting_ref) {
-                certifying_stake.add(*cert_author, committee);
-            }
-        }
-        scores[author.value()] = certifying_stake.stake();
-    }
-
-    scores
+    certifying_stake.iter().map(|agg| agg.stake()).collect()
 }
 
 #[cfg(test)]
@@ -558,6 +558,87 @@ mod tests {
         assert_eq!(
             scores, expected,
             "equivocating certifier's stake must be counted once, not per block"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compute_per_commit_contribution_attributes_partial_certification() {
+        // Each voting author is certified by a different subset of round-(r+2)
+        // blocks, so every authority expects a distinct score and any
+        // misattribution is visible.
+        let context = Arc::new(Context::new_for_test(4).0);
+        let committee = &context.committee;
+        let r: Round = 10;
+
+        let subdag = |leader_round: Round, headers: Vec<VerifiedBlockHeader>| SubDagBase {
+            leader: BlockRef::new(
+                leader_round,
+                AuthorityIndex::new_for_test(0),
+                BlockHeaderDigest::MIN,
+            ),
+            headers,
+            committed_header_refs: vec![],
+            timestamp_ms: 0,
+            commit_ref: CommitRef::new(0, CommitDigest::MIN),
+            reputation_scores_desc: vec![],
+        };
+
+        let c_minus_3 = subdag(r, vec![]);
+
+        // Authorities 0, 1, 2 vote for the leader at round r+1; authority 3's
+        // round-(r+1) block does not link the leader, so it is not a vote.
+        let vote = |author: u8| {
+            VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(r + 1, author)
+                    .set_ancestors(vec![c_minus_3.leader])
+                    .build(),
+            )
+        };
+        let vote_0 = vote(0);
+        let vote_1 = vote(1);
+        let vote_2 = vote(2);
+        let non_vote_3 = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(r + 1, 3).build());
+
+        // Certifiers at round r+2: authority 0 links all round-(r+1) blocks
+        // (including the non-vote, which must credit no one), authority 1
+        // links votes {0, 1}, authority 2 links vote {0} only.
+        let cert = |author: u8, ancestors: Vec<BlockRef>| {
+            VerifiedBlockHeader::new_for_test(
+                TestBlockHeader::new(r + 2, author)
+                    .set_ancestors(ancestors)
+                    .build(),
+            )
+        };
+        let cert_0 = cert(
+            0,
+            vec![
+                vote_0.reference(),
+                vote_1.reference(),
+                vote_2.reference(),
+                non_vote_3.reference(),
+            ],
+        );
+        let cert_1 = cert(1, vec![vote_0.reference(), vote_1.reference()]);
+        let cert_2 = cert(2, vec![vote_0.reference()]);
+
+        // Spread the blocks across the three commits following `c_minus_3`.
+        let c_minus_2 = subdag(r + 1, vec![vote_0, vote_1, vote_2, non_vote_3]);
+        let c_minus_1 = subdag(r + 2, vec![cert_0, cert_1]);
+        let c = subdag(r + 3, vec![cert_2]);
+
+        let scores =
+            compute_per_commit_contribution(&context, &c_minus_3, &c_minus_2, &c_minus_1, &c);
+
+        let stake = |index: u8| committee.stake(AuthorityIndex::new_for_test(index));
+        let expected = vec![
+            stake(0) + stake(1) + stake(2),
+            stake(0) + stake(1),
+            stake(0),
+            0,
+        ];
+        assert_eq!(
+            scores, expected,
+            "each voting author must be credited exactly its own certifiers' stake"
         );
     }
 

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -271,6 +271,15 @@ impl ScoringSubdag {
     }
 }
 
+/// Reputation multiplier applied to a strong vote relative to an ordinary vote.
+/// A strong vote (only produced under `consensus_starfish_speed`) is a stronger
+/// signal that the voter promptly saw and backed the leader — it attests
+/// holding the leader's transaction data, not just its header — so it scores
+/// double. This scorer only runs under
+/// `consensus_enable_sliding_window_leader_schedule`, so the weighting ships
+/// as part of the redesigned schedule and V2 scoring is unaffected.
+const STRONG_VOTE_MULTIPLIER: u64 = 2;
+
 /// Compute the per-commit score contribution for the new commit `c`, scoring
 /// the oldest of the 3 pending commits (`c_minus_3`). Returns per-authority
 /// score deltas indexed by `AuthorityIndex`.
@@ -281,6 +290,9 @@ impl ScoringSubdag {
 /// where A's voting block strongly links to `c_minus_3`'s leader block (round
 /// r). The round-(r+1) and round-(r+2) blocks are collected from all three
 /// commits following `c_minus_3` (`c_minus_2`, `c_minus_1`, `c`).
+///
+/// Under `consensus_starfish_speed`, a voting block that is a *strong* vote for
+/// the leader has its contribution multiplied by [`STRONG_VOTE_MULTIPLIER`].
 ///
 /// Equivocation: if A has multiple voting blocks at r+1 within that window,
 /// `contribution[A] = 0`.
@@ -297,10 +309,16 @@ pub(crate) fn compute_per_commit_contribution(
     let vote_round = r + 1;
     let certify_round = r + 2;
 
-    // Voting blocks at round r+1 that strongly link to the leader block, grouped by
-    // author. Multiple blocks per author indicates equivocation in the lookback
-    // window.
-    let mut voting_blocks_by_author: BTreeMap<AuthorityIndex, Vec<BlockRef>> = BTreeMap::new();
+    // Strong votes score double. Gate on the flag so a stray strong_vote on a
+    // non-speed block can never change scoring (strong votes only exist under
+    // starfish speed).
+    let double_strong_votes = context.protocol_config.consensus_starfish_speed();
+
+    // Voting blocks at round r+1 that strongly link to the leader block, grouped
+    // by author, each tagged with whether it is a strong vote for the leader.
+    // Multiple blocks per author indicates equivocation in the lookback window.
+    let mut voting_blocks_by_author: BTreeMap<AuthorityIndex, Vec<(BlockRef, bool)>> =
+        BTreeMap::new();
     for commit in [c_minus_2, c_minus_1, c] {
         for header in &commit.headers {
             if header.round() != vote_round {
@@ -312,16 +330,22 @@ pub(crate) fn compute_per_commit_contribution(
             voting_blocks_by_author
                 .entry(header.author())
                 .or_default()
-                .push(header.reference());
+                .push((
+                    header.reference(),
+                    header.is_strong_vote_for(leader_ref.author),
+                ));
         }
     }
 
     // Voting-block ref → author, for authors with exactly one voting block.
     // Equivocation in the lookback window → excluded, zero contribution.
+    // `strong_voter[A]` is true when A's single voting block is a strong vote.
     let mut voting_author_by_ref: HashMap<BlockRef, AuthorityIndex> = HashMap::new();
+    let mut strong_voter = vec![false; committee.size()];
     for (author, voting_refs) in &voting_blocks_by_author {
-        if let [voting_ref] = voting_refs.as_slice() {
+        if let [(voting_ref, strong)] = voting_refs.as_slice() {
             voting_author_by_ref.insert(*voting_ref, *author);
+            strong_voter[author.value()] = *strong;
         }
     }
 
@@ -343,7 +367,17 @@ pub(crate) fn compute_per_commit_contribution(
         }
     }
 
-    certifying_stake.iter().map(|agg| agg.stake()).collect()
+    certifying_stake
+        .iter()
+        .enumerate()
+        .map(|(author, agg)| {
+            if double_strong_votes && strong_voter[author] {
+                agg.stake() * STRONG_VOTE_MULTIPLIER
+            } else {
+                agg.stake()
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -351,7 +385,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_header::{BlockHeaderDigest, Round, TestBlockHeader, VerifiedBlockHeader},
+        authority_set::AuthoritySet,
+        block_header::{
+            BlockHeaderDigest, Round, StrongVote, TestBlockHeader, VerifiedBlockHeader,
+        },
         commit::{CommitDigest, CommitRef},
         test_dag_builder::DagBuilder,
     };
@@ -640,6 +677,72 @@ mod tests {
             scores, expected,
             "each voting author must be credited exactly its own certifiers' stake"
         );
+    }
+
+    #[tokio::test]
+    async fn test_compute_per_commit_contribution_doubles_strong_vote() {
+        telemetry_subscribers::init_for_testing();
+        // Strong votes score double under starfish speed.
+        let mut ctx = Context::new_for_test(4).0;
+        ctx.protocol_config
+            .set_consensus_starfish_speed_for_testing(true);
+        let context = Arc::new(ctx);
+        let committee = &context.committee;
+        let r: Round = 10;
+        let leader_authority = AuthorityIndex::new_for_test(0);
+
+        let subdag = |leader_round: Round, headers: Vec<VerifiedBlockHeader>| SubDagBase {
+            leader: BlockRef::new(leader_round, leader_authority, BlockHeaderDigest::MIN),
+            headers,
+            committed_header_refs: vec![],
+            timestamp_ms: 0,
+            commit_ref: CommitRef::new(0, CommitDigest::MIN),
+            reputation_scores_desc: vec![],
+        };
+
+        let c_minus_3 = subdag(r, vec![]);
+
+        // Authority 1 casts an ordinary vote; authority 2 casts a strong vote
+        // for the same leader. Both link the leader at round r+1.
+        let ordinary_vote = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 1, 1)
+                .set_ancestors(vec![c_minus_3.leader])
+                .build(),
+        );
+        let strong_vote = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 1, 2)
+                .set_ancestors(vec![c_minus_3.leader])
+                .set_strong_vote(Some(StrongVote {
+                    leader_authority,
+                    missing: AuthoritySet::new(),
+                }))
+                .build(),
+        );
+        let ordinary_ref = ordinary_vote.reference();
+        let strong_ref = strong_vote.reference();
+
+        // One certifier (authority 3) certifies both voting blocks at r+2, so
+        // both voters collect the same certifying stake — the only difference
+        // is that the strong vote is doubled.
+        let certifier = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(r + 2, 3)
+                .set_ancestors(vec![ordinary_ref, strong_ref])
+                .build(),
+        );
+
+        let c_minus_2 = subdag(r + 1, vec![ordinary_vote, strong_vote]);
+        let c_minus_1 = subdag(r + 2, vec![certifier]);
+        let c = subdag(r + 3, vec![]);
+
+        let scores =
+            compute_per_commit_contribution(&context, &c_minus_3, &c_minus_2, &c_minus_1, &c);
+
+        let stake_3 = committee.stake(AuthorityIndex::new_for_test(3));
+        assert_eq!(
+            scores[1], stake_3,
+            "ordinary vote earns the certifying stake"
+        );
+        assert_eq!(scores[2], 2 * stake_3, "strong vote earns double");
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -32,6 +32,7 @@ mod network;
 pub mod network;
 mod peer_responsiveness;
 mod quantile_gauge;
+mod sliding_window_schedule;
 
 mod header_synchronizer;
 mod stake_aggregator;

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -283,7 +283,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) last_known_own_block_header_round: IntGauge,
     pub(crate) sync_last_known_own_block_header_retries: IntCounter,
     pub(crate) commit_round_advancement_interval: SumCount,
-    pub(crate) last_decided_leader_round: IntGauge,
+    pub(crate) last_finalized_leader_round: IntGauge,
     pub(crate) missing_block_headers_total: IntCounter,
     pub(crate) missing_block_headers_after_fetch_total: IntCounter,
     pub(crate) num_of_bad_nodes: IntGauge,
@@ -977,9 +977,9 @@ impl NodeMetrics {
                 registry,
                 MetricLevel::Debug,
             ),
-            last_decided_leader_round: register_int_gauge_with_registry!(
-                "last_decided_leader_round",
-                "The last round where a commit decision was made.",
+            last_finalized_leader_round: register_int_gauge_with_registry!(
+                "last_finalized_leader_round",
+                "The round of the last finalized leader.",
                 registry,
             ).unwrap(),
             missing_block_headers_total: register_int_counter_with_registry!(

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sliding-window reputation scoring for the Starfish leader schedule.
+//!
+//! Maintains a running aggregate of per-commit scoring contributions (computed
+//! by [`crate::leader_scoring::compute_per_commit_contribution`]) over the most
+//! recent `window_size` scored commits. The aggregate updates on every commit
+//! (O(1) amortized over committee size): each commit's contribution is added,
+//! and once the window is full the oldest is evicted and subtracted.
+//!
+//! [`SlidingWindowSchedule::reputation_scores`] exposes the aggregate as
+//! [`ReputationScores`] — the same type the V2 `LeaderSwapTable` is built from.
+//! The sliding window is an alternative *score source* for the existing swap
+//! table; it does not select leaders itself.
+//!
+//! # Intended usage
+//!
+//! This scorer is not yet wired into the leader schedule (hence the
+//! `expect(dead_code)` below). Once wired, the leader schedule feeds each
+//! committed subdag to [`SlidingWindowSchedule::add_commit`] in consecutive
+//! index order and rebuilds the `LeaderSwapTable` from
+//! [`SlidingWindowSchedule::reputation_scores`] at its usual cadence.
+//!
+//! On a restart or fast-sync the in-memory window starts empty and is rebuilt
+//! from storage: [`SlidingWindowSchedule::replay_start`] gives the earliest
+//! commit index to replay, and the committed subdags from that index up to the
+//! last persisted commit are fed back through
+//! [`SlidingWindowSchedule::add_commit`] to repopulate the window before any
+//! scores are read.
+
+#![cfg_attr(
+    not(test),
+    expect(dead_code, reason = "not yet wired into the leader schedule")
+)]
+
+use std::{collections::VecDeque, sync::Arc};
+
+use crate::{
+    commit::{CommitIndex, CommitRange, SubDagBase},
+    context::Context,
+    leader_scoring::{ReputationScores, compute_per_commit_contribution},
+};
+
+/// Number of pending committed subdags retained for scoring lookback.
+/// `compute_per_commit_contribution` scores `c_minus_3` using `c_minus_2..=c`
+/// as the lookback window.
+const MAX_PENDING_COMMITS: usize = 3;
+
+/// Sliding-window reputation scorer.
+pub(crate) struct SlidingWindowSchedule {
+    context: Arc<Context>,
+    /// Running window length (number of scored commits aggregated).
+    window_size: u32,
+    /// Running aggregate, indexed by `AuthorityIndex`.
+    total_scores_per_authority: Vec<u64>,
+    /// Last [`MAX_PENDING_COMMITS`] committed subdags, retained for scoring
+    /// lookback.
+    pending_commits: VecDeque<SubDagBase>,
+    /// Per-commit score contributions currently in the running window, each
+    /// tagged with the index of the commit it scored. Retained so eviction can
+    /// subtract them from the aggregate and so the window's commit range can be
+    /// reported alongside the scores.
+    scores_entries: VecDeque<(CommitIndex, Vec<u64>)>,
+}
+
+impl SlidingWindowSchedule {
+    /// Creates a fresh scorer. `window_size` must be at least 1.
+    pub(crate) fn new(context: Arc<Context>, window_size: u32) -> Self {
+        assert!(
+            window_size >= 1,
+            "window_size ({window_size}) must be at least 1"
+        );
+        let committee_size = context.committee.size();
+        Self {
+            context,
+            window_size,
+            total_scores_per_authority: vec![0u64; committee_size],
+            pending_commits: VecDeque::with_capacity(MAX_PENDING_COMMITS),
+            scores_entries: VecDeque::with_capacity(window_size as usize),
+        }
+    }
+
+    /// Earliest commit index a caller must replay through [`Self::add_commit`]
+    /// to rebuild the window state as of `last_commit_index`.
+    pub(crate) fn replay_start(last_commit_index: CommitIndex, window_size: u32) -> CommitIndex {
+        // Replays a full window, not just the latest commit: the window slides by
+        // adding new and subtracting evicted per-commit contributions, so recovery
+        // must rebuild those per-commit entries — the aggregate sum alone cannot
+        // evict. The swap table in effect at restart is recovered separately, from
+        // the scores persisted in `CommitInfo`, not by this replay.
+        last_commit_index
+            .saturating_sub(window_size + MAX_PENDING_COMMITS as u32)
+            .max(1)
+    }
+
+    /// Ingest a new committed subdag, updating the running aggregate. Commits
+    /// must be supplied in consecutive index order.
+    pub(crate) fn add_commit(&mut self, c: SubDagBase) {
+        if let Some(last) = self.pending_commits.back() {
+            assert_eq!(c.commit_ref.index, last.commit_ref.index + 1);
+        }
+
+        if self.pending_commits.len() < MAX_PENDING_COMMITS {
+            self.pending_commits.push_back(c);
+            return;
+        }
+
+        // Steady state: 3 commits already pending; this is the 4th. The scored
+        // commit is c_minus_3 (the oldest pending).
+        let c_minus_3 = &self.pending_commits[0];
+        let c_minus_2 = &self.pending_commits[1];
+        let c_minus_1 = &self.pending_commits[2];
+        let scored_index = c_minus_3.commit_ref.index;
+
+        let contribution =
+            compute_per_commit_contribution(&self.context, c_minus_3, c_minus_2, c_minus_1, &c);
+
+        // Evict if the window is full. saturating_sub is defensive — under normal
+        // operation contributions are added and later subtracted symmetrically.
+        while self.scores_entries.len() >= self.window_size as usize {
+            let (_, evicted) = self
+                .scores_entries
+                .pop_front()
+                .expect("scores_entries is non-empty when len >= window_size >= 1");
+            for (i, &delta) in evicted.iter().enumerate() {
+                self.total_scores_per_authority[i] =
+                    self.total_scores_per_authority[i].saturating_sub(delta);
+            }
+        }
+
+        // Add the new contribution.
+        for (i, &delta) in contribution.iter().enumerate() {
+            self.total_scores_per_authority[i] =
+                self.total_scores_per_authority[i].saturating_add(delta);
+        }
+        self.scores_entries.push_back((scored_index, contribution));
+
+        // Rotate pending commits: drop the now-scored c_minus_3, append c.
+        self.pending_commits.pop_front();
+        self.pending_commits.push_back(c);
+    }
+
+    /// Current running aggregate as [`ReputationScores`], tagged with the
+    /// commit range of the scored commits in the window. Returns all-zero
+    /// scores over the empty range until the first commit is scored.
+    pub(crate) fn reputation_scores(&self) -> ReputationScores {
+        let commit_range = match (self.scores_entries.front(), self.scores_entries.back()) {
+            (Some((first, _)), Some((last, _))) => CommitRange::new(*first..=*last),
+            _ => CommitRange::default(),
+        };
+        ReputationScores::new(commit_range, self.total_scores_per_authority.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_dag_builder::DagBuilder;
+
+    fn build_full_commits(context: Arc<Context>, n: u32) -> Vec<SubDagBase> {
+        let mut dag_builder = DagBuilder::new(context);
+        dag_builder.layers(1..=n).build();
+        dag_builder
+            .get_sub_dag_and_commits(1..=n)
+            .into_iter()
+            .map(|(sub_dag, _)| sub_dag.base)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_warmup_no_scoring_before_three_commits() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10);
+        let subdags = build_full_commits(context, 2);
+        for s in &subdags {
+            schedule.add_commit(s.clone());
+        }
+        assert_eq!(schedule.total_scores_per_authority, vec![0u64; 4]);
+        assert_eq!(schedule.scores_entries.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_eviction_subtracts_from_aggregate() {
+        // Small window so we can saturate it within a small DAG.
+        let window_size: u32 = 2;
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), window_size);
+        // 6 commits → 3 scored (commits 1..=3 scored as c_minus_3 in iterations 4..=6).
+        let subdags = build_full_commits(context.clone(), 6);
+        for s in &subdags {
+            schedule.add_commit(s.clone());
+        }
+        // Window holds at most 2 entries; 3 were added so 1 was evicted.
+        assert_eq!(schedule.scores_entries.len(), window_size as usize);
+
+        // In a fully-connected DAG each scored commit contributes
+        // committee.total_stake() to every authority. The aggregate equals
+        // `window_size * total_stake` because earlier contributions were
+        // subtracted on eviction.
+        let per_commit = context.committee.total_stake();
+        let expected = per_commit * (window_size as u64);
+        assert_eq!(
+            schedule.total_scores_per_authority,
+            vec![expected; context.committee.size()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reputation_scores_reports_window_aggregate_and_range() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mut schedule = SlidingWindowSchedule::new(context.clone(), 10);
+
+        // Before anything is scored: all-zero scores over the empty range.
+        let empty = schedule.reputation_scores();
+        assert_eq!(
+            empty.scores_per_authority,
+            vec![0u64; context.committee.size()]
+        );
+        assert_eq!(empty.commit_range, CommitRange::default());
+
+        // 6 commits → commits 1..=3 scored (as c_minus_3 in iterations 4..=6).
+        let subdags = build_full_commits(context.clone(), 6);
+        for s in &subdags {
+            schedule.add_commit(s.clone());
+        }
+        let scores = schedule.reputation_scores();
+        assert_eq!(scores.commit_range, (1..=3).into());
+        let per_commit = context.committee.total_stake();
+        assert_eq!(
+            scores.scores_per_authority,
+            vec![per_commit * 3; context.committee.size()]
+        );
+    }
+
+    #[test]
+    fn test_replay_start_basic() {
+        // window=10, last_commit=23 → replay_start = max(1, 23 - (10 + 3)) = 10.
+        assert_eq!(SlidingWindowSchedule::replay_start(23, 10), 10);
+        // Small last_commit_index → clamps to 1.
+        assert_eq!(SlidingWindowSchedule::replay_start(2, 10), 1);
+    }
+}

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -14,13 +14,14 @@
 //! The sliding window is an alternative *score source* for the existing swap
 //! table; it does not select leaders itself.
 //!
-//! # Intended usage
+//! # Usage
 //!
-//! This scorer is not yet wired into the leader schedule (hence the
-//! `expect(dead_code)` below). Once wired, the leader schedule feeds each
-//! committed subdag to [`SlidingWindowSchedule::add_commit`] in consecutive
-//! index order and rebuilds the `LeaderSwapTable` from
-//! [`SlidingWindowSchedule::reputation_scores`] at its usual cadence.
+//! When the sliding-window leader schedule is enabled (protocol flag
+//! `consensus_enable_sliding_window_leader_schedule`), the leader schedule
+//! feeds each committed subdag to [`SlidingWindowSchedule::add_commit`] in
+//! consecutive index order and rebuilds the `LeaderSwapTable` from
+//! [`SlidingWindowSchedule::reputation_scores`] every `commits_per_schedule`
+//! commits.
 //!
 //! On a restart or fast-sync the in-memory window starts empty and is rebuilt
 //! from storage: [`SlidingWindowSchedule::replay_start`] gives the earliest
@@ -28,11 +29,6 @@
 //! last persisted commit are fed back through
 //! [`SlidingWindowSchedule::add_commit`] to repopulate the window before any
 //! scores are read.
-
-#![cfg_attr(
-    not(test),
-    expect(dead_code, reason = "not yet wired into the leader schedule")
-)]
 
 use std::{collections::VecDeque, sync::Arc};
 
@@ -83,12 +79,15 @@ impl SlidingWindowSchedule {
 
     /// Earliest commit index a caller must replay through [`Self::add_commit`]
     /// to rebuild the window state as of `last_commit_index`.
+    ///
+    /// Replays a full window: the window slides by adding new and subtracting
+    /// evicted per-commit contributions, so recovery must rebuild those
+    /// per-commit entries — the aggregate sum alone cannot evict. The extra
+    /// `MAX_PENDING_COMMITS` starts the replay three commits before the window
+    /// so the lookback buffer (`pending_commits`) is refilled and the first
+    /// in-window commit scores identically to live operation. The swap table in
+    /// effect at restart is not recovered by this replay.
     pub(crate) fn replay_start(last_commit_index: CommitIndex, window_size: u32) -> CommitIndex {
-        // Replays a full window, not just the latest commit: the window slides by
-        // adding new and subtracting evicted per-commit contributions, so recovery
-        // must rebuild those per-commit entries — the aggregate sum alone cannot
-        // evict. The swap table in effect at restart is recovered separately, from
-        // the scores persisted in `CommitInfo`, not by this replay.
         last_commit_index
             .saturating_sub(window_size + MAX_PENDING_COMMITS as u32)
             .max(1)
@@ -106,8 +105,11 @@ impl SlidingWindowSchedule {
             return;
         }
 
-        // Steady state: 3 commits already pending; this is the 4th. The scored
-        // commit is c_minus_3 (the oldest pending).
+        // Steady state: the window now holds four consecutive commits. We score
+        // the OLDEST of the four, c_minus_3: its leader is at round r, and the
+        // r+1 votes and r+2 certifiers that score it live in the three newer
+        // commits. So a commit is scored only once the third commit after it is
+        // committed; the just-fed c merely unlocks scoring c_minus_3.
         let c_minus_3 = &self.pending_commits[0];
         let c_minus_2 = &self.pending_commits[1];
         let c_minus_1 = &self.pending_commits[2];
@@ -142,8 +144,11 @@ impl SlidingWindowSchedule {
     }
 
     /// Current running aggregate as [`ReputationScores`], tagged with the
-    /// commit range of the scored commits in the window. Returns all-zero
-    /// scores over the empty range until the first commit is scored.
+    /// commit range of the scored commits in the window. The range ends at
+    /// the last *scored* commit, which trails the last fed commit by
+    /// `MAX_PENDING_COMMITS` (a commit is scored only once the third commit
+    /// after it arrives). Returns all-zero scores over the empty range
+    /// until the first commit is scored.
     pub(crate) fn reputation_scores(&self) -> ReputationScores {
         let commit_range = match (self.scores_entries.front(), self.scores_entries.back()) {
             (Some((first, _)), Some((last, _))) => CommitRange::new(*first..=*last),

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -96,6 +96,14 @@ impl SlidingWindowSchedule {
     /// Ingest a new committed subdag, updating the running aggregate. Commits
     /// must be supplied in consecutive index order.
     pub(crate) fn add_commit(&mut self, c: SubDagBase) {
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["SlidingWindowSchedule::add_commit"])
+            .start_timer();
+
         if let Some(last) = self.pending_commits.back() {
             assert_eq!(c.commit_ref.index, last.commit_ref.index + 1);
         }

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -655,7 +655,7 @@ async fn indirect_metastate_standard_when_strong_qc_outside_anchor_path() {
 }
 
 #[tokio::test]
-async fn leader_status_is_final_classification() {
+async fn leader_status_is_resolved_classification() {
     let (context, dag_state) = test_context_with_flag(true);
     let refs = build_v2_layers(&context, &dag_state, None, 1);
     let block = dag_state
@@ -665,17 +665,18 @@ async fn leader_status_is_final_classification() {
 
     let slot = Slot::new(3, AuthorityIndex::from(0u8));
     assert!(
-        !LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending), vec![]).is_final()
+        !LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Pending), vec![]).is_resolved()
     );
     assert!(
-        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic), vec![]).is_final()
+        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Optimistic), vec![])
+            .is_resolved()
     );
     assert!(
-        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard), vec![]).is_final()
+        LeaderStatus::Commit(block.clone(), Some(CommitMetastate::Standard), vec![]).is_resolved()
     );
-    assert!(LeaderStatus::Commit(block, None, vec![]).is_final());
-    assert!(LeaderStatus::Skip(slot).is_final());
-    assert!(!LeaderStatus::Undecided(slot).is_final());
+    assert!(LeaderStatus::Commit(block, None, vec![]).is_resolved());
+    assert!(LeaderStatus::Skip(slot).is_resolved());
+    assert!(!LeaderStatus::Undecided(slot).is_resolved());
 }
 
 fn build_universal_committer(

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -27,8 +27,8 @@ async fn direct_commit() {
     let decision_round_wave_0_pipeline_1 = committer.committers[1].certifying_round(0);
     build_dag(context, dag_state, None, decision_round_wave_0_pipeline_1);
 
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 1);
 
@@ -56,8 +56,8 @@ async fn idempotence() {
     build_dag(context, dag_state, None, certifying_round_pipeline_1_wave_0);
 
     // Commit one leader.
-    let last_decided = Slot::new(0, 0);
-    let first_sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let first_sequence = committer.try_decide(last_finalized);
     assert_eq!(first_sequence.len(), 1);
     tracing::info!("Commit sequence: {first_sequence:#?}");
 
@@ -73,7 +73,7 @@ async fn idempotence() {
 
     // Ensure that if try_commit is called again with the same last decided leader
     // input the commit decision will be the same.
-    let first_sequence = committer.try_decide(last_decided);
+    let first_sequence = committer.try_decide(last_finalized);
 
     assert_eq!(first_sequence.len(), 1);
     if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
@@ -88,8 +88,8 @@ async fn idempotence() {
 
     // Ensure we don't commit the same leader again once last decided has been
     // updated.
-    let last_decided = Slot::new(first_sequence[0].round(), first_sequence[0].authority());
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(first_sequence[0].round(), first_sequence[0].authority());
+    let sequence = committer.try_decide(last_finalized);
     assert!(sequence.is_empty());
 }
 
@@ -99,7 +99,7 @@ async fn multiple_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
     let wave_length = WAVE_LENGTH;
 
-    let mut last_decided = Slot::new(0, 0);
+    let mut last_finalized = Slot::new(0, 0);
     let mut ancestors = None;
     for n in 1..=10 {
         // Build the dag up to the decision round for each pipeline's wave starting
@@ -118,7 +118,7 @@ async fn multiple_direct_commit() {
         ));
 
         // Because of pipelining we are committing a leader every round.
-        let sequence = committer.try_decide(last_decided);
+        let sequence = committer.try_decide(last_finalized);
         tracing::info!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), 1);
@@ -135,7 +135,7 @@ async fn multiple_direct_commit() {
         // Update the last decided leader so only one new leader is committed as
         // each new wave is completed.
         let last = sequence.into_iter().next_back().unwrap();
-        last_decided = Slot::new(last.round(), last.authority());
+        last_finalized = Slot::new(last.round(), last.authority());
     }
 }
 
@@ -153,8 +153,8 @@ async fn direct_commit_late_call() {
 
     build_dag(context, dag_state, None, certifying_round);
 
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), n);
@@ -184,8 +184,8 @@ async fn no_genesis_commit() {
     for r in 0..certifying_round_pipeline_0_wave_0 {
         ancestors = Some(build_dag(context.clone(), dag_state.clone(), ancestors, r));
 
-        let last_decided = Slot::new(0, 0);
-        let sequence = committer.try_decide(last_decided);
+        let last_finalized = Slot::new(0, 0);
+        let sequence = committer.try_decide(last_finalized);
         assert!(sequence.is_empty());
     }
 }
@@ -228,8 +228,8 @@ async fn direct_skip_no_leader() {
 
     // Ensure no blocks are committed because there are 2f+1 blame (non-votes) for
     // the missing leader.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 1);
@@ -302,8 +302,8 @@ async fn direct_skip_enough_blame() {
 
     // Ensure the leader is skipped because there are 2f+1 blame (non-votes) for
     // the wave 0 leader of pipeline 1.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 1);
@@ -408,8 +408,8 @@ async fn indirect_commit() {
     );
 
     // Ensure we commit the first leaders.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 5);
 
@@ -489,8 +489,8 @@ async fn indirect_skip() {
 
     // Ensure we commit the first 3 leaders, skip the 4th, and commit the last 2
     // leaders.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 7);
 
@@ -567,8 +567,8 @@ async fn undecided() {
     );
 
     // Ensure no blocks are committed.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     assert!(sequence.is_empty());
 }
 
@@ -725,8 +725,8 @@ async fn test_byzantine_validator() {
 
     // Expect a successful direct commit of A12 and leaders at rounds 1 ~ 11 as
     // pipelining is enabled.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);
@@ -748,15 +748,15 @@ async fn test_byzantine_validator() {
 
     // Ensure B13 is marked as undecided as there is <2f+1 blame and <2f+1 certs
     let last_sequenced = sequence.last().unwrap();
-    let last_decided = Slot::new(last_sequenced.round(), last_sequenced.authority());
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(last_sequenced.round(), last_sequenced.authority());
+    let sequence = committer.try_decide(last_finalized);
     assert!(sequence.is_empty());
 
     // Now build an additional 3 dag layers on top of the existing dag so a commit
     // decision can be made about leader A16 and then an indirect decision can be
     // made about B13
     build_dag(context, dag_state, Some(references_round_15), 18);
-    let sequence = committer.try_decide(last_decided);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 4);
 

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -53,8 +53,8 @@ async fn test_randomized_dag_all_direct_commit() {
             "Running test with committee size {num_authorities} & {NUM_ROUNDS} rounds in the DAG..."
         );
 
-        let last_decided = Slot::new(0, 0);
-        let sequence = authority.committer.try_decide(last_decided);
+        let last_finalized = Slot::new(0, 0);
+        let sequence = authority.committer.try_decide(last_finalized);
         tracing::debug!("Commit sequence: {sequence:#?}");
 
         assert_eq!(sequence.len(), (NUM_ROUNDS - 2) as usize);
@@ -79,7 +79,7 @@ async fn test_randomized_dag_all_direct_commit() {
 ///
 /// Blocks will randomly be fed through BlockManager and after each accepted
 /// block we will try_decide() and if there is a committed sequence we will
-/// update last_decided and continue. We do this from the perspective of two
+/// update last_finalized and continue. We do this from the perspective of two
 /// different authorities who receive the blocks in different orders and ensure
 /// the resulting sequence is the same for both authorities. The resulting
 /// sequence will include Commit & Skip decisions and potentially will stop
@@ -116,7 +116,7 @@ async fn test_randomized_dag_and_decision_sequence() {
         all_blocks.shuffle(&mut random_test_setup.seeded_rng);
 
         let mut sequenced_leaders_1 = vec![];
-        let mut last_decided = Slot::new(0, 0);
+        let mut last_finalized = Slot::new(0, 0);
         let mut i = 0;
         let mut seen_so_far = vec![];
         while i < all_blocks.len() {
@@ -128,12 +128,12 @@ async fn test_randomized_dag_and_decision_sequence() {
             let _ = authority_1
                 .block_manager
                 .try_accept_block_headers(chunk.to_vec(), DataSource::Test);
-            let sequence = authority_1.committer.try_decide(last_decided);
+            let sequence = authority_1.committer.try_decide(last_finalized);
 
             if !sequence.is_empty() {
                 sequenced_leaders_1.extend(sequence.clone());
                 let leader_status = sequence.last().unwrap();
-                last_decided = Slot::new(leader_status.round(), leader_status.authority());
+                last_finalized = Slot::new(leader_status.round(), leader_status.authority());
             }
 
             i += chunk_size;
@@ -158,7 +158,7 @@ async fn test_randomized_dag_and_decision_sequence() {
         all_blocks.shuffle(&mut random_test_setup.seeded_rng);
 
         let mut sequenced_leaders_2 = vec![];
-        let mut last_decided = Slot::new(0, 0);
+        let mut last_finalized = Slot::new(0, 0);
         let mut i = 0;
         let mut seen_so_far = vec![];
         while i < all_blocks.len() {
@@ -171,12 +171,12 @@ async fn test_randomized_dag_and_decision_sequence() {
             let _ = authority_2
                 .block_manager
                 .try_accept_block_headers(chunk.to_vec(), DataSource::Test);
-            let sequence = authority_2.committer.try_decide(last_decided);
+            let sequence = authority_2.committer.try_decide(last_finalized);
 
             if !sequence.is_empty() {
                 sequenced_leaders_2.extend(sequence.clone());
                 let leader_status = sequence.last().unwrap();
-                last_decided = Slot::new(leader_status.round(), leader_status.authority());
+                last_finalized = Slot::new(leader_status.round(), leader_status.authority());
             }
             // Evaluate the seen blocks so far
             let (suspended, missing) = evaluate_block_headers(&seen_so_far);

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -43,12 +43,12 @@ async fn direct_commit() {
 
     // Genesis cert will not be included in commit sequence, marking it as last
     // decided
-    let last_decided = Slot::new(0, 0);
+    let last_finalized = Slot::new(0, 0);
 
     // The universal committer should mark the potential leaders in leader round 6
     // as undecided because there is no way to get enough certificates for
     // leaders of leader round 6 without completing wave (6-7-8).
-    let sequence = test_setup.committer.try_decide(last_decided);
+    let sequence = test_setup.committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     // The decided leaders should be all from round 1 to round 5
     assert_eq!(sequence.len(), 5);
@@ -80,8 +80,8 @@ async fn idempotence() {
     );
 
     // Commit one leader.
-    let last_decided = Slot::new(0, 0);
-    let first_sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let first_sequence = committer.try_decide(last_finalized);
     assert_eq!(first_sequence.len(), 1);
 
     if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
@@ -96,7 +96,7 @@ async fn idempotence() {
 
     // Ensure that if try_commit is called again with the same last decided leader
     // input the commit decision will be the same.
-    let first_sequence = committer.try_decide(last_decided);
+    let first_sequence = committer.try_decide(last_finalized);
 
     assert_eq!(first_sequence.len(), 1);
     if let DecidedLeader::Commit(ref block, _, _) = first_sequence[0] {
@@ -121,12 +121,12 @@ async fn idempotence() {
     // Ensure we don't commit the same leader of round 1 again if we mark it as the
     // last decided.
     let leader_status_first_leader = first_sequence.last().unwrap();
-    let last_decided = Slot::new(
+    let last_finalized = Slot::new(
         leader_status_first_leader.round(),
         leader_status_first_leader.authority(),
     );
     let round_5 = 5;
-    let second_sequence = committer.try_decide(last_decided);
+    let second_sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {second_sequence:#?}");
 
     // Expect that all leaders between round 2 and round 5 are committed.
@@ -146,7 +146,7 @@ async fn multiple_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
 
     let mut ancestors = None;
-    let mut last_decided = Slot::new(0, 0);
+    let mut last_finalized = Slot::new(0, 0);
     for n in 1..=10 {
         // Build the DAG up to the certifying round for leader blocks of authority 1,
         // i.e. full DAG is built with chunks of 3 rounds
@@ -161,7 +161,7 @@ async fn multiple_direct_commit() {
 
         // After every 3 rounds, try commit all leaders in between
         let leader_round = committer.committers[0].leader_round(n);
-        let sequence = committer.try_decide(last_decided);
+        let sequence = committer.try_decide(last_finalized);
         tracing::info!("Commit sequence: {sequence:#?}");
         assert_eq!(sequence.len(), 3);
         if let DecidedLeader::Commit(ref block, _, _) = sequence[2] {
@@ -174,7 +174,7 @@ async fn multiple_direct_commit() {
         // Update the last decided leader so only one new leader is committed as
         // each new wave is completed.
         let leader_status = sequence.last().unwrap();
-        last_decided = Slot::new(leader_status.round(), leader_status.authority());
+        last_finalized = Slot::new(leader_status.round(), leader_status.authority());
     }
 }
 
@@ -189,8 +189,8 @@ async fn direct_commit_late_call() {
     let certifying_round_wave_10 = committer.committers[0].certifying_round(10);
     build_dag(context, dag_state, None, certifying_round_wave_10);
 
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     // With 11 full non-intersecting waves completed, excluding genesis in wave 0 as
@@ -267,8 +267,8 @@ async fn direct_skip_no_leader_votes() {
     // committer.
     assert_eq!(committer.committers.len(), 3);
 
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     // Only leader for slot B1 should be decided, specifically, skipped
     assert_eq!(sequence.len(), 1);
     if let DecidedLeader::Skip(leader) = sequence[0] {
@@ -385,8 +385,8 @@ async fn indirect_commit() {
 
     // Ensure we indirectly commit the leader of round 3 via the directly committed
     // leader of round 6.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 6);
 
@@ -463,8 +463,8 @@ async fn indirect_skip() {
 
     // Ensure we indirectly skip the leader of round 4 via the directly committed
     // leader of round 7.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 7);
 
@@ -545,8 +545,8 @@ async fn undecided() {
 
     // Ensure we indirectly commit the leader of round3 via the directly committed
     // leader of round 6.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert!(sequence.is_empty());
 }
@@ -694,8 +694,8 @@ async fn test_byzantine_direct_commit() {
     // all of these blocks also have good votes for leader A12 through A, B, D.
 
     // Expect a successful direct commit of A12 and all leaders at previous rounds.
-    let last_decided = Slot::new(0, 0);
-    let sequence = committer.try_decide(last_decided);
+    let last_finalized = Slot::new(0, 0);
+    let sequence = committer.try_decide(last_finalized);
     tracing::info!("Commit sequence: {sequence:#?}");
 
     assert_eq!(sequence.len(), 12);

--- a/crates/starfish/core/src/universal_committer.rs
+++ b/crates/starfish/core/src/universal_committer.rs
@@ -42,14 +42,14 @@ pub(crate) struct UniversalCommitter {
 impl UniversalCommitter {
     /// Try to decide part of the dag. This function is idempotent and returns
     /// an ordered list of decided leaders.
-    #[tracing::instrument(skip_all, fields(last_decided = %last_decided))]
-    pub(crate) fn try_decide(&self, last_decided: Slot) -> Vec<DecidedLeader> {
+    #[tracing::instrument(skip_all, fields(last_finalized = %last_finalized))]
+    pub(crate) fn try_decide(&self, last_finalized: Slot) -> Vec<DecidedLeader> {
         let highest_accepted_round = self.dag_state.read().highest_accepted_round();
 
         // Try to decide as many leaders as possible, starting with the highest round.
         let mut leaders: VecDeque<(LeaderStatus, Decision)> = VecDeque::new();
 
-        let last_round = last_decided.round + 1;
+        let last_round = last_finalized.round + 1;
 
         // try to commit a leader up to the highest_accepted_round - 2. There is no
         // reason to try and iterate on higher rounds as in order to make a direct
@@ -63,9 +63,9 @@ impl UniversalCommitter {
                     continue;
                 };
 
-                // now that we reached the last committed leader we can stop the commit rule
-                if slot == last_decided {
-                    tracing::debug!("Reached last committed {slot}, now exit");
+                // now that we reached the last finalized leader we can stop the commit rule
+                if slot == last_finalized {
+                    tracing::debug!("Reached last finalized {slot}, now exit");
                     break 'outer;
                 }
 
@@ -75,11 +75,11 @@ impl UniversalCommitter {
                 let mut decision = Decision::Direct;
                 tracing::debug!("Outcome of direct rule: {status} with {committer}");
 
-                // If the direct result is not final (Commit(Pending) or
+                // If the direct result is not resolved (Commit(Pending) or
                 // Undecided), run the indirect rule. For Pending, a
                 // committed anchor's path can upgrade the metastate; for
                 // Undecided, indirect may resolve the slot entirely.
-                if !status.is_final() {
+                if !status.is_resolved() {
                     let indirect = committer
                         .try_indirect_decide(status.clone(), leaders.iter().map(|(x, _)| x));
                     if indirect != status {
@@ -98,20 +98,21 @@ impl UniversalCommitter {
             }
         }
 
-        // The decided sequence is the longest prefix of final decisions.
-        // Commit(Pending) is decided but non-final — sequencing stops until
-        // the metastate is upgraded on a subsequent commit pass.
+        // The decided sequence is the longest prefix where every leader is
+        // resolved. Commit(Pending) is decided but not resolved — its metastate
+        // is still pending — so sequencing stops there until a later commit pass
+        // upgrades it.
         let mut decided_leaders = Vec::new();
         for (leader, decision) in leaders {
             if leader.round() == GENESIS_ROUND {
                 continue;
             }
-            if !leader.is_final() {
+            if !leader.is_resolved() {
                 break;
             }
             let decided_leader = leader
                 .into_decided_leader()
-                .expect("is_final implies decided");
+                .expect("is_resolved implies a DecidedLeader");
             Self::update_metrics(&self.context, &decided_leader, decision);
             decided_leaders.push(decided_leader);
         }


### PR DESCRIPTION
# Description of change

Redesign of the Starfish leader schedule, aimed at removing crashed or degraded validators from the leader rotation faster. Two independently flag-gated changes, both off by default:

- **Sliding-window reputation scoring** (`consensus_enable_sliding_window_leader_schedule`): replaces V2's batch scoring (accumulate votes for a full schedule period, then rebuild from scratch) with a running window aggregate updated incrementally on every commit. The schedule can rotate much more frequently (e.g. every 60 commits over a 300-commit window) with no per-rotation rebuild cost; on restart the window is rebuilt by replaying committed subdags. Under `consensus_starfish_speed`, a strong vote (attesting the voter holds the leader's transaction data, not just its header) counts double in the sliding-window scorer, so validators that vote on time but consistently lag on payloads score lower.
- **Absolute-score bad-node selection** (`consensus_enable_absolute_score_leader_schedule`): replaces the fixed bottom-stake-rank cut with thresholds on scores normalized to the window's top performer, so a failing validator is excluded on its own score instead of having to out-decay the chronically lowest-ranked ones. Applies to both scoring paths.

Landed parts:

- #11875 sliding-window leader scorer
- #11975 wiring behind the protocol flag
- #12076 metric rename
- #12123 skip V2 vote scoring on the sliding-window path
- #12264 skip sliding-window recovery during fast sync
- #12295 leader-schedule window invariant check
- #12350 certifier scan refactor
- #12408 absolute-score bad-node selection
- #12304 rebuild the sliding window from a recovered scoring backlog
- #12470 double strong votes in sliding-window reputation scoring

Measured on a 20-validator network with crash injection: post-crash leader timeouts roughly halve versus the current V2 + stake-rank configuration (~2×, idle and under 100 TPS load), with no steady-state cost in leader timeouts, block latency, or transaction latency. The improvement decomposes into ~1.4–1.6× from absolute selection alone and ~1.5–2× from the sliding-window path on top of it. The strong-vote weighting is inert when strong-vote rates are uniform and becomes decisive under correlated data degradation, where it excludes validators that base scoring alone tolerates.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Additionally the feature was tested extensively in a private local network.


