### PR TITLE
upstream(core): Use a longer WaitForLocalExecution timeout under msim

### DIFF
--- a/crates/iota-sdk/src/apis/quorum_driver.rs
+++ b/crates/iota-sdk/src/apis/quorum_driver.rs
@@ -16,7 +16,6 @@ use crate::{
     error::{Error, IotaRpcResult},
 };
 
-const WAIT_FOR_LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(60);
 const WAIT_FOR_LOCAL_EXECUTION_MIN_INTERVAL: Duration = Duration::from_millis(100);
 const WAIT_FOR_LOCAL_EXECUTION_MAX_INTERVAL: Duration = Duration::from_secs(2);
 
@@ -70,7 +69,13 @@ impl QuorumDriverApi {
 
         // JSON-RPC ignores WaitForLocalExecution, so simulate it by polling for the
         // transaction.
-        let mut poll_response = tokio::time::timeout(WAIT_FOR_LOCAL_EXECUTION_TIMEOUT, async {
+        let wait_for_local_execution_timeout: Duration = if cfg!(msim) {
+            // In simtests, fullnodes can stop receiving checkpoints for > 30s.
+            Duration::from_secs(120)
+        } else {
+            Duration::from_secs(60)
+        };
+        let mut poll_response = tokio::time::timeout(wait_for_local_execution_timeout, async {
             let mut backoff = iota_common::backoff::ExponentialBackoff::new(
                 WAIT_FOR_LOCAL_EXECUTION_MIN_INTERVAL,
                 WAIT_FOR_LOCAL_EXECUTION_MAX_INTERVAL,


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.52.3, v1.53.2)
- Port commit:
  - [MystenLabs/sui@4c0b46c](https://github.com/MystenLabs/sui/commit/4c0b46c74d324db60c6fbaf80460eebb829a67dc)
- Description:

Upstream fixes a few small issues hit when running benchmark simtests. Only the SDK part applies to this repo: raise the JSON-RPC `WaitForLocalExecution` polling timeout from 60s to 120s under `msim`, since fullnodes in simtests can stop receiving checkpoints for more than 30s.

Note:
- Changes in `delegation.rs`, `slow.rs` live in `network-benchmark` and is ported there separately.

## Links to any relevant issues

Part of #12269

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes