### PR TITLE
upstream(iota-execution): Port upstream object runtime type tags (pull IotaDataStore into a separate module)

### DIFF
--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -40,12 +40,12 @@ mod checked {
     };
     use move_binary_format::{
         CompiledModule,
-        errors::{Location, PartialVMError, PartialVMResult, VMError, VMResult},
+        errors::{Location, PartialVMError, VMError, VMResult},
         file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
     };
     use move_core_types::{
         account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
-        resolver::ModuleResolver, vm_status::StatusCode,
+        vm_status::StatusCode,
     };
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::{
@@ -53,7 +53,7 @@ mod checked {
         native_extensions::NativeContextExtensions,
         session::{LoadedFunctionInstantiation, SerializedReturnValues},
     };
-    use move_vm_types::{data_store::DataStore, loaded_data::runtime_types::Type};
+    use move_vm_types::loaded_data::runtime_types::Type;
     use tracing::instrument;
 
     use crate::{
@@ -66,7 +66,7 @@ mod checked {
         },
         gas_charger::GasCharger,
         gas_meter::IotaGasMeter,
-        programmable_transactions::linkage_view::LinkageView,
+        programmable_transactions::{data_store::IotaDataStore, linkage_view::LinkageView},
         type_resolver::TypeTagResolver,
     };
 
@@ -1690,101 +1690,6 @@ mod checked {
             contents,
             protocol_config,
         )
-    }
-
-    // Implementation of the `DataStore` trait for the Move VM.
-    // When used during execution it may have a list of new packages that have
-    // just been published in the current context. Those are used for module/type
-    // resolution when executing module init.
-    // It may be created with an empty slice of packages either when no
-    // publish/upgrade are performed or when a type is requested not during
-    // execution.
-    pub(crate) struct IotaDataStore<'state, 'a> {
-        linkage_view: &'a LinkageView<'state>,
-        new_packages: &'a [MovePackage],
-    }
-
-    impl<'state, 'a> IotaDataStore<'state, 'a> {
-        pub(crate) fn new(
-            linkage_view: &'a LinkageView<'state>,
-            new_packages: &'a [MovePackage],
-        ) -> Self {
-            Self {
-                linkage_view,
-                new_packages,
-            }
-        }
-
-        fn get_module(&self, module_id: &ModuleId) -> Option<&Vec<u8>> {
-            for package in self.new_packages {
-                if package.id != ObjectId::from(module_id.address().into_bytes()) {
-                    continue;
-                }
-
-                let module = package.get_module(&identifier_core_to_sdk(module_id.name()));
-
-                if module.is_some() {
-                    return module;
-                }
-            }
-            None
-        }
-    }
-
-    // TODO: `DataStore` will be reworked and this is likely to disappear.
-    //       Leaving this comment around until then as testament to better days to
-    // come...
-    impl DataStore for IotaDataStore<'_, '_> {
-        fn link_context(&self) -> AccountAddress {
-            self.linkage_view.link_context()
-        }
-
-        fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId> {
-            self.linkage_view.relocate(module_id).map_err(|err| {
-                PartialVMError::new(StatusCode::LINKER_ERROR)
-                    .with_message(format!("Error relocating {module_id}: {err:?}"))
-            })
-        }
-
-        fn defining_module(
-            &self,
-            runtime_id: &ModuleId,
-            struct_: &IdentStr,
-        ) -> PartialVMResult<ModuleId> {
-            self.linkage_view
-                .defining_module(runtime_id, struct_)
-                .map_err(|err| {
-                    PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
-                        "Error finding defining module for {runtime_id}::{struct_}: {err:?}"
-                    ))
-                })
-        }
-
-        fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
-            if let Some(bytes) = self.get_module(module_id) {
-                return Ok(bytes.clone());
-            }
-            match self.linkage_view.get_module(module_id) {
-                Ok(Some(bytes)) => Ok(bytes),
-                Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
-                    .with_message(format!("Cannot find {module_id:?} in data cache"))
-                    .finish(Location::Undefined)),
-                Err(err) => {
-                    let msg = format!("Unexpected storage error: {err:?}");
-                    Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(msg)
-                            .finish(Location::Undefined),
-                    )
-                }
-            }
-        }
-
-        fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {
-            // we cannot panic here because during execution and publishing this is
-            // currently called from the publish flow in the Move runtime
-            Ok(())
-        }
     }
 
     enum EitherError {

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/data_store.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/data_store.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_sdk_types::{ObjectId, move_package::MovePackage};
+use iota_types::iota_sdk_types_conversions::identifier_core_to_sdk;
+use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+    resolver::ModuleResolver, vm_status::StatusCode,
+};
+use move_vm_types::data_store::DataStore;
+
+use crate::programmable_transactions::linkage_view::LinkageView;
+
+// Implementation of the `DataStore` trait for the Move VM.
+// When used during execution it may have a list of new packages that have
+// just been published in the current context. Those are used for module/type
+// resolution when executing module init.
+// It may be created with an empty slice of packages either when no
+// publish/upgrade are performed or when a type is requested not during
+// execution.
+pub(crate) struct IotaDataStore<'state, 'a> {
+    linkage_view: &'a LinkageView<'state>,
+    new_packages: &'a [MovePackage],
+}
+
+impl<'state, 'a> IotaDataStore<'state, 'a> {
+    pub(crate) fn new(
+        linkage_view: &'a LinkageView<'state>,
+        new_packages: &'a [MovePackage],
+    ) -> Self {
+        Self {
+            linkage_view,
+            new_packages,
+        }
+    }
+
+    fn get_module(&self, module_id: &ModuleId) -> Option<&Vec<u8>> {
+        for package in self.new_packages {
+            if package.id != ObjectId::from(module_id.address().into_bytes()) {
+                continue;
+            }
+
+            let module = package.get_module(&identifier_core_to_sdk(module_id.name()));
+
+            if module.is_some() {
+                return module;
+            }
+        }
+        None
+    }
+}
+
+// TODO: `DataStore` will be reworked and this is likely to disappear.
+//       Leaving this comment around until then as testament to better days to
+// come...
+impl DataStore for IotaDataStore<'_, '_> {
+    fn link_context(&self) -> AccountAddress {
+        self.linkage_view.link_context()
+    }
+
+    fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId> {
+        self.linkage_view.relocate(module_id).map_err(|err| {
+            PartialVMError::new(StatusCode::LINKER_ERROR)
+                .with_message(format!("Error relocating {module_id}: {err:?}"))
+        })
+    }
+
+    fn defining_module(
+        &self,
+        runtime_id: &ModuleId,
+        struct_: &IdentStr,
+    ) -> PartialVMResult<ModuleId> {
+        self.linkage_view
+            .defining_module(runtime_id, struct_)
+            .map_err(|err| {
+                PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
+                    "Error finding defining module for {runtime_id}::{struct_}: {err:?}"
+                ))
+            })
+    }
+
+    fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
+        if let Some(bytes) = self.get_module(module_id) {
+            return Ok(bytes.clone());
+        }
+        match self.linkage_view.get_module(module_id) {
+            Ok(Some(bytes)) => Ok(bytes),
+            Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+                .with_message(format!("Cannot find {module_id:?} in data cache"))
+                .finish(Location::Undefined)),
+            Err(err) => {
+                let msg = format!("Unexpected storage error: {err:?}");
+                Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(msg)
+                        .finish(Location::Undefined),
+                )
+            }
+        }
+    }
+
+    fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {
+        // we cannot panic here because during execution and publishing this is
+        // currently called from the publish flow in the Move runtime
+        Ok(())
+    }
+}

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -77,7 +77,7 @@ mod checked {
             ensure_serialized_size,
         },
         gas_charger::GasCharger,
-        programmable_transactions::{context::*, package_metadata::*},
+        programmable_transactions::{context::*, data_store::IotaDataStore, package_metadata::*},
     };
 
     /// Executes a `ProgrammableTransaction` in the specified `ExecutionMode`,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/mod.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod context;
+pub mod data_store;
 pub mod execution;
 pub mod linkage_view;
 pub mod package_metadata;


### PR DESCRIPTION
[run-ci]

# Description of change


Ports the surviving cleanup commit from the upstream Sui "object runtime type tags” series. The functional changes (adding type tags to the object runtime) were reverted upstream within the same release range, so only the module-extraction cleanup is ported.

- Pulls `IotaDataStore` out of `context.rs` into its own `programmable_transactions/data_store.rs` module. 
No semantic changes.


| Commit | Description |
|--------|-------------|
| `86feabc2e95e62cd6f570e8db02cb145a183fb36` | [1/n][object runtime type tags][cleanup-only] Pull `SuiDataStore` into a separate module (#22079) |

### Skipped commits (net-zero — reverted upstream within the range)

| Commit | Description | Reason |
|--------|-------------|--------|
| `e04baee853fd7ca2e7c3a263ee1321b3dadff864` | [2/n] Normalize to defining ID (TypeInput → TypeTag) (#22081) | Reverted by #22154 |
| `b4ea7a49e20e4b5eb187c54e9582140b5515801a` | [3/n] Add type tags to object runtime adapter (#22092) | Reverted by #22154 |
| `4c12d160ebff7ff14e573f51f0dc685fc773fabf` | Revert object runtime changes (#22154) | Reverts #22081 + #22092 |
| `84b515d4028ede7020742d13b89a04c54a2022e7` | [3/n] Add type tags to object runtime (part 2) (#22169) | Reverted by #22213 |
| `3ef6fe80517063424a7b1d7e481897b49d0afad9` | Revert part 2 (#22213) | Reverts #22169 |

## Links to any relevant issues

Fixes #10829 .
