### PR TITLE
Sc platform/graphql archival fallback events by tx with cursors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6357,6 +6357,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.move
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL checkpoint queries under pruning, with no historical
+// fallback configured. Covers:
+// - top-level `Query.checkpoints` after pruning
+// - paginating with a cursor that points below the pruning watermark
+// - `Query.checkpoint(sequenceNumber)` for both pruned and unpruned seqs
+// - nested `Epoch.checkpoints` on a fully-pruned epoch and on the current one
+
+//# init --protocol-version 12 --addresses Test=0x0 --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public entry fun noop() {}
+}
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: top-level checkpoints, defaults.
+# After waiting for pruning, only unpruned checkpoints come back.
+# `hasPreviousPage` must be `false` because we clamp `absolute_lo_incl` to the
+# pruning watermark.
+{
+  checkpoints {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql
+# B: top-level checkpoints with `first: 2`.
+# `hasNextPage` should be `true` (more unpruned data above), `hasPreviousPage`
+# should be `false` (we're at the bottom of the reachable range).
+{
+  checkpoints(first: 2) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":2}
+# C: paginate forward from a cursor below the pruning watermark.
+# `c` is the view-at checkpoint, `s` is the cursor's sequence number. A cursor
+# below the watermark means the referenced data has been pruned -- the request
+# is rejected with DATA_PRUNED, telling the client to retry from scratch.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":42}
+# C2: cursor above the upper bound (viewed_at is 9, but cursor seq is 42).
+# The cursor contradicts its own `checkpoint_viewed_at`, so it's malformed --
+# return BAD_USER_INPUT.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":7}
+# D: paginate forward from a cursor sitting at the lower bound (s=7, the
+# lowest unpruned seq). The boundary is in-range, so the page returns the
+# items strictly above it.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql
+# E: Query.checkpoint(seq) for a pruned seq.
+# Should resolve to `null` -- the DataLoader can't find the row in either
+# Postgres or the (absent) fallback.
+{
+  pruned: checkpoint(id: { sequenceNumber: 0 }) {
+    sequenceNumber
+  }
+}
+
+//# run-graphql
+# F: Query.checkpoint(seq) for an unpruned seq -- resolves to the row.
+{
+  unpruned: checkpoint(id: { sequenceNumber: 7 }) {
+    sequenceNumber
+  }
+}
+
+//# run-graphql
+# G: nested Epoch.checkpoints on a fully-pruned epoch.
+# Epoch 0's range is entirely below the watermark; without a fallback we have
+# no way to serve any of its checkpoints. `epochId` resolves, the
+# `checkpoints` sub-field errors with DATA_PRUNED.
+{
+  epoch(id: 0) {
+    epochId
+    checkpoints {
+      pageInfo { hasPreviousPage hasNextPage }
+      nodes { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql
+# H: nested Epoch.checkpoints on the unpruned epoch -- paginates normally.
+{
+  epoch(id: 3) {
+    epochId
+    checkpoints {
+      pageInfo { hasPreviousPage hasNextPage }
+      nodes { sequenceNumber }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.snap
@@ -1,0 +1,231 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 20 tasks
+
+task 1, lines 13-16:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3374400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 18:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, line 20:
+//# advance-epoch
+Epoch advanced: 0
+
+task 4, line 22:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 5, line 24:
+//# advance-epoch
+Epoch advanced: 1
+
+task 6, line 26:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 7, line 28:
+//# advance-epoch
+Epoch advanced: 2
+
+task 8, line 30:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 9, line 32:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 10, line 34:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 11, lines 36-46:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 12, lines 48-57:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 13, lines 59-69:
+//# run-graphql --cursors {"c":9,"s":2}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: `after` cursor (seq 2) is below the available range 7..=9",
+      "locations": [
+        {
+          "line": 6,
+          "column": 3
+        }
+      ],
+      "path": [
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 14, lines 71-80:
+//# run-graphql --cursors {"c":9,"s":42}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "`after` cursor (seq 42) is above the available range 7..=9",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 15, lines 82-91:
+//# run-graphql --cursors {"c":9,"s":7}
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 16, lines 93-101:
+//# run-graphql
+Response: {
+  "data": {
+    "pruned": null
+  }
+}
+
+task 17, lines 103-109:
+//# run-graphql
+Response: {
+  "data": {
+    "unpruned": {
+      "sequenceNumber": 7
+    }
+  }
+}
+
+task 18, lines 111-124:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "epochId": 0
+    }
+  },
+  "errors": [
+    {
+      "message": "Requested data has been pruned: all checkpoints in the requested range have been pruned",
+      "locations": [
+        {
+          "line": 8,
+          "column": 5
+        }
+      ],
+      "path": [
+        "epoch",
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 19, lines 126-136:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 7
+          },
+          {
+            "sequenceNumber": 8
+          },
+          {
+            "sequenceNumber": 9
+          }
+        ],
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        }
+      },
+      "epochId": 3
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.move
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL event queries filtered by transaction digest under
+// pruning, with no historical fallback configured. Covers:
+// - `Query.events(filter: { transactionDigest })`
+// - `TransactionBlockEffects.events`
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    use iota::event;
+
+    public struct Foo has key, store { id: UID, v: u64 }
+    public struct Bumped has copy, drop { v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+
+    public entry fun bump(foo: &mut Foo, times: u64) {
+        let mut i = 0;
+        while (i < times) {
+            foo.v = foo.v + 1;
+            event::emit(Bumped { v: foo.v });
+            i = i + 1;
+        }
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# run Test::M::bump --sender A --args object(2,0) 3
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run Test::M::bump --sender A --args object(2,0) 3
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: Query.events on a pruned transaction — no fallback.
+# The transaction has been pruned, so the request errors with DATA_PRUNED.
+{
+  events(filter: { transactionDigest: "@{digest_3}" }) {
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# B: Query.events on an unpruned transaction resolves. The cursors printed
+# here are the inputs for the window in D.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }) {
+    pageInfo { hasPreviousPage hasNextPage startCursor endCursor }
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# C: TransactionBlockEffects.events on an unpruned transaction.
+{
+  transactionBlock(digest: "@{digest_11}") {
+    effects {
+      events {
+        nodes { json }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"tx":7,"e":0,"c":10} {"tx":7,"e":2,"c":10}
+# D: both cursors set — the window between the first and the last event of
+# the transaction. Only the middle event is inside the window (cursors are
+# exclusive). Both page flags are true because events exist at the cursor
+# positions, outside the window.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}
+
+//# run-graphql --cursors {"tx":5,"e":0,"c":10}
+# E: `after` cursor from a different transaction. No event of this
+# transaction sits at the cursor, so the bound is invalid and the connection
+# comes back empty, as for other event queries.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# F: digest combined with another filter — served by the lookup-table path,
+# without fallback support.
+{
+  events(filter: { transactionDigest: "@{digest_11}", sender: "@{A}" }) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.snap
@@ -1,0 +1,220 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 21 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-30:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6604400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 32:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 34:
+//# run Test::M::bump --sender A --args object(2,0) 3
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AQAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AgAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AwAAAAAAAAA=" }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 4, line 36:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, line 38:
+//# advance-epoch
+Epoch advanced: 0
+
+task 6, line 40:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 42:
+//# advance-epoch
+Epoch advanced: 1
+
+task 8, line 44:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 9, line 46:
+//# advance-epoch
+Epoch advanced: 2
+
+task 10, line 48:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 11, line 50:
+//# run Test::M::bump --sender A --args object(2,0) 3
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BAAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BQAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BgAAAAAAAAA=" }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 12, line 52:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 13, line 54:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 14, line 56:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 15, lines 58-65:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: data for tx BFJpQE4QdDmhuC72E6cqJMmvhBhiA8gTdqH5AZ8NRhHk potentially pruned",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "events"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 16, lines 67-75:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "4"
+          }
+        },
+        {
+          "json": {
+            "v": "5"
+          }
+        },
+        {
+          "json": {
+            "v": "6"
+          }
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJ0eCI6NywiZSI6MiwiYyI6MTB9",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "eyJ0eCI6NywiZSI6MCwiYyI6MTB9"
+      }
+    }
+  }
+}
+
+task 17, lines 77-87:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlock": {
+      "effects": {
+        "events": {
+          "nodes": [
+            {
+              "json": {
+                "v": "4"
+              }
+            },
+            {
+              "json": {
+                "v": "5"
+              }
+            },
+            {
+              "json": {
+                "v": "6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 18, lines 89-99:
+//# run-graphql --cursors {"tx":7,"e":0,"c":10} {"tx":7,"e":2,"c":10}
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "5"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 19, lines 101-110:
+//# run-graphql --cursors {"tx":5,"e":0,"c":10}
+Response: {
+  "data": {
+    "events": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 20, lines 112-120:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "4"
+          }
+        },
+        {
+          "json": {
+            "v": "5"
+          }
+        },
+        {
+          "json": {
+            "v": "6"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.move
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transaction-by-digest queries under pruning, with no
+// historical fallback configured. Covers:
+// - `Query.transactionBlock(digest)` for pruned and unpruned digests
+// - `Query.transactionBlocksByDigests` for pruned and unpruned digests
+// - `Event.transactionBlock` on an event from an unpruned tx
+// - `MoveObject.previousTransactionBlock` where the prior-tx digest is pruned
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    use iota::event;
+
+    public struct Foo has key, store { id: UID, v: u64 }
+    public struct Bumped has copy, drop { v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+
+    public entry fun bump(foo: &mut Foo) {
+        foo.v = foo.v + 1;
+        event::emit(Bumped { v: foo.v })
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M::bump --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: pruned digest resolves to null (no fallback).
+{
+  pruned: transactionBlock(digest: "@{digest_2}") { digest }
+}
+
+//# run-graphql
+# B: unpruned digest resolves correctly
+{
+  unpruned: transactionBlock(digest: "@{digest_10}") { digest }
+}
+
+//# run-graphql
+# C: mixed case - one pruned and one unpruned
+{
+  transactionBlocksByDigests(digests: ["@{digest_2}", "@{digest_10}"]) {
+    digest
+  }
+}
+
+//# run-graphql
+# D: Event.transactionBlock on an event from an unpruned tx
+{
+  events(filter: { sender: "@{A}" }, last: 1) {
+    nodes {
+      transactionBlock { digest }
+    }
+  }
+}
+
+//# run-graphql
+# E: MoveObject.previousTransactionBlock where the tx is pruned.
+{
+  object(address: "@{obj_5_0}") {
+    asMoveObject {
+      previousTransactionBlock { digest }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
@@ -1,0 +1,126 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 19 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 13-28:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6285200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 30:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 32:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 34:
+//# advance-epoch
+Epoch advanced: 0
+
+task 5, line 36:
+//# run Test::M::create --sender A
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 6, line 38:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 40:
+//# advance-epoch
+Epoch advanced: 1
+
+task 8, line 42:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 9, line 44:
+//# advance-epoch
+Epoch advanced: 2
+
+task 10, line 46:
+//# run Test::M::bump --sender A --args object(2,0)
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
+
+task 11, line 48:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 12, line 50:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 13, line 52:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 14, lines 54-58:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "pruned": null
+  }
+}
+
+task 15, lines 60-64:
+//# run-graphql
+Response: {
+  "data": {
+    "unpruned": {
+      "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+    }
+  }
+}
+
+task 16, lines 66-72:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocksByDigests": [
+      null,
+      {
+        "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+      }
+    ]
+  }
+}
+
+task 17, lines 74-82:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "transactionBlock": {
+            "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 18, lines 84-92:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "previousTransactionBlock": null
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
@@ -50,7 +50,7 @@ Epoch advanced: 2
 
 task 10, line 46:
 //# run Test::M::bump --sender A --args object(2,0)
-events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AQAAAAAAAAA=" }
 mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 2257200, non_refundable_storage_fee: 0
 

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.move
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transaction queries filtered by checkpoint under
+// pruning, with no historical fallback configured. Covers:
+// - `Query.transactionBlocks(filter: { atCheckpoint })`
+// - `Checkpoint.transactionBlocks`
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public struct Foo has key, store { id: UID, v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: Query.transactionBlocks(filter: { atCheckpoint: <pruned> }) — no fallback.
+# The checkpoint has been pruned, so the request errors with DATA_PRUNED.
+{
+  transactionBlocks(filter: { atCheckpoint: 1 }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# B: Query.transactionBlocks(filter: { atCheckpoint: <unpruned> }) resolves.
+{
+  transactionBlocks(filter: { atCheckpoint: 8 }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# C: Checkpoint.transactionBlocks on a pruned checkpoint — no fallback.
+# The parent `checkpoint(...)` resolves to null, so no nested field is
+# fetched.
+{
+  checkpoint(id: { sequenceNumber: 1 }) {
+    transactionBlocks {
+      nodes { digest }
+    }
+  }
+}
+
+//# run-graphql
+# D: Checkpoint.transactionBlocks on an unpruned checkpoint.
+{
+  checkpoint(id: { sequenceNumber: 8 }) {
+    transactionBlocks {
+      nodes { digest }
+    }
+  }
+}
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# run-graphql
+# E: a checkpoint holding several transactions. The cursors printed here are
+# the inputs for the window in F.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }) {
+    pageInfo { startCursor endCursor }
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":11,"t":7,"i":false} {"c":11,"t":9,"i":false}
+# F: both cursors set — the window between the first and the last transaction
+# of checkpoint 11. Only the middle transaction is inside the window
+# (cursors are exclusive). Both page flags are true because transactions
+# exist at the cursor positions, outside the window.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":11,"t":3,"i":false}
+# G: `after` cursor below the checkpoint's transaction range. No transaction
+# in this checkpoint sits at the cursor, so the bound is invalid and the
+# connection comes back empty, as for other transaction queries.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.snap
@@ -1,0 +1,204 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 25 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-18:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5236400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 20:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 24:
+//# advance-epoch
+Epoch advanced: 0
+
+task 5, line 26:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 6, line 28:
+//# advance-epoch
+Epoch advanced: 1
+
+task 7, line 30:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 8, line 32:
+//# advance-epoch
+Epoch advanced: 2
+
+task 9, line 34:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 10, line 36:
+//# run Test::M::create --sender A
+created: object(10,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 11, line 38:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 12, line 40:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 13, line 42:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 14, lines 44-51:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: checkpoint 1 has been pruned (min available: 7)",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 15, lines 53-59:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        }
+      ]
+    }
+  }
+}
+
+task 16, lines 61-71:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": null
+  }
+}
+
+task 17, lines 73-81:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 18, line 83:
+//# run Test::M::create --sender A
+created: object(18,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 19, line 85:
+//# run Test::M::create --sender A
+created: object(19,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 20, line 87:
+//# run Test::M::create --sender A
+created: object(20,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 21, line 89:
+//# create-checkpoint
+Checkpoint created: 11
+
+task 22, lines 91-99:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        },
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        },
+        {
+          "digest": "ACqVVgcSRS3QDERCcJm7arkawv2rGbu153oNrTcGTiuy"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJjIjoxMSwidCI6OSwiaSI6ZmFsc2V9",
+        "startCursor": "eyJjIjoxMSwidCI6NywiaSI6ZmFsc2V9"
+      }
+    }
+  }
+}
+
+task 23, lines 101-111:
+//# run-graphql --cursors {"c":11,"t":7,"i":false} {"c":11,"t":9,"i":false}
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 24, lines 113-122:
+//# run-graphql --cursors {"c":11,"t":3,"i":false}
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -42,6 +42,7 @@ toml.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+url.workspace = true
 uuid.workspace = true
 
 # internal dependencies

--- a/crates/iota-graphql-rpc/src/commands.rs
+++ b/crates/iota-graphql-rpc/src/commands.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use clap::*;
 
-use crate::config::{ConnectionConfig, Ide, TxExecFullNodeConfig};
+use crate::config::{ConnectionConfig, HistoricFallbackOptions, Ide, TxExecFullNodeConfig};
 
 #[derive(Parser)]
 #[command(name = "iota-graphql-rpc", about = "IOTA GraphQL RPC", author)]
@@ -28,6 +28,9 @@ pub enum Command {
 
         #[command(flatten)]
         connection: ConnectionConfig,
+
+        #[command(flatten)]
+        historic_fallback: Box<HistoricFallbackOptions>,
 
         /// Path to TOML file containing configuration for service.
         #[arg(short, long)]

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -8,6 +8,7 @@ use async_graphql::*;
 use iota_graphql_config::GraphQLConfig;
 use iota_names::config::IotaNamesConfig;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::functional_group::FunctionalGroup;
 
@@ -23,6 +24,7 @@ pub struct ServerConfig {
     pub internal_features: InternalFeatureConfig,
     pub tx_exec_full_node: TxExecFullNodeConfig,
     pub ide: Ide,
+    pub historic_fallback: HistoricFallbackOptions,
 }
 
 /// Configuration for connections for the RPC, passed in as command-line
@@ -64,6 +66,59 @@ pub struct ConnectionConfig {
         env = "MAX_AVAILABLE_RANGE",
     )]
     pub max_available_range: u64,
+}
+
+/// CLI options that control the archival fallback used when Postgres data has
+/// been pruned.
+#[GraphQLConfig]
+#[derive(clap::Args, Debug, Clone)]
+pub struct HistoricFallbackOptions {
+    #[arg(
+        long,
+        help = "Experimental: REST KV store URL for historic fallback. Depends on the iota-rest-kv API which is still being finalized."
+    )]
+    pub fallback_kv_url: Option<Url>,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_MULTI_FETCH_BATCH_SIZE,
+        env = "FALLBACK_KV_MULTI_FETCH_BATCH_SIZE",
+        help = "Experimental: Maximum number of keys per batch request to fallback KV store."
+    )]
+    pub fallback_kv_multi_fetch_batch_size: usize,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_CONCURRENT_FETCHES,
+        env = "FALLBACK_KV_CONCURRENT_FETCHES",
+        help = "Experimental: Maximum number of concurrent batch requests to fallback KV store."
+    )]
+    pub fallback_kv_concurrent_fetches: usize,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_CACHE_SIZE,
+        env = "FALLBACK_KV_CACHE_SIZE",
+        help = "Experimental: Cache size for historic fallback."
+    )]
+    pub fallback_kv_cache_size: u64,
+}
+
+impl HistoricFallbackOptions {
+    pub const DEFAULT_MULTI_FETCH_BATCH_SIZE: usize = 100;
+    pub const DEFAULT_CONCURRENT_FETCHES: usize = 10;
+    pub const DEFAULT_CACHE_SIZE: u64 = 100_000;
+}
+
+impl Default for HistoricFallbackOptions {
+    fn default() -> Self {
+        Self {
+            fallback_kv_url: None,
+            fallback_kv_multi_fetch_batch_size: Self::DEFAULT_MULTI_FETCH_BATCH_SIZE,
+            fallback_kv_concurrent_fetches: Self::DEFAULT_CONCURRENT_FETCHES,
+            fallback_kv_cache_size: Self::DEFAULT_CACHE_SIZE,
+        }
+    }
 }
 
 /// Configuration on features supported by the GraphQL service, passed in a

--- a/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use iota_indexer::{
     apis::GovernanceReadApi,
     db::ConnectionPoolConfig,
+    historical_fallback::HistoricalFallbackReader,
     metrics::IndexerMetrics,
     pruning::watermark_task::{WatermarkCache, WatermarkTask},
     read::IndexerReader,
@@ -17,9 +18,11 @@ use iota_types::{
     governance::StakedIota as NativeStakedIota,
     iota_system_state::iota_system_state_summary::IotaSystemStateSummary as NativeIotaSystemStateSummary,
 };
+use prometheus_filtered::Registry;
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
-use crate::error::Error;
+use crate::{config::HistoricFallbackOptions, error::Error};
 
 pub(crate) struct PgManager {
     pub inner: IndexerReader,
@@ -31,13 +34,17 @@ impl PgManager {
     }
 
     /// Create a new underlying reader, which is used by this type as well as
-    /// other data providers.
+    /// other data providers. If `historic_fallback` carries a URL, an archival
+    /// fallback reader is attached so reads can be served from the REST KV
+    /// store if Postgres data is pruned.
     pub(crate) fn reader_with_config(
         db_url: impl Into<String>,
         pool_size: u32,
         timeout_ms: u64,
         indexer_metrics: IndexerMetrics,
         cancellation_token: CancellationToken,
+        historic_fallback: &HistoricFallbackOptions,
+        registry: &Registry,
     ) -> Result<IndexerReader, Error> {
         let mut config = ConnectionPoolConfig::default();
         config.set_pool_size(pool_size);
@@ -56,7 +63,35 @@ impl PgManager {
         watermark_task.start(cancellation_token);
 
         // Create reader with watermark cache
-        Ok(IndexerReader::new(connection_pool, watermark_cache))
+        let mut reader = IndexerReader::new(connection_pool, watermark_cache);
+
+        if let HistoricFallbackOptions {
+            fallback_kv_url: Some(url),
+            fallback_kv_multi_fetch_batch_size,
+            fallback_kv_concurrent_fetches,
+            fallback_kv_cache_size,
+        } = historic_fallback
+        {
+            let fallback = HistoricalFallbackReader::new(
+                url.as_str(),
+                *fallback_kv_cache_size,
+                reader.package_resolver().clone(),
+                *fallback_kv_multi_fetch_batch_size,
+                *fallback_kv_concurrent_fetches,
+                registry,
+            )
+            .map_err(|e| {
+                Error::Internal(format!(
+                    "Failed to construct historical fallback reader: {e}"
+                ))
+            })?;
+            info!("HistoricalFallbackReader initialized with URL: {url}");
+            reader.with_fallback_reader(fallback);
+        } else {
+            info!("No config for HistoricalFallbackReader provided, skipping...");
+        }
+
+        Ok(reader)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/error.rs
+++ b/crates/iota-graphql-rpc/src/error.rs
@@ -14,6 +14,7 @@ use iota_names::error::IotaNamesError;
 pub(crate) mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
     pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
+    pub const DATA_PRUNED: &str = "DATA_PRUNED";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";
     pub const REQUEST_TIMEOUT: &str = "REQUEST_TIMEOUT";
     pub const UNKNOWN: &str = "UNKNOWN";
@@ -77,6 +78,8 @@ pub enum Error {
     // Catch-all for client-fault errors
     #[error("{0}")]
     Client(String),
+    #[error("Requested data has been pruned: {0}")]
+    DataPruned(String),
     #[error("Internal error occurred while processing request: {0}")]
     Internal(String),
     #[error(transparent)]
@@ -96,6 +99,9 @@ impl ErrorExtensions for Error {
             | Error::Client(_) => {
                 e.set("code", code::BAD_USER_INPUT);
             }
+            Error::DataPruned(_) => {
+                e.set("code", code::DATA_PRUNED);
+            }
             Error::Internal(_) => {
                 e.set("code", code::INTERNAL_SERVER_ERROR);
             }
@@ -114,7 +120,10 @@ impl ErrorExtensions for Error {
 
 impl From<IndexerError> for Error {
     fn from(e: IndexerError) -> Self {
-        Error::Internal(e.to_string())
+        match e {
+            IndexerError::DataPruned(msg) => Error::DataPruned(msg),
+            _ => Error::Internal(e.to_string()),
+        }
     }
 }
 

--- a/crates/iota-graphql-rpc/src/main.rs
+++ b/crates/iota-graphql-rpc/src/main.rs
@@ -53,6 +53,7 @@ async fn main() {
         Command::StartServer {
             ide,
             connection,
+            historic_fallback,
             config,
             tx_exec_full_node,
         } => {
@@ -69,6 +70,7 @@ async fn main() {
                 service: service_config,
                 ide,
                 tx_exec_full_node,
+                historic_fallback: *historic_fallback,
                 ..ServerConfig::default()
             };
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -447,8 +447,10 @@ impl ServerBuilder {
             config.service.limits.request_timeout_ms.into(),
             indexer_metrics.clone(),
             cancellation_token,
+            &config.historic_fallback,
+            &registry,
         )
-        .map_err(|e| Error::ServerInit(format!("Failed to create pg connection pool: {e}")))?;
+        .map_err(|e| Error::ServerInit(format!("Failed to initialize indexer reader: {e}")))?;
 
         if !config.connection.skip_migration_consistency_check {
             // Compatibility check
@@ -794,7 +796,7 @@ pub mod tests {
 
     use super::*;
     use crate::{
-        config::{ConnectionConfig, Limits, ServiceConfig, Version},
+        config::{ConnectionConfig, HistoricFallbackOptions, Limits, ServiceConfig, Version},
         context_data::db_data_provider::PgManager,
         extensions::{query_limits_checker::QueryLimitsChecker, timeout::Timeout},
         test_infra::cluster::Cluster,
@@ -810,12 +812,15 @@ pub mod tests {
         let connection_config = connection_config.unwrap_or_default();
         let service_config = service_config.unwrap_or_default();
 
+        let registry = prometheus_filtered::Registry::new();
         let reader = PgManager::reader_with_config(
             connection_config.db_url.clone(),
             connection_config.db_pool_size,
             service_config.limits.request_timeout_ms.into(),
-            IndexerMetrics::new(&prometheus_filtered::Registry::new()),
+            IndexerMetrics::new(&registry),
             CancellationToken::new(),
+            &HistoricFallbackOptions::default(),
+            &registry,
         )
         .expect("failed to create pg connection pool");
 

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    ops::RangeInclusive,
+};
 
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
@@ -11,7 +14,9 @@ use async_graphql::{
 };
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
-use iota_indexer::{models::checkpoints::StoredCheckpoint, schema::checkpoints};
+use iota_indexer::{
+    models::checkpoints::StoredCheckpoint, pruning::CommitterTables, schema::checkpoints,
+};
 use iota_types::messages_checkpoint::CheckpointDigest;
 use serde::{Deserialize, Serialize};
 
@@ -19,11 +24,11 @@ use crate::{
     config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::Checkpointed,
-    data::{self, Conn, DataLoader, Db, DbConnection, QueryExecutor},
+    data::{Conn, DataLoader, Db, DbConnection, QueryExecutor},
     error::Error,
     types::{
         base64::Base64,
-        cursor::{self, Page, Paginated, ScanLimited, Target},
+        cursor::{self, Page, ScanLimited, Target},
         date_time::DateTime,
         digest::Digest,
         epoch::Epoch,
@@ -71,7 +76,6 @@ pub(crate) struct Checkpoint {
 }
 
 pub(crate) type Cursor = cursor::JsonCursor<CheckpointCursor>;
-type Query<ST, GB> = data::Query<ST, checkpoints::table, GB>;
 
 /// The cursor returned for each `Checkpoint` in a connection's page of results.
 /// The `checkpoint_viewed_at` will set the consistent upper bound for
@@ -322,6 +326,44 @@ impl Checkpoint {
         Ok(stored as u64)
     }
 
+    /// Returns the inclusive `[lo, hi]` checkpoint sequence-number range to
+    /// paginate over, given the `checkpoint_viewed_at` and optional `epoch`
+    /// filter. Returns `None` when `filter` targets an epoch that does not
+    /// exist.
+    ///
+    /// The `epochs` table is never pruned but an in-progress epoch's
+    /// `last_checkpoint_id` is NULL - in that case the upper bound is
+    /// capped at `checkpoint_viewed_at`.
+    async fn pagination_range(
+        db: &Db,
+        filter: Option<u64>,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Option<(u64, u64)>, Error> {
+        let Some(epoch) = filter else {
+            return Ok(Some((0, checkpoint_viewed_at)));
+        };
+
+        let row: Option<(i64, Option<i64>)> = db
+            .execute(move |conn| {
+                use iota_indexer::schema::epochs::dsl as e;
+                conn.first(move || {
+                    e::epochs
+                        .select((e::first_checkpoint_id, e::last_checkpoint_id))
+                        .filter(e::epoch.eq(epoch as i64))
+                })
+                .optional()
+            })
+            .await
+            .map_err(|err| Error::Internal(format!("Failed to fetch epoch range: {err}")))?;
+
+        Ok(row.map(|(first, last)| {
+            let hi = last
+                .map(|l| std::cmp::min(l as u64, checkpoint_viewed_at))
+                .unwrap_or(checkpoint_viewed_at);
+            (first as u64, hi)
+        }))
+    }
+
     /// Query the database for a `page` of checkpoints. The Page uses the
     /// checkpoint sequence number of the stored checkpoint and the
     /// checkpoint at which this was viewed at as the cursor, and
@@ -336,37 +378,89 @@ impl Checkpoint {
     ///
     /// If the `Page<Cursor>` is set, then this function will defer to the
     /// `checkpoint_viewed_at` in the cursor if they are consistent.
+    ///
+    /// Specifying cursor or requesting epoch from the pruned range will result
+    /// in an error.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
         filter: Option<u64>,
         checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, Checkpoint>, Error> {
-        use checkpoints::dsl;
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredCheckpoint, _, _, _>(
-                    conn,
-                    checkpoint_viewed_at,
-                    move || {
-                        let mut query = dsl::checkpoints.into_boxed();
-                        query = query.filter(dsl::sequence_number.le(checkpoint_viewed_at as i64));
-                        if let Some(epoch) = filter {
-                            query = query.filter(dsl::epoch.eq(epoch as i64));
-                        }
-                        query
-                    },
-                )
-            })
-            .await?;
+        if page.limit() == 0 {
+            return Ok(Connection::new(false, false));
+        }
 
-        // The "checkpoint viewed at" sets a consistent upper bound for the nested
-        // queries.
-        let mut conn = Connection::new(prev, next);
-        for stored in results {
+        let Some((mut absolute_lo_incl, absolute_hi_incl)) =
+            Self::pagination_range(db, filter, checkpoint_viewed_at).await?
+        else {
+            return Ok(Connection::new(false, false));
+        };
+
+        // Without a fallback, anything below the pruning watermark is unreachable
+        if !db.inner.is_fallback_enabled() {
+            if let Some(lowest_unpruned_cp) = db
+                .inner
+                .watermark_cache()
+                .get_lowest_available_cp_for_tables(&[CommitterTables::Checkpoints])
+                .map(|w| w as u64)
+            {
+                absolute_lo_incl = absolute_lo_incl.max(lowest_unpruned_cp);
+            }
+        }
+
+        let available_range = absolute_lo_incl..=absolute_hi_incl;
+
+        if available_range.is_empty() {
+            return Err(Error::DataPruned(
+                "all checkpoints in the requested range have been pruned".into(),
+            ));
+        }
+
+        let Some(page_range) = page.narrow_to_available_range(&available_range)? else {
+            return Ok(Connection::new(false, false));
+        };
+
+        // Take `limit` sequence numbers from the appropriate end of the page range.
+        let limit = page.limit();
+        let picked_seqs: Vec<u64> = if page.is_from_front() {
+            page_range.take(limit).collect()
+        } else {
+            page_range.rev().take(limit).collect()
+        };
+        let mut all_rows: Vec<StoredCheckpoint> = db
+            .inner
+            .get_stored_checkpoints_by_seqs_with_fallback(picked_seqs.clone())
+            .await
+            .map_err(|err| Error::Internal(format!("Failed to fetch checkpoints: {err}")))?
+            .into_iter()
+            .flatten()
+            .collect();
+        all_rows.sort_by_key(|s| s.sequence_number);
+
+        // We validated the available range earlier, unpruned range should be present in
+        // the DB, rest should be present in fallback KV if configured. In such case we
+        // expect all checkpoints to be returned.
+        if all_rows.len() < picked_seqs.len() {
+            let picked: BTreeSet<u64> = picked_seqs.iter().copied().collect();
+            let returned: BTreeSet<u64> =
+                all_rows.iter().map(|r| r.sequence_number as u64).collect();
+            let misses: Vec<u64> = picked.difference(&returned).copied().collect();
+            return Err(Error::Internal(format!(
+                "checkpoints {misses:?} expected to be available but not found"
+            )));
+        }
+
+        let fetched_lo = all_rows.first().expect("checked non-empty").sequence_number as u64;
+        let fetched_hi = all_rows.last().expect("checked non-empty").sequence_number as u64;
+        let has_prev = fetched_lo > absolute_lo_incl;
+        let has_next = fetched_hi < absolute_hi_incl;
+
+        let mut conn = Connection::new(has_prev, has_next);
+        for stored in all_rows {
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
             conn.edges.push(Edge::new(
                 cursor,
@@ -378,27 +472,6 @@ impl Checkpoint {
         }
 
         Ok(conn)
-    }
-}
-
-impl Paginated<Cursor> for StoredCheckpoint {
-    type Source = checkpoints::table;
-
-    fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.ge(cursor.sequence_number as i64))
-    }
-
-    fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.le(cursor.sequence_number as i64))
-    }
-
-    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
-        use checkpoints::dsl;
-        if asc {
-            query.order(dsl::sequence_number)
-        } else {
-            query.order(dsl::sequence_number.desc())
-        }
     }
 }
 
@@ -419,35 +492,82 @@ impl Checkpointed for Cursor {
 
 impl ScanLimited for Cursor {}
 
+impl Page<Cursor> {
+    /// Narrow page range to the `available` range and return the inclusive
+    /// range this page should cover, or `None` if the range is empty.
+    ///
+    /// A cursor below `available.start()` returns `Error::DataPruned` (the
+    /// data was pruned since the cursor was issued). A cursor above
+    /// `available.end()` returns `Error::Client` (the cursor is malformed).
+    /// When `after > before` the range is empty and no error is returned.
+    fn narrow_to_available_range(
+        &self,
+        available: &RangeInclusive<u64>,
+    ) -> Result<Option<RangeInclusive<u64>>, Error> {
+        let lo = *available.start();
+        let hi = *available.end();
+
+        let after = self.after().map(|c| ("after", c.sequence_number));
+        let before = self.before().map(|c| ("before", c.sequence_number));
+
+        // If `after > before`, the range is empty; skip cursor validation.
+        if let (Some((_, after_seq)), Some((_, before_seq))) = (after, before) {
+            if after_seq > before_seq {
+                return Ok(None);
+            }
+        }
+
+        // Since `after <= before`, it's enough to check if the smaller cursor is below
+        // `lo`. Analogously for `hi`.
+        if let Some((name, seq)) = after.or(before) {
+            if seq < lo {
+                return Err(Error::DataPruned(format!(
+                    "`{name}` cursor (seq {seq}) is below the available range {available:?}"
+                )));
+            }
+        }
+        if let Some((name, seq)) = before.or(after) {
+            if seq > hi {
+                return Err(Error::Client(format!(
+                    "`{name}` cursor (seq {seq}) is above the available range {available:?}"
+                )));
+            }
+        }
+
+        // Cursors are exclusive.
+        let page_lo = after.map(|(_, seq)| seq.saturating_add(1)).unwrap_or(lo);
+        let page_hi = before.map(|(_, seq)| seq.saturating_sub(1)).unwrap_or(hi);
+        let range = page_lo..=page_hi;
+        if range.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(range))
+        }
+    }
+}
+
 impl Loader<SeqNumKey> for Db {
     type Value = Checkpoint;
     type Error = Error;
 
     async fn load(&self, keys: &[SeqNumKey]) -> Result<HashMap<SeqNumKey, Checkpoint>, Error> {
-        use checkpoints::dsl;
-
-        let checkpoint_ids: BTreeSet<_> = keys
+        // Drop keys querying for a checkpoint after their own consistency cursor.
+        let seqs: Vec<u64> = keys
             .iter()
-            .filter_map(|key| {
-                // Filter out keys querying for checkpoints after their own consistency cursor.
-                (key.checkpoint_viewed_at >= key.sequence_number)
-                    .then_some(key.sequence_number as i64)
-            })
+            .filter(|key| key.checkpoint_viewed_at >= key.sequence_number)
+            .map(|key| key.sequence_number)
             .collect();
 
-        let checkpoints: Vec<StoredCheckpoint> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    dsl::checkpoints
-                        .filter(dsl::sequence_number.eq_any(checkpoint_ids.iter().cloned()))
-                })
-            })
+        let rows = self
+            .inner
+            .get_stored_checkpoints_by_seqs_with_fallback(seqs.clone())
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoints: {e}")))?;
 
-        let checkpoint_id_to_stored: BTreeMap<_, _> = checkpoints
+        let checkpoint_id_to_stored: BTreeMap<u64, StoredCheckpoint> = seqs
             .into_iter()
-            .map(|stored| (stored.sequence_number as u64, stored))
+            .zip(rows)
+            .filter_map(|(seq, row)| row.map(|stored| (seq, stored)))
             .collect();
 
         Ok(keys
@@ -475,22 +595,18 @@ impl Loader<DigestKey> for Db {
     type Error = Error;
 
     async fn load(&self, keys: &[DigestKey]) -> Result<HashMap<DigestKey, Checkpoint>, Error> {
-        use checkpoints::dsl;
+        let digests: Vec<CheckpointDigest> = keys.iter().map(|key| key.digest.into()).collect();
 
-        let digests: BTreeSet<_> = keys.iter().map(|key| key.digest.to_vec()).collect();
-
-        let checkpoints: Vec<StoredCheckpoint> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    dsl::checkpoints.filter(dsl::checkpoint_digest.eq_any(digests.iter().cloned()))
-                })
-            })
+        let rows = self
+            .inner
+            .get_stored_checkpoints_by_digests_with_fallback(digests.clone())
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoints: {e}")))?;
 
-        let checkpoint_id_to_stored: BTreeMap<_, _> = checkpoints
+        let checkpoint_id_to_stored: BTreeMap<Vec<u8>, StoredCheckpoint> = digests
             .into_iter()
-            .map(|stored| (stored.checkpoint_digest.clone(), stored))
+            .zip(rows)
+            .filter_map(|(digest, row)| row.map(|stored| (digest.inner().to_vec(), stored)))
             .collect();
 
         Ok(keys

--- a/crates/iota-graphql-rpc/src/types/cursor.rs
+++ b/crates/iota-graphql-rpc/src/types/cursor.rs
@@ -411,7 +411,11 @@ impl<C: CursorType + ScanLimited + Eq + Clone + Send + Sync + 'static> Page<C> {
     /// in the range, followed by an iterator of values in the page, fetched
     /// from the database. The values returned implement `Target<C>`, so are
     /// able to compute their own cursors.
-    fn paginate_results<T>(
+    ///
+    /// `results` must be sorted in ascending cursor order and fetched with
+    /// inclusive cursor bounds, so that the rows at the `after`/`before`
+    /// cursors are part of the result set (see [`Page::apply`]).
+    pub(crate) fn paginate_results<T>(
         &self,
         f_cursor: Option<C>,
         l_cursor: Option<C>,

--- a/crates/iota-graphql-rpc/src/types/digest.rs
+++ b/crates/iota-graphql-rpc/src/types/digest.rs
@@ -6,7 +6,7 @@ use std::{fmt, str::FromStr};
 
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
-use iota_types::digests::{ObjectDigest, TransactionDigest};
+use iota_types::digests::{CheckpointDigest, ObjectDigest, TransactionDigest};
 
 use crate::types::string_input::impl_string_input;
 
@@ -72,6 +72,12 @@ impl From<Digest> for ObjectDigest {
 impl From<Digest> for TransactionDigest {
     fn from(digest: Digest) -> Self {
         TransactionDigest::new(digest.0)
+    }
+}
+
+impl From<Digest> for CheckpointDigest {
+    fn from(digest: Digest) -> Self {
+        CheckpointDigest::new(digest.0)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/digest.rs
+++ b/crates/iota-graphql-rpc/src/types/digest.rs
@@ -25,10 +25,6 @@ pub(crate) enum Error {
 }
 
 impl Digest {
-    pub(crate) fn to_vec(self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
     pub(crate) fn as_slice(&self) -> &[u8] {
         &self.0
     }

--- a/crates/iota-graphql-rpc/src/types/event/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/event/filter.rs
@@ -50,3 +50,14 @@ pub(crate) struct EventFilter {
     // pub all
     // pub not
 }
+
+impl EventFilter {
+    /// Returns the transaction digest when `transaction_digest` is the only
+    /// filter set.
+    pub(crate) fn only_transaction_digest(&self) -> Option<Digest> {
+        if self.sender.is_some() || self.emitting_module.is_some() || self.event_type.is_some() {
+            return None;
+        }
+        self.transaction_digest
+    }
+}

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -29,9 +29,10 @@ use crate::{
         base64::Base64,
         cursor::{Page, Target},
         date_time::DateTime,
+        digest::Digest,
         move_module::MoveModule,
         move_value::MoveValue,
-        transaction_block::{SeqKey, TransactionBlock},
+        transaction_block::{DigestKey, TransactionBlock},
     },
 };
 
@@ -44,18 +45,22 @@ pub(crate) use filter::EventFilter;
 /// An event emitted in a transaction that has been checkpointed.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct CheckpointedEventInfo {
-    /// The sequence number of the parent transaction.
-    tx_sequence_number: u64,
+    /// The digest of the parent transaction.
+    tx_digest: Digest,
     /// The timestamp of the parent transaction.
     timestamp_ms: i64,
 }
 
-impl From<&StoredEvent> for CheckpointedEventInfo {
-    fn from(value: &StoredEvent) -> Self {
-        Self {
-            tx_sequence_number: value.tx_sequence_number as u64,
+impl TryFrom<&StoredEvent> for CheckpointedEventInfo {
+    type Error = Error;
+
+    fn try_from(value: &StoredEvent) -> Result<Self, Self::Error> {
+        let tx_digest = Digest::try_from(value.transaction_digest.as_slice())
+            .map_err(|e| Error::Internal(format!("Bad transaction digest on event: {e}")))?;
+        Ok(Self {
+            tx_digest,
             timestamp_ms: value.timestamp_ms,
-        }
+        })
     }
 }
 
@@ -89,9 +94,9 @@ impl Event {
         let Some(checkpointed) = &self.checkpointed_info else {
             return Ok(None);
         };
-        let key = SeqKey::new(checkpointed.tx_sequence_number, self.checkpoint_viewed_at);
+        let key = DigestKey::new(checkpointed.tx_digest, self.checkpoint_viewed_at);
 
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     /// The Move module containing some function that when called by
@@ -279,8 +284,10 @@ impl Event {
             ))
         })?;
 
+        let tx_digest = Digest::try_from(stored_tx.transaction_digest.as_slice())
+            .map_err(|e| Error::Internal(format!("Bad transaction digest on transaction: {e}")))?;
         let checkpointed = CheckpointedEventInfo {
-            tx_sequence_number: stored_tx.tx_sequence_number as u64,
+            tx_digest,
             timestamp_ms: stored_tx.timestamp_ms,
         };
         Ok(Self {
@@ -297,7 +304,7 @@ impl Event {
         let Some(Some(sender_bytes)) = stored.senders.first() else {
             return Err(Error::Internal("No senders found for event".to_string()));
         };
-        let checkpointed = CheckpointedEventInfo::from(&stored);
+        let checkpointed = CheckpointedEventInfo::try_from(&stored)?;
         let sender =
             NativeAddress::from_bytes(sender_bytes).map_err(|e| Error::Internal(e.to_string()))?;
         let package_id =

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Bound;
+
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
@@ -171,6 +173,30 @@ impl Event {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
+        use checkpoints::dsl;
+        // Exclusive upperbound, we cannot return newer data than `checkpoint_viewed_at`
+        let tx_hi: i64 = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    dsl::checkpoints
+                        .select(dsl::network_total_transactions)
+                        .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
+                })
+            })
+            .await?;
+
+        // For the only-`transactionDigest` case, we support fallback.
+        if let Some(tx_digest) = filter.only_transaction_digest() {
+            return Self::paginate_by_tx_digest_with_fallback(
+                db,
+                page,
+                tx_digest,
+                checkpoint_viewed_at,
+                tx_hi,
+            )
+            .await;
+        }
+
         // Construct tx and ev sequence number query with table-relevant filters, if
         // they exist. The resulting query will look something like `SELECT
         // tx_sequence_number, event_sequence_number FROM lookup_table WHERE
@@ -188,14 +214,8 @@ impl Event {
             }
         };
 
-        use checkpoints::dsl;
         let (prev, next, results) = db
             .execute(move |conn| {
-                let tx_hi: i64 = conn.first(move || {
-                    dsl::checkpoints.select(dsl::network_total_transactions)
-                        .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
-                })?;
-
                 let (prev, next, mut events): (bool, bool, Vec<StoredEvent>) =
                     if let Some(filter_query) =  query_constraint {
                         let query = add_bounds(filter_query, &filter.transaction_digest, &page, tx_hi);
@@ -262,6 +282,58 @@ impl Event {
             ));
         }
 
+        Ok(conn)
+    }
+
+    /// Paginates events of a single transaction with fallback support.
+    ///
+    /// `tx_hi` is the exclusive upperbound on transaction sequence numbers
+    async fn paginate_by_tx_digest_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        tx_digest: Digest,
+        checkpoint_viewed_at: u64,
+        tx_hi: i64,
+    ) -> Result<Connection<String, Event>, Error> {
+        // Fetch the page plus the rows at the cursors, to later compute
+        // `has_next`/`has_prev` via `paginate_results`.
+        let min_tx_ev_seq = page
+            .after()
+            .map_or(Bound::Unbounded, |c| Bound::Included((c.tx, c.e)));
+        // Events of transactions at or above `tx_hi` are not visible at
+        // `checkpoint_viewed_at`.
+        let max_tx_ev_seq = match page.before() {
+            Some(c) if c.tx < tx_hi as u64 => Bound::Included((c.tx, c.e)),
+            _ => Bound::Excluded((tx_hi as u64, 0)),
+        };
+        let mut results = db
+            .inner
+            .query_stored_events_by_tx_digest_with_fallback(
+                tx_digest.into(),
+                (min_tx_ev_seq, max_tx_ev_seq),
+                page.limit() + 2,
+                !page.is_from_front(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !page.is_from_front() {
+            results.reverse();
+        }
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = Connection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            conn.edges.push(Edge::new(
+                cursor,
+                Event::try_from_stored_event(stored, checkpoint_viewed_at)?,
+            ));
+        }
         Ok(conn)
     }
 

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Bound;
-
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
@@ -18,7 +16,7 @@ use iota_indexer::{
     schema::{checkpoints, events},
 };
 use iota_sdk_types::{Address as NativeAddress, Event as NativeEvent, Identifier, ObjectId};
-use iota_types::parse_iota_struct_tag;
+use iota_types::{event::EventID, parse_iota_struct_tag};
 use lookups::{add_bounds, select_emit_module, select_event_type, select_sender};
 
 use crate::{
@@ -295,22 +293,32 @@ impl Event {
         checkpoint_viewed_at: u64,
         tx_hi: i64,
     ) -> Result<Connection<String, Event>, Error> {
-        // Fetch the page plus the rows at the cursors, to later compute
-        // `has_next`/`has_prev` via `paginate_results`.
-        let min_tx_ev_seq = page
-            .after()
-            .map_or(Bound::Unbounded, |c| Bound::Included((c.tx, c.e)));
-        // Events of transactions at or above `tx_hi` are not visible at
-        // `checkpoint_viewed_at`.
-        let max_tx_ev_seq = match page.before() {
-            Some(c) if c.tx < tx_hi as u64 => Bound::Included((c.tx, c.e)),
-            _ => Bound::Excluded((tx_hi as u64, 0)),
+        // Page cursors are inclusive, we need to convert them to exclusive
+        let cursor = if page.is_from_front() {
+            // Cannot do -1 when cursor=0
+            page.after().and_then(|cursor| {
+                cursor.e.checked_sub(1).map(|event_seq| EventID {
+                    tx_digest: tx_digest.into(),
+                    event_seq,
+                })
+            })
+        } else {
+            // Cannot do +1 when cursor=`u64::MAX`
+            page.before().and_then(|cursor| {
+                cursor.e.checked_add(1).map(|event_seq| EventID {
+                    tx_digest: tx_digest.into(),
+                    event_seq,
+                })
+            })
         };
+
+        // we fetch with limit+2, so that we receive back both cursors in case of full
+        // page, as required by `page.paginate_results`
         let mut results = db
             .inner
             .query_stored_events_by_tx_digest_with_fallback(
                 tx_digest.into(),
-                (min_tx_ev_seq, max_tx_ev_seq),
+                cursor,
                 page.limit() + 2,
                 !page.is_from_front(),
             )
@@ -319,6 +327,18 @@ impl Event {
         if !page.is_from_front() {
             results.reverse();
         }
+
+        // Initial fetch above honored only the start cursor. We filter the result to
+        // also honor the end cursor and the `tx_hi`
+        results.retain(|ev| {
+            let key = (
+                ev.tx_sequence_number as u64,
+                ev.event_sequence_number as u64,
+            );
+            ev.tx_sequence_number < tx_hi
+                && page.after().is_none_or(|c| (c.tx, c.e) <= key)
+                && page.before().is_none_or(|c| key <= (c.tx, c.e))
+        });
 
         let (prev, next, results) = page.paginate_results(
             results.first().map(|f| f.cursor(checkpoint_viewed_at)),

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -665,7 +665,7 @@ impl ObjectImpl<'_> {
         let digest = native.previous_transaction;
         let key = transaction_block::DigestKey::new(digest.into(), self.0.checkpoint_viewed_at);
 
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     pub(crate) async fn storage_rebate(&self) -> Option<BigInt> {

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -387,7 +387,7 @@ impl Query {
     ) -> Result<Option<TransactionBlock>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
         let key = transaction_block::DigestKey::new(digest, checkpoint);
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     /// Fetch multiple transaction blocks by their digests.

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -130,6 +130,16 @@ impl TransactionBlockFilter {
             || self.transaction_ids.is_some()
     }
 
+    /// Returns the checkpoint sequence number when `at_checkpoint` is the
+    /// only filter set.
+    pub(crate) fn only_at_checkpoint(&self) -> Option<UInt53> {
+        if self.has_filters() || self.after_checkpoint.is_some() || self.before_checkpoint.is_some()
+        {
+            return None;
+        }
+        self.at_checkpoint
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.before_checkpoint == Some(UInt53::from(0))
             || matches!(

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Bound,
+};
 
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
@@ -405,6 +408,18 @@ impl TransactionBlock {
         let db: &Db = ctx.data_unchecked();
         let is_from_front = page.is_from_front();
 
+        // For the only-`atCheckpoint` case, we support fallback.
+        // `scan_limit` is ignored here
+        if let Some(at_checkpoint) = filter.only_at_checkpoint() {
+            return Self::paginate_at_checkpoint_with_fallback(
+                db,
+                page,
+                u64::from(at_checkpoint),
+                checkpoint_viewed_at,
+            )
+            .await;
+        }
+
         use transactions::dsl as tx;
         let (prev, next, transactions, tx_bounds): (
             bool,
@@ -497,6 +512,61 @@ impl TransactionBlock {
     /// Returns whether this transaction block is within the available range.
     pub(crate) fn is_available(&self) -> bool {
         self.checkpoint_viewed_at < UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
+    }
+
+    /// Paginates transactions in a single checkpoint with fallback support.
+    async fn paginate_at_checkpoint_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        at_checkpoint: u64,
+        checkpoint_viewed_at: u64,
+    ) -> Result<ScanConnection<String, TransactionBlock>, Error> {
+        if at_checkpoint > checkpoint_viewed_at {
+            return Ok(ScanConnection::new(false, false));
+        }
+
+        // Fetch the page plus the rows at the cursors, to later compute
+        // `has_next`/`has_prev` via `paginate_results`. The bounds are
+        // inclusive so that the cursor rows themselves are fetched.
+        let tx_seq_range = (
+            page.after()
+                .map_or(Bound::Unbounded, |c| Bound::Included(c.tx_sequence_number)),
+            page.before()
+                .map_or(Bound::Unbounded, |c| Bound::Included(c.tx_sequence_number)),
+        );
+        let mut results = db
+            .inner
+            .query_stored_transactions_by_checkpoint_seq_with_fallback(
+                at_checkpoint,
+                tx_seq_range,
+                page.limit() + 2,
+                !page.is_from_front(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !page.is_from_front() {
+            results.reverse();
+        }
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = ScanConnection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            let inner = TransactionBlockInner::try_from(stored)?;
+            conn.edges.push(Edge::new(
+                cursor,
+                TransactionBlock {
+                    inner,
+                    checkpoint_viewed_at,
+                },
+            ));
+        }
+        Ok(conn)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -7,16 +7,18 @@ use std::collections::{BTreeMap, HashMap};
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
 use cursor::TxLookup;
-use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
+use diesel::{ExpressionMethods, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{
     apis::ReadApi,
     models::transactions::{OptimisticTransaction, StoredTransaction},
-    schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
+    read::TransactionRead,
+    schema::transactions,
 };
 use iota_json_rpc_api::ReadApiServer;
 use iota_sdk_types::{Address as NativeAddress, Event as NativeEvent, TransactionExpiration};
 use iota_types::{
+    digests::TransactionDigest,
     effects::TransactionEffects as NativeTransactionEffects,
     message_envelope::Message,
     transaction::{
@@ -150,41 +152,6 @@ impl DigestKey {
             digest,
             checkpoint_viewed_at,
         }
-    }
-}
-
-/// `DataLoader` key for fetching a `TransactionBlock` by its sequence number,
-/// constrained by a consistency cursor.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub(crate) struct SeqKey {
-    pub tx_sequence_number: u64,
-    pub checkpoint_viewed_at: u64,
-}
-
-impl SeqKey {
-    pub fn new(tx_sequence_number: u64, checkpoint_viewed_at: u64) -> Self {
-        Self {
-            tx_sequence_number,
-            checkpoint_viewed_at,
-        }
-    }
-}
-
-/// Filter for a point query of a TransactionBlock.
-pub(crate) enum TransactionBlockLookup {
-    ByDigest(DigestKey),
-    BySeq(SeqKey),
-}
-
-impl From<DigestKey> for TransactionBlockLookup {
-    fn from(key: DigestKey) -> Self {
-        TransactionBlockLookup::ByDigest(key)
-    }
-}
-
-impl From<SeqKey> for TransactionBlockLookup {
-    fn from(key: SeqKey) -> Self {
-        TransactionBlockLookup::BySeq(key)
     }
 }
 
@@ -349,15 +316,9 @@ impl TransactionBlock {
     /// or sequence number. Treats it as if it is being viewed at the
     /// `checkpoint_viewed_at` (e.g. the state of all relevant addresses
     /// will be at that checkpoint).
-    pub(crate) async fn query(
-        ctx: &Context<'_>,
-        key: TransactionBlockLookup,
-    ) -> Result<Option<Self>, Error> {
+    pub(crate) async fn query(ctx: &Context<'_>, key: DigestKey) -> Result<Option<Self>, Error> {
         let DataLoader(loader) = ctx.data_unchecked();
-        match key {
-            TransactionBlockLookup::ByDigest(digest_key) => loader.load_one(digest_key).await,
-            TransactionBlockLookup::BySeq(seq_key) => loader.load_one(seq_key).await,
-        }
+        loader.load_one(key).await
     }
 
     /// Look up multiple `TransactionBlock`s by their digests. Returns a map
@@ -547,145 +508,41 @@ impl Loader<DigestKey> for Db {
         &self,
         keys: &[DigestKey],
     ) -> Result<HashMap<DigestKey, TransactionBlock>, Error> {
-        use optimistic_transactions::dsl as opt_tx;
-        use transactions::dsl as tx;
-        use tx_digests::dsl as ds;
-        use tx_global_order::dsl as tx_global;
+        let digests: Vec<TransactionDigest> = keys.iter().map(|k| k.digest.into()).collect();
 
-        let digests: Vec<_> = keys.iter().map(|k| k.digest.to_vec()).collect();
-
-        // First, fetch from the main transactions table
-        let transactions: Vec<StoredTransaction> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    let join = ds::tx_sequence_number.eq(tx::tx_sequence_number);
-
-                    tx::transactions
-                        .inner_join(ds::tx_digests.on(join))
-                        .select(StoredTransaction::as_select())
-                        .filter(ds::tx_digest.eq_any(digests.clone()))
-                })
-            })
+        let by_digest: BTreeMap<Vec<u8>, TransactionRead> = self
+            .inner
+            .multi_get_transactions_with_fallback(&digests)
             .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
-
-        let transaction_digest_to_stored: BTreeMap<Vec<u8>, StoredTransaction> = transactions
+            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?
             .into_iter()
-            .map(|tx| (tx.transaction_digest.clone(), tx))
+            .map(|tx| (tx.transaction_digest().to_vec(), tx))
             .collect();
 
-        // Process stored transactions and collect missing digests
         let mut results = HashMap::new();
-        let mut missing_digests = Vec::new();
-
         for key in keys {
-            let digest_bytes = key.digest.as_slice();
-
-            if let Some(stored) = transaction_digest_to_stored.get(digest_bytes) {
-                let mut checkpoint_viewed_at = key.checkpoint_viewed_at;
-                if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                    checkpoint_viewed_at = UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER;
-                }
-                let tx_block = TransactionBlock {
-                    inner: TransactionBlockInner::try_from(stored.clone())?,
-                    checkpoint_viewed_at,
-                };
-                results.insert(*key, tx_block);
-            } else {
-                missing_digests.push(key.digest.to_vec());
-            }
-        }
-
-        if !missing_digests.is_empty() {
-            let optimistic_transactions: Vec<OptimisticTransaction> = self
-                .execute(move |conn| {
-                    conn.results(move || {
-                        opt_tx::optimistic_transactions
-                            .inner_join(
-                                tx_global::tx_global_order.on(opt_tx::global_sequence_number
-                                    .eq(tx_global::global_sequence_number)
-                                    .and(
-                                        opt_tx::optimistic_sequence_number
-                                            .eq(tx_global::optimistic_sequence_number),
-                                    )),
-                            )
-                            // Filter by digest on tx_global_order table because it is indexed by
-                            // digest, optimistic_transactions table is not
-                            .filter(tx_global::tx_digest.eq_any(missing_digests.clone()))
-                            .select(OptimisticTransaction::as_select())
-                    })
-                })
-                .await
-                .map_err(|e| {
-                    Error::Internal(format!("Failed to fetch optimistic transactions: {e}"))
-                })?;
-
-            let transaction_digest_to_optimistic: BTreeMap<Vec<u8>, OptimisticTransaction> =
-                optimistic_transactions
-                    .into_iter()
-                    .map(|opt_tx| (opt_tx.transaction_digest.clone(), opt_tx))
-                    .collect();
-
-            for key in keys {
-                let digest_bytes = key.digest.as_slice();
-                if let Some(optimistic) = transaction_digest_to_optimistic.get(digest_bytes) {
-                    let tx_block = TransactionBlock {
-                        inner: TransactionBlockInner::try_from(optimistic.clone())?,
-                        checkpoint_viewed_at: UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER,
-                    };
-                    results.insert(*key, tx_block);
-                }
-            }
-        }
-
-        Ok(results)
-    }
-}
-
-impl Loader<SeqKey> for Db {
-    type Value = TransactionBlock;
-    type Error = Error;
-
-    async fn load(&self, keys: &[SeqKey]) -> Result<HashMap<SeqKey, TransactionBlock>, Error> {
-        use transactions::dsl as tx;
-
-        let tx_seqs = keys
-            .iter()
-            .map(|k| k.tx_sequence_number as i64)
-            .collect::<Vec<_>>();
-        let transactions: Vec<StoredTransaction> = self
-            .execute(move |conn| {
-                conn.results(|| {
-                    tx::transactions
-                        .select(StoredTransaction::as_select())
-                        .filter(tx::tx_sequence_number.eq_any(tx_seqs.clone()))
-                })
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
-
-        let seq_num_to_tx: HashMap<i64, StoredTransaction> = transactions
-            .into_iter()
-            .map(|tx| (tx.tx_sequence_number, tx))
-            .collect();
-
-        let mut results = HashMap::with_capacity(keys.len());
-        for key in keys {
-            let Some(stored) = seq_num_to_tx.get(&(key.tx_sequence_number as i64)) else {
+            let Some(tx) = by_digest.get(key.digest.as_slice()) else {
                 continue;
             };
-
-            let mut checkpoint_viewed_at = key.checkpoint_viewed_at;
-            if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                checkpoint_viewed_at = UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER;
-            }
-            results.insert(
-                *key,
-                TransactionBlock {
-                    inner: TransactionBlockInner::try_from(stored.clone())?,
-                    checkpoint_viewed_at,
+            let block = match tx {
+                TransactionRead::Checkpointed(stored) => {
+                    let checkpoint_viewed_at =
+                        if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                            UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
+                        } else {
+                            key.checkpoint_viewed_at
+                        };
+                    TransactionBlock {
+                        inner: TransactionBlockInner::try_from(stored.clone())?,
+                        checkpoint_viewed_at,
+                    }
+                }
+                TransactionRead::Optimistic(opt) => TransactionBlock {
+                    inner: TransactionBlockInner::try_from(opt.clone())?,
+                    checkpoint_viewed_at: UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER,
                 },
-            );
+            };
+            results.insert(*key, block);
         }
 
         Ok(results)

--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -15,7 +15,10 @@ use iota_types::{
     digests::TransactionDigest,
     effects::TransactionEvents,
     full_checkpoint_content::CheckpointTransaction,
-    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt,
+        CheckpointSequenceNumber,
+    },
     object::Object,
 };
 use prometheus_filtered::Registry;
@@ -26,10 +29,11 @@ use crate::{
     metrics::IndexerMetrics,
     models::{
         checkpoints::StoredCheckpoint,
+        events::StoredEvent,
         objects::StoredObject,
         transactions::{StoredTransaction, tx_events_to_iota_tx_events},
     },
-    types::{IndexedCheckpoint, IndexedObject},
+    types::{IndexedCheckpoint, IndexedEvent, IndexedObject},
 };
 
 /// Alias for an [`Object`] fetched from historical fallback storage.
@@ -66,21 +70,52 @@ impl From<HistoricalFallbackCheckpoint> for StoredCheckpoint {
 /// Wrapper for [`TransactionEvents`] and additional data fetched from
 /// historical fallback storage.
 ///
-/// Contains all data needed to reconstruct [`IotaEvent`]s.
+/// Contains all data needed to reconstruct [`IotaEvent`]s or [`StoredEvent`]s.
 #[derive(Debug, Clone)]
 pub struct HistoricalFallbackEvents {
     /// Events emitted during transaction execution.
     events: TransactionEvents,
+    /// Digest of the transaction that emitted the events.
+    tx_digest: TransactionDigest,
+    /// Sequence number of the transaction that emitted the events.
+    tx_sequence_number: u64,
+    /// Sequence number of the checkpoint the transaction is part of.
+    checkpoint_sequence_number: CheckpointSequenceNumber,
     /// Checkpoint timestamp.
     timestamp: u64,
 }
 
 impl HistoricalFallbackEvents {
-    pub fn new(events: TransactionEvents, checkpoint_summary: CertifiedCheckpointSummary) -> Self {
-        Self {
+    /// Creates the wrapper from the events of the `tx_digest` transaction and
+    /// the checkpoint the transaction is part of.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IndexerError::HistoricalFallbackStorageError`] when
+    /// transaction is not part of the provided checkpoint.
+    pub fn new(
+        events: TransactionEvents,
+        tx_digest: TransactionDigest,
+        checkpoint_summary: &CertifiedCheckpointSummary,
+        checkpoint_contents: &CheckpointContents,
+    ) -> IndexerResult<Self> {
+        let Some(tx_sequence_number) = checkpoint_contents
+            .enumerate_transactions(checkpoint_summary)
+            .find(|(_, execution_digest)| execution_digest.transaction == tx_digest)
+            .map(|(seq, _)| seq)
+        else {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "cannot find transaction sequence number to transaction: {tx_digest}"
+            )));
+        };
+
+        Ok(Self {
             events,
+            tx_digest,
+            tx_sequence_number,
+            checkpoint_sequence_number: checkpoint_summary.sequence_number,
             timestamp: checkpoint_summary.timestamp_ms,
-        }
+        })
     }
 
     /// Converts the raw [`TransactionEvents`] into JSON RPC compatible
@@ -88,16 +123,33 @@ impl HistoricalFallbackEvents {
     pub(crate) async fn into_iota_events(
         self,
         package_resolver: &Arc<Resolver<impl PackageStore>>,
-        tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
         tx_events_to_iota_tx_events(
             self.events,
             package_resolver,
-            tx_digest,
+            self.tx_digest,
             Some(self.timestamp),
         )
         .await
         .map(|tx_block_event| tx_block_event.data)
+    }
+
+    /// Converts the raw [`TransactionEvents`] into [`StoredEvent`]s.
+    pub(crate) fn into_stored_events(self) -> Vec<StoredEvent> {
+        self.events
+            .iter()
+            .enumerate()
+            .map(|(idx, event)| {
+                StoredEvent::from(IndexedEvent::from_event(
+                    self.tx_sequence_number,
+                    idx as u64,
+                    self.checkpoint_sequence_number,
+                    self.tx_digest,
+                    event,
+                    self.timestamp,
+                ))
+            })
+            .collect()
     }
 }
 

--- a/crates/iota-indexer/src/historical_fallback/mod.rs
+++ b/crates/iota-indexer/src/historical_fallback/mod.rs
@@ -12,3 +12,5 @@ pub(crate) mod client;
 pub(crate) mod convert;
 pub(crate) mod metrics;
 pub(crate) mod reader;
+
+pub use reader::HistoricalFallbackReader;

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -19,8 +19,9 @@ use iota_json_rpc_types::{CheckpointId, IotaEvent};
 use iota_sdk_types::{Address, ObjectId, Version};
 use iota_types::{
     digests::TransactionDigest,
-    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
-    event::EventID,
+    effects::{
+        TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt, TransactionEvents,
+    },
     full_checkpoint_content::CheckpointTransaction,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt, CheckpointDigest,
@@ -45,9 +46,11 @@ use crate::{
         metrics::HistoricalFallbackClientMetrics,
     },
     models::{
-        checkpoints::StoredCheckpoint, objects::StoredObject, transactions::StoredTransaction,
+        checkpoints::StoredCheckpoint, events::StoredEvent, objects::StoredObject,
+        transactions::StoredTransaction,
     },
     read::PackageResolver,
+    types::IndexedEvent,
 };
 
 /// Represents the Input objects of a transaction.
@@ -331,24 +334,8 @@ impl HistoricalFallbackReader {
         &self,
         tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
-        let tx_digests = &[tx_digest];
-        let (events, checkpoint_summaries) = tokio::try_join!(
-            self.client.multi_get_events_by_tx_digests(tx_digests),
-            self.resolve_checkpoints(tx_digests)
-        )?;
-
-        // check first if transaction exists, all valid transaction are part of a
-        // checkpoint, if not found then the provided digest is invalid.
-        let (summary, _) = checkpoint_summaries
-            .get(&tx_digest)
-            .cloned()
-            .ok_or_else(|| {
-                IndexerError::HistoricalFallbackStorageError(format!(
-                    "transaction: {tx_digest} does not exist"
-                ))
-            })?;
-
-        let Some(Some(events)) = events.into_iter().next() else {
+        let (events, (summary, _)) = self.events_with_checkpoint(tx_digest).await?;
+        let Some(events) = events else {
             // transaction does not have associated events.
             return Ok(vec![]);
         };
@@ -356,6 +343,31 @@ impl HistoricalFallbackReader {
         HistoricalFallbackEvents::new(events, summary)
             .into_iota_events(&self.package_resolver, tx_digest)
             .await
+    }
+
+    /// Fetches the events of a transaction together with the checkpoint the
+    /// transaction belongs to.
+    ///
+    /// The events are `None` when the transaction did not emit any.
+    async fn events_with_checkpoint(
+        &self,
+        tx_digest: TransactionDigest,
+    ) -> IndexerResult<(Option<TransactionEvents>, HistoricalFallbackCheckpoint)> {
+        let tx_digests = &[tx_digest];
+        let (events, checkpoints) = tokio::try_join!(
+            self.client.multi_get_events_by_tx_digests(tx_digests),
+            self.resolve_checkpoints(tx_digests)
+        )?;
+
+        // check first if transaction exists, all valid transaction are part of a
+        // checkpoint, if not found then the provided digest is invalid.
+        let checkpoint = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
+            IndexerError::HistoricalFallbackStorageError(format!(
+                "transaction: {tx_digest} does not exist"
+            ))
+        })?;
+
+        Ok((events.into_iter().next().flatten(), checkpoint))
     }
 
     /// Fetches transactions from the provided transaction digests.
@@ -555,69 +567,64 @@ impl HistoricalFallbackReader {
         Ok(transactions.into_iter().flatten().collect())
     }
 
-    /// Fetches events for a specific transaction.
+    /// Fetches events of a transaction from `event_seq` range.
     ///
-    /// Returns events emitted by the specified transaction, with support for
-    /// cursor-based pagination and ordering.
-    ///
-    /// # Pagination Behavior
-    ///
-    /// Events are indexed by their position in the transaction (event_seq = 0,
-    /// 1, 2, ...).
-    ///
-    /// | cursor      | descending | Result                   |
-    /// |-------------|------------|--------------------------|
-    /// | `None`      | `false`    | Starts from event_seq 0  |
-    /// | `None`      | `true`     | Starts from last event   |
-    /// | `Some(seq)` | `false`    | Starts after event_seq   |
-    /// | `Some(seq)` | `true`     | Starts before event_seq  |
-    pub(crate) async fn events(
+    /// Returns up to `limit` events ordered by `event_seq` according to
+    /// `is_descending` flag.
+    pub(crate) async fn events_in_seq_range(
         &self,
         tx_digest: TransactionDigest,
-        cursor: Option<EventID>,
+        ev_seq_range: (Bound<u64>, Bound<u64>),
         limit: usize,
-        descending_order: bool,
-    ) -> IndexerResult<Vec<IotaEvent>> {
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
         if limit == 0 {
             return Ok(vec![]);
         }
 
-        // validate cursor if provided
-        let start_seq = if let Some(cursor) = cursor {
-            if cursor.tx_digest != tx_digest {
-                return Err(IndexerError::InvalidArgument(format!(
-                    "Cursor tx_digest {} does not match requested tx_digest {tx_digest}",
-                    cursor.tx_digest
-                )));
-            }
-            Some(cursor.event_seq)
-        } else {
-            None
+        let (events, (summary, contents)) = self.events_with_checkpoint(tx_digest).await?;
+        let Some(events) = events else {
+            // transaction does not have associated events.
+            return Ok(vec![]);
         };
 
-        let events = self.all_events(tx_digest).await?;
-
-        // apply ordering, cursor, and limit
-        let events = if descending_order {
-            events
-                .into_iter()
-                .enumerate()
-                .rev() // reverse for descending
-                .filter(|(idx, _)| start_seq.is_none_or(|seq| (*idx as u64) < seq))
-                .take(limit)
-                .map(|(_, event)| event)
-                .collect()
-        } else {
-            events
-                .into_iter()
-                .enumerate()
-                .filter(|(idx, _)| start_seq.is_none_or(|seq| (*idx as u64) > seq))
-                .take(limit)
-                .map(|(_, event)| event)
-                .collect()
+        let Some(tx_sequence_number) = contents
+            .enumerate_transactions(&summary)
+            .find(|(_, execution_digest)| execution_digest.transaction == tx_digest)
+            .map(|(seq, _)| seq)
+        else {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "cannot find transaction sequence number to transaction: {tx_digest}"
+            )));
         };
 
-        Ok(events)
+        // events are indexed by their position in the transaction
+        // (event_sequence_number = 0, 1, 2, ...)
+        let in_range = events
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| ev_seq_range.contains(&(*idx as u64)))
+            .map(|(idx, event)| {
+                StoredEvent::from(IndexedEvent::from_event(
+                    tx_sequence_number,
+                    idx as u64,
+                    summary.sequence_number,
+                    tx_digest,
+                    event,
+                    summary.timestamp_ms,
+                ))
+            });
+
+        let stored_events: Vec<StoredEvent> = if is_descending {
+            let mut stored_events: Vec<_> = in_range.collect();
+            stored_events.reverse();
+            stored_events.truncate(limit);
+            stored_events
+        } else {
+            in_range.take(limit).collect()
+        };
+
+        Ok(stored_events)
     }
 
     /// Resolves the sequence number for a given [`TransactionDigest`] by
@@ -634,7 +641,7 @@ impl HistoricalFallbackReader {
     /// If the resolved checkpoint's contents do not contain the digest,
     /// which would indicate inconsistency between the historical store's index
     /// and its checkpoint contents.
-    async fn resolve_transaction_sequence_number(
+    pub(crate) async fn resolve_transaction_sequence_number(
         &self,
         digest: TransactionDigest,
     ) -> IndexerResult<TransactionSequenceNumber> {

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -9,7 +9,10 @@
 //! the indexer is unable to fetch data from the database, which is especially
 //! useful when pruning is enabled.
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    ops::{Bound, RangeBounds},
+};
 
 use futures::future;
 use iota_json_rpc_types::{CheckpointId, IotaEvent};
@@ -492,14 +495,64 @@ impl HistoricalFallbackReader {
             .collect::<Vec<TransactionDigest>>();
 
         let transactions = self.transactions(&tx_digests).await?;
-
         if transactions.iter().any(|tx| tx.is_none()) {
             return Err(IndexerError::HistoricalFallbackStorageError(format!(
                 "KV doesn't have full transaction data for checkpoint {checkpoint_sequence_number}"
             )));
         }
+        Ok(transactions.into_iter().flatten().collect())
+    }
 
-        Ok(transactions.into_iter().flatten().collect::<Vec<_>>())
+    /// Fetches transactions belonging to a specific checkpoint whose
+    /// `tx_sequence_number` falls within the given range.
+    ///
+    /// Returns up to `limit` transactions ordered by `tx_sequence_number`,
+    /// in order determined by `is_descending`.
+    pub(crate) async fn checkpoint_transactions_in_seq_range(
+        &self,
+        checkpoint_sequence_number: CheckpointSequenceNumber,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+
+        let seqs = [checkpoint_sequence_number];
+        let (summaries, contents) = tokio::try_join!(
+            self.client
+                .multi_get_checkpoints_summaries_by_sequence_numbers(&seqs),
+            self.client.multi_get_checkpoints_contents(&seqs),
+        )?;
+        let (Some(Some(summary)), Some(Some(contents))) =
+            (summaries.into_iter().next(), contents.into_iter().next())
+        else {
+            return Ok(vec![]);
+        };
+
+        // digests sorted by tx_sequence_number, ascending
+        let in_range = contents
+            .enumerate_transactions(&summary)
+            .filter(|(seq, _)| tx_seq_range.contains(seq))
+            .map(|(_, digests)| digests.transaction);
+
+        let tx_digests: Vec<TransactionDigest> = if is_descending {
+            let mut tx_digests: Vec<_> = in_range.collect();
+            tx_digests.reverse();
+            tx_digests.truncate(limit);
+            tx_digests
+        } else {
+            in_range.take(limit).collect()
+        };
+
+        let transactions = self.transactions(&tx_digests).await?;
+        if transactions.iter().any(|tx| tx.is_none()) {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "KV doesn't have full transaction data for checkpoint {checkpoint_sequence_number}"
+            )));
+        }
+        Ok(transactions.into_iter().flatten().collect())
     }
 
     /// Fetches events for a specific transaction.

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -61,7 +61,7 @@ pub type OutputObjects = Vec<Object>;
 /// when the indexer is unable to fetch data from the database, which is
 /// especially useful when pruning is enabled.
 #[derive(Clone)]
-pub(crate) struct HistoricalFallbackReader {
+pub struct HistoricalFallbackReader {
     /// Client responsible for fetching data from the historical fallback
     /// storage through REST API interface.
     client: HttpRestKVClient,

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -20,7 +20,7 @@ use iota_types::{
     event::EventID,
     full_checkpoint_content::CheckpointTransaction,
     messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt,
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt, CheckpointDigest,
         CheckpointSequenceNumber,
     },
     object::Object,
@@ -266,6 +266,61 @@ impl HistoricalFallbackReader {
             .collect();
 
         Ok(checkpoints)
+    }
+
+    /// Fetches multiple checkpoints by their digests from the historical
+    /// fallback storage. The returned vector has the same length as `digests`
+    /// and preserves its order; missing entries become `None`.
+    ///
+    /// # NOTE
+    /// As with [`checkpoints`](Self::checkpoints),
+    /// `StoredCheckpoint.successful_tx_num` is hardcoded to 0 in
+    /// fallback-returned data.
+    pub(crate) async fn checkpoints_by_digests(
+        &self,
+        digests: Vec<CheckpointDigest>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let summaries = self
+            .client
+            .multi_get_checkpoints_summaries_by_digests(&digests)
+            .await?;
+
+        let mut seqs_for_contents: Vec<CheckpointSequenceNumber> = summaries
+            .iter()
+            .filter_map(|s| s.as_ref().map(|s| s.sequence_number))
+            .collect();
+        seqs_for_contents.sort_unstable();
+        seqs_for_contents.dedup();
+
+        if seqs_for_contents.is_empty() {
+            return Ok(vec![None; digests.len()]);
+        }
+
+        let contents = self
+            .client
+            .multi_get_checkpoints_contents(&seqs_for_contents)
+            .await?;
+        let content_by_seq: HashMap<CheckpointSequenceNumber, CheckpointContents> =
+            seqs_for_contents
+                .iter()
+                .zip(contents)
+                .filter_map(|(seq, content)| content.map(|c| (*seq, c)))
+                .collect();
+
+        let result = summaries
+            .into_iter()
+            .map(|summary| {
+                let summary = summary?;
+                let content = content_by_seq.get(&summary.sequence_number)?.clone();
+                Some(StoredCheckpoint::from((summary, content)))
+            })
+            .collect();
+
+        Ok(result)
     }
 
     /// Fetches all events belonging to the provided transaction digest.

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -20,6 +20,7 @@ use iota_sdk_types::{Address, ObjectId, Version};
 use iota_types::{
     digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
+    event::EventID,
     full_checkpoint_content::CheckpointTransaction,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt, CheckpointDigest,
@@ -48,7 +49,6 @@ use crate::{
         transactions::StoredTransaction,
     },
     read::PackageResolver,
-    types::IndexedEvent,
 };
 
 /// Represents the Input objects of a transaction.
@@ -332,31 +332,37 @@ impl HistoricalFallbackReader {
         &self,
         tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
+        self.fetch_events(tx_digest)
+            .await?
+            .into_iota_events(&self.package_resolver)
+            .await
+    }
+
+    /// Fetches the events of a transaction from the historical fallback
+    /// storage, together with the transaction and checkpoint data needed to
+    /// convert them to other formats.
+    async fn fetch_events(
+        &self,
+        tx_digest: TransactionDigest,
+    ) -> IndexerResult<HistoricalFallbackEvents> {
         let tx_digests = &[tx_digest];
-        let (events, checkpoint_summaries) = tokio::try_join!(
+        let (events, checkpoints) = tokio::try_join!(
             self.client.multi_get_events_by_tx_digests(tx_digests),
             self.resolve_checkpoints(tx_digests)
         )?;
 
         // check first if transaction exists, all valid transaction are part of a
         // checkpoint, if not found then the provided digest is invalid.
-        let (summary, _) = checkpoint_summaries
-            .get(&tx_digest)
-            .cloned()
-            .ok_or_else(|| {
-                IndexerError::HistoricalFallbackStorageError(format!(
-                    "transaction: {tx_digest} does not exist"
-                ))
-            })?;
+        let (summary, contents) = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
+            IndexerError::HistoricalFallbackStorageError(format!(
+                "transaction: {tx_digest} does not exist"
+            ))
+        })?;
 
-        let Some(Some(events)) = events.into_iter().next() else {
-            // transaction does not have associated events.
-            return Ok(vec![]);
-        };
+        // the transaction did not emit any events when `None`.
+        let events = events.into_iter().next().flatten().unwrap_or_default();
 
-        HistoricalFallbackEvents::new(events, summary)
-            .into_iota_events(&self.package_resolver, tx_digest)
-            .await
+        HistoricalFallbackEvents::new(events, tx_digest, &summary, &contents)
     }
 
     /// Fetches transactions from the provided transaction digests.
@@ -556,77 +562,69 @@ impl HistoricalFallbackReader {
         Ok(transactions.into_iter().flatten().collect())
     }
 
-    /// Fetches events of a transaction from `event_seq` range.
+    /// Fetches events for a specific transaction.
     ///
-    /// Returns up to `limit` events ordered by `event_seq` according to
-    /// `is_descending` flag.
-    pub(crate) async fn events_in_seq_range(
+    /// Returns events emitted by the specified transaction, with support for
+    /// cursor-based pagination and ordering.
+    ///
+    /// # Pagination Behavior
+    ///
+    /// Events are indexed by their position in the transaction (event_seq = 0,
+    /// 1, 2, ...).
+    ///
+    /// | cursor      | descending | Result                   |
+    /// |-------------|------------|--------------------------|
+    /// | `None`      | `false`    | Starts from event_seq 0  |
+    /// | `None`      | `true`     | Starts from last event   |
+    /// | `Some(seq)` | `false`    | Starts after event_seq   |
+    /// | `Some(seq)` | `true`     | Starts before event_seq  |
+    pub(crate) async fn events(
         &self,
         tx_digest: TransactionDigest,
-        ev_seq_range: (Bound<u64>, Bound<u64>),
+        cursor: Option<EventID>,
         limit: usize,
-        is_descending: bool,
+        descending_order: bool,
     ) -> IndexerResult<Vec<StoredEvent>> {
         if limit == 0 {
             return Ok(vec![]);
         }
 
-        let tx_digests = &[tx_digest];
-        let (events, checkpoints) = tokio::try_join!(
-            self.client.multi_get_events_by_tx_digests(tx_digests),
-            self.resolve_checkpoints(tx_digests)
-        )?;
-
-        // check first if transaction exists, all valid transaction are part of a
-        // checkpoint, if not found then the provided digest is invalid.
-        let (summary, contents) = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
-            IndexerError::HistoricalFallbackStorageError(format!(
-                "transaction: {tx_digest} does not exist"
-            ))
-        })?;
-
-        let Some(Some(events)) = events.into_iter().next() else {
-            // transaction does not have associated events.
-            return Ok(vec![]);
-        };
-
-        let Some(tx_sequence_number) = contents
-            .enumerate_transactions(&summary)
-            .find(|(_, execution_digest)| execution_digest.transaction == tx_digest)
-            .map(|(seq, _)| seq)
-        else {
-            return Err(IndexerError::HistoricalFallbackStorageError(format!(
-                "cannot find transaction sequence number to transaction: {tx_digest}"
-            )));
-        };
-
-        // events are indexed by their position in the transaction
-        // (event_sequence_number = 0, 1, 2, ...)
-        let in_range = events
-            .iter()
-            .enumerate()
-            .filter(|(idx, _)| ev_seq_range.contains(&(*idx as u64)))
-            .map(|(idx, event)| {
-                StoredEvent::from(IndexedEvent::from_event(
-                    tx_sequence_number,
-                    idx as u64,
-                    summary.sequence_number,
-                    tx_digest,
-                    event,
-                    summary.timestamp_ms,
-                ))
-            });
-
-        let stored_events: Vec<StoredEvent> = if is_descending {
-            let mut stored_events: Vec<_> = in_range.collect();
-            stored_events.reverse();
-            stored_events.truncate(limit);
-            stored_events
+        // validate cursor if provided
+        let start_seq = if let Some(cursor) = cursor {
+            if cursor.tx_digest != tx_digest {
+                return Err(IndexerError::InvalidArgument(format!(
+                    "Cursor tx_digest {} does not match requested tx_digest {tx_digest}",
+                    cursor.tx_digest
+                )));
+            }
+            Some(cursor.event_seq)
         } else {
-            in_range.take(limit).collect()
+            None
         };
 
-        Ok(stored_events)
+        let events = self.fetch_events(tx_digest).await?.into_stored_events();
+
+        // apply ordering, cursor, and limit
+        let events = if descending_order {
+            events
+                .into_iter()
+                .rev() // reverse for descending
+                .filter(|event| {
+                    start_seq.is_none_or(|seq| (event.event_sequence_number as u64) < seq)
+                })
+                .take(limit)
+                .collect()
+        } else {
+            events
+                .into_iter()
+                .filter(|event| {
+                    start_seq.is_none_or(|seq| (event.event_sequence_number as u64) > seq)
+                })
+                .take(limit)
+                .collect()
+        };
+
+        Ok(events)
     }
 
     /// Resolves the sequence number for a given [`TransactionDigest`] by
@@ -643,7 +641,7 @@ impl HistoricalFallbackReader {
     /// If the resolved checkpoint's contents do not contain the digest,
     /// which would indicate inconsistency between the historical store's index
     /// and its checkpoint contents.
-    pub(crate) async fn resolve_transaction_sequence_number(
+    async fn resolve_transaction_sequence_number(
         &self,
         digest: TransactionDigest,
     ) -> IndexerResult<TransactionSequenceNumber> {

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -19,9 +19,7 @@ use iota_json_rpc_types::{CheckpointId, IotaEvent};
 use iota_sdk_types::{Address, ObjectId, Version};
 use iota_types::{
     digests::TransactionDigest,
-    effects::{
-        TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt, TransactionEvents,
-    },
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
     full_checkpoint_content::CheckpointTransaction,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsExt, CheckpointDigest,
@@ -334,8 +332,24 @@ impl HistoricalFallbackReader {
         &self,
         tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
-        let (events, (summary, _)) = self.events_with_checkpoint(tx_digest).await?;
-        let Some(events) = events else {
+        let tx_digests = &[tx_digest];
+        let (events, checkpoint_summaries) = tokio::try_join!(
+            self.client.multi_get_events_by_tx_digests(tx_digests),
+            self.resolve_checkpoints(tx_digests)
+        )?;
+
+        // check first if transaction exists, all valid transaction are part of a
+        // checkpoint, if not found then the provided digest is invalid.
+        let (summary, _) = checkpoint_summaries
+            .get(&tx_digest)
+            .cloned()
+            .ok_or_else(|| {
+                IndexerError::HistoricalFallbackStorageError(format!(
+                    "transaction: {tx_digest} does not exist"
+                ))
+            })?;
+
+        let Some(Some(events)) = events.into_iter().next() else {
             // transaction does not have associated events.
             return Ok(vec![]);
         };
@@ -343,31 +357,6 @@ impl HistoricalFallbackReader {
         HistoricalFallbackEvents::new(events, summary)
             .into_iota_events(&self.package_resolver, tx_digest)
             .await
-    }
-
-    /// Fetches the events of a transaction together with the checkpoint the
-    /// transaction belongs to.
-    ///
-    /// The events are `None` when the transaction did not emit any.
-    async fn events_with_checkpoint(
-        &self,
-        tx_digest: TransactionDigest,
-    ) -> IndexerResult<(Option<TransactionEvents>, HistoricalFallbackCheckpoint)> {
-        let tx_digests = &[tx_digest];
-        let (events, checkpoints) = tokio::try_join!(
-            self.client.multi_get_events_by_tx_digests(tx_digests),
-            self.resolve_checkpoints(tx_digests)
-        )?;
-
-        // check first if transaction exists, all valid transaction are part of a
-        // checkpoint, if not found then the provided digest is invalid.
-        let checkpoint = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
-            IndexerError::HistoricalFallbackStorageError(format!(
-                "transaction: {tx_digest} does not exist"
-            ))
-        })?;
-
-        Ok((events.into_iter().next().flatten(), checkpoint))
     }
 
     /// Fetches transactions from the provided transaction digests.
@@ -582,8 +571,21 @@ impl HistoricalFallbackReader {
             return Ok(vec![]);
         }
 
-        let (events, (summary, contents)) = self.events_with_checkpoint(tx_digest).await?;
-        let Some(events) = events else {
+        let tx_digests = &[tx_digest];
+        let (events, checkpoints) = tokio::try_join!(
+            self.client.multi_get_events_by_tx_digests(tx_digests),
+            self.resolve_checkpoints(tx_digests)
+        )?;
+
+        // check first if transaction exists, all valid transaction are part of a
+        // checkpoint, if not found then the provided digest is invalid.
+        let (summary, contents) = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
+            IndexerError::HistoricalFallbackStorageError(format!(
+                "transaction: {tx_digest} does not exist"
+            ))
+        })?;
+
+        let Some(Some(events)) = events.into_iter().next() else {
             // transaction does not have associated events.
             return Ok(vec![]);
         };

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -302,6 +302,7 @@ impl OptimisticTransactionExecutor {
             .multi_get_transactions(&[tx_digest])
             .await?
             .pop()
+            .map(StoredTransaction::from)
             .ok_or_else(|| {
                 IndexerError::PersistentStorageDataCorruption(format!(
                     "transaction {tx_digest} not found in the DB after being marked as indexed."

--- a/crates/iota-indexer/src/pruning/mod.rs
+++ b/crates/iota-indexer/src/pruning/mod.rs
@@ -4,3 +4,5 @@
 
 pub mod pruner;
 pub mod watermark_task;
+
+pub use crate::ingestion::common::persist::CommitterTables;

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -200,7 +200,7 @@ impl IndexerReader {
     ///
     /// In case the IndexerReader fails to retrieve data, the fallback reader
     /// will be used to retrieve the data.
-    pub(crate) fn with_fallback_reader(&mut self, fallback: HistoricalFallbackReader) {
+    pub fn with_fallback_reader(&mut self, fallback: HistoricalFallbackReader) {
         self.fallback = Some(fallback);
     }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -209,6 +209,13 @@ impl IndexerReader {
         self.fallback.as_ref()
     }
 
+    /// Returns `true` if a historical fallback reader is configured on this
+    /// `IndexerReader`. Callers can use this to decide whether pruned-range
+    /// reads will be served by the fallback.
+    pub fn is_fallback_enabled(&self) -> bool {
+        self.fallback.is_some()
+    }
+
     /// Accesses the watermark cache.
     pub fn watermark_cache(&self) -> &WatermarkCache {
         &self.watermark_cache
@@ -810,6 +817,87 @@ impl IndexerReader {
             .flatten()
             .map(iota_json_rpc_types::Checkpoint::try_from)
             .collect()
+    }
+
+    /// Fetches a batch of checkpoints by sequence number. Each requested seq
+    /// resolves to `Some(StoredCheckpoint)` if it lives in Postgres or in the
+    /// historical fallback (when enabled), or to `None` otherwise. The
+    /// returned vector has the same length as `seqs` and preserves its order.
+    pub async fn get_stored_checkpoints_by_seqs_with_fallback(
+        &self,
+        seqs: Vec<CheckpointSequenceNumber>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if seqs.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let db_rows = self.db().multi_get_checkpoints_by_seqs(&seqs).await?;
+        let mut by_seq: HashMap<CheckpointSequenceNumber, StoredCheckpoint> = db_rows
+            .into_iter()
+            .map(|c| (c.sequence_number as u64, c))
+            .collect();
+
+        let missing: Vec<CheckpointSequenceNumber> = seqs
+            .iter()
+            .copied()
+            .filter(|s| !by_seq.contains_key(s))
+            .collect();
+        if !missing.is_empty() {
+            if let Some(fallback) = self.fallback_reader() {
+                for stored in fallback.checkpoints(missing).await?.into_iter().flatten() {
+                    by_seq.insert(stored.sequence_number as u64, stored);
+                }
+            }
+        }
+
+        Ok(seqs.into_iter().map(|s| by_seq.get(&s).cloned()).collect())
+    }
+
+    /// Fetches a batch of checkpoints by digest. Each requested digest
+    /// resolves to `Some(StoredCheckpoint)` if it lives in Postgres or in the
+    /// historical fallback (when enabled), or to `None` otherwise. The
+    /// returned vector has the same length as `digests` and preserves its
+    /// order.
+    pub async fn get_stored_checkpoints_by_digests_with_fallback(
+        &self,
+        digests: Vec<CheckpointDigest>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let digest_bytes: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
+        let db_rows = self
+            .db()
+            .multi_get_checkpoints_by_digests(&digest_bytes)
+            .await?;
+        let mut by_digest: HashMap<Vec<u8>, StoredCheckpoint> = db_rows
+            .into_iter()
+            .map(|c| (c.checkpoint_digest.clone(), c))
+            .collect();
+
+        let missing: Vec<CheckpointDigest> = digests
+            .iter()
+            .filter(|d| !by_digest.contains_key(d.inner().as_slice()))
+            .copied()
+            .collect();
+        if !missing.is_empty() {
+            if let Some(fallback) = self.fallback_reader() {
+                for stored in fallback
+                    .checkpoints_by_digests(missing)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                {
+                    by_digest.insert(stored.checkpoint_digest.clone(), stored);
+                }
+            }
+        }
+
+        Ok(digests
+            .into_iter()
+            .map(|d| by_digest.get(d.inner().as_slice()).cloned())
+            .collect())
     }
 
     /// Fetches multiple transactions from the database.
@@ -3006,6 +3094,42 @@ impl<'a> DBReader<'a> {
         }
 
         Ok(checkpoint)
+    }
+
+    /// Fetches from the `checkpoints` table by sequence numbers list.
+    /// Pruned/missing seqs are simply absent from the result.
+    async fn multi_get_checkpoints_by_seqs(
+        &self,
+        seqs: &[CheckpointSequenceNumber],
+    ) -> IndexerResult<Vec<StoredCheckpoint>> {
+        if seqs.is_empty() {
+            return Ok(vec![]);
+        }
+        let seqs_i64: Vec<i64> = seqs.iter().map(|s| *s as i64).collect();
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            checkpoints::dsl::checkpoints
+                .filter(checkpoints::sequence_number.eq_any(seqs_i64))
+                .load::<StoredCheckpoint>(conn)
+        })
+    }
+
+    /// Fetches from the `checkpoints` table by digests list.
+    /// Pruned/missing digests are simply absent from the result.
+    async fn multi_get_checkpoints_by_digests(
+        &self,
+        digests: &[Vec<u8>],
+    ) -> IndexerResult<Vec<StoredCheckpoint>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+        let digests = digests.to_vec();
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            checkpoints::dsl::checkpoints
+                .filter(checkpoints::checkpoint_digest.eq_any(digests))
+                .load::<StoredCheckpoint>(conn)
+        })
     }
 
     async fn get_checkpoints(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -7,6 +7,7 @@ use std::{
     cmp::Reverse,
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
+    ops::Bound,
     sync::{Arc, Mutex},
 };
 
@@ -1300,6 +1301,42 @@ impl IndexerReader {
         };
         self.stored_transaction_to_transaction_block(stored_txs, options)
             .await
+    }
+
+    /// Fetches transactions belonging to a checkpoint whose
+    /// `tx_sequence_number` falls within the given range. Falls back to the
+    /// historical storage (when configured) if the checkpoint has been pruned
+    /// from Postgres.
+    pub async fn query_stored_transactions_by_checkpoint_seq_with_fallback(
+        &self,
+        checkpoint_seq: u64,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let db_res = self
+            .db()
+            .query_transactions_by_checkpoint_seq_in_range(
+                checkpoint_seq,
+                tx_seq_range,
+                limit,
+                is_descending,
+            )
+            .await;
+        if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.fallback_reader())
+        {
+            return kv_reader
+                .checkpoint_transactions_in_seq_range(
+                    checkpoint_seq,
+                    tx_seq_range,
+                    limit,
+                    is_descending,
+                )
+                .await
+                .context(&format!("fallback triggered by {err}"));
+        }
+        db_res
     }
 
     /// Fetches a paginated list of transactions that affect a given address,
@@ -2875,6 +2912,35 @@ impl<'a> DBReader<'a> {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
+        let tx_seq_range = match cursor {
+            Some(cursor) => {
+                let cursor_tx_seq = self.resolve_cursor_tx_digest_to_seq_num(cursor).await? as u64;
+                if is_descending {
+                    (Bound::Unbounded, Bound::Excluded(cursor_tx_seq))
+                } else {
+                    (Bound::Excluded(cursor_tx_seq), Bound::Unbounded)
+                }
+            }
+            None => (Bound::Unbounded, Bound::Unbounded),
+        };
+        self.query_transactions_by_checkpoint_seq_in_range(
+            checkpoint_seq,
+            tx_seq_range,
+            limit,
+            is_descending,
+        )
+        .await
+    }
+
+    /// Same as [`Self::query_transactions_by_checkpoint_seq`], but bounded by
+    /// a `tx_sequence_number` range instead of a digest cursor.
+    async fn query_transactions_by_checkpoint_seq_in_range(
+        &self,
+        checkpoint_seq: u64,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
         self.main_reader.ensure_data_not_pruned_for_checkpoint(
             checkpoint_seq,
             &[
@@ -2898,24 +2964,29 @@ impl<'a> DBReader<'a> {
         })
         .context("failed to get transaction range from pruner_cp_watermark table")?;
 
-        let cursor_tx_seq = if let Some(cursor) = cursor {
-            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
-        } else {
-            None
-        };
-
         let mut query = transactions::dsl::transactions
             .filter(transactions::tx_sequence_number.between(tx_range.0, tx_range.1))
             .into_boxed();
 
-        // Translate transaction digest cursor to tx sequence number
-        if let Some(cursor_tx_seq) = cursor_tx_seq {
-            if is_descending {
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(cursor_tx_seq));
-            } else {
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(cursor_tx_seq));
+        let (min_tx_seq, max_tx_seq) = tx_seq_range;
+        query = match min_tx_seq {
+            Bound::Included(min) => {
+                query.filter(transactions::dsl::tx_sequence_number.ge(min as i64))
             }
-        }
+            Bound::Excluded(min) => {
+                query.filter(transactions::dsl::tx_sequence_number.gt(min as i64))
+            }
+            Bound::Unbounded => query,
+        };
+        query = match max_tx_seq {
+            Bound::Included(max) => {
+                query.filter(transactions::dsl::tx_sequence_number.le(max as i64))
+            }
+            Bound::Excluded(max) => {
+                query.filter(transactions::dsl::tx_sequence_number.lt(max as i64))
+            }
+            Bound::Unbounded => query,
+        };
         if is_descending {
             query = query.order(transactions::dsl::tx_sequence_number.desc());
         } else {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -296,6 +296,34 @@ impl IndexerReader {
     }
 }
 
+/// A transaction returned by `IndexerReader::multi_get_transactions` or
+/// [`IndexerReader::multi_get_transactions_with_fallback`]. Each row is
+/// either checkpointed (from Postgres or the historical fallback) or
+/// optimistic (from Postgres).
+pub enum TransactionRead {
+    Checkpointed(StoredTransaction),
+    Optimistic(OptimisticTransaction),
+}
+
+impl TransactionRead {
+    /// Raw transaction digest bytes, common to both variants.
+    pub fn transaction_digest(&self) -> &[u8] {
+        match self {
+            Self::Checkpointed(s) => &s.transaction_digest,
+            Self::Optimistic(o) => &o.transaction_digest,
+        }
+    }
+}
+
+impl From<TransactionRead> for StoredTransaction {
+    fn from(tx: TransactionRead) -> Self {
+        match tx {
+            TransactionRead::Checkpointed(s) => s,
+            TransactionRead::Optimistic(o) => o.into(),
+        }
+    }
+}
+
 // Impl for reading data from the DB
 impl IndexerReader {
     fn get_object_from_db(
@@ -900,101 +928,71 @@ impl IndexerReader {
             .collect())
     }
 
-    /// Fetches multiple transactions from the database.
+    /// Fetches multiple transactions from the database. Each row is returned
+    /// as [`TransactionRead::Checkpointed`] or [`TransactionRead::Optimistic`]
+    /// depending on which table it came from.
     ///
-    ///  Retrieval order:
+    /// Retrieval order per digest:
     /// 1. Checkpointed data (finalized transactions)
     /// 2. Optimistic data (pending transactions not yet checkpointed)
     pub(crate) async fn multi_get_transactions(
         &self,
         digests: &[TransactionDigest],
-    ) -> IndexerResult<Vec<StoredTransaction>> {
-        let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
-        let checkpointed_txs = self
+    ) -> IndexerResult<Vec<TransactionRead>> {
+        let digest_bytes: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
+        let mut found: Vec<TransactionRead> = self
             .db()
-            .get_checkpointed_transactions(digests.clone())
-            .await?;
-
-        if checkpointed_txs.len() == digests.len() {
-            return Ok(checkpointed_txs);
-        }
-
-        let missing_digests = Self::check_for_missing_tx_digests(&digests, &checkpointed_txs);
-        let optimistic_txs = self
-            .db()
-            .get_optimistic_transactions(missing_digests)
-            .await?;
-
-        Ok(checkpointed_txs
-            .into_iter()
-            .chain(optimistic_txs.into_iter().map(Into::into))
-            .collect::<Vec<StoredTransaction>>())
-    }
-
-    /// Fetches multiple transactions from the indexer storage.
-    ///
-    /// Retrieval order:
-    /// 1. Checkpointed data (finalized transactions)
-    /// 2. Optimistic data (pending transactions not yet checkpointed)
-    /// 3. Historical fallback storage (if enabled)
-    async fn multi_get_transactions_with_fallback(
-        &self,
-        digests: &[TransactionDigest],
-    ) -> IndexerResult<Vec<StoredTransaction>> {
-        let fetched_transactions = self.multi_get_transactions(digests).await?;
-
-        // fallback to historical storage
-        let Some(fallback) = self
-            .fallback_reader()
-            // As for now we don't have a way to identify if the user requested pruned or invalid
-            // transaction digests. As a measure, we check if the number of requested transactions
-            // matches the number of fetched transactions. In case of missing transactions,
-            // if fallback is enabled, we use it to fetch the missing ones.
-            .filter(|_| fetched_transactions.len() != digests.len())
-        else {
-            // return data from database.
-            return Ok(fetched_transactions);
-        };
-
-        let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
-        let missing_digests = Self::check_for_missing_tx_digests(&digests, &fetched_transactions)
-            .iter()
-            .map(|digest| {
-                TransactionDigest::from_bytes(digest.as_slice()).map_err(|e| {
-                    IndexerError::PersistentStorageDataCorruption(format!(
-                        "can't convert {digest:?} as tx_digest. Error: {e}",
-                    ))
-                })
-            })
-            .collect::<IndexerResult<Vec<TransactionDigest>>>()?;
-
-        let historical_transactions = fallback
-            .transactions(&missing_digests)
+            .get_checkpointed_transactions(digest_bytes)
             .await?
             .into_iter()
-            .flatten()
-            .collect::<Vec<StoredTransaction>>();
+            .map(TransactionRead::Checkpointed)
+            .collect();
 
-        Ok(fetched_transactions
-            .into_iter()
-            .chain(historical_transactions)
-            .collect())
+        let missing = Self::check_for_missing_tx_digests(digests, &found);
+        if !missing.is_empty() {
+            let missing_bytes: Vec<Vec<u8>> = missing.iter().map(|d| d.inner().to_vec()).collect();
+            for opt in self.db().get_optimistic_transactions(missing_bytes).await? {
+                found.push(TransactionRead::Optimistic(opt));
+            }
+        }
+        Ok(found)
     }
 
-    /// Checks for missing transaction digests in the fetched transactions.
+    /// Same as `Self::multi_get_transactions`, but also reads from the
+    /// historical fallback (when configured) for digests not found in
+    /// Postgres. Fallback rows are returned as
+    /// [`TransactionRead::Checkpointed`].
+    pub async fn multi_get_transactions_with_fallback(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> IndexerResult<Vec<TransactionRead>> {
+        let mut found = self.multi_get_transactions(digests).await?;
+
+        if found.len() == digests.len() {
+            return Ok(found);
+        }
+        let Some(fallback) = self.fallback_reader() else {
+            return Ok(found);
+        };
+
+        let missing = Self::check_for_missing_tx_digests(digests, &found);
+        for stored in fallback.transactions(&missing).await?.into_iter().flatten() {
+            found.push(TransactionRead::Checkpointed(stored));
+        }
+        Ok(found)
+    }
+
+    /// Returns the `requested` digests that are not in `found`.
     fn check_for_missing_tx_digests(
-        requested_digests: &[Vec<u8>],
-        fetched_txs: &[StoredTransaction],
-    ) -> Vec<Vec<u8>> {
-        let fetched_txs_digests_set = fetched_txs
+        requested: &[TransactionDigest],
+        found: &[TransactionRead],
+    ) -> Vec<TransactionDigest> {
+        let found_set: HashSet<&[u8]> = found.iter().map(|t| t.transaction_digest()).collect();
+        requested
             .iter()
-            .map(|tx| &tx.transaction_digest)
-            .collect::<HashSet<&Vec<u8>>>();
-        requested_digests
-            .iter()
-            .filter(|digest| !fetched_txs_digests_set.contains(digest))
-            .cloned()
-            .collect::<Vec<Vec<u8>>>()
+            .filter(|d| !found_set.contains(d.inner().as_slice()))
+            .copied()
+            .collect()
     }
 
     /// This method tries to transform [`StoredTransaction`] values
@@ -1750,7 +1748,12 @@ impl IndexerReader {
         digests: &[TransactionDigest],
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
     ) -> Result<Vec<iota_json_rpc_types::IotaTransactionBlockResponse>, IndexerError> {
-        let stored_txes = self.multi_get_transactions_with_fallback(digests).await?;
+        let stored_txes: Vec<StoredTransaction> = self
+            .multi_get_transactions_with_fallback(digests)
+            .await?
+            .into_iter()
+            .map(StoredTransaction::from)
+            .collect();
         self.stored_transaction_to_transaction_block(stored_txes, options)
             .await
     }

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -92,7 +92,7 @@ use crate::{
         diesel_macro::{mark_in_blocking_pool, *},
         package_resolver::IndexerStorePackageResolver,
     },
-    types::{IndexerResult, OwnerType},
+    types::{IndexerResult, OwnerType, TxEventSeqRange},
 };
 
 pub const TX_SEQUENCE_NUMBER_STR: &str = "tx_sequence_number";
@@ -1339,6 +1339,55 @@ impl IndexerReader {
         db_res
     }
 
+    /// Fetches events belonging to a transaction from given `(tx_seq,
+    /// event_seq)` range. Falls back to the historical storage (when
+    /// configured) if the transaction has been pruned from Postgres.
+    pub async fn query_stored_events_by_tx_digest_with_fallback(
+        &self,
+        tx_digest: TransactionDigest,
+        tx_ev_seq_range: TxEventSeqRange,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
+        if let Some(tx_seq) = self
+            .db()
+            .resolve_cursor_tx_digest_to_seq_num_maybe(tx_digest)
+            .await?
+        {
+            // resolve  `(tx_seq, event_seq)` range to just `event_seq` range
+            let Some(ev_seq_range) = event_seq_range_for_tx(tx_ev_seq_range, tx_seq as u64) else {
+                return Ok(vec![]);
+            };
+            return self
+                .db()
+                .query_events_by_tx_digest_in_seq_range(
+                    tx_digest,
+                    ev_seq_range,
+                    limit,
+                    is_descending,
+                )
+                .await;
+        }
+
+        let Some(kv_reader) = self.fallback_reader() else {
+            return Err(IndexerError::DataPruned(format!(
+                "data for tx {tx_digest} potentially pruned"
+            )));
+        };
+        let context = format!("fallback triggered by tx {tx_digest} missing from Postgres");
+        let tx_seq = kv_reader
+            .resolve_transaction_sequence_number(tx_digest)
+            .await
+            .context(&context)?;
+        let Some(ev_seq_range) = event_seq_range_for_tx(tx_ev_seq_range, tx_seq) else {
+            return Ok(vec![]);
+        };
+        kv_reader
+            .events_in_seq_range(tx_digest, ev_seq_range, limit, is_descending)
+            .await
+            .context(&context)
+    }
+
     /// Fetches a paginated list of transactions that affect a given address,
     /// using the fallback storage if the database is pruned.
     async fn query_transactions_by_affected_addresses_with_fallback(
@@ -2024,35 +2073,58 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<IotaEvent>> {
+        let ev_seq_range = match cursor {
+            Some(cursor) => {
+                if cursor.tx_digest != tx_digest {
+                    return Err(IndexerError::InvalidArgument(
+                        "Cursor tx_digest does not match the tx_digest in the query.".into(),
+                    ));
+                }
+                // the cursor is exclusive
+                if descending_order {
+                    (Bound::Unbounded, Bound::Excluded(cursor.event_seq))
+                } else {
+                    (Bound::Excluded(cursor.event_seq), Bound::Unbounded)
+                }
+            }
+            None => (Bound::Unbounded, Bound::Unbounded),
+        };
         let db_res = self
             .db()
-            .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
+            .query_events_by_tx_digest_in_seq_range(
+                tx_digest,
+                ev_seq_range,
+                limit,
+                descending_order,
+            )
             .await;
 
-        if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
+        let stored_events = if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
             (db_res.as_ref(), self.fallback_reader())
         {
             kv_reader
-                .events(tx_digest, cursor, limit, descending_order)
+                .events_in_seq_range(tx_digest, ev_seq_range, limit, descending_order)
                 .await
-                .context(&format!("fallback triggered by {err}"))
+                .context(&format!("fallback triggered by {err}"))?
         } else {
-            let mut iota_event_futures = vec![];
-            for stored_event in db_res? {
-                iota_event_futures.push(tokio::task::spawn(
-                    stored_event.try_into_iota_event(self.package_resolver.clone()),
-                ));
-            }
+            db_res?
+        };
 
-            futures::future::join_all(iota_event_futures)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
+        let mut iota_event_futures = vec![];
+        for stored_event in stored_events {
+            iota_event_futures.push(tokio::task::spawn(
+                stored_event.try_into_iota_event(self.package_resolver.clone()),
+            ));
         }
+
+        futures::future::join_all(iota_event_futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
     }
 
     pub(crate) async fn query_only_checkpointed_events_in_blocking_task(
@@ -2898,6 +2970,28 @@ impl DataReader for IndexerReader {
     }
 }
 
+/// Narrows a `(tx_seq, event_seq)` range to just `event_seq` range, for events
+/// of the `tx_seq` transaction. Returns `None` when no event of that
+/// transaction is in the range.
+fn event_seq_range_for_tx(
+    (min, max): TxEventSeqRange,
+    tx_seq: u64,
+) -> Option<(Bound<u64>, Bound<u64>)> {
+    let min_ev_seq = match min {
+        Bound::Included((tx, ev)) if tx == tx_seq => Bound::Included(ev),
+        Bound::Excluded((tx, ev)) if tx == tx_seq => Bound::Excluded(ev),
+        Bound::Included((tx, _)) | Bound::Excluded((tx, _)) if tx > tx_seq => return None,
+        _ => Bound::Unbounded,
+    };
+    let max_ev_seq = match max {
+        Bound::Included((tx, ev)) if tx == tx_seq => Bound::Included(ev),
+        Bound::Excluded((tx, ev)) if tx == tx_seq => Bound::Excluded(ev),
+        Bound::Included((tx, _)) | Bound::Excluded((tx, _)) if tx < tx_seq => return None,
+        _ => Bound::Unbounded,
+    };
+    Some((min_ev_seq, max_ev_seq))
+}
+
 impl<'a> DBReader<'a> {
     pub fn new(reader: &'a IndexerReader) -> Self {
         Self {
@@ -2998,36 +3092,38 @@ impl<'a> DBReader<'a> {
             .load::<StoredTransaction>(conn))
     }
 
-    async fn query_events_by_tx_digest(
+    /// Fetches events of a transaction from `event_seq` range.
+    ///
+    /// Returns up to `limit` events ordered by `event_seq` according to
+    /// `is_descending` flag. Returns [`IndexerError::DataPruned`] when
+    /// nothing matches and the transaction is missing from Postgres.
+    async fn query_events_by_tx_digest_in_seq_range(
         &self,
         tx_digest: TransactionDigest,
-        cursor: Option<EventID>,
+        ev_seq_range: (Bound<u64>, Bound<u64>),
         limit: usize,
-        descending_order: bool,
+        is_descending: bool,
     ) -> IndexerResult<Vec<StoredEvent>> {
+        use events::dsl::{event_sequence_number as ev_seq, tx_sequence_number as tx_seq};
+
         let mut query = events::table.into_boxed();
 
-        if let Some(cursor) = cursor {
-            if cursor.tx_digest != tx_digest {
-                return Err(IndexerError::InvalidArgument(
-                    "Cursor tx_digest does not match the tx_digest in the query.".into(),
-                ));
-            }
-            if descending_order {
-                query = query.filter(events::event_sequence_number.lt(cursor.event_seq as i64));
-            } else {
-                query = query.filter(events::event_sequence_number.gt(cursor.event_seq as i64));
-            }
-        } else if descending_order {
-            query = query.filter(events::event_sequence_number.le(i64::MAX));
-        } else {
-            query = query.filter(events::event_sequence_number.ge(0));
+        let (min_ev_seq, max_ev_seq) = ev_seq_range;
+        query = match min_ev_seq {
+            Bound::Included(min) => query.filter(ev_seq.ge(min as i64)),
+            Bound::Excluded(min) => query.filter(ev_seq.gt(min as i64)),
+            Bound::Unbounded => query,
+        };
+        query = match max_ev_seq {
+            Bound::Included(max) => query.filter(ev_seq.le(max as i64)),
+            Bound::Excluded(max) => query.filter(ev_seq.lt(max as i64)),
+            Bound::Unbounded => query,
         };
 
-        if descending_order {
-            query = query.order(events::event_sequence_number.desc());
+        if is_descending {
+            query = query.order((tx_seq.desc(), ev_seq.desc()));
         } else {
-            query = query.order(events::event_sequence_number.asc());
+            query = query.order((tx_seq.asc(), ev_seq.asc()));
         }
 
         query = query.filter(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1355,7 +1355,8 @@ impl IndexerReader {
             .await?
         {
             // resolve  `(tx_seq, event_seq)` range to just `event_seq` range
-            let Some(ev_seq_range) = event_seq_range_for_tx(tx_ev_seq_range, tx_seq as u64) else {
+            let Some(ev_seq_range) = event_seq_range_within_tx(tx_ev_seq_range, tx_seq as u64)
+            else {
                 return Ok(vec![]);
             };
             return self
@@ -1379,7 +1380,7 @@ impl IndexerReader {
             .resolve_transaction_sequence_number(tx_digest)
             .await
             .context(&context)?;
-        let Some(ev_seq_range) = event_seq_range_for_tx(tx_ev_seq_range, tx_seq) else {
+        let Some(ev_seq_range) = event_seq_range_within_tx(tx_ev_seq_range, tx_seq) else {
             return Ok(vec![]);
         };
         kv_reader
@@ -2970,23 +2971,44 @@ impl DataReader for IndexerReader {
     }
 }
 
-/// Narrows a `(tx_seq, event_seq)` range to just `event_seq` range, for events
-/// of the `tx_seq` transaction. Returns `None` when no event of that
-/// transaction is in the range.
-fn event_seq_range_for_tx(
+/// Converts a range over `(tx_seq, event_seq)` pairs into a range over just
+/// `event_seq`, for the events of the transaction `tx_seq`.
+///
+/// The input range orders the events of all transactions by `(tx_seq,
+/// event_seq)`. Restricted to the events of a single transaction, each input
+/// bound either:
+/// - keeps its `event_seq` part, when the bound lies on the transaction itself,
+///   or
+/// - becomes `Unbounded`, when the bound lies on an earlier (for the lower
+///   bound) or later (for the upper bound) transaction, and so does not
+///   constrain the events of this transaction.
+///
+/// Returns `None` when the whole transaction falls outside the range, meaning
+/// no event of the transaction can be in the range.
+fn event_seq_range_within_tx(
     (min, max): TxEventSeqRange,
     tx_seq: u64,
 ) -> Option<(Bound<u64>, Bound<u64>)> {
     let min_ev_seq = match min {
-        Bound::Included((tx, ev)) if tx == tx_seq => Bound::Included(ev),
-        Bound::Excluded((tx, ev)) if tx == tx_seq => Bound::Excluded(ev),
-        Bound::Included((tx, _)) | Bound::Excluded((tx, _)) if tx > tx_seq => return None,
+        Bound::Included((start_tx, ev)) if start_tx == tx_seq => Bound::Included(ev),
+        Bound::Excluded((start_tx, ev)) if start_tx == tx_seq => Bound::Excluded(ev),
+        // the range starts after the whole transaction
+        Bound::Included((start_tx, _)) | Bound::Excluded((start_tx, _)) if start_tx > tx_seq => {
+            return None;
+        }
+        // the range starts before the transaction, so it does not constrain
+        // its events from below
         _ => Bound::Unbounded,
     };
     let max_ev_seq = match max {
-        Bound::Included((tx, ev)) if tx == tx_seq => Bound::Included(ev),
-        Bound::Excluded((tx, ev)) if tx == tx_seq => Bound::Excluded(ev),
-        Bound::Included((tx, _)) | Bound::Excluded((tx, _)) if tx < tx_seq => return None,
+        Bound::Included((end_tx, ev)) if end_tx == tx_seq => Bound::Included(ev),
+        Bound::Excluded((end_tx, ev)) if end_tx == tx_seq => Bound::Excluded(ev),
+        // the range ends before the whole transaction
+        Bound::Included((end_tx, _)) | Bound::Excluded((end_tx, _)) if end_tx < tx_seq => {
+            return None;
+        }
+        // the range ends after the transaction, so it does not constrain
+        // its events from above
         _ => Bound::Unbounded,
     };
     Some((min_ev_seq, max_ev_seq))

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -92,7 +92,7 @@ use crate::{
         diesel_macro::{mark_in_blocking_pool, *},
         package_resolver::IndexerStorePackageResolver,
     },
-    types::{IndexerResult, OwnerType, TxEventSeqRange},
+    types::{IndexerResult, OwnerType},
 };
 
 pub const TX_SEQUENCE_NUMBER_STR: &str = "tx_sequence_number";
@@ -1339,56 +1339,6 @@ impl IndexerReader {
         db_res
     }
 
-    /// Fetches events belonging to a transaction from given `(tx_seq,
-    /// event_seq)` range. Falls back to the historical storage (when
-    /// configured) if the transaction has been pruned from Postgres.
-    pub async fn query_stored_events_by_tx_digest_with_fallback(
-        &self,
-        tx_digest: TransactionDigest,
-        tx_ev_seq_range: TxEventSeqRange,
-        limit: usize,
-        is_descending: bool,
-    ) -> IndexerResult<Vec<StoredEvent>> {
-        if let Some(tx_seq) = self
-            .db()
-            .resolve_cursor_tx_digest_to_seq_num_maybe(tx_digest)
-            .await?
-        {
-            // resolve  `(tx_seq, event_seq)` range to just `event_seq` range
-            let Some(ev_seq_range) = event_seq_range_within_tx(tx_ev_seq_range, tx_seq as u64)
-            else {
-                return Ok(vec![]);
-            };
-            return self
-                .db()
-                .query_events_by_tx_digest_in_seq_range(
-                    tx_digest,
-                    ev_seq_range,
-                    limit,
-                    is_descending,
-                )
-                .await;
-        }
-
-        let Some(kv_reader) = self.fallback_reader() else {
-            return Err(IndexerError::DataPruned(format!(
-                "data for tx {tx_digest} potentially pruned"
-            )));
-        };
-        let context = format!("fallback triggered by tx {tx_digest} missing from Postgres");
-        let tx_seq = kv_reader
-            .resolve_transaction_sequence_number(tx_digest)
-            .await
-            .context(&context)?;
-        let Some(ev_seq_range) = event_seq_range_within_tx(tx_ev_seq_range, tx_seq) else {
-            return Ok(vec![]);
-        };
-        kv_reader
-            .events_in_seq_range(tx_digest, ev_seq_range, limit, is_descending)
-            .await
-            .context(&context)
-    }
-
     /// Fetches a paginated list of transactions that affect a given address,
     /// using the fallback storage if the database is pruned.
     async fn query_transactions_by_affected_addresses_with_fallback(
@@ -2067,6 +2017,32 @@ impl IndexerReader {
             .map(|iota_tx_event| iota_tx_event.data)
     }
 
+    /// Fetches events belonging to a transaction, paginated by an exclusive
+    /// `cursor`. Falls back to the historical storage (when configured) if the
+    /// transaction has been pruned from Postgres.
+    pub async fn query_stored_events_by_tx_digest_with_fallback(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
+        let db_res = self
+            .db()
+            .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
+            .await;
+
+        if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.fallback_reader())
+        {
+            return kv_reader
+                .events(tx_digest, cursor, limit, descending_order)
+                .await
+                .context(&format!("fallback triggered by {err}"));
+        }
+        db_res
+    }
+
     async fn query_events_by_tx_digest_with_fallback(
         &self,
         tx_digest: TransactionDigest,
@@ -2074,42 +2050,14 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<IotaEvent>> {
-        let ev_seq_range = match cursor {
-            Some(cursor) => {
-                if cursor.tx_digest != tx_digest {
-                    return Err(IndexerError::InvalidArgument(
-                        "Cursor tx_digest does not match the tx_digest in the query.".into(),
-                    ));
-                }
-                // the cursor is exclusive
-                if descending_order {
-                    (Bound::Unbounded, Bound::Excluded(cursor.event_seq))
-                } else {
-                    (Bound::Excluded(cursor.event_seq), Bound::Unbounded)
-                }
-            }
-            None => (Bound::Unbounded, Bound::Unbounded),
-        };
-        let db_res = self
-            .db()
-            .query_events_by_tx_digest_in_seq_range(
+        let stored_events = self
+            .query_stored_events_by_tx_digest_with_fallback(
                 tx_digest,
-                ev_seq_range,
+                cursor,
                 limit,
                 descending_order,
             )
-            .await;
-
-        let stored_events = if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
-            (db_res.as_ref(), self.fallback_reader())
-        {
-            kv_reader
-                .events_in_seq_range(tx_digest, ev_seq_range, limit, descending_order)
-                .await
-                .context(&format!("fallback triggered by {err}"))?
-        } else {
-            db_res?
-        };
+            .await?;
 
         let mut iota_event_futures = vec![];
         for stored_event in stored_events {
@@ -2971,49 +2919,6 @@ impl DataReader for IndexerReader {
     }
 }
 
-/// Converts a range over `(tx_seq, event_seq)` pairs into a range over just
-/// `event_seq`, for the events of the transaction `tx_seq`.
-///
-/// The input range orders the events of all transactions by `(tx_seq,
-/// event_seq)`. Restricted to the events of a single transaction, each input
-/// bound either:
-/// - keeps its `event_seq` part, when the bound lies on the transaction itself,
-///   or
-/// - becomes `Unbounded`, when the bound lies on an earlier (for the lower
-///   bound) or later (for the upper bound) transaction, and so does not
-///   constrain the events of this transaction.
-///
-/// Returns `None` when the whole transaction falls outside the range, meaning
-/// no event of the transaction can be in the range.
-fn event_seq_range_within_tx(
-    (min, max): TxEventSeqRange,
-    tx_seq: u64,
-) -> Option<(Bound<u64>, Bound<u64>)> {
-    let min_ev_seq = match min {
-        Bound::Included((start_tx, ev)) if start_tx == tx_seq => Bound::Included(ev),
-        Bound::Excluded((start_tx, ev)) if start_tx == tx_seq => Bound::Excluded(ev),
-        // the range starts after the whole transaction
-        Bound::Included((start_tx, _)) | Bound::Excluded((start_tx, _)) if start_tx > tx_seq => {
-            return None;
-        }
-        // the range starts before the transaction, so it does not constrain
-        // its events from below
-        _ => Bound::Unbounded,
-    };
-    let max_ev_seq = match max {
-        Bound::Included((end_tx, ev)) if end_tx == tx_seq => Bound::Included(ev),
-        Bound::Excluded((end_tx, ev)) if end_tx == tx_seq => Bound::Excluded(ev),
-        // the range ends before the whole transaction
-        Bound::Included((end_tx, _)) | Bound::Excluded((end_tx, _)) if end_tx < tx_seq => {
-            return None;
-        }
-        // the range ends after the transaction, so it does not constrain
-        // its events from above
-        _ => Bound::Unbounded,
-    };
-    Some((min_ev_seq, max_ev_seq))
-}
-
 impl<'a> DBReader<'a> {
     pub fn new(reader: &'a IndexerReader) -> Self {
         Self {
@@ -3114,38 +3019,36 @@ impl<'a> DBReader<'a> {
             .load::<StoredTransaction>(conn))
     }
 
-    /// Fetches events of a transaction from `event_seq` range.
-    ///
-    /// Returns up to `limit` events ordered by `event_seq` according to
-    /// `is_descending` flag. Returns [`IndexerError::DataPruned`] when
-    /// nothing matches and the transaction is missing from Postgres.
-    async fn query_events_by_tx_digest_in_seq_range(
+    async fn query_events_by_tx_digest(
         &self,
         tx_digest: TransactionDigest,
-        ev_seq_range: (Bound<u64>, Bound<u64>),
+        cursor: Option<EventID>,
         limit: usize,
-        is_descending: bool,
+        descending_order: bool,
     ) -> IndexerResult<Vec<StoredEvent>> {
-        use events::dsl::{event_sequence_number as ev_seq, tx_sequence_number as tx_seq};
-
         let mut query = events::table.into_boxed();
 
-        let (min_ev_seq, max_ev_seq) = ev_seq_range;
-        query = match min_ev_seq {
-            Bound::Included(min) => query.filter(ev_seq.ge(min as i64)),
-            Bound::Excluded(min) => query.filter(ev_seq.gt(min as i64)),
-            Bound::Unbounded => query,
-        };
-        query = match max_ev_seq {
-            Bound::Included(max) => query.filter(ev_seq.le(max as i64)),
-            Bound::Excluded(max) => query.filter(ev_seq.lt(max as i64)),
-            Bound::Unbounded => query,
+        if let Some(cursor) = cursor {
+            if cursor.tx_digest != tx_digest {
+                return Err(IndexerError::InvalidArgument(
+                    "Cursor tx_digest does not match the tx_digest in the query.".into(),
+                ));
+            }
+            if descending_order {
+                query = query.filter(events::event_sequence_number.lt(cursor.event_seq as i64));
+            } else {
+                query = query.filter(events::event_sequence_number.gt(cursor.event_seq as i64));
+            }
+        } else if descending_order {
+            query = query.filter(events::event_sequence_number.le(i64::MAX));
+        } else {
+            query = query.filter(events::event_sequence_number.ge(0));
         };
 
-        if is_descending {
-            query = query.order((tx_seq.desc(), ev_seq.desc()));
+        if descending_order {
+            query = query.order(events::event_sequence_number.desc());
         } else {
-            query = query.order((tx_seq.asc(), ev_seq.asc()));
+            query = query.order(events::event_sequence_number.asc());
         }
 
         query = query.filter(

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Bound;
+
 use iota_json_rpc_types::{
     BalanceChange, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
     IotaTransactionKind, ObjectChange,
@@ -32,6 +34,10 @@ use serde_with::{DisplayFromStr, serde_as};
 use crate::errors::IndexerError;
 
 pub type IndexerResult<T> = Result<T, IndexerError>;
+
+/// Range of events, in the form of `(tx_sequence_number,
+/// event_sequence_number)` cursors
+pub type TxEventSeqRange = (Bound<(u64, u64)>, Bound<(u64, u64)>);
 
 #[derive(Debug)]
 pub struct IndexedCheckpoint {

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -2,8 +2,6 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Bound;
-
 use iota_json_rpc_types::{
     BalanceChange, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
     IotaTransactionKind, ObjectChange,
@@ -34,10 +32,6 @@ use serde_with::{DisplayFromStr, serde_as};
 use crate::errors::IndexerError;
 
 pub type IndexerResult<T> = Result<T, IndexerError>;
-
-/// Range of events, in the form of `(tx_sequence_number,
-/// event_sequence_number)` cursors
-pub type TxEventSeqRange = (Bound<(u64, u64)>, Bound<(u64, u64)>);
 
 #[derive(Debug)]
 pub struct IndexedCheckpoint {


### PR DESCRIPTION
# Description of change

Please write a summary of your changes and why you made them.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

#### Breaking Changes Rollout

If your PR introduces breaking changes, list all of the affected crates. Provide detailed information about when those changes are expected to land on a particular public network and what actions users need to take to keep their applications running. See the comment below for an example.

<!-- EXAMPLE

Affected Crates:

- iota-data-ingestion-core
- iota-data-ingestion

Required User Actions:

- devnet: <action-needed-by> E.g. Users of these libraries should update their application immediately.
- testnet: Update dependent applications by v1.20
- mainnet: ...

-->

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---
