### PR TITLE
feat(starfish): prefer commit-sync peers that have the requested range

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -145,6 +145,16 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_enable_fast_commit_syncer")]
     pub enable_fast_commit_syncer: bool,
 
+    /// Ask commit-sync peers that have voted for the end of the requested
+    /// range before those that have not, since a vote means the peer has
+    /// solidified every commit in the range. Peers without an observed vote
+    /// are ordered behind; each fetch round tries a bounded number of peers,
+    /// so on a committee larger than that bound they can stay outside the
+    /// round until their votes are observed. Enabled by default; disabling it
+    /// restores a plain uniform order.
+    #[serde(default = "Parameters::default_enable_commit_sync_peer_selection_by_commit_votes")]
+    pub enable_commit_sync_peer_selection_by_commit_votes: bool,
+
     /// Enable adaptive acknowledgment filtering for StarfishSpeed.
     /// Local heuristic that drops acks for authorities persistently blamed
     /// by recent strong-vote masks. Effective only when the protocol-level
@@ -429,6 +439,11 @@ impl Parameters {
         true
     }
 
+    pub(crate) fn default_enable_commit_sync_peer_selection_by_commit_votes() -> bool {
+        // Enabled by default. Ordering only, so it cannot diverge consensus.
+        true
+    }
+
     pub(crate) fn default_enable_starfish_speed_adaptive_acknowledgments() -> bool {
         true
     }
@@ -468,6 +483,8 @@ impl Default for Parameters {
             fast_commit_sync_batch_size: Parameters::default_fast_commit_sync_batch_size(),
             commit_sync_gap_threshold: Parameters::default_commit_sync_gap_threshold(),
             enable_fast_commit_syncer: Parameters::default_enable_fast_commit_syncer(),
+            enable_commit_sync_peer_selection_by_commit_votes:
+                Parameters::default_enable_commit_sync_peer_selection_by_commit_votes(),
             enable_starfish_speed_adaptive_acknowledgments:
                 Parameters::default_enable_starfish_speed_adaptive_acknowledgments(),
             enable_peer_responsiveness_ranking:

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -49,6 +49,7 @@ tonic:
 fast_commit_sync_batch_size: 1000
 commit_sync_gap_threshold: 1000
 enable_fast_commit_syncer: true
+enable_commit_sync_peer_selection_by_commit_votes: true
 enable_starfish_speed_adaptive_acknowledgments: true
 enable_peer_responsiveness_ranking: true
 dag_visualizer_port: ~

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1005,7 +1005,7 @@ mod tests {
             transactions_synchronizer::TransactionsSynchronizer,
         };
 
-        fn make_inner(
+        pub(crate) fn make_inner(
             context: Arc<Context>,
             network_client: Arc<FakeNetworkClient>,
         ) -> Arc<Inner<FakeNetworkClient>> {
@@ -1132,6 +1132,7 @@ mod tests {
                     vote_headers,
                     response_transactions,
                 )),
+                ..Default::default()
             });
             let inner = make_inner(context.clone(), network_client);
 
@@ -1160,6 +1161,88 @@ mod tests {
                     .with_label_values(&[CommitSyncType::Fast.as_str()])
                     .get(),
                 1
+            );
+        }
+    }
+
+    /// Covers the commit-vote ordering in the shared `fetch_loop`, driven
+    /// through the fast syncer because that is the flavour `FakeNetworkClient`
+    /// serves.
+    mod peer_selection_by_commit_votes {
+        use std::{sync::Arc, time::Duration};
+
+        use starfish_config::AuthorityIndex;
+
+        use super::fetch_once::make_inner;
+        use crate::{
+            block_header::{TestBlockHeader, VerifiedBlockHeader},
+            commit::{CommitDigest, CommitRef},
+            commit_syncer::{fast::FastCommitSyncer, fetch_loop, tests::FakeNetworkClient},
+            context::Context,
+        };
+
+        /// Drives one pass of `fetch_loop` over a committee where no peer can
+        /// serve, and reports the order peers were asked in.
+        async fn asked_peers(enabled: bool, voters: &[u8]) -> Vec<AuthorityIndex> {
+            let (mut context, _) = Context::new_for_test(4);
+            context
+                .protocol_config
+                .set_consensus_fast_commit_sync_for_testing(true);
+            context
+                .parameters
+                .enable_commit_sync_peer_selection_by_commit_votes = enabled;
+            let context = Arc::new(context);
+
+            // No canned response, so every fetch fails and the loop keeps
+            // trying peers, exposing the full selection order.
+            let network_client = Arc::new(FakeNetworkClient::default());
+            let inner = make_inner(context, network_client.clone());
+            for voter in voters {
+                inner
+                    .commit_vote_monitor
+                    .observe_block(&VerifiedBlockHeader::new_for_test(
+                        TestBlockHeader::new(3, *voter)
+                            .set_commit_votes(vec![CommitRef::new(2, CommitDigest::MIN)])
+                            .build(),
+                    ));
+            }
+
+            let _ = tokio::time::timeout(
+                Duration::from_secs(1),
+                fetch_loop(inner, (1..=2).into(), 2, FastCommitSyncer::fetch_once),
+            )
+            .await;
+
+            let asked = network_client.requested_peers.lock().clone();
+            asked.into_iter().take(3).collect()
+        }
+
+        /// A peer that voted for the end of the range leads, and the peers
+        /// without a vote still follow rather than being dropped.
+        #[tokio::test(start_paused = true)]
+        async fn voters_are_asked_first() {
+            let asked = asked_peers(true, &[3]).await;
+            assert_eq!(
+                asked,
+                vec![
+                    AuthorityIndex::new_for_test(3),
+                    AuthorityIndex::new_for_test(1),
+                    AuthorityIndex::new_for_test(2),
+                ]
+            );
+        }
+
+        /// With the flag off the votes are ignored, restoring the plain order.
+        #[tokio::test(start_paused = true)]
+        async fn disabled_ignores_commit_votes() {
+            let asked = asked_peers(false, &[3]).await;
+            assert_eq!(
+                asked,
+                vec![
+                    AuthorityIndex::new_for_test(1),
+                    AuthorityIndex::new_for_test(2),
+                    AuthorityIndex::new_for_test(3),
+                ]
             );
         }
     }
@@ -1519,6 +1602,11 @@ mod tests {
                 commit_sync_gap_threshold: COMMIT_GAP_THRESHOLD,
                 fast_commit_sync_batch_size: 20,
                 enable_fast_commit_syncer: true,
+                // The assertion below depends on B asking A first, so keep the
+                // peer order plain. Ordering peers by their commit votes is
+                // covered separately and is orthogonal to serving voting
+                // headers.
+                enable_commit_sync_peer_selection_by_commit_votes: false,
                 sync_last_known_own_block_timeout: Duration::from_millis(2_000),
                 ..Default::default()
             };
@@ -1596,6 +1684,7 @@ mod tests {
             fast_commit_sync_batch_size: 20,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             enable_fast_commit_syncer: true,
+            enable_commit_sync_peer_selection_by_commit_votes: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(
@@ -1657,6 +1746,7 @@ mod tests {
             fast_commit_sync_batch_size: 20,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             enable_fast_commit_syncer: true,
+            enable_commit_sync_peer_selection_by_commit_votes: false,
             ..Default::default()
         };
         let (authority, receiver, monitor) = make_authority_with_params(

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -542,6 +542,30 @@ where
             .collect_vec();
         #[cfg(not(test))]
         target_authorities.shuffle(&mut ThreadRng::default());
+        // A peer that has voted for the end of the range has solidified every
+        // commit in it, so it is the one worth asking. A peer that has not may
+        // still serve the range: votes are only seen from blocks we received,
+        // and serving additionally needs the certifying headers in the peer's
+        // storage. So it is ordered behind, keeping the shuffled order within
+        // each group. Since the truncation below runs after this, a committee
+        // with more voters than MAX_NUM_TARGETS fills every round with voters,
+        // and a peer whose headers do not reach us is not asked until they do.
+        // Accepted: rounds retry forever over the up-to-24 peers that
+        // provably solidified the range, and any header from a behind-listed
+        // peer carrying a recent commit vote promotes it immediately.
+        if inner
+            .context
+            .parameters
+            .enable_commit_sync_peer_selection_by_commit_votes
+        {
+            let (caught_up, behind): (Vec<_>, Vec<_>) =
+                target_authorities.into_iter().partition(|authority| {
+                    inner
+                        .commit_vote_monitor
+                        .has_voted_for_commit(*authority, commit_range.end())
+                });
+            target_authorities = caught_up.into_iter().chain(behind).collect();
+        }
         target_authorities.truncate(MAX_NUM_TARGETS);
         // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
         timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
@@ -822,11 +846,13 @@ pub(crate) mod tests {
     };
 
     /// Fake `NetworkClient` for commit syncer tests. Serves the canned
-    /// `fetch_commits_and_transactions` response when one is set; all other
-    /// endpoints are unimplemented.
+    /// `fetch_commits_and_transactions` response when one is set and fails the
+    /// fetch when none is; all other endpoints are unimplemented.
     #[derive(Default)]
     pub(crate) struct FakeNetworkClient {
         pub(crate) commits_and_transactions: Option<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)>,
+        /// Every peer asked for commits, in the order it was asked.
+        pub(crate) requested_peers: parking_lot::Mutex<Vec<AuthorityIndex>>,
     }
 
     #[async_trait::async_trait]
@@ -870,13 +896,14 @@ pub(crate) mod tests {
 
         async fn fetch_commits_and_transactions(
             &self,
-            _peer: AuthorityIndex,
+            peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
         ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+            self.requested_peers.lock().push(peer);
             match &self.commits_and_transactions {
                 Some(response) => Ok(response.clone()),
-                None => unimplemented!("Unimplemented"),
+                None => Err(ConsensusError::NoCommitReceived { peer }),
             }
         }
 

--- a/crates/starfish/core/src/commit_vote_monitor.rs
+++ b/crates/starfish/core/src/commit_vote_monitor.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use starfish_config::AuthorityIndex;
 
 use crate::{
     CommitIndex,
@@ -37,6 +38,25 @@ impl CommitVoteMonitor {
                 highest_voted_commits[block.author()] = vote.index;
             }
         }
+    }
+
+    /// Whether `authority` has voted for a commit at `index` or later, meaning
+    /// it has solidified every commit up to `index` and can be expected to
+    /// serve them.
+    ///
+    /// Votes are only observed from blocks this node has received, so a peer we
+    /// have not heard from recently reads as behind even when it is not: a
+    /// `true` is evidence the peer holds the commits, a `false` is only the
+    /// absence of it.
+    pub(crate) fn has_voted_for_commit(
+        &self,
+        authority: AuthorityIndex,
+        index: CommitIndex,
+    ) -> bool {
+        self.highest_voted_commits
+            .lock()
+            .get(authority.value())
+            .is_some_and(|highest| *highest >= index)
     }
 
     // Finds the highest commit index certified by a quorum.


### PR DESCRIPTION
# Description of change

The commit syncer draws its fetch candidates from the whole committee, with no signal about which peers actually hold the range. A peer asked for a range it does not have answers with an empty success, which costs a full request and one slot in the sequential per-round pass. On a network where only part of the committee is caught up, the wasted round trips scale with committee size over the number of caught-up peers.

`CommitVoteMonitor` already tracks the highest commit index voted by each authority, and `commit_syncer::Inner` already holds it — only the aggregate `quorum_commit_index()` was being read. This uses the per-authority value to ask peers that voted for the end of the range first, keeping the existing shuffled order within each group.

Peers without an observed vote are ordered behind. The signal is one-sided: entries only advance when this node observes a block from that author, and serving additionally needs the certifying headers in the peer's storage. One consequence to be aware of: each fetch round is truncated to `MAX_NUM_TARGETS` (24) **after** this ordering, so on a committee with more than 24 observed voters every round consists of voters, and a peer whose headers do not reach us is not asked until they do. Accepted because rounds retry forever over up to 24 peers that provably solidified the range, and any header from such a peer carrying a recent commit vote promotes it immediately; committees of 25 or fewer are unaffected.

Gated by the node-local `enable_commit_sync_peer_selection_by_commit_votes`, default on. It only reorders candidates, so it cannot diverge consensus; with the flag off the selection is exactly what it is today.

`test_fast_sync_voting_blocks_served_to_peer` asserts that B fetches from A specifically, which depends on the peer order, so it sets the flag off — the property it covers (voting headers are served from A's storage) is orthogonal to how peers are ordered. Verified 10/10 runs with the change, matching `develop`.

## Links to any relevant issues

Fixes #12484

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
