### PR TITLE
feat(iota-protocol-config): enable the checkpoint rate window on testnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -189,6 +189,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             thresholds, grace period) into the protocol config.
 //             Enable the optimistic commit rule (StarfishSpeed) in Starfish
 //             consensus on testnet.
+//             Amortize the minimum checkpoint interval over a sliding window
+//             on testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3110,6 +3112,9 @@ impl ProtocolConfig {
                         // Enable the optimistic commit rule (StarfishSpeed) in
                         // Starfish consensus.
                         cfg.feature_flags.consensus_starfish_speed = true;
+                        // Amortize the minimum checkpoint interval over a sliding
+                        // window so the checkpoint rate holds at the ceiling.
+                        cfg.checkpoint_rate_window_size = Some(20);
                     }
                 }
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_32.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_32.snap
@@ -322,6 +322,7 @@ consensus_max_transactions_in_block_bytes: 524288
 consensus_max_num_transactions_in_block: 512
 max_deferral_rounds_for_congestion_control: 10
 min_checkpoint_interval_ms: 200
+checkpoint_rate_window_size: 20
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10


### PR DESCRIPTION
# Description of change

Enable `checkpoint_rate_window_size` (introduced in #12118, currently devnet-only) on testnet in protocol version 32, keeping the same window size of 20 checkpoints. This amortizes `min_checkpoint_interval_ms` over a sliding window of recent checkpoints so the checkpoint rate holds at the ceiling.

Changes:

- `iota-protocol-config`: set `checkpoint_rate_window_size = Some(20)` for non-mainnet chains in the version 32 block and update the testnet v32 snapshot.

## Links to any relevant issues

fixes #12476

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: The minimum checkpoint interval is now amortized over a sliding window of 20 checkpoints on testnet (protocol version 32).
