### PR TITLE
fix: stop failing a batched gRPC read when one item is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "bech32 0.11.1",
  "bip32",
@@ -7452,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7481,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7508,7 +7508,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=475b0de92e4b9e3115367382e1bba56630b785b9#475b0de92e4b9e3115367382e1bba56630b785b9"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7426,8 +7426,9 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
+ "base64ct",
  "bech32 0.11.1",
  "bip32",
  "bip39",
@@ -7451,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7480,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7488,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7507,7 +7508,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7523,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7542,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7426,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "bech32 0.11.1",
  "bip32",
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7507,7 +7507,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7523,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7542,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6397,7 +6397,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.7.8",
- "tonic 0.14.2",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,9 +398,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "475b0de92e4b9e3115367382e1bba56630b785b9" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "475b0de92e4b9e3115367382e1bba56630b785b9" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -439,10 +439,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,9 +398,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -439,10 +439,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,9 +398,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -439,10 +439,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-analytics-indexer/src/package_store.rs
+++ b/crates/iota-analytics-indexer/src/package_store.rs
@@ -110,10 +110,16 @@ impl LocalDBPackageStore {
                 .await
                 .map_err(grpc_err)?
                 .into_inner();
-            let proto_obj = objects
-                .into_iter()
-                .next()
-                .ok_or(PackageResolverError::PackageNotFound(id))?;
+            let proto_obj = match objects.into_iter().next() {
+                Some(Ok(proto_obj)) => proto_obj,
+                // The node reports a package it cannot serve against the ref
+                // that asked for it.
+                Some(Err(e)) if e.is_not_found() => {
+                    return Err(PackageResolverError::PackageNotFound(id));
+                }
+                Some(Err(e)) => return Err(grpc_err(e)),
+                None => return Err(PackageResolverError::PackageNotFound(id)),
+            };
             let object = proto_obj.object().map_err(grpc_err)?.into();
             self.update(&object)?;
             object

--- a/crates/iota-e2e-tests/tests/grpc/client/objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/objects.rs
@@ -22,6 +22,8 @@ async fn get_objects_scenarios() {
     assert_eq!(objects.body().len(), 1, "Expected exactly one object");
     assert!(
         objects.body()[0]
+            .as_ref()
+            .expect("Object should be found")
             .object_reference()
             .expect("Failed to get object reference")
             .version()
@@ -45,6 +47,7 @@ async fn get_objects_scenarios() {
         "Should return same number of objects as requested"
     );
     for object in objects.body() {
+        let object = object.as_ref().expect("System package should be found");
         assert!(
             object
                 .object_reference()
@@ -80,6 +83,8 @@ async fn get_objects_scenarios() {
         .await
         .expect("Failed to get object");
     let current_version = objects.body()[0]
+        .as_ref()
+        .expect("Object should be found")
         .object_reference()
         .expect("Failed to get object reference")
         .version();
@@ -89,6 +94,8 @@ async fn get_objects_scenarios() {
         .expect("Failed to get object with specific version");
     assert_eq!(
         objects_with_version.body()[0]
+            .as_ref()
+            .expect("Object should be found")
             .object_reference()
             .expect("Failed to get object reference")
             .version(),
@@ -96,33 +103,49 @@ async fn get_objects_scenarios() {
         "Object version should match requested version"
     );
 
-    // Test: nonexistent object returns not-found error
+    // Test: a nonexistent object is reported against the ref that asked for it,
+    // not as a failure of the call
     let fake_id: ObjectId = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
         .parse()
         .expect("Invalid object ID");
-    let result = client.get_objects(&[(fake_id, None)], None).await;
-    assert_server_not_found(result);
+    let mut results = client
+        .get_objects(&[(fake_id, None)], None)
+        .await
+        .expect("The call itself should succeed")
+        .into_inner();
+    assert_eq!(results.len(), 1, "Expected one result per requested ref");
+    assert_server_not_found(results.pop().expect("Length asserted above"));
 
-    // Test: invalid version returns error
+    // Test: invalid version returns a per-ref error
     let object_id: ObjectId = "0x2".parse().expect("Invalid object ID");
-    let result = client
+    let mut results = client
         .get_objects(&[(object_id, Some(Version::from_u64(999_999_999)))], None)
-        .await;
+        .await
+        .expect("The call itself should succeed")
+        .into_inner();
+    assert_eq!(results.len(), 1, "Expected one result per requested ref");
     assert!(
-        result.is_err(),
+        results.pop().expect("Length asserted above").is_err(),
         "Fetching object with invalid version should return an error"
     );
 
-    // Test: mixed valid/invalid returns error
+    // Test: a missing object fails only its own slot, leaving the objects the
+    // node could serve intact
     let valid_id: ObjectId = "0x2".parse().expect("Invalid object ID");
     let invalid_id: ObjectId = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
         .parse()
         .expect("Invalid object ID");
-    let result = client
+    let mut results = client
         .get_objects(&[(valid_id, None), (invalid_id, None)], None)
-        .await;
+        .await
+        .expect("The call itself should succeed")
+        .into_inner();
+    assert_eq!(results.len(), 2, "Expected one result per requested ref");
+    let missing = results.pop().expect("Length asserted above");
+    let found = results.pop().expect("Length asserted above");
     assert!(
-        result.is_err(),
-        "Mixed valid/invalid should return an error when encountering invalid object"
+        found.is_ok(),
+        "The object that exists should still be returned, got: {found:?}"
     );
+    assert_server_not_found(missing);
 }

--- a/crates/iota-e2e-tests/tests/grpc/client/objects.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/objects.rs
@@ -124,10 +124,7 @@ async fn get_objects_scenarios() {
         .expect("The call itself should succeed")
         .into_inner();
     assert_eq!(results.len(), 1, "Expected one result per requested ref");
-    assert!(
-        results.pop().expect("Length asserted above").is_err(),
-        "Fetching object with invalid version should return an error"
-    );
+    assert_server_not_found(results.pop().expect("Length asserted above"));
 
     // Test: a missing object fails only its own slot, leaving the objects the
     // node could serve intact

--- a/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
+++ b/crates/iota-e2e-tests/tests/grpc/client/transactions.rs
@@ -29,9 +29,11 @@ async fn get_transactions_scenarios() {
         1,
         "Expected exactly one transaction"
     );
+    let tx = transactions.body()[0]
+        .as_ref()
+        .expect("Transaction should be found");
     assert_eq!(
-        transactions.body()[0]
-            .transaction()
+        tx.transaction()
             .expect("Failed to get transaction from executed transaction")
             .digest()
             .expect("Failed to get digest from transaction"),
@@ -39,8 +41,7 @@ async fn get_transactions_scenarios() {
         "Transaction digest should match requested digest"
     );
     assert!(
-        !transactions.body()[0]
-            .signatures()
+        !tx.signatures()
             .expect("Failed to get signatures from transaction")
             .signatures
             .is_empty(),
@@ -59,6 +60,8 @@ async fn get_transactions_scenarios() {
     );
     assert_eq!(
         transactions.body()[0]
+            .as_ref()
+            .expect("First transaction should be found")
             .transaction()
             .expect("Failed to get transaction from executed transaction")
             .digest()
@@ -68,6 +71,8 @@ async fn get_transactions_scenarios() {
     );
     assert_eq!(
         transactions.body()[1]
+            .as_ref()
+            .expect("Second transaction should be found")
             .transaction()
             .expect("Failed to get transaction from executed transaction")
             .digest()
@@ -86,18 +91,33 @@ async fn get_transactions_scenarios() {
         "Expected EmptyRequest error, got: {err}"
     );
 
-    // Test: nonexistent transaction returns not-found error
+    // Test: a nonexistent transaction is reported against the digest that asked
+    // for it, not as a failure of the call
     let fake_digest = TransactionDigest::new([0u8; 32]);
-    let result = client.get_transactions(&[fake_digest], None).await;
-    assert_server_not_found(result);
+    let mut results = client
+        .get_transactions(&[fake_digest], None)
+        .await
+        .expect("The call itself should succeed")
+        .into_inner();
+    assert_eq!(results.len(), 1, "Expected one result per requested digest");
+    assert_server_not_found(results.pop().expect("Length asserted above"));
 
-    // Test: mixed valid/invalid returns error
+    // Test: a missing transaction fails only its own slot, leaving the
+    // transactions the node could serve intact
     let fake_digest = TransactionDigest::new([0u8; 32]);
-    let result = client.get_transactions(&[digest1, fake_digest], None).await;
+    let mut results = client
+        .get_transactions(&[digest1, fake_digest], None)
+        .await
+        .expect("The call itself should succeed")
+        .into_inner();
+    assert_eq!(results.len(), 2, "Expected one result per requested digest");
+    let missing = results.pop().expect("Length asserted above");
+    let found = results.pop().expect("Length asserted above");
     assert!(
-        result.is_err(),
-        "Mixed valid/invalid should return an error when encountering invalid digest"
+        found.is_ok(),
+        "The transaction that exists should still be returned, got: {found:?}"
     );
+    assert_server_not_found(missing);
 
     // Test: response fields match the default mask (transaction, signatures,
     // checkpoint, timestamp).
@@ -105,7 +125,9 @@ async fn get_transactions_scenarios() {
         .get_transactions(&[digest1], None)
         .await
         .expect("Failed to get transaction");
-    let tx = &transactions.body()[0];
+    let tx = transactions.body()[0]
+        .as_ref()
+        .expect("Transaction should be found");
     assert_eq!(
         tx.transaction()
             .expect("Failed to get transaction from executed transaction")
@@ -142,6 +164,8 @@ async fn get_transactions_scenarios() {
 
     let transactions = result.expect("request should work");
     let conversion_result = transactions.body()[0]
+        .as_ref()
+        .expect("Transaction should be found")
         .transaction()
         .expect("Failed to get transaction from executed transaction")
         .transaction()

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -42,7 +42,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "ti
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 toml.workspace = true
-tonic.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/iota-indexer/src/apis/read_api.rs
+++ b/crates/iota-indexer/src/apis/read_api.rs
@@ -162,28 +162,23 @@ impl ReadApi {
         &self,
         digest: TransactionDigest,
     ) -> IndexerResult<bool> {
-        match self
+        let result = self
             .fullnode_grpc_client
             .get_transactions(
                 &[digest],
                 Some(ReadMask::from(TransactionField::TRANSACTION_DIGEST)),
             )
-            .await
-        {
-            Ok(txns) => {
-                let executed_tx = txns.into_inner().pop().ok_or_else(|| {
-                    IndexerError::Grpc("there should be one tx lookup response".into())
-                })?;
+            .await?
+            .into_inner()
+            .pop()
+            .ok_or_else(|| IndexerError::Grpc("there should be one tx lookup response".into()))?;
 
-                Ok(executed_tx.transaction()?.digest()? == digest)
-            }
-            Err(e) => {
-                if matches!(e, iota_grpc_client::Error::Server(ref e) if e.to_tonic_status().code() == tonic::Code::NotFound)
-                {
-                    return Ok(false);
-                }
-                Err(IndexerError::from(e))
-            }
+        match result {
+            Ok(executed_tx) => Ok(executed_tx.transaction()?.digest()? == digest),
+            // The node reports a transaction it has not indexed as a per-digest
+            // `NOT_FOUND`.
+            Err(e) if e.is_not_found() => Ok(false),
+            Err(e) => Err(IndexerError::from(e)),
         }
     }
 }

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 iota-grpc-client = { workspace = true, optional = true }
 iota-grpc-types = { workspace = true, optional = true }
 iota-sdk-crypto = { workspace = true, optional = true }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", optional = true }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9", default-features = false, optional = true }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", optional = true }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false, optional = true }
 iota-sdk-types = { workspace = true, optional = true }
 
 [features]

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 iota-grpc-client = { workspace = true, optional = true }
 iota-grpc-types = { workspace = true, optional = true }
 iota-sdk-crypto = { workspace = true, optional = true }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", optional = true }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false, optional = true }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26", optional = true }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26", default-features = false, optional = true }
 iota-sdk-types = { workspace = true, optional = true }
 
 [features]

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 iota-grpc-client = { workspace = true, optional = true }
 iota-grpc-types = { workspace = true, optional = true }
 iota-sdk-crypto = { workspace = true, optional = true }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", optional = true }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b", default-features = false, optional = true }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", optional = true }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550", default-features = false, optional = true }
 iota-sdk-types = { workspace = true, optional = true }
 
 [features]

--- a/crates/iota-test-transaction-builder/src/lib.rs
+++ b/crates/iota-test-transaction-builder/src/lib.rs
@@ -862,6 +862,7 @@ pub async fn split_coin_equal_tx(
         .into_inner()
         .into_iter()
         .next()
+        .expect("no result for the requested coin")
         .expect("coin not found")
         .object()
         .expect("invalid coin object");

--- a/crates/iota-vm-sdk/src/grpc.rs
+++ b/crates/iota-vm-sdk/src/grpc.rs
@@ -142,26 +142,16 @@ impl ObjectFetcher for GrpcFetcher {
         &self,
         refs: &[(ObjectId, Option<Version>)],
     ) -> Result<Vec<Object>, StoreError> {
-        let proto_objects = match self.client.get_objects(refs, None).await {
-            Ok(resp) => resp.into_inner(),
-            // A missing object is reported by the node as a `NOT_FOUND` server
-            // error. The `Store` contract treats absence as `Ok(None)` (the
-            // VM's child-object resolver relies on this — a dynamic field that
-            // does not exist must read as absent, not fault), so a single-object
-            // request that comes back not-found yields no objects rather than an
-            // error. A batched request can't say which ref was missing, so its
-            // error still propagates; the on-demand resolution path only ever
-            // fetches one object at a time.
-            Err(iota_grpc_client::api::Error::Server(status))
-                if refs.len() == 1 && status.code == tonic::Code::NotFound as i32 =>
-            {
-                return Ok(Vec::new());
-            }
-            Err(e) => return Err(StoreError::new("fetch objects via gRPC", e)),
-        };
+        let results = self
+            .client
+            .get_objects(refs, None)
+            .await
+            .map_err(|e| StoreError::new("fetch objects via gRPC", e))?
+            .into_inner();
+
         // The proto helper yields the SDK `Object`, which the node's
         // `iota_types::object::Object` is a newtype over.
-        proto_objects
+        skip_not_found(results)?
             .into_iter()
             .map(|proto_obj| {
                 proto_obj
@@ -170,5 +160,66 @@ impl ObjectFetcher for GrpcFetcher {
                     .map_err(|e| StoreError::new("decode gRPC object", e))
             })
             .collect()
+    }
+}
+
+/// Keep the items the node returned, dropping the ones it reported as
+/// `NOT_FOUND`.
+///
+/// The `Store` contract treats absence as `Ok(None)` — the VM's child-object
+/// resolver relies on this, since a dynamic field that does not exist must read
+/// as absent rather than fault. The batched read reports a missing object per
+/// requested ref, so the refs the node could serve survive a missing one.
+fn skip_not_found<T>(
+    results: Vec<Result<T, iota_grpc_client::api::Error>>,
+) -> Result<Vec<T>, StoreError> {
+    let mut items = Vec::with_capacity(results.len());
+    for result in results {
+        match result {
+            Ok(item) => items.push(item),
+            Err(e) if e.is_not_found() => {}
+            Err(e) => return Err(StoreError::new("fetch objects via gRPC", e)),
+        }
+    }
+    Ok(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_grpc_client::{RpcStatus, api::Error};
+
+    use super::skip_not_found;
+
+    fn server_error(code: tonic::Code) -> Error {
+        Error::Server(RpcStatus {
+            code: code.into(),
+            message: String::new(),
+            details: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn a_missing_ref_is_skipped_without_dropping_the_rest() {
+        let results = vec![Ok(1), Err(server_error(tonic::Code::NotFound)), Ok(3)];
+
+        assert_eq!(skip_not_found(results).unwrap(), vec![1, 3]);
+    }
+
+    #[test]
+    fn every_ref_missing_yields_no_objects() {
+        let results: Vec<Result<u32, Error>> = vec![
+            Err(server_error(tonic::Code::NotFound)),
+            Err(server_error(tonic::Code::NotFound)),
+        ];
+
+        assert!(skip_not_found(results).unwrap().is_empty());
+    }
+
+    #[test]
+    fn an_error_other_than_not_found_fails_the_fetch() {
+        let results: Vec<Result<u32, Error>> =
+            vec![Ok(1), Err(server_error(tonic::Code::Internal))];
+
+        assert!(skip_not_found(results).is_err());
     }
 }

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3689,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "fastcrypto",
  "iota-sdk-types",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3738,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3689,8 +3689,9 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
+ "base64ct",
  "fastcrypto",
  "iota-sdk-types",
  "rand_core 0.6.4",
@@ -3703,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3722,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3738,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3757,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3be565c034fdbb56bacd84ad15901c08bdd3a550#3be565c034fdbb56bacd84ad15901c08bdd3a550"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2f021d0556e47564e9b04bcd0b3e8347c41a0a26#2f021d0556e47564e9b04bcd0b3e8347c41a0a26"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "iota-metrics",
  "iota-names",
  "iota-protocol-config",
+ "iota-sdk-crypto",
  "iota-sdk-types",
  "iota-types",
  "move-vm-config",
@@ -3428,6 +3429,7 @@ dependencies = [
  "anyhow",
  "bip32",
  "fastcrypto",
+ "iota-sdk-crypto",
  "iota-sdk-types",
  "iota-types",
  "rand 0.8.6",
@@ -3687,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "fastcrypto",
  "iota-sdk-types",
@@ -3701,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3720,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3736,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3755,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b77fcd5ac5fedb3dfbc77ba7d183140e43512339#b77fcd5ac5fedb3dfbc77ba7d183140e43512339"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=f786c044db92d8b9a7e686f278cefd3723d51c1b#f786c044db92d8b9a7e686f278cefd3723d51c1b"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "475b0de92e4b9e3115367382e1bba56630b785b9" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2f021d0556e47564e9b04bcd0b3e8347c41a0a26" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "f786c044db92d8b9a7e686f278cefd3723d51c1b" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3be565c034fdbb56bacd84ad15901c08bdd3a550" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
# Description of change

The SDK's `get_objects`/`get_transactions` discarded the whole batch as soon as one requested item came back with a per-item error — including the routine case of an object that no longer exists (consumed or smashed during execution, deleted, or pruned by the serving node). Callers worked around this by refetching one item at a time whenever a batch failed.

iotaledger/iota-rust-sdk#1292 changes those calls to return one result per request. This PR bumps the pinned rev and adopts the new shape:

- **`iota-vm-sdk`** — a missing or pruned object no longer fails the fetch for the refs the node could serve, so a batch no longer has to be resolved one object at a time.
- **`iota-indexer`** — `is_transaction_indexed_on_node` reads the per-digest `NOT_FOUND`. Its previous call-level check can no longer fire, and keeping it would have reported a misrouted endpoint as "not indexed".
- **`iota-analytics-indexer`** — a per-item `NOT_FOUND` maps to `PackageNotFound` instead of a generic store error.
- **gRPC client e2e tests** — now assert that the items the node can serve survive a missing one. The previous assertions encoded the old behaviour (`"Mixed valid/invalid should return an error"`).

The node's gRPC server is untouched: `ObjectResult`/`TransactionResult` already carried a per-item `google.rpc.Status` and the stream never aborted on one. Only the client discarded it.

## Links to any relevant issues

Depends on iotaledger/iota-rust-sdk#1292. Draft until that lands — the pinned rev (`087bb1fe`) is the PR branch head, so it needs re-pointing at the squash-merge commit on `develop` before this can merge.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check --workspace --all-targets`, clippy and nightly fmt are clean. `cargo simtest -p iota-e2e-tests --test grpc` passes 105/105. New unit tests in `iota-vm-sdk` cover a batch with one missing ref, an all-missing batch, and an error other than `NOT_FOUND`.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: `iota-vm-sdk` gRPC object fetches now skip objects the node cannot serve instead of failing the whole fetch
- [ ] gRPC: