### PR TITLE
fix(consensus): treat empty and genesis block transactions as available

### DIFF
--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -26,7 +26,7 @@ use crate::{
     authority_set::AuthoritySet,
     commit::CommitVote,
     context::Context,
-    encoder::ShardEncoder,
+    encoder::{ShardEncoder, create_encoder},
     error::{ConsensusError, ConsensusResult},
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
@@ -939,6 +939,18 @@ impl TransactionsCommitment {
             tree_size,
         )
     }
+
+    /// Commitment over an empty transaction list. The value depends on the
+    /// committee size through the erasure-coding shard counts.
+    pub(crate) fn compute_empty_transactions_commitment(
+        context: &Arc<Context>,
+    ) -> TransactionsCommitment {
+        let mut encoder = create_encoder(context);
+        let serialized = Transaction::serialize(&[])
+            .expect("Serializing an empty transaction list should not fail");
+        Self::compute_transactions_commitment(&serialized, context, &mut encoder)
+            .expect("Computing the empty transactions commitment should not fail")
+    }
 }
 
 impl Hash for TransactionsCommitment {
@@ -1396,6 +1408,18 @@ impl VerifiedTransactions {
     pub fn has_transactions(&self) -> bool {
         !self.transactions.is_empty()
     }
+
+    /// Transactions object holding the empty payload for `header`.
+    pub(crate) fn new_empty(header: &VerifiedBlockHeader) -> Self {
+        let serialized = Transaction::serialize(&[])
+            .expect("Serializing an empty transaction list should not fail");
+        Self::new(
+            vec![],
+            header.transaction_ref(),
+            Some(header.digest()),
+            serialized,
+        )
+    }
 }
 
 /// VerifiedBlock is a pair of verified block header and transactions. It is
@@ -1495,12 +1519,7 @@ pub(crate) fn genesis_blocks(context: &Context) -> Vec<VerifiedBlock> {
             let verified_block_header = VerifiedBlockHeader::new_verified(signed_block, serialized);
             VerifiedBlock {
                 verified_block_header: verified_block_header.clone(),
-                verified_transactions: VerifiedTransactions::new(
-                    vec![],
-                    verified_block_header.transaction_ref(),
-                    Some(verified_block_header.digest()),
-                    Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
-                ),
+                verified_transactions: VerifiedTransactions::new_empty(&verified_block_header),
             }
         })
         .collect::<Vec<VerifiedBlock>>()

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1409,11 +1409,6 @@ impl VerifiedTransactions {
         !self.transactions.is_empty()
     }
 
-    /// Transactions object holding the empty payload for `header`.
-    pub(crate) fn new_empty(header: &VerifiedBlockHeader) -> Self {
-        Self::new_empty_from_ref(header.transaction_ref(), Some(header.digest()))
-    }
-
     /// Transactions object holding the empty payload for `transaction_ref`.
     pub(crate) fn new_empty_from_ref(
         transaction_ref: TransactionRef,
@@ -1522,7 +1517,10 @@ pub(crate) fn genesis_blocks(context: &Context) -> Vec<VerifiedBlock> {
             let verified_block_header = VerifiedBlockHeader::new_verified(signed_block, serialized);
             VerifiedBlock {
                 verified_block_header: verified_block_header.clone(),
-                verified_transactions: VerifiedTransactions::new_empty(&verified_block_header),
+                verified_transactions: VerifiedTransactions::new_empty_from_ref(
+                    verified_block_header.transaction_ref(),
+                    Some(verified_block_header.digest()),
+                ),
             }
         })
         .collect::<Vec<VerifiedBlock>>()

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1411,14 +1411,17 @@ impl VerifiedTransactions {
 
     /// Transactions object holding the empty payload for `header`.
     pub(crate) fn new_empty(header: &VerifiedBlockHeader) -> Self {
+        Self::new_empty_from_ref(header.transaction_ref(), Some(header.digest()))
+    }
+
+    /// Transactions object holding the empty payload for `transaction_ref`.
+    pub(crate) fn new_empty_from_ref(
+        transaction_ref: TransactionRef,
+        block_digest: Option<BlockHeaderDigest>,
+    ) -> Self {
         let serialized = Transaction::serialize(&[])
             .expect("Serializing an empty transaction list should not fail");
-        Self::new(
-            vec![],
-            header.transaction_ref(),
-            Some(header.digest()),
-            serialized,
-        )
+        Self::new(vec![], transaction_ref, block_digest, serialized)
     }
 }
 

--- a/crates/starfish/core/src/commit_solidifier.rs
+++ b/crates/starfish/core/src/commit_solidifier.rs
@@ -225,10 +225,13 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_header::{genesis_block_headers, genesis_blocks},
+        block_header::{
+            TestBlockHeader, VerifiedBlockHeader, genesis_block_headers, genesis_blocks,
+        },
         commit::{CommitRef, PendingSubDag},
         context::Context,
         dag_state::{DagState, DataSource},
+        encoder::create_encoder,
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
     };
@@ -581,6 +584,42 @@ mod tests {
         assert_eq!(missing[0], committed_ref);
         assert_eq!(commit_solidifier.pending_subdags.len(), 1);
         assert_eq!(commit_solidifier.last_solid_committed_index, 0);
+    }
+
+    /// A committed ref whose commitment is over an empty transaction list
+    /// counts as present without a stored payload, so it neither blocks
+    /// solidification nor enters the missing set.
+    #[tokio::test]
+    async fn test_empty_transactions_solidify_without_payload() {
+        let setup = Arc::new(TestSetup::new(3));
+        let mut commit_solidifier = CommitSolidifier::new(setup.dag_state.clone());
+
+        let mut encoder = create_encoder(&setup.context);
+        let empty_header = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 1, &setup.context, &mut encoder).build(),
+        );
+        setup
+            .dag_state
+            .write()
+            .accept_block_header(empty_header.clone(), DataSource::Test);
+        let empty_ref = GenericTransactionRef::TransactionRef(empty_header.transaction_ref());
+
+        let subdag = SubDagBuilder::new(setup.clone(), 1)
+            .leader(3, 0)
+            .with_blocks(vec![
+                BlockSpec::all_from_round(0),
+                BlockSpec::all_from_round(1),
+                BlockSpec::all_from_round(2),
+            ])
+            .with_committed_refs(vec![empty_ref])
+            .build();
+
+        let (committed, missing) = commit_solidifier.try_get_solid_sub_dags(&[subdag]);
+        assert_eq!(committed.len(), 1);
+        assert!(missing.is_empty());
+        assert_eq!(committed[0].transactions.len(), 1);
+        assert!(!committed[0].transactions[0].has_transactions());
+        assert!(commit_solidifier.pending_subdags.is_empty());
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2879,9 +2879,7 @@ impl DagState {
     }
 
     /// Returns the empty transactions object for `tx_ref` when its commitment
-    /// is the commitment over an empty transaction list, `None` otherwise. For
-    /// a `BlockRef`-form reference the commitment comes from the cached
-    /// header, when present.
+    /// is the commitment over an empty transaction list, `None` otherwise.
     fn empty_transactions_for_ref(
         &self,
         tx_ref: &GenericTransactionRef,
@@ -2890,11 +2888,10 @@ impl DagState {
             GenericTransactionRef::TransactionRef(tx_ref) => (tx_ref.transactions_commitment
                 == self.empty_transactions_commitment)
                 .then(|| VerifiedTransactions::new_empty_from_ref(*tx_ref, None)),
-            GenericTransactionRef::BlockRef(block_ref) => {
-                let header = self.recent_block_headers.get(block_ref)?;
-                (header.transactions_commitment() == self.empty_transactions_commitment)
-                    .then(|| VerifiedTransactions::new_empty(header))
-            }
+            // The legacy BlockRef form carries no commitment; commits that
+            // use it derive refs from acknowledgments, which never include
+            // empty blocks.
+            GenericTransactionRef::BlockRef(_) => None,
         }
     }
 }
@@ -4136,12 +4133,13 @@ mod test {
         dag_state.accept_block_header(empty_header.clone(), DataSource::Test);
 
         // An empty-commitment ref counts as present and reads back as the
-        // empty payload, in both ref forms, although no payload was stored.
+        // empty payload, although no payload was stored. The legacy BlockRef
+        // form carries no commitment and is not recognized.
         let tx_ref = GenericTransactionRef::from(empty_header.transaction_ref());
         let block_ref = GenericTransactionRef::BlockRef(empty_header.reference());
         assert_eq!(
             dag_state.contains_transactions(vec![tx_ref, block_ref]),
-            vec![true, true]
+            vec![true, false]
         );
         let read = dag_state.try_get_verified_transactions(&[tx_ref]).unwrap();
         let transactions = read[0].as_ref().unwrap();

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -325,6 +325,9 @@ pub(crate) struct DagState {
     /// leader rounds, keyed by leader round.
     starfish_speed_leader_hints: BTreeMap<Round, StarfishSpeedLeaderRoundHints>,
 
+    /// Commitment over an empty transaction list for this committee.
+    empty_transactions_commitment: TransactionsCommitment,
+
     /// Broadcast sender for DAG visualizer events.
     #[cfg(feature = "dag-visualizer")]
     dag_visualizer_sender: Option<tokio::sync::broadcast::Sender<DagVisualizerEvent>>,
@@ -420,6 +423,9 @@ impl DagState {
             unscored_committed_subdags.len()
         );
 
+        let empty_transactions_commitment =
+            TransactionsCommitment::compute_empty_transactions_commitment(&context);
+
         let mut state = Self {
             context,
             genesis,
@@ -451,6 +457,7 @@ impl DagState {
             evicted_rounds: vec![0; num_authorities],
             cordial_knowledge_senders: None,
             starfish_speed_leader_hints: BTreeMap::new(),
+            empty_transactions_commitment,
             #[cfg(feature = "dag-visualizer")]
             dag_visualizer_sender: None,
         };
@@ -713,6 +720,11 @@ impl DagState {
             );
         }
         self.update_block_header_metadata(&block_header, source);
+        // An empty payload is fully determined by the header's commitment, so
+        // accepting such a header makes the block's transactions available.
+        if block_header.transactions_commitment() == self.empty_transactions_commitment {
+            self.add_transactions(VerifiedTransactions::new_empty(&block_header), source);
+        }
         debug!(
             "block header {} pushed to write to store batch by {}",
             block_header, self.context.own_index
@@ -2133,6 +2145,10 @@ impl DagState {
 
     /// Check if a block's transactions are locally available.
     pub(crate) fn are_transactions_available(&self, block_ref: &BlockRef) -> bool {
+        // Genesis blocks carry no transactions.
+        if self.genesis.contains_key(block_ref) {
+            return true;
+        }
         let Some(header) = self.recent_block_headers.get(block_ref) else {
             return false;
         };
@@ -4024,7 +4040,7 @@ mod test {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context, store);
+        let mut dag_state = DagState::new(context.clone(), store.clone());
 
         let block = VerifiedBlock::new_for_test(TestBlockHeader::new(5, 1).build());
         let block_ref = block.reference();
@@ -4045,6 +4061,33 @@ mod test {
         let other_ref = other.reference();
         dag_state.add_transactions(other.verified_transactions, DataSource::Test);
         assert!(!dag_state.are_transactions_available(&other_ref));
+
+        // Genesis blocks carry no transactions.
+        let genesis_ref = dag_state.genesis_blocks()[0].reference();
+        assert!(dag_state.are_transactions_available(&genesis_ref));
+
+        // A fabricated round-0 ref that is not a genesis block.
+        let fake_genesis_ref = BlockRef::new(
+            GENESIS_ROUND,
+            AuthorityIndex::new_for_test(0),
+            BlockHeaderDigest::MIN,
+        );
+        assert!(!dag_state.are_transactions_available(&fake_genesis_ref));
+
+        // A header whose commitment matches the empty transaction list is
+        // available without its payload.
+        let mut encoder = create_encoder(&context);
+        let empty_header = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new_with_commitment(7, 3, &context, &mut encoder).build(),
+        );
+        let empty_ref = empty_header.reference();
+        dag_state.accept_block_header(empty_header, DataSource::Test);
+        assert!(dag_state.are_transactions_available(&empty_ref));
+
+        // The synthesized empty payload is persisted and recovered.
+        dag_state.flush();
+        let dag_state = DagState::new(context, store);
+        assert!(dag_state.are_transactions_available(&empty_ref));
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -720,11 +720,6 @@ impl DagState {
             );
         }
         self.update_block_header_metadata(&block_header, source);
-        // An empty payload is fully determined by the header's commitment, so
-        // accepting such a header makes the block's transactions available.
-        if block_header.transactions_commitment() == self.empty_transactions_commitment {
-            self.add_transactions(VerifiedTransactions::new_empty(&block_header), source);
-        }
         debug!(
             "block header {} pushed to write to store batch by {}",
             block_header, self.context.own_index
@@ -2152,6 +2147,10 @@ impl DagState {
         let Some(header) = self.recent_block_headers.get(block_ref) else {
             return false;
         };
+        // An empty payload is fully determined by the header's commitment.
+        if header.transactions_commitment() == self.empty_transactions_commitment {
+            return true;
+        }
         let transaction_ref = GenericTransactionRef::from(TransactionRef {
             round: block_ref.round,
             author: block_ref.author,
@@ -4084,7 +4083,8 @@ mod test {
         dag_state.accept_block_header(empty_header, DataSource::Test);
         assert!(dag_state.are_transactions_available(&empty_ref));
 
-        // The synthesized empty payload is persisted and recovered.
+        // The empty block stays available after a restart, from the recovered
+        // header alone.
         dag_state.flush();
         let dag_state = DagState::new(context, store);
         assert!(dag_state.are_transactions_available(&empty_ref));

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1107,6 +1107,10 @@ impl DagState {
                 transactions[index] = Some(transaction.clone());
                 continue;
             }
+            if let Some(empty) = self.empty_transactions_for_ref(transactions_ref) {
+                transactions[index] = Some(empty);
+                continue;
+            }
             missing.push((index, transactions_ref));
         }
 
@@ -1158,6 +1162,10 @@ impl DagState {
             .get(transactions_ref)
             {
                 transactions[index] = Some(transaction.serialized().clone());
+                continue;
+            }
+            if let Some(empty) = self.empty_transactions_for_ref(transactions_ref) {
+                transactions[index] = Some(empty.serialized().clone());
                 continue;
             }
             missing.push((index, transactions_ref));
@@ -1956,6 +1964,10 @@ impl DagState {
         for (index, tx_ref) in transaction_refs.into_iter().enumerate() {
             if tx_ref.round() == GENESIS_ROUND {
                 exist[index] = self.get_genesis_block(tx_ref).is_some();
+                continue;
+            }
+            if self.empty_transactions_for_ref(&tx_ref).is_some() {
+                exist[index] = true;
                 continue;
             }
             if self.recent_transactions_by_authority[tx_ref.author()].contains_key(&tx_ref) {
@@ -2864,6 +2876,26 @@ impl DagState {
                     .base
             })
             .collect()
+    }
+
+    /// Returns the empty transactions object for `tx_ref` when its commitment
+    /// is the commitment over an empty transaction list, `None` otherwise. For
+    /// a `BlockRef`-form reference the commitment comes from the cached
+    /// header, when present.
+    fn empty_transactions_for_ref(
+        &self,
+        tx_ref: &GenericTransactionRef,
+    ) -> Option<VerifiedTransactions> {
+        match tx_ref {
+            GenericTransactionRef::TransactionRef(tx_ref) => (tx_ref.transactions_commitment
+                == self.empty_transactions_commitment)
+                .then(|| VerifiedTransactions::new_empty_from_ref(*tx_ref, None)),
+            GenericTransactionRef::BlockRef(block_ref) => {
+                let header = self.recent_block_headers.get(block_ref)?;
+                (header.transactions_commitment() == self.empty_transactions_commitment)
+                    .then(|| VerifiedTransactions::new_empty(header))
+            }
+        }
     }
 }
 #[cfg(test)]
@@ -4088,6 +4120,55 @@ mod test {
         dag_state.flush();
         let dag_state = DagState::new(context, store);
         assert!(dag_state.are_transactions_available(&empty_ref));
+    }
+
+    #[tokio::test]
+    async fn test_empty_transactions_readable_without_payload() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store);
+
+        let mut encoder = create_encoder(&context);
+        let empty_header = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new_with_commitment(5, 2, &context, &mut encoder).build(),
+        );
+        dag_state.accept_block_header(empty_header.clone(), DataSource::Test);
+
+        // An empty-commitment ref counts as present and reads back as the
+        // empty payload, in both ref forms, although no payload was stored.
+        let tx_ref = GenericTransactionRef::from(empty_header.transaction_ref());
+        let block_ref = GenericTransactionRef::BlockRef(empty_header.reference());
+        assert_eq!(
+            dag_state.contains_transactions(vec![tx_ref, block_ref]),
+            vec![true, true]
+        );
+        let read = dag_state.try_get_verified_transactions(&[tx_ref]).unwrap();
+        let transactions = read[0].as_ref().unwrap();
+        assert!(!transactions.has_transactions());
+        assert_eq!(
+            transactions.transaction_ref(),
+            empty_header.transaction_ref()
+        );
+        assert_eq!(
+            dag_state.get_serialized_transactions(&[tx_ref])[0].as_ref(),
+            Some(transactions.serialized())
+        );
+
+        // A non-empty commitment without a stored payload stays missing.
+        let other = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(6, 1).build());
+        let other_ref = GenericTransactionRef::from(other.transaction_ref());
+        dag_state.accept_block_header(other, DataSource::Test);
+        assert_eq!(
+            dag_state.contains_transactions(vec![other_ref]),
+            vec![false]
+        );
+        assert!(
+            dag_state
+                .try_get_verified_transactions(&[other_ref])
+                .unwrap()[0]
+                .is_none()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description of change

An empty block's payload is fully determined by its `transactions_commitment`, but availability was tracked purely through stored payload entries. A header that arrived without its payload was treated as missing transactions even when the commitment says there are none:

- voters recorded strong blames against empty leaders — in particular, every round-1 block blamed the genesis leader, so the round-2 proposal always waited for the leader timeout at epoch start;
- the transactions synchronizer fetched empty payloads of optimistically committed leaders, and such commits stayed pending until the fetch returned.

`DagState` now computes the commitment over an empty transaction list once per epoch and derives emptiness from it:

- `are_transactions_available` answers true for headers carrying the empty commitment, and for genesis refs by membership in the genesis set — genesis headers carry the zero default commitment, not a computed one;
- `contains_transactions` and the payload read paths treat empty-commitment refs as present and produce the empty payload directly, so nothing is stored or fetched for them.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
