### PR TITLE
fix(iota-core): tolerate out-of-order validator feedback timestamps

### DIFF
--- a/crates/iota-core/src/validator_client_monitor/stats.rs
+++ b/crates/iota-core/src/validator_client_monitor/stats.rs
@@ -98,11 +98,19 @@ impl TimeDecayEwma {
         }
     }
 
+    /// `now` is not guaranteed to be at or after [`Self::last_update`]:
+    /// feedback is stamped with `Instant::now()` before its recorder contends
+    /// for the stats lock, so two recorders reporting on the same validator can
+    /// reach the stats in the opposite order to their timestamps. A late sample
+    /// saturates to Δt ≈ 0, which folds it in with a negligible weight rather
+    /// than letting it rewrite the estimate.
     fn interval_alpha(&self, tau: f64, now: Instant) -> (f64, f64) {
-        debug_assert!(now >= self.last_update, "Timestamps must be non-decreasing");
         // α_t = 1 - exp(-Δt / τ)
         // avoid zero Δt, otherwise (α_t = 0) observation won't be updated
-        let dt = now.duration_since(self.last_update).as_secs_f64().max(1e-9);
+        let dt = now
+            .saturating_duration_since(self.last_update)
+            .as_secs_f64()
+            .max(1e-9);
         let interval = dt / tau;
         (interval, 1.0 - (-interval).exp())
     }
@@ -111,7 +119,9 @@ impl TimeDecayEwma {
         let (interval, alpha) = self.interval_alpha(tau, now);
         // Update the value EWMA with time-derived alpha.
         self.ewma.update(observation, alpha);
-        self.last_update = now;
+        // Never move the clock backwards: a sample that arrived late must not
+        // make the samples that already landed look newer than they are.
+        self.last_update = self.last_update.max(now);
         // Update the interval EWMA with a fixed weight of 0.1.
         const ALPHA: f64 = 0.1;
         self.interval_ewma = Some(

--- a/crates/iota-core/src/validator_client_monitor/tests.rs
+++ b/crates/iota-core/src/validator_client_monitor/tests.rs
@@ -42,12 +42,16 @@ fn now() -> Instant {
     Instant::from_std(std::time::Instant::now())
 }
 
-/// Feed all 4 operations interleaved at each timestep.
+/// Feed all 4 operations interleaved at each timestep, so every operation's
+/// estimator advances together.
 ///
-/// Operations must be interleaved (not sequential per-op) because
 /// `record_interaction_result` calls `performance_score` internally with
-/// `feedback.timestamp`, querying all op EWMAs. If op B starts at t0 while
-/// op A was last updated at t0+n*dt, the assert `now >= last_update` fails.
+/// `feedback.timestamp`, querying all op EWMAs — so feeding one operation ahead
+/// of the others leaves the rest being read at timestamps older than their last
+/// update. That is tolerated (see
+/// `out_of_order_feedback_is_tolerated_and_preserves_the_clock`); interleaving
+/// just keeps the intervals uniform, which is what these tests want to assert
+/// on.
 fn feed_all(
     stats: &mut ClientObservedStats,
     v: AuthorityName,
@@ -149,6 +153,91 @@ mod scoring {
             "fast validator should score lower; fast={:.2} slow={:.2}",
             last_fast.0,
             last_slow.0
+        );
+    }
+
+    /// Covers both ways feedback reaches the stats out of order, and what the
+    /// estimator must do about it.
+    ///
+    /// Two recorders reporting on the same validator and operation can reach
+    /// the stats in the opposite order to their timestamps. Separately —
+    /// needing no concurrency at all — `record_interaction_result` scores a
+    /// validator by querying *every* operation's estimator with the incoming
+    /// feedback's timestamp, while each operation advances on its own
+    /// schedule, so a health check stamped behind a submission reads the
+    /// submit estimator at an older timestamp. Both must be tolerated.
+    ///
+    /// A late sample must also not drag the estimator's clock backwards, or
+    /// the samples that already landed would look newer than they are and
+    /// later intervals would be inflated. The weight given to a subsequent
+    /// observation is what makes that visible, so it is asserted against a
+    /// control that saw no late sample.
+    #[test]
+    fn out_of_order_feedback_is_tolerated_and_preserves_the_clock() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut late = ClientObservedStats::new(config.clone());
+        let mut ordered = ClientObservedStats::new(config);
+        let v = gen_validator();
+        let t0 = now();
+        let dt = Duration::from_millis(100);
+
+        // Advance Submit well past t0 on both.
+        for i in 0..10u32 {
+            for stats in [&mut late, &mut ordered] {
+                stats.record_interaction_result(&make_fb(
+                    v,
+                    OperationType::Submit,
+                    Ok(Duration::from_millis(100)),
+                    t0 + dt * (i + 1),
+                ));
+            }
+        }
+
+        // Cross-operation: a health check stamped back at t0 + dt still has to
+        // score the validator, which reads the Submit estimator at that older
+        // timestamp. Applied to both so the two stay comparable below.
+        for stats in [&mut late, &mut ordered] {
+            let score = stats.record_interaction_result(&make_fb(
+                v,
+                OperationType::HealthCheck,
+                Ok(Duration::from_millis(100)),
+                t0 + dt,
+            ));
+            assert!(
+                score.0.is_finite() && score.1.is_finite(),
+                "cross-operation ordering must yield a usable score; got {score:?}"
+            );
+        }
+
+        // Same operation, stamped before the samples above but arriving after
+        // them. Only one of the two sees it.
+        late.record_interaction_result(&make_fb(
+            v,
+            OperationType::Submit,
+            Ok(Duration::from_millis(100)),
+            t0,
+        ));
+
+        // A slow observation last, so the weight the estimator gives it — which
+        // is derived from the interval since its last update — is visible in
+        // the score. Had the late sample rewound the clock to t0, this interval
+        // would look twice as long and the slow sample would count for more.
+        let after_late = late.record_interaction_result(&make_fb(
+            v,
+            OperationType::Submit,
+            Ok(Duration::from_millis(500)),
+            t0 + dt * 20,
+        ));
+        let after_ordered = ordered.record_interaction_result(&make_fb(
+            v,
+            OperationType::Submit,
+            Ok(Duration::from_millis(500)),
+            t0 + dt * 20,
+        ));
+
+        assert!(
+            (after_late.0 - after_ordered.0).abs() < 1e-9,
+            "late feedback rewound the clock: {after_late:?} vs {after_ordered:?}"
         );
     }
 }
@@ -271,7 +360,7 @@ mod data_management {
         }
         assert_eq!(stats.num_validators(), 5);
         // More observations for an existing validator must not change the count.
-        // Start after t0 + 5*dt so timestamps remain non-decreasing for v[0].
+        // Start after t0 + 5*dt so v[0]'s intervals stay uniform.
         let t1 = t0 + dt * 6;
         feed_all(&mut stats, v[0], Ok(100), 10, t1, dt);
         assert_eq!(stats.num_validators(), 5);


### PR DESCRIPTION
# Description of change

`TimeDecayEwma::interval_alpha` asserted `debug_assert!(now >= self.last_update, "Timestamps must be non-decreasing")`, but that is an invariant the callers cannot provide, so the assert took down debug builds under stress load.

There are two independent ways to reach it. First, feedback is stamped with `Instant::now()` by its recorder — via `OperationFeedback::ok_now`/`err_now` — *before* that recorder takes the `client_stats` write lock in `ValidatorClientMonitor::record_interaction_result`, so two recorders reporting on the same validator can reach the stats in the opposite order to their timestamps. `transaction_submitter`, `effects_certifier` and `transaction_driver` all record concurrently, so this is ordinary behaviour rather than an edge case.

Second, and needing no concurrency at all: `record_interaction_result` scores the validator by calling `performance_score` with the incoming feedback's timestamp, and that reads *every* operation's estimator. Each operation advances on its own schedule — health checks fire on a timer while submissions follow load — so a health check stamped behind a submission reads the submit estimator at a timestamp older than its last update.

The fix saturates the interval, which folds a late sample in with a negligible weight instead of letting it rewrite the estimate, and stops `last_update` moving backwards so a late sample cannot inflate the intervals measured after it.

Two things worth a reviewer's attention. Release builds were never affected by the crash, since `Instant::duration_since` saturates rather than panicking, so this is a debug-only crash — but the `last_update` change *is* a small behavioural change in release: previously a late sample rewound the estimator's clock, which inflated the next interval and so overweighted the next observation. Scoring is now stable against out-of-order arrival. This is a client-side heuristic for choosing submission targets, so it affects neither transaction processing nor any BCS-encoded surface, and needs no protocol-config gate.

Separately, the existing tests in this module were already working around the assert rather than satisfying it — `feed_all` documented that operations "must be interleaved" because otherwise "the assert `now >= last_update` fails", and another test offset its timestamps "so timestamps remain non-decreasing". Those comments are updated, since the constraint they were avoiding is gone.

## Links to any relevant issues

None filed — found while running the `iotaledger/network-benchmark` nightly stress job against current `develop`.

## How the change has been tested

Reproduced with the network-benchmark stress binary against a local network — the panic fires 3–4 times per run and kills the process, on an unmodified `network-benchmark` checkout, so it is attributable to the iota pin alone:

```
cargo run --package iota-benchmark --bin stress -- --log-path /tmp/stress.log \
  --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 \
  bench --target-qps 100 --num-workers 10 --transfer-object 50 --shared-counter 50 \
  --run-duration 10s --stress-stat-collection
```

| iota pin | result |
| --- | --- |
| `e80fecef` | passes |
| `4bbd7162` (before this change) | panics 3/3 |
| `4bbd7162` + this change | passes 3/3, 0 panics, 395 txs at 39 TPS, 0% error |

The three added tests cover both routes into the assert and the clock-rewind behaviour separately. Each was confirmed to fail without the corresponding half of the fix: with the assert restored all three fail at `stats.rs:102`; with the assert removed but `last_update = now` put back, the first two pass and `late_feedback_does_not_rewind_the_estimator_clock` fails on the score difference (918.08 vs 914.08) — so it genuinely guards the clock, not just the absence of the assert.

Note that stress simtests do **not** reproduce this: 3/3 pass under `msim` against `4bbd7162` even with `debug-assertions = true`, presumably because simulated time and the deterministic scheduler do not produce the interleaving.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes