### PR TITLE
fix(iota-core): make index pruning race-safe, bound the backfill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8033,7 +8033,6 @@ dependencies = [
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
- "move-core-types",
  "num_cpus",
  "object_store 0.13.1",
  "prometheus-filtered",

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -34,7 +34,7 @@ use iota_types::{
     inner_temporary_store::TxCoins,
     iota_sdk_types_conversions::type_tag_core_to_sdk,
     layout_resolver::LayoutResolver,
-    messages_checkpoint::{CheckpointContentsExt, CheckpointSequenceNumber},
+    messages_checkpoint::{CheckpointContentsExt, CheckpointSequenceNumber, VerifiedCheckpoint},
     object::{Object, bounded_visitor::BoundedVisitor},
     parse_iota_struct_tag,
     storage::{ObjectStore, error::Error as StorageError},
@@ -790,6 +790,10 @@ pub struct IndexStore {
     max_type_length: u64,
     pending_updates: Mutex<BTreeMap<CheckpointSequenceNumber, PendingCheckpointUpdate>>,
     history_backfill_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// The retention horizon recorded by the last [`Self::prune`] call:
+    /// epochs below it are dropped on the pruner's next pass. Zero until the
+    /// first prune — no pruning means no horizon.
+    earliest_retained_epoch: AtomicU64,
 }
 
 /// The pieces produced by opening the index database.
@@ -1380,8 +1384,9 @@ impl IndexStore {
 
     /// Fills the history tables for the checkpoints below
     /// `history_watermark`, newest first, until it reaches the
-    /// checkpoint-contents pruner. The marker commits atomically with each
-    /// checkpoint's rows, so an interrupted run resumes where it stopped.
+    /// checkpoint-contents pruner or falls below the index retention
+    /// horizon recorded by [`Self::prune`]. The marker commits atomically with
+    /// each checkpoint's rows, so an interrupted run resumes where it stopped.
     /// No-op when the marker is absent (the history was indexed continuously
     /// and is complete).
     #[tracing::instrument(skip_all)]
@@ -1412,7 +1417,19 @@ impl IndexStore {
             if next < lowest {
                 break;
             }
-            self.replay_checkpoint_history(authority_store, checkpoint_store, next)?;
+            let summary = checkpoint_store
+                .get_checkpoint_by_sequence_number(next)?
+                .ok_or_else(|| StorageError::missing(format!("missing checkpoint {next}")))?;
+            let horizon = self.earliest_retained_epoch.load(Ordering::Relaxed);
+            if summary.epoch < horizon {
+                info!(
+                    "Stopping the JSON-RPC history backfill at checkpoint {next}: epoch {} is \
+                     below the index retention horizon {horizon}",
+                    summary.epoch
+                );
+                break;
+            }
+            self.replay_checkpoint_history(authority_store, checkpoint_store, &summary)?;
             replayed += 1;
             if last_report.elapsed() >= PROGRESS_REPORT_INTERVAL {
                 last_report = Instant::now();
@@ -1450,11 +1467,9 @@ impl IndexStore {
         &self,
         authority_store: &AuthorityStore,
         checkpoint_store: &CheckpointStore,
-        checkpoint_seq: CheckpointSequenceNumber,
+        summary: &VerifiedCheckpoint,
     ) -> Result<(), StorageError> {
-        let summary = checkpoint_store
-            .get_checkpoint_by_sequence_number(checkpoint_seq)?
-            .ok_or_else(|| StorageError::missing(format!("missing checkpoint {checkpoint_seq}")))?;
+        let checkpoint_seq = summary.sequence_number;
         let contents = checkpoint_store
             .get_checkpoint_contents(&summary.content_digest)?
             .ok_or_else(|| {
@@ -1560,6 +1575,7 @@ impl IndexStore {
             max_type_length: max_type_length.unwrap_or(128),
             pending_updates: Mutex::new(BTreeMap::new()),
             history_backfill_task: Mutex::new(None),
+            earliest_retained_epoch: AtomicU64::new(0),
         }
     }
 
@@ -1677,34 +1693,47 @@ impl IndexStore {
     /// `epochs_to_retain` = N, the buckets of the newest N epochs are kept
     /// and every older bucket is dropped wholesale — one constant-time
     /// column-family drop each, with no per-row deletes and no compaction
-    /// churn. Returns the earliest retained epoch.
+    /// churn. Returns the earliest retained epoch, and records it so the
+    /// history backfill stops instead of replaying epochs the next pass
+    /// would drop.
     ///
     /// A query racing a drop may report an error for the dropped epoch's
     /// rows; a retry no longer sees the bucket.
     pub fn prune(&self, epochs_to_retain: u64) -> IotaResult<Option<EpochId>> {
-        let (expired, earliest_retained) = {
-            let mut history = self.history.write();
-            let Some((&newest, _)) = history.last_key_value() else {
-                return Ok(None);
-            };
-            let earliest_retained = newest.saturating_sub(epochs_to_retain.saturating_sub(1));
-            let expired: Vec<EpochId> = history
-                .range(..earliest_retained)
-                .map(|(&e, _)| e)
-                .collect();
-            history.retain(|&epoch, _| epoch >= earliest_retained);
-            (expired, earliest_retained)
+        let mut history = self.history.write();
+        let Some((&newest, _)) = history.last_key_value() else {
+            return Ok(None);
         };
+        let earliest_retained = newest.saturating_sub(epochs_to_retain.saturating_sub(1));
+        let expired: Vec<EpochId> = history
+            .range(..earliest_retained)
+            .map(|(&e, _)| e)
+            .collect();
+        history.retain(|&epoch, _| epoch >= earliest_retained);
+        self.earliest_retained_epoch
+            .store(earliest_retained, Ordering::Relaxed);
+        // The drops run under the map's write lock: `ensure_history_bucket`
+        // could otherwise hand out a bucket for an epoch whose column family
+        // is dropped a moment later.
+        let mut result = Ok(());
         for epoch in expired {
             info!(
                 epoch,
                 "dropping the JSON-RPC index history of an expired epoch"
             );
-            self.db
-                .drop_cf(&history_cf_name(epoch))
-                .map_err(|e| IotaError::Storage(e.to_string()))?;
+            if let Err(e) = self.db.drop_cf(&history_cf_name(epoch)) {
+                // Keep dropping the rest; a leftover column family is
+                // rediscovered and dropped again after the next reopen.
+                warn!(
+                    epoch,
+                    "failed to drop an expired history column family: {e}"
+                );
+                if result.is_ok() {
+                    result = Err(IotaError::Storage(e.to_string()));
+                }
+            }
         }
-        Ok(Some(earliest_retained))
+        result.map(|()| Some(earliest_retained))
     }
 
     pub fn tables(&self) -> &IndexStoreTables {
@@ -2749,7 +2778,9 @@ impl IndexStore {
 
 #[cfg(test)]
 mod tests {
-    use iota_sdk_types::{CheckpointSummary, GasCostSummary, ObjectId, StructTag};
+    use iota_sdk_types::{
+        CheckpointSummary, GasCostSummary, ObjectId, StructTag, TransactionDigest,
+    };
     use iota_types::{
         committee::EpochId,
         crypto::AuthorityStrongQuorumSignInfo,
@@ -2798,11 +2829,24 @@ mod tests {
             .unwrap();
     }
 
+    /// Seeds `epochs` history buckets with one transaction each.
+    fn seed_history_buckets(index_store: &IndexStore, epochs: u64) {
+        for epoch in 0..epochs {
+            let bucket = index_store.ensure_history_bucket(epoch).unwrap();
+            let mut batch = index_store.tables.meta.batch();
+            bucket
+                .transaction_order
+                .insert_batch(&mut batch, [(epoch, TransactionDigest::random())])
+                .unwrap();
+            batch.write().unwrap();
+        }
+    }
+
     /// `CoinInfo::from_object` must reject non-coin objects even when their
     /// BCS contents happen to match `Coin`'s `{UID, u64}` layout.
     #[test]
     fn test_coin_info_from_object_requires_coin_type() {
-        use iota_sdk_types::{Address, MoveStruct, Owner, TransactionDigest, Version};
+        use iota_sdk_types::{Address, MoveStruct, Owner, Version};
         use iota_types::object::{MoveStructExt, Object};
 
         let owner = Owner::Address(Address::ZERO);
@@ -3011,7 +3055,7 @@ mod tests {
     /// layouts and no particular object order.
     #[tokio::test]
     async fn test_restore_built_store_is_adopted_on_open() {
-        use iota_sdk_types::{MoveStruct, Owner, TransactionDigest, Version};
+        use iota_sdk_types::{MoveStruct, Owner, Version};
         use iota_types::{
             base_types::dbg_addr,
             object::{MoveStructExt, Object},
@@ -3495,8 +3539,6 @@ mod tests {
     /// table's rows, whose bytes do not deserialize under its types.
     #[tokio::test]
     async fn test_history_tables_do_not_bleed_across_tags() {
-        use iota_sdk_types::TransactionDigest;
-
         let tmp_dir = iota_common::tempdir();
         let index_store = IndexStore::new_without_init(
             tmp_dir.path().to_path_buf(),
@@ -3536,6 +3578,192 @@ mod tests {
             .collect::<Result<_, _>>()
             .unwrap();
         assert_eq!(rows, vec![(digest, 7)]);
+    }
+
+    /// The backfill must stop at the index retention horizon recorded by
+    /// `prune` instead of replaying epochs the pruner would drop. The
+    /// checkpoint below the horizon has no contents on purpose: replaying it
+    /// would fail, stopping cleanly must not.
+    #[tokio::test]
+    async fn test_backfill_stops_at_the_index_retention_horizon() {
+        let dir = iota_common::tempdir();
+        let checkpoint_store = CheckpointStore::new(&dir.path().join("checkpoints"));
+        checkpoint_store
+            .insert_verified_checkpoint(&executed_checkpoint(0, 5))
+            .unwrap();
+
+        let index_store = IndexStore::new_without_init(
+            dir.path().join("indexes"),
+            &Registry::default(),
+            Some(128),
+        );
+        seed_history_buckets(&index_store, 2);
+        assert_eq!(index_store.prune(1).unwrap(), Some(1));
+        index_store
+            .tables
+            .history_watermark
+            .insert(&(), &6)
+            .unwrap();
+
+        let authority_store = crate::authority::AuthorityStore::open_no_genesis(
+            std::sync::Arc::new(
+                crate::authority::authority_store_tables::AuthorityPerpetualTables::open(
+                    &dir.path().join("store"),
+                    None,
+                ),
+            ),
+            false,
+            &Registry::default(),
+        )
+        .unwrap();
+
+        index_store
+            .backfill_history(&authority_store, &checkpoint_store)
+            .expect("the backfill must stop at the horizon, not fail on missing contents");
+        assert_eq!(
+            index_store.tables.history_watermark.get(&()).unwrap(),
+            Some(6),
+            "nothing below the horizon may be replayed"
+        );
+    }
+
+    /// A query that snapshotted the history buckets before a `prune` must
+    /// report an error for the dropped epoch's rows, as [`IndexStore::prune`]
+    /// documents, rather than panicking.
+    #[tokio::test]
+    async fn test_prune_racing_a_reader_reports_an_error() {
+        let tmp_dir = iota_common::tempdir();
+        let index_store = IndexStore::new_without_init(
+            tmp_dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+        );
+        seed_history_buckets(&index_store, 2);
+
+        // Every digest probe and range scan reads through such a snapshot.
+        let snapshot = index_store.history_buckets(false);
+        assert_eq!(snapshot.len(), 2);
+
+        assert_eq!(index_store.prune(1).unwrap(), Some(1));
+
+        assert!(
+            snapshot[0]
+                .transaction_order
+                .iter()
+                .next()
+                .expect("the scan must yield an error item")
+                .is_err()
+        );
+        assert!(
+            snapshot[0]
+                .transaction_order
+                .iter_reversed()
+                .next()
+                .expect("the reverse scan must yield an error item")
+                .is_err()
+        );
+        assert!(
+            snapshot[0]
+                .transactions_seq
+                .get(&Default::default())
+                .is_err()
+        );
+
+        // The retained bucket keeps serving, and a retry no longer sees the
+        // dropped one.
+        assert!(
+            snapshot[1]
+                .transaction_order
+                .iter()
+                .next()
+                .expect("the retained bucket must still yield a row")
+                .is_ok()
+        );
+        assert_eq!(index_store.history_buckets(false).len(), 1);
+        assert_eq!(
+            index_store
+                .get_transactions(None, None, None, false)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    /// Queries running concurrently with repeated pruning must never panic:
+    /// readers hold bucket handles across the pruner's column-family drops.
+    #[tokio::test]
+    async fn test_concurrent_prune_and_queries_never_panic() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        };
+
+        const EPOCHS: u64 = 64;
+
+        let tmp_dir = iota_common::tempdir();
+        let index_store = Arc::new(IndexStore::new_without_init(
+            tmp_dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+        ));
+        seed_history_buckets(&index_store, EPOCHS);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut workers: Vec<_> = (0..3)
+            .map(|_| {
+                let index_store = index_store.clone();
+                let stop = stop.clone();
+                // Blocking threads, so the reads race the drops instead of
+                // interleaving at await points.
+                std::thread::spawn(move || {
+                    while !stop.load(Ordering::Relaxed) {
+                        let _ = index_store.get_transactions(None, None, Some(1000), false);
+                        let _ = index_store.get_transaction_seq(&Default::default());
+                    }
+                })
+            })
+            .collect();
+        workers.push({
+            let index_store = index_store.clone();
+            let stop = stop.clone();
+            // Recreates low epochs like a backfill would, racing the drops.
+            // Opening a bucket spawns metrics sampling tasks, so the thread
+            // needs the runtime context the real backfill gets from
+            // `spawn_blocking`.
+            let runtime = tokio::runtime::Handle::current();
+            std::thread::spawn(move || {
+                let _guard = runtime.enter();
+                let mut round = 0;
+                while !stop.load(Ordering::Relaxed) {
+                    let _ = index_store.ensure_history_bucket(round % 8);
+                    round += 1;
+                }
+            })
+        });
+
+        for retained in (1..EPOCHS).rev() {
+            index_store.prune(retained).unwrap();
+        }
+        stop.store(true, Ordering::Relaxed);
+        for worker in workers {
+            worker.join().expect("a worker thread panicked");
+        }
+
+        // No bucket left in the map may point at a dropped column family.
+        for bucket in index_store.history_buckets(false) {
+            bucket
+                .transactions_seq
+                .get(&Default::default())
+                .expect("every bucket in the map must be readable");
+        }
+
+        assert_eq!(
+            index_store
+                .get_transactions(None, None, None, false)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -791,8 +791,7 @@ pub struct IndexStore {
     pending_updates: Mutex<BTreeMap<CheckpointSequenceNumber, PendingCheckpointUpdate>>,
     history_backfill_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// The retention horizon recorded by the last [`Self::prune`] call:
-    /// epochs below it are dropped on the pruner's next pass. Zero until the
-    /// first prune — no pruning means no horizon.
+    /// epochs below it are dropped on the pruner's next pass.
     earliest_retained_epoch: AtomicU64,
 }
 

--- a/crates/iota-tool/Cargo.toml
+++ b/crates/iota-tool/Cargo.toml
@@ -58,7 +58,6 @@ iota-snapshot.workspace = true
 iota-storage.workspace = true
 iota-tls.workspace = true
 iota-types.workspace = true
-move-core-types.workspace = true
 prometheus-filtered.workspace = true
 telemetry-subscribers.workspace = true
 typed-store.workspace = true

--- a/crates/typed-store-error/src/errors.rs
+++ b/crates/typed-store-error/src/errors.rs
@@ -12,7 +12,7 @@ pub enum TypedStoreError {
     RocksDB(String),
     #[error("(de)serialization error: {0}")]
     Serialization(String),
-    #[error("the column family {0} was not registered with the database")]
+    #[error("column family {0} is not open")]
     UnregisteredColumn(String),
     #[error("a batch operation can't operate across databases")]
     CrossDBBatch,

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -62,19 +62,6 @@ impl ColumnFamily {
             ColumnFamily::InMemory(name) => name,
         }
     }
-
-    pub(crate) fn rocks_cf<'a>(
-        &self,
-        rocks_db: &'a RocksDB,
-    ) -> Arc<rocksdb::BoundColumnFamily<'a>> {
-        match &self {
-            ColumnFamily::Rocks(name) => rocks_db
-                .underlying
-                .cf_handle(name)
-                .expect("Map-keying column family should have been checked at DB creation"),
-            _ => unreachable!("invariant is checked by the caller"),
-        }
-    }
 }
 
 pub(crate) enum Storage {
@@ -175,7 +162,7 @@ impl Database {
         match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => Ok(db
                 .underlying
-                .get_pinned_cf_opt(&cf.rocks_cf(db), key, readopts)
+                .get_pinned_cf_opt(&rocks_cf(db, cf.name())?, key, readopts)
                 .map_err(typed_store_err_from_rocks_err)?
                 .map(GetResult::Rocks)),
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
@@ -201,8 +188,13 @@ impl Database {
         match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => {
                 let keys_vec: Vec<K> = keys.into_iter().collect();
+                let handle = match rocks_cf(db, cf.name()) {
+                    Ok(handle) => handle,
+                    // Fail every key, so the result keeps one slot per key.
+                    Err(e) => return keys_vec.iter().map(|_| Err(e.clone())).collect(),
+                };
                 let res = db.underlying.batched_multi_get_cf_opt(
-                    &cf.rocks_cf(db),
+                    &handle,
                     keys_vec.iter(),
                     // sorted_input
                     false,
@@ -274,10 +266,13 @@ impl Database {
     ) -> Result<(), TypedStoreError> {
         fail_point!("delete-cf-before");
         let ret = match (&self.storage, cf) {
-            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
-                .underlying
-                .delete_cf(&cf.rocks_cf(db), key)
-                .map_err(typed_store_err_from_rocks_err),
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => {
+                rocks_cf(db, cf.name()).and_then(|handle| {
+                    db.underlying
+                        .delete_cf(&handle, key)
+                        .map_err(typed_store_err_from_rocks_err)
+                })
+            }
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
                 db.delete(cf_name, key.as_ref());
                 Ok(())
@@ -306,10 +301,13 @@ impl Database {
     ) -> Result<(), TypedStoreError> {
         fail_point!("put-cf-before");
         let ret = match (&self.storage, cf) {
-            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
-                .underlying
-                .put_cf(&cf.rocks_cf(db), key, value)
-                .map_err(typed_store_err_from_rocks_err),
+            (Storage::Rocks(db), ColumnFamily::Rocks(_)) => {
+                rocks_cf(db, cf.name()).and_then(|handle| {
+                    db.underlying
+                        .put_cf(&handle, key, value)
+                        .map_err(typed_store_err_from_rocks_err)
+                })
+            }
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
                 db.put(cf_name, key, value);
                 Ok(())
@@ -332,11 +330,13 @@ impl Database {
         match &self.storage {
             // [`rocksdb::DBWithThreadMode::key_may_exist_cf`] can have false positives,
             // but no false negatives. We use it to short-circuit the absent case
-            Storage::Rocks(rocks) => {
-                rocks
+            Storage::Rocks(rocks) => match rocks_cf(rocks, cf.name()) {
+                Ok(handle) => rocks
                     .underlying
-                    .key_may_exist_cf_opt(&rocks_cf(rocks, cf.name()), key, readopts)
-            }
+                    .key_may_exist_cf_opt(&handle, key, readopts),
+                // Not a definitive absence: let the real read report it.
+                Err(_) => true,
+            },
             _ => true,
         }
     }
@@ -393,7 +393,7 @@ impl Database {
     }
 
     pub fn write(&self, batch: StorageWriteBatch) -> Result<(), TypedStoreError> {
-        self.write_opt(batch, &rocksdb::WriteOptions::default())
+        self.write_opt(batch, &batch_write_options())
     }
 
     pub fn write_opt(
@@ -427,12 +427,12 @@ impl Database {
         cf: &ColumnFamily,
         start: Option<K>,
         end: Option<K>,
-    ) {
+    ) -> Result<(), TypedStoreError> {
         if let Storage::Rocks(rocksdb) = &self.storage {
-            rocksdb
-                .underlying
-                .compact_range_cf(&rocks_cf(rocksdb, cf.name()), start, end);
+            let handle = rocks_cf(rocksdb, cf.name())?;
+            rocksdb.underlying.compact_range_cf(&handle, start, end);
         }
+        Ok(())
     }
 
     pub fn checkpoint(&self, path: &Path) -> Result<(), TypedStoreError> {
@@ -495,10 +495,7 @@ fn rocks_cf_from_db<'a>(
     cf_name: &str,
 ) -> Result<Arc<rocksdb::BoundColumnFamily<'a>>, TypedStoreError> {
     match &db.storage {
-        Storage::Rocks(rocksdb) => Ok(rocksdb
-            .underlying
-            .cf_handle(cf_name)
-            .expect("Map-keying column family should have been checked at DB creation")),
+        Storage::Rocks(rocksdb) => rocks_cf(rocksdb, cf_name),
         _ => Err(TypedStoreError::RocksDB(
             "using invalid batch type for the database".to_string(),
         )),
@@ -636,8 +633,7 @@ impl<K, V> DBMap<K, V> {
         let from_buf = be_fix_int_ser(start);
         let to_buf = be_fix_int_ser(end);
         self.db
-            .compact_range_cf(&self.column_family, Some(from_buf), Some(to_buf));
-        Ok(())
+            .compact_range_cf(&self.column_family, Some(from_buf), Some(to_buf))
     }
 
     pub fn compact_range_raw(
@@ -650,8 +646,7 @@ impl<K, V> DBMap<K, V> {
             Storage::Rocks(_) => ColumnFamily::Rocks(cf_name.to_string()),
             Storage::InMemory(_) => ColumnFamily::InMemory(cf_name.to_string()),
         };
-        self.db.compact_range_cf(&cf, Some(start), Some(end));
-        Ok(())
+        self.db.compact_range_cf(&cf, Some(start), Some(end))
     }
 
     /// Returns a vector of raw values corresponding to the keys provided.
@@ -772,16 +767,20 @@ impl<K, V> DBMap<K, V> {
 
     /// Shared rocksdb `SafeIter` construction (raw iterator + scan metrics)
     /// used by both the forward and reverse raw iterators.
-    fn rocks_safe_iter<'a>(&self, db: &'a RocksDB, readopts: ReadOptions) -> SafeIter<'a, K, V>
+    fn rocks_safe_iter<'a>(
+        &self,
+        db: &'a RocksDB,
+        readopts: ReadOptions,
+    ) -> Result<SafeIter<'a, K, V>, TypedStoreError>
     where
         K: DeserializeOwned,
         V: DeserializeOwned,
     {
         let db_iter = db
             .underlying
-            .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name()), readopts);
+            .raw_iterator_cf_opt(&rocks_cf(db, self.column_family.name())?, readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
+        Ok(SafeIter::new(
             self.cf_name().to_string(),
             db_iter,
             _timer,
@@ -789,7 +788,7 @@ impl<K, V> DBMap<K, V> {
             bytes_scanned,
             keys_scanned,
             Some(self.db_metrics.clone()),
-        )
+        ))
     }
 
     /// Forward iterator over the raw byte bounds `[lower_bound, upper_bound)`;
@@ -808,7 +807,10 @@ impl<K, V> DBMap<K, V> {
             Storage::Rocks(db) => {
                 let readopts =
                     rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, upper_bound);
-                Box::new(self.rocks_safe_iter(db, readopts))
+                match self.rocks_safe_iter(db, readopts) {
+                    Ok(iter) => Box::new(iter),
+                    Err(e) => error_iterator(e),
+                }
             }
             Storage::InMemory(db) => {
                 db.iterator(self.column_family.name(), lower_bound, upper_bound, false)
@@ -835,10 +837,10 @@ impl<K, V> DBMap<K, V> {
             Storage::Rocks(db) => {
                 let readopts =
                     rocks_util::apply_range_bounds(self.opts.readopts(), lower_bound, None);
-                Box::new(SafeRevIter::new(
-                    self.rocks_safe_iter(db, readopts),
-                    upper_bound,
-                ))
+                match self.rocks_safe_iter(db, readopts) {
+                    Ok(iter) => Box::new(SafeRevIter::new(iter, upper_bound)),
+                    Err(e) => error_iterator(e),
+                }
             }
             Storage::InMemory(db) => {
                 db.iterator(self.column_family.name(), lower_bound, upper_bound, true)
@@ -1013,11 +1015,16 @@ impl DBBatch {
     /// Consume the batch and write its operations to the database
     #[instrument(level = "trace", skip_all, err)]
     pub fn write(self) -> Result<(), TypedStoreError> {
-        self.write_opt(&rocksdb::WriteOptions::default())
+        self.write_opt(&batch_write_options())
     }
 
     /// Consume the batch and write its operations to the database with custom
-    /// write options
+    /// write options.
+    ///
+    /// `write_options` must have `ignore_missing_column_families` set (see
+    /// [`batch_write_options`]): staging already fails on a column family
+    /// that does not exist, so an entry can only lose its column family to a
+    /// runtime drop between staging and this write.
     #[instrument(level = "trace", skip_all, err)]
     pub fn write_opt(self, write_options: &rocksdb::WriteOptions) -> Result<(), TypedStoreError> {
         let db_name = self.database.db_name();
@@ -1351,22 +1358,10 @@ where
 
     fn safe_iter(&'a self) -> DbIterator<'a, (K, V)> {
         match &self.db.storage {
-            Storage::Rocks(db) => {
-                let db_iter = db.underlying.raw_iterator_cf_opt(
-                    &rocks_cf(db, self.column_family.name()),
-                    self.opts.readopts(),
-                );
-                let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-                Box::new(SafeIter::new(
-                    self.cf_name().to_string(),
-                    db_iter,
-                    _timer,
-                    _perf_ctx,
-                    bytes_scanned,
-                    keys_scanned,
-                    Some(self.db_metrics.clone()),
-                ))
-            }
+            Storage::Rocks(db) => match self.rocks_safe_iter(db, self.opts.readopts()) {
+                Ok(iter) => Box::new(iter),
+                Err(e) => error_iterator(e),
+            },
             Storage::InMemory(db) => db.iterator(self.column_family.name(), None, None, false),
         }
     }
@@ -1558,6 +1553,19 @@ where
             .safe_range_iter_reversed((self.tag, lower)..=(self.tag, upper))
             .map(|result| result.map(|((_, key), value)| (key, value)))
     }
+}
+
+/// Returns an iterator whose only item is `Err(error)`.
+fn error_iterator<'a, T: 'a>(error: TypedStoreError) -> DbIterator<'a, T> {
+    Box::new(std::iter::once(Err(error)))
+}
+
+/// Write options for batch writes: entries of a column family dropped after
+/// staging are discarded, see [`DBBatch::write_opt`].
+pub fn batch_write_options() -> rocksdb::WriteOptions {
+    let mut options = rocksdb::WriteOptions::default();
+    options.set_ignore_missing_column_families(true);
+    options
 }
 
 fn default_hash(value: &[u8]) -> Digest<32> {

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -64,14 +64,17 @@ impl Drop for RocksDB {
     }
 }
 
+/// Resolves a column family handle. Fails with
+/// [`TypedStoreError::UnregisteredColumn`] if the column family is not open,
+/// which includes one dropped after the caller obtained its map.
 pub(crate) fn rocks_cf<'a>(
     rocks_db: &'a RocksDB,
     cf_name: &str,
-) -> Arc<rocksdb::BoundColumnFamily<'a>> {
+) -> Result<Arc<rocksdb::BoundColumnFamily<'a>>, TypedStoreError> {
     rocks_db
         .underlying
         .cf_handle(cf_name)
-        .expect("Map-keying column family should have been checked at DB creation")
+        .ok_or_else(|| TypedStoreError::UnregisteredColumn(cf_name.to_string()))
 }
 
 // Check if the database is corrupted, and if so, panic.

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -63,7 +63,7 @@ pub struct DBOptions {
 /// Write options tuned for one-shot bulk ingestion into a freshly created
 /// store.
 pub fn bulk_ingestion_write_options() -> rocksdb::WriteOptions {
-    let mut opts = rocksdb::WriteOptions::default();
+    let mut opts = crate::database::batch_write_options();
     opts.disable_wal(true);
     opts
 }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1152,6 +1152,122 @@ async fn test_tagged_dbmaps_share_a_column_family() {
     assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
 }
 
+/// Operations on a column family dropped at runtime must report
+/// [`TypedStoreError::UnregisteredColumn`] rather than panicking.
+#[tokio::test]
+async fn test_operations_on_dropped_cf_report_an_error() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["doomed"]);
+    let map =
+        DBMap::<u32, String>::reopen(&db, Some("doomed"), &ReadWriteOptions::default(), false)
+            .expect("the map should open");
+    map.insert(&1, &"one".to_string())
+        .expect("the row should insert");
+
+    db.drop_cf("doomed").expect("the column family should drop");
+
+    let assert_unregistered = |op: &str, error: TypedStoreError| {
+        assert!(
+            matches!(&error, TypedStoreError::UnregisteredColumn(cf) if cf == "doomed"),
+            "{op}: unexpected error: {error}"
+        );
+    };
+
+    assert_unregistered("get", map.get(&1).unwrap_err());
+    assert_unregistered("contains_key", map.contains_key(&1).unwrap_err());
+    assert_unregistered("multi_get", map.multi_get([1, 2, 3]).unwrap_err());
+    assert_unregistered("insert", map.insert(&2, &"two".to_string()).unwrap_err());
+    assert_unregistered("remove", map.remove(&1).unwrap_err());
+
+    // A batch resolves the handle when the operation is staged, not at write.
+    let mut batch = map.batch();
+    assert_unregistered(
+        "insert_batch",
+        batch
+            .insert_batch(&map, [(3u32, "three".to_string())])
+            .map(drop)
+            .unwrap_err(),
+    );
+    assert_unregistered(
+        "delete_batch",
+        batch.delete_batch(&map, [1u32]).map(drop).unwrap_err(),
+    );
+    assert_unregistered(
+        "schedule_delete_range",
+        batch
+            .schedule_delete_range(&map, &0, &9)
+            .map(drop)
+            .unwrap_err(),
+    );
+
+    // A scan reports the error as its first item, having no fallible
+    // constructor.
+    for (op, mut scan) in [
+        ("safe_iter", map.safe_iter()),
+        ("safe_range_iter", map.safe_range_iter(..)),
+        ("safe_range_iter_reversed", map.safe_range_iter_reversed(..)),
+    ] {
+        assert_unregistered(
+            op,
+            scan.next()
+                .expect("the scan should yield an item")
+                .unwrap_err(),
+        );
+    }
+}
+
+/// Dropping one column family must leave the others serving.
+#[tokio::test]
+async fn test_dropping_one_cf_leaves_the_others_serving() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["doomed", "kept"]);
+    let doomed =
+        DBMap::<u32, String>::reopen(&db, Some("doomed"), &ReadWriteOptions::default(), false)
+            .expect("the doomed map should open");
+    let kept = DBMap::<u32, String>::reopen(&db, Some("kept"), &ReadWriteOptions::default(), false)
+        .expect("the kept map should open");
+    doomed.insert(&1, &"one".to_string()).unwrap();
+    kept.insert(&1, &"one".to_string()).unwrap();
+
+    db.drop_cf("doomed").expect("the column family should drop");
+
+    assert!(doomed.get(&1).is_err());
+    assert_eq!(kept.get(&1).unwrap(), Some("one".to_string()));
+    kept.insert(&2, &"two".to_string())
+        .expect("the kept column family should still accept writes");
+    assert_eq!(kept.safe_iter().count(), 2);
+}
+
+/// A batch staged while its column family existed must write cleanly after
+/// the column family is dropped.
+#[tokio::test]
+async fn test_batch_staged_before_cf_drop_still_writes() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["doomed", "kept"]);
+    let doomed =
+        DBMap::<u32, String>::reopen(&db, Some("doomed"), &ReadWriteOptions::default(), false)
+            .expect("the doomed map should open");
+    let kept = DBMap::<u32, String>::reopen(&db, Some("kept"), &ReadWriteOptions::default(), false)
+        .expect("the kept map should open");
+
+    let mut batch = doomed.batch();
+    batch
+        .insert_batch(&doomed, [(1u32, "one".to_string())])
+        .unwrap();
+    batch
+        .insert_batch(&kept, [(1u32, "one".to_string())])
+        .unwrap();
+
+    db.drop_cf("doomed").expect("the column family should drop");
+
+    batch.write().expect("the batch should write");
+    assert_eq!(kept.get(&1).unwrap(), Some("one".to_string()));
+
+    // The database was not stopped by the dropped entries.
+    kept.insert(&2, &"two".to_string())
+        .expect("the kept column family should still accept writes");
+}
+
 fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> {
     let cf_key = opt_cf.unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME);
     DBMap::<K, V>::reopen(


### PR DESCRIPTION
# Description of change

Stacked on #12332, which makes column-family drops a routine runtime operation (`IndexStore::prune` drops one column family per expired epoch). typed-store still resolved column-family handles with a panicking `expect`, and RocksDB escalates a batch write referencing a dropped column family to a fatal error that stops the whole database — so with index pruning configured, a query or the history backfill racing a prune aborted the node (release profile is `panic = "abort"`).

- typed-store: column-family handle resolution returns `TypedStoreError::UnregisteredColumn` instead of panicking, from a single `rocks_cf` helper (the two other resolvers now delegate to it).
  - Point reads and writes propagate the error; `multi_get` fails every key so the result keeps one slot per key; scans yield a single `Err` item; `key_may_exist_cf` returns `true` so a dropped column family is never reported as a definitive absence; `compact_range_cf` is now fallible instead of silently skipping (its wrappers already returned `Result`).
- typed-store: batch writes go through `batch_write_options()`, which sets `ignore_missing_column_families` — entries staged before a drop are discarded with their column family instead of escalating to RocksDB's fatal `kMemTable` background error. Safe because staging already fails on a column family that does not exist, so a missing id at write time can only mean it was dropped in between.
- typed-store-error: reword `UnregisteredColumn`'s display to "column family {0} is not open" (the variant previously had no producers, so the change is free).
- iota-core: `IndexStore::prune` now records its earliest retained epoch, and the history backfill stops there instead of replaying epochs the pruner would immediately drop — previously the backfill was bounded only by the checkpoint-contents pruner (default: never), so an in-place rebuild on a long-history node replayed history down to genesis while the index pruner deleted it, with each drop a chance to hit the write race.
- iota-core: `IndexStore::prune` performs its column-family drops while holding the history map's write lock (a racing `ensure_history_bucket` could otherwise cache a bucket over a column family dropped a moment later), and a failed drop no longer abandons the remaining expired epochs — it warns, keeps dropping, and surfaces the first error.
- Tests — typed-store: per-operation-class dropped-column-family error coverage, error scoping across sibling column families, and the stage-before-drop batch write. iota-core: a deterministic prune-vs-reader interleaving through the real `IndexStore::prune`; a concurrent stress test with reader threads plus a bucket-recreating backfill thread racing 63 prunes, asserting no bucket in the map is left pointing at a dropped column family; and a backfill test proving it stops at the retention horizon instead of failing on pruned data.

## Links to any relevant issues

Fixes a node-abort race introduced in #12332 (part of #12307).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Test details
- `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p typed-store` — 66/66.
- `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib -E 'test(/jsonrpc_index/)'` — 19/19, including all pre-existing #12332 index tests.
- Negative controls: with the error path reverted, the new tests panic at the old `expect` (the concurrent test crashes in all three reader threads); with `ignore_missing_column_families` removed, the stage-before-drop test fails with RocksDB's exact `"Invalid column family specified in write batch"` error; with the retention bound disabled, the backfill test fails on the missing pruned contents.
- `cargo check --workspace --all-targets`, `cargo clippy --all-targets --all-features -- -D warnings` on the touched crates, `cargo +nightly fmt`.
