### PR TITLE
upstream(core): Restore marker table pruning

### DIFF
--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1258,7 +1258,7 @@ impl WritebackCache {
         self.cache_latest_object_by_id(object_id, LatestObjectCacheEntry::NonExistent, ticket);
     }
 
-    fn clear_state_end_of_epoch_impl(&self, _execution_guard: &ExecutionLockWriteGuard<'_>) {
+    fn clear_state_end_of_epoch_impl(&self, execution_guard: &ExecutionLockWriteGuard<'_>) {
         info!("clearing state at end of epoch");
         assert!(
             self.dirty.pending_transaction_writes.is_empty(),
@@ -1267,6 +1267,10 @@ impl WritebackCache {
         self.dirty.clear();
         info!("clearing old transaction locks");
         self.object_locks.clear();
+        info!("clearing object per epoch marker table");
+        self.store
+            .clear_object_per_epoch_marker_table(execution_guard)
+            .expect("db error");
     }
 
     fn revert_state_update_impl(&self, tx: &TransactionDigest) -> IotaResult {


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.52.3, v1.53.2)
- Port commit:
  - [MystenLabs/sui@e98196c](https://github.com/MystenLabs/sui/commit/e98196c5dbb4980875b415bfa0ae70b87ab0027e)
- Description:

`WritebackCache::clear_state_end_of_epoch_impl` stopped clearing the object per epoch
marker table, leaving stale marker entries in the perpetual table across epoch
boundaries. Restore the `clear_object_per_epoch_marker_table` call and pass through the
execution lock write guard, which enforces that it only happens during reconfiguration.

## Links to any relevant issues

Part of #12269

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes