### PR TITLE
refactor(iota-core,iota-json-rpc,iota-types): unify dry run and dev inspect on `simulate_transaction`

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2238,22 +2238,11 @@ impl AuthorityState {
 
         let protocol_config = epoch_store.protocol_config();
 
-        // Fill in the gas the caller left unset. Nobody submits a simulation to pay
-        // for it, and neither zero is a value the gas checks could accept anyway: a
-        // zero price is below the reference gas price, and a zero budget cannot cover
-        // any computation. Callers that do declare gas are metered against it, so a
-        // dry run still rejects the gas a validator would.
-        if transaction.gas_price() == 0 {
-            let reference_gas_price = epoch_store.reference_gas_price();
-            transaction.gas_data_mut().price = reference_gas_price;
-        }
-        if transaction.gas_budget() == 0 {
-            // The protocol maximum, rather than what the gas coins hold: a budget
-            // equal to the whole balance would leave nothing for a transaction that
-            // also pays out of its gas coin.
-            let max_tx_gas = protocol_config.max_tx_gas();
-            transaction.gas_data_mut().budget = max_tx_gas;
-        }
+        iota_types::gas::fill_in_unset_simulation_gas(
+            &mut transaction,
+            epoch_store.reference_gas_price(),
+            protocol_config,
+        );
 
         // `MoveAuthenticator`s are not supported in simulation, so we set the
         // `authenticator_gas_budget` to 0.

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2111,12 +2111,13 @@ impl AuthorityState {
     /// `VmChecks::Disabled` relaxes the checks around entry functions and
     /// argument values, and reports per-command return values (a dev inspect).
     ///
-    /// If the transaction carries no gas payment, a mock gas coin is minted for
-    /// it and its ID is reported back in
-    /// [`SimulateTransactionResult::mock_gas_id`]. With `VmChecks::Disabled`, a
-    /// zero gas price or gas budget is replaced by the epoch's reference gas
-    /// price and the protocol maximum gas budget respectively, so callers with
-    /// no gas to declare can leave both unset.
+    /// Under either `checks`, the simulation fills in whatever gas the
+    /// transaction leaves unset, so that a caller with no gas to declare can
+    /// leave all of it out: no gas payment mints a mock gas coin, whose ID is
+    /// reported back in [`SimulateTransactionResult::mock_gas_id`]; a zero gas
+    /// price becomes the epoch's reference gas price; and a zero gas budget
+    /// becomes the protocol maximum. Anything the transaction does declare is
+    /// metered as given, so a dry run still rejects the gas a validator would.
     pub fn simulate_transaction(
         &self,
         transaction: TransactionData,
@@ -2185,6 +2186,20 @@ impl AuthorityState {
         // mock gas object. It checks for other transaction input validity.
         transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
 
+        // The full validity check caps the gas payment size alongside requiring a
+        // gas payment at all, which a simulation relaxes so it can mock one. The cap
+        // still applies, and is cheapest before any object is loaded.
+        let max_gas_payment_objects =
+            epoch_store.protocol_config().max_gas_payment_objects() as usize;
+        fp_ensure!(
+            transaction.gas().len() < max_gas_payment_objects,
+            UserInputError::SizeLimitExceeded {
+                limit: "maximum number of gas payment objects".to_string(),
+                value: max_gas_payment_objects.to_string(),
+            }
+            .into()
+        );
+
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
@@ -2221,24 +2236,21 @@ impl AuthorityState {
 
         let protocol_config = epoch_store.protocol_config();
 
-        // In a simulation with "checks disabled", a zero gas price or
-        // budget means "use this epoch's defaults" rather than being metered as
-        // an actual zero: a zero price is below the reference gas price, and a
-        // zero budget cannot cover any computation, so either would fail the
-        // simulation over gas the caller never meant to set.
-        //
-        // A simulation with "checks enabled" has to reject the same way a validator
-        // would.
-        if checks.disabled() {
+        // Fill in the gas the caller left unset. Nobody submits a simulation to pay
+        // for it, and neither zero is a value the gas checks could accept anyway: a
+        // zero price is below the reference gas price, and a zero budget cannot cover
+        // any computation. Callers that do declare gas are metered against it, so a
+        // dry run still rejects the gas a validator would.
+        if transaction.gas_price() == 0 {
             let reference_gas_price = epoch_store.reference_gas_price();
+            transaction.gas_data_mut().price = reference_gas_price;
+        }
+        if transaction.gas_budget() == 0 {
+            // The protocol maximum, rather than what the gas coins hold: a budget
+            // equal to the whole balance would leave nothing for a transaction that
+            // also pays out of its gas coin.
             let max_tx_gas = protocol_config.max_tx_gas();
-            let gas_data = transaction.gas_data_mut();
-            if gas_data.price == 0 {
-                gas_data.price = reference_gas_price;
-            }
-            if gas_data.budget == 0 {
-                gas_data.budget = max_tx_gas;
-            }
+            transaction.gas_data_mut().budget = max_tx_gas;
         }
 
         // `MoveAuthenticator`s are not supported in simulation, so we set the
@@ -2259,6 +2271,21 @@ impl AuthorityState {
                 authenticator_gas_budget,
             )?
         } else {
+            // Execution reserves the whole gas budget from the gas coins before running
+            // any command, so they have to cover it even though the rest of the gas
+            // checks are skipped here. With the checks enabled,
+            // `check_transaction_input` covers this.
+            let gas_balance = iota_types::gas::gas_coins_balance(&input_objects, transaction.gas());
+            let gas_budget = transaction.gas_budget();
+            fp_ensure!(
+                gas_balance >= gas_budget as u128,
+                UserInputError::GasBalanceTooLow {
+                    gas_balance,
+                    needed_gas_amount: gas_budget as u128,
+                }
+                .into()
+            );
+
             let checked_input_objects = iota_transaction_checks::check_simulation_input(
                 protocol_config,
                 transaction.kind(),

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2113,7 +2113,10 @@ impl AuthorityState {
     ///
     /// If the transaction carries no gas payment, a mock gas coin is minted for
     /// it and its ID is reported back in
-    /// [`SimulateTransactionResult::mock_gas_id`].
+    /// [`SimulateTransactionResult::mock_gas_id`]. With `VmChecks::Disabled`, a
+    /// zero gas price or gas budget is replaced by the epoch's reference gas
+    /// price and the protocol maximum gas budget respectively, so callers with
+    /// no gas to declare can leave both unset.
     pub fn simulate_transaction(
         &self,
         transaction: TransactionData,
@@ -2217,6 +2220,26 @@ impl AuthorityState {
         };
 
         let protocol_config = epoch_store.protocol_config();
+
+        // In a simulation with "checks disabled", a zero gas price or
+        // budget means "use this epoch's defaults" rather than being metered as
+        // an actual zero: a zero price is below the reference gas price, and a
+        // zero budget cannot cover any computation, so either would fail the
+        // simulation over gas the caller never meant to set.
+        //
+        // A simulation with "checks enabled" has to reject the same way a validator
+        // would.
+        if checks.disabled() {
+            let reference_gas_price = epoch_store.reference_gas_price();
+            let max_tx_gas = protocol_config.max_tx_gas();
+            let gas_data = transaction.gas_data_mut();
+            if gas_data.price == 0 {
+                gas_data.price = reference_gas_price;
+            }
+            if gas_data.budget == 0 {
+                gas_data.budget = max_tx_gas;
+            }
+        }
 
         // `MoveAuthenticator`s are not supported in simulation, so we set the
         // `authenticator_gas_budget` to 0.

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2270,7 +2270,7 @@ impl AuthorityState {
             // that they are gas coins at all — so with those checks skipped here, this
             // has to stand in for them. With the checks enabled,
             // `check_transaction_input` covers it.
-            iota_types::gas::check_gas_coins_cover_budget(
+            iota_types::gas::check_gas_coins_cover_budget_in_simulation(
                 &input_objects,
                 transaction.gas(),
                 transaction.gas_budget(),

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2118,6 +2118,16 @@ impl AuthorityState {
     /// price becomes the epoch's reference gas price; and a zero gas budget
     /// becomes the protocol maximum. Anything the transaction does declare is
     /// metered as given, so a dry run still rejects the gas a validator would.
+    ///
+    /// Whatever the budget resolves to, the gas coins have to cover it, since
+    /// execution reserves the whole budget from them before running any
+    /// command. Note what that means for a caller leaving the budget at zero to
+    /// have the cost estimated: the mock gas coin covers the protocol maximum,
+    /// but a real gas coin has to hold
+    /// [`max_tx_gas`](iota_protocol_config::ProtocolConfig::max_tx_gas) or the
+    /// simulation is rejected with
+    /// [`UserInputError::GasBalanceTooLow`]. Declaring a budget the coins do
+    /// cover avoids that.
     pub fn simulate_transaction(
         &self,
         transaction: TransactionData,
@@ -2189,16 +2199,7 @@ impl AuthorityState {
         // The full validity check caps the gas payment size alongside requiring a
         // gas payment at all, which a simulation relaxes so it can mock one. The cap
         // still applies, and is cheapest before any object is loaded.
-        let max_gas_payment_objects =
-            epoch_store.protocol_config().max_gas_payment_objects() as usize;
-        fp_ensure!(
-            transaction.gas().len() < max_gas_payment_objects,
-            UserInputError::SizeLimitExceeded {
-                limit: "maximum number of gas payment objects".to_string(),
-                value: max_gas_payment_objects.to_string(),
-            }
-            .into()
-        );
+        transaction.check_gas_payment_size(epoch_store.protocol_config())?;
 
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -31,8 +31,7 @@ use iota_config::{
 };
 use iota_framework::{BuiltInFramework, SystemPackage as FrameworkSystemPackage};
 use iota_json_rpc_types::{
-    DevInspectResults, DryRunTransactionBlockResponse, EventFilter, IotaEvent, IotaMoveValue,
-    IotaObjectDataFilter, IotaTransactionBlockData, IotaTransactionBlockEffects,
+    EventFilter, IotaEvent, IotaMoveValue, IotaObjectDataFilter, IotaTransactionBlockEffects,
     IotaTransactionBlockEvents, TransactionFilter,
 };
 use iota_macros::{fail_point, fail_point_async, fail_point_if};
@@ -41,12 +40,11 @@ use iota_metrics::{
 };
 use iota_sdk_types::{
     Address, CheckpointContentsDigest, CheckpointDigest, Digest, EndOfEpochTransactionKind,
-    ExecutionStatus, GasPayment, MoveAuthenticator, MoveStruct, ObjectDigest, ObjectId,
-    ObjectReference, Owner, RandomnessRound, SenderSignedTransaction, StructTag, SystemPackage,
-    TransactionDigest, TransactionEffects, TransactionEffectsDigest, TransactionEvents,
-    TransactionExpiration, TransactionKind, TransactionV1, TypeTag, Version,
+    ExecutionStatus, MoveAuthenticator, ObjectDigest, ObjectId, ObjectReference, Owner,
+    RandomnessRound, SenderSignedTransaction, StructTag, SystemPackage, TransactionDigest,
+    TransactionEffects, TransactionEffectsDigest, TransactionEvents, TypeTag, Version,
     checkpoint::{CheckpointCommitment, CheckpointContents, CheckpointSummary},
-    crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
+    crypto::{Intent, IntentScope},
     gas::GasCostSummary,
 };
 use iota_storage::{
@@ -81,10 +79,9 @@ use iota_types::{
     execution_config_utils::to_binary_config,
     fp_ensure,
     gas::IotaGasStatus,
-    gas_coin::{SIMULATION_GAS_COIN_VALUE, mock_simulation_gas_coin},
+    gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::{
-        InnerTemporaryStore, ObjectMap, PackageStoreWithFallback, TemporaryModuleResolver, TxCoins,
-        WrittenObjects,
+        InnerTemporaryStore, ObjectMap, PackageStoreWithFallback, TxCoins, WrittenObjects,
     },
     iota_sdk_types_conversions::type_tag_core_to_sdk,
     iota_system_state::{
@@ -106,10 +103,7 @@ use iota_types::{
     },
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
     move_authenticator::MoveAuthenticatorExt,
-    object::{
-        MoveStructExt, OBJECT_START_VERSION, Object, ObjectRead, PastObjectRead,
-        bounded_visitor::BoundedVisitor,
-    },
+    object::{Object, ObjectRead, PastObjectRead, bounded_visitor::BoundedVisitor},
     storage::{
         BackingPackageStore, BackingStore, ObjectKey, ObjectOrTombstone, ObjectStore, WriteKind,
     },
@@ -2110,260 +2104,54 @@ impl AuthorityState {
         )
     }
 
-    /// TO BE DEPRECATED SOON: Use `simulate_transaction` with
-    /// `VmChecks::Enabled` instead.
-    #[instrument("dry_exec_tx", level = "trace", skip_all)]
-    #[allow(clippy::type_complexity)]
-    pub fn dry_exec_transaction(
+    /// Simulate a transaction without committing it.
+    ///
+    /// `checks` selects the Move VM semantics: `VmChecks::Enabled` runs the
+    /// transaction as it would run on chain (a dry run), while
+    /// `VmChecks::Disabled` relaxes the checks around entry functions and
+    /// argument values, and reports per-command return values (a dev inspect).
+    ///
+    /// If the transaction carries no gas payment, a mock gas coin is minted for
+    /// it and its ID is reported back in
+    /// [`SimulateTransactionResult::mock_gas_id`].
+    #[instrument("simulate_tx", level = "trace", skip_all)]
+    pub fn simulate_transaction(
         &self,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> IotaResult<(
-        DryRunTransactionBlockResponse,
-        BTreeMap<ObjectId, (ObjectReference, Object, WriteKind)>,
-        TransactionEffects,
-        Option<ObjectId>,
-    )> {
+        checks: VmChecks,
+    ) -> IotaResult<SimulateTransactionResult> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
         if !self.is_fullnode(&epoch_store) {
             return Err(IotaError::UnsupportedFeature {
-                error: "dry-exec is only supported on fullnodes".to_string(),
+                error: "simulate is only supported on fullnodes".to_string(),
             });
         }
 
-        if transaction.kind().is_system() {
-            return Err(IotaError::UnsupportedFeature {
-                error: "dry-exec does not support system transactions".to_string(),
-            });
-        }
-
-        self.dry_exec_transaction_impl(&epoch_store, transaction, transaction_digest)
+        self.simulate_transaction_inner(&epoch_store, transaction, checks)
     }
 
-    #[allow(clippy::type_complexity)]
-    pub fn dry_exec_transaction_for_benchmark(
+    /// Same as [`AuthorityState::simulate_transaction`], but runs on a
+    /// validator too. Only the single-node benchmark, which has no fullnode
+    /// to run against, needs this.
+    pub fn simulate_transaction_for_benchmark(
         &self,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> IotaResult<(
-        DryRunTransactionBlockResponse,
-        BTreeMap<ObjectId, (ObjectReference, Object, WriteKind)>,
-        TransactionEffects,
-        Option<ObjectId>,
-    )> {
+        checks: VmChecks,
+    ) -> IotaResult<SimulateTransactionResult> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
-        self.dry_exec_transaction_impl(&epoch_store, transaction, transaction_digest)
+        self.simulate_transaction_inner(&epoch_store, transaction, checks)
     }
 
     #[instrument(level = "trace", skip_all)]
-    #[allow(clippy::type_complexity)]
-    fn dry_exec_transaction_impl(
+    fn simulate_transaction_inner(
         &self,
         epoch_store: &AuthorityPerEpochStore,
-        transaction: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> IotaResult<(
-        DryRunTransactionBlockResponse,
-        BTreeMap<ObjectId, (ObjectReference, Object, WriteKind)>,
-        TransactionEffects,
-        Option<ObjectId>,
-    )> {
-        // Cheap validity checks for a transaction, including input size limits.
-        transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
-
-        let input_object_kinds = transaction.input_objects()?;
-        let receiving_object_refs = transaction.receiving_objects();
-
-        iota_transaction_checks::deny::check_transaction_for_validation(
-            &transaction,
-            &[],
-            &input_object_kinds,
-            &receiving_object_refs,
-            &self.config.transaction_deny_config,
-            self.get_backing_package_store().as_ref(),
-        )?;
-
-        let (input_objects, receiving_objects) = self.input_loader.read_objects_for_signing(
-            // We don't want to cache this transaction since it's a dry run.
-            None,
-            &input_object_kinds,
-            &receiving_object_refs,
-            epoch_store.epoch(),
-        )?;
-
-        // make a gas object if one was not provided
-        let mut transaction = transaction;
-        let reference_gas_price = epoch_store.reference_gas_price();
-        let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
-            let sender = transaction.gas_owner();
-            let gas_object_id = ObjectId::random();
-            let gas_object = Object::new_move(
-                MoveStruct::new_gas_coin(
-                    OBJECT_START_VERSION,
-                    gas_object_id,
-                    SIMULATION_GAS_COIN_VALUE,
-                ),
-                Owner::Address(sender),
-                TransactionDigest::GENESIS_MARKER,
-            );
-            let gas_object_ref = gas_object.object_ref();
-            // Add gas object to transaction gas payment
-            transaction.gas_data_mut().objects = vec![gas_object_ref];
-            (
-                iota_transaction_checks::check_transaction_input_with_given_gas(
-                    epoch_store.protocol_config(),
-                    reference_gas_price,
-                    &transaction,
-                    input_objects,
-                    receiving_objects,
-                    gas_object,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?,
-                Some(gas_object_id),
-            )
-        } else {
-            // `MoveAuthenticator`s are not supported in dry runs, so we set the
-            // `authenticator_gas_budget` to 0.
-            let authenticator_gas_budget = 0;
-
-            (
-                iota_transaction_checks::check_transaction_input(
-                    epoch_store.protocol_config(),
-                    reference_gas_price,
-                    &transaction,
-                    input_objects,
-                    &receiving_objects,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                    authenticator_gas_budget,
-                )?,
-                None,
-            )
-        };
-
-        let protocol_config = epoch_store.protocol_config();
-        let (kind, signer, gas_data) = transaction.execution_parts();
-
-        let silent = true;
-        let executor = iota_execution::executor(protocol_config, silent, None)
-            .expect("Creating an executor should not fail here");
-
-        let expensive_checks = false;
-        let (inner_temp_store, _, effects, execution_error) = executor
-            .execute_transaction_to_effects(
-                self.get_backing_store().as_ref(),
-                protocol_config,
-                self.metrics.limits_metrics.clone(),
-                expensive_checks,
-                self.config.certificate_deny_config.certificate_deny_set(),
-                &epoch_store.epoch_start_config().epoch_data().epoch_id(),
-                epoch_store
-                    .epoch_start_config()
-                    .epoch_data()
-                    .epoch_start_timestamp(),
-                checked_input_objects,
-                gas_data,
-                gas_status,
-                kind,
-                signer,
-                transaction_digest,
-                &mut None,
-            );
-        let tx_digest = *effects.transaction_digest();
-
-        let module_cache =
-            TemporaryModuleResolver::new(&inner_temp_store, epoch_store.module_cache().clone());
-
-        let mut layout_resolver =
-            epoch_store
-                .executor()
-                .type_layout_resolver(Box::new(PackageStoreWithFallback::new(
-                    &inner_temp_store,
-                    self.get_backing_package_store(),
-                )));
-        // Returning empty vector here because we recalculate changes in the rpc layer.
-        let object_changes = Vec::new();
-
-        // Returning empty vector here because we recalculate changes in the rpc layer.
-        let balance_changes = Vec::new();
-
-        let written_with_kind = effects
-            .created()
-            .into_iter()
-            .map(|(oref, _)| (oref, WriteKind::Create))
-            .chain(
-                effects
-                    .unwrapped()
-                    .into_iter()
-                    .map(|(oref, _)| (oref, WriteKind::Unwrap)),
-            )
-            .chain(
-                effects
-                    .mutated()
-                    .into_iter()
-                    .map(|(oref, _)| (oref, WriteKind::Mutate)),
-            )
-            .map(|(oref, kind)| {
-                let obj = inner_temp_store.written.get(&oref.object_id).unwrap();
-                // TODO: Avoid clones.
-                (oref.object_id, (oref, obj.clone(), kind))
-            })
-            .collect();
-
-        let execution_error_source = execution_error
-            .as_ref()
-            .err()
-            .and_then(|e| e.source().as_ref().map(|e| e.to_string()));
-
-        Ok((
-            DryRunTransactionBlockResponse {
-                // to avoid cloning `transaction`, fields are populated in this order
-                suggested_gas_price: self
-                    .congestion_tracker
-                    .get_prediction_suggested_gas_price(&transaction),
-                input: IotaTransactionBlockData::try_from_with_module_cache(
-                    transaction,
-                    &module_cache,
-                    tx_digest,
-                )
-                .map_err(|e| IotaError::TransactionSerialization {
-                    error: format!(
-                        "Failed to convert transaction to IotaTransactionBlockData: {e}",
-                    ),
-                })?, // TODO: replace the underlying try_from to IotaError. This one goes deep
-                effects: effects.clone().try_into()?,
-                events: IotaTransactionBlockEvents::try_from(
-                    inner_temp_store.events.clone(),
-                    tx_digest,
-                    None,
-                    layout_resolver.as_mut(),
-                )?,
-                object_changes,
-                balance_changes,
-                execution_error_source,
-            },
-            written_with_kind,
-            effects,
-            mock_gas,
-        ))
-    }
-
-    pub fn simulate_transaction(
-        &self,
         mut transaction: TransactionData,
         checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult> {
         if transaction.kind().is_system() {
             return Err(IotaError::UnsupportedFeature {
                 error: "simulate does not support system transactions".to_string(),
-            });
-        }
-
-        let epoch_store = self.load_epoch_store_one_call_per_task();
-        if !self.is_fullnode(&epoch_store) {
-            return Err(IotaError::UnsupportedFeature {
-                error: "simulate is only supported on fullnodes".to_string(),
             });
         }
 
@@ -2485,221 +2273,6 @@ impl AuthorityState {
                 .get_prediction_suggested_gas_price(&transaction),
             mock_gas_id,
         })
-    }
-
-    /// TO BE DEPRECATED SOON: Use `simulate_transaction` with
-    /// `VmChecks::DISABLED` instead.
-    /// The object ID for gas can be any
-    /// object ID, even for an uncreated object
-    #[instrument("dev_inspect_tx", level = "trace", skip_all)]
-    pub async fn dev_inspect_transaction_block(
-        &self,
-        sender: Address,
-        transaction_kind: TransactionKind,
-        gas_price: Option<u64>,
-        gas_budget: Option<u64>,
-        gas_sponsor: Option<Address>,
-        gas_objects: Option<Vec<ObjectReference>>,
-        show_raw_txn_data_and_effects: Option<bool>,
-        skip_checks: Option<bool>,
-    ) -> IotaResult<DevInspectResults> {
-        let epoch_store = self.load_epoch_store_one_call_per_task();
-
-        if !self.is_fullnode(&epoch_store) {
-            return Err(IotaError::UnsupportedFeature {
-                error: "dev-inspect is only supported on fullnodes".to_string(),
-            });
-        }
-
-        if transaction_kind.is_system() {
-            return Err(IotaError::UnsupportedFeature {
-                error: "system transactions are not supported".to_string(),
-            });
-        }
-
-        let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
-        let skip_checks = skip_checks.unwrap_or(true);
-        let reference_gas_price = epoch_store.reference_gas_price();
-        let protocol_config = epoch_store.protocol_config();
-        let max_tx_gas = protocol_config.max_tx_gas();
-
-        let price = gas_price.unwrap_or(reference_gas_price);
-        let budget = gas_budget.unwrap_or(max_tx_gas);
-        let owner = gas_sponsor.unwrap_or(sender);
-        // Payment might be empty here, but it's fine we'll have to deal with it later
-        // after reading all the input objects.
-        let payment = gas_objects.unwrap_or_default();
-        let mut transaction = TransactionData::V1(TransactionV1 {
-            kind: transaction_kind.clone(),
-            sender,
-            gas_payment: GasPayment {
-                objects: payment,
-                owner,
-                price,
-                budget,
-            },
-            expiration: TransactionExpiration::None,
-        });
-
-        let raw_txn_data = if show_raw_txn_data_and_effects {
-            bcs::to_bytes(&transaction).map_err(|_| IotaError::TransactionSerialization {
-                error: "Failed to serialize transaction during dev inspect".to_string(),
-            })?
-        } else {
-            vec![]
-        };
-
-        transaction.validity_check_no_gas_check(protocol_config)?;
-
-        let input_object_kinds = transaction.input_objects()?;
-        let receiving_object_refs = transaction.receiving_objects();
-
-        iota_transaction_checks::deny::check_transaction_for_validation(
-            &transaction,
-            &[],
-            &input_object_kinds,
-            &receiving_object_refs,
-            &self.config.transaction_deny_config,
-            self.get_backing_package_store().as_ref(),
-        )?;
-
-        let (mut input_objects, receiving_objects) = self.input_loader.read_objects_for_signing(
-            // We don't want to cache this transaction since it's a dev inspect.
-            None,
-            &input_object_kinds,
-            &receiving_object_refs,
-            epoch_store.epoch(),
-        )?;
-
-        let (gas_status, checked_input_objects) = if skip_checks {
-            // If we are skipping checks, then we call the check_dev_inspect_input function
-            // which will perform only lightweight checks on the transaction
-            // input. And if the gas field is empty, that means we will
-            // use the dummy gas object so we need to add it to the input objects vector.
-            if transaction.gas().is_empty() {
-                // Create and use a dummy gas object if there is no gas object provided.
-                let dummy_gas_object = Object::new_gas_with_balance_and_owner_for_testing(
-                    SIMULATION_GAS_COIN_VALUE,
-                    transaction.gas_owner(),
-                );
-                let gas_object_ref = dummy_gas_object.object_ref();
-                transaction.gas_data_mut().objects = vec![gas_object_ref];
-                input_objects.push(ObjectReadResult::new(
-                    InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref),
-                    dummy_gas_object.into(),
-                ));
-            }
-            let checked_input_objects = iota_transaction_checks::check_dev_inspect_input(
-                protocol_config,
-                &transaction_kind,
-                input_objects,
-                receiving_objects,
-            )?;
-            let gas_status = IotaGasStatus::new(
-                max_tx_gas,
-                transaction.gas_price(),
-                reference_gas_price,
-                protocol_config,
-            )?;
-
-            (gas_status, checked_input_objects)
-        } else {
-            // If we are not skipping checks, then we call the check_transaction_input
-            // function and its dummy gas variant which will perform full
-            // fledged checks just like a real transaction execution.
-            if transaction.gas().is_empty() {
-                // Create and use a dummy gas object if there is no gas object provided.
-                let dummy_gas_object = Object::new_gas_with_balance_and_owner_for_testing(
-                    SIMULATION_GAS_COIN_VALUE,
-                    transaction.gas_owner(),
-                );
-                let gas_object_ref = dummy_gas_object.object_ref();
-                transaction.gas_data_mut().objects = vec![gas_object_ref];
-                iota_transaction_checks::check_transaction_input_with_given_gas(
-                    epoch_store.protocol_config(),
-                    reference_gas_price,
-                    &transaction,
-                    input_objects,
-                    receiving_objects,
-                    dummy_gas_object,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                )?
-            } else {
-                // `MoveAuthenticator`s are not supported in dev inspects, so we set the
-                // `authenticator_gas_budget` to 0.
-                let authenticator_gas_budget = 0;
-
-                iota_transaction_checks::check_transaction_input(
-                    epoch_store.protocol_config(),
-                    reference_gas_price,
-                    &transaction,
-                    input_objects,
-                    &receiving_objects,
-                    &self.metrics.bytecode_verifier_metrics,
-                    &self.config.verifier_signing_config,
-                    authenticator_gas_budget,
-                )?
-            }
-        };
-
-        let executor = iota_execution::executor(protocol_config, /* silent */ true, None)
-            .expect("Creating an executor should not fail here");
-        let gas_data = transaction.gas_data().clone();
-        let intent_msg = IntentMessage::new(
-            Intent {
-                version: IntentVersion::V0,
-                scope: IntentScope::TransactionData,
-                app_id: IntentAppId::Iota,
-            },
-            transaction,
-        );
-        let transaction_digest = TransactionDigest::new(intent_msg.value.digest().into_inner());
-        let (inner_temp_store, _, effects, execution_result) = executor.dev_inspect_transaction(
-            self.get_backing_store().as_ref(),
-            protocol_config,
-            self.metrics.limits_metrics.clone(),
-            // expensive checks
-            false,
-            self.config.certificate_deny_config.certificate_deny_set(),
-            &epoch_store.epoch_start_config().epoch_data().epoch_id(),
-            epoch_store
-                .epoch_start_config()
-                .epoch_data()
-                .epoch_start_timestamp(),
-            checked_input_objects,
-            gas_data,
-            gas_status,
-            transaction_kind,
-            sender,
-            transaction_digest,
-            skip_checks,
-        );
-
-        let raw_effects = if show_raw_txn_data_and_effects {
-            bcs::to_bytes(&effects).map_err(|_| IotaError::TransactionSerialization {
-                error: "Failed to serialize transaction effects during dev inspect".to_string(),
-            })?
-        } else {
-            vec![]
-        };
-
-        let mut layout_resolver =
-            epoch_store
-                .executor()
-                .type_layout_resolver(Box::new(PackageStoreWithFallback::new(
-                    &inner_temp_store,
-                    self.get_backing_package_store(),
-                )));
-
-        DevInspectResults::new(
-            effects,
-            inner_temp_store.events.clone(),
-            execution_result,
-            raw_txn_data,
-            raw_effects,
-            layout_resolver.as_mut(),
-        )
     }
 
     // Only used for testing because of how epoch store is loaded.

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2344,6 +2344,7 @@ impl AuthorityState {
                 .congestion_tracker
                 .get_prediction_suggested_gas_price(&transaction),
             mock_gas_id,
+            gas_data: transaction.gas_data().clone(),
         })
     }
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2236,7 +2236,7 @@ impl AuthorityState {
                 authenticator_gas_budget,
             )?
         } else {
-            let checked_input_objects = iota_transaction_checks::check_dev_inspect_input(
+            let checked_input_objects = iota_transaction_checks::check_simulation_input(
                 protocol_config,
                 transaction.kind(),
                 input_objects,
@@ -2282,8 +2282,8 @@ impl AuthorityState {
             checks.disabled(),
         );
 
-        // In the case of a dev inspect, the execution_result could be filled with some
-        // values. Else, execution_result is empty in the case of a dry run.
+        // `execution_result` carries the per-command return values only when the
+        // checks are disabled; with them enabled it is empty.
         Ok(SimulateTransactionResult {
             input_objects: inner_temp_store.input_objects,
             output_objects: inner_temp_store.written,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2109,7 +2109,8 @@ impl AuthorityState {
     /// `checks` selects the Move VM semantics: `VmChecks::Enabled` runs the
     /// transaction as it would run on chain (a dry run), while
     /// `VmChecks::Disabled` relaxes the checks around entry functions and
-    /// argument values, and reports per-command return values (a dev inspect).
+    /// argument values (a dev inspect). Both report the per-command return
+    /// values in [`SimulateTransactionResult::execution_result`].
     ///
     /// Under either `checks`, the simulation fills in whatever gas the
     /// transaction leaves unset, so that a caller with no gas to declare can
@@ -2272,20 +2273,16 @@ impl AuthorityState {
                 authenticator_gas_budget,
             )?
         } else {
-            // Execution reserves the whole gas budget from the gas coins before running
-            // any command, so they have to cover it even though the rest of the gas
-            // checks are skipped here. With the checks enabled,
-            // `check_transaction_input` covers this.
-            let gas_balance = iota_types::gas::gas_coins_balance(&input_objects, transaction.gas());
-            let gas_budget = transaction.gas_budget();
-            fp_ensure!(
-                gas_balance >= gas_budget as u128,
-                UserInputError::GasBalanceTooLow {
-                    gas_balance,
-                    needed_gas_amount: gas_budget as u128,
-                }
-                .into()
-            );
+            // Execution smashes the gas coins and reserves the whole budget from them
+            // before running any command, treating the input checks as having verified
+            // that they are gas coins at all — so with those checks skipped here, this
+            // has to stand in for them. With the checks enabled,
+            // `check_transaction_input` covers it.
+            iota_types::gas::check_gas_coins_cover_budget(
+                &input_objects,
+                transaction.gas(),
+                transaction.gas_budget(),
+            )?;
 
             let checked_input_objects = iota_transaction_checks::check_simulation_input(
                 protocol_config,
@@ -2333,8 +2330,6 @@ impl AuthorityState {
             checks.disabled(),
         );
 
-        // `execution_result` carries the per-command return values only when the
-        // checks are disabled; with them enabled it is empty.
         Ok(SimulateTransactionResult {
             input_objects: inner_temp_store.input_objects,
             output_objects: inner_temp_store.written,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2117,18 +2117,20 @@ impl AuthorityState {
     /// leave all of it out: no gas payment mints a mock gas coin, whose ID is
     /// reported back in [`SimulateTransactionResult::mock_gas_id`]; a zero gas
     /// price becomes the epoch's reference gas price; and a zero gas budget
-    /// becomes the protocol maximum. Anything the transaction does declare is
-    /// metered as given, so a dry run still rejects the gas a validator would.
+    /// becomes as much as the gas coins can back, up to
+    /// [`max_tx_gas`](iota_protocol_config::ProtocolConfig::max_tx_gas).
+    /// Anything the transaction does declare is metered as given, so a dry run
+    /// still rejects the gas a validator would.
     ///
     /// Whatever the budget resolves to, the gas coins have to cover it, since
-    /// execution reserves the whole budget from them before running any
-    /// command. Note what that means for a caller leaving the budget at zero to
-    /// have the cost estimated: the mock gas coin covers the protocol maximum,
-    /// but a real gas coin has to hold
-    /// [`max_tx_gas`](iota_protocol_config::ProtocolConfig::max_tx_gas) or the
-    /// simulation is rejected with
-    /// [`UserInputError::GasBalanceTooLow`]. Declaring a budget the coins do
-    /// cover avoids that.
+    /// execution reserves the whole budget from them before running any command
+    /// and refunds it afterwards. A caller leaving the budget at zero to have
+    /// the cost estimated therefore gets an estimate whatever its coins hold,
+    /// but the reserved budget is off limits for the duration of the
+    /// programmable transaction: a transaction that also pays out of its gas
+    /// coin has to declare a budget leaving room for that, exactly as it would
+    /// on chain. A balance too small to declare the minimum budget at all is
+    /// rejected with [`UserInputError::GasBalanceTooLow`].
     pub fn simulate_transaction(
         &self,
         transaction: TransactionData,
@@ -2240,6 +2242,7 @@ impl AuthorityState {
 
         iota_types::gas::fill_in_unset_simulation_gas(
             &mut transaction,
+            &input_objects,
             epoch_store.reference_gas_price(),
             protocol_config,
         );

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2114,20 +2114,42 @@ impl AuthorityState {
     /// If the transaction carries no gas payment, a mock gas coin is minted for
     /// it and its ID is reported back in
     /// [`SimulateTransactionResult::mock_gas_id`].
-    #[instrument("simulate_tx", level = "trace", skip_all)]
     pub fn simulate_transaction(
         &self,
         transaction: TransactionData,
         checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
-        if !self.is_fullnode(&epoch_store) {
+        self.simulate_transaction_in_epoch(&epoch_store, transaction, checks)
+    }
+
+    /// Same as [`AuthorityState::simulate_transaction`], for callers that
+    /// already hold an epoch store.
+    ///
+    /// Callers that derive gas parameters from an epoch, or resolve types
+    /// against its executor once the simulation returns, should pass that same
+    /// epoch store here so the whole operation observes one epoch.
+    ///
+    /// Nothing here checks that `epoch_store` is the current one — pinning a
+    /// superseded epoch is the point, and is what
+    /// [`AuthorityState::simulate_transaction`] does for the span of its own
+    /// call. Keeping one across an unbounded period is the caller's problem:
+    /// the simulation would run against that epoch's protocol config,
+    /// executor, and reference gas price.
+    #[instrument("simulate_tx", level = "trace", skip_all)]
+    pub fn simulate_transaction_in_epoch(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        transaction: TransactionData,
+        checks: VmChecks,
+    ) -> IotaResult<SimulateTransactionResult> {
+        if !self.is_fullnode(epoch_store) {
             return Err(IotaError::UnsupportedFeature {
                 error: "simulate is only supported on fullnodes".to_string(),
             });
         }
 
-        self.simulate_transaction_inner(&epoch_store, transaction, checks)
+        self.simulate_transaction_inner(epoch_store, transaction, checks)
     }
 
     /// Same as [`AuthorityState::simulate_transaction`], but runs on a

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -847,38 +847,58 @@ async fn test_dev_inspect_uses_supplied_gas_budget() {
     );
 }
 
-/// An unset gas budget becomes `max_tx_gas`, so a supplied gas coin has to back
-/// that budget for a dry run to go through, exactly as a validator would
-/// require.
+/// An unset gas budget becomes as much as the gas coins can back, up to
+/// `max_tx_gas`, so a coin holding less than the maximum still gets an estimate
+/// rather than being rejected over a budget the caller never asked for.
 ///
-/// The budget deliberately is not the coin's balance: a transaction that pays
-/// out of its own gas coin would then have nothing left to pay with.
+/// The budget is still held back for the whole programmable transaction, so
+/// capping it to the balance leaves a transaction that also pays out of its own
+/// gas coin nothing to pay with — that caller has to declare a budget, as it
+/// would on chain.
 #[tokio::test]
-async fn test_simulate_unset_gas_budget_uses_max_tx_gas() {
+async fn test_simulate_unset_gas_budget_is_capped_by_the_gas_coin_balance() {
     let sender = Address::random();
     let recipient = Address::random();
-    let (validator, fullnode, _object_basics) =
+    let (validator, fullnode, object_basics) =
         init_state_with_ids_and_object_basics_with_fullnode(vec![]).await;
 
-    let max_tx_gas = validator
+    let protocol_config = validator
         .epoch_store_for_testing()
         .protocol_config()
-        .max_tx_gas();
+        .clone();
+    let max_tx_gas = protocol_config.max_tx_gas();
+    let min_gas_budget =
+        protocol_config.base_tx_cost_fixed() * fullnode.reference_gas_price_for_testing().unwrap();
 
-    let simulate_paying_from_gas_coin = |gas_balance: u64, checks| {
+    // A transfer out of the gas coin, which competes with the budget execution
+    // holds back, and a Move call that leaves the gas coin's balance alone.
+    let paying_from_gas_coin = || {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.pay_iota(vec![recipient], vec![500]).unwrap();
+        TransactionKind::new_programmable(builder.finish())
+    };
+    let leaving_gas_coin_alone = || {
+        TransactionKind::new_programmable(ProgrammableTransaction {
+            inputs: vec![CallArg::pure(&(32_u64)), CallArg::pure(&sender)],
+            commands: vec![Command::new_move_call(
+                object_basics.object_id,
+                Identifier::from_static("object_basics"),
+                Identifier::from_static("create"),
+                vec![],
+                vec![Argument::Input(0), Argument::Input(1)],
+            )],
+        })
+    };
+
+    let simulate = |gas_balance: u64, kind: TransactionKind, checks| {
         let gas_object = Object::new_gas_with_balance_and_owner_for_testing(gas_balance, sender);
         let gas_object_ref = gas_object.object_ref();
         validator.insert_genesis_object(gas_object.clone());
         fullnode.insert_genesis_object(gas_object);
 
-        let pt = {
-            let mut builder = ProgrammableTransactionBuilder::new();
-            builder.pay_iota(vec![recipient], vec![500]).unwrap();
-            builder.finish()
-        };
         fullnode.simulate_transaction(
             TransactionData::V1(TransactionV1 {
-                kind: TransactionKind::new_programmable(pt),
+                kind,
                 sender,
                 gas_payment: GasPayment {
                     objects: vec![gas_object_ref],
@@ -892,21 +912,43 @@ async fn test_simulate_unset_gas_budget_uses_max_tx_gas() {
         )
     };
 
-    // A coin that backs `max_tx_gas` with room to spare.
     for checks in [VmChecks::Enabled, VmChecks::Disabled] {
-        let result = simulate_paying_from_gas_coin(max_tx_gas * 4, checks)
-            .unwrap_or_else(|e| panic!("simulation with {checks:?} failed: {e}"));
-        assert!(result.effects.status().is_success());
+        // A coin backing `max_tx_gas` with room to spare: the budget stays at the
+        // protocol maximum, leaving the rest of the balance for the transfer.
+        let result = simulate(max_tx_gas * 4, paying_from_gas_coin(), checks)
+            .unwrap_or_else(|e| panic!("{checks:?} should simulate a well-funded coin: {e}"));
+        assert!(result.effects.status().is_success(), "{checks:?}");
         // The supplied coin was used rather than a mock one being minted.
-        assert!(result.mock_gas_id.is_none());
-    }
+        assert!(result.mock_gas_id.is_none(), "{checks:?}");
 
-    // A coin that cannot back the budget is rejected over the gas, up front,
-    // rather than part-way through the transaction. Execution reserves the budget
-    // from the coin either way, so this does not depend on the checks.
-    for checks in [VmChecks::Enabled, VmChecks::Disabled] {
-        let Err(error) = simulate_paying_from_gas_coin(max_tx_gas / 2, checks) else {
-            panic!("{checks:?} should reject a gas coin that cannot back the budget");
+        // A coin below `max_tx_gas` still reports what the transaction costs, as
+        // long as the transaction does not also spend the coin down. Being able to
+        // estimate without holding `max_tx_gas` is the point of the cap.
+        let result = simulate(max_tx_gas / 2, leaving_gas_coin_alone(), checks)
+            .unwrap_or_else(|e| panic!("{checks:?} should simulate a coin under the maximum: {e}"));
+        assert!(result.effects.status().is_success(), "{checks:?}");
+        let gas_used = result.effects.gas_cost_summary().net_gas_usage();
+        assert!(gas_used > 0, "{checks:?}: the run should report a cost");
+        assert!(
+            (gas_used as u64) < max_tx_gas / 2,
+            "{checks:?}: the cost should sit inside the coin's balance"
+        );
+
+        // The same coin cannot also pay out of itself: the capped budget is held
+        // back for the whole programmable transaction, so the transfer runs out of
+        // balance. Such a caller has to name a budget it can cover, as it would
+        // for a real transaction.
+        let result = simulate(max_tx_gas / 2, paying_from_gas_coin(), checks)
+            .unwrap_or_else(|e| panic!("{checks:?} should run rather than reject: {e}"));
+        assert!(
+            !result.effects.status().is_success(),
+            "{checks:?}: paying out of a capped gas coin should fail during execution"
+        );
+
+        // A balance under the smallest budget a transaction may declare is
+        // reported against the balance, not against a budget the caller never set.
+        let Err(error) = simulate(min_gas_budget - 1, leaving_gas_coin_alone(), checks) else {
+            panic!("{checks:?} should reject a balance below the minimum budget");
         };
         assert!(
             matches!(

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -1202,12 +1202,6 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
 
 /// A gas payment that names an object which is not a gas coin is rejected, in
 /// either check mode.
-///
-/// With the checks disabled nothing else verifies the gas coins:
-/// `GasCharger::smash_gas` treats the input checks as having done it and panics
-/// rather than returning an error, and it only inspects the coins when the
-/// payment names more than one — so a funded coin alongside a non-coin object
-/// passes any check that merely sums balances.
 #[tokio::test]
 async fn test_simulate_rejects_a_gas_payment_that_is_not_a_gas_coin() {
     let sender = Address::random();

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -809,6 +809,44 @@ async fn test_dev_inspect_gas_coin_argument() {
     assert!(return_values.is_empty());
 }
 
+/// A gas budget supplied by the caller is metered against, rather than being
+/// replaced by `max_tx_gas`.
+#[tokio::test]
+async fn test_dev_inspect_uses_supplied_gas_budget() {
+    let (validator, fullnode, _object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![]).await;
+    let epoch_store = validator.epoch_store_for_testing();
+    let max_tx_gas = epoch_store.protocol_config().max_tx_gas();
+    let gas_budget = max_tx_gas / 2;
+    assert_ne!(gas_budget, max_tx_gas);
+
+    let sender = Address::random();
+    let recipient = Address::random();
+    let amount = 500;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.pay_iota(vec![recipient], vec![amount]).unwrap();
+        builder.finish()
+    };
+    let kind = TransactionKind::new_programmable(pt);
+    let results = dev_inspect_with_budget(&fullnode, sender, kind, None, Some(gas_budget))
+        .unwrap()
+        .execution_result
+        .unwrap();
+
+    // The gas coin is debited by the supplied budget, not by `max_tx_gas`.
+    assert_eq!(results.len(), 2);
+    let (mutable_reference_outputs, _) = &results[0];
+    assert_eq!(mutable_reference_outputs.len(), 1);
+    let (arg, arg_value, arg_type) = &mutable_reference_outputs[0];
+    assert_eq!(arg, &Argument::Gas);
+    check_coin_value(
+        arg_value,
+        arg_type,
+        SIMULATION_GAS_COIN_VALUE - gas_budget - amount,
+    );
+}
+
 #[tokio::test]
 async fn test_dev_inspect_gas_price() {
     let (_, fullnode, _object_basics) =
@@ -4415,6 +4453,18 @@ pub fn dev_inspect(
     kind: TransactionKind,
     gas_price: Option<u64>,
 ) -> IotaResult<SimulateTransactionResult> {
+    dev_inspect_with_budget(authority, sender, kind, gas_price, None)
+}
+
+/// Same as [`dev_inspect`], but with control over the gas budget the RPC layer
+/// would otherwise default to `max_tx_gas`.
+pub fn dev_inspect_with_budget(
+    authority: &AuthorityState,
+    sender: Address,
+    kind: TransactionKind,
+    gas_price: Option<u64>,
+    gas_budget: Option<u64>,
+) -> IotaResult<SimulateTransactionResult> {
     let epoch_store = authority.epoch_store_for_testing();
     let transaction = TransactionData::V1(TransactionV1 {
         kind,
@@ -4423,11 +4473,11 @@ pub fn dev_inspect(
             objects: vec![],
             owner: sender,
             price: gas_price.unwrap_or_else(|| epoch_store.reference_gas_price()),
-            budget: epoch_store.protocol_config().max_tx_gas(),
+            budget: gas_budget.unwrap_or_else(|| epoch_store.protocol_config().max_tx_gas()),
         },
         expiration: TransactionExpiration::None,
     });
-    authority.simulate_transaction(transaction, VmChecks::Disabled)
+    authority.simulate_transaction_in_epoch(&epoch_store, transaction, VmChecks::Disabled)
 }
 
 /// Resolve a simulation's events for display the way the RPC layer does: over

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -1158,6 +1158,87 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     assert_eq!(execution_error_source(&result), Some("VMError with status ABORTED with sub status 1 at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier(\"dynamic_field\") } at code offset 0 in function definition 13".to_string()));
 }
 
+/// A gas payment that names an object which is not a gas coin is rejected, in
+/// either check mode.
+///
+/// With the checks disabled nothing else verifies the gas coins:
+/// `GasCharger::smash_gas` treats the input checks as having done it and panics
+/// rather than returning an error, and it only inspects the coins when the
+/// payment names more than one — so a funded coin alongside a non-coin object
+/// passes any check that merely sums balances.
+#[tokio::test]
+async fn test_simulate_rejects_a_gas_payment_that_is_not_a_gas_coin() {
+    let sender = Address::random();
+    let recipient = Address::random();
+    let (validator, fullnode, _object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![]).await;
+
+    let max_tx_gas = validator
+        .epoch_store_for_testing()
+        .protocol_config()
+        .max_tx_gas();
+
+    // A funded gas coin, so the combined balance covers any budget.
+    let funded_coin = Object::new_gas_with_balance_and_owner_for_testing(max_tx_gas * 4, sender);
+    // An owned object of the same sender that is not a coin at all.
+    let not_a_coin_id = ObjectId::random();
+    let not_a_coin = Object::new_move(
+        MoveStruct::new(
+            StructTag::new(
+                Address::FRAMEWORK,
+                Identifier::from_static("object_basics"),
+                Identifier::from_static("Object"),
+                vec![],
+            )
+            .into(),
+            OBJECT_START_VERSION,
+            // A Move object's contents lead with its own id.
+            bcs::to_bytes(&(not_a_coin_id, 7u64)).unwrap(),
+        )
+        .unwrap(),
+        Owner::Address(sender),
+        TransactionDigest::GENESIS_MARKER,
+    );
+
+    for object in [funded_coin.clone(), not_a_coin.clone()] {
+        validator.insert_genesis_object(object.clone());
+        fullnode.insert_genesis_object(object);
+    }
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.pay_iota(vec![recipient], vec![500]).unwrap();
+        builder.finish()
+    };
+
+    for checks in [VmChecks::Enabled, VmChecks::Disabled] {
+        let transaction = TransactionData::V1(TransactionV1 {
+            kind: TransactionKind::new_programmable(pt.clone()),
+            sender,
+            gas_payment: GasPayment {
+                objects: vec![funded_coin.object_ref(), not_a_coin.object_ref()],
+                owner: sender,
+                price: 0,
+                budget: 0,
+            },
+            expiration: TransactionExpiration::None,
+        });
+
+        let Err(error) = fullnode.simulate_transaction(transaction, checks) else {
+            panic!("{checks:?} should reject a gas payment that is not a gas coin");
+        };
+        assert!(
+            matches!(
+                error,
+                IotaError::UserInput {
+                    error: UserInputError::InvalidGasObject { object_id }
+                } if object_id == not_a_coin_id
+            ),
+            "unexpected error for {checks:?}: {error:?}"
+        );
+    }
+}
+
 // tests using a gas coin with version MAX - 1
 #[tokio::test]
 async fn test_dry_run_dev_inspect_max_gas_version() {

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -847,6 +847,79 @@ async fn test_dev_inspect_uses_supplied_gas_budget() {
     );
 }
 
+/// An unset gas budget becomes `max_tx_gas`, so a supplied gas coin has to back
+/// that budget for a dry run to go through, exactly as a validator would
+/// require.
+///
+/// The budget deliberately is not the coin's balance: a transaction that pays
+/// out of its own gas coin would then have nothing left to pay with.
+#[tokio::test]
+async fn test_simulate_unset_gas_budget_uses_max_tx_gas() {
+    let sender = Address::random();
+    let recipient = Address::random();
+    let (validator, fullnode, _object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![]).await;
+
+    let max_tx_gas = validator
+        .epoch_store_for_testing()
+        .protocol_config()
+        .max_tx_gas();
+
+    let simulate_paying_from_gas_coin = |gas_balance: u64, checks| {
+        let gas_object = Object::new_gas_with_balance_and_owner_for_testing(gas_balance, sender);
+        let gas_object_ref = gas_object.object_ref();
+        validator.insert_genesis_object(gas_object.clone());
+        fullnode.insert_genesis_object(gas_object);
+
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder.pay_iota(vec![recipient], vec![500]).unwrap();
+            builder.finish()
+        };
+        fullnode.simulate_transaction(
+            TransactionData::V1(TransactionV1 {
+                kind: TransactionKind::new_programmable(pt),
+                sender,
+                gas_payment: GasPayment {
+                    objects: vec![gas_object_ref],
+                    owner: sender,
+                    price: 0,
+                    budget: 0,
+                },
+                expiration: TransactionExpiration::None,
+            }),
+            checks,
+        )
+    };
+
+    // A coin that backs `max_tx_gas` with room to spare.
+    for checks in [VmChecks::Enabled, VmChecks::Disabled] {
+        let result = simulate_paying_from_gas_coin(max_tx_gas * 4, checks)
+            .unwrap_or_else(|e| panic!("simulation with {checks:?} failed: {e}"));
+        assert!(result.effects.status().is_success());
+        // The supplied coin was used rather than a mock one being minted.
+        assert!(result.mock_gas_id.is_none());
+    }
+
+    // A coin that cannot back the budget is rejected over the gas, up front,
+    // rather than part-way through the transaction. Execution reserves the budget
+    // from the coin either way, so this does not depend on the checks.
+    for checks in [VmChecks::Enabled, VmChecks::Disabled] {
+        let Err(error) = simulate_paying_from_gas_coin(max_tx_gas / 2, checks) else {
+            panic!("{checks:?} should reject a gas coin that cannot back the budget");
+        };
+        assert!(
+            matches!(
+                error,
+                IotaError::UserInput {
+                    error: UserInputError::GasBalanceTooLow { .. }
+                }
+            ),
+            "unexpected error for {checks:?}: {error:?}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn test_dev_inspect_gas_price() {
     let (_, fullnode, _object_basics) =
@@ -4470,10 +4543,12 @@ pub fn dev_inspect_with_budget(
         kind,
         sender,
         gas_payment: GasPayment {
+            // Left unset the same way the RPC layer leaves them, so that the
+            // simulation fills them in.
             objects: vec![],
             owner: sender,
-            price: gas_price.unwrap_or_else(|| epoch_store.reference_gas_price()),
-            budget: gas_budget.unwrap_or_else(|| epoch_store.protocol_config().max_tx_gas()),
+            price: gas_price.unwrap_or_default(),
+            budget: gas_budget.unwrap_or_default(),
         },
         expiration: TransactionExpiration::None,
     });

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4652,8 +4652,8 @@ pub fn dev_inspect(
     dev_inspect_with_budget(authority, sender, kind, gas_price, None)
 }
 
-/// Same as [`dev_inspect`], but with control over the gas budget the RPC layer
-/// would otherwise default to `max_tx_gas`.
+/// Same as [`dev_inspect`], but with control over the gas budget, which is
+/// otherwise left at zero for the simulation to fill in.
 pub fn dev_inspect_with_budget(
     authority: &AuthorityState,
     sender: Address,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -17,8 +17,8 @@ use futures::{StreamExt, stream::FuturesUnordered};
 use iota_config::genesis::Genesis;
 use iota_framework::BuiltInFramework;
 use iota_json_rpc_types::{
-    DevInspectResults, DryRunTransactionBlockResponse, IotaArgument, IotaExecutionResult,
-    IotaExecutionStatus, IotaTransactionBlockEffectsAPI, IotaTypeTag,
+    IotaExecutionStatus, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
+    IotaTransactionBlockEvents,
 };
 use iota_macros::sim_test;
 use iota_protocol_config::{
@@ -29,8 +29,8 @@ use iota_sdk_types::{
     ConsensusDeterminedVersionAssignments, Digest, EpochId, ExecutionError, ExecutionStatus,
     GasPayment, Identifier, MoveStruct, ObjectData, ObjectDigest, ObjectId, ObjectReference, Owner,
     ProgrammableTransaction, SharedObjectReference, StructTag, TransactionDigest,
-    TransactionEffects, TransactionKind, TypeTag, Version, VersionAssignment,
-    crypto::SimpleSignature,
+    TransactionEffects, TransactionExpiration, TransactionKind, TransactionV1, TypeTag, Version,
+    VersionAssignment, crypto::SimpleSignature,
 };
 use iota_types::{
     base_types::{AuthorityName, TxContext, dbg_addr, dbg_object_id, random_object_ref},
@@ -46,6 +46,8 @@ use iota_types::{
     executable_transaction::VerifiedExecutableTransaction,
     execution::SharedInput,
     gas_coin::{GasCoin, SIMULATION_GAS_COIN_VALUE},
+    in_memory_storage::InMemoryStorage,
+    inner_temporary_store::PackageStoreWithFallback,
     iota_system_state::{IotaSystemStateTrait, IotaSystemStateWrapper},
     messages_consensus::{AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKind},
     messages_grpc::{LayoutGenerationOption, ObjectInfoRequest, TransactionInfoRequest},
@@ -58,6 +60,7 @@ use iota_types::{
         TEST_ONLY_GAS_UNIT_FOR_PUBLISH, TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData,
         TransactionDataAPI, TransactionEnvelope, VerifiedCertificate, VerifiedTransaction,
     },
+    transaction_executor::{SimulateTransactionResult, VmChecks},
     utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
 };
 use move_binary_format::{
@@ -232,13 +235,11 @@ async fn test_dry_run_transaction_block() {
         construct_shared_object_transaction_with_version(None).await;
     let initial_shared_object_version = validator.get_object(&shared_object_id).unwrap().version();
 
-    let transaction_digest = *transaction.digest();
-
-    let (response, _, _, _) = fullnode
-        .dry_exec_transaction(transaction.data().transaction().clone(), transaction_digest)
+    let result = fullnode
+        .simulate_transaction(transaction.data().transaction().clone(), VmChecks::Enabled)
         .unwrap();
-    assert_eq!(*response.effects.status(), IotaExecutionStatus::Success);
-    let gas_usage = response.effects.gas_cost_summary();
+    assert_eq!(result.effects.status(), &ExecutionStatus::Success);
+    let gas_usage = result.effects.gas_cost_summary().clone();
 
     // Make sure that objects are not mutated after dry run.
     let gas_object_version = fullnode.get_object(&gas_object_id).unwrap().version();
@@ -254,12 +255,12 @@ async fn test_dry_run_transaction_block() {
         tx.gas_budget(),
         tx.gas_price(),
     );
-    let (response, _, _, _) = fullnode
-        .dry_exec_transaction(txn_data, transaction_digest)
+    let result = fullnode
+        .simulate_transaction(txn_data, VmChecks::Enabled)
         .unwrap();
-    let gas_usage_no_gas = response.effects.gas_cost_summary();
-    assert_eq!(*response.effects.status(), IotaExecutionStatus::Success);
-    assert_eq!(gas_usage, gas_usage_no_gas);
+    let gas_usage_no_gas = result.effects.gas_cost_summary();
+    assert_eq!(result.effects.status(), &ExecutionStatus::Success);
+    assert_eq!(&gas_usage, gas_usage_no_gas);
 }
 
 #[tokio::test]
@@ -284,10 +285,10 @@ async fn test_dry_run_no_gas_big_transfer() {
 
     let signed = to_sender_signed_transaction(data, &sender_key);
 
-    let (dry_run_res, _, _, _) = fullnode
-        .dry_exec_transaction(signed.data().transaction().clone(), *signed.digest())
+    let result = fullnode
+        .simulate_transaction(signed.data().transaction().clone(), VmChecks::Enabled)
         .unwrap();
-    assert_eq!(*dry_run_res.effects.status(), IotaExecutionStatus::Success);
+    assert_eq!(result.effects.status(), &ExecutionStatus::Success);
 }
 
 #[tokio::test]
@@ -298,8 +299,10 @@ async fn test_dev_inspect_object_by_bytes() {
         init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
 
     // test normal call
-    let DevInspectResults {
-        effects, results, ..
+    let SimulateTransactionResult {
+        effects,
+        execution_result,
+        ..
     } = call_dev_inspect(
         &fullnode,
         &sender,
@@ -321,13 +324,10 @@ async fn test_dev_inspect_object_by_bytes() {
     assert!(effects.gas_cost_summary().computation_cost > 0);
     assert!(effects.gas_cost_summary().computation_cost_burned > 0);
 
-    let mut results = results.unwrap();
+    let mut results = execution_result.unwrap();
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        return_values,
-    } = exec_results;
+    let (mutable_reference_outputs, return_values) = exec_results;
     assert!(mutable_reference_outputs.is_empty());
     assert!(return_values.is_empty());
     let dev_inspect_gas_summary = effects.gas_cost_summary().clone();
@@ -363,8 +363,10 @@ async fn test_dev_inspect_object_by_bytes() {
     assert_eq!(effects.gas_cost_summary(), &dev_inspect_gas_summary);
 
     // use the created object directly, via its bytes
-    let DevInspectResults {
-        effects, results, ..
+    let SimulateTransactionResult {
+        effects,
+        execution_result,
+        ..
     } = call_dev_inspect(
         &fullnode,
         &sender,
@@ -387,13 +389,10 @@ async fn test_dev_inspect_object_by_bytes() {
     assert!(effects.gas_cost_summary().computation_cost > 0);
     assert!(effects.gas_cost_summary().computation_cost_burned > 0);
 
-    let mut results = results.unwrap();
+    let mut results = execution_result.unwrap();
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        return_values,
-    } = exec_results;
+    let (mutable_reference_outputs, return_values) = exec_results;
     assert_eq!(mutable_reference_outputs.len(), 1);
     assert!(return_values.is_empty());
     let updated_reference_bytes = &mutable_reference_outputs[0].1;
@@ -461,8 +460,10 @@ async fn test_dev_inspect_unowned_object() {
     assert_eq!(created_object.owner, Owner::Address(bob));
 
     // alice uses the object with dev inspect, despite not being the owner
-    let DevInspectResults {
-        effects, results, ..
+    let SimulateTransactionResult {
+        effects,
+        execution_result,
+        ..
     } = call_dev_inspect(
         &fullnode,
         &alice,
@@ -484,13 +485,10 @@ async fn test_dev_inspect_unowned_object() {
     assert!(effects.gas_cost_summary().computation_cost > 0);
     assert!(effects.gas_cost_summary().computation_cost_burned > 0);
 
-    let mut results = results.unwrap();
+    let mut results = execution_result.unwrap();
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        return_values,
-    } = exec_results;
+    let (mutable_reference_outputs, return_values) = exec_results;
     assert_eq!(mutable_reference_outputs.len(), 1);
     assert!(return_values.is_empty());
 }
@@ -557,20 +555,19 @@ async fn test_dev_inspect_dynamic_field() {
         )],
     };
     let kind = TransactionKind::new_programmable(pt);
-    let DevInspectResults { error, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, None, None, None, None, None, None)
-        .await
-        .unwrap();
+    let result = dev_inspect(&fullnode, sender, kind, None).unwrap();
     // produces an error
-    let err = error.unwrap();
+    let err = result.execution_result.unwrap_err().to_string();
     assert!(
         err.contains("CircularObjectOwnership"),
         "unexpected error: {err}"
     );
 
     // add a dynamic field to an object
-    let DevInspectResults {
-        effects, results, ..
+    let SimulateTransactionResult {
+        effects,
+        execution_result,
+        ..
     } = call_dev_inspect(
         &fullnode,
         &sender,
@@ -585,7 +582,7 @@ async fn test_dev_inspect_dynamic_field() {
     )
     .await
     .unwrap();
-    let mut results = results.unwrap();
+    let mut results = execution_result.unwrap();
     assert_eq!(effects.created().len(), 1);
     // random gas is mutated
     assert_eq!(effects.mutated().len(), 1);
@@ -596,10 +593,7 @@ async fn test_dev_inspect_dynamic_field() {
 
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        return_values,
-    } = exec_results;
+    let (mutable_reference_outputs, return_values) = exec_results;
     assert_eq!(mutable_reference_outputs.len(), 1);
     assert!(return_values.is_empty());
 }
@@ -641,7 +635,9 @@ async fn test_dev_inspect_return_values() {
         .to_vec();
 
     // mutably borrow a value from it's bytes
-    let DevInspectResults { results, .. } = call_dev_inspect(
+    let SimulateTransactionResult {
+        execution_result, ..
+    } = call_dev_inspect(
         &fullnode,
         &sender,
         &object_basics.object_id,
@@ -652,23 +648,21 @@ async fn test_dev_inspect_return_values() {
     )
     .await
     .unwrap();
-    let mut results = results.unwrap();
+    let mut results = execution_result.unwrap();
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        mut return_values,
-    } = exec_results;
+    let (mutable_reference_outputs, mut return_values) = exec_results;
     assert_eq!(mutable_reference_outputs.len(), 1);
     assert_eq!(return_values.len(), 1);
     let (return_value_1, return_type) = return_values.pop().unwrap();
     let deserialized_rv1: u64 = bcs::from_bytes(&return_value_1).unwrap();
     assert_eq!(init_value, deserialized_rv1);
-    let type_tag: TypeTag = return_type.try_into().unwrap();
-    assert!(matches!(type_tag, TypeTag::U64));
+    assert!(matches!(return_type, TypeTag::U64));
 
     // borrow a value from it's bytes
-    let DevInspectResults { results, .. } = call_dev_inspect(
+    let SimulateTransactionResult {
+        execution_result, ..
+    } = call_dev_inspect(
         &fullnode,
         &sender,
         &object_basics.object_id,
@@ -679,23 +673,21 @@ async fn test_dev_inspect_return_values() {
     )
     .await
     .unwrap();
-    let mut results = results.unwrap();
+    let mut results = execution_result.unwrap();
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        mut return_values,
-    } = exec_results;
+    let (mutable_reference_outputs, mut return_values) = exec_results;
     assert!(mutable_reference_outputs.is_empty());
     assert_eq!(return_values.len(), 1);
     let (return_value_1, return_type) = return_values.pop().unwrap();
     let deserialized_rv1: u64 = bcs::from_bytes(&return_value_1).unwrap();
     assert_eq!(init_value, deserialized_rv1);
-    let type_tag: TypeTag = return_type.try_into().unwrap();
-    assert!(matches!(type_tag, TypeTag::U64));
+    assert!(matches!(return_type, TypeTag::U64));
 
     // read one value from it's bytes
-    let DevInspectResults { results, .. } = call_dev_inspect(
+    let SimulateTransactionResult {
+        execution_result, ..
+    } = call_dev_inspect(
         &fullnode,
         &sender,
         &object_basics.object_id,
@@ -706,20 +698,16 @@ async fn test_dev_inspect_return_values() {
     )
     .await
     .unwrap();
-    let mut results = results.unwrap();
+    let mut results = execution_result.unwrap();
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        mut return_values,
-    } = exec_results;
+    let (mutable_reference_outputs, mut return_values) = exec_results;
     assert!(mutable_reference_outputs.is_empty());
     assert_eq!(return_values.len(), 1);
     let (return_value_1, return_type) = return_values.pop().unwrap();
     let deserialized_rv1: u64 = bcs::from_bytes(&return_value_1).unwrap();
     assert_eq!(init_value, deserialized_rv1);
-    let type_tag: TypeTag = return_type.try_into().unwrap();
-    assert!(matches!(type_tag, TypeTag::U64));
+    assert!(matches!(return_type, TypeTag::U64));
 
     // An unused value without drop is an error normally
     let effects = call_move_(
@@ -749,7 +737,9 @@ async fn test_dev_inspect_return_values() {
     );
 
     // An unused value without drop is not an error in dev inspect
-    let DevInspectResults { results, .. } = call_dev_inspect(
+    let SimulateTransactionResult {
+        execution_result, ..
+    } = call_dev_inspect(
         &fullnode,
         &sender,
         &object_basics.object_id,
@@ -760,13 +750,10 @@ async fn test_dev_inspect_return_values() {
     )
     .await
     .unwrap();
-    let mut results = results.unwrap();
+    let mut results = execution_result.unwrap();
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        mut return_values,
-    } = exec_results;
+    let (mutable_reference_outputs, mut return_values) = exec_results;
     assert!(mutable_reference_outputs.is_empty());
     assert_eq!(return_values.len(), 1);
     let (_return_value, return_type) = return_values.pop().unwrap();
@@ -776,7 +763,6 @@ async fn test_dev_inspect_return_values() {
         Identifier::from_static("Wrapper"),
         vec![],
     )));
-    let return_type: TypeTag = return_type.try_into().unwrap();
     assert_eq!(return_type, expected_type);
 }
 
@@ -796,22 +782,17 @@ async fn test_dev_inspect_gas_coin_argument() {
         builder.finish()
     };
     let kind = TransactionKind::new_programmable(pt);
-    let results = fullnode
-        .dev_inspect_transaction_block(sender, kind, None, None, None, None, None, None)
-        .await
+    let results = dev_inspect(&fullnode, sender, kind, None)
         .unwrap()
-        .results
+        .execution_result
         .unwrap();
     assert_eq!(results.len(), 2);
     // Split results
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        return_values,
-    } = &results[0];
+    let (mutable_reference_outputs, return_values) = &results[0];
     // check argument is the gas coin updated
     assert_eq!(mutable_reference_outputs.len(), 1);
     let (arg, arg_value, arg_type) = &mutable_reference_outputs[0];
-    assert_eq!(arg, &IotaArgument::GasCoin);
+    assert_eq!(arg, &Argument::Gas);
     check_coin_value(
         arg_value,
         arg_type,
@@ -823,10 +804,7 @@ async fn test_dev_inspect_gas_coin_argument() {
     check_coin_value(ret_value, ret_type, amount);
 
     // Transfer results
-    let IotaExecutionResult {
-        mutable_reference_outputs,
-        return_values,
-    } = &results[1];
+    let (mutable_reference_outputs, return_values) = &results[1];
     assert!(mutable_reference_outputs.is_empty());
     assert!(return_values.is_empty());
 }
@@ -845,10 +823,9 @@ async fn test_dev_inspect_gas_price() {
         builder.finish()
     };
     let kind = TransactionKind::new_programmable(pt);
-    let error = fullnode
-        .dev_inspect_transaction_block(sender, kind.clone(), Some(1), None, None, None, None, None)
-        .await
-        .unwrap_err();
+    let Err(error) = dev_inspect(&fullnode, sender, kind.clone(), Some(1)) else {
+        panic!("a gas price below the reference gas price should be rejected")
+    };
     assert!(
         matches!(
             UserInputError::try_from(error.clone()).unwrap(),
@@ -857,21 +834,13 @@ async fn test_dev_inspect_gas_price() {
         "{}",
         error
     );
-    let epoch_store = fullnode.epoch_store_for_testing();
-    let protocol_config = epoch_store.protocol_config();
-    let error = fullnode
-        .dev_inspect_transaction_block(
-            sender,
-            kind,
-            Some(protocol_config.max_gas_price() + 1),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await
-        .unwrap_err();
+    let max_gas_price = fullnode
+        .epoch_store_for_testing()
+        .protocol_config()
+        .max_gas_price();
+    let Err(error) = dev_inspect(&fullnode, sender, kind, Some(max_gas_price + 1)) else {
+        panic!("a gas price above the maximum should be rejected")
+    };
     assert!(
         matches!(
             UserInputError::try_from(error.clone()).unwrap(),
@@ -882,11 +851,10 @@ async fn test_dev_inspect_gas_price() {
     );
 }
 
-fn check_coin_value(actual_value: &[u8], actual_type: &IotaTypeTag, expected_value: u64) {
-    let actual_type: TypeTag = actual_type.clone().try_into().unwrap();
+fn check_coin_value(actual_value: &[u8], actual_type: &TypeTag, expected_value: u64) {
     assert_eq!(
         actual_type,
-        TypeTag::Struct(Box::new(StructTag::new_gas_coin()))
+        &TypeTag::Struct(Box::new(StructTag::new_gas_coin()))
     );
     let actual_coin: GasCoin = bcs::from_bytes(actual_value).unwrap();
     assert_eq!(actual_coin.value(), expected_value);
@@ -914,18 +882,12 @@ async fn test_dev_inspect_uses_unbound_object() {
     };
     let kind = TransactionKind::new_programmable(pt);
 
-    let result = fullnode
-        .dev_inspect_transaction_block(
-            sender,
-            kind,
-            Some(fullnode.reference_gas_price_for_testing().unwrap()),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await;
+    let result = dev_inspect(
+        &fullnode,
+        sender,
+        kind,
+        Some(fullnode.reference_gas_price_for_testing().unwrap()),
+    );
     let Err(err) = result else { panic!() };
     assert!(matches!(
         err,
@@ -963,9 +925,8 @@ async fn test_dev_inspect_on_validator() {
 async fn test_dry_run_on_validator() {
     let (validator, _fullnode, transaction, _gas_object_id, _shared_object_id) =
         construct_shared_object_transaction_with_version(None).await;
-    let transaction_digest = *transaction.digest();
-    let response = validator
-        .dry_exec_transaction(transaction.data().transaction().clone(), transaction_digest);
+    let response =
+        validator.simulate_transaction(transaction.data().transaction().clone(), VmChecks::Enabled);
     assert!(response.is_err());
 }
 
@@ -1068,11 +1029,8 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     let kind = TransactionKind::new_programmable(pt.clone());
     let rgp = fullnode.reference_gas_price_for_testing().unwrap();
     // dev inspect
-    let DevInspectResults { effects, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(rgp), None, None, None, None, None)
-        .await
-        .unwrap();
-    assert_eq!(effects.deleted().len(), 0);
+    let result = dev_inspect(&fullnode, sender, kind, Some(rgp)).unwrap();
+    assert_eq!(result.effects.deleted().len(), 0);
     // dry run
     let rgp = fullnode.reference_gas_price_for_testing().unwrap();
     let data = TransactionData::new_programmable(
@@ -1082,21 +1040,17 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
         rgp,
     );
-    let transaction = to_sender_signed_transaction(data.clone(), &sender_key);
-    let digest = *transaction.digest();
-    let DryRunTransactionBlockResponse {
-        effects,
-        execution_error_source,
-        ..
-    } = fullnode.dry_exec_transaction(data, digest).unwrap().0;
-    assert_eq!(effects.deleted().len(), 0);
-    assert_eq!(execution_error_source, Some("VMError with status ABORTED with sub status 1 at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier(\"dynamic_field\") } at code offset 0 in function definition 13".to_string()));
+    let result = fullnode
+        .simulate_transaction(data, VmChecks::Enabled)
+        .unwrap();
+    assert_eq!(result.effects.deleted().len(), 0);
+    assert_eq!(execution_error_source(&result), Some("VMError with status ABORTED with sub status 1 at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier(\"dynamic_field\") } at code offset 0 in function definition 13".to_string()));
 }
 
 // tests using a gas coin with version MAX - 1
 #[tokio::test]
 async fn test_dry_run_dev_inspect_max_gas_version() {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let (sender, _sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas_object_id = ObjectId::random();
     let (validator, fullnode) = init_state_validator_with_fullnode().await;
     let (validator, object_basics) = publish_object_basics(validator).await;
@@ -1122,11 +1076,8 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
     };
     let kind = TransactionKind::new_programmable(pt.clone());
     // dev inspect
-    let DevInspectResults { effects, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(rgp + 100), None, None, None, None, None)
-        .await
-        .unwrap();
-    assert_eq!(effects.status(), &IotaExecutionStatus::Success);
+    let result = dev_inspect(&fullnode, sender, kind, Some(rgp + 100)).unwrap();
+    assert_eq!(result.effects.status(), &ExecutionStatus::Success);
 
     // dry run
     let data = TransactionData::new_programmable(
@@ -1136,11 +1087,10 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
         rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
         rgp,
     );
-    let transaction = to_sender_signed_transaction(data.clone(), &sender_key);
-    let digest = *transaction.digest();
-    let DryRunTransactionBlockResponse { effects, .. } =
-        fullnode.dry_exec_transaction(data, digest).unwrap().0;
-    assert_eq!(effects.status(), &IotaExecutionStatus::Success);
+    let result = fullnode
+        .simulate_transaction(data, VmChecks::Enabled)
+        .unwrap();
+    assert_eq!(result.effects.status(), &ExecutionStatus::Success);
 }
 
 #[tokio::test]
@@ -4438,7 +4388,7 @@ pub async fn call_dev_inspect(
     function: &str,
     type_arguments: Vec<TypeTag>,
     test_args: Vec<TestCallArg>,
-) -> IotaResult<DevInspectResults> {
+) -> IotaResult<SimulateTransactionResult> {
     let mut builder = ProgrammableTransactionBuilder::new();
     let mut arguments = Vec::with_capacity(test_args.len());
     for a in test_args {
@@ -4454,9 +4404,64 @@ pub async fn call_dev_inspect(
     ));
     let kind = TransactionKind::new_programmable(builder.finish());
     let rgp = authority.reference_gas_price_for_testing().unwrap();
-    authority
-        .dev_inspect_transaction_block(*sender, kind, Some(rgp), None, None, None, None, None)
-        .await
+    dev_inspect(authority, *sender, kind, Some(rgp))
+}
+
+/// Assemble the transaction a dev inspect runs, filling in the gas payment the
+/// way the RPC layer does, and simulate it with the Move VM checks relaxed.
+pub fn dev_inspect(
+    authority: &AuthorityState,
+    sender: Address,
+    kind: TransactionKind,
+    gas_price: Option<u64>,
+) -> IotaResult<SimulateTransactionResult> {
+    let epoch_store = authority.epoch_store_for_testing();
+    let transaction = TransactionData::V1(TransactionV1 {
+        kind,
+        sender,
+        gas_payment: GasPayment {
+            objects: vec![],
+            owner: sender,
+            price: gas_price.unwrap_or_else(|| epoch_store.reference_gas_price()),
+            budget: epoch_store.protocol_config().max_tx_gas(),
+        },
+        expiration: TransactionExpiration::None,
+    });
+    authority.simulate_transaction(transaction, VmChecks::Disabled)
+}
+
+/// Resolve a simulation's events for display the way the RPC layer does: over
+/// the objects the simulation wrote, falling back to the authority's store, so
+/// that events of a package published by the transaction itself resolve too.
+fn simulated_events(
+    authority: &AuthorityState,
+    result: &SimulateTransactionResult,
+) -> IotaTransactionBlockEvents {
+    let epoch_store = authority.epoch_store_for_testing();
+    let written = InMemoryStorage::new(result.output_objects.values().cloned().collect());
+    let mut layout_resolver =
+        epoch_store
+            .executor()
+            .type_layout_resolver(Box::new(PackageStoreWithFallback::new(
+                &written,
+                authority.get_backing_package_store(),
+            )));
+    IotaTransactionBlockEvents::try_from(
+        result.events.clone().unwrap_or_default(),
+        *result.effects.transaction_digest(),
+        None,
+        layout_resolver.as_mut(),
+    )
+    .unwrap()
+}
+
+/// The source of a simulation's execution error, as the RPC layer reports it.
+fn execution_error_source(result: &SimulateTransactionResult) -> Option<String> {
+    result
+        .execution_result
+        .as_ref()
+        .err()
+        .and_then(|e| e.source().as_ref().map(|e| e.to_string()))
 }
 
 /// This function creates a transaction that calls a
@@ -5646,19 +5651,14 @@ async fn test_for_inc_201_dev_inspect() {
         BuiltInFramework::all_package_ids(),
     ));
     let kind = TransactionKind::new_programmable(builder.finish());
-    let DevInspectResults { events, .. } = fullnode
-        .dev_inspect_transaction_block(
-            sender,
-            kind,
-            Some(fullnode.reference_gas_price_for_testing().unwrap() + 1000),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await
-        .unwrap();
+    let result = dev_inspect(
+        &fullnode,
+        sender,
+        kind,
+        Some(fullnode.reference_gas_price_for_testing().unwrap() + 1000),
+    )
+    .unwrap();
+    let events = simulated_events(&fullnode, &result);
 
     assert_eq!(1, events.data.len());
     assert_eq!(
@@ -5699,18 +5699,12 @@ async fn test_for_inc_201_dry_run() {
     );
 
     let signed = to_sender_signed_transaction(txn_data, &sender_key);
-    let (
-        DryRunTransactionBlockResponse {
-            events, effects, ..
-        },
-        _,
-        _,
-        _,
-    ) = fullnode
-        .dry_exec_transaction(signed.data().transaction().clone(), *signed.digest())
+    let result = fullnode
+        .simulate_transaction(signed.data().transaction().clone(), VmChecks::Enabled)
         .unwrap();
-    assert_eq!(effects.status(), &IotaExecutionStatus::Success);
+    assert_eq!(result.effects.status(), &ExecutionStatus::Success);
 
+    let events = simulated_events(&fullnode, &result);
     assert_eq!(1, events.data.len());
     assert_eq!(
         "PublishEvent".to_string(),
@@ -5748,18 +5742,10 @@ async fn test_function_not_found() {
     );
 
     let signed = to_sender_signed_transaction(txn_data, &sender_key);
-    let (
-        DryRunTransactionBlockResponse {
-            effects,
-            execution_error_source,
-            ..
-        },
-        _,
-        _,
-        _,
-    ) = fullnode
-        .dry_exec_transaction(signed.data().transaction().clone(), *signed.digest())
+    let result = fullnode
+        .simulate_transaction(signed.data().transaction().clone(), VmChecks::Enabled)
         .unwrap();
+    let effects: IotaTransactionBlockEffects = result.effects.clone().try_into().unwrap();
     assert_eq!(
         effects.status(),
         &IotaExecutionStatus::Failure {
@@ -5767,7 +5753,7 @@ async fn test_function_not_found() {
         }
     );
 
-    assert_eq!(execution_error_source, Some("Could not resolve function 'bad_function' in module 0000000000000000000000000000000000000000000000000000000000000001::option".to_string()),)
+    assert_eq!(execution_error_source(&result), Some("Could not resolve function 'bad_function' in module 0000000000000000000000000000000000000000000000000000000000000001::option".to_string()),)
 }
 
 #[tokio::test]
@@ -5801,18 +5787,10 @@ async fn test_arity_mismatch() {
     );
 
     let signed = to_sender_signed_transaction(txn_data, &sender_key);
-    let (
-        DryRunTransactionBlockResponse {
-            effects,
-            execution_error_source,
-            ..
-        },
-        _,
-        _,
-        _,
-    ) = authority
-        .dry_exec_transaction(signed.data().transaction().clone(), *signed.digest())
+    let result = authority
+        .simulate_transaction(signed.data().transaction().clone(), VmChecks::Enabled)
         .unwrap();
+    let effects: IotaTransactionBlockEffects = result.effects.clone().try_into().unwrap();
     assert_eq!(
         effects.status(),
         &IotaExecutionStatus::Failure {
@@ -5821,7 +5799,7 @@ async fn test_arity_mismatch() {
     );
 
     assert_eq!(
-        execution_error_source,
+        execution_error_source(&result),
         Some("Expected 1 argument calling function 'is_none', but found 0".to_string()),
     )
 }

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -50,7 +50,10 @@ macro_rules! assert_matches {
 }
 
 use fastcrypto::traits::AggregateAuthenticator;
-use iota_sdk_types::ConsensusCommitDigest;
+use iota_sdk_types::{
+    ConsensusCommitDigest,
+    crypto::{IntentAppId, IntentVersion},
+};
 use iota_types::{
     messages_grpc::HandleCertificateRequestV1,
     programmable_transaction_builder::ProgrammableTransactionBuilder,

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
@@ -245,8 +245,55 @@ async fn simulate_transaction_zero_gas_budget_uses_max() {
     let returned_tx: TransactionData = bcs::from_bytes(&bcs_data.data).unwrap();
     assert!(
         returned_tx.gas_data().budget > 0,
-        "gas budget should have been replaced with max_tx_gas, but was 0"
+        "the budget should have been replaced with the gas the simulation charged, but was 0"
     );
+    // Only the computation half of the cost scales with the price, so the budget
+    // above cannot be read without the price it was charged at.
+    assert_eq!(
+        returned_tx.gas_data().price,
+        1000,
+        "the price the caller sent should be reported back"
+    );
+
+    // The same with the price left at zero, which the simulation fills in from the
+    // epoch: the response has to report what it charged at, not the zero.
+    let tx_data = TransactionData::new_transfer(
+        recipient,
+        *obj_to_send,
+        sender,
+        *gas_obj,
+        0, // zero gas budget
+        0, // zero gas price
+    );
+    let item = SimulateTransactionItem::default()
+        .with_transaction(
+            ProtoTransaction::default()
+                .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap())),
+        )
+        .with_tx_checks(vec![TransactionCheckModes::DisableVmChecks as i32]);
+    let response = exec_client
+        .simulate_transactions(SimulateTransactionsRequest::default().with_transactions(vec![item]))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let bcs_data = first_simulated_transaction(&response)
+        .executed_transaction
+        .as_ref()
+        .unwrap()
+        .transaction
+        .as_ref()
+        .unwrap()
+        .bcs
+        .as_ref()
+        .unwrap();
+    let returned_tx: TransactionData = bcs::from_bytes(&bcs_data.data).unwrap();
+    assert_eq!(
+        returned_tx.gas_data().price,
+        test_cluster.get_reference_gas_price().await,
+        "the price the simulation filled in should be reported back"
+    );
+    assert!(returned_tx.gas_data().budget > 0);
 }
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
@@ -19,6 +19,7 @@ use iota_grpc_types::{
 use iota_macros::sim_test;
 use iota_sdk_types::{Address, Command};
 use iota_types::{
+    effects::TransactionEffectsAPI,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{CallArg, TransactionData, TransactionDataAPI},
 };
@@ -294,6 +295,83 @@ async fn simulate_transaction_zero_gas_budget_uses_max() {
         "the price the simulation filled in should be reported back"
     );
     assert!(returned_tx.gas_data().budget > 0);
+}
+
+/// A transaction with no gas payment is simulated against a mock gas coin, and
+/// the response reports the transaction that ran, mock coin included. The
+/// effects charge gas to that coin, so reporting the payment as sent — empty —
+/// leaves the caller no way to tell which object they refer to.
+///
+/// With a budget the caller declared, the reported transaction is exactly the
+/// one that ran and hashes to the digest the effects are keyed by. That does
+/// not hold for a zero budget, which comes back as the gas charged instead: see
+/// `simulate_transaction_zero_gas_budget_uses_max`.
+#[sim_test]
+async fn simulate_transaction_gasless_reports_the_transaction_that_ran() {
+    let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
+
+    let mut exec_client = client.execution_service_client();
+
+    let (sender, gas) = test_cluster.wallet.get_one_account().await.unwrap();
+    let obj_to_send = gas.first().unwrap();
+    let reference_gas_price = test_cluster.get_reference_gas_price().await;
+
+    // No gas payment, but a declared price and budget, so that the only thing the
+    // simulation fills in is the payment.
+    let mut tx_data = TransactionData::new_transfer(
+        Address::random(),
+        *obj_to_send,
+        sender,
+        *gas.last().unwrap(),
+        reference_gas_price * 10_000_000,
+        reference_gas_price,
+    );
+    tx_data.gas_data_mut().objects = vec![];
+
+    let item = build_simulate_item(
+        ProtoTransaction::default()
+            .with_bcs(BcsData::default().with_data(bcs::to_bytes(&tx_data).unwrap())),
+    );
+    let response = exec_client
+        .simulate_transactions(SimulateTransactionsRequest::default().with_transactions(vec![item]))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let executed = first_simulated_transaction(&response)
+        .executed_transaction
+        .as_ref()
+        .unwrap();
+    let returned_tx: TransactionData = bcs::from_bytes(
+        &executed
+            .transaction
+            .as_ref()
+            .unwrap()
+            .bcs
+            .as_ref()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+
+    // The mock gas coin the run charged gas to is named in the reported payment.
+    assert_eq!(
+        returned_tx.gas_data().objects.len(),
+        1,
+        "the mock gas coin should be reported in the gas payment"
+    );
+    // Nothing else was filled in, so the reported transaction is the one that ran.
+    let effects = executed.effects.as_ref().unwrap().effects().unwrap();
+    assert_eq!(
+        returned_tx.digest(),
+        *effects.transaction_digest(),
+        "the reported transaction should hash to the digest the effects are keyed by"
+    );
+    assert_eq!(
+        returned_tx.gas_data().objects[0].object_id,
+        effects.gas_object().0.object_id,
+        "the reported gas payment should name the object the effects charged"
+    );
 }
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/transaction_execution_service/simulate.rs
@@ -191,7 +191,7 @@ async fn simulate_transaction_derived_changes() {
 }
 
 #[sim_test]
-async fn simulate_transaction_zero_gas_budget_uses_max() {
+async fn simulate_transaction_zero_gas_budget_reports_the_gas_charged() {
     let (test_cluster, client) = setup_grpc_test(Some(1), None).await;
 
     let mut exec_client = client.execution_service_client();
@@ -209,7 +209,7 @@ async fn simulate_transaction_zero_gas_budget_uses_max() {
         *obj_to_send,
         sender,
         *gas_obj,
-        0,    // zero gas budget — server should replace with max_tx_gas
+        0,    // zero gas budget — the server estimates and reports the cost
         1000, // gas price
     );
 
@@ -230,8 +230,8 @@ async fn simulate_transaction_zero_gas_budget_uses_max() {
 
     let simulated = first_simulated_transaction(&response);
 
-    // Verify that the returned transaction has a non-zero gas budget (replaced with
-    // max_tx_gas)
+    // Verify that the returned transaction reports the gas the simulation charged
+    // in place of the zero the caller sent.
     let bcs_data = simulated
         .executed_transaction
         .as_ref()
@@ -305,7 +305,7 @@ async fn simulate_transaction_zero_gas_budget_uses_max() {
 /// With a budget the caller declared, the reported transaction is exactly the
 /// one that ran and hashes to the digest the effects are keyed by. That does
 /// not hold for a zero budget, which comes back as the gas charged instead: see
-/// `simulate_transaction_zero_gas_budget_uses_max`.
+/// `simulate_transaction_zero_gas_budget_reports_the_gas_charged`.
 #[sim_test]
 async fn simulate_transaction_gasless_reports_the_transaction_that_ran() {
     let (test_cluster, client) = setup_grpc_test(Some(1), None).await;

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -195,10 +195,10 @@ async fn simulate_single_transaction(
         VmChecks::Enabled
     };
 
-    // A zero gas budget with VM checks disabled means "estimate the cost for me":
-    // the simulation meters against the maximum gas budget, and the transaction in
-    // the response reports the cost it actually incurred.
-    let report_gas_used_as_budget = vm_checks.disabled() && transaction_data.gas_data().budget == 0;
+    // A zero gas budget means "estimate the cost for me": the simulation meters
+    // against the protocol maximum gas budget, and the transaction in the response
+    // reports the cost it actually incurred rather than the zero that was sent.
+    let report_gas_used_as_budget = transaction_data.gas_data().budget == 0;
 
     let system_state = if read_mask.contains(SimulatedTransaction::SUGGESTED_GAS_PRICE_FIELD.name) {
         Some(reader.get_system_state_summary().map_err(|e| {

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -18,7 +18,6 @@ use iota_grpc_types::{
         },
     },
 };
-use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     effects::TransactionEffectsAPI,
     transaction::TransactionDataAPI,
@@ -196,15 +195,12 @@ async fn simulate_single_transaction(
         VmChecks::Enabled
     };
 
-    // If the transaction has a zero gas budget and VM checks are disabled, we'll
-    // set the gas budget in the result to the actual cost from the simulation.
-    // This allows clients to estimate the gas cost by simulating with a zero
-    // budget.
-    let set_gas_budget = vm_checks.disabled() && transaction_data.gas_data().budget == 0;
+    // A zero gas budget with VM checks disabled means "estimate the cost for me":
+    // the simulation meters against the maximum gas budget, and the transaction in
+    // the response reports the cost it actually incurred.
+    let report_gas_used_as_budget = vm_checks.disabled() && transaction_data.gas_data().budget == 0;
 
-    let system_state = if read_mask.contains(SimulatedTransaction::SUGGESTED_GAS_PRICE_FIELD.name)
-        || set_gas_budget
-    {
+    let system_state = if read_mask.contains(SimulatedTransaction::SUGGESTED_GAS_PRICE_FIELD.name) {
         Some(reader.get_system_state_summary().map_err(|e| {
             RpcError::new(
                 tonic::Code::Internal,
@@ -214,26 +210,6 @@ async fn simulate_single_transaction(
     } else {
         None
     };
-
-    if set_gas_budget {
-        let protocol_config = ProtocolConfig::get_for_version_if_supported(
-            system_state
-                .as_ref()
-                .expect("system state should be available")
-                .protocol_version(),
-            reader.get_chain_identifier()?.chain(),
-        )
-        .ok_or_else(|| {
-            RpcError::new(
-                tonic::Code::Internal,
-                "failed to get protocol config for gas budget validation".to_string(),
-            )
-        })?;
-
-        // A zero budget signals "use maximum" — run the dry run with
-        // max_tx_gas so the actual cost shows up in the gas status.
-        transaction_data.gas_data_mut().budget = protocol_config.max_tx_gas();
-    }
 
     // Simulate the transaction
     let InternalSimulateResult {
@@ -259,7 +235,7 @@ async fn simulate_single_transaction(
     // Only include transaction if requested
     if let Some(tx_mask) = read_mask.subtree(SimulatedTransaction::EXECUTED_TRANSACTION_FIELD.name)
     {
-        if set_gas_budget {
+        if report_gas_used_as_budget {
             transaction_data.gas_data_mut().budget = effects.gas_cost_summary().gas_used();
         }
 

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -195,11 +195,6 @@ async fn simulate_single_transaction(
         VmChecks::Enabled
     };
 
-    // A zero gas budget means "estimate the cost for me": the simulation meters
-    // against the protocol maximum gas budget, and the transaction in the response
-    // reports the cost it actually incurred rather than the zero that was sent.
-    let estimating_gas_budget = transaction_data.gas_data().budget == 0;
-
     let system_state = if read_mask.contains(SimulatedTransaction::SUGGESTED_GAS_PRICE_FIELD.name) {
         Some(reader.get_system_state_summary().map_err(|e| {
             RpcError::new(
@@ -236,13 +231,13 @@ async fn simulate_single_transaction(
     // Only include transaction if requested
     if let Some(tx_mask) = read_mask.subtree(SimulatedTransaction::EXECUTED_TRANSACTION_FIELD.name)
     {
-        // Report the price the simulation charged at, which it fills in for a caller
-        // that leaves it at zero. Only the computation half of the cost scales with
-        // the price, so an estimate cannot be read without it.
-        transaction_data.gas_data_mut().price = gas_data.price;
-        if estimating_gas_budget {
-            transaction_data.gas_data_mut().budget = effects.gas_cost_summary().gas_used();
-        }
+        // The gas payment is left as it was sent: a mock gas coin the simulation
+        // minted is reported separately, in `mocked_coin` below.
+        iota_types::gas::report_simulation_gas(
+            transaction_data.gas_data_mut(),
+            &gas_data,
+            effects.gas_cost_summary().gas_used(),
+        );
 
         // Create a source for the merge
         let source = TransactionReadSource {

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -198,7 +198,7 @@ async fn simulate_single_transaction(
     // A zero gas budget means "estimate the cost for me": the simulation meters
     // against the protocol maximum gas budget, and the transaction in the response
     // reports the cost it actually incurred rather than the zero that was sent.
-    let report_gas_used_as_budget = transaction_data.gas_data().budget == 0;
+    let estimating_gas_budget = transaction_data.gas_data().budget == 0;
 
     let system_state = if read_mask.contains(SimulatedTransaction::SUGGESTED_GAS_PRICE_FIELD.name) {
         Some(reader.get_system_state_summary().map_err(|e| {
@@ -220,6 +220,7 @@ async fn simulate_single_transaction(
         execution_result,
         mock_gas_id,
         suggested_gas_price,
+        gas_data,
     } = executor
         .simulate_transaction(transaction_data.clone(), vm_checks)
         .map_err(|e| {
@@ -235,7 +236,11 @@ async fn simulate_single_transaction(
     // Only include transaction if requested
     if let Some(tx_mask) = read_mask.subtree(SimulatedTransaction::EXECUTED_TRANSACTION_FIELD.name)
     {
-        if report_gas_used_as_budget {
+        // Report the price the simulation charged at, which it fills in for a caller
+        // that leaves it at zero. Only the computation half of the cost scales with
+        // the price, so an estimate cannot be read without it.
+        transaction_data.gas_data_mut().price = gas_data.price;
+        if estimating_gas_budget {
             transaction_data.gas_data_mut().budget = effects.gas_cost_summary().gas_used();
         }
 

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -231,8 +231,9 @@ async fn simulate_single_transaction(
     // Only include transaction if requested
     if let Some(tx_mask) = read_mask.subtree(SimulatedTransaction::EXECUTED_TRANSACTION_FIELD.name)
     {
-        // The gas payment is left as it was sent: a mock gas coin the simulation
-        // minted is reported separately, in `mocked_coin` below.
+        // Report the transaction the simulation ran, gas payment included, so it
+        // hashes to the digest the effects below are keyed by. Same rule as the
+        // JSON-RPC dry run, which shares the helper.
         iota_types::gas::report_simulation_gas(
             transaction_data.gas_data_mut(),
             &gas_data,

--- a/crates/iota-json-rpc-tests/tests/balance_changes_tests.rs
+++ b/crates/iota-json-rpc-tests/tests/balance_changes_tests.rs
@@ -50,3 +50,49 @@ async fn test_dry_run_publish_with_mocked_coin() -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+/// A dry run resolves event types against the packages the transaction itself
+/// published, not just those already in the store. Exercised through the
+/// JSON-RPC layer so it covers the resolver the server actually builds.
+#[tokio::test]
+async fn test_dry_run_resolves_events_of_newly_published_package() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await;
+    let context = &cluster.wallet;
+
+    let address = cluster.get_address_0();
+    let client: IotaClient = context.get_client().await.unwrap();
+
+    // This package emits a `PublishEvent { foo: "bar" }` from its `init`, so the
+    // only way to decode the event is to resolve the type out of the package the
+    // dry run just published.
+    move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["tests", "data", "publish_with_event"]);
+    let compiled_package = BuildConfig::new_for_testing().build(&path)?;
+    let compiled_modules_bytes = compiled_package
+        .get_package_base64(false)
+        .into_iter()
+        .map(|b| b.to_vec().unwrap())
+        .collect::<Vec<_>>();
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.publish_immutable(compiled_modules_bytes, dependencies);
+
+    let publish = TransactionKind::new_programmable(builder.finish());
+    let transaction_bytes =
+        TransactionData::new_with_gas_coins(publish, address, vec![], 100000000, 1000);
+
+    let response = client
+        .read_api()
+        .dry_run_transaction_block(transaction_bytes)
+        .await?;
+
+    assert_eq!(response.events.data.len(), 1);
+    let event = &response.events.data[0];
+    assert_eq!(event.type_.name().to_string(), "PublishEvent");
+    // An unresolved type would leave the payload undecoded.
+    assert_eq!(event.parsed_json, serde_json::json!({ "foo": "bar" }));
+
+    Ok(())
+}

--- a/crates/iota-json-rpc-tests/tests/data/publish_with_event/Move.toml
+++ b/crates/iota-json-rpc-tests/tests/data/publish_with_event/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "Examples"
+version = "0.0.1"
+edition = "2024"
+
+[dependencies]
+Iota = { local = "../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+examples = "0x0"

--- a/crates/iota-json-rpc-tests/tests/data/publish_with_event/sources/publish.move
+++ b/crates/iota-json-rpc-tests/tests/data/publish_with_event/sources/publish.move
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module examples::publish_with_event {
+    use std::ascii::{Self, String};
+
+    use iota::event;
+
+    public struct PublishEvent has copy, drop {
+        foo: String
+    }
+
+    fun init(_ctx: &mut TxContext) {
+        event::emit(PublishEvent { foo: ascii::string(b"bar") })
+    }
+}

--- a/crates/iota-json-rpc-tests/tests/write_api.rs
+++ b/crates/iota-json-rpc-tests/tests/write_api.rs
@@ -15,12 +15,14 @@ use iota_json_rpc_types::{
 };
 use iota_macros::sim_test;
 use iota_move_build::BuildConfig;
-use iota_sdk_types::{GasPayment, ObjectId, Owner, TransactionExpiration, TransactionKind};
+use iota_sdk_types::{
+    GasPayment, ObjectId, Owner, TransactionExpiration, TransactionKind, TransactionV1,
+};
 use iota_simulator::fastcrypto::encoding::Base64;
 use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     quorum_driver_types::ExecuteTransactionRequestType,
-    transaction::{TransactionData, TransactionDataAPI, TransactionDataV1},
+    transaction::{TransactionData, TransactionDataAPI},
 };
 use test_cluster::TestClusterBuilder;
 
@@ -218,7 +220,7 @@ async fn test_zero_gas_budget_is_reported_as_the_gas_used() -> Result<(), anyhow
     };
 
     // No gas payment, no price and no budget: the simulation fills all of it in.
-    let transaction = TransactionData::V1(TransactionDataV1 {
+    let transaction = TransactionData::V1(TransactionV1 {
         kind: TransactionKind::new_programmable(pt.clone()),
         sender: address,
         gas_payment: GasPayment {
@@ -236,12 +238,23 @@ async fn test_zero_gas_budget_is_reported_as_the_gas_used() -> Result<(), anyhow
     assert_eq!(*response.effects.status(), IotaExecutionStatus::Success);
 
     let gas_used = response.effects.gas_cost_summary().gas_used();
+    let reference_gas_price = cluster.get_reference_gas_price().await;
     assert_ne!(gas_used, 0, "a successful transfer has to cost something");
     assert_eq!(
         response.input.gas_data().budget,
         gas_used,
         "the reported budget should be the cost the simulation charged"
     );
+    // Only the computation half of the cost scales with the price, so the estimate
+    // above cannot be read without the price it was charged at.
+    assert_eq!(
+        response.input.gas_data().price,
+        reference_gas_price,
+        "the reported price should be the one the simulation charged at"
+    );
+    // A mock gas coin was minted, so the reported payment names it rather than
+    // staying empty.
+    assert_eq!(response.input.gas_data().payment.len(), 1);
 
     // The same for the raw transaction a dev inspect hands back.
     let raw_txn_data = http_client
@@ -258,7 +271,8 @@ async fn test_zero_gas_budget_is_reported_as_the_gas_used() -> Result<(), anyhow
         .await?
         .raw_txn_data;
     let reported: TransactionData = bcs::from_bytes(&raw_txn_data)?;
-    assert_ne!(reported.gas_data().budget, 0);
+    assert_ne!(reported.gas_budget(), 0);
+    assert_eq!(reported.gas_price(), reference_gas_price);
 
     Ok(())
 }

--- a/crates/iota-json-rpc-tests/tests/write_api.rs
+++ b/crates/iota-json-rpc-tests/tests/write_api.rs
@@ -8,8 +8,8 @@ use iota_json_rpc_api::{
     IndexerApiClient, ReadApiClient, TransactionBuilderClient, WriteApiClient,
 };
 use iota_json_rpc_types::{
-    IotaExecutionStatus, IotaMoveValue, IotaObjectDataOptions, IotaObjectResponseQuery,
-    IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
+    DevInspectArgs, IotaExecutionStatus, IotaMoveValue, IotaObjectDataOptions,
+    IotaObjectResponseQuery, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
     IotaTransactionBlockResponseOptions, ObjectChange, TransactionBlockBytes,
 };
 use iota_macros::sim_test;
@@ -98,6 +98,77 @@ async fn test_dev_inspect_transaction_block() -> Result<(), anyhow::Error> {
     assert_eq!(
         actual_object_info.data.unwrap().owner.unwrap(),
         Owner::Address(address)
+    );
+
+    Ok(())
+}
+
+/// A dev inspect fills a zero gas price and a zero gas budget in from the
+/// epoch, rather than metering against those zeroes and failing with
+/// `GasPriceUnderRGP` or `InsufficientGas`.
+#[sim_test]
+async fn test_dev_inspect_transaction_block_zero_gas_price_and_budget() -> Result<(), anyhow::Error>
+{
+    let cluster = TestClusterBuilder::new().build().await;
+    let http_client = cluster.rpc_client();
+    let address = cluster.get_address_0();
+    let other_address = cluster.get_address_1();
+
+    let objects = http_client
+        .get_owned_objects(
+            address,
+            Some(IotaObjectResponseQuery::new_with_options(
+                IotaObjectDataOptions::new().with_owner(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+    let obj = objects.first().unwrap().object().unwrap().object_ref();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.transfer_object(other_address, obj).unwrap();
+        builder.finish()
+    };
+    let tx_bytes = Base64::from_bytes(&bcs::to_bytes(&TransactionKind::new_programmable(pt))?);
+    let reference_gas_price = cluster.get_reference_gas_price().await;
+
+    // A zero budget on its own, with a gas price the epoch would accept as-is.
+    let devinspect_response = http_client
+        .dev_inspect_transaction_block(
+            address,
+            tx_bytes.clone(),
+            Some(reference_gas_price.into()),
+            None,
+            Some(DevInspectArgs {
+                gas_budget: Some(0),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    assert_eq!(
+        *devinspect_response.effects.status(),
+        IotaExecutionStatus::Success
+    );
+
+    // A zero price and a zero budget together.
+    let devinspect_response = http_client
+        .dev_inspect_transaction_block(
+            address,
+            tx_bytes,
+            Some(0.into()),
+            None,
+            Some(DevInspectArgs {
+                gas_budget: Some(0),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    assert_eq!(
+        *devinspect_response.effects.status(),
+        IotaExecutionStatus::Success
     );
 
     Ok(())

--- a/crates/iota-json-rpc-tests/tests/write_api.rs
+++ b/crates/iota-json-rpc-tests/tests/write_api.rs
@@ -105,7 +105,9 @@ async fn test_dev_inspect_transaction_block() -> Result<(), anyhow::Error> {
 
 /// A dev inspect fills a zero gas price and a zero gas budget in from the
 /// epoch, rather than metering against those zeroes and failing with
-/// `GasPriceUnderRGP` or `InsufficientGas`.
+/// `GasPriceUnderRGP` or `InsufficientGas`. This holds whether or not the
+/// caller asks for the checks to be skipped: `DevInspectArgs` models both
+/// fields as optional, so leaving them out has to work in either mode.
 #[sim_test]
 async fn test_dev_inspect_transaction_block_zero_gas_price_and_budget() -> Result<(), anyhow::Error>
 {
@@ -157,7 +159,7 @@ async fn test_dev_inspect_transaction_block_zero_gas_price_and_budget() -> Resul
     let devinspect_response = http_client
         .dev_inspect_transaction_block(
             address,
-            tx_bytes,
+            tx_bytes.clone(),
             Some(0.into()),
             None,
             Some(DevInspectArgs {
@@ -170,6 +172,29 @@ async fn test_dev_inspect_transaction_block_zero_gas_price_and_budget() -> Resul
         *devinspect_response.effects.status(),
         IotaExecutionStatus::Success
     );
+
+    // Both gas fields omitted entirely, with and without the checks. GraphQL's
+    // `dryRunTransactionBlock` issues exactly the `skip_checks: false` shape when
+    // it is given a `txMeta` carrying only a sender.
+    for skip_checks in [true, false] {
+        let devinspect_response = http_client
+            .dev_inspect_transaction_block(
+                address,
+                tx_bytes.clone(),
+                None,
+                None,
+                Some(DevInspectArgs {
+                    skip_checks: Some(skip_checks),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("dev inspect with skip_checks={skip_checks} failed: {e}"));
+        assert_eq!(
+            *devinspect_response.effects.status(),
+            IotaExecutionStatus::Success
+        );
+    }
 
     Ok(())
 }

--- a/crates/iota-json-rpc-tests/tests/write_api.rs
+++ b/crates/iota-json-rpc-tests/tests/write_api.rs
@@ -9,16 +9,18 @@ use iota_json_rpc_api::{
 };
 use iota_json_rpc_types::{
     DevInspectArgs, IotaExecutionStatus, IotaMoveValue, IotaObjectDataOptions,
-    IotaObjectResponseQuery, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    IotaTransactionBlockResponseOptions, ObjectChange, TransactionBlockBytes,
+    IotaObjectResponseQuery, IotaTransactionBlockDataAPI, IotaTransactionBlockEffectsAPI,
+    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
+    TransactionBlockBytes,
 };
 use iota_macros::sim_test;
 use iota_move_build::BuildConfig;
-use iota_sdk_types::{ObjectId, Owner, TransactionKind};
+use iota_sdk_types::{GasPayment, ObjectId, Owner, TransactionExpiration, TransactionKind};
 use iota_simulator::fastcrypto::encoding::Base64;
 use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     quorum_driver_types::ExecuteTransactionRequestType,
+    transaction::{TransactionData, TransactionDataAPI, TransactionDataV1},
 };
 use test_cluster::TestClusterBuilder;
 
@@ -195,6 +197,68 @@ async fn test_dev_inspect_transaction_block_zero_gas_price_and_budget() -> Resul
             IotaExecutionStatus::Success
         );
     }
+
+    Ok(())
+}
+
+/// A caller that declares no gas budget is asking what the transaction costs,
+/// so the reported transaction carries the cost the simulation charged rather
+/// than the zero that was sent. Matches gRPC `simulate_transactions`.
+#[sim_test]
+async fn test_zero_gas_budget_is_reported_as_the_gas_used() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await;
+    let http_client = cluster.rpc_client();
+    let address = cluster.get_address_0();
+    let other_address = cluster.get_address_1();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.transfer_iota(other_address, Some(1_000));
+        builder.finish()
+    };
+
+    // No gas payment, no price and no budget: the simulation fills all of it in.
+    let transaction = TransactionData::V1(TransactionDataV1 {
+        kind: TransactionKind::new_programmable(pt.clone()),
+        sender: address,
+        gas_payment: GasPayment {
+            objects: vec![],
+            owner: address,
+            price: 0,
+            budget: 0,
+        },
+        expiration: TransactionExpiration::None,
+    });
+
+    let response = http_client
+        .dry_run_transaction_block(Base64::from_bytes(&bcs::to_bytes(&transaction)?))
+        .await?;
+    assert_eq!(*response.effects.status(), IotaExecutionStatus::Success);
+
+    let gas_used = response.effects.gas_cost_summary().gas_used();
+    assert_ne!(gas_used, 0, "a successful transfer has to cost something");
+    assert_eq!(
+        response.input.gas_data().budget,
+        gas_used,
+        "the reported budget should be the cost the simulation charged"
+    );
+
+    // The same for the raw transaction a dev inspect hands back.
+    let raw_txn_data = http_client
+        .dev_inspect_transaction_block(
+            address,
+            Base64::from_bytes(&bcs::to_bytes(&TransactionKind::new_programmable(pt))?),
+            None,
+            None,
+            Some(DevInspectArgs {
+                show_raw_txn_data_and_effects: Some(true),
+                ..Default::default()
+            }),
+        )
+        .await?
+        .raw_txn_data;
+    let reported: TransactionData = bcs::from_bytes(&raw_txn_data)?;
+    assert_ne!(reported.gas_data().budget, 0);
 
     Ok(())
 }

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -102,8 +102,9 @@ pub trait StateRead: Send + Sync {
     ) -> StateReadResult<Vec<IotaEvent>>;
 
     // transaction_execution_api
-    fn simulate_transaction(
+    fn simulate_transaction_in_epoch(
         &self,
+        epoch_store: &AuthorityPerEpochStore,
         transaction: TransactionData,
         checks: VmChecks,
     ) -> StateReadResult<SimulateTransactionResult>;
@@ -295,12 +296,13 @@ impl StateRead for AuthorityState {
             .await?)
     }
 
-    fn simulate_transaction(
+    fn simulate_transaction_in_epoch(
         &self,
+        epoch_store: &AuthorityPerEpochStore,
         transaction: TransactionData,
         checks: VmChecks,
     ) -> StateReadResult<SimulateTransactionResult> {
-        Ok(self.simulate_transaction(transaction, checks)?)
+        Ok(self.simulate_transaction_in_epoch(epoch_store, transaction, checks)?)
     }
 
     fn get_subscription_handler(&self) -> Arc<SubscriptionHandler> {

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -2,10 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use arc_swap::Guard;
 use async_trait::async_trait;
@@ -16,13 +13,11 @@ use iota_core::{
     subscription_handler::SubscriptionHandler,
 };
 use iota_json_rpc_types::{
-    Coin as IotaCoin, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, IotaEvent,
-    IotaObjectDataFilter, TransactionFilter,
+    Coin as IotaCoin, EventFilter, IotaEvent, IotaObjectDataFilter, TransactionFilter,
 };
 use iota_sdk_types::{
-    Address, CheckpointContentsDigest, CheckpointDigest, ObjectId, ObjectReference, StructTag,
-    TransactionDigest, TransactionEffects, TransactionKind, TypeTag, Version,
-    checkpoint::CheckpointContents,
+    Address, CheckpointContentsDigest, CheckpointDigest, ObjectId, StructTag, TransactionDigest,
+    TransactionEffects, TypeTag, Version, checkpoint::CheckpointContents,
 };
 use iota_storage::key_value_store::{
     KVStoreTransactionData, TransactionKeyValueStore, TransactionKeyValueStoreTrait,
@@ -39,9 +34,10 @@ use iota_types::{
     iota_system_state::IotaSystemState,
     messages_checkpoint::{CheckpointSequenceNumber, VerifiedCheckpoint},
     object::{Object, ObjectRead, PastObjectRead},
-    storage::{BackingPackageStore, ObjectStore, WriteKind},
+    storage::{BackingPackageStore, ObjectStore},
     timelock::timelocked_staked_iota::TimelockedStakedIota,
     transaction::{TransactionData, TransactionEnvelope},
+    transaction_executor::{SimulateTransactionResult, VmChecks},
 };
 #[cfg(test)]
 use mockall::automock;
@@ -106,29 +102,11 @@ pub trait StateRead: Send + Sync {
     ) -> StateReadResult<Vec<IotaEvent>>;
 
     // transaction_execution_api
-    #[allow(clippy::type_complexity)]
-    fn dry_exec_transaction(
+    fn simulate_transaction(
         &self,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> StateReadResult<(
-        DryRunTransactionBlockResponse,
-        BTreeMap<ObjectId, (ObjectReference, Object, WriteKind)>,
-        TransactionEffects,
-        Option<ObjectId>,
-    )>;
-
-    async fn dev_inspect_transaction_block(
-        &self,
-        sender: Address,
-        transaction_kind: TransactionKind,
-        gas_price: Option<u64>,
-        gas_budget: Option<u64>,
-        gas_sponsor: Option<Address>,
-        gas_objects: Option<Vec<ObjectReference>>,
-        show_raw_txn_data_and_effects: Option<bool>,
-        skip_checks: Option<bool>,
-    ) -> StateReadResult<DevInspectResults>;
+        checks: VmChecks,
+    ) -> StateReadResult<SimulateTransactionResult>;
 
     // indexer_api
     fn get_subscription_handler(&self) -> Arc<SubscriptionHandler>;
@@ -317,42 +295,12 @@ impl StateRead for AuthorityState {
             .await?)
     }
 
-    fn dry_exec_transaction(
+    fn simulate_transaction(
         &self,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> StateReadResult<(
-        DryRunTransactionBlockResponse,
-        BTreeMap<ObjectId, (ObjectReference, Object, WriteKind)>,
-        TransactionEffects,
-        Option<ObjectId>,
-    )> {
-        Ok(self.dry_exec_transaction(transaction, transaction_digest)?)
-    }
-
-    async fn dev_inspect_transaction_block(
-        &self,
-        sender: Address,
-        transaction_kind: TransactionKind,
-        gas_price: Option<u64>,
-        gas_budget: Option<u64>,
-        gas_sponsor: Option<Address>,
-        gas_objects: Option<Vec<ObjectReference>>,
-        show_raw_txn_data_and_effects: Option<bool>,
-        skip_checks: Option<bool>,
-    ) -> StateReadResult<DevInspectResults> {
-        Ok(self
-            .dev_inspect_transaction_block(
-                sender,
-                transaction_kind,
-                gas_price,
-                gas_budget,
-                gas_sponsor,
-                gas_objects,
-                show_raw_txn_data_and_effects,
-                skip_checks,
-            )
-            .await?)
+        checks: VmChecks,
+    ) -> StateReadResult<SimulateTransactionResult> {
+        Ok(self.simulate_transaction(transaction, checks)?)
     }
 
     fn get_subscription_handler(&self) -> Arc<SubscriptionHandler> {

--- a/crates/iota-json-rpc/src/balance_changes.rs
+++ b/crates/iota-json-rpc/src/balance_changes.rs
@@ -10,15 +10,13 @@ use std::{
 use async_trait::async_trait;
 use iota_json_rpc_types::BalanceChange;
 use iota_sdk_types::{
-    ExecutionStatus, ObjectDigest, ObjectId, ObjectReference, Owner, TransactionEffects, TypeTag,
-    Version,
+    ExecutionStatus, ObjectDigest, ObjectId, Owner, TransactionEffects, TypeTag, Version,
 };
 use iota_types::{
     coin::Coin,
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
     gas_coin::GAS,
     object::Object,
-    storage::WriteKind,
     transaction::InputObjectKind,
 };
 use tokio::sync::RwLock;
@@ -211,27 +209,14 @@ impl<P> ObjectProviderCache<P> {
         }
     }
 
-    pub fn new_with_cache(
-        provider: P,
-        written_objects: BTreeMap<ObjectId, (ObjectReference, Object, WriteKind)>,
-    ) -> Self {
+    pub fn new_with_cache(provider: P, written_objects: &BTreeMap<ObjectId, Object>) -> Self {
         let mut object_cache = BTreeMap::new();
         let mut last_version_cache = BTreeMap::new();
 
-        for (object_id, (object_ref, object, _)) in written_objects {
-            let key = (object_id, object_ref.version);
+        for (object_id, object) in written_objects {
+            let key = (*object_id, object.version());
             object_cache.insert(key, object.clone());
-
-            match last_version_cache.get_mut(&key) {
-                Some(existing_seq_number) => {
-                    if object_ref.version > *existing_seq_number {
-                        *existing_seq_number = object_ref.version
-                    }
-                }
-                None => {
-                    last_version_cache.insert(key, object_ref.version);
-                }
-            }
+            last_version_cache.insert(key, object.version());
         }
 
         Self {

--- a/crates/iota-json-rpc/src/balance_changes.rs
+++ b/crates/iota-json-rpc/src/balance_changes.rs
@@ -171,7 +171,10 @@ pub trait ObjectProvider {
 
 pub struct ObjectProviderCache<P> {
     object_cache: RwLock<BTreeMap<(ObjectId, Version), Object>>,
-    last_version_cache: RwLock<BTreeMap<(ObjectId, Version), Version>>,
+    /// Memoizes [`ObjectProvider::find_object_lt_or_eq_version`]: maps an
+    /// object and the version asked for to the version that answered the
+    /// query.
+    resolved_version_cache: RwLock<BTreeMap<(ObjectId, Version), Version>>,
     provider: P,
 }
 
@@ -179,7 +182,7 @@ impl<P> ObjectProviderCache<P> {
     pub fn new(provider: P) -> Self {
         Self {
             object_cache: Default::default(),
-            last_version_cache: Default::default(),
+            resolved_version_cache: Default::default(),
             provider,
         }
     }
@@ -187,47 +190,28 @@ impl<P> ObjectProviderCache<P> {
     #[instrument(level = "trace", skip_all)]
     pub fn insert_objects_into_cache(&mut self, objects: Vec<Object>) {
         let object_cache = self.object_cache.get_mut();
-        let last_version_cache = self.last_version_cache.get_mut();
+        let resolved_version_cache = self.resolved_version_cache.get_mut();
 
         for object in objects {
-            let object_id = object.id();
-            let version = object.version();
-
-            let key = (object_id, version);
-            object_cache.insert(key, object.clone());
-
-            match last_version_cache.get_mut(&key) {
-                Some(existing_seq_number) => {
-                    if version > *existing_seq_number {
-                        *existing_seq_number = version
-                    }
-                }
-                None => {
-                    last_version_cache.insert(key, version);
-                }
-            }
+            let key = (object.id(), object.version());
+            resolved_version_cache.insert(key, object.version());
+            object_cache.insert(key, object);
         }
     }
 
     pub fn new_with_cache(provider: P, written_objects: &BTreeMap<ObjectId, Object>) -> Self {
         let mut object_cache = BTreeMap::new();
-        let mut last_version_cache = BTreeMap::new();
+        let mut resolved_version_cache = BTreeMap::new();
 
         for (object_id, object) in written_objects {
             let key = (*object_id, object.version());
+            resolved_version_cache.insert(key, object.version());
             object_cache.insert(key, object.clone());
-            // No keep-the-greater-version check here, unlike
-            // `insert_objects_into_cache`: `last_version_cache` is keyed by the
-            // version being looked up, and the value is that same version, so any
-            // entry this loop could collide with holds a value equal to the one
-            // being written. `written_objects` is also keyed by object ID, so each
-            // key is produced at most once to begin with.
-            last_version_cache.insert(key, object.version());
         }
 
         Self {
             object_cache: RwLock::new(object_cache),
-            last_version_cache: RwLock::new(last_version_cache),
+            resolved_version_cache: RwLock::new(resolved_version_cache),
             provider,
         }
     }
@@ -258,8 +242,13 @@ where
         id: &ObjectId,
         version: &Version,
     ) -> Result<Option<Object>, Self::Error> {
-        if let Some(version) = self.last_version_cache.read().await.get(&(*id, *version)) {
-            return Ok(self.get_object(id, version).await.ok());
+        if let Some(resolved) = self
+            .resolved_version_cache
+            .read()
+            .await
+            .get(&(*id, *version))
+        {
+            return Ok(self.get_object(id, resolved).await.ok());
         }
         if let Some(o) = self
             .provider
@@ -270,7 +259,7 @@ where
                 .write()
                 .await
                 .insert((*id, o.version()), o.clone());
-            self.last_version_cache
+            self.resolved_version_cache
                 .write()
                 .await
                 .insert((*id, *version), o.version());

--- a/crates/iota-json-rpc/src/balance_changes.rs
+++ b/crates/iota-json-rpc/src/balance_changes.rs
@@ -216,6 +216,12 @@ impl<P> ObjectProviderCache<P> {
         for (object_id, object) in written_objects {
             let key = (*object_id, object.version());
             object_cache.insert(key, object.clone());
+            // No keep-the-greater-version check here, unlike
+            // `insert_objects_into_cache`: `last_version_cache` is keyed by the
+            // version being looked up, and the value is that same version, so any
+            // entry this loop could collide with holds a value equal to the one
+            // being written. `written_objects` is also keyed by object ID, so each
+            // key is produced at most once to begin with.
             last_version_cache.insert(key, object.version());
         }
 

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -15,9 +15,10 @@ use iota_json_rpc_api::{JsonRpcMetrics, WriteApiOpenRpc, WriteApiServer};
 use iota_json_rpc_types::{
     DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse,
     ExecuteTransactionRequestType as ExecuteTransactionRequestTypeSchema, IotaExecutionStatus,
-    IotaMoveViewCallResults, IotaTransactionBlock, IotaTransactionBlockEffects,
-    IotaTransactionBlockEffectsAPI, IotaTransactionBlockEvents, IotaTransactionBlockResponse,
-    IotaTransactionBlockResponseOptions, IotaTypeTag, MoveFunctionName,
+    IotaMoveViewCallResults, IotaTransactionBlock, IotaTransactionBlockData,
+    IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, IotaTransactionBlockEvents,
+    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, IotaTypeTag,
+    MoveFunctionName,
 };
 use iota_metrics::spawn_monitored_task;
 use iota_open_rpc::Module;
@@ -25,18 +26,23 @@ use iota_package_resolver::{
     Package, PackageStore, Resolver, error::Error as PackageResolverError,
 };
 use iota_sdk_types::{
-    Address, ObjectId, TransactionDigest, TransactionKind, UserSignature,
-    crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion},
+    Address, GasPayment, ObjectId, ObjectReference, TransactionDigest, TransactionExpiration,
+    TransactionKind, TransactionV1, UserSignature,
 };
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
+    execution_config_utils::to_binary_config,
+    gas_coin::mock_simulation_gas_coin,
+    in_memory_storage::InMemoryStorage,
+    inner_temporary_store::{PackageStoreWithFallback, TemporaryModuleResolver},
     iota_serde::BigInt,
     quorum_driver_types::{
         ExecuteTransactionRequestType, ExecuteTransactionRequestV1, ExecuteTransactionResponseV1,
     },
     storage::PostExecutionPackageResolver,
     transaction::{InputObjectKind, TransactionData, TransactionDataAPI, TransactionEnvelope},
+    transaction_executor::VmChecks,
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
 use tracing::{Instrument, instrument};
@@ -317,72 +323,201 @@ impl TransactionExecutionApi {
     pub fn prepare_dry_run_transaction_block(
         &self,
         tx_bytes: Base64,
-    ) -> Result<(TransactionData, TransactionDigest, Vec<InputObjectKind>), IotaRpcInputError> {
+    ) -> Result<(TransactionData, Vec<InputObjectKind>), IotaRpcInputError> {
         let tx_data: TransactionData = self.convert_bytes(tx_bytes)?;
         let input_objs = tx_data.input_objects()?;
-        let intent_msg = IntentMessage::new(
-            Intent {
-                version: IntentVersion::V0,
-                scope: IntentScope::TransactionData,
-                app_id: IntentAppId::Iota,
-            },
-            tx_data,
-        );
-        let txn_digest = TransactionDigest::new(intent_msg.value.digest().into_inner());
-        Ok((intent_msg.value, txn_digest, input_objs))
+        Ok((tx_data, input_objs))
     }
 
     async fn dry_run_transaction_block(
         &self,
         tx_bytes: Base64,
     ) -> Result<DryRunTransactionBlockResponse, Error> {
-        let (txn_data, txn_digest, input_objs) =
-            self.prepare_dry_run_transaction_block(tx_bytes)?;
+        let (mut txn_data, input_objs) = self.prepare_dry_run_transaction_block(tx_bytes)?;
         let sender = txn_data.sender();
 
-        // Use spawn_blocking since dry_exec_transaction is a long-running synchronous
-        // operation
+        // Use spawn_blocking since simulating a transaction is a long-running
+        // synchronous operation
         let state = self.state.clone();
-        let (resp, written_objects, transaction_effects, mock_gas) =
+        let simulation = {
+            let txn_data = txn_data.clone();
             tokio::task::spawn_blocking(move || {
-                state.dry_exec_transaction(txn_data.clone(), txn_digest)
+                state.simulate_transaction(txn_data, VmChecks::Enabled)
             })
             .await
-            .map_err(Error::from)??;
+            .map_err(Error::from)??
+        };
 
-        let object_cache = ObjectProviderCache::new_with_cache(self.state.clone(), written_objects);
+        // A transaction submitted without a gas payment is simulated against a mock gas
+        // coin, which the reported transaction input has to account for.
+        if simulation.mock_gas_id.is_some() {
+            let mock_gas = mock_simulation_gas_coin(txn_data.gas_data().owner);
+            txn_data.gas_data_mut().objects = vec![mock_gas.object_ref()];
+        }
+
+        let tx_digest = *simulation.effects.transaction_digest();
+        // Resolve types against the objects the simulation wrote before falling back to
+        // the store, so that packages published by the transaction itself are visible.
+        let (input, events) = {
+            let epoch_store = self.state.load_epoch_store_one_call_per_task();
+            let written =
+                InMemoryStorage::new(simulation.output_objects.values().cloned().collect());
+            let mut layout_resolver = epoch_store.executor().type_layout_resolver(Box::new(
+                PackageStoreWithFallback::new(&written, self.state.get_backing_package_store()),
+            ));
+            let module_cache = TemporaryModuleResolver::new(
+                &simulation.output_objects,
+                to_binary_config(epoch_store.protocol_config()),
+                epoch_store.module_cache().clone(),
+            );
+
+            let input = IotaTransactionBlockData::try_from_with_module_cache(
+                txn_data,
+                &module_cache,
+                tx_digest,
+            )
+            .map_err(|e| {
+                Error::Unexpected(format!(
+                    "Failed to convert transaction to IotaTransactionBlockData: {e}",
+                ))
+            })?;
+            let events = IotaTransactionBlockEvents::try_from(
+                simulation.events.clone().unwrap_or_default(),
+                tx_digest,
+                None,
+                layout_resolver.as_mut(),
+            )?;
+
+            (input, events)
+        };
+
+        let execution_error_source = simulation
+            .execution_result
+            .as_ref()
+            .err()
+            .and_then(|e| e.source().as_ref().map(|e| e.to_string()));
+
+        let object_cache =
+            ObjectProviderCache::new_with_cache(self.state.clone(), &simulation.output_objects);
         let balance_changes = get_balance_changes_from_effect(
             &object_cache,
-            &transaction_effects,
+            &simulation.effects,
             input_objs,
-            mock_gas,
+            simulation.mock_gas_id,
         )
         .await?;
         let object_changes = get_object_changes(
             &object_cache,
             sender,
-            transaction_effects.modified_at_versions(),
-            transaction_effects.all_changed_objects(),
-            transaction_effects.all_removed_objects(),
+            simulation.effects.modified_at_versions(),
+            simulation.effects.all_changed_objects(),
+            simulation.effects.all_removed_objects(),
         )
         .await?;
 
         let resolver = Resolver::new(self.clone());
         let effects = IotaTransactionBlockEffects::from_native_with_clever_error(
-            transaction_effects,
+            simulation.effects,
             &resolver,
         )
         .await;
 
         Ok(DryRunTransactionBlockResponse {
             effects,
-            events: resp.events,
+            events,
             object_changes,
             balance_changes,
-            input: resp.input,
-            suggested_gas_price: resp.suggested_gas_price,
-            execution_error_source: resp.execution_error_source,
+            input,
+            suggested_gas_price: simulation.suggested_gas_price,
+            execution_error_source,
         })
+    }
+
+    /// Simulate `transaction_kind` with the Move VM checks around entry
+    /// functions and argument values relaxed, reporting the return values of
+    /// every command.
+    ///
+    /// Any part of the gas payment the caller leaves out is filled in with the
+    /// reference gas price, the protocol maximum gas budget, and `sender` as
+    /// the gas owner.
+    #[allow(clippy::too_many_arguments)]
+    async fn dev_inspect_transaction(
+        &self,
+        sender: Address,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+        gas_budget: Option<u64>,
+        gas_sponsor: Option<Address>,
+        gas_objects: Option<Vec<ObjectReference>>,
+        show_raw_txn_data_and_effects: Option<bool>,
+        skip_checks: Option<bool>,
+    ) -> Result<DevInspectResults, Error> {
+        let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
+        let skip_checks = skip_checks.unwrap_or(true);
+
+        let transaction = {
+            let epoch_store = self.state.load_epoch_store_one_call_per_task();
+            TransactionData::V1(TransactionV1 {
+                kind: transaction_kind,
+                sender,
+                gas_payment: GasPayment {
+                    // Payment might be empty here, but that is fine: a mock gas coin is
+                    // minted for it during the simulation.
+                    objects: gas_objects.unwrap_or_default(),
+                    owner: gas_sponsor.unwrap_or(sender),
+                    price: gas_price.unwrap_or_else(|| epoch_store.reference_gas_price()),
+                    budget: gas_budget
+                        .unwrap_or_else(|| epoch_store.protocol_config().max_tx_gas()),
+                },
+                expiration: TransactionExpiration::None,
+            })
+        };
+
+        let raw_txn_data = if show_raw_txn_data_and_effects {
+            bcs::to_bytes(&transaction).map_err(|_| {
+                Error::Unexpected("Failed to serialize transaction during dev inspect".to_string())
+            })?
+        } else {
+            vec![]
+        };
+
+        let checks = if skip_checks {
+            VmChecks::Disabled
+        } else {
+            VmChecks::Enabled
+        };
+        let simulation = self.state.simulate_transaction(transaction, checks)?;
+
+        let raw_effects = if show_raw_txn_data_and_effects {
+            bcs::to_bytes(&simulation.effects).map_err(|_| {
+                Error::Unexpected(
+                    "Failed to serialize transaction effects during dev inspect".to_string(),
+                )
+            })?
+        } else {
+            vec![]
+        };
+
+        // Resolve types against the objects the simulation wrote before falling back to
+        // the store, so that packages published by the transaction itself are visible.
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        let written = InMemoryStorage::new(simulation.output_objects.values().cloned().collect());
+        let mut layout_resolver =
+            epoch_store
+                .executor()
+                .type_layout_resolver(Box::new(PackageStoreWithFallback::new(
+                    &written,
+                    self.state.get_backing_package_store(),
+                )));
+
+        Ok(DevInspectResults::new(
+            simulation.effects,
+            simulation.events.unwrap_or_default(),
+            simulation.execution_result,
+            raw_txn_data,
+            raw_effects,
+            layout_resolver.as_mut(),
+        )?)
     }
 }
 
@@ -426,9 +561,8 @@ impl WriteApiServer for TransactionExecutionApi {
             )
             .await
             .map_err(Error::from)?;
-        let tx_bytes = Base64::from_bytes(&bcs::to_bytes(&tx_kind).map_err(Error::from)?);
         let dev_inspect_results = self
-            .dev_inspect_transaction_block(sender, tx_bytes, None, None, None)
+            .dev_inspect_transaction(sender, tx_kind, None, None, None, None, None, None)
             .await?;
         Ok(
             IotaMoveViewCallResults::from_dev_inspect_results(self.clone(), dev_inspect_results)
@@ -455,19 +589,17 @@ impl WriteApiServer for TransactionExecutionApi {
                 skip_checks,
             } = additional_args.unwrap_or_default();
             let tx_kind: TransactionKind = self.convert_bytes(tx_bytes)?;
-            self.state
-                .dev_inspect_transaction_block(
-                    sender_address,
-                    tx_kind,
-                    gas_price.map(|i| *i),
-                    gas_budget,
-                    gas_sponsor,
-                    gas_objects,
-                    show_raw_txn_data_and_effects,
-                    skip_checks,
-                )
-                .await
-                .map_err(Error::from)
+            self.dev_inspect_transaction(
+                sender_address,
+                tx_kind,
+                gas_price.map(|i| *i),
+                gas_budget,
+                gas_sponsor,
+                gas_objects,
+                show_raw_txn_data_and_effects,
+                skip_checks,
+            )
+            .await
         }
         .trace()
         .await

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -330,6 +330,20 @@ impl TransactionExecutionApi {
         Ok((tx_data, input_objs))
     }
 
+    /// Report the gas the simulation ran with, in place of whatever the caller
+    /// left unset. Same rule as gRPC `simulate_transactions`, which shares the
+    /// helper.
+    fn report_simulation_gas(
+        transaction: &mut TransactionData,
+        simulation: &SimulateTransactionResult,
+    ) {
+        iota_types::gas::report_simulation_gas(
+            transaction.gas_data_mut(),
+            &simulation.gas_data,
+            simulation.effects.gas_cost_summary().gas_used(),
+        );
+    }
+
     /// The synchronous part of
     /// [`dry_run_transaction_block`](Self::dry_run_transaction_block): the
     /// simulation, and the resolution of the response's input and events over
@@ -455,45 +469,6 @@ impl TransactionExecutionApi {
         })
     }
 
-    /// Simulate `transaction_kind` with the Move VM checks around entry
-    /// functions and argument values relaxed, reporting the return values of
-    /// every command.
-    ///
-    /// Any part of the gas payment the caller leaves out is filled in: an
-    /// empty payment gets a mock gas coin, a zero price the epoch's reference
-    /// gas price, and a zero budget as much as the gas coins can back, up to
-    /// the protocol maximum. `sender` stands in as the gas owner.
-    async fn dev_inspect_transaction(
-        &self,
-        sender: Address,
-        transaction_kind: TransactionKind,
-        gas_price: Option<u64>,
-        args: DevInspectArgs,
-    ) -> Result<DevInspectResults, Error> {
-        // Use spawn_blocking since simulating a transaction is a long-running
-        // synchronous operation
-        let this = self.clone();
-        tokio::task::spawn_blocking(move || {
-            this.dev_inspect_transaction_impl(sender, transaction_kind, gas_price, args)
-        })
-        .await
-        .map_err(Error::from)?
-    }
-
-    /// Report the gas the simulation ran with, in place of whatever the caller
-    /// left unset. Same rule as gRPC `simulate_transactions`, which shares the
-    /// helper.
-    fn report_simulation_gas(
-        transaction: &mut TransactionData,
-        simulation: &SimulateTransactionResult,
-    ) {
-        iota_types::gas::report_simulation_gas(
-            transaction.gas_data_mut(),
-            &simulation.gas_data,
-            simulation.effects.gas_cost_summary().gas_used(),
-        );
-    }
-
     fn dev_inspect_transaction_impl(
         &self,
         sender: Address,
@@ -582,6 +557,23 @@ impl TransactionExecutionApi {
             raw_effects,
             layout_resolver.as_mut(),
         )?)
+    }
+
+    async fn dev_inspect_transaction(
+        &self,
+        sender: Address,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+        args: DevInspectArgs,
+    ) -> Result<DevInspectResults, Error> {
+        // Use spawn_blocking since simulating a transaction is a long-running
+        // synchronous operation
+        let this = self.clone();
+        tokio::task::spawn_blocking(move || {
+            this.dev_inspect_transaction_impl(sender, transaction_kind, gas_price, args)
+        })
+        .await
+        .map_err(Error::from)?
     }
 }
 

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -31,7 +31,7 @@ use iota_sdk_types::{
 };
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
-    effects::{TransactionEffectsAPI, TransactionEffectsExt},
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
     execution_config_utils::to_binary_config,
     inner_temporary_store::{PackageStoreWithFallback, TemporaryModuleResolver},
     iota_serde::BigInt,
@@ -363,6 +363,7 @@ impl TransactionExecutionApi {
             })?;
             txn_data.gas_data_mut().objects = vec![mock_gas.object_ref()];
         }
+        Self::report_gas_used_as_budget(&mut txn_data, &simulation.effects);
 
         let tx_digest = *simulation.effects.transaction_digest();
         // Resolve types against the objects the simulation wrote before falling back to
@@ -466,6 +467,17 @@ impl TransactionExecutionApi {
         .map_err(Error::from)?
     }
 
+    /// Report the gas the simulation charged in place of a zero gas budget.
+    ///
+    /// A caller that declares no budget is asking what the transaction costs,
+    /// so echoing its own zero back tells it nothing. gRPC
+    /// `simulate_transactions` reports the cost in the same field.
+    fn report_gas_used_as_budget(transaction: &mut TransactionData, effects: &TransactionEffects) {
+        if transaction.gas_budget() == 0 {
+            transaction.gas_data_mut().budget = effects.gas_cost_summary().gas_used();
+        }
+    }
+
     fn dev_inspect_transaction_impl(
         &self,
         sender: Address,
@@ -503,22 +515,29 @@ impl TransactionExecutionApi {
             expiration: TransactionExpiration::None,
         });
 
-        let raw_txn_data = if show_raw_txn_data_and_effects {
-            bcs::to_bytes(&transaction).map_err(|_| {
-                Error::Unexpected("Failed to serialize transaction during dev inspect".to_string())
-            })?
-        } else {
-            vec![]
-        };
-
         let checks = if skip_checks {
             VmChecks::Disabled
         } else {
             VmChecks::Enabled
         };
+        // Kept back from the simulation, which consumes the transaction, so that the
+        // reported gas can be filled in from what the simulation charged.
+        let mut reported_transaction = show_raw_txn_data_and_effects.then(|| transaction.clone());
         let simulation =
             self.state
                 .simulate_transaction_in_epoch(&epoch_store, transaction, checks)?;
+
+        let raw_txn_data = match reported_transaction.as_mut() {
+            Some(transaction) => {
+                Self::report_gas_used_as_budget(transaction, &simulation.effects);
+                bcs::to_bytes(transaction).map_err(|_| {
+                    Error::Unexpected(
+                        "Failed to serialize transaction during dev inspect".to_string(),
+                    )
+                })?
+            }
+            None => vec![],
+        };
 
         let raw_effects = if show_raw_txn_data_and_effects {
             bcs::to_bytes(&simulation.effects).map_err(|_| {

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -33,7 +33,6 @@ use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
     execution_config_utils::to_binary_config,
-    gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::{PackageStoreWithFallback, TemporaryModuleResolver},
     iota_serde::BigInt,
     quorum_driver_types::{
@@ -353,9 +352,15 @@ impl TransactionExecutionApi {
         };
 
         // A transaction submitted without a gas payment is simulated against a mock gas
-        // coin, which the reported transaction input has to account for.
-        if simulation.mock_gas_id.is_some() {
-            let mock_gas = mock_simulation_gas_coin(txn_data.gas_data().owner);
+        // coin, which the reported transaction input has to account for. Take the coin
+        // back out of the simulation's inputs rather than minting a second one, so the
+        // reported payment is the reference the simulation actually charged.
+        if let Some(mock_gas_id) = simulation.mock_gas_id {
+            let mock_gas = simulation.input_objects.get(&mock_gas_id).ok_or_else(|| {
+                Error::Unexpected(format!(
+                    "simulation minted mock gas coin {mock_gas_id} but did not report it as an input",
+                ))
+            })?;
             txn_data.gas_data_mut().objects = vec![mock_gas.object_ref()];
         }
 
@@ -386,7 +391,7 @@ impl TransactionExecutionApi {
                 ))
             })?;
             let events = IotaTransactionBlockEvents::try_from(
-                simulation.events.clone().unwrap_or_default(),
+                simulation.events.unwrap_or_default(),
                 tx_digest,
                 None,
                 layout_resolver.as_mut(),

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -491,9 +491,10 @@ impl TransactionExecutionApi {
             kind: transaction_kind,
             sender,
             gas_payment: GasPayment {
-                // Any of these the caller leaves out is filled in by the simulation: an
-                // empty payment gets a mock gas coin, and a zero price or budget gets
-                // this epoch's defaults.
+                // Any of these the caller leaves out is filled in by the simulation,
+                // whether or not the checks are skipped: an empty payment gets a mock
+                // gas coin, a zero price gets the epoch's reference gas price, and a
+                // zero budget gets the protocol maximum.
                 objects: gas_objects.unwrap_or_default(),
                 owner: gas_sponsor.unwrap_or(sender),
                 price: gas_price.unwrap_or_default(),

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -354,7 +354,7 @@ impl TransactionExecutionApi {
             .map_err(Error::from)??
         };
 
-        Self::report_simulation_gas_and_payment(&mut txn_data, &simulation);
+        Self::report_simulation_gas(&mut txn_data, &simulation);
 
         let tx_digest = *simulation.effects.transaction_digest();
         // Resolve types against the objects the simulation wrote before falling back to
@@ -457,22 +457,17 @@ impl TransactionExecutionApi {
     }
 
     /// Report the gas the simulation ran with, in place of whatever the caller
-    /// left unset, gas payment included.
-    ///
-    /// The payment is reported here because that is where a JSON-RPC client
-    /// reads a mock gas coin the simulation minted; gRPC reports it separately
-    /// and so leaves the payment as it was sent. The price and budget are the
-    /// same rule for both, so they come from
-    /// [`iota_types::gas::report_simulation_gas`].
-    fn report_simulation_gas_and_payment(
+    /// left unset. Same rule as gRPC `simulate_transactions`, which shares the
+    /// helper.
+    fn report_simulation_gas(
         transaction: &mut TransactionData,
         simulation: &SimulateTransactionResult,
     ) {
-        let gas_used = simulation.effects.gas_cost_summary().gas_used();
-        let gas_data = transaction.gas_data_mut();
-        gas_data.objects = simulation.gas_data.objects.clone();
-        gas_data.owner = simulation.gas_data.owner;
-        iota_types::gas::report_simulation_gas(gas_data, &simulation.gas_data, gas_used);
+        iota_types::gas::report_simulation_gas(
+            transaction.gas_data_mut(),
+            &simulation.gas_data,
+            simulation.effects.gas_cost_summary().gas_used(),
+        );
     }
 
     fn dev_inspect_transaction_impl(
@@ -526,7 +521,7 @@ impl TransactionExecutionApi {
 
         let raw_txn_data = match reported_transaction.as_mut() {
             Some(transaction) => {
-                Self::report_simulation_gas_and_payment(transaction, &simulation);
+                Self::report_simulation_gas(transaction, &simulation);
                 bcs::to_bytes(transaction).map_err(|_| IotaError::TransactionSerialization {
                     error: "Failed to serialize transaction during dev inspect".to_string(),
                 })?

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -500,7 +500,8 @@ impl TransactionExecutionApi {
                 // Any of these the caller leaves out is filled in by the simulation,
                 // whether or not the checks are skipped: an empty payment gets a mock
                 // gas coin, a zero price gets the epoch's reference gas price, and a
-                // zero budget gets the protocol maximum.
+                // zero budget as much as the gas coins can back, up to the protocol
+                // maximum.
                 objects: gas_objects.unwrap_or_default(),
                 owner: gas_sponsor.unwrap_or(sender),
                 price: gas_price.unwrap_or_default(),

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -483,21 +483,21 @@ impl TransactionExecutionApi {
         let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
         let skip_checks = skip_checks.unwrap_or(true);
 
-        // Hold on to one epoch store for the whole operation, so that the gas
-        // parameters, the simulation and the type resolution below observe the same
-        // epoch.
+        // Hold on to one epoch store for the whole operation, so that the simulation
+        // and the type resolution below observe the same epoch.
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
 
         let transaction = TransactionData::V1(TransactionV1 {
             kind: transaction_kind,
             sender,
             gas_payment: GasPayment {
-                // Payment might be empty here, but that is fine: a mock gas coin is
-                // minted for it during the simulation.
+                // Any of these the caller leaves out is filled in by the simulation: an
+                // empty payment gets a mock gas coin, and a zero price or budget gets
+                // this epoch's defaults.
                 objects: gas_objects.unwrap_or_default(),
                 owner: gas_sponsor.unwrap_or(sender),
-                price: gas_price.unwrap_or_else(|| epoch_store.reference_gas_price()),
-                budget: gas_budget.unwrap_or_else(|| epoch_store.protocol_config().max_tx_gas()),
+                price: gas_price.unwrap_or_default(),
+                budget: gas_budget.unwrap_or_default(),
             },
             expiration: TransactionExpiration::None,
         });

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -34,7 +34,9 @@ use iota_types::{
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
     error::IotaError,
     execution_config_utils::to_binary_config,
-    inner_temporary_store::{PackageStoreWithFallback, TemporaryModuleResolver},
+    inner_temporary_store::{
+        ObjectMapPackageStore, PackageStoreWithFallback, TemporaryModuleResolver,
+    },
     iota_serde::BigInt,
     quorum_driver_types::{
         ExecuteTransactionRequestType, ExecuteTransactionRequestV1, ExecuteTransactionResponseV1,
@@ -352,7 +354,7 @@ impl TransactionExecutionApi {
             .map_err(Error::from)??
         };
 
-        Self::report_effective_gas(&mut txn_data, &simulation);
+        Self::report_simulation_gas_and_payment(&mut txn_data, &simulation);
 
         let tx_digest = *simulation.effects.transaction_digest();
         // Resolve types against the objects the simulation wrote before falling back to
@@ -360,7 +362,7 @@ impl TransactionExecutionApi {
         let (input, events) = {
             let mut layout_resolver = epoch_store.executor().type_layout_resolver(Box::new(
                 PackageStoreWithFallback::new(
-                    &simulation.output_objects,
+                    ObjectMapPackageStore(&simulation.output_objects),
                     self.state.get_backing_package_store(),
                 ),
             ));
@@ -455,23 +457,22 @@ impl TransactionExecutionApi {
     }
 
     /// Report the gas the simulation ran with, in place of whatever the caller
-    /// left unset.
+    /// left unset, gas payment included.
     ///
-    /// A zero budget asks what the transaction costs, so it comes back as the
-    /// gas charged rather than as the caller's own zero, which would say
-    /// nothing. The price it was charged at comes back too: only the
-    /// computation half of the cost scales with the price, so an estimate
-    /// cannot be read without it. gRPC `simulate_transactions` reports the
-    /// cost in the same field.
-    fn report_effective_gas(
+    /// The payment is reported here because that is where a JSON-RPC client
+    /// reads a mock gas coin the simulation minted; gRPC reports it separately
+    /// and so leaves the payment as it was sent. The price and budget are the
+    /// same rule for both, so they come from
+    /// [`iota_types::gas::report_simulation_gas`].
+    fn report_simulation_gas_and_payment(
         transaction: &mut TransactionData,
         simulation: &SimulateTransactionResult,
     ) {
-        let estimating = transaction.gas_budget() == 0;
-        *transaction.gas_data_mut() = simulation.gas_data.clone();
-        if estimating {
-            transaction.gas_data_mut().budget = simulation.effects.gas_cost_summary().gas_used();
-        }
+        let gas_used = simulation.effects.gas_cost_summary().gas_used();
+        let gas_data = transaction.gas_data_mut();
+        gas_data.objects = simulation.gas_data.objects.clone();
+        gas_data.owner = simulation.gas_data.owner;
+        iota_types::gas::report_simulation_gas(gas_data, &simulation.gas_data, gas_used);
     }
 
     fn dev_inspect_transaction_impl(
@@ -525,7 +526,7 @@ impl TransactionExecutionApi {
 
         let raw_txn_data = match reported_transaction.as_mut() {
             Some(transaction) => {
-                Self::report_effective_gas(transaction, &simulation);
+                Self::report_simulation_gas_and_payment(transaction, &simulation);
                 bcs::to_bytes(transaction).map_err(|_| IotaError::TransactionSerialization {
                     error: "Failed to serialize transaction during dev inspect".to_string(),
                 })?
@@ -547,7 +548,7 @@ impl TransactionExecutionApi {
             epoch_store
                 .executor()
                 .type_layout_resolver(Box::new(PackageStoreWithFallback::new(
-                    &simulation.output_objects,
+                    ObjectMapPackageStore(&simulation.output_objects),
                     self.state.get_backing_package_store(),
                 )));
 

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -330,29 +330,33 @@ impl TransactionExecutionApi {
         Ok((tx_data, input_objs))
     }
 
-    async fn dry_run_transaction_block(
+    /// The synchronous part of
+    /// [`dry_run_transaction_block`](Self::dry_run_transaction_block): the
+    /// simulation, and the resolution of the response's input and events over
+    /// the objects it wrote. Meant to run on a blocking thread; the async
+    /// object- and balance-change queries stay with the caller.
+    fn dry_run_transaction_block_impl(
         &self,
-        tx_bytes: Base64,
-    ) -> Result<DryRunTransactionBlockResponse, Error> {
-        let (mut txn_data, input_objs) = self.prepare_dry_run_transaction_block(tx_bytes)?;
-        let sender = txn_data.sender();
-
+        mut txn_data: TransactionData,
+    ) -> Result<
+        (
+            SimulateTransactionResult,
+            IotaTransactionBlockData,
+            IotaTransactionBlockEvents,
+        ),
+        Error,
+    > {
         // Hold on to one epoch store for the whole operation, so that the simulation
-        // and the type resolution below observe the same epoch.
+        // and the type resolution below observe the same epoch. A full `Arc` rather
+        // than the arc-swap guard: a guard occupies one of arc-swap's scarce
+        // per-thread borrow slots, meant for short borrows, not a whole simulation.
         let epoch_store = Arc::clone(&self.state.load_epoch_store_one_call_per_task());
 
-        // Use spawn_blocking since simulating a transaction is a long-running
-        // synchronous operation
-        let simulation = {
-            let state = self.state.clone();
-            let epoch_store = epoch_store.clone();
-            let txn_data = txn_data.clone();
-            tokio::task::spawn_blocking(move || {
-                state.simulate_transaction_in_epoch(&epoch_store, txn_data, VmChecks::Enabled)
-            })
-            .await
-            .map_err(Error::from)??
-        };
+        let mut simulation = self.state.simulate_transaction_in_epoch(
+            &epoch_store,
+            txn_data.clone(),
+            VmChecks::Enabled,
+        )?;
 
         Self::report_simulation_gas(&mut txn_data, &simulation);
 
@@ -381,13 +385,32 @@ impl TransactionExecutionApi {
                 error: format!("Failed to convert transaction to IotaTransactionBlockData: {e}"),
             })?;
             let events = IotaTransactionBlockEvents::try_from(
-                simulation.events.unwrap_or_default(),
+                simulation.events.take().unwrap_or_default(),
                 tx_digest,
                 None,
                 layout_resolver.as_mut(),
             )?;
 
             (input, events)
+        };
+
+        Ok((simulation, input, events))
+    }
+
+    async fn dry_run_transaction_block(
+        &self,
+        tx_bytes: Base64,
+    ) -> Result<DryRunTransactionBlockResponse, Error> {
+        let (txn_data, input_objs) = self.prepare_dry_run_transaction_block(tx_bytes)?;
+        let sender = txn_data.sender();
+
+        // Use spawn_blocking since simulating a transaction and resolving types
+        // over its output are long-running synchronous operations
+        let (simulation, input, events) = {
+            let this = self.clone();
+            tokio::task::spawn_blocking(move || this.dry_run_transaction_block_impl(txn_data))
+                .await
+                .map_err(Error::from)??
         };
 
         let execution_error_source = simulation
@@ -436,9 +459,10 @@ impl TransactionExecutionApi {
     /// functions and argument values relaxed, reporting the return values of
     /// every command.
     ///
-    /// Any part of the gas payment the caller leaves out is filled in with the
-    /// reference gas price, the protocol maximum gas budget, and `sender` as
-    /// the gas owner.
+    /// Any part of the gas payment the caller leaves out is filled in: an
+    /// empty payment gets a mock gas coin, a zero price the epoch's reference
+    /// gas price, and a zero budget as much as the gas coins can back, up to
+    /// the protocol maximum. `sender` stands in as the gas owner.
     async fn dev_inspect_transaction(
         &self,
         sender: Address,

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -32,6 +32,7 @@ use iota_sdk_types::{
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
+    error::IotaError,
     execution_config_utils::to_binary_config,
     inner_temporary_store::{PackageStoreWithFallback, TemporaryModuleResolver},
     iota_serde::BigInt,
@@ -374,10 +375,8 @@ impl TransactionExecutionApi {
                 &module_cache,
                 tx_digest,
             )
-            .map_err(|e| {
-                Error::Unexpected(format!(
-                    "Failed to convert transaction to IotaTransactionBlockData: {e}",
-                ))
+            .map_err(|e| IotaError::TransactionSerialization {
+                error: format!("Failed to convert transaction to IotaTransactionBlockData: {e}"),
             })?;
             let events = IotaTransactionBlockEvents::try_from(
                 simulation.events.unwrap_or_default(),
@@ -527,20 +526,16 @@ impl TransactionExecutionApi {
         let raw_txn_data = match reported_transaction.as_mut() {
             Some(transaction) => {
                 Self::report_effective_gas(transaction, &simulation);
-                bcs::to_bytes(transaction).map_err(|_| {
-                    Error::Unexpected(
-                        "Failed to serialize transaction during dev inspect".to_string(),
-                    )
+                bcs::to_bytes(transaction).map_err(|_| IotaError::TransactionSerialization {
+                    error: "Failed to serialize transaction during dev inspect".to_string(),
                 })?
             }
             None => vec![],
         };
 
         let raw_effects = if show_raw_txn_data_and_effects {
-            bcs::to_bytes(&simulation.effects).map_err(|_| {
-                Error::Unexpected(
-                    "Failed to serialize transaction effects during dev inspect".to_string(),
-                )
+            bcs::to_bytes(&simulation.effects).map_err(|_| IotaError::TransactionSerialization {
+                error: "Failed to serialize transaction effects during dev inspect".to_string(),
             })?
         } else {
             vec![]

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -488,8 +488,10 @@ impl TransactionExecutionApi {
         let skip_checks = skip_checks.unwrap_or(true);
 
         // Hold on to one epoch store for the whole operation, so that the simulation
-        // and the type resolution below observe the same epoch.
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        // and the type resolution below observe the same epoch. A full `Arc` rather
+        // than the arc-swap guard: a guard occupies one of arc-swap's scarce
+        // per-thread borrow slots, meant for short borrows, not a whole simulation.
+        let epoch_store = Arc::clone(&self.state.load_epoch_store_one_call_per_task());
 
         let transaction = TransactionData::V1(TransactionV1 {
             kind: transaction_kind,

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -26,15 +26,14 @@ use iota_package_resolver::{
     Package, PackageStore, Resolver, error::Error as PackageResolverError,
 };
 use iota_sdk_types::{
-    Address, GasPayment, ObjectId, ObjectReference, TransactionDigest, TransactionExpiration,
-    TransactionKind, TransactionV1, UserSignature,
+    Address, GasPayment, ObjectId, TransactionDigest, TransactionExpiration, TransactionKind,
+    TransactionV1, UserSignature,
 };
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
     execution_config_utils::to_binary_config,
     gas_coin::mock_simulation_gas_coin,
-    in_memory_storage::InMemoryStorage,
     inner_temporary_store::{PackageStoreWithFallback, TemporaryModuleResolver},
     iota_serde::BigInt,
     quorum_driver_types::{
@@ -336,13 +335,18 @@ impl TransactionExecutionApi {
         let (mut txn_data, input_objs) = self.prepare_dry_run_transaction_block(tx_bytes)?;
         let sender = txn_data.sender();
 
+        // Hold on to one epoch store for the whole operation, so that the simulation
+        // and the type resolution below observe the same epoch.
+        let epoch_store = Arc::clone(&self.state.load_epoch_store_one_call_per_task());
+
         // Use spawn_blocking since simulating a transaction is a long-running
         // synchronous operation
-        let state = self.state.clone();
         let simulation = {
+            let state = self.state.clone();
+            let epoch_store = epoch_store.clone();
             let txn_data = txn_data.clone();
             tokio::task::spawn_blocking(move || {
-                state.simulate_transaction(txn_data, VmChecks::Enabled)
+                state.simulate_transaction_in_epoch(&epoch_store, txn_data, VmChecks::Enabled)
             })
             .await
             .map_err(Error::from)??
@@ -359,11 +363,11 @@ impl TransactionExecutionApi {
         // Resolve types against the objects the simulation wrote before falling back to
         // the store, so that packages published by the transaction itself are visible.
         let (input, events) = {
-            let epoch_store = self.state.load_epoch_store_one_call_per_task();
-            let written =
-                InMemoryStorage::new(simulation.output_objects.values().cloned().collect());
             let mut layout_resolver = epoch_store.executor().type_layout_resolver(Box::new(
-                PackageStoreWithFallback::new(&written, self.state.get_backing_package_store()),
+                PackageStoreWithFallback::new(
+                    &simulation.output_objects,
+                    self.state.get_backing_package_store(),
+                ),
             ));
             let module_cache = TemporaryModuleResolver::new(
                 &simulation.output_objects,
@@ -440,38 +444,58 @@ impl TransactionExecutionApi {
     /// Any part of the gas payment the caller leaves out is filled in with the
     /// reference gas price, the protocol maximum gas budget, and `sender` as
     /// the gas owner.
-    #[allow(clippy::too_many_arguments)]
     async fn dev_inspect_transaction(
         &self,
         sender: Address,
         transaction_kind: TransactionKind,
         gas_price: Option<u64>,
-        gas_budget: Option<u64>,
-        gas_sponsor: Option<Address>,
-        gas_objects: Option<Vec<ObjectReference>>,
-        show_raw_txn_data_and_effects: Option<bool>,
-        skip_checks: Option<bool>,
+        args: DevInspectArgs,
     ) -> Result<DevInspectResults, Error> {
+        // Use spawn_blocking since simulating a transaction is a long-running
+        // synchronous operation
+        let this = self.clone();
+        tokio::task::spawn_blocking(move || {
+            this.dev_inspect_transaction_impl(sender, transaction_kind, gas_price, args)
+        })
+        .await
+        .map_err(Error::from)?
+    }
+
+    fn dev_inspect_transaction_impl(
+        &self,
+        sender: Address,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+        args: DevInspectArgs,
+    ) -> Result<DevInspectResults, Error> {
+        let DevInspectArgs {
+            gas_sponsor,
+            gas_budget,
+            gas_objects,
+            show_raw_txn_data_and_effects,
+            skip_checks,
+        } = args;
         let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
         let skip_checks = skip_checks.unwrap_or(true);
 
-        let transaction = {
-            let epoch_store = self.state.load_epoch_store_one_call_per_task();
-            TransactionData::V1(TransactionV1 {
-                kind: transaction_kind,
-                sender,
-                gas_payment: GasPayment {
-                    // Payment might be empty here, but that is fine: a mock gas coin is
-                    // minted for it during the simulation.
-                    objects: gas_objects.unwrap_or_default(),
-                    owner: gas_sponsor.unwrap_or(sender),
-                    price: gas_price.unwrap_or_else(|| epoch_store.reference_gas_price()),
-                    budget: gas_budget
-                        .unwrap_or_else(|| epoch_store.protocol_config().max_tx_gas()),
-                },
-                expiration: TransactionExpiration::None,
-            })
-        };
+        // Hold on to one epoch store for the whole operation, so that the gas
+        // parameters, the simulation and the type resolution below observe the same
+        // epoch.
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+
+        let transaction = TransactionData::V1(TransactionV1 {
+            kind: transaction_kind,
+            sender,
+            gas_payment: GasPayment {
+                // Payment might be empty here, but that is fine: a mock gas coin is
+                // minted for it during the simulation.
+                objects: gas_objects.unwrap_or_default(),
+                owner: gas_sponsor.unwrap_or(sender),
+                price: gas_price.unwrap_or_else(|| epoch_store.reference_gas_price()),
+                budget: gas_budget.unwrap_or_else(|| epoch_store.protocol_config().max_tx_gas()),
+            },
+            expiration: TransactionExpiration::None,
+        });
 
         let raw_txn_data = if show_raw_txn_data_and_effects {
             bcs::to_bytes(&transaction).map_err(|_| {
@@ -486,7 +510,9 @@ impl TransactionExecutionApi {
         } else {
             VmChecks::Enabled
         };
-        let simulation = self.state.simulate_transaction(transaction, checks)?;
+        let simulation =
+            self.state
+                .simulate_transaction_in_epoch(&epoch_store, transaction, checks)?;
 
         let raw_effects = if show_raw_txn_data_and_effects {
             bcs::to_bytes(&simulation.effects).map_err(|_| {
@@ -500,13 +526,11 @@ impl TransactionExecutionApi {
 
         // Resolve types against the objects the simulation wrote before falling back to
         // the store, so that packages published by the transaction itself are visible.
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        let written = InMemoryStorage::new(simulation.output_objects.values().cloned().collect());
         let mut layout_resolver =
             epoch_store
                 .executor()
                 .type_layout_resolver(Box::new(PackageStoreWithFallback::new(
-                    &written,
+                    &simulation.output_objects,
                     self.state.get_backing_package_store(),
                 )));
 
@@ -562,7 +586,7 @@ impl WriteApiServer for TransactionExecutionApi {
             .await
             .map_err(Error::from)?;
         let dev_inspect_results = self
-            .dev_inspect_transaction(sender, tx_kind, None, None, None, None, None, None)
+            .dev_inspect_transaction(sender, tx_kind, None, DevInspectArgs::default())
             .await?;
         Ok(
             IotaMoveViewCallResults::from_dev_inspect_results(self.clone(), dev_inspect_results)
@@ -581,23 +605,12 @@ impl WriteApiServer for TransactionExecutionApi {
         additional_args: Option<DevInspectArgs>,
     ) -> RpcResult<DevInspectResults> {
         async move {
-            let DevInspectArgs {
-                gas_sponsor,
-                gas_budget,
-                gas_objects,
-                show_raw_txn_data_and_effects,
-                skip_checks,
-            } = additional_args.unwrap_or_default();
             let tx_kind: TransactionKind = self.convert_bytes(tx_bytes)?;
             self.dev_inspect_transaction(
                 sender_address,
                 tx_kind,
                 gas_price.map(|i| *i),
-                gas_budget,
-                gas_sponsor,
-                gas_objects,
-                show_raw_txn_data_and_effects,
-                skip_checks,
+                additional_args.unwrap_or_default(),
             )
             .await
         }

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -31,7 +31,7 @@ use iota_sdk_types::{
 };
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
-    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
+    effects::{TransactionEffectsAPI, TransactionEffectsExt},
     execution_config_utils::to_binary_config,
     inner_temporary_store::{PackageStoreWithFallback, TemporaryModuleResolver},
     iota_serde::BigInt,
@@ -40,7 +40,7 @@ use iota_types::{
     },
     storage::PostExecutionPackageResolver,
     transaction::{InputObjectKind, TransactionData, TransactionDataAPI, TransactionEnvelope},
-    transaction_executor::VmChecks,
+    transaction_executor::{SimulateTransactionResult, VmChecks},
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
 use tracing::{Instrument, instrument};
@@ -351,19 +351,7 @@ impl TransactionExecutionApi {
             .map_err(Error::from)??
         };
 
-        // A transaction submitted without a gas payment is simulated against a mock gas
-        // coin, which the reported transaction input has to account for. Take the coin
-        // back out of the simulation's inputs rather than minting a second one, so the
-        // reported payment is the reference the simulation actually charged.
-        if let Some(mock_gas_id) = simulation.mock_gas_id {
-            let mock_gas = simulation.input_objects.get(&mock_gas_id).ok_or_else(|| {
-                Error::Unexpected(format!(
-                    "simulation minted mock gas coin {mock_gas_id} but did not report it as an input",
-                ))
-            })?;
-            txn_data.gas_data_mut().objects = vec![mock_gas.object_ref()];
-        }
-        Self::report_gas_used_as_budget(&mut txn_data, &simulation.effects);
+        Self::report_effective_gas(&mut txn_data, &simulation);
 
         let tx_digest = *simulation.effects.transaction_digest();
         // Resolve types against the objects the simulation wrote before falling back to
@@ -467,14 +455,23 @@ impl TransactionExecutionApi {
         .map_err(Error::from)?
     }
 
-    /// Report the gas the simulation charged in place of a zero gas budget.
+    /// Report the gas the simulation ran with, in place of whatever the caller
+    /// left unset.
     ///
-    /// A caller that declares no budget is asking what the transaction costs,
-    /// so echoing its own zero back tells it nothing. gRPC
-    /// `simulate_transactions` reports the cost in the same field.
-    fn report_gas_used_as_budget(transaction: &mut TransactionData, effects: &TransactionEffects) {
-        if transaction.gas_budget() == 0 {
-            transaction.gas_data_mut().budget = effects.gas_cost_summary().gas_used();
+    /// A zero budget asks what the transaction costs, so it comes back as the
+    /// gas charged rather than as the caller's own zero, which would say
+    /// nothing. The price it was charged at comes back too: only the
+    /// computation half of the cost scales with the price, so an estimate
+    /// cannot be read without it. gRPC `simulate_transactions` reports the
+    /// cost in the same field.
+    fn report_effective_gas(
+        transaction: &mut TransactionData,
+        simulation: &SimulateTransactionResult,
+    ) {
+        let estimating = transaction.gas_budget() == 0;
+        *transaction.gas_data_mut() = simulation.gas_data.clone();
+        if estimating {
+            transaction.gas_data_mut().budget = simulation.effects.gas_cost_summary().gas_used();
         }
     }
 
@@ -529,7 +526,7 @@ impl TransactionExecutionApi {
 
         let raw_txn_data = match reported_transaction.as_mut() {
             Some(transaction) => {
-                Self::report_gas_used_as_budget(transaction, &simulation.effects);
+                Self::report_effective_gas(transaction, &simulation);
                 bcs::to_bytes(transaction).map_err(|_| {
                     Error::Unexpected(
                         "Failed to serialize transaction during dev inspect".to_string(),

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -37,6 +37,7 @@ use iota_types::{
         CertifiedTransaction, DEFAULT_VALIDATOR_GAS_PRICE, SenderSignedTransactionAPI,
         TransactionDataAPI, TransactionEnvelope, VerifiedCertificate, VerifiedTransaction,
     },
+    transaction_executor::VmChecks,
 };
 
 use crate::{command::Component, mock_storage::InMemoryObjectStore};
@@ -148,12 +149,12 @@ impl SingleValidator {
     pub async fn execute_dry_run(&self, transaction: TransactionEnvelope) -> TransactionEffects {
         let effects = self
             .get_validator()
-            .dry_exec_transaction_for_benchmark(
+            .simulate_transaction_for_benchmark(
                 transaction.data().transaction().clone(),
-                *transaction.digest(),
+                VmChecks::Enabled,
             )
             .unwrap()
-            .2;
+            .effects;
         assert!(effects.status().is_success());
         effects
     }

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -167,20 +167,23 @@ mod checked {
         Ok((gas_status, input_objects.into_checked()))
     }
 
-    /// WARNING! This should only be used for the dev-inspect transaction. This
-    /// transaction type bypasses many of the normal object checks
+    /// WARNING! Only for simulating a transaction with
+    /// [`VmChecks::Disabled`](iota_types::transaction_executor::VmChecks::Disabled).
+    /// This bypasses many of the normal object checks. A simulation with
+    /// `VmChecks::Enabled` goes through [`check_transaction_input`] instead,
+    /// the same as a transaction bound for execution.
     #[instrument(level = "trace", skip_all)]
-    pub fn check_dev_inspect_input(
+    pub fn check_simulation_input(
         config: &ProtocolConfig,
         kind: &TransactionKind,
         input_objects: InputObjects,
-        // TODO: check ReceivingObjects for dev inspect?
+        // TODO: check ReceivingObjects when simulating?
         _receiving_objects: ReceivingObjects,
     ) -> IotaResult<CheckedInputObjects> {
         kind.validity_check(config)?;
         if kind.is_system() {
             return Err(UserInputError::Unsupported(format!(
-                "Transaction kind {kind} is not supported in dev-inspect"
+                "Transaction kind {kind} is not supported in a simulation"
             ))
             .into());
         }

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -103,10 +103,6 @@ pub trait TransactionalAdapter: Send + Sync + ReadStore {
         checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult>;
 
-    /// Reference gas price and maximum transaction gas budget of the current
-    /// epoch, used to fill in the gas payment a dev inspect leaves out.
-    async fn gas_price_and_max_budget(&self) -> IotaResult<(u64, u64)>;
-
     async fn query_tx_events_asc(
         &self,
         tx_digest: &TransactionDigest,
@@ -176,14 +172,6 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult> {
         self.fullnode.simulate_transaction(transaction, checks)
-    }
-
-    async fn gas_price_and_max_budget(&self) -> IotaResult<(u64, u64)> {
-        let epoch_store = self.fullnode.load_epoch_store_one_call_per_task();
-        Ok((
-            epoch_store.reference_gas_price(),
-            epoch_store.protocol_config().max_tx_gas(),
-        ))
     }
 
     async fn query_tx_events_asc(
@@ -430,13 +418,6 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult> {
         Simulacrum::simulate_transaction(self, transaction, checks)
-    }
-
-    async fn gas_price_and_max_budget(&self) -> IotaResult<(u64, u64)> {
-        Ok((
-            Simulacrum::reference_gas_price(self),
-            Simulacrum::max_tx_gas(self),
-        ))
     }
 
     async fn query_tx_events_asc(

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -18,10 +18,10 @@ use iota_core::authority::{
     authority_test_utils::send_and_confirm_transaction_with_execution_error,
 };
 use iota_json_rpc::authority_state::StateRead;
-use iota_json_rpc_types::{DevInspectResults, DryRunTransactionBlockResponse, EventFilter};
+use iota_json_rpc_types::EventFilter;
 use iota_sdk_types::{
     Address, CheckpointContentsDigest, CheckpointDigest, Event, ObjectId, TransactionDigest,
-    TransactionEffects, TransactionEvents, TransactionKind, checkpoint::CheckpointContents,
+    TransactionEffects, TransactionEvents, checkpoint::CheckpointContents,
 };
 use iota_storage::key_value_store::TransactionKeyValueStore;
 use iota_types::{
@@ -37,6 +37,7 @@ use iota_types::{
     object::Object,
     storage::{ObjectStore, ReadStore},
     transaction::{InputObjects, SenderSignedTransactionAPI, TransactionData, TransactionEnvelope},
+    transaction_executor::{SimulateTransactionResult, VmChecks},
 };
 pub use move_transactional_test_runner::framework::{
     create_adapter, run_tasks_with_adapter, run_test_impl,
@@ -96,18 +97,13 @@ pub trait TransactionalAdapter: Send + Sync + ReadStore {
         amount: u64,
     ) -> anyhow::Result<TransactionEffects>;
 
-    async fn dry_run_transaction_block(
+    async fn simulate_transaction(
         &self,
-        transaction_block: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> IotaResult<DryRunTransactionBlockResponse>;
+        transaction: TransactionData,
+        checks: VmChecks,
+    ) -> IotaResult<SimulateTransactionResult>;
 
-    async fn dev_inspect_transaction_block(
-        &self,
-        sender: Address,
-        transaction_kind: TransactionKind,
-        gas_price: Option<u64>,
-    ) -> IotaResult<DevInspectResults>;
+    async fn reference_gas_price(&self) -> IotaResult<u64>;
 
     async fn query_tx_events_asc(
         &self,
@@ -172,34 +168,19 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         Ok((effects, error))
     }
 
-    async fn dry_run_transaction_block(
+    async fn simulate_transaction(
         &self,
-        transaction_block: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> IotaResult<DryRunTransactionBlockResponse> {
-        self.fullnode
-            .dry_exec_transaction(transaction_block, transaction_digest)
-            .map(|result| result.0)
+        transaction: TransactionData,
+        checks: VmChecks,
+    ) -> IotaResult<SimulateTransactionResult> {
+        self.fullnode.simulate_transaction(transaction, checks)
     }
 
-    async fn dev_inspect_transaction_block(
-        &self,
-        sender: Address,
-        transaction_kind: TransactionKind,
-        gas_price: Option<u64>,
-    ) -> IotaResult<DevInspectResults> {
-        self.fullnode
-            .dev_inspect_transaction_block(
-                sender,
-                transaction_kind,
-                gas_price,
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
-            .await
+    async fn reference_gas_price(&self) -> IotaResult<u64> {
+        Ok(self
+            .fullnode
+            .load_epoch_store_one_call_per_task()
+            .reference_gas_price())
     }
 
     async fn query_tx_events_asc(
@@ -440,21 +421,16 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         unimplemented!("prepare_txn not supported in simulator mode")
     }
 
-    async fn dev_inspect_transaction_block(
+    async fn simulate_transaction(
         &self,
-        _sender: Address,
-        _transaction_kind: TransactionKind,
-        _gas_price: Option<u64>,
-    ) -> IotaResult<DevInspectResults> {
-        unimplemented!("dev_inspect_transaction_block not supported in simulator mode")
+        _transaction: TransactionData,
+        _checks: VmChecks,
+    ) -> IotaResult<SimulateTransactionResult> {
+        unimplemented!("simulate_transaction not supported in simulator mode")
     }
 
-    async fn dry_run_transaction_block(
-        &self,
-        _transaction_block: TransactionData,
-        _transaction_digest: TransactionDigest,
-    ) -> IotaResult<DryRunTransactionBlockResponse> {
-        unimplemented!("dry_run_transaction_block not supported in simulator mode")
+    async fn reference_gas_price(&self) -> IotaResult<u64> {
+        Ok(self.reference_gas_price())
     }
 
     async fn query_tx_events_asc(

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -430,7 +430,7 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
     }
 
     async fn reference_gas_price(&self) -> IotaResult<u64> {
-        Ok(self.reference_gas_price())
+        Ok(Simulacrum::reference_gas_price(self))
     }
 
     async fn query_tx_events_asc(

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -103,7 +103,9 @@ pub trait TransactionalAdapter: Send + Sync + ReadStore {
         checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult>;
 
-    async fn reference_gas_price(&self) -> IotaResult<u64>;
+    /// Reference gas price and maximum transaction gas budget of the current
+    /// epoch, used to fill in the gas payment a dev inspect leaves out.
+    async fn gas_price_and_max_budget(&self) -> IotaResult<(u64, u64)>;
 
     async fn query_tx_events_asc(
         &self,
@@ -176,11 +178,12 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         self.fullnode.simulate_transaction(transaction, checks)
     }
 
-    async fn reference_gas_price(&self) -> IotaResult<u64> {
-        Ok(self
-            .fullnode
-            .load_epoch_store_one_call_per_task()
-            .reference_gas_price())
+    async fn gas_price_and_max_budget(&self) -> IotaResult<(u64, u64)> {
+        let epoch_store = self.fullnode.load_epoch_store_one_call_per_task();
+        Ok((
+            epoch_store.reference_gas_price(),
+            epoch_store.protocol_config().max_tx_gas(),
+        ))
     }
 
     async fn query_tx_events_asc(
@@ -423,14 +426,17 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
 
     async fn simulate_transaction(
         &self,
-        _transaction: TransactionData,
-        _checks: VmChecks,
+        transaction: TransactionData,
+        checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult> {
-        unimplemented!("simulate_transaction not supported in simulator mode")
+        Simulacrum::simulate_transaction(self, transaction, checks)
     }
 
-    async fn reference_gas_price(&self) -> IotaResult<u64> {
-        Ok(Simulacrum::reference_gas_price(self))
+    async fn gas_price_and_max_budget(&self) -> IotaResult<(u64, u64)> {
+        Ok((
+            Simulacrum::reference_gas_price(self),
+            Simulacrum::max_tx_gas(self),
+        ))
     }
 
     async fn query_tx_events_asc(

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -23,17 +23,17 @@ use iota_core::authority::{AuthorityState, test_authority_builder::TestAuthority
 use iota_framework::DEFAULT_FRAMEWORK_PATH;
 use iota_json_rpc_api::QUERY_MAX_RESULT_LIMIT;
 use iota_json_rpc_types::{
-    DevInspectResults, DryRunTransactionBlockResponse, IotaExecutionStatus,
-    IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, IotaTransactionBlockEvents,
+    IotaExecutionStatus, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
 };
 use iota_node_storage::GrpcStateReader;
 use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::{
     Address, Argument, CheckpointContentsDigest, CheckpointDigest, Command, ConsensusCommitDigest,
-    Event, ExecutionStatus, Identifier, MoveAuthenticatorV1, ObjectData, ObjectId, ObjectReference,
-    ProgrammableTransaction, RandomnessRound, TransactionDigest, TransactionEffects,
-    TransactionEvents, TransactionKind, TypeTag, UserSignature, Version,
-    checkpoint::CheckpointContents, gas::GasCostSummary, move_package::MovePackage,
+    Event, ExecutionStatus, GasPayment, Identifier, MoveAuthenticatorV1, ObjectData, ObjectId,
+    ObjectReference, ProgrammableTransaction, RandomnessRound, TransactionDigest,
+    TransactionEffects, TransactionEvents, TransactionExpiration, TransactionKind, TransactionV1,
+    TypeTag, UserSignature, Version, checkpoint::CheckpointContents, gas::GasCostSummary,
+    move_package::MovePackage,
 };
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
@@ -57,6 +57,7 @@ use iota_types::{
         CallArg, SenderSignedTransactionAPI, TransactionData, TransactionDataAPI,
         TransactionEnvelope, VerifiedTransaction,
     },
+    transaction_executor::{SimulateTransactionResult, VmChecks},
     utils::{
         to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,
         to_sender_signed_transaction_with_optional_sponsor,
@@ -168,6 +169,9 @@ pub struct IotaTestAdapter {
     digest_enumeration: BTreeMap<u64, TransactionDigest>,
     next_fake: (u64, u64),
     gas_price: u64,
+    /// Mirror of the active protocol config's `max_tx_gas`, used as the gas
+    /// budget for dev inspect, where a budget cannot be given explicitly.
+    max_tx_gas: u64,
     /// Mirror of the active protocol config's
     /// `package_metadata_with_dynamic_module_metadata` feature flag: when set,
     /// published modules receive V2 (dynamic) runtime metadata, otherwise V1.
@@ -430,6 +434,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
             next_fake: (0, 0),
             // TODO: make this configurable
             gas_price: default_gas_price.unwrap_or(DEFAULT_GAS_PRICE),
+            max_tx_gas: protocol_config.max_tx_gas(),
             dynamic_module_metadata: protocol_config
                 .package_metadata_with_dynamic_module_metadata(),
             staged_modules: BTreeMap::new(),
@@ -1917,16 +1922,11 @@ impl IotaTestAdapter {
     }
 
     async fn dry_run(&mut self, transaction: TransactionData) -> anyhow::Result<TxnSummary> {
-        let digest = transaction.digest();
-        let results = self
+        let result = self
             .executor
-            .dry_run_transaction_block(transaction, digest)
+            .simulate_transaction(transaction, VmChecks::Enabled)
             .await?;
-        let DryRunTransactionBlockResponse {
-            effects, events, ..
-        } = results;
-
-        self.tx_summary_from_effects(effects, events)
+        self.tx_summary_from_simulation(result)
     }
 
     async fn dev_inspect(
@@ -1935,21 +1935,34 @@ impl IotaTestAdapter {
         transaction_kind: TransactionKind,
         gas_price: Option<u64>,
     ) -> anyhow::Result<TxnSummary> {
-        let results = self
+        let price = match gas_price {
+            Some(price) => price,
+            None => self.executor.reference_gas_price().await?,
+        };
+        let transaction = TransactionData::V1(TransactionV1 {
+            kind: transaction_kind,
+            sender,
+            gas_payment: GasPayment {
+                objects: vec![],
+                owner: sender,
+                price,
+                budget: self.max_tx_gas,
+            },
+            expiration: TransactionExpiration::None,
+        });
+        let result = self
             .executor
-            .dev_inspect_transaction_block(sender, transaction_kind, gas_price)
+            .simulate_transaction(transaction, VmChecks::Disabled)
             .await?;
-        let DevInspectResults {
-            effects, events, ..
-        } = results;
-        self.tx_summary_from_effects(effects, events)
+        self.tx_summary_from_simulation(result)
     }
 
-    fn tx_summary_from_effects(
+    fn tx_summary_from_simulation(
         &mut self,
-        effects: IotaTransactionBlockEffects,
-        events: IotaTransactionBlockEvents,
+        result: SimulateTransactionResult,
     ) -> anyhow::Result<TxnSummary> {
+        let events = result.events.unwrap_or_default().0;
+        let effects: IotaTransactionBlockEffects = result.effects.try_into()?;
         if let IotaExecutionStatus::Failure { error } = effects.status() {
             bail!(self.stabilize_str(format!(
                 "Transaction Effects Status: {error}\nExecution Error: {error}",
@@ -1991,12 +2004,6 @@ impl IotaTestAdapter {
         deleted_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
         unwrapped_then_deleted_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
         wrapped_ids.sort_by_key(|id| self.real_to_fake_object_id(id));
-
-        let events = events
-            .data
-            .into_iter()
-            .map(|iota_event| iota_event.into())
-            .collect();
 
         Ok(TxnSummary {
             events,

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -169,9 +169,6 @@ pub struct IotaTestAdapter {
     digest_enumeration: BTreeMap<u64, TransactionDigest>,
     next_fake: (u64, u64),
     gas_price: u64,
-    /// Mirror of the active protocol config's `max_tx_gas`, used as the gas
-    /// budget for dev inspect, where a budget cannot be given explicitly.
-    max_tx_gas: u64,
     /// Mirror of the active protocol config's
     /// `package_metadata_with_dynamic_module_metadata` feature flag: when set,
     /// published modules receive V2 (dynamic) runtime metadata, otherwise V1.
@@ -434,7 +431,6 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
             next_fake: (0, 0),
             // TODO: make this configurable
             gas_price: default_gas_price.unwrap_or(DEFAULT_GAS_PRICE),
-            max_tx_gas: protocol_config.max_tx_gas(),
             dynamic_module_metadata: protocol_config
                 .package_metadata_with_dynamic_module_metadata(),
             staged_modules: BTreeMap::new(),
@@ -1935,18 +1931,15 @@ impl IotaTestAdapter {
         transaction_kind: TransactionKind,
         gas_price: Option<u64>,
     ) -> anyhow::Result<TxnSummary> {
-        let price = match gas_price {
-            Some(price) => price,
-            None => self.executor.reference_gas_price().await?,
-        };
+        let (reference_gas_price, max_tx_gas) = self.executor.gas_price_and_max_budget().await?;
         let transaction = TransactionData::V1(TransactionV1 {
             kind: transaction_kind,
             sender,
             gas_payment: GasPayment {
                 objects: vec![],
                 owner: sender,
-                price,
-                budget: self.max_tx_gas,
+                price: gas_price.unwrap_or(reference_gas_price),
+                budget: max_tx_gas,
             },
             expiration: TransactionExpiration::None,
         });

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -1931,15 +1931,16 @@ impl IotaTestAdapter {
         transaction_kind: TransactionKind,
         gas_price: Option<u64>,
     ) -> anyhow::Result<TxnSummary> {
-        let (reference_gas_price, max_tx_gas) = self.executor.gas_price_and_max_budget().await?;
         let transaction = TransactionData::V1(TransactionV1 {
             kind: transaction_kind,
             sender,
             gas_payment: GasPayment {
+                // The simulation fills all of this in: an empty payment gets a mock gas
+                // coin, and a zero price or budget gets the epoch's defaults.
                 objects: vec![],
                 owner: sender,
-                price: gas_price.unwrap_or(reference_gas_price),
-                budget: max_tx_gas,
+                price: gas_price.unwrap_or_default(),
+                budget: 0,
             },
             expiration: TransactionExpiration::None,
         });

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -175,26 +175,27 @@ pub mod checked {
 
     /// Reports the gas a simulation ran with in `reported`, in place of what
     /// the caller left unset — the mirror of
-    /// [`fill_in_unset_simulation_gas`], for the response rather than the
-    /// run.
+    /// [`fill_in_unset_simulation_gas`], for the response rather than the run.
+    ///
+    /// Everything the simulation resolved comes back: the price it charged at,
+    /// because only the computation half of the cost scales with the price and
+    /// the estimate cannot be read without it; and the gas payment, so that a
+    /// caller who sent none learns the mock gas coin the run actually charged
+    /// gas to, which the effects otherwise refer to without naming.
     ///
     /// A zero budget asks what the transaction costs, so it comes back as
     /// `gas_used` rather than as the caller's own zero, which would say
-    /// nothing. The price comes back too: only the computation half of the
-    /// cost scales with the price, so the estimate cannot be read without
-    /// it.
-    ///
-    /// The gas payment is left alone, because a mock gas coin is not reported
-    /// the same way by every API — the JSON-RPC response carries it in the
-    /// payment, while gRPC reports it separately — so that is the caller's
-    /// call.
+    /// nothing. Note what that costs: `gas_used` is not the budget the run
+    /// metered against, so a transaction reported this way does not hash to the
+    /// digest the effects are keyed by. Anything else leaves the caller no way
+    /// to read the estimate, and a simulated transaction is not submittable in
+    /// any case.
     pub fn report_simulation_gas(reported: &mut GasPayment, simulated: &GasPayment, gas_used: u64) {
-        reported.price = simulated.price;
-        reported.budget = if reported.budget == 0 {
-            gas_used
-        } else {
-            simulated.budget
-        };
+        let estimating = reported.budget == 0;
+        *reported = simulated.clone();
+        if estimating {
+            reported.budget = gas_used;
+        }
     }
 
     /// Checks that every object `gas` refers to is an address-owned gas coin

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -8,16 +8,18 @@ pub use checked::*;
 #[iota_macros::with_checked_arithmetic]
 pub mod checked {
 
+    use std::collections::HashSet;
+
     use enum_dispatch::enum_dispatch;
     use iota_protocol_config::ProtocolConfig;
-    use iota_sdk_types::gas::GasCostSummary;
+    use iota_sdk_types::{ObjectReference, gas::GasCostSummary};
 
     use crate::{
         ObjectId,
         error::{ExecutionError, IotaResult, UserInputError, UserInputResult},
         gas_model::{gas_v1::IotaGasStatus as IotaGasStatusV1, tables::GasStatus},
         object::{MoveStructExt, Object},
-        transaction::ObjectReadResult,
+        transaction::{InputObjects, ObjectReadResult},
     };
 
     #[enum_dispatch]
@@ -144,5 +146,20 @@ pub mod checked {
                 object_id: gas_object.id(),
             })
         }
+    }
+
+    /// Combined balance of the gas coins `gas` refers to.
+    ///
+    /// Anything `gas` names that `input_objects` does not hold, or that is not
+    /// a gas coin, contributes nothing, since the gas checks report those
+    /// cases themselves.
+    pub fn gas_coins_balance(input_objects: &InputObjects, gas: &[ObjectReference]) -> u128 {
+        let gas_ids: HashSet<_> = gas.iter().map(|gas_ref| gas_ref.object_id).collect();
+        input_objects
+            .iter()
+            .filter(|object| gas_ids.contains(&object.id()))
+            .filter_map(|object| object.as_object())
+            .filter_map(|object| get_gas_balance(object).ok())
+            .fold(0u128, |total, balance| total + balance as u128)
     }
 }

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -8,7 +8,7 @@ pub use checked::*;
 #[iota_macros::with_checked_arithmetic]
 pub mod checked {
 
-    use std::collections::HashSet;
+    use std::collections::HashMap;
 
     use enum_dispatch::enum_dispatch;
     use iota_protocol_config::ProtocolConfig;
@@ -148,21 +148,53 @@ pub mod checked {
         }
     }
 
-    /// Combined balance of the gas coins `gas` refers to.
+    /// Checks that every object `gas` refers to is an address-owned gas coin
+    /// present in `input_objects`, and that their combined balance covers
+    /// `gas_budget`.
     ///
-    /// Anything `gas` names that `input_objects` does not hold, or that is not
-    /// a gas coin, contributes nothing rather than being reported as the
-    /// missing or invalid gas object it is. A caller comparing the result
-    /// against a budget therefore reports those inputs as too low a balance.
-    /// This is only for callers that skip the full gas checks, which do tell
-    /// the cases apart; anything else should go through those instead.
-    pub fn gas_coins_balance(input_objects: &InputObjects, gas: &[ObjectReference]) -> u128 {
-        let gas_ids: HashSet<_> = gas.iter().map(|gas_ref| gas_ref.object_id).collect();
-        input_objects
+    /// This is [`IotaGasStatus::check_gas_balance`] without the bounds on the
+    /// budget itself, for a simulation that skips the gas checks: it still has
+    /// to reject gas the engine cannot take the budget from, because
+    /// `GasCharger::smash_gas` treats the input checks as having guaranteed
+    /// that and panics rather than returning an error. It deliberately does not
+    /// bound the budget, which a simulation leaves to metering, so a caller
+    /// probing with a small budget runs out of gas instead of being rejected.
+    pub fn check_gas_coins_cover_budget(
+        input_objects: &InputObjects,
+        gas: &[ObjectReference],
+        gas_budget: u64,
+    ) -> UserInputResult {
+        let objects: HashMap<_, _> = input_objects
             .iter()
-            .filter(|object| gas_ids.contains(&object.id()))
-            .filter_map(|object| object.as_object())
-            .filter_map(|object| get_gas_balance(object).ok())
-            .fold(0u128, |total, balance| total + balance as u128)
+            .map(|object| (object.id(), object))
+            .collect();
+
+        let mut gas_balance = 0u128;
+        for gas_ref in gas {
+            let read = objects
+                .get(&gas_ref.object_id)
+                .ok_or(UserInputError::ObjectNotFound {
+                    object_id: gas_ref.object_id,
+                    version: Some(gas_ref.version),
+                })?;
+            // `as_object` returning `None` means the object was deleted, which makes
+            // it a shared one, and gas cannot be shared.
+            let object = read.as_object().ok_or(UserInputError::MissingGasPayment)?;
+            if !object.is_address_owned() {
+                return Err(UserInputError::GasObjectNotOwnedObject {
+                    owner: object.owner,
+                });
+            }
+            gas_balance += get_gas_balance(object)? as u128;
+        }
+
+        if gas_balance < gas_budget as u128 {
+            return Err(UserInputError::GasBalanceTooLow {
+                gas_balance,
+                needed_gas_amount: gas_budget as u128,
+            });
+        }
+
+        Ok(())
     }
 }

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -19,7 +19,7 @@ pub mod checked {
         error::{ExecutionError, IotaResult, UserInputError, UserInputResult},
         gas_model::{gas_v1::IotaGasStatus as IotaGasStatusV1, tables::GasStatus},
         object::{MoveStructExt, Object},
-        transaction::{InputObjects, ObjectReadResult},
+        transaction::{InputObjects, ObjectReadResult, TransactionData, TransactionDataAPI},
     };
 
     #[enum_dispatch]
@@ -145,6 +145,31 @@ pub mod checked {
             Err(UserInputError::InvalidGasObject {
                 object_id: gas_object.id(),
             })
+        }
+    }
+
+    /// Fills in the gas a simulated transaction leaves unset: a zero price
+    /// becomes `reference_gas_price`, and a zero budget the protocol maximum.
+    ///
+    /// Nobody submits a simulation to pay for it, and neither zero is a value
+    /// the gas checks could accept anyway — a zero price is below the reference
+    /// gas price, and a zero budget cannot cover any computation. Gas the
+    /// caller does declare is left alone and metered as given, so a dry run
+    /// still rejects the gas a validator would.
+    ///
+    /// A zero budget becomes the protocol maximum rather than what the gas
+    /// coins hold: a budget equal to the whole balance would leave nothing
+    /// for a transaction that also pays out of its gas coin.
+    pub fn fill_in_unset_simulation_gas(
+        transaction: &mut TransactionData,
+        reference_gas_price: u64,
+        protocol_config: &ProtocolConfig,
+    ) {
+        if transaction.gas_price() == 0 {
+            transaction.gas_data_mut().price = reference_gas_price;
+        }
+        if transaction.gas_budget() == 0 {
+            transaction.gas_data_mut().budget = protocol_config.max_tx_gas();
         }
     }
 

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -12,7 +12,7 @@ pub mod checked {
 
     use enum_dispatch::enum_dispatch;
     use iota_protocol_config::ProtocolConfig;
-    use iota_sdk_types::{ObjectReference, gas::GasCostSummary};
+    use iota_sdk_types::{GasPayment, ObjectReference, gas::GasCostSummary};
 
     use crate::{
         ObjectId,
@@ -171,6 +171,30 @@ pub mod checked {
         if transaction.gas_budget() == 0 {
             transaction.gas_data_mut().budget = protocol_config.max_tx_gas();
         }
+    }
+
+    /// Reports the gas a simulation ran with in `reported`, in place of what
+    /// the caller left unset — the mirror of
+    /// [`fill_in_unset_simulation_gas`], for the response rather than the
+    /// run.
+    ///
+    /// A zero budget asks what the transaction costs, so it comes back as
+    /// `gas_used` rather than as the caller's own zero, which would say
+    /// nothing. The price comes back too: only the computation half of the
+    /// cost scales with the price, so the estimate cannot be read without
+    /// it.
+    ///
+    /// The gas payment is left alone, because a mock gas coin is not reported
+    /// the same way by every API — the JSON-RPC response carries it in the
+    /// payment, while gRPC reports it separately — so that is the caller's
+    /// call.
+    pub fn report_simulation_gas(reported: &mut GasPayment, simulated: &GasPayment, gas_used: u64) {
+        reported.price = simulated.price;
+        reported.budget = if reported.budget == 0 {
+            gas_used
+        } else {
+            simulated.budget
+        };
     }
 
     /// Checks that every object `gas` refers to is an address-owned gas coin

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -151,8 +151,11 @@ pub mod checked {
     /// Combined balance of the gas coins `gas` refers to.
     ///
     /// Anything `gas` names that `input_objects` does not hold, or that is not
-    /// a gas coin, contributes nothing, since the gas checks report those
-    /// cases themselves.
+    /// a gas coin, contributes nothing rather than being reported as the
+    /// missing or invalid gas object it is. A caller comparing the result
+    /// against a budget therefore reports those inputs as too low a balance.
+    /// This is only for callers that skip the full gas checks, which do tell
+    /// the cases apart; anything else should go through those instead.
     pub fn gas_coins_balance(input_objects: &InputObjects, gas: &[ObjectReference]) -> u128 {
         let gas_ids: HashSet<_> = gas.iter().map(|gas_ref| gas_ref.object_id).collect();
         input_objects

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -149,7 +149,8 @@ pub mod checked {
     }
 
     /// Fills in the gas a simulated transaction leaves unset: a zero price
-    /// becomes `reference_gas_price`, and a zero budget the protocol maximum.
+    /// becomes `reference_gas_price`, and a zero budget as much as the gas
+    /// coins can back, up to the protocol maximum.
     ///
     /// Nobody submits a simulation to pay for it, and neither zero is a value
     /// the gas checks could accept anyway — a zero price is below the reference
@@ -157,11 +158,23 @@ pub mod checked {
     /// caller does declare is left alone and metered as given, so a dry run
     /// still rejects the gas a validator would.
     ///
-    /// A zero budget becomes the protocol maximum rather than what the gas
-    /// coins hold: a budget equal to the whole balance would leave nothing
-    /// for a transaction that also pays out of its gas coin.
+    /// The budget is capped at the gas coins' combined balance rather than left
+    /// at the protocol maximum, so that coins holding less than `max_tx_gas`
+    /// still produce an estimate instead of being rejected for not covering a
+    /// budget the caller never asked for. Execution keeps the whole budget off
+    /// limits inside the programmable transaction and refunds it afterwards, so
+    /// the cap costs a transaction that also pays out of its gas coin the room
+    /// to do so — but only where the balance is under `max_tx_gas`, which is
+    /// where the alternative was to reject it outright. Such a caller has to
+    /// name a budget it can cover, exactly as a real transaction would.
+    ///
+    /// The cap is raised back to the minimum budget a transaction may declare
+    /// when the balance falls below it, so a balance too small to transact at
+    /// all is still reported against the balance by the gas checks, rather than
+    /// against a budget the caller never set.
     pub fn fill_in_unset_simulation_gas(
         transaction: &mut TransactionData,
+        input_objects: &InputObjects,
         reference_gas_price: u64,
         protocol_config: &ProtocolConfig,
     ) {
@@ -169,8 +182,35 @@ pub mod checked {
             transaction.gas_data_mut().price = reference_gas_price;
         }
         if transaction.gas_budget() == 0 {
-            transaction.gas_data_mut().budget = protocol_config.max_tx_gas();
+            // The minimum budget scales with the price, so it is read after the
+            // price above has been filled in.
+            let min_gas_budget = protocol_config
+                .base_tx_cost_fixed()
+                .saturating_mul(transaction.gas_price());
+            let gas_balance = gas_coins_balance(input_objects, transaction.gas());
+            let budget = std::cmp::min(protocol_config.max_tx_gas() as u128, gas_balance)
+                .max(min_gas_budget as u128);
+            transaction.gas_data_mut().budget = budget as u64;
         }
+    }
+
+    /// Sums the balance of the gas coins `gas` refers to among `input_objects`.
+    ///
+    /// Anything that is not a gas coin present in `input_objects` contributes
+    /// nothing, rather than being reported here: the gas checks run over the
+    /// same coins straight after and name the offending object, which is more
+    /// use than a balance that came out short.
+    fn gas_coins_balance(input_objects: &InputObjects, gas: &[ObjectReference]) -> u128 {
+        let objects: HashMap<_, _> = input_objects
+            .iter()
+            .map(|object| (object.id(), object))
+            .collect();
+
+        gas.iter()
+            .filter_map(|gas_ref| objects.get(&gas_ref.object_id)?.as_object())
+            .filter_map(|object| get_gas_balance(object).ok())
+            .map(u128::from)
+            .sum()
     }
 
     /// Reports the gas a simulation ran with in `reported`, in place of what

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -151,27 +151,6 @@ pub mod checked {
     /// Fills in the gas a simulated transaction leaves unset: a zero price
     /// becomes `reference_gas_price`, and a zero budget as much as the gas
     /// coins can back, up to the protocol maximum.
-    ///
-    /// Nobody submits a simulation to pay for it, and neither zero is a value
-    /// the gas checks could accept anyway — a zero price is below the reference
-    /// gas price, and a zero budget cannot cover any computation. Gas the
-    /// caller does declare is left alone and metered as given, so a dry run
-    /// still rejects the gas a validator would.
-    ///
-    /// The budget is capped at the gas coins' combined balance rather than left
-    /// at the protocol maximum, so that coins holding less than `max_tx_gas`
-    /// still produce an estimate instead of being rejected for not covering a
-    /// budget the caller never asked for. Execution keeps the whole budget off
-    /// limits inside the programmable transaction and refunds it afterwards, so
-    /// the cap costs a transaction that also pays out of its gas coin the room
-    /// to do so — but only where the balance is under `max_tx_gas`, which is
-    /// where the alternative was to reject it outright. Such a caller has to
-    /// name a budget it can cover, exactly as a real transaction would.
-    ///
-    /// The cap is raised back to the minimum budget a transaction may declare
-    /// when the balance falls below it, so a balance too small to transact at
-    /// all is still reported against the balance by the gas checks, rather than
-    /// against a budget the caller never set.
     pub fn fill_in_unset_simulation_gas(
         transaction: &mut TransactionData,
         input_objects: &InputObjects,
@@ -182,24 +161,29 @@ pub mod checked {
             transaction.gas_data_mut().price = reference_gas_price;
         }
         if transaction.gas_budget() == 0 {
-            // The minimum budget scales with the price, so it is read after the
-            // price above has been filled in.
             let min_gas_budget = protocol_config
                 .base_tx_cost_fixed()
                 .saturating_mul(transaction.gas_price());
+
+            // The gas budget is capped at the gas coins' combined balance rather than left
+            // at the protocol maximum, so that coins holding less than `max_tx_gas`
+            // still produce an estimate instead of being rejected for not covering a
+            // budget the caller never asked for.
             let gas_balance = gas_coins_balance(input_objects, transaction.gas());
+
+            // The cap is raised back to the minimum budget a transaction may declare
+            // when the balance falls below it, so a balance too small to transact at
+            // all is still reported against the balance by the gas checks, rather than
+            // against a budget the caller never set.
             let budget = std::cmp::min(protocol_config.max_tx_gas() as u128, gas_balance)
                 .max(min_gas_budget as u128);
+
             transaction.gas_data_mut().budget = budget as u64;
         }
     }
 
-    /// Sums the balance of the gas coins `gas` refers to among `input_objects`.
-    ///
-    /// Anything that is not a gas coin present in `input_objects` contributes
-    /// nothing, rather than being reported here: the gas checks run over the
-    /// same coins straight after and name the offending object, which is more
-    /// use than a balance that came out short.
+    /// Sums the balance of the gas coins `gas` refers to among `input_objects`
+    /// and skips all non-gas coins.
     fn gas_coins_balance(input_objects: &InputObjects, gas: &[ObjectReference]) -> u128 {
         let objects: HashMap<_, _> = input_objects
             .iter()
@@ -214,22 +198,16 @@ pub mod checked {
     }
 
     /// Reports the gas a simulation ran with in `reported`, in place of what
-    /// the caller left unset — the mirror of
-    /// [`fill_in_unset_simulation_gas`], for the response rather than the run.
-    ///
-    /// Everything the simulation resolved comes back: the price it charged at,
-    /// because only the computation half of the cost scales with the price and
-    /// the estimate cannot be read without it; and the gas payment, so that a
-    /// caller who sent none learns the mock gas coin the run actually charged
-    /// gas to, which the effects otherwise refer to without naming.
+    /// the caller left unset — the mirror of [`fill_in_unset_simulation_gas`],
+    /// for the response rather than the run.
     ///
     /// A zero budget asks what the transaction costs, so it comes back as
     /// `gas_used` rather than as the caller's own zero, which would say
-    /// nothing. Note what that costs: `gas_used` is not the budget the run
+    /// nothing.
+    ///
+    /// Note what that costs: `gas_used` is not the budget the run
     /// metered against, so a transaction reported this way does not hash to the
-    /// digest the effects are keyed by. Anything else leaves the caller no way
-    /// to read the estimate, and a simulated transaction is not submittable in
-    /// any case.
+    /// digest the effects are keyed by.
     pub fn report_simulation_gas(reported: &mut GasPayment, simulated: &GasPayment, gas_used: u64) {
         let estimating = reported.budget == 0;
         *reported = simulated.clone();
@@ -241,15 +219,7 @@ pub mod checked {
     /// Checks that every object `gas` refers to is an address-owned gas coin
     /// present in `input_objects`, and that their combined balance covers
     /// `gas_budget`.
-    ///
-    /// This is [`IotaGasStatus::check_gas_balance`] without the bounds on the
-    /// budget itself, for a simulation that skips the gas checks: it still has
-    /// to reject gas the engine cannot take the budget from, because
-    /// `GasCharger::smash_gas` treats the input checks as having guaranteed
-    /// that and panics rather than returning an error. It deliberately does not
-    /// bound the budget, which a simulation leaves to metering, so a caller
-    /// probing with a small budget runs out of gas instead of being rejected.
-    pub fn check_gas_coins_cover_budget(
+    pub fn check_gas_coins_cover_budget_in_simulation(
         input_objects: &InputObjects,
         gas: &[ObjectReference],
         gas_budget: u64,

--- a/crates/iota-types/src/gas_model/gas_v1.rs
+++ b/crates/iota-types/src/gas_model/gas_v1.rs
@@ -303,6 +303,9 @@ mod checked {
         // 1. Gas object has an address owner.
         // 2. Gas budget is between min and max budget allowed
         // 3. Gas balance (all gas coins together) is bigger or equal to budget
+        //
+        // Keep the three checks together: it is only sound because step 1 has already
+        // rejected every gas object that `as_object` returns `None` for.
         pub(crate) fn check_gas_balance(
             &self,
             gas_objs: &[&ObjectReadResult],

--- a/crates/iota-types/src/inner_temporary_store.rs
+++ b/crates/iota-types/src/inner_temporary_store.rs
@@ -95,15 +95,19 @@ impl InnerTemporaryStore {
     }
 }
 
+/// Resolves modules out of a set of objects written by an execution, falling
+/// back to `fallback` for modules the execution did not write.
 pub struct TemporaryModuleResolver<'a, R> {
-    temp_store: &'a InnerTemporaryStore,
+    written: &'a WrittenObjects,
+    binary_config: BinaryConfig,
     fallback: R,
 }
 
 impl<'a, R> TemporaryModuleResolver<'a, R> {
-    pub fn new(temp_store: &'a InnerTemporaryStore, fallback: R) -> Self {
+    pub fn new(written: &'a WrittenObjects, binary_config: BinaryConfig, fallback: R) -> Self {
         Self {
-            temp_store,
+            written,
+            binary_config,
             fallback,
         }
     }
@@ -117,15 +121,12 @@ where
     type Item = Arc<CompiledModule>;
 
     fn get_module_by_id(&self, id: &ModuleId) -> anyhow::Result<Option<Self::Item>, Self::Error> {
-        let obj = self
-            .temp_store
-            .written
-            .get(&ObjectId::new(id.address().into_bytes()));
+        let obj = self.written.get(&ObjectId::new(id.address().into_bytes()));
         if let Some(o) = obj {
             if let Some(p) = o.data.as_opt_package() {
                 return Ok(Some(Arc::new(p.deserialize_module(
                     &identifier_core_to_sdk(id.name()),
-                    &self.temp_store.binary_config,
+                    &self.binary_config,
                 )?)));
             }
         }

--- a/crates/iota-types/src/inner_temporary_store.rs
+++ b/crates/iota-types/src/inner_temporary_store.rs
@@ -147,11 +147,6 @@ impl BackingPackageStore for InnerTemporaryStore {
 /// Resolves packages out of a map of objects, so that a caller holding only an
 /// execution's inputs or outputs — rather than the whole
 /// [`InnerTemporaryStore`] — can use them as a package store.
-///
-/// A wrapper rather than an impl on the map itself: [`WrittenObjects`] and
-/// [`ObjectMap`] are both aliases for the same `BTreeMap`, so implementing the
-/// trait on either would turn every map of that shape in the tree into a
-/// package store.
 pub struct ObjectMapPackageStore<'a>(pub &'a ObjectMap);
 
 impl BackingPackageStore for ObjectMapPackageStore<'_> {

--- a/crates/iota-types/src/inner_temporary_store.rs
+++ b/crates/iota-types/src/inner_temporary_store.rs
@@ -144,15 +144,19 @@ impl BackingPackageStore for InnerTemporaryStore {
     }
 }
 
-/// Resolves packages out of a map of objects, so that callers holding only an
+/// Resolves packages out of a map of objects, so that a caller holding only an
 /// execution's inputs or outputs — rather than the whole
 /// [`InnerTemporaryStore`] — can use them as a package store.
 ///
-/// [`WrittenObjects`] and [`ObjectMap`] are the same type, so this one impl
-/// serves both.
-impl BackingPackageStore for WrittenObjects {
+/// A wrapper rather than an impl on the map itself: [`WrittenObjects`] and
+/// [`ObjectMap`] are both aliases for the same `BTreeMap`, so implementing the
+/// trait on either would turn every map of that shape in the tree into a
+/// package store.
+pub struct ObjectMapPackageStore<'a>(pub &'a ObjectMap);
+
+impl BackingPackageStore for ObjectMapPackageStore<'_> {
     fn get_package_object(&self, package_id: &ObjectId) -> IotaResult<Option<PackageObject>> {
-        Ok(self.get(package_id).cloned().map(PackageObject::new))
+        Ok(self.0.get(package_id).cloned().map(PackageObject::new))
     }
 }
 

--- a/crates/iota-types/src/inner_temporary_store.rs
+++ b/crates/iota-types/src/inner_temporary_store.rs
@@ -144,6 +144,18 @@ impl BackingPackageStore for InnerTemporaryStore {
     }
 }
 
+/// Resolves packages out of a map of objects, so that callers holding only an
+/// execution's inputs or outputs — rather than the whole
+/// [`InnerTemporaryStore`] — can use them as a package store.
+///
+/// [`WrittenObjects`] and [`ObjectMap`] are the same type, so this one impl
+/// serves both.
+impl BackingPackageStore for WrittenObjects {
+    fn get_package_object(&self, package_id: &ObjectId) -> IotaResult<Option<PackageObject>> {
+        Ok(self.get(package_id).cloned().map(PackageObject::new))
+    }
+}
+
 pub struct PackageStoreWithFallback<P, F> {
     primary: P,
     fallback: F,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1017,10 +1017,6 @@ pub trait TransactionDataAPI {
 
     /// Checks the gas payment against the protocol's cap on how many objects it
     /// may name.
-    ///
-    /// Part of [`TransactionDataAPI::validity_check`]. Callers that relax the
-    /// gas checks, such as a simulation that may mock the gas payment, should
-    /// still apply this one.
     fn check_gas_payment_size(&self, config: &ProtocolConfig) -> UserInputResult;
 
     /// Check if the transaction is compliant with sponsorship.

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1015,6 +1015,14 @@ pub trait TransactionDataAPI {
     /// skipping gas-related checks.
     fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult;
 
+    /// Checks the gas payment against the protocol's cap on how many objects it
+    /// may name.
+    ///
+    /// Part of [`TransactionDataAPI::validity_check`]. Callers that relax the
+    /// gas checks, such as a simulation that may mock the gas payment, should
+    /// still apply this one.
+    fn check_gas_payment_size(&self, config: &ProtocolConfig) -> UserInputResult;
+
     /// Check if the transaction is compliant with sponsorship.
     fn check_sponsorship(&self) -> UserInputResult;
 
@@ -1342,13 +1350,7 @@ impl TransactionDataAPI for TransactionData {
 
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {
         fp_ensure!(!self.gas().is_empty(), UserInputError::MissingGasPayment);
-        fp_ensure!(
-            self.gas().len() < config.max_gas_payment_objects() as usize,
-            UserInputError::SizeLimitExceeded {
-                limit: "maximum number of gas payment objects".to_string(),
-                value: config.max_gas_payment_objects().to_string()
-            }
-        );
+        self.check_gas_payment_size(config)?;
         self.validity_check_no_gas_check(config)
     }
 
@@ -1356,6 +1358,17 @@ impl TransactionDataAPI for TransactionData {
     fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult {
         self.kind().validity_check(config)?;
         self.check_sponsorship()
+    }
+
+    fn check_gas_payment_size(&self, config: &ProtocolConfig) -> UserInputResult {
+        fp_ensure!(
+            self.gas().len() < config.max_gas_payment_objects() as usize,
+            UserInputError::SizeLimitExceeded {
+                limit: "maximum number of gas payment objects".to_string(),
+                value: config.max_gas_payment_objects().to_string()
+            }
+        );
+        Ok(())
     }
 
     fn is_sponsored_tx(&self) -> bool {

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -86,6 +86,9 @@ pub struct SimulateTransactionResult {
     pub events: Option<TransactionEvents>,
     pub input_objects: BTreeMap<ObjectId, Object>,
     pub output_objects: BTreeMap<ObjectId, Object>,
+    /// The return values and mutable-reference outputs of every command, under
+    /// either [`VmChecks`] — both run through the executor's dev-inspect entry
+    /// point, which collects them regardless of which checks are in force.
     pub execution_result: Result<Vec<ExecutionResult>, ExecutionError>,
     pub mock_gas_id: Option<ObjectId>,
     pub suggested_gas_price: Option<u64>,
@@ -105,14 +108,12 @@ pub struct SimulateTransactionResult {
 pub enum VmChecks {
     /// Run the transaction as it would run on chain: the same input and gas
     /// checks a validator applies, and metering against the transaction's own
-    /// budget. Command return values are not reported.
+    /// budget.
     #[default]
     Enabled,
     /// Relax the rules around entry functions and argument values, so that any
-    /// Move function can be called and any value built from its bytes, and
-    /// report the return values of every command. Input checks are reduced to
-    /// the ones execution cannot proceed without, and a gas budget the caller
-    /// left at zero is resolved for them.
+    /// Move function can be called and any value built from its bytes. Input
+    /// checks are reduced to the ones execution cannot proceed without.
     Disabled,
 }
 

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -89,10 +89,23 @@ pub struct SimulateTransactionResult {
     pub suggested_gas_price: Option<u64>,
 }
 
+/// Which Move VM checks a simulation runs with.
+///
+/// This is the only thing that separates the two ways a transaction can be
+/// simulated, so it is what callers pick between: a dry run wants
+/// [`VmChecks::Enabled`], a dev inspect wants [`VmChecks::Disabled`].
 #[derive(Default, Debug, Copy, Clone)]
 pub enum VmChecks {
+    /// Run the transaction as it would run on chain: the same input and gas
+    /// checks a validator applies, and metering against the transaction's own
+    /// budget. Command return values are not reported.
     #[default]
     Enabled,
+    /// Relax the rules around entry functions and argument values, so that any
+    /// Move function can be called and any value built from its bytes, and
+    /// report the return values of every command. Input checks are reduced to
+    /// the ones execution cannot proceed without, and a gas budget the caller
+    /// left at zero is resolved for them.
     Disabled,
 }
 

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -4,7 +4,9 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use iota_sdk_types::{ObjectId, TransactionDigest, TransactionEffects, TransactionEvents};
+use iota_sdk_types::{
+    GasPayment, ObjectId, TransactionDigest, TransactionEffects, TransactionEvents,
+};
 
 use crate::{
     error::{ExecutionError, IotaError},
@@ -87,6 +89,11 @@ pub struct SimulateTransactionResult {
     pub execution_result: Result<Vec<ExecutionResult>, ExecutionError>,
     pub mock_gas_id: Option<ObjectId>,
     pub suggested_gas_price: Option<u64>,
+    /// The gas the simulation ran with, once whatever the transaction left
+    /// unset was filled in. Callers reporting the transaction back should
+    /// use this rather than re-deriving it, which would read a possibly
+    /// different epoch.
+    pub gas_data: GasPayment,
 }
 
 /// Which Move VM checks a simulation runs with.

--- a/crates/iota-vm-sdk/docs/execution-model.md
+++ b/crates/iota-vm-sdk/docs/execution-model.md
@@ -26,11 +26,11 @@ in every phase.
 `ExecutionMode` selects input-check relaxation, the gas budget, and whether
 effects are committed:
 
-| Mode         | Input check                                                                         | Gas price                                   | Gas budget                       | Mock gas coin if none supplied? | Commits to store? |
-| ------------ | ----------------------------------------------------------------------------------- | ------------------------------------------- | -------------------------------- | ------------------------------- | ----------------- |
-| `DevInspect` | `check_simulation_input` (relaxed), plus a gas balance check                        | declared, or the reference gas price if `0` | declared, or `max_tx_gas` if `0` | yes                             | no                |
-| `DryRun`     | `check_transaction_input` (authenticator budget `0` → meters at the full tx budget) | declared, or the reference gas price if `0` | declared, or `max_tx_gas` if `0` | yes                             | no                |
-| `Execute`    | `check_transaction_input` (authenticator budget `0` → meters at the full tx budget) | declared                                    | declared                         | no — requires real gas          | yes, on success   |
+| Mode         | Input check                                                                         | Gas price                                   | Gas budget                                                    | Mock gas coin if none supplied? | Commits to store? |
+| ------------ | ----------------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------- | ------------------------------- | ----------------- |
+| `DevInspect` | `check_simulation_input` (relaxed), plus a gas balance check                        | declared, or the reference gas price if `0` | declared, or the coins' balance capped at `max_tx_gas` if `0` | yes                             | no                |
+| `DryRun`     | `check_transaction_input` (authenticator budget `0` → meters at the full tx budget) | declared, or the reference gas price if `0` | declared, or the coins' balance capped at `max_tx_gas` if `0` | yes                             | no                |
+| `Execute`    | `check_transaction_input` (authenticator budget `0` → meters at the full tx budget) | declared                                    | declared                                                      | no — requires real gas          | yes, on success   |
 
 Both simulation modes fill in gas the caller left unset, the same way the node's
 simulation paths do: a zero price is below the reference gas price and a zero
@@ -43,8 +43,11 @@ Whatever the budget resolves to, the gas coins have to cover it — the engine
 smashes the whole budget off them before running any command. `DryRun` gets that
 check from `check_transaction_input`; `DevInspect` skips that check and so
 carries its own, rejecting an under-funded coin with `GasBalanceTooLow` rather
-than letting the engine hit an invariant violation. Note that this means
-estimating with a zero budget needs a gas coin holding at least `max_tx_gas`.
+than letting the engine hit an invariant violation. A zero budget is capped at
+what the coins hold, so estimating does not require holding `max_tx_gas` — but
+the budget is still held back for the whole programmable transaction, so a
+transaction that also pays out of its gas coin has to declare a budget leaving
+room for that.
 
 `DryRun` and `Execute` are otherwise identical in preparation and budget; they
 differ only in the mock-gas rule and whether effects are committed.

--- a/crates/iota-vm-sdk/docs/execution-model.md
+++ b/crates/iota-vm-sdk/docs/execution-model.md
@@ -28,7 +28,7 @@ effects are committed:
 
 | Mode         | Input check                                             | Gas budget                                                            | Mock gas coin if none supplied? | Commits to store? |
 | ------------ | ------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------- | ----------------- |
-| `DevInspect` | `check_dev_inspect_input` (relaxed)                     | `max_tx_gas` (mock gas) or `min(max_tx_gas, coin balance)` (real gas) | yes                             | no                |
+| `DevInspect` | `check_simulation_input` (relaxed)                      | `max_tx_gas` (mock gas) or `min(max_tx_gas, coin balance)` (real gas) | yes                             | no                |
 | `DryRun`     | `check_transaction_input` (budget `0` → full tx budget) | transaction's declared budget                                         | yes                             | no                |
 | `Execute`    | `check_transaction_input` (budget `0` → full tx budget) | transaction's declared budget                                         | no — requires real gas          | yes, on success   |
 

--- a/crates/iota-vm-sdk/docs/execution-model.md
+++ b/crates/iota-vm-sdk/docs/execution-model.md
@@ -26,11 +26,11 @@ in every phase.
 `ExecutionMode` selects input-check relaxation, the gas budget, and whether
 effects are committed:
 
-| Mode         | Input check                                                  | Gas price                                   | Gas budget                       | Mock gas coin if none supplied? | Commits to store? |
-| ------------ | ------------------------------------------------------------ | ------------------------------------------- | -------------------------------- | ------------------------------- | ----------------- |
-| `DevInspect` | `check_simulation_input` (relaxed), plus a gas balance check | declared, or the reference gas price if `0` | declared, or `max_tx_gas` if `0` | yes                             | no                |
-| `DryRun`     | `check_transaction_input` (budget `0` → full tx budget)      | declared, or the reference gas price if `0` | declared, or `max_tx_gas` if `0` | yes                             | no                |
-| `Execute`    | `check_transaction_input` (budget `0` → full tx budget)      | declared                                    | declared                         | no — requires real gas          | yes, on success   |
+| Mode         | Input check                                                                         | Gas price                                   | Gas budget                       | Mock gas coin if none supplied? | Commits to store? |
+| ------------ | ----------------------------------------------------------------------------------- | ------------------------------------------- | -------------------------------- | ------------------------------- | ----------------- |
+| `DevInspect` | `check_simulation_input` (relaxed), plus a gas balance check                        | declared, or the reference gas price if `0` | declared, or `max_tx_gas` if `0` | yes                             | no                |
+| `DryRun`     | `check_transaction_input` (authenticator budget `0` → meters at the full tx budget) | declared, or the reference gas price if `0` | declared, or `max_tx_gas` if `0` | yes                             | no                |
+| `Execute`    | `check_transaction_input` (authenticator budget `0` → meters at the full tx budget) | declared                                    | declared                         | no — requires real gas          | yes, on success   |
 
 Both simulation modes fill in gas the caller left unset, the same way the node's
 simulation paths do: a zero price is below the reference gas price and a zero

--- a/crates/iota-vm-sdk/docs/execution-model.md
+++ b/crates/iota-vm-sdk/docs/execution-model.md
@@ -26,16 +26,28 @@ in every phase.
 `ExecutionMode` selects input-check relaxation, the gas budget, and whether
 effects are committed:
 
-| Mode         | Input check                                             | Gas budget                                                            | Mock gas coin if none supplied? | Commits to store? |
-| ------------ | ------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------- | ----------------- |
-| `DevInspect` | `check_simulation_input` (relaxed)                      | `max_tx_gas` (mock gas) or `min(max_tx_gas, coin balance)` (real gas) | yes                             | no                |
-| `DryRun`     | `check_transaction_input` (budget `0` → full tx budget) | transaction's declared budget                                         | yes                             | no                |
-| `Execute`    | `check_transaction_input` (budget `0` → full tx budget) | transaction's declared budget                                         | no — requires real gas          | yes, on success   |
+| Mode         | Input check                                                  | Gas price                                   | Gas budget                       | Mock gas coin if none supplied? | Commits to store? |
+| ------------ | ------------------------------------------------------------ | ------------------------------------------- | -------------------------------- | ------------------------------- | ----------------- |
+| `DevInspect` | `check_simulation_input` (relaxed), plus a gas balance check | declared, or the reference gas price if `0` | declared, or `max_tx_gas` if `0` | yes                             | no                |
+| `DryRun`     | `check_transaction_input` (budget `0` → full tx budget)      | declared, or the reference gas price if `0` | declared, or `max_tx_gas` if `0` | yes                             | no                |
+| `Execute`    | `check_transaction_input` (budget `0` → full tx budget)      | declared                                    | declared                         | no — requires real gas          | yes, on success   |
 
-Dev-inspect meters at `max_tx_gas` rather than the declared budget because a run
-before a budget is settled isn't limited by one; a real gas coin still caps it at
-the coin's balance. `DryRun` and `Execute` use the same preparation and budget;
-they differ only in the mock-gas rule and whether effects are committed.
+Both simulation modes fill in gas the caller left unset, the same way the node's
+simulation paths do: a zero price is below the reference gas price and a zero
+budget cannot cover any computation, so neither is a value to meter against, and
+a run whose gas is not yet settled is the common case. `Execute` commits its
+effects, so it holds a transaction to its own declared gas the way a validator
+would.
+
+Whatever the budget resolves to, the gas coins have to cover it — the engine
+smashes the whole budget off them before running any command. `DryRun` gets that
+check from `check_transaction_input`; `DevInspect` skips that check and so
+carries its own, rejecting an under-funded coin with `GasBalanceTooLow` rather
+than letting the engine hit an invariant violation. Note that this means
+estimating with a zero budget needs a gas coin holding at least `max_tx_gas`.
+
+`DryRun` and `Execute` are otherwise identical in preparation and budget; they
+differ only in the mock-gas rule and whether effects are committed.
 
 ## SDK entry points and the phase each mirrors
 

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -145,7 +145,7 @@ pub(super) fn prepare_transaction(
     };
 
     // Snapshot the received objects for the coin deny-list check below: the
-    // dev-inspect branch consumes `receiving_objects`, which is not `Clone`.
+    // simulation branch consumes `receiving_objects`, which is not `Clone`.
     let coin_deny_receiving = check_coin_deny_list.then(|| {
         receiving_objects
             .objects
@@ -155,13 +155,14 @@ pub(super) fn prepare_transaction(
     });
 
     let (gas_status, checked_input_objects) = if matches!(mode, ExecutionMode::DevInspect) {
-        let checked_input_objects = iota_transaction_checks::check_dev_inspect_input(
+        let checked_input_objects = iota_transaction_checks::check_simulation_input(
             &env.protocol_config,
             transaction.kind(),
             input_objects,
             receiving_objects,
         )
-        .map_err(|e| ValidationError::new("dev-inspect input check", e))?;
+        .map_err(|e| ValidationError::new("simulation input check", e))?;
+
         // Dev-inspect meters at `max_tx_gas`, not the transaction's declared
         // budget, matching the node's dev-inspect entry point — a run before a
         // budget is settled isn't limited by it. Real gas coins cap the budget

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -151,12 +151,6 @@ pub(super) fn prepare_transaction(
     // cannot cover any computation, so neither is a value to meter against.
     // `Execute` commits its effects, so it holds a transaction to its own gas the
     // way a validator would.
-
-    // Fill in the gas the caller left unset, the same way the node's simulation
-    // paths do: a zero price is below the reference gas price and a zero budget
-    // cannot cover any computation, so neither is a value to meter against.
-    // `Execute` commits its effects, so it holds a transaction to its own gas the
-    // way a validator would.
     if !matches!(mode, ExecutionMode::Execute) {
         if transaction.gas_price() == 0 {
             transaction.gas_data_mut().price = env.reference_gas_price;
@@ -187,11 +181,25 @@ pub(super) fn prepare_transaction(
 
         // Dev-inspect meters against the transaction's budget, which the fill-in
         // above resolves to `max_tx_gas` when the caller declares none, matching
-        // the node's dev-inspect entry point. The gas coins cap it at their total
-        // balance, since the engine smashes the budget off them up front.
-        let dev_inspect_gas_budget = transaction.gas_budget().min(gas_balance);
+        // the node's dev-inspect entry point.
+        //
+        // The engine smashes the whole budget off the gas coins before running any
+        // command, so they have to cover it even though the rest of the gas checks
+        // are skipped here. Rejecting up front is what the node does; letting it
+        // through would hit an invariant violation inside the engine instead.
+        let gas_budget = transaction.gas_budget();
+        if gas_balance < gas_budget {
+            return Err(ValidationError::new(
+                "gas balance check",
+                UserInputError::GasBalanceTooLow {
+                    gas_balance: gas_balance as u128,
+                    needed_gas_amount: gas_budget as u128,
+                },
+            )
+            .into());
+        }
         let gas_status = IotaGasStatus::new(
-            dev_inspect_gas_budget,
+            gas_budget,
             transaction.gas_price(),
             env.reference_gas_price,
             &env.protocol_config,

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -13,8 +13,8 @@ use std::collections::HashSet;
 
 use iota_config::transaction_deny_config::TransactionDenyConfig;
 use iota_sdk_types::{
-    Address, Digest, Event, MoveAuthenticator, ObjectId, ObjectReference, TransactionEffects,
-    UserSignature,
+    Address, Digest, Event, GasPayment, MoveAuthenticator, ObjectId, ObjectReference,
+    TransactionEffects, UserSignature,
 };
 use iota_types::{
     account_abstraction::authenticator_function::{
@@ -270,6 +270,7 @@ pub(super) fn execute_prepared(
         effects,
         execution_result,
         mock_gas_id,
+        transaction.gas_data().clone(),
     ))
 }
 
@@ -279,6 +280,7 @@ fn simulation_result(
     effects: TransactionEffects,
     execution_result: Result<Vec<CommandResult>, iota_types::error::ExecutionError>,
     mock_gas_id: Option<ObjectId>,
+    gas_data: GasPayment,
 ) -> SimulateTransactionResult {
     SimulateTransactionResult {
         input_objects: inner_temp_store.input_objects,
@@ -288,6 +290,7 @@ fn simulation_result(
         execution_result,
         mock_gas_id,
         suggested_gas_price: None,
+        gas_data,
     }
 }
 
@@ -441,6 +444,7 @@ pub(super) fn execute_with_move_authenticators(
             effects,
             execution_result.map(|_| Vec::new()),
             mock_gas_id,
+            transaction.gas_data().clone(),
         ),
         authenticator_outcome,
     ))

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -26,7 +26,8 @@ use iota_types::{
     effects::TransactionEffectsAPI,
     error::{IotaError, UserInputError},
     gas::{
-        IotaGasStatus, IotaGasStatusAPI, check_gas_coins_cover_budget, fill_in_unset_simulation_gas,
+        IotaGasStatus, IotaGasStatusAPI, check_gas_coins_cover_budget_in_simulation,
+        fill_in_unset_simulation_gas,
     },
     gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::InnerTemporaryStore,
@@ -177,7 +178,7 @@ pub(super) fn prepare_transaction(
         // that they are gas coins at all — so with those checks skipped here, this
         // stands in for them, the same way the node's simulation does.
         let gas_budget = transaction.gas_budget();
-        check_gas_coins_cover_budget(&input_objects, transaction.gas(), gas_budget)
+        check_gas_coins_cover_budget_in_simulation(&input_objects, transaction.gas(), gas_budget)
             .map_err(|e| ValidationError::new("gas balance check", e))?;
 
         let checked_input_objects = iota_transaction_checks::check_simulation_input(

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -81,6 +81,10 @@ pub(super) fn prepare_transaction(
         .validity_check_no_gas_check(&env.protocol_config)
         .map_err(|e| ValidationError::new("transaction validity check", e))?;
 
+    transaction
+        .check_gas_payment_size(&env.protocol_config)
+        .map_err(|e| ValidationError::new("transaction validity check", e))?;
+
     // Update gas payment references to match actual object versions in the store.
     let mut updated_gas = Vec::with_capacity(transaction.gas().len());
     for gas_ref in transaction.gas() {

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -151,6 +151,7 @@ pub(super) fn prepare_transaction(
     if !matches!(mode, ExecutionMode::Execute) {
         fill_in_unset_simulation_gas(
             &mut transaction,
+            &input_objects,
             env.reference_gas_price,
             &env.protocol_config,
         );

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -25,7 +25,7 @@ use iota_types::{
     auth_context::AuthContextData,
     effects::TransactionEffectsAPI,
     error::{IotaError, UserInputError},
-    gas::{IotaGasStatus, IotaGasStatusAPI},
+    gas::{IotaGasStatus, IotaGasStatusAPI, check_gas_coins_cover_budget},
     gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::InnerTemporaryStore,
     layout_resolver::LayoutResolver,
@@ -79,19 +79,14 @@ pub(super) fn prepare_transaction(
         .validity_check_no_gas_check(&env.protocol_config)
         .map_err(|e| ValidationError::new("transaction validity check", e))?;
 
-    // Update gas payment references to match actual object versions in the
-    // store, summing the coins' balance for the dev-inspect budget below.
-    let mut gas_balance: u64 = 0;
+    // Update gas payment references to match actual object versions in the store.
     let mut updated_gas = Vec::with_capacity(transaction.gas().len());
     for gas_ref in transaction.gas() {
         let obj = store
             .as_object_store()
             .try_get_object(&gas_ref.object_id)
             .map_err(|e| StoreError::new("load gas object", e))?;
-        updated_gas.push(obj.map_or(*gas_ref, |o| {
-            gas_balance = gas_balance.saturating_add(o.as_coin_maybe().map_or(0, |c| c.value()));
-            o.object_ref()
-        }));
+        updated_gas.push(obj.map_or(*gas_ref, |o| o.object_ref()));
     }
     transaction.gas_data_mut().objects = updated_gas;
 
@@ -138,8 +133,6 @@ pub(super) fn prepare_transaction(
         let mock_gas_object = mock_simulation_gas_coin(transaction.gas_data().owner);
         let mock_gas_object_ref = mock_gas_object.object_ref();
         transaction.gas_data_mut().objects = vec![mock_gas_object_ref];
-        gas_balance =
-            gas_balance.saturating_add(mock_gas_object.as_coin_maybe().map_or(0, |c| c.value()));
         input_objects.push(ObjectReadResult::new_from_gas_object(&mock_gas_object));
         Some(mock_gas_object.id())
     } else {
@@ -171,6 +164,18 @@ pub(super) fn prepare_transaction(
     });
 
     let (gas_status, checked_input_objects) = if matches!(mode, ExecutionMode::DevInspect) {
+        // Dev-inspect meters against the transaction's budget, which the fill-in
+        // above resolves to `max_tx_gas` when the caller declares none, matching
+        // the node's dev-inspect entry point.
+        //
+        // The engine smashes the gas coins and reserves the whole budget from them
+        // before running any command, treating the input checks as having verified
+        // that they are gas coins at all — so with those checks skipped here, this
+        // stands in for them, the same way the node's simulation does.
+        let gas_budget = transaction.gas_budget();
+        check_gas_coins_cover_budget(&input_objects, transaction.gas(), gas_budget)
+            .map_err(|e| ValidationError::new("gas balance check", e))?;
+
         let checked_input_objects = iota_transaction_checks::check_simulation_input(
             &env.protocol_config,
             transaction.kind(),
@@ -179,25 +184,6 @@ pub(super) fn prepare_transaction(
         )
         .map_err(|e| ValidationError::new("simulation input check", e))?;
 
-        // Dev-inspect meters against the transaction's budget, which the fill-in
-        // above resolves to `max_tx_gas` when the caller declares none, matching
-        // the node's dev-inspect entry point.
-        //
-        // The engine smashes the whole budget off the gas coins before running any
-        // command, so they have to cover it even though the rest of the gas checks
-        // are skipped here. Rejecting up front is what the node does; letting it
-        // through would hit an invariant violation inside the engine instead.
-        let gas_budget = transaction.gas_budget();
-        if gas_balance < gas_budget {
-            return Err(ValidationError::new(
-                "gas balance check",
-                UserInputError::GasBalanceTooLow {
-                    gas_balance: gas_balance as u128,
-                    needed_gas_amount: gas_budget as u128,
-                },
-            )
-            .into());
-        }
         let gas_status = IotaGasStatus::new(
             gas_budget,
             transaction.gas_price(),

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -25,7 +25,9 @@ use iota_types::{
     auth_context::AuthContextData,
     effects::TransactionEffectsAPI,
     error::{IotaError, UserInputError},
-    gas::{IotaGasStatus, IotaGasStatusAPI, check_gas_coins_cover_budget},
+    gas::{
+        IotaGasStatus, IotaGasStatusAPI, check_gas_coins_cover_budget, fill_in_unset_simulation_gas,
+    },
     gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::InnerTemporaryStore,
     layout_resolver::LayoutResolver,
@@ -139,18 +141,15 @@ pub(super) fn prepare_transaction(
         None
     };
 
-    // Fill in the gas the caller left unset, the same way the node's simulation
-    // paths do: a zero price is below the reference gas price and a zero budget
-    // cannot cover any computation, so neither is a value to meter against.
-    // `Execute` commits its effects, so it holds a transaction to its own gas the
-    // way a validator would.
+    // `Execute` commits its effects, so it holds a transaction to its own declared
+    // gas the way a validator would; the two simulation modes fill in what the
+    // caller left unset, the same way the node's simulation paths do.
     if !matches!(mode, ExecutionMode::Execute) {
-        if transaction.gas_price() == 0 {
-            transaction.gas_data_mut().price = env.reference_gas_price;
-        }
-        if transaction.gas_budget() == 0 {
-            transaction.gas_data_mut().budget = env.protocol_config.max_tx_gas();
-        }
+        fill_in_unset_simulation_gas(
+            &mut transaction,
+            env.reference_gas_price,
+            &env.protocol_config,
+        );
     }
 
     // Snapshot the received objects for the coin deny-list check below: the

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -138,11 +138,33 @@ pub(super) fn prepare_transaction(
         let mock_gas_object = mock_simulation_gas_coin(transaction.gas_data().owner);
         let mock_gas_object_ref = mock_gas_object.object_ref();
         transaction.gas_data_mut().objects = vec![mock_gas_object_ref];
+        gas_balance =
+            gas_balance.saturating_add(mock_gas_object.as_coin_maybe().map_or(0, |c| c.value()));
         input_objects.push(ObjectReadResult::new_from_gas_object(&mock_gas_object));
         Some(mock_gas_object.id())
     } else {
         None
     };
+
+    // Fill in the gas the caller left unset, the same way the node's simulation
+    // paths do: a zero price is below the reference gas price and a zero budget
+    // cannot cover any computation, so neither is a value to meter against.
+    // `Execute` commits its effects, so it holds a transaction to its own gas the
+    // way a validator would.
+
+    // Fill in the gas the caller left unset, the same way the node's simulation
+    // paths do: a zero price is below the reference gas price and a zero budget
+    // cannot cover any computation, so neither is a value to meter against.
+    // `Execute` commits its effects, so it holds a transaction to its own gas the
+    // way a validator would.
+    if !matches!(mode, ExecutionMode::Execute) {
+        if transaction.gas_price() == 0 {
+            transaction.gas_data_mut().price = env.reference_gas_price;
+        }
+        if transaction.gas_budget() == 0 {
+            transaction.gas_data_mut().budget = env.protocol_config.max_tx_gas();
+        }
+    }
 
     // Snapshot the received objects for the coin deny-list check below: the
     // simulation branch consumes `receiving_objects`, which is not `Clone`.
@@ -163,16 +185,11 @@ pub(super) fn prepare_transaction(
         )
         .map_err(|e| ValidationError::new("simulation input check", e))?;
 
-        // Dev-inspect meters at `max_tx_gas`, not the transaction's declared
-        // budget, matching the node's dev-inspect entry point — a run before a
-        // budget is settled isn't limited by it. Real gas coins cap the budget
-        // at their total balance, since the engine smashes the budget off the
-        // coin up front (the mock coin's balance always covers `max_tx_gas`).
-        let dev_inspect_gas_budget = if mock_gas_id.is_some() {
-            env.protocol_config.max_tx_gas()
-        } else {
-            env.protocol_config.max_tx_gas().min(gas_balance)
-        };
+        // Dev-inspect meters against the transaction's budget, which the fill-in
+        // above resolves to `max_tx_gas` when the caller declares none, matching
+        // the node's dev-inspect entry point. The gas coins cap it at their total
+        // balance, since the engine smashes the budget off them up front.
+        let dev_inspect_gas_budget = transaction.gas_budget().min(gas_balance);
         let gas_status = IotaGasStatus::new(
             dev_inspect_gas_budget,
             transaction.gas_price(),

--- a/crates/iota-vm-sdk/tests/execute_commit.rs
+++ b/crates/iota-vm-sdk/tests/execute_commit.rs
@@ -7,7 +7,7 @@
 //! only the built-in framework, no Move compiler.
 
 use iota_sdk_types::{
-    MoveStruct, ObjectId, Owner, TransactionDigest,
+    Identifier, MoveStruct, ObjectId, Owner, StructTag, TransactionDigest,
     transaction::{GenesisTransaction, TransactionKind},
 };
 use iota_types::{
@@ -383,6 +383,48 @@ fn dev_inspect_rejects_a_gas_coin_that_cannot_back_the_budget() {
     let err = vm
         .execute(tx, ExecuteOptions::dev_inspect())
         .expect_err("a gas coin that cannot back the budget must be rejected");
+    assert!(matches!(err, VmSdkError::Validation(_)), "got {err:?}");
+}
+
+/// A gas payment naming an object that is not a gas coin is rejected, even when
+/// another coin in the payment covers the budget on its own. The engine only
+/// inspects the coins when the payment names more than one, and panics there
+/// rather than returning an error.
+#[test]
+fn dev_inspect_rejects_a_gas_payment_that_is_not_a_gas_coin() {
+    let sender = Address::ZERO;
+    let recipient = Address::from(ObjectId::random());
+
+    let funded_coin = gas_coin(sender);
+    let not_a_coin = Object::new_move(
+        MoveStruct::new(
+            StructTag::new(
+                Address::FRAMEWORK,
+                Identifier::from_static("object_basics"),
+                Identifier::from_static("Object"),
+                vec![],
+            )
+            .into(),
+            OBJECT_START_VERSION,
+            // A Move object's contents lead with its own id.
+            bcs::to_bytes(&(ObjectId::random(), 7u64)).unwrap(),
+        )
+        .unwrap(),
+        Owner::Address(sender),
+        TransactionDigest::ZERO,
+    );
+
+    let mut store = InMemoryStore::with_framework();
+    store.insert(funded_coin.clone());
+    store.insert(not_a_coin.clone());
+    let mut vm = LocalVm::new(chain_context(), store).expect("build LocalVm");
+
+    let mut tx = transfer_tx(sender, &funded_coin, recipient, TRANSFER_AMOUNT);
+    tx.gas_data_mut().objects = vec![funded_coin.object_ref(), not_a_coin.object_ref()];
+
+    let err = vm
+        .execute(tx, ExecuteOptions::dev_inspect())
+        .expect_err("a gas payment that is not a gas coin must be rejected");
     assert!(matches!(err, VmSdkError::Validation(_)), "got {err:?}");
 }
 

--- a/crates/iota-vm-sdk/tests/execute_commit.rs
+++ b/crates/iota-vm-sdk/tests/execute_commit.rs
@@ -428,6 +428,40 @@ fn dev_inspect_rejects_a_gas_payment_that_is_not_a_gas_coin() {
     assert!(matches!(err, VmSdkError::Validation(_)), "got {err:?}");
 }
 
+/// A simulation relaxes the requirement to carry a gas payment at all, so it
+/// also skips the cap on how many coins that payment may hold. The cap still
+/// applies: the engine smashes every coin it is given before running anything.
+#[test]
+fn dev_inspect_rejects_more_gas_coins_than_the_protocol_allows() {
+    let sender = Address::ZERO;
+    let recipient = Address::from(ObjectId::random());
+
+    let funded_coin = gas_coin(sender);
+    let mut store = InMemoryStore::with_framework();
+    store.insert(funded_coin.clone());
+
+    let max_gas_payment_objects =
+        iota_protocol_config::ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown)
+            .max_gas_payment_objects() as usize;
+    let extra_coins: Vec<Object> = (0..max_gas_payment_objects)
+        .map(|_| gas_coin(sender))
+        .collect();
+    for coin in &extra_coins {
+        store.insert(coin.clone());
+    }
+    let mut vm = LocalVm::new(chain_context(), store).expect("build LocalVm");
+
+    let mut tx = transfer_tx(sender, &funded_coin, recipient, TRANSFER_AMOUNT);
+    tx.gas_data_mut().objects = std::iter::once(funded_coin.object_ref())
+        .chain(extra_coins.iter().map(|coin| coin.object_ref()))
+        .collect();
+
+    let err = vm
+        .execute(tx, ExecuteOptions::dev_inspect())
+        .expect_err("a gas payment over the protocol cap must be rejected");
+    assert!(matches!(err, VmSdkError::Validation(_)), "got {err:?}");
+}
+
 /// System transactions are rejected in every mode.
 #[test]
 fn system_transactions_are_rejected() {

--- a/crates/iota-vm-sdk/tests/execute_commit.rs
+++ b/crates/iota-vm-sdk/tests/execute_commit.rs
@@ -296,10 +296,11 @@ fn dev_inspect_and_dry_run_fund_gasless_transactions_with_mock_coin() {
     }
 }
 
-/// Dev-inspect meters at `max_tx_gas` even when a real gas coin with a lower
-/// declared budget is supplied, matching the node's dev-inspect entry point.
+/// A zero budget is filled in from the epoch even when a real gas coin is
+/// supplied, so a dev inspect whose gas is not yet settled still runs. The coin
+/// is used as-is rather than being replaced by a mock one.
 #[test]
-fn dev_inspect_with_real_gas_coin_ignores_declared_budget() {
+fn dev_inspect_with_real_gas_coin_fills_in_a_zero_budget() {
     let sender = Address::ZERO;
     let recipient = Address::from(ObjectId::random());
 
@@ -322,6 +323,32 @@ fn dev_inspect_with_real_gas_coin_ignores_declared_budget() {
     assert!(
         result.mock_gas_id.is_none(),
         "a supplied gas coin must be used as-is"
+    );
+}
+
+/// A budget the caller does declare is metered against, rather than being
+/// replaced by `max_tx_gas`: a budget too small for the transfer runs out of
+/// gas.
+#[test]
+fn dev_inspect_meters_against_a_declared_budget() {
+    let sender = Address::ZERO;
+    let recipient = Address::from(ObjectId::random());
+
+    let gas = gas_coin(sender);
+    let mut store = InMemoryStore::with_framework();
+    store.insert(gas.clone());
+    let mut vm = LocalVm::new(chain_context(), store).expect("build LocalVm");
+
+    let mut tx = transfer_tx(sender, &gas, recipient, TRANSFER_AMOUNT);
+    tx.gas_data_mut().budget = GAS_PRICE;
+
+    let result = vm
+        .execute(tx, ExecuteOptions::dev_inspect())
+        .expect("dev-inspect must not error");
+    assert!(
+        !result.status.is_success(),
+        "a budget too small for the transfer should not succeed, got {:?}",
+        result.status
     );
 }
 

--- a/crates/iota-vm-sdk/tests/execute_commit.rs
+++ b/crates/iota-vm-sdk/tests/execute_commit.rs
@@ -353,9 +353,7 @@ fn dev_inspect_meters_against_a_declared_budget() {
 }
 
 /// A gas coin that cannot back the budget is rejected up front, the same way
-/// the node rejects it, rather than reaching the engine — which smashes the
-/// budget off the coin before running any command and would hit an invariant
-/// violation.
+/// the node rejects it.
 #[test]
 fn dev_inspect_rejects_a_gas_coin_that_cannot_back_the_budget() {
     let sender = Address::ZERO;
@@ -387,9 +385,7 @@ fn dev_inspect_rejects_a_gas_coin_that_cannot_back_the_budget() {
 }
 
 /// A gas payment naming an object that is not a gas coin is rejected, even when
-/// another coin in the payment covers the budget on its own. The engine only
-/// inspects the coins when the payment names more than one, and panics there
-/// rather than returning an error.
+/// another coin in the payment covers the budget on its own.
 #[test]
 fn dev_inspect_rejects_a_gas_payment_that_is_not_a_gas_coin() {
     let sender = Address::ZERO;

--- a/crates/iota-vm-sdk/tests/execute_commit.rs
+++ b/crates/iota-vm-sdk/tests/execute_commit.rs
@@ -12,6 +12,7 @@ use iota_sdk_types::{
 };
 use iota_types::{
     effects::TransactionEffectsAPI,
+    error::{IotaError, UserInputError},
     object::{MoveStructExt, OBJECT_START_VERSION, Object},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
@@ -24,6 +25,9 @@ use iota_vm_sdk::{
 };
 
 const GAS_PRICE: u64 = 1000;
+/// Mirrors `ProtocolConfig::base_tx_cost_fixed`, the floor an unset budget is
+/// raised to when the gas coins hold less.
+const BASE_TX_COST_FIXED: u64 = 1000;
 const GAS_COIN_VALUE: u64 = 1_000_000_000_000;
 const TRANSFER_AMOUNT: u64 = 1000;
 
@@ -354,6 +358,10 @@ fn dev_inspect_meters_against_a_declared_budget() {
 
 /// A gas coin that cannot back the budget is rejected up front, the same way
 /// the node rejects it.
+///
+/// An unset budget is capped at what the coins hold, so it takes a coin holding
+/// less than the smallest budget a transaction may declare to get here: the cap
+/// is raised back to that minimum, and the coin cannot cover even that.
 #[test]
 fn dev_inspect_rejects_a_gas_coin_that_cannot_back_the_budget() {
     let sender = Address::ZERO;
@@ -373,15 +381,31 @@ fn dev_inspect_rejects_a_gas_coin_that_cannot_back_the_budget() {
     store.insert(gas.clone());
     let mut vm = LocalVm::new(chain_context(), store).expect("build LocalVm");
 
-    // Left at zero, so the budget is filled in with `max_tx_gas`, which the coin
-    // above cannot cover.
+    // Left at zero, so the budget is filled in: capped at the coin's balance,
+    // then raised to `base_tx_cost_fixed * gas_price`, which the coin above still
+    // cannot cover.
     let mut tx = transfer_tx(sender, &gas, recipient, TRANSFER_AMOUNT);
     tx.gas_data_mut().budget = 0;
+    let min_gas_budget = u128::from(BASE_TX_COST_FIXED) * u128::from(GAS_PRICE);
+    assert!(u128::from(underfunded_balance) < min_gas_budget);
 
     let err = vm
         .execute(tx, ExecuteOptions::dev_inspect())
         .expect_err("a gas coin that cannot back the budget must be rejected");
-    assert!(matches!(err, VmSdkError::Validation(_)), "got {err:?}");
+    assert!(
+        matches!(
+            &err,
+            VmSdkError::Validation(e)
+                if matches!(
+                    &e.source,
+                    IotaError::UserInput {
+                        error: UserInputError::GasBalanceTooLow { gas_balance, needed_gas_amount },
+                    } if *gas_balance == u128::from(underfunded_balance)
+                        && *needed_gas_amount == min_gas_budget
+                )
+        ),
+        "got {err:?}"
+    );
 }
 
 /// A gas payment naming an object that is not a gas coin is rejected, even when
@@ -424,9 +448,6 @@ fn dev_inspect_rejects_a_gas_payment_that_is_not_a_gas_coin() {
     assert!(matches!(err, VmSdkError::Validation(_)), "got {err:?}");
 }
 
-/// A simulation relaxes the requirement to carry a gas payment at all, so it
-/// also skips the cap on how many coins that payment may hold. The cap still
-/// applies: the engine smashes every coin it is given before running anything.
 #[test]
 fn dev_inspect_rejects_more_gas_coins_than_the_protocol_allows() {
     let sender = Address::ZERO;

--- a/crates/iota-vm-sdk/tests/execute_commit.rs
+++ b/crates/iota-vm-sdk/tests/execute_commit.rs
@@ -352,6 +352,40 @@ fn dev_inspect_meters_against_a_declared_budget() {
     );
 }
 
+/// A gas coin that cannot back the budget is rejected up front, the same way
+/// the node rejects it, rather than reaching the engine — which smashes the
+/// budget off the coin before running any command and would hit an invariant
+/// violation.
+#[test]
+fn dev_inspect_rejects_a_gas_coin_that_cannot_back_the_budget() {
+    let sender = Address::ZERO;
+    let recipient = Address::from(ObjectId::random());
+
+    let underfunded_balance = GAS_PRICE;
+    let gas = Object::new_move(
+        MoveStruct::new_gas_coin(
+            OBJECT_START_VERSION,
+            ObjectId::random(),
+            underfunded_balance,
+        ),
+        Owner::Address(sender),
+        TransactionDigest::ZERO,
+    );
+    let mut store = InMemoryStore::with_framework();
+    store.insert(gas.clone());
+    let mut vm = LocalVm::new(chain_context(), store).expect("build LocalVm");
+
+    // Left at zero, so the budget is filled in with `max_tx_gas`, which the coin
+    // above cannot cover.
+    let mut tx = transfer_tx(sender, &gas, recipient, TRANSFER_AMOUNT);
+    tx.gas_data_mut().budget = 0;
+
+    let err = vm
+        .execute(tx, ExecuteOptions::dev_inspect())
+        .expect_err("a gas coin that cannot back the budget must be rejected");
+    assert!(matches!(err, VmSdkError::Validation(_)), "got {err:?}");
+}
+
 /// System transactions are rejected in every mode.
 #[test]
 fn system_transactions_are_rejected() {

--- a/crates/iota-vm-sdk/tests/move_authenticator.rs
+++ b/crates/iota-vm-sdk/tests/move_authenticator.rs
@@ -238,9 +238,9 @@ fn move_authenticator_dev_inspect_rerun_ignores_zero_declared_budget() {
     let mut tx = f.transaction();
     tx.gas_data_mut().budget = 0;
     let mut vm = f.vm();
-    // A zero budget resolves to `max_tx_gas`, which the gas coins have to cover,
-    // so top up the fixture's coin — otherwise the run is rejected over the gas
-    // before reaching the metering this test is about.
+    // A zero budget resolves to as much as the gas coins can back, up to
+    // `max_tx_gas`, so top up the fixture's coin — otherwise it resolves to that
+    // smaller balance rather than the maximum this test is about.
     fund_gas_coins_for_max_budget(&mut vm, &tx);
 
     // First run: the free-access authenticator accepts and `add_field`

--- a/crates/iota-vm-sdk/tests/move_authenticator.rs
+++ b/crates/iota-vm-sdk/tests/move_authenticator.rs
@@ -17,9 +17,9 @@
 use std::{fs, path::PathBuf};
 
 use fastcrypto::encoding::{Base64, Encoding};
-use iota_sdk_types::{SenderSignedTransaction, UserSignature};
+use iota_sdk_types::{MoveStruct, SenderSignedTransaction, TransactionDigest, UserSignature};
 use iota_types::{
-    object::Object,
+    object::{MoveStructExt, Object},
     transaction::{TransactionData, TransactionDataAPI},
 };
 use iota_vm_sdk::{
@@ -45,6 +45,10 @@ struct Fixture {
 struct FixtureObject {
     bcs_b64: String,
 }
+
+/// Comfortably above `max_tx_gas`, so a coin holding it backs any budget a
+/// simulation can resolve to.
+const FUNDED_GAS_COIN_VALUE: u64 = 1_000_000_000_000;
 
 impl Fixture {
     fn transaction(&self) -> TransactionData {
@@ -92,6 +96,26 @@ fn chain_context(f: &Fixture) -> ChainContext {
         .with_reference_gas_price(f.reference_gas_price)
         .with_epoch_id(f.epoch_id)
         .with_epoch_timestamp_ms(f.epoch_timestamp_ms)
+}
+
+/// Replace the balance of every gas coin `tx` pays with, so the coins can back
+/// a budget of `max_tx_gas`.
+///
+/// The fixtures carry the coin balance they were captured with, which need not
+/// cover the protocol maximum a zero declared budget resolves to.
+fn fund_gas_coins_for_max_budget(vm: &mut LocalVm, tx: &TransactionData) {
+    for gas_ref in tx.gas() {
+        let coin = vm
+            .store()
+            .get_object(&gas_ref.object_id, None)
+            .expect("store lookup")
+            .expect("fixture carries the gas coin it pays with");
+        vm.store_mut().insert(Object::new_move(
+            MoveStruct::new_gas_coin(coin.version(), coin.id(), FUNDED_GAS_COIN_VALUE),
+            coin.owner,
+            TransactionDigest::ZERO,
+        ));
+    }
 }
 
 /// The fixture's `MoveAuthenticator` signature.
@@ -214,6 +238,10 @@ fn move_authenticator_dev_inspect_rerun_ignores_zero_declared_budget() {
     let mut tx = f.transaction();
     tx.gas_data_mut().budget = 0;
     let mut vm = f.vm();
+    // A zero budget resolves to `max_tx_gas`, which the gas coins have to cover,
+    // so top up the fixture's coin — otherwise the run is rejected over the gas
+    // before reaching the metering this test is about.
+    fund_gas_coins_for_max_budget(&mut vm, &tx);
 
     // First run: the free-access authenticator accepts and `add_field`
     // succeeds — dev-inspect meters at the dev-inspect budget, not the

--- a/crates/iota-vm-sdk/tests/offline_dev_inspect.rs
+++ b/crates/iota-vm-sdk/tests/offline_dev_inspect.rs
@@ -70,10 +70,10 @@ fn dev_inspect_runs_offline_and_leaves_store_unchanged() {
     );
 }
 
-/// Dev-inspect meters at `max_tx_gas`, not the transaction's declared budget,
-/// so a zero-budget transaction (gas not yet settled — the common dev-inspect
-/// case) still runs, matching the node. Metering at the budget would abort this
-/// with `InsufficientGas`.
+/// A zero gas budget is filled in from the epoch's maximum, so a transaction
+/// whose gas is not yet settled — the common dev-inspect case — still runs,
+/// matching the node. Metering against the zero would abort this with
+/// `InsufficientGas`.
 #[test]
 fn dev_inspect_succeeds_with_zero_gas_budget() {
     let tx_bytes = Base64::decode(BLAKE2B_TX_B64).expect("base64 decode");
@@ -88,6 +88,28 @@ fn dev_inspect_succeeds_with_zero_gas_budget() {
     assert!(
         result.status.is_success(),
         "zero-budget dev-inspect must succeed, got {:?}",
+        result.status
+    );
+}
+
+/// A zero gas price is filled in from the epoch's reference gas price, which
+/// otherwise rejects the transaction outright: a price below the reference is a
+/// `GasPriceUnderRGP` user input error, not a failed run.
+#[test]
+fn dev_inspect_succeeds_with_zero_gas_price() {
+    let tx_bytes = Base64::decode(BLAKE2B_TX_B64).expect("base64 decode");
+    let mut tx: TransactionData = bcs::from_bytes(&tx_bytes).expect("decode tx");
+    tx.gas_data_mut().price = 0;
+    tx.gas_data_mut().budget = 0;
+
+    let mut vm =
+        LocalVm::new(chain_context(), InMemoryStore::with_framework()).expect("build LocalVm");
+    let result = vm
+        .execute(tx, ExecuteOptions::dev_inspect())
+        .expect("zero-price dev-inspect must not error");
+    assert!(
+        result.status.is_success(),
+        "zero-price dev-inspect must succeed, got {:?}",
         result.status
     );
 }

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -184,14 +184,7 @@ impl EpochState {
         // The full validity check caps the gas payment size alongside requiring a
         // gas payment at all, which a simulation relaxes so it can mock one. The cap
         // still applies, and is cheapest before any object is loaded.
-        let max_gas_payment_objects = self.protocol_config.max_gas_payment_objects() as usize;
-        if transaction.gas().len() >= max_gas_payment_objects {
-            return Err(UserInputError::SizeLimitExceeded {
-                limit: "maximum number of gas payment objects".to_string(),
-                value: max_gas_payment_objects.to_string(),
-            }
-            .into());
-        }
+        transaction.check_gas_payment_size(&self.protocol_config)?;
 
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -247,7 +247,7 @@ impl EpochState {
             // that they are gas coins at all — so with those checks skipped here, this
             // has to stand in for them. With the checks enabled,
             // `check_transaction_input` covers it.
-            iota_types::gas::check_gas_coins_cover_budget(
+            iota_types::gas::check_gas_coins_cover_budget_in_simulation(
                 &input_objects,
                 transaction.gas(),
                 transaction.gas_budget(),

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -14,7 +14,7 @@ use iota_sdk_types::TransactionEffects;
 use iota_types::{
     committee::{Committee, EpochId},
     effects::TransactionEffectsAPI,
-    error::{IotaResult, UserInputError},
+    error::IotaResult,
     gas::IotaGasStatus,
     gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::InnerTemporaryStore,
@@ -252,19 +252,16 @@ impl EpochState {
                 authenticator_gas_budget,
             )?
         } else {
-            // Execution reserves the whole gas budget from the gas coins before running
-            // any command, so they have to cover it even though the rest of the gas
-            // checks are skipped here. With the checks enabled,
-            // `check_transaction_input` covers this.
-            let gas_balance = iota_types::gas::gas_coins_balance(&input_objects, transaction.gas());
-            let gas_budget = transaction.gas_budget();
-            if gas_balance < gas_budget as u128 {
-                return Err(UserInputError::GasBalanceTooLow {
-                    gas_balance,
-                    needed_gas_amount: gas_budget as u128,
-                }
-                .into());
-            }
+            // Execution smashes the gas coins and reserves the whole budget from them
+            // before running any command, treating the input checks as having verified
+            // that they are gas coins at all — so with those checks skipped here, this
+            // has to stand in for them. With the checks enabled,
+            // `check_transaction_input` covers it.
+            iota_types::gas::check_gas_coins_cover_budget(
+                &input_objects,
+                transaction.gas(),
+                transaction.gas_budget(),
+            )?;
 
             let checked_input_objects = iota_transaction_checks::check_simulation_input(
                 &self.protocol_config,

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -14,7 +14,7 @@ use iota_sdk_types::TransactionEffects;
 use iota_types::{
     committee::{Committee, EpochId},
     effects::TransactionEffectsAPI,
-    error::IotaResult,
+    error::{IotaResult, UserInputError},
     gas::IotaGasStatus,
     gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::InnerTemporaryStore,
@@ -181,6 +181,18 @@ impl EpochState {
         // Cheap validity checks for a transaction, including input size limits.
         transaction.validity_check_no_gas_check(&self.protocol_config)?;
 
+        // The full validity check caps the gas payment size alongside requiring a
+        // gas payment at all, which a simulation relaxes so it can mock one. The cap
+        // still applies, and is cheapest before any object is loaded.
+        let max_gas_payment_objects = self.protocol_config.max_gas_payment_objects() as usize;
+        if transaction.gas().len() >= max_gas_payment_objects {
+            return Err(UserInputError::SizeLimitExceeded {
+                limit: "maximum number of gas payment objects".to_string(),
+                value: max_gas_payment_objects.to_string(),
+            }
+            .into());
+        }
+
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
@@ -212,24 +224,21 @@ impl EpochState {
             None
         };
 
-        // In a simulation with "checks disabled", a zero gas price or
-        // budget means "use this epoch's defaults" rather than being metered as
-        // an actual zero: a zero price is below the reference gas price, and a
-        // zero budget cannot cover any computation, so either would fail the
-        // simulation over gas the caller never meant to set.
-        //
-        // A simulation with "checks enabled" has to reject the same way a validator
-        // would.
-        if checks.disabled() {
+        // Fill in the gas the caller left unset. Nobody submits a simulation to pay
+        // for it, and neither zero is a value the gas checks could accept anyway: a
+        // zero price is below the reference gas price, and a zero budget cannot cover
+        // any computation. Callers that do declare gas are metered against it, so a
+        // dry run still rejects the gas a validator would.
+        if transaction.gas_price() == 0 {
             let reference_gas_price = self.epoch_start_state.reference_gas_price();
+            transaction.gas_data_mut().price = reference_gas_price;
+        }
+        if transaction.gas_budget() == 0 {
+            // The protocol maximum, rather than what the gas coins hold: a budget
+            // equal to the whole balance would leave nothing for a transaction that
+            // also pays out of its gas coin.
             let max_tx_gas = self.protocol_config.max_tx_gas();
-            let gas_data = transaction.gas_data_mut();
-            if gas_data.price == 0 {
-                gas_data.price = reference_gas_price;
-            }
-            if gas_data.budget == 0 {
-                gas_data.budget = max_tx_gas;
-            }
+            transaction.gas_data_mut().budget = max_tx_gas;
         }
 
         // `MoveAuthenticator`s are not supported in Simulacrum, so we set the
@@ -250,6 +259,20 @@ impl EpochState {
                 authenticator_gas_budget,
             )?
         } else {
+            // Execution reserves the whole gas budget from the gas coins before running
+            // any command, so they have to cover it even though the rest of the gas
+            // checks are skipped here. With the checks enabled,
+            // `check_transaction_input` covers this.
+            let gas_balance = iota_types::gas::gas_coins_balance(&input_objects, transaction.gas());
+            let gas_budget = transaction.gas_budget();
+            if gas_balance < gas_budget as u128 {
+                return Err(UserInputError::GasBalanceTooLow {
+                    gas_balance,
+                    needed_gas_amount: gas_budget as u128,
+                }
+                .into());
+            }
+
             let checked_input_objects = iota_transaction_checks::check_simulation_input(
                 &self.protocol_config,
                 transaction.kind(),

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -230,7 +230,7 @@ impl EpochState {
                 authenticator_gas_budget,
             )?
         } else {
-            let checked_input_objects = iota_transaction_checks::check_dev_inspect_input(
+            let checked_input_objects = iota_transaction_checks::check_simulation_input(
                 &self.protocol_config,
                 transaction.kind(),
                 input_objects,

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -217,22 +217,11 @@ impl EpochState {
             None
         };
 
-        // Fill in the gas the caller left unset. Nobody submits a simulation to pay
-        // for it, and neither zero is a value the gas checks could accept anyway: a
-        // zero price is below the reference gas price, and a zero budget cannot cover
-        // any computation. Callers that do declare gas are metered against it, so a
-        // dry run still rejects the gas a validator would.
-        if transaction.gas_price() == 0 {
-            let reference_gas_price = self.epoch_start_state.reference_gas_price();
-            transaction.gas_data_mut().price = reference_gas_price;
-        }
-        if transaction.gas_budget() == 0 {
-            // The protocol maximum, rather than what the gas coins hold: a budget
-            // equal to the whole balance would leave nothing for a transaction that
-            // also pays out of its gas coin.
-            let max_tx_gas = self.protocol_config.max_tx_gas();
-            transaction.gas_data_mut().budget = max_tx_gas;
-        }
+        iota_types::gas::fill_in_unset_simulation_gas(
+            &mut transaction,
+            self.epoch_start_state.reference_gas_price(),
+            &self.protocol_config,
+        );
 
         // `MoveAuthenticator`s are not supported in Simulacrum, so we set the
         // `authenticator_gas_budget` to 0.

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -212,6 +212,26 @@ impl EpochState {
             None
         };
 
+        // In a simulation with "checks disabled", a zero gas price or
+        // budget means "use this epoch's defaults" rather than being metered as
+        // an actual zero: a zero price is below the reference gas price, and a
+        // zero budget cannot cover any computation, so either would fail the
+        // simulation over gas the caller never meant to set.
+        //
+        // A simulation with "checks enabled" has to reject the same way a validator
+        // would.
+        if checks.disabled() {
+            let reference_gas_price = self.epoch_start_state.reference_gas_price();
+            let max_tx_gas = self.protocol_config.max_tx_gas();
+            let gas_data = transaction.gas_data_mut();
+            if gas_data.price == 0 {
+                gas_data.price = reference_gas_price;
+            }
+            if gas_data.budget == 0 {
+                gas_data.budget = max_tx_gas;
+            }
+        }
+
         // `MoveAuthenticator`s are not supported in Simulacrum, so we set the
         // `authenticator_gas_budget` to 0.
         let authenticator_gas_budget = 0;

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -219,6 +219,7 @@ impl EpochState {
 
         iota_types::gas::fill_in_unset_simulation_gas(
             &mut transaction,
+            &input_objects,
             self.epoch_start_state.reference_gas_price(),
             &self.protocol_config,
         );

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -317,6 +317,7 @@ impl EpochState {
             execution_result,
             mock_gas_id,
             suggested_gas_price: None,
+            gas_data: transaction.gas_data().clone(),
         })
     }
 }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -452,17 +452,6 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         self.inner.read().unwrap().epoch_state.reference_gas_price()
     }
 
-    /// Return the largest gas budget a transaction may declare in the current
-    /// epoch.
-    pub fn max_tx_gas(&self) -> u64 {
-        self.inner
-            .read()
-            .unwrap()
-            .epoch_state
-            .protocol_config()
-            .max_tx_gas()
-    }
-
     /// Request that `amount` Nanos be sent to `address` from a faucet account.
     ///
     /// ```

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -452,6 +452,17 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         self.inner.read().unwrap().epoch_state.reference_gas_price()
     }
 
+    /// Return the largest gas budget a transaction may declare in the current
+    /// epoch.
+    pub fn max_tx_gas(&self) -> u64 {
+        self.inner
+            .read()
+            .unwrap()
+            .epoch_state
+            .protocol_config()
+            .max_tx_gas()
+    }
+
     /// Request that `amount` Nanos be sent to `address` from a faucet account.
     ///
     /// ```

--- a/dev-tools/iota-private-network/README.md
+++ b/dev-tools/iota-private-network/README.md
@@ -185,5 +185,5 @@ Here are some examples of how to set the `TRACE_FILTER` variable based on your t
 - Trace the **checkpoint lifecycle** only, set `TRACE_FILTER=[checkpoint_received_from_state_sync]=trace,[checkpoint_received_from_consensus]=trace`
 - Trace the **transaction lifecycle** only, set `TRACE_FILTER=[handle_consensus_output]=trace,[tx_orchestrator_execute_transaction_block]=trace,[json_rpc_api_execute_transaction_block]=trace`.
   - Trace the transaction sequencing only, set `TRACE_FILTER=[transactions_sequencing]=trace`.
-  - Trace the transaction execution only, set `TRACE_FILTER=[transaction_manager_enqueue_transactions]=trace,[start_execute_pending_certs]=trace, [dev_inspect_tx]=trace,[tx_execute_to_effects]=trace,[dry_exec_tx]=trace`.
+  - Trace the transaction execution only, set `TRACE_FILTER=[transaction_manager_enqueue_transactions]=trace,[start_execute_pending_certs]=trace,[tx_execute_to_effects]=trace,[simulate_tx]=trace`.
 - Trace the consensus, set `TRACE_FILTER=[consensus_add_blocks]=trace,[new_consensus_round_received]=trace`.


### PR DESCRIPTION
# Description of change

`AuthorityState` had four near-duplicate simulation entry points. `dry_exec_transaction`, `dry_exec_transaction_for_benchmark` and `dev_inspect_transaction_block` each carried their own copy of the preflight checks, mock gas handling and executor call — all of which `simulate_transaction` already does, with dry run as `VmChecks::Enabled` and dev inspect as `VmChecks::Disabled`.

- Remove the three functions. Two implementations of the same thing collapse into one, `simulate_transaction_inner`, behind three thin wrappers on `AuthorityState`: `simulate_transaction` loads its own epoch store, `simulate_transaction_in_epoch` takes one from the caller, and `simulate_transaction_for_benchmark` skips the fullnode check for the single-node benchmark, which has no fullnode to run against. That is one fewer public entry point than before, and the ~500 lines cut from `authority.rs` are the duplication going away.
- `simulate_transaction_in_epoch` exists so that deriving gas parameters from an epoch, simulating, and resolving types against that epoch's executor all observe the same epoch. Both JSON-RPC paths use it; the old code got this for free by holding a single guard, and the split would otherwise have opened a reconfiguration window where a dev inspect could see a stale reference gas price.
- Move the JSON-RPC response shaping into `iota-json-rpc`. It resolves packages and types over the objects the simulation wrote before falling back to the store, so packages published by the simulated transaction stay visible.
- Drop `written_with_kind` and its `WriteKind` mapping — `ObjectProviderCache` only ever used the object and its version.
- Generalize `TemporaryModuleResolver` to take the written objects and a binary config rather than the whole `InnerTemporaryStore`, and add `ObjectMapPackageStore`, so both RPC paths resolve packages by borrowing the simulation output instead of copying every written object.
- Run dev inspect on a blocking thread, matching dry run. It was previously an `async fn` with no `await` that executed Move on the reactor. Its five caller-supplied gas fields collapse into the `DevInspectArgs` the JSON-RPC API already models.

## One rule for the gas a simulation runs with, and one for what it reports

A simulation never pays for its gas, so it fills in whatever the caller leaves unset, in either check mode: a zero gas price becomes the epoch's reference gas price, a zero gas budget as much as the gas coins can back up to the protocol maximum, and an empty gas payment a mock gas coin. Neither zero is a value the gas checks could accept anyway — a zero price is below the reference gas price, and a zero budget cannot cover any computation. A budget the caller does set is metered against as given, and either way the gas coins have to cover the resolved budget.

Capping the resolved budget at the coins' balance is what lets a caller estimate without holding `max_tx_gas`: the mock coin covers the maximum, but a real gas coin usually does not, and resolving to the maximum only to reject it for not covering the maximum helps nobody. The cap is raised back to the smallest budget a transaction may declare when the balance falls below even that, so a balance too small to transact at all is still reported against the balance rather than against a budget the caller never set. Execution holds the resolved budget back for the whole programmable transaction and refunds it afterwards, so a transaction that also pays out of its gas coin has to declare a budget leaving room for that, exactly as it would on chain.

What comes back is the gas the run actually used: the price it charged at, the payment it charged to, and — for a caller who declared no budget, and so is asking what the transaction costs — the gas charged in place of their own zero.

Both rules now live in `iota-types::gas`, as `fill_in_unset_simulation_gas` and `report_simulation_gas`, instead of a copy per API:

- `iota-json-rpc` `dev_inspect_transaction_impl` passes the caller's gas through untouched and reports through the shared helper.
- `IotaTestAdapter::dev_inspect` no longer reads an epoch store at all, so `gas_price_and_max_budget` is deleted from `TransactionalAdapter` and both impls, along with the `Simulacrum::max_tx_gas` accessor added for it.
- The gRPC `simulate` handler drops the input rewrite that used to substitute `max_tx_gas` before simulating, and the protocol-config lookup that fed it.
- `Simulacrum::simulate_transaction` is a second implementation of the same logic reached through the same adapter, so it gets the same helpers; without that the simulator-mode transactional tests would break.

The result is that `simulate_transactions` over gRPC and `iota_dryRunTransactionBlock` / `iota_devInspectTransactionBlock` over JSON-RPC now agree on all four of gas price, gas budget, mock gas coin and input checks:

| | zero gas price | zero gas budget | empty gas payment | checks |
| --- | --- | --- | --- | --- |
| **before** — gRPC, checks on | rejected `GasPriceUnderRGP` | rejected `GasBudgetTooLow` | mock coin minted, not reported | full |
| **before** — gRPC, checks off | rejected `GasPriceUnderRGP` | handler rewrote to `max_tx_gas`; returned as gas used | mock coin minted, not reported | relaxed |
| **before** — `dryRun` | rejected `GasPriceUnderRGP` | rejected `GasBudgetTooLow` | minted (random id), reported | full |
| **before** — `devInspect` | omitted → RGP, explicit `0` rejected | omitted → `max_tx_gas`, explicit `0` rejected; a declared budget was ignored and always metered at `max_tx_gas` | minted, not reported | relaxed |
| **after** — all four | → reference gas price | → the coins' balance capped at `max_tx_gas`; returned as the gas charged | minted, reported in the payment | full, or relaxed with the same gas-payment requirements |

## Behavior changes

Everything else is unchanged; these are called out in the release notes.

- `iota_devInspectTransactionBlock` no longer fails on a zero `gas_price` or `gas_budget`, and meters against a budget the caller does supply rather than always against `max_tx_gas`.
- A zero `gas_budget` is an estimate request on every API, not only where the checks are disabled.
- A zero `gas_budget` resolves to what the gas coins can back rather than to `max_tx_gas`, so estimating with real coins no longer requires holding the protocol maximum. Where the coins do cover the maximum nothing changes. The one case this gives up is a transaction that both estimates and pays out of its own gas coin with coins under the maximum: the capped budget is held back for the whole programmable transaction, so it now fails during execution instead of being rejected over the gas up front. That caller has to declare a budget it can cover, which a real transaction requires of it anyway.
- gRPC `simulate_transactions` reports the price it charged at, and names the mock gas coin in the returned transaction's payment rather than echoing the empty payment that was sent.
- The digest a simulation reports is the digest of what actually ran — taken after the gas is filled in — on every endpoint. gRPC `simulate_transactions` already did this; the two JSON-RPC methods now do too, so a transaction sent without a gas payment reports different created object IDs than before. They are also reproducible for a given transaction now, which they were not on either JSON-RPC method.

## Verified rather than assumed

- `check_transaction_input` with the mock coin in the input objects is equivalent to `check_transaction_input_with_given_gas`. The two differ only in `gas_override` (moot — the mock ref is already in `gas_data`) and `is_execute_transaction_to_effects`, which `check_gas` reads only when `authentication_gas_budget > 0`, hard-coded to 0 in every simulation path.
- `DevInspect<false>` returns exactly `Normal`'s values for all five execution-mode gates, so swapping `execute_transaction_to_effects` for `dev_inspect_transaction` leaves effects, gas and events identical. It only additionally collects per-command return values.
- The digest each removed function used, against the one `simulate_transaction` computes. They differed only for a transaction sent without a gas payment, and differently per path: the removed dry run hashed the transaction as submitted, before the mock coin; the removed dev inspect hashed it after, but minted its coin at a random `ObjectId`. gRPC `simulate_transactions` already hashed after, with the fixed coin, and is unaffected. So both JSON-RPC methods now report different created object IDs for a gasless transaction — `TxContext::fresh_id` derives them from the digest — and report the same ones on every run, which neither did before. Nothing was reproducible to break: a real transaction carries its own gas coin, so its digest differs from any of these variants.
- Reporting the gas charged in place of a zero budget means the reported transaction does not hash to the digest the effects are keyed by. That is inherent to estimation, holds identically on both APIs, and is written down on `report_simulation_gas`. With a declared budget the reported transaction is exactly the one that ran, which `simulate_transaction_gasless_reports_the_transaction_that_ran` pins.
- The mock gas coin now sits at a fixed `ObjectId::MAX` instead of a random ID. It is still reported via `mock_gas_id`, so balance-change filtering is unaffected.
- `TryFrom<TransactionEffects> for IotaTransactionBlockEffects` is infallible, so dropping the redundant conversion in the dry-run response loses no error path.
- The `last_version_cache` in `ObjectProviderCache::new_with_cache` is keyed by `(ObjectId, Version)` with the version as its value, so the `if version > existing` branch removed alongside `WriteKind` could never fire.
- `validity_check_no_gas_check` checks the transaction kind and sponsorship and never looks at gas, so a zero price or budget survives to be filled in rather than being rejected before the gas status is built.
- Execution reserves the resolved budget off the smashed gas coin before running any command and refunds it at the end (`ExecutionContext` subtracts it up front, `refund_max_gas_budget` adds it back), then charges the actual cost. That is why capping a resolved budget at the coins' balance costs a transaction paying out of its gas coin the room to do so, and why nothing else is affected.
- Flooring a capped budget at `min_transaction_cost` keeps a balance too small to transact reported as `GasBalanceTooLow` in both check modes, the same variant as before, rather than reporting a budget the caller never set. Checking the balance against it in the fill-in instead would report it ahead of the more specific gas-object errors, which the checkers raise while walking the same coins.

## Smaller notes for reviewers

- The benchmark entry point now also rejects system transactions, which `dry_exec_transaction_for_benchmark` did not. The benchmark never builds one, so this is an added guard rather than a change in behavior.
- `TRACE_FILTER` docs in `dev-tools/iota-private-network/README.md` are updated: the `dry_exec_tx` and `dev_inspect_tx` spans are replaced by `simulate_tx`.
- The gas-payment-object count limit (`max_gas_payment_objects`) applies on the simulation path too, checked before any object is loaded. The boundary lives in one place, `TransactionDataAPI::check_gas_payment_size`, called from `validity_check` and from each simulation path — `iota-core`, `simulacrum` and `iota-vm-sdk` — rather than being spelled out per caller.
- Both check modes now reach the same conclusions about the gas payment: every object it names has to be an address-owned gas coin present in the inputs, and their combined balance has to cover the resolved budget. With the checks enabled that comes from `check_transaction_input`; with them disabled, from `iota_types::gas::check_gas_coins_cover_budget`, which is `IotaGasStatus::check_gas_balance` minus the bounds on the budget itself — a simulation deliberately leaves those to metering, so a caller probing with a small budget runs out of gas rather than being rejected.
- `iota-vm-sdk` had already capped a dev-inspect budget at the coin balance, which is the rule the node now adopts — but it did so without the floor at the smallest declarable budget and without checking the coins cover the result, so it silently succeeded where the node rejected. It now calls the same helpers on the same inputs, so a `LocalVm` preview and the node agree on the same transaction. `docs/execution-model.md` is brought in line (its `DevInspect`/`DryRun` gas rows described the pre-fill-in behavior).
- `ObjectMapPackageStore` is a wrapper rather than an impl on the map itself: `WrittenObjects` and `ObjectMap` are both aliases for the same `BTreeMap`, so implementing `BackingPackageStore` on either would turn every map of that shape in the tree into a package store.
- Two code comments claimed the per-command return values are reported only with the checks disabled. `DevInspect<S>::finish_command` collects them for either `S`, so both modes report them. Corrected on `VmChecks` and `SimulateTransactionResult::execution_result`.

## Links to any relevant issues

None.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: `iota_dryRunTransactionBlock` and `iota_devInspectTransactionBlock` now fill in unset gas the same way and report what the simulation charged.
  - Unset gas is resolved: no payment gets a mock gas coin, a zero `gas_price` the epoch's reference gas price, and a zero `gas_budget` what the gas coins can back — capped at the protocol maximum, and raised to the smallest budget a transaction may declare if the coins hold less.
  - `iota_devInspectTransactionBlock` no longer fails on a zero `gas_price` or `gas_budget`, and meters against a `gas_budget` you do supply instead of always the protocol maximum.
  - The gas coins must cover the resolved budget (`GasBalanceTooLow`), every object in the payment must be an address-owned `Coin<IOTA>` (`InvalidGasObject` / `GasObjectNotOwnedObject`), and `max_gas_payment_objects` applies (`SizeLimitExceeded`).
  - With `gas_budget: 0` the reported transaction carries the gas charged and the price it was charged at, so the estimate can be read back — matching gRPC `simulate_transactions`.
  - Both report the digest of what actually ran, so a transaction sent without a gas payment reports different created object IDs than before, and the same ones on every run.
  - A system transaction is now rejected with `simulate` in the message rather than `dev-inspect`/`dry-exec`.
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] gRPC: `simulate_transactions` now reports the gas the run actually used.
  - The returned transaction carries the price it was charged at, and the mock gas coin for a transaction sent without a gas payment, in place of the empty payment echoed back before.
  - Estimating no longer depends on `DisableVmChecks`: a zero `gas_budget` resolves and comes back as the cost charged in either check mode, where with the checks enabled it previously failed with `GasBudgetTooLow`.
  - The resolved budget is capped at the gas coins' balance, so estimating with a real gas coin no longer requires it to cover the protocol maximum. A balance below the smallest declarable budget is still reported as `GasBalanceTooLow`.

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---


