### PR TITLE
feat(starfish): improve commit-syncer peer selection

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -163,12 +163,13 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_enable_starfish_speed_adaptive_acknowledgments")]
     pub enable_starfish_speed_adaptive_acknowledgments: bool,
 
-    /// Prefer more responsive peers when the transactions synchronizer selects
-    /// peers to fetch from. Ranking is a preference within the already-eligible
-    /// candidate set, not a change of eligibility, so it cannot affect safety.
-    /// Enabled by default; disabling it restores the previous selection: a
-    /// uniform random order that excludes the most recently failed peers (up
-    /// to less than f+1 by stake).
+    /// Prefer more responsive peers when the transactions synchronizer and the
+    /// commit syncer select peers to fetch from. Responses are verified the
+    /// same way regardless, so it cannot affect safety. Enabled by default;
+    /// disabling it restores the previous selection: for the transactions
+    /// synchronizer a uniform random order that excludes the most recently
+    /// failed peers (up to less than f+1 by stake), and for the commit syncer a
+    /// uniform random order.
     #[serde(default = "Parameters::default_enable_peer_responsiveness_ranking")]
     pub enable_peer_responsiveness_ranking: bool,
 

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -557,6 +557,7 @@ pub(crate) mod tests {
         let temp_dir = TempDir::new().unwrap();
         let parameters = Parameters {
             db_path: temp_dir.keep(),
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};
@@ -605,6 +606,7 @@ pub(crate) mod tests {
         let parameters = Parameters {
             db_path: temp_dir.keep(),
             enable_fast_commit_syncer: false,
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};
@@ -665,6 +667,7 @@ pub(crate) mod tests {
         let parameters = Parameters {
             db_path,
             enable_fast_commit_syncer: false,
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};
@@ -1196,6 +1199,7 @@ pub(crate) mod tests {
             commit_sync_batch_size: 10,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             enable_fast_commit_syncer: true,
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};
@@ -1321,6 +1325,7 @@ pub(crate) mod tests {
                 fast_commit_sync_batch_size: 20,
                 enable_fast_commit_syncer: true,
                 sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+                enable_peer_responsiveness_ranking: false,
                 ..Default::default()
             };
             let (authority, receiver, monitor) = make_authority_with_params(
@@ -1391,6 +1396,7 @@ pub(crate) mod tests {
             fast_commit_sync_batch_size: 20,
             enable_fast_commit_syncer: true,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(
@@ -1520,6 +1526,7 @@ pub(crate) mod tests {
             fast_commit_sync_batch_size: 20,
             enable_fast_commit_syncer: true,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(
@@ -1769,6 +1776,7 @@ pub(crate) mod tests {
                 fast_commit_sync_batch_size: 20,
                 enable_fast_commit_syncer: true,
                 sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+                enable_peer_responsiveness_ranking: false,
                 ..Default::default()
             };
             let (authority, receiver, monitor) = make_authority_with_params(
@@ -1839,6 +1847,7 @@ pub(crate) mod tests {
             fast_commit_sync_batch_size: 20,
             enable_fast_commit_syncer: true,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(
@@ -1941,6 +1950,7 @@ pub(crate) mod tests {
             fast_commit_sync_batch_size: 20,
             enable_fast_commit_syncer: true,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1350,9 +1350,12 @@ mod tests {
             dag_state::DataSource,
         };
 
-        /// `fetch_loop`'s test-build base timeout times the fast syncer's
-        /// multiplier, i.e. the constant a failed attempt is charged.
-        const FAILURE_PENALTY_MS: f64 = 1_000.0;
+        /// What a failed attempt records. `fetch_loop` charges its base timeout
+        /// times the fast syncer's multiplier, which in a test build is 1s and
+        /// so is lifted to the fast-sync neutral prior; in production the
+        /// charge is 20s and stands on its own. Either way it must not climb
+        /// with the fetch timeout as rounds escalate.
+        const FAILURE_PENALTY_MS: f64 = 2_000.0;
 
         fn fast_sync_context(committee_size: usize) -> Arc<Context> {
             let (mut context, _) = Context::new_for_test(committee_size);

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -15,9 +15,15 @@ use bytes::Bytes;
 use iota_metrics::spawn_logged_monitored_task;
 use parking_lot::RwLock;
 #[cfg(not(test))]
-use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
+use rand::prelude::SliceRandom as _;
+use rand::{SeedableRng as _, rngs::StdRng, thread_rng};
 use starfish_config::AuthorityIndex;
-use tokio::{runtime::Handle, sync::oneshot, task::JoinSet, time::MissedTickBehavior};
+use tokio::{
+    runtime::Handle,
+    sync::oneshot,
+    task::JoinSet,
+    time::{Instant, MissedTickBehavior},
+};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -26,7 +32,7 @@ use crate::{
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, CommittedSubDag, TrustedCommit},
     commit_syncer::{
-        CommitSyncType, CommitSyncerHandle, Inner, fetch_loop as shared_fetch_loop,
+        CommitSyncType, CommitSyncerHandle, FetchedCommits, Inner, fetch_loop as shared_fetch_loop,
         handle_fetch_join_error, requeue_partial_range, schedule_commit_ranges,
         try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
         verify_transactions_with_transactions_refs,
@@ -34,7 +40,7 @@ use crate::{
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::DagState,
+    dag_state::{DagState, DataSource},
     error::{ConsensusError, ConsensusResult},
     header_synchronizer::HeaderSynchronizerHandle,
     misbehavior_store::MisbehaviorStore,
@@ -45,6 +51,22 @@ use crate::{
 
 /// Timeout for fetching block headers during close-to-quorum finalization.
 const FETCH_HEADERS_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Demotes `authority` for subsequent header chunks after it failed to serve
+/// one, whether it errored, timed out, or returned headers that did not verify.
+fn record_headers_for_reinitialization_failure<C: NetworkClient>(
+    inner: &Inner<C>,
+    authority: AuthorityIndex,
+) {
+    inner
+        .context
+        .peer_responsiveness
+        .record_failure_with_timeout(
+            DataSource::FastCommitSyncer,
+            authority,
+            FETCH_HEADERS_TIMEOUT,
+        );
+}
 
 /// Which worker skipped a step because the fast commit syncer was active.
 /// Used as the `source` label on `syncer_paused_by_fast_sync`. All
@@ -105,6 +127,12 @@ pub struct FastSyncOutput {
     pub commits: Vec<TrustedCommit>,
     pub committed_subdags: Vec<CommittedSubDag>,
     pub voting_block_headers: Vec<VerifiedBlockHeader>,
+}
+
+impl FetchedCommits for FastSyncOutput {
+    fn delivered_commits(&self) -> usize {
+        self.committed_subdags.len()
+    }
 }
 
 pub(crate) struct FastCommitSyncer<C: NetworkClient> {
@@ -765,8 +793,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             commits_since_schedule_update
         );
 
-        // Shuffle target authorities for load balancing
-        #[cfg_attr(test, expect(unused_mut))]
         let mut target_authorities: Vec<_> = inner
             .context
             .committee
@@ -779,17 +805,33 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 }
             })
             .collect();
+        let mut rng = StdRng::from_rng(thread_rng()).expect("thread_rng should be available");
+        // Without ranking, one shuffle for load balancing covers every chunk.
         #[cfg(not(test))]
-        target_authorities.shuffle(&mut ThreadRng::default());
+        if !inner.context.parameters.enable_peer_responsiveness_ranking {
+            target_authorities.shuffle(&mut rng);
+        }
 
         // Fetch headers in chunks to avoid overwhelming the network
         let mut all_headers = Vec::new();
         for chunk in block_refs.chunks(max_headers_per_fetch) {
             let chunk_refs: Vec<_> = chunk.to_vec();
 
+            // Reordered per chunk rather than once, so a peer that stalls on one
+            // chunk is demoted for the rest instead of costing the full timeout
+            // on every one of them.
+            if inner.context.parameters.enable_peer_responsiveness_ranking {
+                inner.context.peer_responsiveness.prioritize(
+                    DataSource::FastCommitSyncer,
+                    &mut target_authorities,
+                    &mut rng,
+                );
+            }
+
             // Try fetching from different authorities until successful
             let mut fetched = false;
             for &authority in &target_authorities {
+                let started = Instant::now();
                 match tokio::time::timeout(
                     FETCH_HEADERS_TIMEOUT,
                     inner.network_client.fetch_block_headers(
@@ -805,6 +847,11 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         // Verify headers match requested refs
                         match verify_fetched_headers(authority, &chunk_refs, serialized_headers) {
                             Ok(headers) => {
+                                inner.context.peer_responsiveness.record_success(
+                                    DataSource::FastCommitSyncer,
+                                    authority,
+                                    started.elapsed(),
+                                );
                                 info!(
                                     "[{}] Fetched {} headers from authority {}",
                                     inner.sync_type.as_str(),
@@ -821,6 +868,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                                 // as Untracked. When per-header faults become observable
                                 // here, record them as peer misbehavior via
                                 // `inner.misbehavior_store.record_faulty_block`.
+                                record_headers_for_reinitialization_failure(&inner, authority);
                                 warn!(
                                     "[{}] Failed to verify headers from {}: {}",
                                     inner.sync_type.as_str(),
@@ -831,6 +879,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         }
                     }
                     Ok(Err(e)) => {
+                        record_headers_for_reinitialization_failure(&inner, authority);
                         warn!(
                             "[{}] Failed to fetch headers from {}: {}",
                             inner.sync_type.as_str(),
@@ -839,6 +888,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                         );
                     }
                     Err(_) => {
+                        record_headers_for_reinitialization_failure(&inner, authority);
                         warn!(
                             "[{}] Timed out fetching headers from {}",
                             inner.sync_type.as_str(),
@@ -1069,18 +1119,13 @@ mod tests {
             .inner
         }
 
-        /// A response whose transaction payload covers only some of the
-        /// returned commits (e.g. the stream was cut off by the response byte
-        /// limit) must still produce output for the covered prefix of commits
-        /// instead of failing the whole fetch.
-        #[tokio::test]
-        async fn returns_covered_prefix_of_truncated_response() {
-            let (mut context, _) = Context::new_for_test(4);
-            context
-                .protocol_config
-                .set_consensus_fast_commit_sync_for_testing(true);
-            let context = Arc::new(context);
-            let mut encoder = create_encoder(&context);
+        /// A complete `fetch_commits_and_transactions` response for commit
+        /// range 1..=2: both serialized commits, vote headers from a quorum
+        /// certifying the last one, and both serialized transactions.
+        pub(crate) fn two_commit_response(
+            context: &Arc<Context>,
+        ) -> (Vec<Bytes>, Vec<Bytes>, Vec<Bytes>) {
+            let mut encoder = create_encoder(context);
 
             // Two chained commits, each committing one transaction.
             let mut transaction_refs = Vec::new();
@@ -1090,7 +1135,7 @@ mod tests {
                     Transaction::serialize(&[Transaction::new(vec![round as u8; 16])]).unwrap();
                 let commitment = TransactionsCommitment::compute_transactions_commitment(
                     &serialized,
-                    &context,
+                    context,
                     &mut encoder,
                 )
                 .unwrap();
@@ -1104,7 +1149,7 @@ mod tests {
             let leader_1 =
                 BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN);
             let commit_1 = TrustedCommit::new_for_test(
-                &context,
+                context,
                 1,
                 CommitDigest::MIN,
                 0,
@@ -1115,7 +1160,7 @@ mod tests {
             let leader_2 =
                 BlockRef::new(2, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN);
             let commit_2 = TrustedCommit::new_for_test(
-                &context,
+                context,
                 2,
                 commit_1.digest(),
                 0,
@@ -1136,22 +1181,45 @@ mod tests {
                 })
                 .collect();
 
-            // The response carries both commits but only the first commit's
-            // transaction, as if the transaction stream was cut off.
-            let response_transactions = vec![
-                bcs::to_bytes(&SerializedTransactionsV2 {
-                    transaction_ref: transaction_refs[0],
-                    serialized_transactions: serialized_transactions[0].clone(),
+            let response_transactions: Vec<Bytes> = transaction_refs
+                .iter()
+                .zip(&serialized_transactions)
+                .map(|(transaction_ref, serialized)| {
+                    bcs::to_bytes(&SerializedTransactionsV2 {
+                        transaction_ref: *transaction_ref,
+                        serialized_transactions: serialized.clone(),
+                    })
+                    .unwrap()
+                    .into()
                 })
-                .unwrap()
-                .into(),
-            ];
+                .collect();
+
+            (
+                vec![commit_1.serialized().clone(), commit_2.serialized().clone()],
+                vote_headers,
+                response_transactions,
+            )
+        }
+
+        /// A response whose transaction payload covers only some of the
+        /// returned commits (e.g. the stream was cut off by the response byte
+        /// limit) must still produce output for the covered prefix of commits
+        /// instead of failing the whole fetch.
+        #[tokio::test]
+        async fn returns_covered_prefix_of_truncated_response() {
+            let (mut context, _) = Context::new_for_test(4);
+            context
+                .protocol_config
+                .set_consensus_fast_commit_sync_for_testing(true);
+            let context = Arc::new(context);
+
+            // Drop the second commit's transaction, as if the transaction
+            // stream was cut off by the response byte limit.
+            let (commits, vote_headers, mut response_transactions) = two_commit_response(&context);
+            response_transactions.truncate(1);
+
             let network_client = Arc::new(FakeNetworkClient {
-                commits_and_transactions: Some((
-                    vec![commit_1.serialized().clone(), commit_2.serialized().clone()],
-                    vote_headers,
-                    response_transactions,
-                )),
+                commits_and_transactions: Some((commits, vote_headers, response_transactions)),
                 ..Default::default()
             });
             let inner = make_inner(context.clone(), network_client);
@@ -1168,9 +1236,9 @@ mod tests {
             // Only the covered first commit is returned; the scheduler
             // requeues the remainder of the range.
             assert_eq!(output.commits.len(), 1);
-            assert_eq!(output.commits[0].reference(), commit_1.reference());
+            assert_eq!(output.commits[0].reference().index, 1);
             assert_eq!(output.committed_subdags.len(), 1);
-            assert_eq!(output.committed_subdags[0].commit_ref, commit_1.reference());
+            assert_eq!(output.committed_subdags[0].commit_ref.index, 1);
             assert_eq!(output.committed_subdags[0].transactions.len(), 1);
             assert_eq!(output.voting_block_headers.len(), 3);
             assert_eq!(
@@ -1264,6 +1332,182 @@ mod tests {
                     AuthorityIndex::new_for_test(3),
                 ]
             );
+        }
+    }
+
+    /// Covers the peer-responsiveness feedback and ordering in the shared
+    /// `fetch_loop`, driven through the fast syncer because that is the flavour
+    /// `FakeNetworkClient` serves.
+    mod fetch_loop_peer_responsiveness {
+        use std::{sync::Arc, time::Duration};
+
+        use starfish_config::AuthorityIndex;
+
+        use super::fetch_once::{make_inner, two_commit_response};
+        use crate::{
+            commit_syncer::{fast::FastCommitSyncer, fetch_loop, tests::FakeNetworkClient},
+            context::Context,
+            dag_state::DataSource,
+        };
+
+        /// `fetch_loop`'s test-build base timeout times the fast syncer's
+        /// multiplier, i.e. the constant a failed attempt is charged.
+        const FAILURE_PENALTY_MS: f64 = 1_000.0;
+
+        fn fast_sync_context(committee_size: usize) -> Arc<Context> {
+            let (mut context, _) = Context::new_for_test(committee_size);
+            context
+                .protocol_config
+                .set_consensus_fast_commit_sync_for_testing(true);
+            Arc::new(context)
+        }
+
+        #[tokio::test]
+        async fn records_success_for_the_serving_peer() {
+            let context = fast_sync_context(4);
+            let (commits, vote_headers, transactions) = two_commit_response(&context);
+            let network_client = Arc::new(FakeNetworkClient {
+                commits_and_transactions: Some((commits, vote_headers, transactions)),
+                ..Default::default()
+            });
+            let inner = make_inner(context.clone(), network_client.clone());
+
+            fetch_loop(inner, (1..=2).into(), 2, FastCommitSyncer::fetch_once).await;
+
+            // Every peer serves, so the first one asked is the one that
+            // succeeded, whichever the selection picked.
+            let requested = network_client.requested_peers.lock().clone();
+            assert_eq!(requested.len(), 1);
+            let latency = context
+                .peer_responsiveness
+                .effective_latency_ms(DataSource::FastCommitSyncer, requested[0])
+                .expect("a served fetch is recorded");
+            assert!(
+                latency < FAILURE_PENALTY_MS,
+                "a success must not be charged the failure penalty, got {latency}"
+            );
+        }
+
+        /// A failed attempt is charged the fixed base timeout rather than the
+        /// timeout that escalates across retry rounds, so a peer that recovers
+        /// is not held at an inflated latency.
+        #[tokio::test(start_paused = true)]
+        async fn records_fixed_penalty_for_the_failing_peer() {
+            let context = fast_sync_context(2);
+            let peer = AuthorityIndex::new_for_test(1);
+            // No canned response, so the only peer always fails and the loop
+            // retries forever.
+            let network_client = Arc::new(FakeNetworkClient::default());
+            let inner = make_inner(context.clone(), network_client);
+
+            let _ = tokio::time::timeout(
+                Duration::from_secs(5),
+                fetch_loop(inner, (1..=2).into(), 2, FastCommitSyncer::fetch_once),
+            )
+            .await;
+
+            assert_eq!(
+                context
+                    .peer_responsiveness
+                    .effective_latency_ms(DataSource::FastCommitSyncer, peer),
+                Some(FAILURE_PENALTY_MS)
+            );
+        }
+
+        /// The recorded latency is scaled by how much of the requested range
+        /// the peer actually delivered, so answering a wide request with a
+        /// short prefix does not rank as if the whole range had been served.
+        #[tokio::test(start_paused = true)]
+        async fn records_success_scaled_by_the_delivered_shortfall() {
+            let context = fast_sync_context(4);
+            let (commits, vote_headers, transactions) = two_commit_response(&context);
+            let network_client = Arc::new(FakeNetworkClient {
+                commits_and_transactions: Some((commits, vote_headers, transactions)),
+                response_delay: Duration::from_millis(200),
+                ..Default::default()
+            });
+            let inner = make_inner(context.clone(), network_client.clone());
+
+            fetch_loop(inner, (1..=10).into(), 10, FastCommitSyncer::fetch_once).await;
+
+            // Ten commits asked for and two delivered, so the 200ms answer is
+            // recorded as the 1s it would have taken at that rate.
+            let requested = network_client.requested_peers.lock().clone();
+            assert_eq!(
+                context
+                    .peer_responsiveness
+                    .effective_latency_ms(DataSource::FastCommitSyncer, requested[0]),
+                Some(1_000.0)
+            );
+        }
+
+        /// The ranked order is what runs in production, so pin that the loop
+        /// reaches it: a peer the tracker has never seen fail leads the rounds,
+        /// which the plain committee order would never produce.
+        #[tokio::test(start_paused = true)]
+        async fn ranking_on_leads_with_the_best_ranked_peer() {
+            let mut context = fast_sync_context(4);
+            Arc::get_mut(&mut context)
+                .unwrap()
+                .parameters
+                .enable_peer_responsiveness_ranking = true;
+            // Recorded at far more than a failure inside the loop costs, so
+            // peer 3 stays ahead of both: healthy in the first round, and the
+            // quickest of the failed ones from then on.
+            for peer in [1, 2] {
+                context.peer_responsiveness.record_failure_with_timeout(
+                    DataSource::FastCommitSyncer,
+                    AuthorityIndex::new_for_test(peer),
+                    Duration::from_secs(300),
+                );
+            }
+            let network_client = Arc::new(FakeNetworkClient::default());
+            let inner = make_inner(context.clone(), network_client.clone());
+
+            let _ = tokio::time::timeout(
+                Duration::from_secs(30),
+                fetch_loop(inner, (1..=2).into(), 2, FastCommitSyncer::fetch_once),
+            )
+            .await;
+
+            // No peer can serve, so every round asks all three and the rounds
+            // are consecutive chunks of the request log.
+            let asked = network_client.requested_peers.lock().clone();
+            let rounds: Vec<_> = asked.chunks(3).filter(|round| round.len() == 3).collect();
+            assert!(rounds.len() > 10, "expected several rounds, got {rounds:?}");
+            let led = rounds
+                .iter()
+                .filter(|round| round[0] == AuthorityIndex::new_for_test(3))
+                .count();
+            assert!(
+                led * 2 > rounds.len(),
+                "the best-ranked peer led {led} of {} rounds",
+                rounds.len()
+            );
+        }
+
+        /// With ranking disabled the loop keeps the previous behaviour: peers
+        /// are tried in committee order under test, where the shuffle is
+        /// compiled out.
+        #[tokio::test(start_paused = true)]
+        async fn ranking_off_preserves_committee_order() {
+            let mut context = fast_sync_context(4);
+            let parameters = &mut Arc::get_mut(&mut context).unwrap().parameters;
+            parameters.enable_peer_responsiveness_ranking = false;
+            // Isolate the ordering under test from the commit-vote grouping.
+            parameters.enable_commit_sync_peer_selection_by_commit_votes = false;
+            let network_client = Arc::new(FakeNetworkClient::default());
+            let inner = make_inner(context.clone(), network_client.clone());
+
+            let _ = tokio::time::timeout(
+                Duration::from_secs(1),
+                fetch_loop(inner, (1..=2).into(), 2, FastCommitSyncer::fetch_once),
+            )
+            .await;
+
+            let requested = network_client.requested_peers.lock().clone();
+            let expected: Vec<_> = (1..4).map(AuthorityIndex::new_for_test).collect();
+            assert_eq!(&requested[..expected.len()], &expected[..]);
         }
     }
 
@@ -1628,6 +1872,7 @@ mod tests {
                 // headers.
                 enable_commit_sync_peer_selection_by_commit_votes: false,
                 sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+                enable_peer_responsiveness_ranking: false,
                 ..Default::default()
             };
             let (authority, receiver, monitor) = make_authority_with_params(
@@ -1705,6 +1950,7 @@ mod tests {
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             enable_fast_commit_syncer: true,
             enable_commit_sync_peer_selection_by_commit_votes: false,
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(
@@ -1767,6 +2013,7 @@ mod tests {
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             enable_fast_commit_syncer: true,
             enable_commit_sync_peer_selection_by_commit_votes: false,
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(
@@ -1964,6 +2211,7 @@ mod tests {
                 fast_commit_sync_batch_size: COMMIT_SYNC_BATCH_SIZE,
                 enable_fast_commit_syncer: index.value() != test_validator_index,
                 sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+                enable_peer_responsiveness_ranking: false,
                 ..Default::default()
             };
             let (authority, receiver, monitor) = make_authority_with_params(
@@ -2148,6 +2396,7 @@ mod tests {
             fast_commit_sync_batch_size: COMMIT_SYNC_BATCH_SIZE,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             enable_fast_commit_syncer: true,
+            enable_peer_responsiveness_ranking: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -42,9 +42,14 @@ use bytes::Bytes;
 use itertools::Itertools;
 use parking_lot::RwLock;
 #[cfg(not(test))]
-use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
+use rand::prelude::SliceRandom as _;
+use rand::{SeedableRng as _, rngs::StdRng, thread_rng};
 use starfish_config::AuthorityIndex;
-use tokio::{sync::oneshot, task::JoinHandle, time::sleep};
+use tokio::{
+    sync::oneshot,
+    task::JoinHandle,
+    time::{Instant, sleep},
+};
 use tracing::{info, warn};
 
 use crate::{
@@ -54,11 +59,14 @@ use crate::{
         VerifiedTransactions,
     },
     block_verifier::{BlockVerifier, serialized_transactions_size_limit},
-    commit::{Commit, CommitAPI as _, CommitDigest, CommitRange, CommitRef, TrustedCommit},
+    commit::{
+        CertifiedCommits, Commit, CommitAPI as _, CommitDigest, CommitRange, CommitRef,
+        TrustedCommit,
+    },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::DagState,
+    dag_state::{DagState, DataSource},
     encoder::create_encoder,
     error::{ConsensusError, ConsensusResult},
     header_synchronizer::HeaderSynchronizerHandle,
@@ -104,6 +112,20 @@ impl CommitSyncType {
         match self {
             CommitSyncType::Fast => "fast_commit_sync",
             CommitSyncType::Regular => "commit_sync",
+        }
+    }
+
+    /// Fetch source under which peer responsiveness is tracked. The two sync
+    /// types are tracked separately because they call different endpoints: fast
+    /// sync asks one request for the commits and their transactions and keeps
+    /// only the prefix the peer covered, while regular sync fetches headers and
+    /// transactions in requests of their own and tolerates a peer that returns
+    /// no transactions. A peer that consistently fails one may serve the other
+    /// well.
+    pub(crate) fn data_source(&self) -> DataSource {
+        match self {
+            CommitSyncType::Fast => DataSource::FastCommitSyncer,
+            CommitSyncType::Regular => DataSource::CommitSyncer,
         }
     }
 
@@ -468,6 +490,28 @@ pub(crate) fn verify_transactions_with_transactions_refs(
     Ok(verified_transactions_map)
 }
 
+/// How much of a requested commit range a fetch response actually delivered.
+/// Implemented by both syncers' payload types so [`fetch_loop`] can scale the
+/// latency it feeds to [`crate::peer_responsiveness::PeerResponsiveness`].
+pub(crate) trait FetchedCommits {
+    fn delivered_commits(&self) -> usize;
+}
+
+impl FetchedCommits for CertifiedCommits {
+    fn delivered_commits(&self) -> usize {
+        self.commits().len()
+    }
+}
+
+/// Factor by which a peer's measured latency is inflated when it delivered less
+/// than the full requested range. A peer that answers a large request with a
+/// short prefix is as costly as a slow one, because the remainder has to be
+/// fetched again, so it must not rank as fast. Never below 1.0: fast sync may
+/// legitimately return more commits than requested.
+pub(crate) fn shortfall_factor(requested: usize, delivered: usize) -> f64 {
+    (requested as f64 / delivered.max(1) as f64).max(1.0)
+}
+
 /// Generic fetch loop that retries fetching data from available authorities
 /// until a request succeeds. This is shared between RegularCommitSyncer and
 /// FastCommitSyncer.
@@ -497,7 +541,7 @@ pub(crate) async fn fetch_loop<C, T, F, Fut>(
 ) -> (CommitIndex, T)
 where
     C: NetworkClient,
-    T: Send,
+    T: Send + FetchedCommits,
     F: Fn(Arc<Inner<C>>, AuthorityIndex, CommitRange, Duration) -> Fut,
     Fut: std::future::Future<Output = ConsensusResult<T>> + Send,
 {
@@ -514,6 +558,15 @@ where
     // system can adjust to slow network or large data sizes quickly.
     const MAX_NUM_TARGETS: usize = 24;
     let mut timeout_multiplier = 0;
+
+    // A failed attempt is reported at this fixed scale rather than at the
+    // escalating `fetch_timeout` below. The tracker keeps the worst latency it
+    // has seen for a peer and only decays it on success, so feeding the
+    // escalated value would leave a peer looking slow for many rounds after it
+    // recovered.
+    let failure_penalty = TIMEOUT * fetch_timeout_multiplier;
+    let data_source = inner.sync_type.data_source();
+    let mut rng = StdRng::from_rng(thread_rng()).expect("thread_rng should be available");
 
     let _timer = inner
         .context
@@ -540,19 +593,36 @@ where
                 }
             })
             .collect_vec();
-        #[cfg(not(test))]
-        target_authorities.shuffle(&mut ThreadRng::default());
+        // Ranking runs before the truncation, so the peers actually tried are
+        // the best-ranked ones rather than a random subset of a committee
+        // larger than MAX_NUM_TARGETS. This changes which peers are reached in
+        // a round: a peer whose last attempt failed is ordered last and can
+        // fall outside the cut. That is safe here because a single peer serving
+        // the range is enough, one success clears the failed state, and the
+        // exploration fraction keeps drawing every peer - though on a committee
+        // much larger than MAX_NUM_TARGETS a given peer comes back slowly.
+        if inner.context.parameters.enable_peer_responsiveness_ranking {
+            inner.context.peer_responsiveness.prioritize(
+                data_source,
+                &mut target_authorities,
+                &mut rng,
+            );
+        } else {
+            #[cfg(not(test))]
+            target_authorities.shuffle(&mut rng);
+        }
         // A peer that has voted for the end of the range has solidified every
         // commit in it, so it is the one worth asking. A peer that has not may
         // still serve the range: votes are only seen from blocks we received,
         // and serving additionally needs the certifying headers in the peer's
-        // storage. So it is ordered behind, keeping the shuffled order within
-        // each group. Since the truncation below runs after this, a committee
-        // with more voters than MAX_NUM_TARGETS fills every round with voters,
-        // and a peer whose headers do not reach us is not asked until they do.
-        // Accepted: rounds retry forever over the up-to-24 peers that
-        // provably solidified the range, and any header from a behind-listed
-        // peer carrying a recent commit vote promotes it immediately.
+        // storage. So it is ordered behind, keeping the order chosen above
+        // within each group. Since the truncation below runs after this, a
+        // committee with more voters than MAX_NUM_TARGETS fills every round
+        // with voters, and a peer whose headers do not reach us is not asked
+        // until they do. Accepted: rounds retry forever over the up-to-24 peers
+        // that provably solidified the range, and any header from a
+        // behind-listed peer carrying a recent commit vote promotes it
+        // immediately.
         if inner
             .context
             .parameters
@@ -574,6 +644,9 @@ where
         let fetch_timeout = request_timeout * fetch_timeout_multiplier;
         // Try fetching from the selected target authority.
         for authority in target_authorities {
+            // Spans fetch and verification, so the cost of checking what a peer
+            // sent counts against it rather than only its time on the wire.
+            let started = Instant::now();
             match tokio::time::timeout(
                 fetch_timeout,
                 fetch_once_fn(
@@ -586,6 +659,14 @@ where
             .await
             {
                 Ok(Ok(data)) => {
+                    inner.context.peer_responsiveness.record_success(
+                        data_source,
+                        authority,
+                        started.elapsed().mul_f64(shortfall_factor(
+                            commit_range.size(),
+                            data.delivered_commits(),
+                        )),
+                    );
                     info!(
                         "[{}] Finished fetching commits in {commit_range:?}",
                         inner.sync_type.as_str()
@@ -593,6 +674,10 @@ where
                     return (commit_range.end(), data);
                 }
                 Ok(Err(e)) => {
+                    inner
+                        .context
+                        .peer_responsiveness
+                        .record_failure_with_timeout(data_source, authority, failure_penalty);
                     let hostname = inner
                         .context
                         .committee
@@ -614,6 +699,10 @@ where
                         .inc();
                 }
                 Err(_) => {
+                    inner
+                        .context
+                        .peer_responsiveness
+                        .record_failure_with_timeout(data_source, authority, failure_penalty);
                     let hostname = inner
                         .context
                         .committee
@@ -851,6 +940,9 @@ pub(crate) mod tests {
     #[derive(Default)]
     pub(crate) struct FakeNetworkClient {
         pub(crate) commits_and_transactions: Option<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)>,
+        /// Waited out before answering, so a test can pin the latency the fetch
+        /// loop records.
+        pub(crate) response_delay: Duration,
         /// Every peer asked for commits, in the order it was asked.
         pub(crate) requested_peers: parking_lot::Mutex<Vec<AuthorityIndex>>,
     }
@@ -901,6 +993,7 @@ pub(crate) mod tests {
             _timeout: Duration,
         ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
             self.requested_peers.lock().push(peer);
+            sleep(self.response_delay).await;
             match &self.commits_and_transactions {
                 Some(response) => Ok(response.clone()),
                 None => Err(ConsensusError::NoCommitReceived { peer }),
@@ -1132,5 +1225,16 @@ pub(crate) mod tests {
                 limit: error_limit,
             }) if error_peer == peer && count == limit + 1 && error_limit == limit
         ));
+    }
+
+    #[test]
+    fn shortfall_factor_penalizes_short_responses() {
+        assert_eq!(shortfall_factor(10, 10), 1.0);
+        assert_eq!(shortfall_factor(10, 2), 5.0);
+        // Fast sync may return more commits than requested.
+        assert_eq!(shortfall_factor(10, 20), 1.0);
+        // Never divides by zero, even though the fetch paths reject empty
+        // responses before reaching this point.
+        assert_eq!(shortfall_factor(10, 0), 10.0);
     }
 }

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -8,8 +8,11 @@
 //! from. On a node with slow or asymmetric inbound links a uniform choice
 //! regularly draws slow-but-not-failing peers, adding avoidable latency to
 //! payload and commit retrieval. Each fetch source in
-//! [`DataSource::RESPONSIVENESS_SOURCES`] is tracked separately, so a peer that
-//! serves one kind of fetch well is not credited for another.
+//! [`DataSource::RESPONSIVENESS_SOURCES`] is tracked separately, so a peer's
+//! record on one kind of fetch does not decide its rank on another. Until a
+//! source has a sample of its own for a peer, it places that peer by what the
+//! nearest source in [`DataSource::responsiveness_fallbacks`] that has measured
+//! it saw.
 //!
 //! [`PeerResponsiveness`] tracks a per-peer smoothed "effective latency" fed by
 //! those existing latency/outcome signals, and exposes
@@ -50,6 +53,42 @@ impl DataSource {
         DataSource::CommitSyncer,
         DataSource::FastCommitSyncer,
     ];
+
+    /// Sources whose measurements order the peers this source has no sample
+    /// for yet, tried in this order until one of them has measured the peer.
+    ///
+    /// The other commit syncer comes first: it fetches the same commits and
+    /// headers over the same links, so what it measured is already on this
+    /// source's scale, and at the handoff between the two flavors it has just
+    /// measured the very peers this one is about to choose between. The
+    /// transactions synchronizer comes last because it fetches continuously and
+    /// so has a reading even when both commit-sync tracks are empty - the state
+    /// of a node that is only starting to recover - but it measures much
+    /// lighter fetches, making it the coarser of the two.
+    fn responsiveness_fallbacks(self) -> &'static [DataSource] {
+        match self {
+            DataSource::CommitSyncer => &[
+                DataSource::FastCommitSyncer,
+                DataSource::TransactionSynchronizer,
+            ],
+            DataSource::FastCommitSyncer => &[
+                DataSource::CommitSyncer,
+                DataSource::TransactionSynchronizer,
+            ],
+            _ => &[],
+        }
+    }
+
+    /// Latency assumed for a peer that neither this source nor any of its
+    /// fallbacks has measured, on the scale of this source's own fetches so
+    /// that an untried peer is not placed ahead of the peers it has measured.
+    fn neutral_latency_ms(self) -> f64 {
+        match self {
+            DataSource::CommitSyncer => COMMIT_SYNC_NEUTRAL_LATENCY_MS,
+            DataSource::FastCommitSyncer => FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS,
+            _ => TRANSACTIONS_SYNC_NEUTRAL_LATENCY_MS,
+        }
+    }
 }
 
 /// Probability that a `prioritize` call ignores ranking and returns a uniform
@@ -72,10 +111,24 @@ const SELECTION_WINDOW: usize = 5;
 /// sample produce an unbounded weight.
 const MIN_LATENCY_MS: f64 = 1.0;
 
-/// Effective latency (ms) assigned to a peer with no samples yet. Sits between
-/// proven-fast and proven-slow so untried peers are explored ahead of
-/// known-slow peers but do not outrank peers with a proven-fast track record.
-const NEUTRAL_LATENCY_MS: f64 = 250.0;
+/// Effective latency (ms) assigned to a peer nothing is known about yet: no
+/// sample for the source being ranked, and none for any of its fallbacks
+/// either. Each source has its own, on the scale its fetches measure, so that
+/// an untried peer is placed among the peers that source has measured rather
+/// than ahead of or behind all of them.
+///
+/// This one is the transactions synchronizer's, whose fetches are small and
+/// frequent.
+const TRANSACTIONS_SYNC_NEUTRAL_LATENCY_MS: f64 = 250.0;
+
+/// Neutral prior for regular commit sync, which fetches the commits, their
+/// headers and their transactions in requests of their own. Taken from what
+/// these fetches measure on testnet and mainnet.
+const COMMIT_SYNC_NEUTRAL_LATENCY_MS: f64 = 4_000.0;
+
+/// Neutral prior for fast commit sync, which serves a range in one request
+/// and so measures quicker than regular sync on the same networks.
+const FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS: f64 = 2_000.0;
 
 /// EWMA weight for a successful sample. Small, so the score is "slow to
 /// trust".
@@ -138,8 +191,8 @@ impl PeerResponsiveness {
     }
 
     /// Records a failed or timed-out fetch from `peer` for `source`, demoting
-    /// it to at least the operation's timeout. Floored at the neutral prior so
-    /// a failure never ranks better than an untried peer. Until its next
+    /// it to at least the operation's timeout, and never below the neutral
+    /// prior so a failure is never recorded as a fast sample. Until its next
     /// success the peer is also ordered behind every non-failed candidate
     /// (see [`Self::prioritize`]).
     pub(crate) fn record_failure_with_timeout(
@@ -148,7 +201,7 @@ impl PeerResponsiveness {
         peer: AuthorityIndex,
         timeout: Duration,
     ) {
-        let sample = (timeout.as_secs_f64() * 1_000.0).max(NEUTRAL_LATENCY_MS);
+        let sample = (timeout.as_secs_f64() * 1_000.0).max(source.neutral_latency_ms());
         self.update_failure(source, peer, sample);
     }
 
@@ -207,6 +260,17 @@ impl PeerResponsiveness {
     /// until its next success. A fraction of calls (see
     /// [`EXPLORE_PROBABILITY`]) ignore ranking and return a uniform shuffle.
     /// `rng` is consumed fresh on every call.
+    ///
+    /// A candidate with no sample for `source` is placed by its latency from
+    /// the nearest source in [`DataSource::responsiveness_fallbacks`] that has
+    /// measured it, and by [`DataSource::neutral_latency_ms`] only when none of
+    /// them has. A fallback that measures lighter fetches than `source` can put
+    /// an untried peer ahead of one this source has already measured; that is
+    /// the intended trade, since it is the reachable-and-quick signal available
+    /// before this source has any sample of its own. Only the latency is taken
+    /// from a fallback, never the failure state, so a peer that failed on
+    /// another source ranks as healthy here - carrying the timeout-scale
+    /// latency that failure left behind.
     pub(crate) fn prioritize<R: Rng>(
         &self,
         source: DataSource,
@@ -225,28 +289,51 @@ impl PeerResponsiveness {
             return;
         }
 
-        // Snapshot each candidate's effective latency and failure state under
-        // the lock, then release it before ordering (parking_lot::Mutex must not
-        // be held across the work). Untried peers use the neutral prior; every
-        // sample is floored so it stays strictly positive.
-        let stats: Vec<(f64, bool)> = {
+        // Snapshot each candidate's own sample, the first fallback sample that
+        // exists for it and its failure state under the lock, then release it
+        // before ordering (parking_lot::Mutex must not be held across the work).
+        let samples: Vec<(Option<f64>, Option<f64>, bool)> = {
             let tracks = self.inner.lock();
             let Some(track) = tracks.per_kind.get(&source) else {
                 return;
             };
+            let fallback_tracks: Vec<_> = source
+                .responsiveness_fallbacks()
+                .iter()
+                .filter_map(|fallback| tracks.per_kind.get(fallback))
+                .collect();
             candidates
                 .iter()
                 .map(|peer| {
                     let stat = track.get(peer.value());
-                    let latency = stat
-                        .and_then(|stat| stat.effective_latency_ms)
-                        .unwrap_or(NEUTRAL_LATENCY_MS)
-                        .max(MIN_LATENCY_MS);
-                    let last_fetch_failed = stat.is_some_and(|stat| stat.last_fetch_failed);
-                    (latency, last_fetch_failed)
+                    let fallback_latency = fallback_tracks.iter().find_map(|track| {
+                        track
+                            .get(peer.value())
+                            .and_then(|stat| stat.effective_latency_ms)
+                    });
+                    (
+                        stat.and_then(|stat| stat.effective_latency_ms),
+                        fallback_latency,
+                        stat.is_some_and(|stat| stat.last_fetch_failed),
+                    )
                 })
                 .collect()
         };
+
+        // A peer with no sample for this source is placed by what the closest
+        // fallback that has measured it saw, and only by the neutral prior when
+        // none of them has. Every sample is floored so it stays strictly
+        // positive.
+        let neutral = source.neutral_latency_ms();
+        let stats: Vec<(f64, bool)> = samples
+            .iter()
+            .map(|(own, fallback, last_fetch_failed)| {
+                (
+                    own.or(*fallback).unwrap_or(neutral).max(MIN_LATENCY_MS),
+                    *last_fetch_failed,
+                )
+            })
+            .collect();
 
         // Healthy peers are sorted by latency (ties broken by a random key so
         // an all-equal set, e.g. cold start, is ordered uniformly). The window
@@ -592,6 +679,109 @@ mod tests {
         }
     }
 
+    /// A commit-sync track with no samples yet still orders peers, using what
+    /// the transactions synchronizer has measured about the same peers.
+    #[test]
+    fn commit_sync_cold_start_follows_transaction_synchronizer_order() {
+        let pr = responsiveness(5);
+        for (peer, latency) in [(1, 400), (2, 300), (3, 200), (4, 100)] {
+            pr.record_success(DataSource::TransactionSynchronizer, idx(peer), ms(latency));
+        }
+
+        let candidates = vec![idx(1), idx(2), idx(3), idx(4)];
+        let counts = lead_counts(&pr, DataSource::CommitSyncer, &candidates, 10_000, 7);
+
+        // Without the fallback all four would tie on the neutral prior and lead
+        // equally often. Instead they lead in transactions-synchronizer order.
+        let lead = |peer| *counts.get(&idx(peer)).unwrap_or(&0);
+        assert!(
+            lead(4) > lead(3) && lead(3) > lead(2) && lead(2) > lead(1),
+            "lead counts should follow the fallback order, got {counts:?}"
+        );
+        // The fallback latencies are close together, so the weights are too:
+        // the fastest peer leads more than the uniform 25% but not always.
+        let fastest = lead(4) as f64 / 10_000.0;
+        assert!(
+            (0.30..0.55).contains(&fastest),
+            "fastest peer elsewhere should lead more than uniformly, got {fastest}"
+        );
+    }
+
+    /// The fallbacks are consulted in order, so a peer the other commit syncer
+    /// measured is placed by that measurement even when the transactions
+    /// synchronizer has a much quicker one for it.
+    #[test]
+    fn commit_sync_reads_the_other_commit_syncer_before_transactions() {
+        for (source, other) in [
+            (DataSource::CommitSyncer, DataSource::FastCommitSyncer),
+            (DataSource::FastCommitSyncer, DataSource::CommitSyncer),
+        ] {
+            let pr = responsiveness(4);
+            // Peer 1 is slow on the other commit syncer but quick on
+            // transaction fetches; peer 2 is only known to the latter.
+            pr.record_success(other, idx(1), ms(5_000));
+            pr.record_success(DataSource::TransactionSynchronizer, idx(1), ms(10));
+            pr.record_success(DataSource::TransactionSynchronizer, idx(2), ms(10));
+
+            let counts = lead_counts(&pr, source, &[idx(1), idx(2)], 10_000, 5);
+
+            // Reading the transactions synchronizer first would place both
+            // peers at 10ms and split the lead evenly between them.
+            let leads = *counts.get(&idx(2)).unwrap_or(&0) as f64 / 10_000.0;
+            assert!(
+                leads > 0.9,
+                "{source:?} should rank by what {other:?} measured, got {counts:?}"
+            );
+        }
+    }
+
+    /// Fallback latencies that are all the same say nothing about which peer is
+    /// quicker, so the order must stay uniform rather than following the peers'
+    /// place in the candidate list.
+    #[test]
+    fn equal_fallback_latencies_keep_a_uniform_order() {
+        let pr = responsiveness(5);
+        for peer in [1, 2, 3, 4] {
+            pr.record_success(DataSource::TransactionSynchronizer, idx(peer), ms(7));
+        }
+
+        let candidates = vec![idx(1), idx(2), idx(3), idx(4)];
+        let counts = lead_counts(&pr, DataSource::CommitSyncer, &candidates, 10_000, 7);
+
+        for peer in [1u8, 2, 3, 4] {
+            let fraction = *counts.get(&idx(peer)).unwrap_or(&0) as f64 / 10_000.0;
+            assert!(
+                (fraction - 0.25).abs() < 0.05,
+                "peer {peer} fraction {fraction}"
+            );
+        }
+    }
+
+    /// A peer with no sample for this source is placed by its fallback latency,
+    /// and only by the neutral prior when the fallback has not measured it
+    /// either. The fallback covers lighter fetches, so an untried peer it saw
+    /// as quick can lead a peer this source measured as slow.
+    #[test]
+    fn untried_peers_are_placed_by_their_fallback_latency() {
+        let pr = responsiveness(6);
+        // Peer 1 has a commit-sync sample of its own, peers 2 and 3 only a
+        // transactions-synchronizer one, and peer 4 none at all.
+        pr.record_success(DataSource::CommitSyncer, idx(1), ms(100));
+        pr.record_success(DataSource::TransactionSynchronizer, idx(2), ms(20));
+        pr.record_success(DataSource::TransactionSynchronizer, idx(3), ms(200));
+
+        let candidates = vec![idx(1), idx(2), idx(3), idx(4)];
+        let counts = lead_counts(&pr, DataSource::CommitSyncer, &candidates, 10_000, 11);
+
+        // Placed at 20ms, 100ms, 200ms and the commit-sync prior of 4000ms, so
+        // the peer neither source has seen trails all three.
+        let lead = |peer| *counts.get(&idx(peer)).unwrap_or(&0);
+        assert!(
+            lead(2) > lead(1) && lead(1) > lead(3) && lead(3) > lead(4),
+            "peers should lead in placed-latency order, got {counts:?}"
+        );
+    }
+
     #[test]
     fn transactions_prefer_low_latency_peers_over_a_large_slow_tail() {
         let pr = responsiveness(50);
@@ -778,7 +968,10 @@ mod tests {
             .effective_latency_ms(DataSource::TransactionSynchronizer, idx(1))
             .unwrap();
         assert!(recovered < penalized);
-        assert!(recovered < NEUTRAL_LATENCY_MS, "recovered to {recovered}");
+        assert!(
+            recovered < TRANSACTIONS_SYNC_NEUTRAL_LATENCY_MS,
+            "recovered to {recovered}"
+        );
     }
 
     #[test]

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -1,13 +1,15 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Per-peer responsiveness tracking and ranking for transaction-synchronizer
-//! peer selection.
+//! Per-peer responsiveness tracking and ranking for synchronizer peer
+//! selection.
 //!
-//! The transactions synchronizer picks peers to fetch missing transactions
+//! The transactions synchronizer and the commit syncer pick peers to fetch
 //! from. On a node with slow or asymmetric inbound links a uniform choice
 //! regularly draws slow-but-not-failing peers, adding avoidable latency to
-//! payload retrieval.
+//! payload and commit retrieval. Each fetch source in
+//! [`DataSource::RESPONSIVENESS_SOURCES`] is tracked separately, so a peer that
+//! serves one kind of fetch well is not credited for another.
 //!
 //! [`PeerResponsiveness`] tracks a per-peer smoothed "effective latency" fed by
 //! those existing latency/outcome signals, and exposes
@@ -41,10 +43,13 @@ use starfish_config::{AuthorityIndex, Committee};
 use crate::{dag_state::DataSource, metrics::Metrics};
 
 impl DataSource {
-    /// Fetch sources ranked by peer responsiveness. Only the transactions
-    /// synchronizer selects peers this way; other sources are not ranked.
-    pub(crate) const RESPONSIVENESS_SOURCES: [DataSource; 1] =
-        [DataSource::TransactionSynchronizer];
+    /// Fetch sources ranked by peer responsiveness. Sources not listed here are
+    /// not ranked, and every [`PeerResponsiveness`] call for them is a no-op.
+    pub(crate) const RESPONSIVENESS_SOURCES: [DataSource; 3] = [
+        DataSource::TransactionSynchronizer,
+        DataSource::CommitSyncer,
+        DataSource::FastCommitSyncer,
+    ];
 }
 
 /// Probability that a `prioritize` call ignores ranking and returns a uniform


### PR DESCRIPTION
# Description of change

The commit syncer picked fetch peers by uniform shuffle over the whole committee and kept no memory of past outcomes, so a recovering node repeatedly paid a full fetch timeout on dead or slow peers before reaching a responsive one. Reinitialization header fetches were worse: the peer order was picked once and reused for every chunk, so one dead peer cost 30s per chunk.

Feed the commit syncer's latency and outcome signals into the existing `PeerResponsiveness` tracker and order candidates by it, in both the shared `fetch_loop` and the reinitialization header fetch, which is now reordered per chunk so a peer that stalls on one chunk is demoted for the rest.

- Regular and fast sync are tracked as separate sources: they call different endpoints with different server-side preconditions, so a peer that fails one may serve the other well.
- Ranking runs before the truncation to `MAX_NUM_TARGETS`, so the peers tried are the best-ranked rather than a random subset of a larger committee. Unlike the transactions synchronizer this can leave a failed peer out of a round — safe because one serving peer is enough, exploration re-admits any peer, and a success clears the failed state.
- Success latency is scaled by the delivered-commit shortfall, so a peer answering a large request with a short prefix cannot rank as fast.
- Failures are charged a fixed base timeout rather than the escalating fetch timeout, which would otherwise hold a recovered peer at an inflated latency for many rounds.
- Recording is unconditional; `enable_peer_responsiveness_ranking` gates only the ordering.

**Second commit — seed a cold track from the other fetch sources (#12487).** A peer with no sample for the requested source falls back to the neutral prior, so a source that has measured nothing yet ties every candidate and orders them at random — the state of the commit-sync tracks at the start of a recovery, while the other sources have been measuring the same peers all along. Place such a peer at the latency the nearest source that has measured it saw, trying the other commit syncer first and the transactions synchronizer last: the other flavor fetches the same commits and headers over the same links, so its numbers are already on the right scale and are freshest exactly at the handoff between the two, while the transactions synchronizer is the coarser reading that is always populated because it fetches continuously.

Each source also gets its own neutral prior, for peers none of the sources has measured — 250ms for the transactions synchronizer, 4s and 2s for regular and fast commit sync, the values their fetches measure on testnet and mainnet. One shared prior on the transaction-fetch scale would place every untried peer ahead of every measured one on the commit-sync tracks, and raising it for all sources would retune the transactions synchronizer's ranking as a side effect. The remaining trade is explicit: a coarser fallback can put an untried peer ahead of one this source has measured, which is the order wanted while a track is cold, since reachable-and-quick elsewhere is the only evidence available before the source has a sample of its own. Encoding a fallback as a latency rather than a sort key is deliberate — peers that tie on latency also tie on the `1/latency` weight, so a secondary sort key would not survive the weighted draw.

Worth noting for review:

- Several concurrent `fetch_loop` tasks rank against the same tracker and commit to their order before any records an outcome, so a dead top-ranked peer is paid for in parallel once. Self-correcting from the next round: the draw is weight-proportional, not argmax, and queuing delay raises a hot peer's own score.
- `fetch_loop` is sequential and returns on first success, so each round measures the winner plus the peers that failed before it. Selection is therefore stickier than the transactions synchronizer's, with exploration as the counterweight.
- Multi-authority tests set `enable_peer_responsiveness_ranking: false` so peer order stays deterministic, following the convention in `Context::new_for_test`.

With the flag off, behaviour is the previous one: a uniform shuffle in `fetch_loop`, and a single shuffle reused across chunks in the reinitialization fetch. Recording still happens either way — it has no effect on selection, and it makes the `peer_responsiveness_expected_latency_ms` gauge usable for judging the ranking before enabling it.

> #12484 (prefer peers that have the requested range) was split out into #12486 and has merged; this branch is rebased on it, so the ranking and the commit-vote partition now sit in one selection block in `fetch_loop`.

## Links to any relevant issues

Fixes #12487
Part of #12113
Part of #12030

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes


