### PR TITLE
feat(protocol): enable aa sponsorship on mainnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -196,6 +196,9 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             Enable the redesigned leader schedule (sliding-window reputation
 //             scoring and absolute-score bad-node selection) in Starfish
 //             consensus on devnet.
+//             Enable Move-based sponsor account authentication on mainnet.
+//             Only sponsor Move authentication is performed pre-consensus on
+//             mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3166,6 +3169,12 @@ impl ProtocolConfig {
                     cfg.validator_low_stake_threshold = Some(1_500_000_000_000_000);
                     cfg.validator_very_low_stake_threshold = Some(1_000_000_000_000_000);
                     cfg.validator_low_stake_grace_period = Some(7);
+
+                    // Enable Move-based sponsor account authentication in mainnet.
+                    cfg.feature_flags.enable_move_authentication_for_sponsor = true;
+                    // Only sponsor Move authentication is performed pre-consensus in mainnet.
+                    cfg.feature_flags
+                        .pre_consensus_sponsor_only_move_authentication = true;
 
                     if chain != Chain::Mainnet {
                         // Enable the optimistic commit rule (StarfishSpeed) in

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_32.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_32.snap
@@ -37,11 +37,13 @@ feature_flags:
   metadata_in_module_bytes: true
   publish_package_metadata: true
   enable_move_authentication: true
+  enable_move_authentication_for_sponsor: true
   pass_validator_scores_to_advance_epoch: true
   consensus_fast_commit_sync: true
   consensus_block_restrictions: true
   move_native_tx_context: true
   additional_borrow_checks: true
+  pre_consensus_sponsor_only_move_authentication: true
   always_advance_dkg_to_resolution: true
   validator_metadata_verify_v2: true
   report_move_authentication_error: true


### PR DESCRIPTION
# Description of change

Enables Move-based sponsor account authentication and the pre-consensus logic to authenticate only the sponsor Move authentication (if present) in mainnet.

### Release Notes

- [x] Protocol: Enables Move-based sponsor account authentication and the pre-consensus logic to authenticate only the sponsor Move authentication (if present) in mainnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---
