### PR TITLE
chore(consensus): test starfish-core under both StarfishSpeed values

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1712,6 +1712,7 @@ mod tests {
     use futures::StreamExt;
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::{Mutex, RwLock};
+    use rstest::rstest;
     use starfish_config::{AuthorityIndex, Parameters};
     use tokio::{
         sync::{broadcast, mpsc},
@@ -1725,8 +1726,8 @@ mod tests {
         },
         block_header::{
             BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
-            TestBlockHeader, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
-            VerifiedOwnShard, VerifiedTransactions,
+            TestBlockHeader, TestBlockHeaderVersion, TransactionsCommitment, VerifiedBlock,
+            VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
@@ -2544,17 +2545,18 @@ mod tests {
             unimplemented!("Unimplemented")
         }
     }
+    #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribed_block_bundle_with_additional_headers() {
+    async fn test_handle_subscribed_block_bundle_with_additional_headers(
+        #[values(false, true)] starfish_speed: bool,
+    ) {
         // GIVEN
         let rounds = 10;
         let validators = 10;
-        // Test headers are V1, which flag-on verification rejects; run with
-        // StarfishSpeed off.
         let (mut context, key_pairs) = Context::new_for_test(validators);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = Arc::new(context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
             context.clone(),
@@ -2713,17 +2715,18 @@ mod tests {
         }
     }
 
+    #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribe_bundle_without_additional_headers() {
+    async fn test_handle_subscribe_bundle_without_additional_headers(
+        #[values(false, true)] starfish_speed: bool,
+    ) {
         // GIVEN
         let rounds = 10;
         let validators = 10;
-        // Test headers are V1, which flag-on verification rejects; run with
-        // StarfishSpeed off.
         let (mut context, key_pairs) = Context::new_for_test(validators);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = Arc::new(context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
             context.clone(),
@@ -3546,17 +3549,18 @@ mod tests {
         );
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_handle_fetch_commits() {
+    async fn test_handle_fetch_commits(#[values(false, true)] starfish_speed: bool) {
         // GIVEN
         let rounds = 15;
         let validators = 4;
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, key_pairs) = Context::new_for_test(validators);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = Arc::new(context);
+        let version = TestBlockHeaderVersion::from_context(&context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
             context.clone(),
             Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
@@ -3682,6 +3686,7 @@ mod tests {
             .collect::<Vec<_>>();
         for validator in 0..validators {
             let test_block_header = TestBlockHeader::new(rounds + 1, validator as u8)
+                .set_version(version)
                 .set_commit_votes(commit_refs.clone())
                 .set_ancestors(refs_to_headers_from_prev_round.clone())
                 .set_timestamp_ms(
@@ -3692,6 +3697,7 @@ mod tests {
             new_block_headers.push(verified_block_header);
         }
         let equivocation = TestBlockHeader::new(rounds + 1, 1)
+            .set_version(version)
             .set_commit_votes(commit_refs.clone())
             .set_ancestors(refs_to_headers_from_prev_round.clone())
             .set_timestamp_ms((rounds as u64 + 2) * 1000)
@@ -3704,6 +3710,7 @@ mod tests {
             .map(|commit_ref| CommitRef::new(commit_ref.index, CommitDigest::MIN))
             .collect::<Vec<_>>();
         let poisoned_equivocation = TestBlockHeader::new(rounds + 1, 2)
+            .set_version(version)
             .set_commit_votes(poisoned_votes)
             .set_ancestors(refs_to_headers_from_prev_round.clone())
             .set_timestamp_ms((rounds as u64 + 2) * 1000 + 1)
@@ -3725,6 +3732,7 @@ mod tests {
                 .collect::<Vec<_>>();
             for validator in 0..validators {
                 let test_block_header = TestBlockHeader::new(round, validator as u8)
+                    .set_version(version)
                     .set_ancestors(refs_to_headers_from_prev_round.clone())
                     .set_timestamp_ms(round as u64 * 1000 + (validator + round as usize + 1) as u64)
                     .build();

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1593,19 +1593,7 @@ impl TestBlockHeader {
         context: &Arc<Context>,
         encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> Self {
-        let txs = vec![];
-        let serialized_transactions = Transaction::serialize(&txs)
-            .expect("We should expect correct serialization of the transactions");
-        Self::with_commitment(
-            round,
-            author,
-            TransactionsCommitment::compute_transactions_commitment(
-                &serialized_transactions,
-                context,
-                encoder,
-            )
-            .unwrap(),
-        )
+        Self::with_transactions(round, author, vec![], context, encoder)
     }
 
     #[cfg(test)]
@@ -1616,12 +1604,27 @@ impl TestBlockHeader {
         context: &Arc<Context>,
         encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> Self {
-        let txs = vec![vec![tx; 16]]
-            .into_iter()
-            .map(Transaction::new)
-            .collect::<Vec<Transaction>>();
+        Self::with_transactions(
+            round,
+            author,
+            vec![Transaction::new(vec![tx; 16])],
+            context,
+            encoder,
+        )
+    }
+
+    /// Commits to `txs` the way a proposer does, so the commitment can be
+    /// checked against the transactions.
+    #[cfg(test)]
+    fn with_transactions(
+        round: Round,
+        author: u8,
+        txs: Vec<Transaction>,
+        context: &Arc<Context>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
+    ) -> Self {
         let serialized_transactions = Transaction::serialize(&txs)
-            .expect("We should expect correct serialization of the transactions for sharding");
+            .expect("We should expect correct serialization of the transactions");
         Self::with_commitment(
             round,
             author,
@@ -1706,21 +1709,23 @@ impl TestBlockHeader {
     }
 
     pub fn build(self) -> BlockHeader {
-        assert!(
-            self.version == TestBlockHeaderVersion::V2 || self.strong_vote.is_none(),
-            "a V1 header cannot carry a strong vote"
-        );
         match self.version {
-            TestBlockHeaderVersion::V1 => BlockHeader::V1(BlockHeaderV1::new(
-                self.epoch,
-                self.round,
-                self.author,
-                self.timestamp_ms,
-                self.ancestors,
-                self.acknowledgments,
-                self.commit_votes,
-                self.transactions_commitment,
-            )),
+            TestBlockHeaderVersion::V1 => {
+                assert!(
+                    self.strong_vote.is_none(),
+                    "a V1 header cannot carry a strong vote"
+                );
+                BlockHeader::V1(BlockHeaderV1::new(
+                    self.epoch,
+                    self.round,
+                    self.author,
+                    self.timestamp_ms,
+                    self.ancestors,
+                    self.acknowledgments,
+                    self.commit_votes,
+                    self.transactions_commitment,
+                ))
+            }
             TestBlockHeaderVersion::V2 => BlockHeader::V2(BlockHeaderV2::new(
                 self.epoch,
                 self.round,

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1543,13 +1543,39 @@ pub(crate) fn genesis_block_headers(context: &Context) -> Vec<VerifiedBlockHeade
         .collect::<Vec<VerifiedBlockHeader>>()
 }
 
+/// The `BlockHeader` variant that [`TestBlockHeader::build`] assembles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TestBlockHeaderVersion {
+    V1,
+    V2,
+}
+
+impl TestBlockHeaderVersion {
+    /// The version `Core` proposes under this context's
+    /// `consensus_starfish_speed` setting.
+    #[cfg(test)]
+    pub(crate) fn from_context(context: &Context) -> Self {
+        if context.protocol_config.consensus_starfish_speed() {
+            Self::V2
+        } else {
+            Self::V1
+        }
+    }
+}
+
 /// This struct is public for testing in other crates.
 #[derive(Clone)]
 pub struct TestBlockHeader {
+    epoch: Epoch,
+    round: Round,
+    author: AuthorityIndex,
+    timestamp_ms: BlockTimestampMs,
     ancestors: Vec<BlockRef>,
     acknowledgments: Vec<BlockRef>,
-    block_header: BlockHeaderV1,
+    commit_votes: Vec<CommitVote>,
+    transactions_commitment: TransactionsCommitment,
     strong_vote: Option<StrongVote>,
+    version: TestBlockHeaderVersion,
 }
 
 impl TestBlockHeader {
@@ -1557,17 +1583,7 @@ impl TestBlockHeader {
     /// of transactions commitment. Use it when you don't need to check the
     /// commitment and don't want to create and pass the encoder.
     pub fn new(round: Round, author: u8) -> Self {
-        Self {
-            block_header: BlockHeaderV1 {
-                round,
-                author: author.into(),
-                transactions_commitment: TransactionsCommitment::DEFAULT_FOR_TEST,
-                ..Default::default()
-            },
-            ancestors: vec![],
-            acknowledgments: vec![],
-            strong_vote: None,
-        }
+        Self::with_commitment(round, author, TransactionsCommitment::DEFAULT_FOR_TEST)
     }
 
     #[cfg(test)]
@@ -1580,22 +1596,16 @@ impl TestBlockHeader {
         let txs = vec![];
         let serialized_transactions = Transaction::serialize(&txs)
             .expect("We should expect correct serialization of the transactions");
-        Self {
-            block_header: BlockHeaderV1 {
-                round,
-                author: author.into(),
-                transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
-                    &serialized_transactions,
-                    context,
-                    encoder,
-                )
-                .unwrap(),
-                ..Default::default()
-            },
-            ancestors: vec![],
-            acknowledgments: vec![],
-            strong_vote: None,
-        }
+        Self::with_commitment(
+            round,
+            author,
+            TransactionsCommitment::compute_transactions_commitment(
+                &serialized_transactions,
+                context,
+                encoder,
+            )
+            .unwrap(),
+        )
     }
 
     #[cfg(test)]
@@ -1612,41 +1622,54 @@ impl TestBlockHeader {
             .collect::<Vec<Transaction>>();
         let serialized_transactions = Transaction::serialize(&txs)
             .expect("We should expect correct serialization of the transactions for sharding");
+        Self::with_commitment(
+            round,
+            author,
+            TransactionsCommitment::compute_transactions_commitment(
+                &serialized_transactions,
+                context,
+                encoder,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn with_commitment(
+        round: Round,
+        author: u8,
+        transactions_commitment: TransactionsCommitment,
+    ) -> Self {
         Self {
-            block_header: BlockHeaderV1 {
-                round,
-                author: author.into(),
-                transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
-                    &serialized_transactions,
-                    context,
-                    encoder,
-                )
-                .unwrap(),
-                ..Default::default()
-            },
+            epoch: 0,
+            round,
+            author: author.into(),
+            timestamp_ms: 0,
             ancestors: vec![],
             acknowledgments: vec![],
+            commit_votes: vec![],
+            transactions_commitment,
             strong_vote: None,
+            version: TestBlockHeaderVersion::V1,
         }
     }
 
     pub fn set_epoch(mut self, epoch: Epoch) -> Self {
-        self.block_header.epoch = epoch;
+        self.epoch = epoch;
         self
     }
 
     pub fn set_round(mut self, round: Round) -> Self {
-        self.block_header.round = round;
+        self.round = round;
         self
     }
 
     pub fn set_author(mut self, author: AuthorityIndex) -> Self {
-        self.block_header.author = author;
+        self.author = author;
         self
     }
 
     pub fn set_timestamp_ms(mut self, timestamp_ms: BlockTimestampMs) -> Self {
-        self.block_header.timestamp_ms = timestamp_ms;
+        self.timestamp_ms = timestamp_ms;
         self
     }
 
@@ -1661,43 +1684,55 @@ impl TestBlockHeader {
     }
 
     pub fn set_commit_votes(mut self, commit_votes: Vec<CommitVote>) -> Self {
-        self.block_header.commit_votes = commit_votes;
+        self.commit_votes = commit_votes;
         self
     }
 
     pub fn set_commitment(mut self, commitment: TransactionsCommitment) -> Self {
-        self.block_header.transactions_commitment = commitment;
+        self.transactions_commitment = commitment;
         self
     }
 
-    /// Sets the V2-only `strong_vote` payload. When `Some`, `build()` emits a
-    /// `BlockHeader::V2`; otherwise a V1.
+    /// Sets the `strong_vote` payload, which only a V2 header carries. Set the
+    /// version to V2 as well, otherwise `build()` panics.
     pub fn set_strong_vote(mut self, strong_vote: Option<StrongVote>) -> Self {
         self.strong_vote = strong_vote;
         self
     }
 
-    pub fn build(mut self) -> BlockHeader {
-        if let Some(strong_vote) = self.strong_vote {
-            return BlockHeader::V2(BlockHeaderV2::new(
-                self.block_header.epoch,
-                self.block_header.round,
-                self.block_header.author,
-                self.block_header.timestamp_ms,
+    pub fn set_version(mut self, version: TestBlockHeaderVersion) -> Self {
+        self.version = version;
+        self
+    }
+
+    pub fn build(self) -> BlockHeader {
+        assert!(
+            self.version == TestBlockHeaderVersion::V2 || self.strong_vote.is_none(),
+            "a V1 header cannot carry a strong vote"
+        );
+        match self.version {
+            TestBlockHeaderVersion::V1 => BlockHeader::V1(BlockHeaderV1::new(
+                self.epoch,
+                self.round,
+                self.author,
+                self.timestamp_ms,
                 self.ancestors,
                 self.acknowledgments,
-                self.block_header.commit_votes,
-                self.block_header.transactions_commitment,
-                Some(strong_vote),
-            ));
+                self.commit_votes,
+                self.transactions_commitment,
+            )),
+            TestBlockHeaderVersion::V2 => BlockHeader::V2(BlockHeaderV2::new(
+                self.epoch,
+                self.round,
+                self.author,
+                self.timestamp_ms,
+                self.ancestors,
+                self.acknowledgments,
+                self.commit_votes,
+                self.transactions_commitment,
+                self.strong_vote,
+            )),
         }
-        let (references, overlap_start_index, overlap_end_index) =
-            BlockHeader::compress_references(self.ancestors, self.acknowledgments);
-        self.block_header.references = references;
-        self.block_header.overlap_start_index = overlap_start_index;
-        self.block_header.overlap_end_index = overlap_end_index;
-
-        BlockHeader::V1(self.block_header)
     }
 }
 

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -370,7 +370,9 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         authority_set::AuthoritySet,
-        block_header::{BlockHeaderDigest, BlockRef, StrongVote, TestBlockHeader},
+        block_header::{
+            BlockHeaderDigest, BlockRef, StrongVote, TestBlockHeader, TestBlockHeaderVersion,
+        },
         context::Context,
         transaction::{TransactionVerifier, ValidationError},
     };
@@ -867,12 +869,14 @@ pub(crate) mod test {
         let leader_authority = AuthorityIndex::new_for_test(0);
         let verifier_on = SignedBlockVerifier::new(context_on, Arc::new(TxnSizeVerifier {}));
 
-        let base = TestBlockHeader::new(10, 2).set_ancestors(vec![
-            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
-            BlockRef::new(9, leader_authority, BlockHeaderDigest::MIN),
-            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
-            BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
-        ]);
+        let base = TestBlockHeader::new(10, 2)
+            .set_version(TestBlockHeaderVersion::V2)
+            .set_ancestors(vec![
+                BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+                BlockRef::new(9, leader_authority, BlockHeaderDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+                BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+            ]);
         let well_formed = StrongVote {
             leader_authority,
             missing: AuthoritySet::new(),

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -365,6 +365,7 @@ impl BlockVerifier for NoopBlockVerifier {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use rstest::rstest;
     use starfish_config::AuthorityIndex;
 
     use super::*;
@@ -444,24 +445,26 @@ pub(crate) mod test {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_verify_block() {
-        // Test headers are V1, which flag-on verification rejects; run with
-        // StarfishSpeed off.
+    async fn test_verify_block(#[values(false, true)] starfish_speed: bool) {
         let (mut context, keypairs) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = Arc::new(context);
+        let version = TestBlockHeaderVersion::from_context(&context);
         let authority_2_protocol_keypair = &keypairs[2].1;
         let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
 
-        let test_block = TestBlockHeader::new(10, 2).set_ancestors(vec![
-            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
-            BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
-            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
-            BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
-        ]);
+        let test_block = TestBlockHeader::new(10, 2)
+            .set_version(version)
+            .set_ancestors(vec![
+                BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+                BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+            ]);
 
         // Valid SignedBlock.
         {
@@ -702,29 +705,31 @@ pub(crate) mod test {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_verify_block_round_gap() {
+    async fn test_verify_block_round_gap(#[values(false, true)] starfish_speed: bool) {
         let (mut context, keypairs) = Context::new_for_test(4);
         // Small gc_depth so we can construct violations without huge round
         // numbers.
         context
             .protocol_config
             .set_consensus_gc_depth_for_testing(5);
-        // Test headers are V1, which flag-on verification rejects; run with
-        // StarfishSpeed off.
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = Arc::new(context);
+        let version = TestBlockHeaderVersion::from_context(&context);
         let authority_2_protocol_keypair = &keypairs[2].1;
         let verifier = SignedBlockVerifier::new(context, Arc::new(TxnSizeVerifier {}));
 
-        let test_block = TestBlockHeader::new(10, 2).set_ancestors(vec![
-            BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
-            BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
-            BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
-            BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
-        ]);
+        let test_block = TestBlockHeader::new(10, 2)
+            .set_version(version)
+            .set_ancestors(vec![
+                BlockRef::new(9, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+                BlockRef::new(9, AuthorityIndex::new_for_test(1), BlockHeaderDigest::MIN),
+                BlockRef::new(7, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
+            ]);
 
         // Acknowledgment at the block's round.
         {

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1226,7 +1226,7 @@ mod tests {
                 Round 7 : { * },
              }";
         let final_round = 6;
-        let result = parse_dag(dag_str);
+        let result = parse_dag(dag_str, false);
         assert!(result.is_ok());
 
         let dag_builder = result.unwrap();

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2489,10 +2489,6 @@ mod test {
         sleep(context.parameters.min_block_delay).await;
         // add blocks to trigger proposal.
         _ = core.add_blocks(vec![block_3], DataSource::Test);
-        // Round 1 blames the genesis leader, whose transactions are never recorded
-        // as available, so no strong-vote quorum stands behind round 2 and
-        // production proposes it on the leader timeout.
-        core.new_block(2, ReasonToCreateBlock::SoftTimeout).unwrap();
 
         assert_eq!(core.last_proposed_round(), 2);
 
@@ -2887,16 +2883,9 @@ mod test {
             )
             .await;
         }
-        // The ordinary path proposes every round but the second, which has no
-        // strong-vote quorum behind it.
-        assert_eq!(
-            rounds_needing_timeout,
-            if starfish_speed {
-                BTreeSet::from([2])
-            } else {
-                BTreeSet::new()
-            }
-        );
+        // The ordinary path proposes every round; this run does not cross a
+        // schedule rotation.
+        assert_eq!(rounds_needing_timeout, BTreeSet::new());
 
         for core_fixture in cores {
             // Check commits have been persisted to store
@@ -2958,11 +2947,9 @@ mod test {
     ///
     /// Stands in for the leader timeout where the ordinary path did not
     /// propose, recording the round in `rounds_needing_timeout`. Under
-    /// StarfishSpeed this is round 2 (a round 1 block votes on the genesis
-    /// leader, whose transactions are never recorded as available, so no
-    /// strong-vote quorum stands behind round 2) and the round after a
-    /// schedule rotation (the strong votes of the previous round are pinned
-    /// to the leader the previous schedule elected).
+    /// StarfishSpeed this is the round after a schedule rotation: the strong
+    /// votes of the previous round are pinned to the leader the previous
+    /// schedule elected, not the one now elected.
     async fn gossip_one_round(
         cores: &mut [CoreTestFixture],
         round: u32,
@@ -3573,11 +3560,8 @@ mod test {
                     .add_blocks(last_round_blocks.clone(), DataSource::Test)
                     .unwrap();
                 // Stand in for the leader timeout where the ordinary path did not
-                // propose. Two kinds of round need it: round 2, which has no
-                // strong-vote quorum behind it because a round 1 block votes on
-                // the genesis leader, whose transactions are never recorded as
-                // available; and the round after the schedule rotates, where the
-                // strong votes of the previous round are pinned to the leader the
+                // propose: the round after the schedule rotates, where the strong
+                // votes of the previous round are pinned to the leader the
                 // previous schedule elected rather than the one now elected.
                 if core_fixture.core.last_proposed_round() < round {
                     rounds_needing_timeout.insert(round);
@@ -3626,12 +3610,12 @@ mod test {
             }
             last_round_blocks = this_round_blocks;
         }
-        // The ordinary path proposes every round but the second and round 23, where
-        // the rotation moves the leader the round 22 votes were pinned to.
+        // The ordinary path proposes every round but round 23, where the
+        // rotation moves the leader the round 22 votes were pinned to.
         assert_eq!(
             rounds_needing_timeout,
             if starfish_speed {
-                BTreeSet::from([2, 23])
+                BTreeSet::from([23])
             } else {
                 BTreeSet::new()
             }
@@ -3732,9 +3716,8 @@ mod test {
                     .add_blocks(last_round_blocks.clone(), DataSource::Test)
                     .unwrap();
                 // Stand in for the leader timeout where the ordinary path did not
-                // propose. Round 1 votes on the genesis leader, whose transactions
-                // are never recorded as available, so no strong-vote quorum stands
-                // behind round 2.
+                // propose, e.g. the round after a schedule rotation moves the
+                // leader the previous round's votes were pinned to.
                 if core_fixture.core.last_proposed_round() < round {
                     rounds_needing_timeout.insert(round);
                     core_fixture
@@ -3785,16 +3768,9 @@ mod test {
 
             last_round_blocks = this_round_blocks;
         }
-        // The ordinary path proposes every round but the second, which has no
-        // strong-vote quorum behind it.
-        assert_eq!(
-            rounds_needing_timeout,
-            if starfish_speed {
-                BTreeSet::from([2])
-            } else {
-                BTreeSet::new()
-            }
-        );
+        // The ordinary path proposes every round; this run does not cross a
+        // schedule rotation.
+        assert_eq!(rounds_needing_timeout, BTreeSet::new());
 
         for core_fixture in cores {
             // Check commits have been persisted to store

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1731,6 +1731,14 @@ impl Core {
     fn last_proposed_block_header(&self) -> VerifiedBlockHeader {
         self.dag_state.read().get_last_proposed_block_header()
     }
+
+    #[cfg(test)]
+    fn last_proposed_block(&self) -> VerifiedBlock {
+        self.dag_state
+            .read()
+            .get_last_own_non_genesis_block()
+            .expect("a block should have been proposed")
+    }
 }
 
 /// Senders of signals from Core, for outputs and events (ex new block
@@ -2481,6 +2489,10 @@ mod test {
         sleep(context.parameters.min_block_delay).await;
         // add blocks to trigger proposal.
         _ = core.add_blocks(vec![block_3], DataSource::Test);
+        // Round 1 blames the genesis leader, whose transactions are never recorded
+        // as available, so no strong-vote quorum stands behind round 2 and
+        // production proposes it on the leader timeout.
+        core.new_block(2, ReasonToCreateBlock::SoftTimeout).unwrap();
 
         assert_eq!(core.last_proposed_round(), 2);
 
@@ -2716,14 +2728,7 @@ mod test {
 
                 assert_eq!(core_fixture.core.last_proposed_round(), round);
 
-                this_round_blocks.push(
-                    core_fixture
-                        .core
-                        .dag_state
-                        .read()
-                        .get_last_own_non_genesis_block()
-                        .expect("a block should have been proposed"),
-                );
+                this_round_blocks.push(core_fixture.core.last_proposed_block());
             }
 
             last_round_blocks = this_round_blocks;
@@ -3196,11 +3201,10 @@ mod test {
             .set_consensus_commit_transactions_only_for_traversed_headers_for_testing(
                 commit_only_for_traversed_headers,
             );
-        // The DAG is built up front, so every strong vote is pinned using the
-        // builder's leader schedule. The core swaps out the authority whose
-        // blocks this DAG never links and elects a different leader for its
-        // rounds, leaving those votes counting for no one and the last leader of
-        // the DAG pending, so this runs with StarfishSpeed off.
+        // Runs with StarfishSpeed off: the DAG is built up front against the
+        // builder's leader schedule, while the core swaps out the authority whose
+        // blocks this DAG never links, so its votes count for no leader the core
+        // elects and the last leader of the DAG never leaves the pending state.
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(false);
@@ -3554,6 +3558,7 @@ mod test {
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
+        let mut rounds_needing_timeout = BTreeSet::new();
         let mut last_round_blocks = Vec::new();
         for round in 1..=33 {
             let mut this_round_blocks = Vec::new();
@@ -3567,15 +3572,20 @@ mod test {
                     .core
                     .add_blocks(last_round_blocks.clone(), DataSource::Test)
                     .unwrap();
-                // Stand in for the leader timeout. On the round after the schedule
-                // rotates, the strong votes of the previous round are pinned to the
-                // leader elected by the previous schedule, so no quorum exists for
-                // the leader this core now elects and the proposal waits for the
-                // soft timeout. Does nothing once the round is already proposed.
-                core_fixture
-                    .core
-                    .new_block(round, ReasonToCreateBlock::SoftTimeout)
-                    .unwrap();
+                // Stand in for the leader timeout where the ordinary path did not
+                // propose. Two kinds of round need it: round 2, which has no
+                // strong-vote quorum behind it because a round 1 block votes on
+                // the genesis leader, whose transactions are never recorded as
+                // available; and the round after the schedule rotates, where the
+                // strong votes of the previous round are pinned to the leader the
+                // previous schedule elected rather than the one now elected.
+                if core_fixture.core.last_proposed_round() < round {
+                    rounds_needing_timeout.insert(round);
+                    core_fixture
+                        .core
+                        .new_block(round, ReasonToCreateBlock::SoftTimeout)
+                        .unwrap();
+                }
                 // A "new round" signal should be received given that all the blocks of previous
                 // round have been processed
                 let new_round = receive(
@@ -3595,16 +3605,13 @@ mod test {
                 assert_eq!(verified_block.round(), round);
                 assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
 
-                // append the new block to this round blocks
-                this_round_blocks.push(verified_block.clone());
-                let block_header = core_fixture.core.last_proposed_block_header();
                 // ensure that produced block is referring to the blocks of last_round
                 assert_eq!(
-                    block_header.ancestors().len(),
+                    verified_block.ancestors().len(),
                     core_fixture.core.context.committee.size()
                 );
-                for ancestor in block_header.ancestors() {
-                    if block_header.round() > 1 {
+                for ancestor in verified_block.ancestors() {
+                    if verified_block.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
                         assert!(
                             last_round_blocks
@@ -3614,9 +3621,21 @@ mod test {
                         );
                     }
                 }
+
+                this_round_blocks.push(verified_block);
             }
             last_round_blocks = this_round_blocks;
         }
+        // The ordinary path proposes every round but the second and round 23, where
+        // the rotation moves the leader the round 22 votes were pinned to.
+        assert_eq!(
+            rounds_needing_timeout,
+            if starfish_speed {
+                BTreeSet::from([2, 23])
+            } else {
+                BTreeSet::new()
+            }
+        );
         for core_fixture in cores {
             // Check commits have been persisted to store
             let last_commit = core_fixture
@@ -3696,6 +3715,7 @@ mod test {
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
+        let mut rounds_needing_timeout = BTreeSet::new();
         let mut last_round_blocks = Vec::new();
         for round in 1..=10 {
             let mut this_round_blocks = Vec::new();
@@ -3711,6 +3731,17 @@ mod test {
                     .core
                     .add_blocks(last_round_blocks.clone(), DataSource::Test)
                     .unwrap();
+                // Stand in for the leader timeout where the ordinary path did not
+                // propose. Round 1 votes on the genesis leader, whose transactions
+                // are never recorded as available, so no strong-vote quorum stands
+                // behind round 2.
+                if core_fixture.core.last_proposed_round() < round {
+                    rounds_needing_timeout.insert(round);
+                    core_fixture
+                        .core
+                        .new_block(round, ReasonToCreateBlock::SoftTimeout)
+                        .unwrap();
+                }
 
                 // A "new round" signal should be received given that all the blocks of previous
                 // round have been processed
@@ -3732,18 +3763,13 @@ mod test {
                 assert_eq!(verified_block.round(), round);
                 assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
 
-                // append the new block to this round blocks
-                this_round_blocks.push(verified_block.clone());
-
-                let block_header = core_fixture.core.last_proposed_block_header();
-
                 // ensure that produced block is referring to the blocks of last_round
                 assert_eq!(
-                    block_header.ancestors().len(),
+                    verified_block.ancestors().len(),
                     core_fixture.core.context.committee.size()
                 );
-                for ancestor in block_header.ancestors() {
-                    if block_header.round() > 1 {
+                for ancestor in verified_block.ancestors() {
+                    if verified_block.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
                         assert!(
                             last_round_blocks
@@ -3753,10 +3779,22 @@ mod test {
                         );
                     }
                 }
+
+                this_round_blocks.push(verified_block);
             }
 
             last_round_blocks = this_round_blocks;
         }
+        // The ordinary path proposes every round but the second, which has no
+        // strong-vote quorum behind it.
+        assert_eq!(
+            rounds_needing_timeout,
+            if starfish_speed {
+                BTreeSet::from([2])
+            } else {
+                BTreeSet::new()
+            }
+        );
 
         for core_fixture in cores {
             // Check commits have been persisted to store
@@ -3815,14 +3853,7 @@ mod test {
                     .new_block(round, ReasonToCreateBlock::MaxLeaderTimeout)
                     .unwrap();
                 // The round 1 block was already proposed while the core recovered.
-                let block = new_block.unwrap_or_else(|| {
-                    core_fixture
-                        .core
-                        .dag_state
-                        .read()
-                        .get_last_own_non_genesis_block()
-                        .expect("a block should have been proposed")
-                });
+                let block = new_block.unwrap_or_else(|| core_fixture.core.last_proposed_block());
                 assert_eq!(block.round(), round);
 
                 // append the new block to this round blocks

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1965,14 +1965,16 @@ mod test {
 
     /// Recover Core and continue proposing from the last round which forms a
     /// quorum.
+    #[rstest]
     #[tokio::test]
-    async fn test_core_recover_from_store_for_full_round() {
+    async fn test_core_recover_from_store_for_full_round(
+        #[values(false, true)] starfish_speed: bool,
+    ) {
         telemetry_subscribers::init_for_testing();
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, mut key_pairs) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -3354,15 +3356,15 @@ mod test {
         assert!(opt_serialized_transaction[0].is_some());
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_add_certified_commits() {
+    async fn test_add_certified_commits(#[values(false, true)] starfish_speed: bool) {
         telemetry_subscribers::init_for_testing();
 
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, _key_pairs) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = context.with_parameters(Parameters {
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()
@@ -3808,14 +3810,14 @@ mod test {
         *receiver.borrow_and_update()
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_commit_and_notify_for_block_status() {
+    async fn test_commit_and_notify_for_block_status(#[values(false, true)] starfish_speed: bool) {
         telemetry_subscribers::init_for_testing();
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, mut key_pairs) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
 
         let context = Arc::new(context);
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1952,8 +1952,8 @@ mod test {
     use crate::{
         CommitConsumer, CommitIndex, Transaction,
         block_header::{
-            BlockHeaderDigest, TestBlockHeader, TransactionsCommitment, genesis_block_headers,
-            genesis_blocks,
+            BlockHeaderDigest, TestBlockHeader, TestBlockHeaderVersion, TransactionsCommitment,
+            genesis_block_headers, genesis_blocks,
         },
         commit::{CommitAPI, CommitRange},
         leader_scoring::ReputationScores,
@@ -4035,6 +4035,7 @@ mod test {
         let add_block = |round: Round, author: u8, sv: StrongVote| {
             let header = VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(round, author)
+                    .set_version(TestBlockHeaderVersion::V2)
                     .set_strong_vote(Some(sv))
                     .build(),
             );

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2093,44 +2093,43 @@ mod test {
     /// Recover Core and continue proposing when having a partial last round
     /// which doesn't form a quorum and we haven't proposed for that round
     /// yet.
+    #[rstest]
     #[tokio::test]
-    async fn test_core_recover_from_store_for_partial_round() {
+    async fn test_core_recover_from_store_for_partial_round(
+        #[values(false, true)] starfish_speed: bool,
+    ) {
         telemetry_subscribers::init_for_testing();
 
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, mut key_pairs) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
 
-        // Create test blocks for all authorities except our's (index = 0).
-        let mut last_round_blocks = genesis_blocks(&context);
-        let mut all_blocks = last_round_blocks.clone();
-        for round in 1..=4 {
-            let mut this_round_blocks = Vec::new();
-
-            // For round 4 only produce f+1 blocks. Skip our validator 0 and that of
-            // position 1 from creating blocks.
-            let authorities_to_skip = if round == 4 {
-                context.committee.validity_threshold() as usize
-            } else {
-                // otherwise always skip creating a block for our authority
-                1
-            };
-
-            for (index, _authority) in context.committee.authorities().skip(authorities_to_skip) {
-                let block = TestBlockHeader::new(round, index.value() as u8)
-                    .set_ancestors(last_round_blocks.iter().map(|b| b.reference()).collect())
-                    .build();
-                this_round_blocks.push(VerifiedBlock::new_for_test(block));
-            }
-            all_blocks.extend(this_round_blocks.clone());
-            last_round_blocks = this_round_blocks;
-        }
+        // Create test blocks for all authorities except our's (index = 0). For
+        // round 4 only produce f+1 blocks, so skip authority 1 as well.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        let own_authority = vec![context.own_index];
+        let round_4_skipped = (0..context.committee.validity_threshold() as u8)
+            .map(AuthorityIndex::new_for_test)
+            .collect();
+        dag_builder
+            .layers(1..=3)
+            .authorities(own_authority)
+            .skip_block()
+            .build();
+        dag_builder
+            .layer(4)
+            .authorities(round_4_skipped)
+            .skip_block()
+            .build();
+        let all_blocks = genesis_blocks(&context)
+            .into_iter()
+            .chain(dag_builder.blocks(1..=4))
+            .collect::<Vec<_>>();
 
         // write them in store
         let (block_headers, block_transactions) = all_blocks
@@ -2389,14 +2388,16 @@ mod test {
         assert_eq!(dag_state.read().last_commit_index(), 0);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_core_propose_once_receiving_a_quorum() {
+    async fn test_core_propose_once_receiving_a_quorum(
+        #[values(false, true)] starfish_speed: bool,
+    ) {
         telemetry_subscribers::init_for_testing();
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, mut key_pairs) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         let context = Arc::new(context);
 
         let store = Arc::new(MemStore::new());
@@ -2440,8 +2441,23 @@ mod test {
 
         let mut expected_ancestors = BTreeSet::new();
 
+        // A round 1 block votes on the genesis leader, whose transactions are
+        // always available, so peers send a strong vote for it.
+        let round_1_strong_vote = starfish_speed.then(|| StrongVote {
+            leader_authority: core.leader_schedule.elect_leader(GENESIS_ROUND, 0),
+            missing: AuthoritySet::new(),
+        });
+        let round_1_block = |author: u8| {
+            VerifiedBlock::new_for_test(
+                TestBlockHeader::new(1, author)
+                    .set_version(TestBlockHeaderVersion::from_context(&context))
+                    .set_strong_vote(round_1_strong_vote)
+                    .build(),
+            )
+        };
+
         // Adding one block now will trigger the creation of new block for round 1
-        let verified_block = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 1).build());
+        let verified_block = round_1_block(1);
         expected_ancestors.insert(verified_block.reference());
         // Wait for min block delay to allow blocks to be proposed.
         sleep(context.parameters.min_block_delay).await;
@@ -2459,7 +2475,7 @@ mod test {
 
         // Adding another block now forms a quorum for round 1, so block at round 2 will
         // be proposed
-        let block_3 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build());
+        let block_3 = round_1_block(2);
         expected_ancestors.insert(block_3.reference());
         // Wait for min block delay to allow blocks to be proposed.
         sleep(context.parameters.min_block_delay).await;
@@ -2627,8 +2643,9 @@ mod test {
         assert_eq!(our_ancestor_included.round, 10);
     }
 
+    #[rstest]
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_core_try_new_block_leader_timeout() {
+    async fn test_core_try_new_block_leader_timeout(#[values(false, true)] starfish_speed: bool) {
         telemetry_subscribers::init_for_testing();
 
         // Since we run the test with started_paused = true, any time-dependent
@@ -2639,7 +2656,7 @@ mod test {
         // need to manually wait for the time diff before processing them. By
         // calling the `tokio::time::sleep` we implicitly also advance the tokio
         // clock.
-        async fn wait_blocks(blocks: &[VerifiedBlockHeader], context: &Context) {
+        async fn wait_blocks(blocks: &[VerifiedBlock], context: &Context) {
             // Simulate the time wait before processing a block to ensure that
             // block.timestamp <= now
             let now = context.clock.timestamp_utc_ms();
@@ -2653,11 +2670,10 @@ mod test {
             sleep(wait_time).await;
         }
 
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, _) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         // Create the cores for all authorities
         let mut all_cores = create_cores(context, vec![1, 1, 1, 1]).await;
 
@@ -2670,7 +2686,7 @@ mod test {
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
-        let mut last_round_blocks = Vec::<VerifiedBlockHeader>::new();
+        let mut last_round_blocks = Vec::<VerifiedBlock>::new();
         for round in 1..=3 {
             let mut this_round_blocks = Vec::new();
 
@@ -2679,7 +2695,7 @@ mod test {
 
                 core_fixture
                     .core
-                    .add_block_headers(last_round_blocks.clone(), DataSource::Test)
+                    .add_blocks(last_round_blocks.clone(), DataSource::Test)
                     .unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
@@ -2700,7 +2716,14 @@ mod test {
 
                 assert_eq!(core_fixture.core.last_proposed_round(), round);
 
-                this_round_blocks.push(core_fixture.core.last_proposed_block_header());
+                this_round_blocks.push(
+                    core_fixture
+                        .core
+                        .dag_state
+                        .read()
+                        .get_last_own_non_genesis_block()
+                        .expect("a block should have been proposed"),
+                );
             }
 
             last_round_blocks = this_round_blocks;
@@ -2714,7 +2737,7 @@ mod test {
 
             core_fixture
                 .core
-                .add_block_headers(last_round_blocks.clone(), DataSource::Test)
+                .add_blocks(last_round_blocks.clone(), DataSource::Test)
                 .unwrap();
             let (new_block_opt, missing_committed_txns) = core_fixture
                 .core
@@ -2823,16 +2846,16 @@ mod test {
         assert!(missing_committed_txns.is_empty());
     }
 
+    #[rstest]
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_leader_schedule_change() {
+    async fn test_leader_schedule_change(#[values(false, true)] starfish_speed: bool) {
         telemetry_subscribers::init_for_testing();
         let default_params = Parameters::default();
 
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, _) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         // The expected scores come from V2 vote scoring and the good/bad split
         // assumes stake-rank selection; run with the sliding-window schedule
         // and absolute-score selection off.
@@ -2847,16 +2870,28 @@ mod test {
 
         // Advance the gossip network round by round; `gossip_one_round` asserts
         // each round is healthy and fully connected.
-        let mut last_round_block_headers = Vec::new();
+        let mut rounds_needing_timeout = BTreeSet::new();
+        let mut last_round_blocks = Vec::new();
         for round in 1..=30 {
-            last_round_block_headers = gossip_one_round(
+            last_round_blocks = gossip_one_round(
                 &mut cores,
                 round,
-                &last_round_block_headers,
+                &last_round_blocks,
                 default_params.min_block_delay,
+                &mut rounds_needing_timeout,
             )
             .await;
         }
+        // The ordinary path proposes every round but the second, which has no
+        // strong-vote quorum behind it.
+        assert_eq!(
+            rounds_needing_timeout,
+            if starfish_speed {
+                BTreeSet::from([2])
+            } else {
+                BTreeSet::new()
+            }
+        );
 
         for core_fixture in cores {
             // Check commits have been persisted to store
@@ -2909,26 +2944,42 @@ mod test {
     }
 
     /// Drives a fully-connected gossip network forward by one block-round:
-    /// feeds the previous round's proposed headers to every core (which
-    /// runs the real `try_commit`) and returns the headers proposed this
+    /// feeds the previous round's proposed blocks to every core (which
+    /// runs the real `try_commit`) and returns the blocks proposed this
     /// round, to be used as ancestors for the next round. A uniform,
     /// fully-connected DAG keeps the reputation scores equal across all
     /// authorities, so the resulting leader schedule is independent of RNG
     /// seed and topology.
+    ///
+    /// Stands in for the leader timeout where the ordinary path did not
+    /// propose, recording the round in `rounds_needing_timeout`. Under
+    /// StarfishSpeed this is round 2 (a round 1 block votes on the genesis
+    /// leader, whose transactions are never recorded as available, so no
+    /// strong-vote quorum stands behind round 2) and the round after a
+    /// schedule rotation (the strong votes of the previous round are pinned
+    /// to the leader the previous schedule elected).
     async fn gossip_one_round(
         cores: &mut [CoreTestFixture],
         round: u32,
-        last_round_block_headers: &[VerifiedBlockHeader],
+        last_round_blocks: &[VerifiedBlock],
         min_block_delay: Duration,
-    ) -> Vec<VerifiedBlockHeader> {
-        let mut this_round_block_headers = Vec::new();
+        rounds_needing_timeout: &mut BTreeSet<Round>,
+    ) -> Vec<VerifiedBlock> {
+        let mut this_round_blocks = Vec::new();
         // Wait for min block delay to allow blocks to be proposed.
         sleep(min_block_delay).await;
         for core_fixture in cores.iter_mut() {
             core_fixture
                 .core
-                .add_block_headers(last_round_block_headers.to_vec(), DataSource::Test)
+                .add_blocks(last_round_blocks.to_vec(), DataSource::Test)
                 .unwrap();
+            if core_fixture.core.last_proposed_round() < round {
+                rounds_needing_timeout.insert(round);
+                core_fixture
+                    .core
+                    .new_block(round, ReasonToCreateBlock::SoftTimeout)
+                    .unwrap();
+            }
             // Feeding the previous round's blocks advances this core a round and
             // triggers a proposal; assert the round signal and a healthy,
             // fully-connected proposed block.
@@ -2945,24 +2996,21 @@ mod test {
                     .unwrap();
             assert_eq!(proposed_block.round(), round);
             assert_eq!(proposed_block.author(), core_fixture.core.context.own_index);
-            let block_header = core_fixture.core.last_proposed_block_header().clone();
             assert_eq!(
-                block_header.ancestors().len(),
+                proposed_block.ancestors().len(),
                 core_fixture.core.context.committee.size()
             );
             if round > 1 {
-                for ancestor in block_header.ancestors() {
+                for ancestor in proposed_block.ancestors() {
                     assert!(
-                        last_round_block_headers
-                            .iter()
-                            .any(|bh| bh.reference() == *ancestor),
+                        last_round_blocks.iter().any(|b| b.reference() == *ancestor),
                         "reference from previous round should be added"
                     );
                 }
             }
-            this_round_block_headers.push(block_header);
+            this_round_blocks.push(proposed_block);
         }
-        this_round_block_headers
+        this_round_blocks
     }
 
     /// Drives the gossip network until `cores[0]` has performed at least one
@@ -2979,7 +3027,7 @@ mod test {
         // Generous safety ceiling; the loop actually breaks dynamically below.
         const MAX_ROUNDS: u32 = 6 * NUM_COMMITS_PER_SCHEDULE as u32;
         let mut round = 0u32;
-        let mut last_round_block_headers = Vec::new();
+        let mut last_round_blocks = Vec::new();
         let mut rotated = false;
         loop {
             round += 1;
@@ -2987,8 +3035,16 @@ mod test {
                 round <= MAX_ROUNDS,
                 "network did not reach a post-rotation mid-interval state within {MAX_ROUNDS} rounds"
             );
-            last_round_block_headers =
-                gossip_one_round(cores, round, &last_round_block_headers, min_block_delay).await;
+            // This network always runs with StarfishSpeed off, so no round ever
+            // needs the timeout stand-in.
+            last_round_blocks = gossip_one_round(
+                cores,
+                round,
+                &last_round_blocks,
+                min_block_delay,
+                &mut BTreeSet::new(),
+            )
+            .await;
 
             // A rotation has occurred once the in-effect swap table carries
             // persisted reputation scores (a non-empty commit range).
@@ -3140,7 +3196,11 @@ mod test {
             .set_consensus_commit_transactions_only_for_traversed_headers_for_testing(
                 commit_only_for_traversed_headers,
             );
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
+        // The DAG is built up front, so every strong vote is pinned using the
+        // builder's leader schedule. The core swaps out the authority whose
+        // blocks this DAG never links and elects a different leader for its
+        // rounds, leaving those votes counting for no one and the last leader of
+        // the DAG pending, so this runs with StarfishSpeed off.
         context
             .protocol_config
             .set_consensus_starfish_speed_for_testing(false);
@@ -3467,16 +3527,18 @@ mod test {
         }
     }
 
+    #[rstest]
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_commit_on_leader_schedule_change_boundary_without_multileader() {
+    async fn test_commit_on_leader_schedule_change_boundary_without_multileader(
+        #[values(false, true)] starfish_speed: bool,
+    ) {
         telemetry_subscribers::init_for_testing();
         let default_params = Parameters::default();
 
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, _) = Context::new_for_test(6);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         // The expected scores come from V2 vote scoring and the good/bad split
         // assumes stake-rank selection; run with the sliding-window schedule
         // and absolute-score selection off.
@@ -3492,9 +3554,9 @@ mod test {
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
-        let mut last_round_block_headers = Vec::new();
+        let mut last_round_blocks = Vec::new();
         for round in 1..=33 {
-            let mut this_round_block_headers = Vec::new();
+            let mut this_round_blocks = Vec::new();
             // Wait for min block delay to allow blocks to be proposed.
             sleep(default_params.min_block_delay).await;
             for core_fixture in &mut cores {
@@ -3503,7 +3565,16 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
+                    .add_blocks(last_round_blocks.clone(), DataSource::Test)
+                    .unwrap();
+                // Stand in for the leader timeout. On the round after the schedule
+                // rotates, the strong votes of the previous round are pinned to the
+                // leader elected by the previous schedule, so no quorum exists for
+                // the leader this core now elects and the proposal waits for the
+                // soft timeout. Does nothing once the round is already proposed.
+                core_fixture
+                    .core
+                    .new_block(round, ReasonToCreateBlock::SoftTimeout)
                     .unwrap();
                 // A "new round" signal should be received given that all the blocks of previous
                 // round have been processed
@@ -3525,8 +3596,7 @@ mod test {
                 assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_block_headers
-                    .push(core_fixture.core.last_proposed_block_header().clone());
+                this_round_blocks.push(verified_block.clone());
                 let block_header = core_fixture.core.last_proposed_block_header();
                 // ensure that produced block is referring to the blocks of last_round
                 assert_eq!(
@@ -3537,7 +3607,7 @@ mod test {
                     if block_header.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
                         assert!(
-                            last_round_block_headers
+                            last_round_blocks
                                 .iter()
                                 .any(|block| block.reference() == *ancestor),
                             "Reference from previous round should be added"
@@ -3545,7 +3615,7 @@ mod test {
                     }
                 }
             }
-            last_round_block_headers = this_round_block_headers;
+            last_round_blocks = this_round_blocks;
         }
         for core_fixture in cores {
             // Check commits have been persisted to store
@@ -3611,24 +3681,24 @@ mod test {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_core_signals() {
+    async fn test_core_signals(#[values(false, true)] starfish_speed: bool) {
         telemetry_subscribers::init_for_testing();
         let default_params = Parameters::default();
 
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, _) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         // create the cores and their signals for all the authorities
         let mut cores = create_cores(context, vec![1, 1, 1, 1]).await;
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
-        let mut last_round_block_headers = Vec::new();
+        let mut last_round_blocks = Vec::new();
         for round in 1..=10 {
-            let mut this_round_block_headers = Vec::new();
+            let mut this_round_blocks = Vec::new();
 
             // Wait for min block delay to allow blocks to be proposed.
             sleep(default_params.min_block_delay).await;
@@ -3639,7 +3709,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
+                    .add_blocks(last_round_blocks.clone(), DataSource::Test)
                     .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous
@@ -3663,8 +3733,7 @@ mod test {
                 assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_block_headers
-                    .push(core_fixture.core.last_proposed_block_header().clone());
+                this_round_blocks.push(verified_block.clone());
 
                 let block_header = core_fixture.core.last_proposed_block_header();
 
@@ -3677,7 +3746,7 @@ mod test {
                     if block_header.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
                         assert!(
-                            last_round_block_headers
+                            last_round_blocks
                                 .iter()
                                 .any(|block_header| block_header.reference() == *ancestor),
                             "Reference from previous round should be added"
@@ -3686,7 +3755,7 @@ mod test {
                 }
             }
 
-            last_round_block_headers = this_round_block_headers;
+            last_round_blocks = this_round_blocks;
         }
 
         for core_fixture in cores {
@@ -3708,26 +3777,26 @@ mod test {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_core_compress_proposal_references() {
+    async fn test_core_compress_proposal_references(#[values(false, true)] starfish_speed: bool) {
         telemetry_subscribers::init_for_testing();
         let default_params = Parameters::default();
 
-        // Test blocks carry no strong votes; run with StarfishSpeed off.
         let (mut context, _) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_starfish_speed_for_testing(false);
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
         // create the cores and their signals for all the authorities
         let mut cores = create_cores(context, vec![1, 1, 1, 1]).await;
 
-        let mut last_round_block_headers = Vec::new();
-        let mut all_block_headers = Vec::new();
+        let mut last_round_blocks = Vec::new();
+        let mut all_blocks = Vec::new();
 
         let excluded_authority = AuthorityIndex::new_for_test(3);
 
         for round in 1..=10 {
-            let mut this_round_block_headers = Vec::new();
+            let mut this_round_blocks = Vec::new();
 
             for core_fixture in &mut cores {
                 // do not produce any block for authority 3
@@ -3739,22 +3808,29 @@ mod test {
                 // leader authority 3
                 core_fixture
                     .core
-                    .add_block_headers(last_round_block_headers.clone(), DataSource::Test)
+                    .add_blocks(last_round_blocks.clone(), DataSource::Test)
                     .unwrap();
-                core_fixture
+                let (new_block, _) = core_fixture
                     .core
                     .new_block(round, ReasonToCreateBlock::MaxLeaderTimeout)
                     .unwrap();
-
-                let block_header = core_fixture.core.last_proposed_block_header();
-                assert_eq!(block_header.round(), round);
+                // The round 1 block was already proposed while the core recovered.
+                let block = new_block.unwrap_or_else(|| {
+                    core_fixture
+                        .core
+                        .dag_state
+                        .read()
+                        .get_last_own_non_genesis_block()
+                        .expect("a block should have been proposed")
+                });
+                assert_eq!(block.round(), round);
 
                 // append the new block to this round blocks
-                this_round_block_headers.push(block_header.clone());
+                this_round_blocks.push(block);
             }
 
-            last_round_block_headers = this_round_block_headers.clone();
-            all_block_headers.extend(this_round_block_headers);
+            last_round_blocks = this_round_blocks.clone();
+            all_blocks.extend(this_round_blocks);
         }
 
         // Now send all the produced blocks to core of authority 3. It should produce a
@@ -3768,7 +3844,7 @@ mod test {
         // add blocks to trigger proposal.
         core_fixture
             .core
-            .add_block_headers(all_block_headers, DataSource::Test)
+            .add_blocks(all_blocks, DataSource::Test)
             .unwrap();
 
         // Assert that a block has been created for round 11 and it references to blocks

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3706,7 +3706,7 @@ mod test {
             },
         }";
 
-        let dag_builder = parse_dag(dag_str).expect("Invalid dag");
+        let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
 
         // Add equivocating block for round 2 authority 3
         let block_header = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(2, 2).build());

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -383,11 +383,14 @@ pub(crate) fn compute_per_commit_contribution(
 #[cfg(test)]
 mod tests {
 
+    use rstest::rstest;
+
     use super::*;
     use crate::{
         authority_set::AuthoritySet,
         block_header::{
-            BlockHeaderDigest, Round, StrongVote, TestBlockHeader, VerifiedBlockHeader,
+            BlockHeaderDigest, Round, StrongVote, TestBlockHeader, TestBlockHeaderVersion,
+            VerifiedBlockHeader,
         },
         commit::{CommitDigest, CommitRef},
         test_dag_builder::DagBuilder,
@@ -514,10 +517,17 @@ mod tests {
             .collect()
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_compute_per_commit_contribution_full_connectivity() {
+    async fn test_compute_per_commit_contribution_full_connectivity(
+        #[values(false, true)] starfish_speed: bool,
+    ) {
         telemetry_subscribers::init_for_testing();
-        let context = Arc::new(Context::new_for_test(4).0);
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
+        let context = Arc::new(context);
         let subdags = build_four_commits(context.clone());
         assert_eq!(subdags.len(), 4);
 
@@ -531,8 +541,10 @@ mod tests {
 
         // In a fully-connected DAG, every authority votes for commit-1's leader and
         // every round-(r+2) block certifies every voting block. So every authority's
-        // contribution equals the full committee stake.
-        let expected_per_authority: u64 = context.committee.total_stake();
+        // contribution equals the full committee stake — doubled under
+        // StarfishSpeed, where every one of these votes is a strong vote.
+        let vote_weight: u64 = if starfish_speed { 2 } else { 1 };
+        let expected_per_authority: u64 = context.committee.total_stake() * vote_weight;
         assert_eq!(
             contribution,
             vec![expected_per_authority; context.committee.size()],
@@ -717,6 +729,7 @@ mod tests {
         );
         let strong_vote = VerifiedBlockHeader::new_for_test(
             TestBlockHeader::new(r + 1, 2)
+                .set_version(TestBlockHeaderVersion::V2)
                 .set_ancestors(vec![c_minus_3.leader])
                 .set_strong_vote(Some(StrongVote {
                     leader_authority,

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -885,7 +885,7 @@ mod tests {
                 Round 5 : { * },
             }";
 
-        let dag_builder = parse_dag(dag_str).expect("Invalid dag");
+        let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
         dag_builder.print();
         dag_builder.persist_all_blocks(dag_state.clone());
 

--- a/crates/starfish/core/src/sliding_window_schedule.rs
+++ b/crates/starfish/core/src/sliding_window_schedule.rs
@@ -168,6 +168,8 @@ impl SlidingWindowSchedule {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
     use crate::test_dag_builder::DagBuilder;
 
@@ -193,11 +195,16 @@ mod tests {
         assert_eq!(schedule.scores_entries.len(), 0);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_eviction_subtracts_from_aggregate() {
+    async fn test_eviction_subtracts_from_aggregate(#[values(false, true)] starfish_speed: bool) {
         // Small window so we can saturate it within a small DAG.
         let window_size: u32 = 2;
-        let context = Arc::new(Context::new_for_test(4).0);
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
+        let context = Arc::new(context);
         let mut schedule = SlidingWindowSchedule::new(context.clone(), window_size);
         // 6 commits → 3 scored (commits 1..=3 scored as c_minus_3 in iterations 4..=6).
         let subdags = build_full_commits(context.clone(), 6);
@@ -208,10 +215,12 @@ mod tests {
         assert_eq!(schedule.scores_entries.len(), window_size as usize);
 
         // In a fully-connected DAG each scored commit contributes
-        // committee.total_stake() to every authority. The aggregate equals
-        // `window_size * total_stake` because earlier contributions were
+        // committee.total_stake() to every authority — doubled under
+        // StarfishSpeed, where every vote is a strong vote. The aggregate
+        // equals `window_size * per_commit` because earlier contributions were
         // subtracted on eviction.
-        let per_commit = context.committee.total_stake();
+        let vote_weight: u64 = if starfish_speed { 2 } else { 1 };
+        let per_commit = context.committee.total_stake() * vote_weight;
         let expected = per_commit * (window_size as u64);
         assert_eq!(
             schedule.total_scores_per_authority,
@@ -219,9 +228,16 @@ mod tests {
         );
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_reputation_scores_reports_window_aggregate_and_range() {
-        let context = Arc::new(Context::new_for_test(4).0);
+    async fn test_reputation_scores_reports_window_aggregate_and_range(
+        #[values(false, true)] starfish_speed: bool,
+    ) {
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(starfish_speed);
+        let context = Arc::new(context);
         let mut schedule = SlidingWindowSchedule::new(context.clone(), 10);
 
         // Before anything is scored: all-zero scores over the empty range.
@@ -239,7 +255,9 @@ mod tests {
         }
         let scores = schedule.reputation_scores();
         assert_eq!(scores.commit_range, (1..=3).into());
-        let per_commit = context.committee.total_stake();
+        // Under StarfishSpeed every vote is a strong vote, which scores double.
+        let vote_weight: u64 = if starfish_speed { 2 } else { 1 };
+        let per_commit = context.committee.total_stake() * vote_weight;
         assert_eq!(
             scores.scores_per_authority,
             vec![per_commit * 3; context.committee.size()]

--- a/crates/starfish/core/src/test_dag.rs
+++ b/crates/starfish/core/src/test_dag.rs
@@ -119,10 +119,10 @@ pub(crate) fn build_dag_layer(
     references
 }
 
-/// The strong vote for a block at `round` linking `ancestors`. Blocks built here
-/// acknowledge nothing, so the vote on the leader at `round - 1` is a blame,
-/// except on the genesis leader, which carries no transactions to be missing.
-/// `None` when the block does not link the leader, or while
+/// The strong vote for a block at `round` linking `ancestors`. Blocks built
+/// here acknowledge nothing, so the vote on the leader at `round - 1` is a
+/// blame, except on the genesis leader, which carries no transactions to be
+/// missing. `None` when the block does not link the leader, or while
 /// `consensus_starfish_speed` is off.
 fn strong_vote_for_leader(
     context: &Context,

--- a/crates/starfish/core/src/test_dag.rs
+++ b/crates/starfish/core/src/test_dag.rs
@@ -9,12 +9,14 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 use starfish_config::AuthorityIndex;
 
 use crate::{
+    authority_set::AuthoritySet,
     block_header::{
-        BlockRef, BlockTimestampMs, Round, TestBlockHeader, VerifiedBlockHeader,
-        genesis_block_headers,
+        BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, StrongVote, TestBlockHeader,
+        TestBlockHeaderVersion, VerifiedBlockHeader, genesis_block_headers,
     },
     context::Context,
     dag_state::{DagState, DataSource},
+    leader_schedule::{LeaderSchedule, LeaderSwapTable},
     test_dag_builder::DagBuilder,
 };
 
@@ -47,6 +49,7 @@ pub(crate) fn build_dag(
 
     let num_authorities = context.committee.size();
     let starting_round = ancestors.first().unwrap().round + 1;
+    let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
     for round in starting_round..=stop {
         let (references, blocks): (Vec<_>, Vec<_>) = context
             .committee
@@ -59,8 +62,15 @@ pub(crate) fn build_dag(
                     + author_idx as BlockTimestampMs;
                 let block = VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(round, author_idx)
+                        .set_version(TestBlockHeaderVersion::from_context(&context))
                         .set_timestamp_ms(ts)
                         .set_ancestors(ancestors.clone())
+                        .set_strong_vote(strong_blame_for_leader(
+                            &context,
+                            &leader_schedule,
+                            round,
+                            &ancestors,
+                        ))
                         .build(),
                 );
 
@@ -78,17 +88,26 @@ pub(crate) fn build_dag(
 
 // TODO: Add layer_round as input parameter so ancestors can be from any round.
 pub(crate) fn build_dag_layer(
+    context: &Arc<Context>,
     // A list of (authority, parents) pairs. For each authority, we add a block
     // linking to the specified parents.
     connections: Vec<(AuthorityIndex, Vec<BlockRef>)>,
     dag_state: Arc<RwLock<DagState>>,
 ) -> Vec<BlockRef> {
+    let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
     let mut references = Vec::new();
     for (authority, ancestors) in connections {
         let round = ancestors.first().unwrap().round + 1;
         let author = authority.value() as u8;
         let block = VerifiedBlockHeader::new_for_test(
             TestBlockHeader::new(round, author)
+                .set_version(TestBlockHeaderVersion::from_context(context))
+                .set_strong_vote(strong_blame_for_leader(
+                    context,
+                    &leader_schedule,
+                    round,
+                    &ancestors,
+                ))
                 .set_ancestors(ancestors)
                 .build(),
         );
@@ -98,6 +117,37 @@ pub(crate) fn build_dag_layer(
             .accept_block_header(block, DataSource::Test);
     }
     references
+}
+
+/// The strong vote for a block at `round` linking `ancestors`. Blocks built
+/// here acknowledge no transactions, so the vote on the leader at `round - 1`
+/// is always a blame. `None` when the block does not link the leader, since an
+/// author that has not seen the leader block cannot vote on it, and `None`
+/// while `consensus_starfish_speed` is off, where headers are V1.
+fn strong_blame_for_leader(
+    context: &Context,
+    leader_schedule: &LeaderSchedule,
+    round: Round,
+    ancestors: &[BlockRef],
+) -> Option<StrongVote> {
+    if !context.protocol_config.consensus_starfish_speed() {
+        return None;
+    }
+    let leader_round = round - 1;
+    let leader_authority = leader_schedule.elect_leader(leader_round, 0);
+    if leader_round != GENESIS_ROUND
+        && !ancestors
+            .iter()
+            .any(|r| r.round == leader_round && r.author == leader_authority)
+    {
+        return None;
+    }
+    let mut missing = AuthoritySet::new();
+    missing.insert(leader_authority);
+    Some(StrongVote {
+        leader_authority,
+        missing,
+    })
 }
 
 pub(crate) fn create_random_dag(

--- a/crates/starfish/core/src/test_dag.rs
+++ b/crates/starfish/core/src/test_dag.rs
@@ -50,7 +50,11 @@ pub(crate) fn build_dag(
     let num_authorities = context.committee.size();
     let starting_round = ancestors.first().unwrap().round + 1;
     let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
+    let version = TestBlockHeaderVersion::from_context(&context);
     for round in starting_round..=stop {
+        // Every block of the round links the same ancestors, so they all carry
+        // the same vote.
+        let strong_vote = strong_vote_for_leader(&context, &leader_schedule, round, &ancestors);
         let (references, blocks): (Vec<_>, Vec<_>) = context
             .committee
             .authorities()
@@ -62,15 +66,10 @@ pub(crate) fn build_dag(
                     + author_idx as BlockTimestampMs;
                 let block = VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(round, author_idx)
-                        .set_version(TestBlockHeaderVersion::from_context(&context))
+                        .set_version(version)
                         .set_timestamp_ms(ts)
                         .set_ancestors(ancestors.clone())
-                        .set_strong_vote(strong_blame_for_leader(
-                            &context,
-                            &leader_schedule,
-                            round,
-                            &ancestors,
-                        ))
+                        .set_strong_vote(strong_vote)
                         .build(),
                 );
 
@@ -95,14 +94,15 @@ pub(crate) fn build_dag_layer(
     dag_state: Arc<RwLock<DagState>>,
 ) -> Vec<BlockRef> {
     let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
+    let version = TestBlockHeaderVersion::from_context(context);
     let mut references = Vec::new();
     for (authority, ancestors) in connections {
         let round = ancestors.first().unwrap().round + 1;
         let author = authority.value() as u8;
         let block = VerifiedBlockHeader::new_for_test(
             TestBlockHeader::new(round, author)
-                .set_version(TestBlockHeaderVersion::from_context(context))
-                .set_strong_vote(strong_blame_for_leader(
+                .set_version(version)
+                .set_strong_vote(strong_vote_for_leader(
                     context,
                     &leader_schedule,
                     round,
@@ -119,12 +119,12 @@ pub(crate) fn build_dag_layer(
     references
 }
 
-/// The strong vote for a block at `round` linking `ancestors`. Blocks built
-/// here acknowledge no transactions, so the vote on the leader at `round - 1`
-/// is always a blame. `None` when the block does not link the leader, since an
-/// author that has not seen the leader block cannot vote on it, and `None`
-/// while `consensus_starfish_speed` is off, where headers are V1.
-fn strong_blame_for_leader(
+/// The strong vote for a block at `round` linking `ancestors`. Blocks built here
+/// acknowledge nothing, so the vote on the leader at `round - 1` is a blame,
+/// except on the genesis leader, which carries no transactions to be missing.
+/// `None` when the block does not link the leader, or while
+/// `consensus_starfish_speed` is off.
+fn strong_vote_for_leader(
     context: &Context,
     leader_schedule: &LeaderSchedule,
     round: Round,
@@ -135,15 +135,16 @@ fn strong_blame_for_leader(
     }
     let leader_round = round - 1;
     let leader_authority = leader_schedule.elect_leader(leader_round, 0);
-    if leader_round != GENESIS_ROUND
-        && !ancestors
+    let mut missing = AuthoritySet::new();
+    if leader_round != GENESIS_ROUND {
+        if !ancestors
             .iter()
             .any(|r| r.round == leader_round && r.author == leader_authority)
-    {
-        return None;
+        {
+            return None;
+        }
+        missing.insert(leader_authority);
     }
-    let mut missing = AuthoritySet::new();
-    missing.insert(leader_authority);
     Some(StrongVote {
         leader_authority,
         missing,

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -14,10 +14,11 @@ use starfish_config::{AuthorityIndex, ProtocolKeyPair};
 
 use crate::{
     CommitRef, CommittedSubDag,
+    authority_set::AuthoritySet,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, Round, Slot,
-        TestBlockHeader, Transaction, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedTransactions, genesis_block_headers,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
+        StrongVote, TestBlockHeader, TestBlockHeaderVersion, Transaction, TransactionsCommitment,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions, genesis_block_headers,
     },
     commit::{CertifiedCommit, CommitAPI, CommitDigest, TrustedCommit, WAVE_LENGTH},
     context::Context,
@@ -121,6 +122,10 @@ pub(crate) struct DagBuilder {
     protocol_keypair: Option<Vec<ProtocolKeyPair>>,
 
     encoder: Box<dyn ShardEncoder + Send + Sync>,
+
+    // Per authority, the blocks whose transactions that authority has acknowledged so far. Stands
+    // in for `DagState::are_transactions_available` when computing strong votes.
+    available_transactions: Vec<HashSet<BlockRef>>,
 }
 /// The `AncestorSelection` enum is an interim data structure used to specify
 /// how ancestors should be selected for a block in the `DagBuilder`. `UseLast`
@@ -158,6 +163,7 @@ impl DagBuilder {
         let encoder = create_encoder(&context);
         Self {
             last_committed_rounds: vec![0; context.committee.size()],
+            available_transactions: vec![HashSet::new(); context.committee.size()],
             context,
             leader_schedule,
             wave_length: WAVE_LENGTH,
@@ -585,19 +591,23 @@ impl DagBuilder {
         for (authority, ancestors) in connections {
             let author = authority.value() as u8;
             let base_ts = round as BlockTimestampMs * 1000;
+            let acknowledgments = transaction_acks
+                .get(&authority)
+                .cloned()
+                .unwrap_or_default();
+            self.available_transactions[authority].extend(acknowledgments.iter().copied());
+            let strong_vote = self.strong_vote(round, authority, &ancestors);
             let block = VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(round, author)
+                    .set_version(TestBlockHeaderVersion::from_context(&self.context))
                     .set_ancestors(ancestors)
-                    .set_acknowledgments(
-                        transaction_acks
-                            .get(&authority)
-                            .cloned()
-                            .unwrap_or_default(),
-                    )
+                    .set_acknowledgments(acknowledgments)
                     .set_timestamp_ms(base_ts + author as u64)
+                    .set_strong_vote(strong_vote)
                     .build(),
             );
             references.push(block.reference());
+            self.available_transactions[authority].insert(block.reference());
             self.block_headers.insert(block.reference(), block.clone());
         }
         let mut rng = StdRng::from_entropy();
@@ -630,6 +640,54 @@ impl DagBuilder {
             self.transactions.insert(block_ref, verified_transactions);
         }
         self.last_ancestors = references;
+    }
+
+    /// The strong vote a block at `round` by `author` linking `ancestors`
+    /// carries, mirroring `Core::compute_strong_vote`: it pins the leader at
+    /// `round - 1` and lists the authorities whose transactions `author` has
+    /// not acknowledged yet. `None` when the block does not link the
+    /// leader, since an author that has not seen the leader block cannot
+    /// vote on it, and `None` while `consensus_starfish_speed` is off,
+    /// where headers are V1.
+    fn strong_vote(
+        &self,
+        round: Round,
+        author: AuthorityIndex,
+        ancestors: &[BlockRef],
+    ) -> Option<StrongVote> {
+        if !self.context.protocol_config.consensus_starfish_speed() {
+            return None;
+        }
+        let leader_round = round - 1;
+        let leader_authority = self.leader_schedule.elect_leader(leader_round, 0);
+        let mut missing = AuthoritySet::new();
+        // Genesis blocks carry no transactions, so a vote on the genesis leader
+        // is always a blame.
+        if leader_round == GENESIS_ROUND {
+            missing.insert(leader_authority);
+            return Some(StrongVote {
+                leader_authority,
+                missing,
+            });
+        }
+
+        let leader_ref = ancestors
+            .iter()
+            .find(|r| r.round == leader_round && r.author == leader_authority)?;
+        let leader_header = self.block_headers.get(leader_ref)?;
+        let available = &self.available_transactions[author];
+        if !available.contains(leader_ref) {
+            missing.insert(leader_authority);
+        }
+        for ack in leader_header.acknowledgments() {
+            if !available.contains(ack) {
+                missing.insert(ack.author);
+            }
+        }
+        Some(StrongVote {
+            leader_authority,
+            missing,
+        })
     }
 }
 /// Refer to doc comments for [`DagBuilder`] for usage information.
@@ -1086,6 +1144,13 @@ impl<'a> LayerBuilder<'a> {
                 continue;
             };
             let num_blocks = self.num_blocks_to_create(authority);
+            let acknowledgments = transaction_acknowledgments
+                .get(&authority)
+                .cloned()
+                .unwrap_or_default();
+            self.dag_builder.available_transactions[authority]
+                .extend(acknowledgments.iter().copied());
+            let strong_vote = self.dag_builder.strong_vote(round, authority, &ancestors);
 
             for num_block in 0..num_blocks {
                 let timestamp = self.block_timestamp(authority, round, num_block);
@@ -1103,15 +1168,14 @@ impl<'a> LayerBuilder<'a> {
                 .unwrap();
 
                 let test_block_header = TestBlockHeader::new(round, authority.value() as u8)
+                    .set_version(TestBlockHeaderVersion::from_context(
+                        &self.dag_builder.context,
+                    ))
                     .set_ancestors(ancestors.clone())
-                    .set_acknowledgments(
-                        transaction_acknowledgments
-                            .get(&authority)
-                            .cloned()
-                            .unwrap_or_default(),
-                    )
+                    .set_acknowledgments(acknowledgments.clone())
                     .set_timestamp_ms(timestamp)
                     .set_commitment(commitment)
+                    .set_strong_vote(strong_vote)
                     .build();
                 let block_header =
                     if let Some(protocol_keypair) = self.dag_builder.protocol_keypair.as_ref() {
@@ -1131,6 +1195,7 @@ impl<'a> LayerBuilder<'a> {
                 );
 
                 references.push(block_header.reference());
+                self.dag_builder.available_transactions[authority].insert(block_header.reference());
                 self.dag_builder
                     .block_headers
                     .insert(block_header.reference(), block_header.clone());

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -587,6 +587,7 @@ impl DagBuilder {
         };
 
         let mut references = Vec::new();
+        let version = TestBlockHeaderVersion::from_context(&self.context);
 
         for (authority, ancestors) in connections {
             let author = authority.value() as u8;
@@ -595,11 +596,10 @@ impl DagBuilder {
                 .get(&authority)
                 .cloned()
                 .unwrap_or_default();
-            self.available_transactions[authority].extend(acknowledgments.iter().copied());
-            let strong_vote = self.strong_vote(round, authority, &ancestors);
+            let strong_vote = self.strong_vote(round, authority, &ancestors, &acknowledgments);
             let block = VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(round, author)
-                    .set_version(TestBlockHeaderVersion::from_context(&self.context))
+                    .set_version(version)
                     .set_ancestors(ancestors)
                     .set_acknowledgments(acknowledgments)
                     .set_timestamp_ms(base_ts + author as u64)
@@ -607,7 +607,7 @@ impl DagBuilder {
                     .build(),
             );
             references.push(block.reference());
-            self.available_transactions[authority].insert(block.reference());
+            self.record_own_block(block.reference());
             self.block_headers.insert(block.reference(), block.clone());
         }
         let mut rng = StdRng::from_entropy();
@@ -642,52 +642,59 @@ impl DagBuilder {
         self.last_ancestors = references;
     }
 
-    /// The strong vote a block at `round` by `author` linking `ancestors`
-    /// carries, mirroring `Core::compute_strong_vote`: it pins the leader at
-    /// `round - 1` and lists the authorities whose transactions `author` has
-    /// not acknowledged yet. `None` when the block does not link the
-    /// leader, since an author that has not seen the leader block cannot
-    /// vote on it, and `None` while `consensus_starfish_speed` is off,
-    /// where headers are V1.
+    /// The strong vote a block at `round` by `author` carries, mirroring
+    /// `Core::compute_strong_vote`: it pins the leader at `round - 1` and lists
+    /// the authorities whose transactions `author` has not acknowledged. Takes
+    /// `acknowledgments` as well as `ancestors` because the block's own
+    /// acknowledgments count towards what it has, so they have to be recorded
+    /// before the vote is derived. `None` when the block does not link the
+    /// leader, since an author that has not seen the leader block cannot vote
+    /// on it, and `None` while `consensus_starfish_speed` is off, where
+    /// headers are V1 and nothing reads the recorded transactions.
     fn strong_vote(
-        &self,
+        &mut self,
         round: Round,
         author: AuthorityIndex,
         ancestors: &[BlockRef],
+        acknowledgments: &[BlockRef],
     ) -> Option<StrongVote> {
         if !self.context.protocol_config.consensus_starfish_speed() {
             return None;
         }
+        self.available_transactions[author].extend(acknowledgments.iter().copied());
+
         let leader_round = round - 1;
         let leader_authority = self.leader_schedule.elect_leader(leader_round, 0);
         let mut missing = AuthoritySet::new();
-        // Genesis blocks carry no transactions, so a vote on the genesis leader
-        // is always a blame.
         if leader_round == GENESIS_ROUND {
-            missing.insert(leader_authority);
-            return Some(StrongVote {
-                leader_authority,
-                missing,
-            });
-        }
-
-        let leader_ref = ancestors
-            .iter()
-            .find(|r| r.round == leader_round && r.author == leader_authority)?;
-        let leader_header = self.block_headers.get(leader_ref)?;
-        let available = &self.available_transactions[author];
-        if !available.contains(leader_ref) {
-            missing.insert(leader_authority);
-        }
-        for ack in leader_header.acknowledgments() {
-            if !available.contains(ack) {
-                missing.insert(ack.author);
+            // A genesis block carries no transactions, so none can be missing.
+        } else {
+            let leader_ref = ancestors
+                .iter()
+                .find(|r| r.round == leader_round && r.author == leader_authority)?;
+            let leader_header = self.block_headers.get(leader_ref)?;
+            let available = &self.available_transactions[author];
+            if !available.contains(leader_ref) {
+                missing.insert(leader_authority);
+            }
+            for ack in leader_header.acknowledgments() {
+                if !available.contains(ack) {
+                    missing.insert(ack.author);
+                }
             }
         }
         Some(StrongVote {
             leader_authority,
             missing,
         })
+    }
+
+    /// Records that an author holds the transactions of the block it just
+    /// built.
+    fn record_own_block(&mut self, block_ref: BlockRef) {
+        if self.context.protocol_config.consensus_starfish_speed() {
+            self.available_transactions[block_ref.author].insert(block_ref);
+        }
     }
 }
 /// Refer to doc comments for [`DagBuilder`] for usage information.
@@ -1138,6 +1145,7 @@ impl<'a> LayerBuilder<'a> {
     ) {
         let mut references = Vec::new();
         let mut rng = StdRng::from_entropy();
+        let version = TestBlockHeaderVersion::from_context(&self.dag_builder.context);
 
         for (authority, ancestors) in connections {
             if self.should_skip_block(round, authority) {
@@ -1148,9 +1156,9 @@ impl<'a> LayerBuilder<'a> {
                 .get(&authority)
                 .cloned()
                 .unwrap_or_default();
-            self.dag_builder.available_transactions[authority]
-                .extend(acknowledgments.iter().copied());
-            let strong_vote = self.dag_builder.strong_vote(round, authority, &ancestors);
+            let strong_vote =
+                self.dag_builder
+                    .strong_vote(round, authority, &ancestors, &acknowledgments);
 
             for num_block in 0..num_blocks {
                 let timestamp = self.block_timestamp(authority, round, num_block);
@@ -1168,9 +1176,7 @@ impl<'a> LayerBuilder<'a> {
                 .unwrap();
 
                 let test_block_header = TestBlockHeader::new(round, authority.value() as u8)
-                    .set_version(TestBlockHeaderVersion::from_context(
-                        &self.dag_builder.context,
-                    ))
+                    .set_version(version)
                     .set_ancestors(ancestors.clone())
                     .set_acknowledgments(acknowledgments.clone())
                     .set_timestamp_ms(timestamp)
@@ -1195,7 +1201,7 @@ impl<'a> LayerBuilder<'a> {
                 );
 
                 references.push(block_header.reference());
-                self.dag_builder.available_transactions[authority].insert(block_header.reference());
+                self.dag_builder.record_own_block(block_header.reference());
                 self.dag_builder
                     .block_headers
                     .insert(block_header.reference(), block_header.clone());

--- a/crates/starfish/core/src/test_dag_parser.rs
+++ b/crates/starfish/core/src/test_dag_parser.rs
@@ -280,10 +280,19 @@ impl<E: std::fmt::Debug> From<nom::Err<E>> for ParseDagError {
 ///     Round 8 : { * },
 ///     }";
 ///
-/// let dag_builder = parse_dag(dag_str).expect("Invalid dag"); // parse DAG DSL
+/// let dag_builder = parse_dag(dag_str, false).expect("Invalid dag"); // parse DAG DSL
 /// dag_builder.print(); // print the parsed DAG
 /// ```
-pub(crate) fn parse_dag(dag_string: &str) -> Result<DagBuilder, ParseDagError> {
+///
+/// `starfish_speed` sets the flag on the context the DAG is built with, which
+/// selects the header version and whether blocks carry strong votes. Strong
+/// votes follow from the acknowledgments each block is given: a block whose
+/// acknowledgments miss the leader's data blames the leader instead of voting
+/// for it.
+pub(crate) fn parse_dag(
+    dag_string: &str,
+    starfish_speed: bool,
+) -> Result<DagBuilder, ParseDagError> {
     // Parse subsequent rounds
     // remove whitespace from the input
     let cleaned: String = dag_string.chars().filter(|c| !c.is_whitespace()).collect();
@@ -291,12 +300,10 @@ pub(crate) fn parse_dag(dag_string: &str) -> Result<DagBuilder, ParseDagError> {
 
     let (mut input, num_authors) = preceded(tag("DAG{"), parse_genesis)(input)?;
 
-    // Parsed DAG strings cannot specify strong votes; run with StarfishSpeed
-    // off.
     let mut context = Context::new_for_test(num_authors as usize).0;
     context
         .protocol_config
-        .set_consensus_starfish_speed_for_testing(false);
+        .set_consensus_starfish_speed_for_testing(starfish_speed);
     let context = Arc::new(context);
     let mut dag_builder = DagBuilder::new(context);
     loop {
@@ -350,7 +357,7 @@ mod tests {
                 C -> ([-A5],[]),
             }
          }";
-        let result = parse_dag(dag_str);
+        let result = parse_dag(dag_str, false);
         assert!(result.is_ok());
 
         let dag_builder = result.unwrap();

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -46,7 +46,7 @@ async fn direct_commit() {
         },
         }";
 
-    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str, false).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state);
 
     let leader_round = committer.leader_round(1);
@@ -90,7 +90,7 @@ async fn direct_skip() {
         Round 5 : { * },
         }";
 
-    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str, false).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state);
 
     let leader_round = committer.leader_round(1);
@@ -134,7 +134,7 @@ async fn direct_undecided() {
         Round 5 : { * },
         }";
 
-    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str, false).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state);
 
     let leader_round = committer.leader_round(1);
@@ -208,7 +208,7 @@ async fn indirect_commit() {
         },
     }";
 
-    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str, false).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state);
 
     let leader_round = committer.leader_round(1);
@@ -292,7 +292,7 @@ async fn indirect_skip() {
         Round 11 : { * },
     }";
 
-    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str, false).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state);
 
     let leader_round = committer.leader_round(1);

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -249,7 +249,7 @@ async fn indirect_commit() {
         .map(|authority| (authority.0, references_leader_round_wave_1.clone()))
         .collect();
     let references_with_votes_for_leader_wave_1 =
-        build_dag_layer(connections_with_leader_wave_1, dag_state.clone());
+        build_dag_layer(&context, connections_with_leader_wave_1, dag_state.clone());
 
     // The validators not part of the 2f+1 above do not vote for the leader
     // of wave 1
@@ -259,8 +259,11 @@ async fn indirect_commit() {
         .skip(context.committee.quorum_threshold() as usize)
         .map(|authority| (authority.0, references_without_leader_wave_1.clone()))
         .collect();
-    let references_without_votes_for_leader_wave_1 =
-        build_dag_layer(connections_without_leader_wave_1, dag_state.clone());
+    let references_without_votes_for_leader_wave_1 = build_dag_layer(
+        &context,
+        connections_without_leader_wave_1,
+        dag_state.clone(),
+    );
 
     // Only f+1 validators certify the leader of wave 1.
     let mut references_certifying_round_wave_1 = Vec::new();
@@ -272,6 +275,7 @@ async fn indirect_commit() {
         .map(|authority| (authority.0, references_with_votes_for_leader_wave_1.clone()))
         .collect();
     references_certifying_round_wave_1.extend(build_dag_layer(
+        &context,
         connections_with_certs_for_leader_wave_1,
         dag_state.clone(),
     ));
@@ -291,6 +295,7 @@ async fn indirect_commit() {
         .map(|authority| (authority.0, references_voting_round_wave_1.clone()))
         .collect();
     references_certifying_round_wave_1.extend(build_dag_layer(
+        &context,
         connections_without_votes_for_leader_1,
         dag_state.clone(),
     ));
@@ -399,6 +404,7 @@ async fn indirect_skip() {
         .collect();
 
     references_voting_round_wave_2.extend(build_dag_layer(
+        &context,
         connections_with_vote_leader_wave_2,
         dag_state.clone(),
     ));
@@ -411,6 +417,7 @@ async fn indirect_skip() {
         .collect();
 
     references_voting_round_wave_2.extend(build_dag_layer(
+        &context,
         connections_without_vote_leader_wave_2,
         dag_state.clone(),
     ));
@@ -540,7 +547,7 @@ async fn undecided() {
         .chain(connections_without_leader_wave_1)
         .collect();
     let references_voting_round_wave_1 =
-        build_dag_layer(connections_voting_round_wave_1, dag_state.clone());
+        build_dag_layer(&context, connections_voting_round_wave_1, dag_state.clone());
 
     // Add enough blocks to reach the certifying round of wave 1.
     let certifying_round_wave_1 = committer.certifying_round(1);

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -5,10 +5,13 @@
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use rstest::rstest;
 use starfish_config::AuthorityIndex;
 
 use crate::{
-    block_header::{BlockHeaderAPI, Slot, TestBlockHeader, VerifiedBlockHeader},
+    block_header::{
+        BlockHeaderAPI, Slot, TestBlockHeader, TestBlockHeaderVersion, VerifiedBlockHeader,
+    },
     commit::{DecidedLeader, WAVE_LENGTH},
     context::Context,
     dag_state::{DagState, DataSource},
@@ -19,9 +22,10 @@ use crate::{
 };
 
 /// Commit one leader.
+#[rstest]
 #[tokio::test]
-async fn direct_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn direct_commit(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // note: pipelines, waves & rounds are zero-indexed.
     let decision_round_wave_0_pipeline_1 = committer.committers[1].certifying_round(0);
@@ -45,9 +49,10 @@ async fn direct_commit() {
 }
 
 /// Ensure idempotent replies.
+#[rstest]
 #[tokio::test]
-async fn idempotence() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn idempotence(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // Add enough blocks to reach decision round of pipeline 1 wave 0 which is round
     // 4. note: pipelines, waves & rounds are zero-indexed.
@@ -94,9 +99,10 @@ async fn idempotence() {
 }
 
 /// Commit one by one each leader as the dag progresses in ideal conditions.
+#[rstest]
 #[tokio::test]
-async fn multiple_direct_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn multiple_direct_commit(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
     let wave_length = WAVE_LENGTH;
 
     let mut last_finalized = Slot::new(0, 0);
@@ -140,9 +146,10 @@ async fn multiple_direct_commit() {
 }
 
 /// Commit 10 leaders in a row (calling the committer after adding them).
+#[rstest]
 #[tokio::test]
-async fn direct_commit_late_call() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn direct_commit_late_call(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
     let wave_length = WAVE_LENGTH;
 
     // note: pipelines, waves & rounds are zero-indexed.
@@ -171,9 +178,10 @@ async fn direct_commit_late_call() {
 }
 
 /// Do not commit anything if we are still in the first wave.
+#[rstest]
 #[tokio::test]
-async fn no_genesis_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn no_genesis_commit(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // Pipeline 0 wave 0 will not have a commit because its leader round is the
     // genesis round.
@@ -191,9 +199,10 @@ async fn no_genesis_commit() {
 }
 
 /// We do not commit anything if we miss the first leader.
+#[rstest]
 #[tokio::test]
-async fn direct_skip_no_leader() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn direct_skip_no_leader(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // Add enough blocks to reach the decision round of the leader of wave 0 for
     // pipeline 1 but without the leader block.
@@ -242,9 +251,10 @@ async fn direct_skip_no_leader() {
 }
 
 /// We directly skip the leader if it has enough blame.
+#[rstest]
 #[tokio::test]
-async fn direct_skip_enough_blame() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn direct_skip_enough_blame(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // Add enough blocks to reach the wave 0 leader for pipeline 1.
     // note: pipelines, waves & rounds are zero-indexed.
@@ -316,9 +326,10 @@ async fn direct_skip_enough_blame() {
 }
 
 /// Indirect-commit the first leader.
+#[rstest]
 #[tokio::test]
-async fn indirect_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn indirect_commit(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
     let wave_length = WAVE_LENGTH;
 
     // Add enough blocks to reach the wave 0 leader of pipeline 1.
@@ -435,9 +446,10 @@ async fn indirect_commit() {
 }
 
 /// Commit the first 3 leaders, skip the 4th, and commit the next 3 leaders.
+#[rstest]
 #[tokio::test]
-async fn indirect_skip() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn indirect_skip(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
     let wave_length = WAVE_LENGTH;
 
     // Add enough blocks to reach the 4th leader.
@@ -531,9 +543,10 @@ async fn indirect_skip() {
 }
 
 /// If there is no leader with enough support nor blame, we commit nothing.
+#[rstest]
 #[tokio::test]
-async fn undecided() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn undecided(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // Add enough blocks to reach the first leader.
     // note: pipelines, waves & rounds are zero-indexed.
@@ -582,9 +595,11 @@ async fn undecided() {
 // blocks. However when extra dag layers are added and the byzantine node is
 // meant to be a leader, its block is skipped as there is not enough votes to
 // directly decide it and not any certified links to indirectly commit it.
+#[rstest]
 #[tokio::test]
-async fn test_byzantine_validator() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn test_byzantine_validator(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
+    let version = TestBlockHeaderVersion::from_context(&context);
 
     // Add enough blocks to reach leader A12
     // note: pipelines, waves & rounds are zero-indexed.
@@ -622,6 +637,7 @@ async fn test_byzantine_validator() {
     // dag state
     let byzantine_block_b13_1 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 1)
+            .set_version(version)
             .set_ancestors(references_without_leader_round_wave_4.clone())
             .build(),
     );
@@ -634,6 +650,7 @@ async fn test_byzantine_validator() {
 
     let byzantine_block_b13_2 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 1)
+            .set_version(version)
             .set_ancestors(references_without_leader_round_wave_4.clone())
             .set_timestamp_ms(timestamp + 1)
             .build(),
@@ -644,6 +661,7 @@ async fn test_byzantine_validator() {
 
     let byzantine_block_b13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 1)
+            .set_version(version)
             .set_ancestors(references_without_leader_round_wave_4)
             .set_timestamp_ms(timestamp + 2)
             .build(),
@@ -659,6 +677,7 @@ async fn test_byzantine_validator() {
     let mut references_round_14 = vec![];
     let decision_block_a14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 0)
+            .set_version(version)
             .set_ancestors(good_references_voting_round_wave_4.clone())
             .build(),
     );
@@ -674,6 +693,7 @@ async fn test_byzantine_validator() {
 
     let decision_block_b14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 1)
+            .set_version(version)
             .set_ancestors(
                 good_references_voting_round_wave_4_without_b13
                     .iter()
@@ -690,6 +710,7 @@ async fn test_byzantine_validator() {
 
     let decision_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
+            .set_version(version)
             .set_ancestors(
                 good_references_voting_round_wave_4_without_b13
                     .iter()
@@ -706,6 +727,7 @@ async fn test_byzantine_validator() {
 
     let decision_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
+            .set_version(version)
             .set_ancestors(
                 good_references_voting_round_wave_4_without_b13
                     .iter()
@@ -776,18 +798,19 @@ async fn test_byzantine_validator() {
     };
 }
 
-fn basic_test_setup() -> (
+fn basic_test_setup(
+    starfish_speed: bool,
+) -> (
     Arc<Context>,
     Arc<RwLock<DagState>>,
     super::UniversalCommitter,
 ) {
     telemetry_subscribers::init_for_testing();
     // Committee of 4 with even stake
-    // Test blocks carry no strong votes; run with StarfishSpeed off.
     let mut context = Context::new_for_test(4).0;
     context
         .protocol_config
-        .set_consensus_starfish_speed_for_testing(false);
+        .set_consensus_starfish_speed_for_testing(starfish_speed);
     let context = Arc::new(context);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -216,7 +216,7 @@ async fn direct_skip_no_leader() {
         .filter(|&authority| authority.0 != leader_pipeline_1_wave_0)
         .map(|authority| (authority.0, genesis.clone()))
         .collect::<Vec<_>>();
-    let references = build_dag_layer(connections, dag_state.clone());
+    let references = build_dag_layer(&context, connections, dag_state.clone());
 
     let decision_round_pipeline_1_wave_0 = committer.committers[1].certifying_round(0);
     build_dag(
@@ -272,7 +272,7 @@ async fn direct_skip_enough_blame() {
         .map(|authority| (authority.0, references_without_leader_1.clone()))
         .collect();
     let references_without_votes_for_leader_1 =
-        build_dag_layer(connections_without_leader_1, dag_state.clone());
+        build_dag_layer(&context, connections_without_leader_1, dag_state.clone());
 
     // one vote for that leader
     let connections_with_leader_1 = context
@@ -282,7 +282,7 @@ async fn direct_skip_enough_blame() {
         .map(|authority| (authority.0, references_round_1.clone()))
         .collect();
     let references_with_votes_for_leader_1 =
-        build_dag_layer(connections_with_leader_1, dag_state.clone());
+        build_dag_layer(&context, connections_with_leader_1, dag_state.clone());
 
     let references: Vec<_> = references_without_votes_for_leader_1
         .into_iter()
@@ -352,7 +352,7 @@ async fn indirect_commit() {
         .map(|authority| (authority.0, references_round_1.clone()))
         .collect();
     let references_with_votes_for_leader_1 =
-        build_dag_layer(connections_with_leader_1, dag_state.clone());
+        build_dag_layer(&context, connections_with_leader_1, dag_state.clone());
 
     let connections_without_leader_1 = context
         .committee
@@ -361,7 +361,7 @@ async fn indirect_commit() {
         .map(|authority| (authority.0, references_without_leader_1.clone()))
         .collect();
     let references_without_votes_for_leader_1 =
-        build_dag_layer(connections_without_leader_1, dag_state.clone());
+        build_dag_layer(&context, connections_without_leader_1, dag_state.clone());
 
     // Only f+1 validators certify that leader.
     let mut references_round_3 = Vec::new();
@@ -373,6 +373,7 @@ async fn indirect_commit() {
         .map(|authority| (authority.0, references_with_votes_for_leader_1.clone()))
         .collect::<Vec<_>>();
     references_round_3.extend(build_dag_layer(
+        &context,
         connections_with_votes_for_leader_1,
         dag_state.clone(),
     ));
@@ -389,6 +390,7 @@ async fn indirect_commit() {
         .map(|authority| (authority.0, references.clone()))
         .collect::<Vec<_>>();
     references_round_3.extend(build_dag_layer(
+        &context,
         connections_without_votes_for_leader_1,
         dag_state.clone(),
     ));
@@ -460,6 +462,7 @@ async fn indirect_skip() {
         .map(|authority| (authority.0, references_round_4.clone()))
         .collect::<Vec<_>>();
     references_round_5.extend(build_dag_layer(
+        &context,
         connections_with_leader_4,
         dag_state.clone(),
     ));
@@ -471,6 +474,7 @@ async fn indirect_skip() {
         .map(|authority| (authority.0, references_without_leader_4.clone()))
         .collect();
     references_round_5.extend(build_dag_layer(
+        &context,
         connections_without_leader_4,
         dag_state.clone(),
     ));
@@ -555,7 +559,7 @@ async fn undecided() {
         .into_iter()
         .chain(non_leader_connections)
         .collect::<Vec<_>>();
-    let references_voting_round_1 = build_dag_layer(connections, dag_state.clone());
+    let references_voting_round_1 = build_dag_layer(&context, connections, dag_state.clone());
 
     // Add enough blocks to reach the first decision round
     let decision_round_1 = committer.committers[1].certifying_round(0);

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -6,17 +6,15 @@ use std::{env, sync::Arc};
 
 use parking_lot::RwLock;
 use rand::{Rng, SeedableRng, prelude::SliceRandom, rngs::StdRng};
-use rstest::rstest;
 use starfish_config::AuthorityIndex;
 
 use crate::{
-    block_header::{BlockHeaderAPI, BlockRef, Slot},
+    block_header::{BlockHeaderAPI, Slot},
     block_manager::{BlockManager, block_suspender::tests::evaluate_block_headers},
-    commit::{CommitMetastate, DecidedLeader},
+    commit::DecidedLeader,
     context::Context,
     dag_state::{DagState, DataSource},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
-    stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::mem_store::MemStore,
     test_dag::create_random_dag,
     universal_committer::{
@@ -32,12 +30,14 @@ const NUM_ROUNDS: u32 = 200;
 /// - Links to leader of previous round.
 ///
 /// Should result in a direct commit for every round.
-#[rstest]
 #[tokio::test]
-async fn test_randomized_dag_all_direct_commit(#[values(false, true)] starfish_speed: bool) {
+async fn test_randomized_dag_all_direct_commit() {
     let mut random_test_setup = random_test_setup();
 
-    for _ in 0..NUM_RUNS {
+    // Alternate the flag across runs rather than repeating the whole campaign
+    // for each value.
+    for run in 0..NUM_RUNS {
+        let starfish_speed = run % 2 == 0;
         let seed = random_test_setup.seeded_rng.gen_range(0..10000);
         let num_authorities = random_test_setup.seeded_rng.gen_range(4..10);
         let authority = authority_setup(num_authorities, 0, starfish_speed);
@@ -88,12 +88,14 @@ async fn test_randomized_dag_all_direct_commit(#[values(false, true)] starfish_s
 /// sequence will include Commit & Skip decisions and potentially will stop
 /// before coming to a decision on all waves as we may have an Undecided leader
 /// somewhere early in the sequence.
-#[rstest]
 #[tokio::test]
-async fn test_randomized_dag_and_decision_sequence(#[values(false, true)] starfish_speed: bool) {
+async fn test_randomized_dag_and_decision_sequence() {
+    // Alternate the flag across runs rather than repeating the whole campaign
+    // for each value.
     let mut random_test_setup = random_test_setup();
 
-    for _ in 0..NUM_RUNS {
+    for run in 0..NUM_RUNS {
+        let starfish_speed = run % 2 == 0;
         let seed = random_test_setup.seeded_rng.gen_range(0..10000);
         let num_authorities = random_test_setup.seeded_rng.gen_range(4..10);
 
@@ -193,20 +195,6 @@ async fn test_randomized_dag_and_decision_sequence(#[values(false, true)] starfi
 
         assert!(authority_2.block_manager.is_empty());
 
-        // Every optimistic commit lists at least a quorum of strong voters, which
-        // is what the linearizer needs to commit the leader's acknowledged refs.
-        for leader in sequenced_leaders_1.iter().chain(sequenced_leaders_2.iter()) {
-            let DecidedLeader::Commit(_, Some(CommitMetastate::Optimistic), strong_voters) = leader
-            else {
-                continue;
-            };
-            let mut stake = StakeAggregator::<QuorumThreshold>::new();
-            let reached = strong_voters
-                .iter()
-                .any(|voter| stake.add(*voter, &authority_1.context.committee));
-            assert!(reached, "optimistic commit with {strong_voters:?}");
-        }
-
         // Ensure despite the difference in when blocks were received eventually after
         // receiving all blocks both authorities should return the same sequence of
         // blocks. The strong voters are left out of the comparison: they are the
@@ -219,18 +207,16 @@ async fn test_randomized_dag_and_decision_sequence(#[values(false, true)] starfi
     }
 }
 
-/// The decisions reduced to what every authority must agree on: the decided
-/// slot, the committed block if any, and its metastate.
-fn decisions_without_strong_voters(
-    leaders: &[DecidedLeader],
-) -> Vec<(Slot, Option<BlockRef>, Option<CommitMetastate>)> {
+/// The decisions with the strong voters cleared, leaving what every authority
+/// must agree on.
+fn decisions_without_strong_voters(leaders: &[DecidedLeader]) -> Vec<DecidedLeader> {
     leaders
         .iter()
         .map(|leader| match leader {
             DecidedLeader::Commit(block, metastate, _) => {
-                (block.slot(), Some(block.reference()), *metastate)
+                DecidedLeader::Commit(block.clone(), *metastate, vec![])
             }
-            DecidedLeader::Skip(slot) => (*slot, None, None),
+            DecidedLeader::Skip(slot) => DecidedLeader::Skip(*slot),
         })
         .collect()
 }

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -6,15 +6,17 @@ use std::{env, sync::Arc};
 
 use parking_lot::RwLock;
 use rand::{Rng, SeedableRng, prelude::SliceRandom, rngs::StdRng};
+use rstest::rstest;
 use starfish_config::AuthorityIndex;
 
 use crate::{
-    block_header::{BlockHeaderAPI, Slot},
+    block_header::{BlockHeaderAPI, BlockRef, Slot},
     block_manager::{BlockManager, block_suspender::tests::evaluate_block_headers},
-    commit::DecidedLeader,
+    commit::{CommitMetastate, DecidedLeader},
     context::Context,
     dag_state::{DagState, DataSource},
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::mem_store::MemStore,
     test_dag::create_random_dag,
     universal_committer::{
@@ -30,14 +32,15 @@ const NUM_ROUNDS: u32 = 200;
 /// - Links to leader of previous round.
 ///
 /// Should result in a direct commit for every round.
+#[rstest]
 #[tokio::test]
-async fn test_randomized_dag_all_direct_commit() {
+async fn test_randomized_dag_all_direct_commit(#[values(false, true)] starfish_speed: bool) {
     let mut random_test_setup = random_test_setup();
 
     for _ in 0..NUM_RUNS {
         let seed = random_test_setup.seeded_rng.gen_range(0..10000);
         let num_authorities = random_test_setup.seeded_rng.gen_range(4..10);
-        let authority = authority_setup(num_authorities, 0);
+        let authority = authority_setup(num_authorities, 0, starfish_speed);
 
         let include_leader_percentage = 100;
         let dag_builder = create_random_dag(
@@ -85,8 +88,9 @@ async fn test_randomized_dag_all_direct_commit() {
 /// sequence will include Commit & Skip decisions and potentially will stop
 /// before coming to a decision on all waves as we may have an Undecided leader
 /// somewhere early in the sequence.
+#[rstest]
 #[tokio::test]
-async fn test_randomized_dag_and_decision_sequence() {
+async fn test_randomized_dag_and_decision_sequence(#[values(false, true)] starfish_speed: bool) {
     let mut random_test_setup = random_test_setup();
 
     for _ in 0..NUM_RUNS {
@@ -94,7 +98,7 @@ async fn test_randomized_dag_and_decision_sequence() {
         let num_authorities = random_test_setup.seeded_rng.gen_range(4..10);
 
         // Setup for Authority 1
-        let mut authority_1 = authority_setup(num_authorities, 1);
+        let mut authority_1 = authority_setup(num_authorities, 1, starfish_speed);
 
         let include_leader_percentage = 50;
         let dag_builder = create_random_dag(
@@ -148,7 +152,7 @@ async fn test_randomized_dag_and_decision_sequence() {
         assert!(authority_1.block_manager.is_empty());
 
         // Setup for Authority 2
-        let mut authority_2 = authority_setup(num_authorities, 2);
+        let mut authority_2 = authority_setup(num_authorities, 2, starfish_speed);
 
         let mut all_blocks = dag_builder
             .block_headers
@@ -189,11 +193,46 @@ async fn test_randomized_dag_and_decision_sequence() {
 
         assert!(authority_2.block_manager.is_empty());
 
+        // Every optimistic commit lists at least a quorum of strong voters, which
+        // is what the linearizer needs to commit the leader's acknowledged refs.
+        for leader in sequenced_leaders_1.iter().chain(sequenced_leaders_2.iter()) {
+            let DecidedLeader::Commit(_, Some(CommitMetastate::Optimistic), strong_voters) = leader
+            else {
+                continue;
+            };
+            let mut stake = StakeAggregator::<QuorumThreshold>::new();
+            let reached = strong_voters
+                .iter()
+                .any(|voter| stake.add(*voter, &authority_1.context.committee));
+            assert!(reached, "optimistic commit with {strong_voters:?}");
+        }
+
         // Ensure despite the difference in when blocks were received eventually after
         // receiving all blocks both authorities should return the same sequence of
-        // blocks.
-        assert_eq!(sequenced_leaders_1, sequenced_leaders_2);
+        // blocks. The strong voters are left out of the comparison: they are the
+        // voters the deciding authority had accepted at that point, so the two
+        // authorities list different supersets of the quorum behind the commit.
+        assert_eq!(
+            decisions_without_strong_voters(&sequenced_leaders_1),
+            decisions_without_strong_voters(&sequenced_leaders_2)
+        );
     }
+}
+
+/// The decisions reduced to what every authority must agree on: the decided
+/// slot, the committed block if any, and its metastate.
+fn decisions_without_strong_voters(
+    leaders: &[DecidedLeader],
+) -> Vec<(Slot, Option<BlockRef>, Option<CommitMetastate>)> {
+    leaders
+        .iter()
+        .map(|leader| match leader {
+            DecidedLeader::Commit(block, metastate, _) => {
+                (block.slot(), Some(block.reference()), *metastate)
+            }
+            DecidedLeader::Skip(slot) => (*slot, None, None),
+        })
+        .collect()
 }
 
 struct AuthorityTestFixture {
@@ -203,14 +242,17 @@ struct AuthorityTestFixture {
     block_manager: BlockManager,
 }
 
-fn authority_setup(num_authorities: usize, authority_index: u8) -> AuthorityTestFixture {
-    // Test blocks carry no strong votes; run with StarfishSpeed off.
+fn authority_setup(
+    num_authorities: usize,
+    authority_index: u8,
+    starfish_speed: bool,
+) -> AuthorityTestFixture {
     let mut context = Context::new_for_test(num_authorities)
         .0
         .with_authority_index(AuthorityIndex::new_for_test(authority_index));
     context
         .protocol_config
-        .set_consensus_starfish_speed_for_testing(false);
+        .set_consensus_starfish_speed_for_testing(starfish_speed);
     let context = Arc::new(context);
     let leader_schedule = Arc::new(LeaderSchedule::new(
         context.clone(),

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -6,6 +6,7 @@ use std::{env, sync::Arc};
 
 use parking_lot::RwLock;
 use rand::{Rng, SeedableRng, prelude::SliceRandom, rngs::StdRng};
+use rstest::rstest;
 use starfish_config::AuthorityIndex;
 
 use crate::{
@@ -30,14 +31,12 @@ const NUM_ROUNDS: u32 = 200;
 /// - Links to leader of previous round.
 ///
 /// Should result in a direct commit for every round.
+#[rstest]
 #[tokio::test]
-async fn test_randomized_dag_all_direct_commit() {
+async fn test_randomized_dag_all_direct_commit(#[values(false, true)] starfish_speed: bool) {
     let mut random_test_setup = random_test_setup();
 
-    // Alternate the flag across runs rather than repeating the whole campaign
-    // for each value.
-    for run in 0..NUM_RUNS {
-        let starfish_speed = run % 2 == 0;
+    for _ in 0..NUM_RUNS {
         let seed = random_test_setup.seeded_rng.gen_range(0..10000);
         let num_authorities = random_test_setup.seeded_rng.gen_range(4..10);
         let authority = authority_setup(num_authorities, 0, starfish_speed);
@@ -88,14 +87,12 @@ async fn test_randomized_dag_all_direct_commit() {
 /// sequence will include Commit & Skip decisions and potentially will stop
 /// before coming to a decision on all waves as we may have an Undecided leader
 /// somewhere early in the sequence.
+#[rstest]
 #[tokio::test]
-async fn test_randomized_dag_and_decision_sequence() {
-    // Alternate the flag across runs rather than repeating the whole campaign
-    // for each value.
+async fn test_randomized_dag_and_decision_sequence(#[values(false, true)] starfish_speed: bool) {
     let mut random_test_setup = random_test_setup();
 
-    for run in 0..NUM_RUNS {
-        let starfish_speed = run % 2 == 0;
+    for _ in 0..NUM_RUNS {
         let seed = random_test_setup.seeded_rng.gen_range(0..10000);
         let num_authorities = random_test_setup.seeded_rng.gen_range(4..10);
 

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -352,9 +352,8 @@ async fn indirect_commit(#[values(false, true)] starfish_speed: bool) {
     // only One needs to wait until the leader of Round 6 is directly decided
     // to indirectly decide the leader of round 3
     // - Fully connected blocks to decide the leader of wave 2.
-    // The blocks with restricted ancestors keep acknowledging every block of the
-    // previous round, so that the missing links alone shape the decisions and
-    // every leader still gets a strong-vote quorum.
+    // Blocks with restricted ancestors keep their acknowledgments, so the missing
+    // links alone shape the decisions.
     let dag_str = "DAG {
         Round 0 : { 4 },
         Round 1 : { * },
@@ -428,9 +427,8 @@ async fn indirect_skip(#[values(false, true)] starfish_speed: bool) {
     // But it is skipped indirectly since the leader of round 7 is directly
     // committed and is not linked with the leader of round 4 through a
     // certificate
-    // The blocks with restricted ancestors keep acknowledging every block of the
-    // previous round, so that the missing links alone shape the decisions and
-    // every leader still gets a strong-vote quorum.
+    // Blocks with restricted ancestors keep their acknowledgments, so the missing
+    // links alone shape the decisions.
     let dag_str = "DAG {
         Round 0 : { 4 },
         Round 1 : { * },

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -247,7 +247,7 @@ async fn direct_skip_no_leader_votes() {
     let first_leader = AuthorityIndex::new_for_test(1);
     let first_round = 1 as Round;
 
-    let dag_builder = parse_dag(dag_str).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -363,7 +363,7 @@ async fn indirect_commit() {
         Round 8 : { * },
      }";
 
-    let dag_builder = parse_dag(dag_str).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -441,7 +441,7 @@ async fn indirect_skip() {
         Round 9 : { * },
      }";
 
-    let dag_builder = parse_dag(dag_str).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -523,7 +523,7 @@ async fn undecided() {
         },
      }";
 
-    let dag_builder = parse_dag(dag_str).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -5,11 +5,14 @@
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use rstest::rstest;
 use starfish_config::AuthorityIndex;
 
 use crate::{
     Round,
-    block_header::{BlockHeaderAPI, Slot, TestBlockHeader, VerifiedBlockHeader},
+    block_header::{
+        BlockHeaderAPI, Slot, TestBlockHeader, TestBlockHeaderVersion, VerifiedBlockHeader,
+    },
     commit::{DecidedLeader, WaveNumber},
     context::Context,
     dag_state::{DagState, DataSource},
@@ -24,9 +27,10 @@ use crate::{
 // TODO: use one same mechanism for constructing a DAG
 
 /// Directly commit 5 leader blocks.
+#[rstest]
 #[tokio::test]
-async fn direct_commit() {
-    let mut test_setup = basic_dag_builder_test_setup();
+async fn direct_commit(#[values(false, true)] starfish_speed: bool) {
+    let mut test_setup = basic_dag_builder_test_setup(starfish_speed);
 
     // Build fully connected dag with empty blocks adding up to round 7
     // such that we can commit all leader block up to round 5
@@ -65,9 +69,10 @@ async fn direct_commit() {
 }
 
 /// Ensure idempotent replies.
+#[rstest]
 #[tokio::test]
-async fn idempotence() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn idempotence(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // note: waves & rounds are zero-indexed.
     let first_non_genesis_leader_round = 1;
@@ -141,9 +146,10 @@ async fn idempotence() {
 }
 
 /// Commit one by one each leader as the dag progresses in ideal conditions.
+#[rstest]
 #[tokio::test]
-async fn multiple_direct_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn multiple_direct_commit(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     let mut ancestors = None;
     let mut last_finalized = Slot::new(0, 0);
@@ -180,9 +186,10 @@ async fn multiple_direct_commit() {
 
 /// Commit leaders from 10 waves in a row (calling the committer after adding
 /// them).
+#[rstest]
 #[tokio::test]
-async fn direct_commit_late_call() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn direct_commit_late_call(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // note: waves & rounds are zero-indexed.
     let num_waves = 11;
@@ -208,9 +215,10 @@ async fn direct_commit_late_call() {
 }
 
 /// Do not commit anything if we are still in the first wave.
+#[rstest]
 #[tokio::test]
-async fn no_genesis_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn no_genesis_commit(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
 
     // note: waves & rounds are zero-indexed.
     let certifying_round = 3;
@@ -226,8 +234,9 @@ async fn no_genesis_commit() {
 }
 
 /// We directly skip the leader if there are enough non-votes (blames).
+#[rstest]
 #[tokio::test]
-async fn direct_skip_no_leader_votes() {
+async fn direct_skip_no_leader_votes(#[values(false, true)] starfish_speed: bool) {
     telemetry_subscribers::init_for_testing();
     // Dag Notes:
     // Pipeline is enabled
@@ -247,7 +256,7 @@ async fn direct_skip_no_leader_votes() {
     let first_leader = AuthorityIndex::new_for_test(1);
     let first_round = 1 as Round;
 
-    let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str, starfish_speed).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -280,9 +289,10 @@ async fn direct_skip_no_leader_votes() {
 }
 
 /// We directly skip the leader if it is missing.
+#[rstest]
 #[tokio::test]
-async fn direct_skip_missing_leader_block() {
-    let mut test_setup = basic_dag_builder_test_setup();
+async fn direct_skip_missing_leader_block(#[values(false, true)] starfish_speed: bool) {
+    let mut test_setup = basic_dag_builder_test_setup(starfish_speed);
 
     // Add enough blocks to reach the certifying round of genesis leader
     // note: waves & rounds are zero-indexed.
@@ -331,8 +341,9 @@ async fn direct_skip_missing_leader_block() {
 }
 
 /// Indirect-commit of the leader of round 3.
+#[rstest]
 #[tokio::test]
-async fn indirect_commit() {
+async fn indirect_commit(#[values(false, true)] starfish_speed: bool) {
     telemetry_subscribers::init_for_testing();
     // Dag Notes:
     // Pipeline is enabled
@@ -341,13 +352,16 @@ async fn indirect_commit() {
     // only One needs to wait until the leader of Round 6 is directly decided
     // to indirectly decide the leader of round 3
     // - Fully connected blocks to decide the leader of wave 2.
+    // The blocks with restricted ancestors keep acknowledging every block of the
+    // previous round, so that the missing links alone shape the decisions and
+    // every leader still gets a strong-vote quorum.
     let dag_str = "DAG {
         Round 0 : { 4 },
         Round 1 : { * },
         Round 2 : { * },
         Round 3 : { * },
         Round 4 : {
-            A -> [-D3],
+            A -> ([-D3],[*]),
             B -> [*],
             C -> [*],
             D -> [*],
@@ -355,15 +369,15 @@ async fn indirect_commit() {
         Round 5 : {
             A -> [*],
             B -> [*],
-            C -> [A4],
-            D -> [A4],
+            C -> ([A4],[*]),
+            D -> ([A4],[*]),
         },
         Round 6 : { * },
         Round 7 : { * },
         Round 8 : { * },
      }";
 
-    let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str, starfish_speed).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -404,8 +418,9 @@ async fn indirect_commit() {
 }
 
 /// Skip indirectly the leader of round 4.
+#[rstest]
 #[tokio::test]
-async fn indirect_skip() {
+async fn indirect_skip(#[values(false, true)] starfish_speed: bool) {
     telemetry_subscribers::init_for_testing();
     // Dag Notes:
     // Pipeline is enabled
@@ -413,6 +428,9 @@ async fn indirect_skip() {
     // But it is skipped indirectly since the leader of round 7 is directly
     // committed and is not linked with the leader of round 4 through a
     // certificate
+    // The blocks with restricted ancestors keep acknowledging every block of the
+    // previous round, so that the missing links alone shape the decisions and
+    // every leader still gets a strong-vote quorum.
     let dag_str = "DAG {
         Round 0 : { 4 },
         Round 1 : { * },
@@ -423,25 +441,25 @@ async fn indirect_skip() {
             A -> [*],
             B -> [*],
             C -> [*],
-            D -> [-A4],
+            D -> ([-A4],[*]),
         },
         Round 6 : {
             A -> [*],
-            B -> [-A5],
-            C -> [-B5],
+            B -> ([-A5],[*]),
+            C -> ([-B5],[*]),
             D -> [*],
         },
         Round 7 : {
             A -> [*],
             B -> [*],
             C -> [*],
-            D -> [B6],
+            D -> ([B6],[*]),
         },
         Round 8 : { * },
         Round 9 : { * },
      }";
 
-    let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str, starfish_speed).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -484,8 +502,9 @@ async fn indirect_skip() {
 }
 
 /// If there is no leader with enough support nor blame, we commit nothing.
+#[rstest]
 #[tokio::test]
-async fn undecided() {
+async fn undecided(#[values(false, true)] starfish_speed: bool) {
     telemetry_subscribers::init_for_testing();
     // Dag Notes:
     // Pipeline is enabled
@@ -523,7 +542,7 @@ async fn undecided() {
         },
      }";
 
-    let dag_builder = parse_dag(dag_str, false).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str, starfish_speed).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -555,9 +574,11 @@ async fn undecided() {
 // will be sending multiple different blocks to different validators for a
 // round. The commit rule should handle this and correctly commit the expected
 // blocks.
+#[rstest]
 #[tokio::test]
-async fn test_byzantine_direct_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+async fn test_byzantine_direct_commit(#[values(false, true)] starfish_speed: bool) {
+    let (context, dag_state, committer) = basic_test_setup(starfish_speed);
+    let version = TestBlockHeaderVersion::from_context(&context);
 
     // Add enough blocks to reach first leader of wave 4
     // note: waves & rounds are zero-indexed.
@@ -596,6 +617,7 @@ async fn test_byzantine_direct_commit() {
     // dag state
     let byzantine_block_c13_1 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
+            .set_version(version)
             .set_ancestors(references_without_leader_round_wave_4.clone())
             .build(),
     );
@@ -605,6 +627,7 @@ async fn test_byzantine_direct_commit() {
 
     let byzantine_block_c13_2 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
+            .set_version(version)
             .set_ancestors(references_without_leader_round_wave_4.clone())
             .build(),
     );
@@ -614,6 +637,7 @@ async fn test_byzantine_direct_commit() {
 
     let byzantine_block_c13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
+            .set_version(version)
             .set_ancestors(references_without_leader_round_wave_4)
             .build(),
     );
@@ -627,6 +651,7 @@ async fn test_byzantine_direct_commit() {
     // we should not skip leader A12.
     let certifying_block_a14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 0)
+            .set_version(version)
             .set_ancestors(good_references_voting_round_for_round_12.clone())
             .build(),
     );
@@ -642,6 +667,7 @@ async fn test_byzantine_direct_commit() {
 
     let certifying_block_b14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 1)
+            .set_version(version)
             .set_ancestors(
                 good_references_voting_round_for_round_12_without_c13
                     .iter()
@@ -657,6 +683,7 @@ async fn test_byzantine_direct_commit() {
 
     let certifying_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
+            .set_version(version)
             .set_ancestors(
                 good_references_voting_round_for_round_12_without_c13
                     .iter()
@@ -672,6 +699,7 @@ async fn test_byzantine_direct_commit() {
 
     let certifying_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
+            .set_version(version)
             .set_ancestors(
                 good_references_voting_round_for_round_12_without_c13
                     .iter()
@@ -709,18 +737,19 @@ async fn test_byzantine_direct_commit() {
 // TODO: Add byzantine variant of tests for indirect/direct
 // commit/skip/undecided decisions
 
-fn basic_test_setup() -> (
+fn basic_test_setup(
+    starfish_speed: bool,
+) -> (
     Arc<Context>,
     Arc<RwLock<DagState>>,
     super::UniversalCommitter,
 ) {
     telemetry_subscribers::init_for_testing();
     // Committee of 4 with even stake
-    // Test blocks carry no strong votes; run with StarfishSpeed off.
     let mut context = Context::new_for_test(4).0;
     context
         .protocol_config
-        .set_consensus_starfish_speed_for_testing(false);
+        .set_consensus_starfish_speed_for_testing(starfish_speed);
     let context = Arc::new(context);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
@@ -749,13 +778,12 @@ struct TestSetup {
 }
 
 // TODO: Make this the basic_test_setup()
-fn basic_dag_builder_test_setup() -> TestSetup {
+fn basic_dag_builder_test_setup(starfish_speed: bool) -> TestSetup {
     telemetry_subscribers::init_for_testing();
-    // Test blocks carry no strong votes; run with StarfishSpeed off.
     let mut context = Context::new_for_test(4).0;
     context
         .protocol_config
-        .set_consensus_starfish_speed_for_testing(false);
+        .set_consensus_starfish_speed_for_testing(starfish_speed);
     let context = Arc::new(context);
     let dag_builder = DagBuilder::new(context);
 


### PR DESCRIPTION
# Description of change

`consensus_starfish_speed` is enabled from protocol v31, which turns it on for every starfish-core
test context. 32 tests were pinned to the flag off because the test builders could not produce the
blocks the flag needs. They can now, and all but one of those tests run under either value.

- `DagBuilder`, `build_dag` and `parse_dag` compute a strong vote per block the way
  `Core::compute_strong_vote` does. Fully connected `DagBuilder` layers therefore commit
  optimistically, while `build_dag` acknowledges no transactions and commits under the standard rule,
  so the two helpers cover both metastates between them.
- Unpinning the shared setup helpers took the whole `universal_committer_tests`,
  `pipelined_committer_tests` and `randomized_tests` modules under both flag values, not only the
  tests named in the issue. The suite goes from 411 to 453 cases.

Test-only; no production code changes.

One round cannot be proposed through `add_blocks` alone, so the tests that drive `Core` without a
timer task ask for the soft leader timeout that production falls back on: the round after the leader
schedule rotates, because those blocks pinned their votes to the leader the previous schedule
elected. The call is inert on every other round, since `new_block` returns early once the round is
proposed.

`core::test::test_sequenced_transactions_no_headers` stays pinned to the flag off. Its DAG is built
up front against the builder's leader schedule, while the core swaps out the authority whose blocks
that DAG never links and elects a different leader for its rounds, so those votes count for no one
and the last leader of the DAG never leaves the pending state.

## Links to any relevant issues

#12293

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
