### PR TITLE
feat(protocol): enable package_metadata_with_dynamic_module_metadata on testnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -3160,6 +3160,10 @@ impl ProtocolConfig {
                         // Amortize the minimum checkpoint interval over a sliding
                         // window so the checkpoint rate holds at the ceiling.
                         cfg.checkpoint_rate_window_size = Some(20);
+                        // Publish package metadata with the module metadata stored as a
+                        // dynamic field.
+                        cfg.feature_flags
+                            .package_metadata_with_dynamic_module_metadata = true;
                     }
                 }
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -191,6 +191,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             consensus on testnet.
 //             Amortize the minimum checkpoint interval over a sliding window
 //             on testnet.
+//             Start publishing package metadata using module metadata as a
+//             dynamic field on testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_32.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_32.snap
@@ -48,6 +48,7 @@ feature_flags:
   consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
   validator_metadata_verify_v2: true
+  package_metadata_with_dynamic_module_metadata: true
   report_move_authentication_error: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048


### PR DESCRIPTION
# Description of change

 Enables package_metadata_with_dynamic_module_metadata on testnet.

### Release Notes

- [x] Protocol: Publish package metadata with the module metadata stored as a dynamic field and allows view functions on Testnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---
