### PR TITLE
fix(ci): diff merge queue runs against the target branch

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -42,6 +42,13 @@ runs:
       uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: diff
       with:
+        # In the merge queue, diff against the target branch instead of the
+        # default merge_group.base_sha, which is the previous queue entry.
+        # The queue merges a whole group once its head entry goes green
+        # (HEADGREEN grouping), so the head entry's run must detect the
+        # changes of every entry in the group, not just its own increment.
+        # Empty (default behavior) for all other events.
+        base: ${{ github.event.merge_group.base_ref }}
         filters: |
           isRust:
             - "consensus/**"
@@ -132,3 +139,14 @@ runs:
             - "scripts/compatibility/split-cluster-sync-check.sh"
             - ".github/workflows/_split_cluster_sync_check.yml"
             - ".github/workflows/hierarchy.yml"
+    # Runs after the filter step because it relies on the history that
+    # paths-filter fetched to find the merge base.
+    - name: Log merge queue comparison
+      if: github.event_name == 'merge_group'
+      shell: bash
+      env:
+        BASE_REF: ${{ github.event.merge_group.base_ref }}
+        ENTRY_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+      run: |
+        base="${BASE_REF#refs/heads/}"
+        echo "Compared $(git rev-parse HEAD) against merge-base with $base: $(git merge-base "origin/$base" HEAD 2>/dev/null || echo 'not found') (this queue entry's base_sha: $ENTRY_BASE_SHA)"

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -65,8 +65,24 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          # In the merge queue, diff against the target branch instead of the
+          # previous queue entry (merge_group.base_sha) so the head entry's
+          # run selects tests for every entry in the group (HEADGREEN
+          # grouping). Empty (default behavior) for all other events.
+          base: ${{ github.event.merge_group.base_ref }}
           list-files: "json"
           filters: .github/crates-filters.yml
+      # Runs after the filter step because it relies on the history that
+      # paths-filter fetched to find the merge base.
+      - name: Log merge queue comparison
+        if: github.event_name == 'merge_group'
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.merge_group.base_ref }}
+          ENTRY_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          base="${BASE_REF#refs/heads/}"
+          echo "Compared $(git rev-parse HEAD) against merge-base with $base: $(git merge-base "origin/$base" HEAD 2>/dev/null || echo 'not found') (this queue entry's base_sha: $ENTRY_BASE_SHA)"
 
   # Only feeds rust-tests, which doesn't run on pull_request events (below).
   external-changes:
@@ -82,8 +98,22 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          # See crates-changes above: cover the whole merge group, not just
+          # this queue entry's increment.
+          base: ${{ github.event.merge_group.base_ref }}
           list-files: "json"
           filters: .github/external-crates-filters.yml
+      # Runs after the filter step because it relies on the history that
+      # paths-filter fetched to find the merge base.
+      - name: Log merge queue comparison
+        if: github.event_name == 'merge_group'
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.merge_group.base_ref }}
+          ENTRY_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          base="${BASE_REF#refs/heads/}"
+          echo "Compared $(git rev-parse HEAD) against merge-base with $base: $(git merge-base "origin/$base" HEAD 2>/dev/null || echo 'not found') (this queue entry's base_sha: $ENTRY_BASE_SHA)"
 
   # Heavy chain (tests + simtests): not on pull_request events — PRs get
   # these in the merge queue (merge_group) via `heavy-tests-status` in


### PR DESCRIPTION
# Description of change

The `develop` merge queue uses HEADGREEN grouping: a group merges once its **head** entry passes required checks, even when the entries below it failed their own runs (that is how #12368 merged with a red `heavy-tests-status`, riding under #12477 — and how #12432 landed earlier the same day, leaving develop broken).

HEADGREEN is only sound if the head entry's run tests the whole group. Our change detection defaulted to `merge_group.base_sha` (the previous queue entry), so the head run only saw its own increment and skipped the tests for everything below it.

- pass `base: ${{ github.event.merge_group.base_ref }}` to all three `dorny/paths-filter` invocations (`.github/actions/diffs`, `crates-changes`, `external-changes`), so merge-queue runs diff against the merge-base with the target branch and cover the cumulative changes of the whole group
- `pull_request` / `push` / `schedule` behavior is unchanged — the expression is empty for those events, and paths-filter ignores `base` for PR events anyway
- log the resolved merge-base (and the unused entry `base_sha`) in each merge-queue run, so it is visible what was compared

Trade-off: stacked queue entries re-run the tests of the entries below them, so batched queue runs get heavier — that is the point, the head run now validates what actually gets merged.

## Links to any relevant issues

Follow-up to the #12368 / #12477 merge-queue incident (2026-07-29).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

`dprint check` and YAML parsing pass; verified against `dorny/paths-filter@v4.0.1` source that an explicit `base` overrides `merge_group.base_sha` and that branch bases use merge-base (three-dot) semantics with iterative-deepening fetch. Replayed the incident locally: with the new base, #12477's head-entry run would have detected all 14 files of the group (including `Cargo.lock` → `isPgIntegration`), re-run the graphql e2e tests, and blocked the merge.
