### PR TITLE
upstream(core): Add logging for long waits in notify_read

### DIFF
--- a/crates/iota-common/Cargo.toml
+++ b/crates/iota-common/Cargo.toml
@@ -26,7 +26,7 @@ iota-macros.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external dependencies
 tempfile.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
 
 # internal dependencies
 iota-metrics.workspace = true

--- a/crates/iota-common/src/sync/notify_read.rs
+++ b/crates/iota-common/src/sync/notify_read.rs
@@ -3,21 +3,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{HashMap, hash_map::DefaultHasher},
+    collections::{HashMap, HashSet, hash_map::DefaultHasher},
     error::Error,
     future::Future,
     hash::{Hash, Hasher},
     mem,
     pin::Pin,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::future::{Either, join_all};
+use iota_metrics::spawn_monitored_task;
 use parking_lot::{Mutex, MutexGuard};
-use tokio::sync::oneshot;
+use tokio::{
+    sync::oneshot,
+    time::{Instant, interval_at},
+};
+use tracing::warn;
+
+use crate::debug_fatal;
 
 type Registrations<V> = Vec<oneshot::Sender<V>>;
+
+/// Wrapper that ensures a spawned task is aborted when dropped
+struct TaskAbortOnDrop {
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl TaskAbortOnDrop {
+    fn new(handle: tokio::task::JoinHandle<()>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for TaskAbortOnDrop {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Interval duration for logging waiting keys when reads take too long
+const LONG_WAIT_LOG_INTERVAL_SECS: u64 = 10;
+
+pub const CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME: &str =
+    "CheckpointBuilder::notify_read_executed_effects";
 
 pub struct NotifyRead<K, V> {
     pending: Vec<Mutex<HashMap<K, Registrations<V>>>>,
@@ -119,24 +157,90 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone + Unpin, V: Clone + Unpin> NotifyRead<K, V> {
+impl<K: Eq + Hash + Clone + Unpin + std::fmt::Debug + Send + Sync + 'static, V: Clone + Unpin>
+    NotifyRead<K, V>
+{
     pub async fn read<E: Error>(
         &self,
+        task_name: &'static str,
         keys: &[K],
         fetch: impl FnOnce(&[K]) -> Result<Vec<Option<V>>, E>,
     ) -> Result<Vec<V>, E> {
+        let _metrics_scope = iota_metrics::monitored_scope(task_name);
         let registrations = self.register_all(keys);
 
         let results = fetch(keys)?;
 
-        let results = results
-            .into_iter()
-            .zip(registrations)
-            .map(|(a, r)| match a {
-                // Note that Some() clause also drops registration that is already fulfilled
-                Some(ready) => Either::Left(futures::future::ready(ready)),
-                None => Either::Right(r),
+        // Track which keys are still waiting
+        let waiting_keys: HashSet<K> = keys
+            .iter()
+            .zip(results.iter())
+            .filter(|&(_key, result)| result.is_none())
+            .map(|(key, _result)| key.clone())
+            .collect();
+        let has_waiting_keys = !waiting_keys.is_empty();
+        let waiting_keys = Arc::new(Mutex::new(waiting_keys));
+
+        // Spawn logging task if there are waiting keys
+        let _log_handle_guard = if has_waiting_keys {
+            let waiting_keys_clone = waiting_keys.clone();
+            let start_time = Instant::now();
+            let task_name = task_name.to_string();
+
+            let handle = spawn_monitored_task!(async move {
+                // Only start logging after the first interval.
+                let start = Instant::now() + Duration::from_secs(LONG_WAIT_LOG_INTERVAL_SECS);
+                let mut interval =
+                    interval_at(start, Duration::from_secs(LONG_WAIT_LOG_INTERVAL_SECS));
+
+                loop {
+                    interval.tick().await;
+                    let current_waiting = waiting_keys_clone.lock();
+                    if current_waiting.is_empty() {
+                        break;
+                    }
+                    let keys_vec: Vec<_> = current_waiting.iter().cloned().collect();
+                    drop(current_waiting); // Release lock before logging
+
+                    let elapsed_secs = start_time.elapsed().as_secs();
+
+                    warn!(
+                        "[{task_name}] Still waiting for {elapsed_secs}s for {} keys: {keys_vec:?}",
+                        keys_vec.len(),
+                    );
+
+                    if task_name == CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME && elapsed_secs >= 60 {
+                        debug_fatal!("{task_name} is stuck");
+                    }
+                }
             });
+            Some(TaskAbortOnDrop::new(handle))
+        } else {
+            None
+        };
+
+        let results =
+            results
+                .into_iter()
+                .zip(registrations)
+                .zip(keys.iter())
+                .map(|((a, r), key)| match a {
+                    // Note that Some() clause also drops registration that is already fulfilled
+                    Some(ready) => Either::Left(futures::future::ready(ready)),
+                    None => {
+                        let waiting_keys = waiting_keys.clone();
+                        let key = key.clone();
+                        Either::Right(async move {
+                            let result = r.await;
+                            // Remove this key from the waiting set
+                            waiting_keys.lock().remove(&key);
+                            result
+                        })
+                    }
+                });
+
+        // The logging task will be automatically aborted when _log_handle_guard is
+        // dropped
 
         Ok(join_all(results).await)
     }
@@ -185,7 +289,10 @@ impl<K: Eq + Hash + Clone, V: Clone> Default for NotifyRead<K, V> {
 
 #[cfg(test)]
 mod tests {
+    use std::{convert::Infallible, sync::Arc};
+
     use futures::future::join_all;
+    use tokio::time::timeout;
 
     use super::*;
 
@@ -202,6 +309,36 @@ mod tests {
         assert_eq!(0, notify_read.count_pending.load(Ordering::Relaxed));
         assert_eq!(reads, vec![1, 2]);
         // ensure cleanup is done correctly
+        for pending in &notify_read.pending {
+            assert!(pending.lock().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    pub async fn test_notify_read_cancellation() {
+        let notify_read = Arc::new(NotifyRead::<u64, u64>::new());
+
+        // Start a read that will wait indefinitely
+        let read_future = notify_read.read::<Infallible>(
+            "test_task",
+            &[1, 2, 3],
+            |_keys| Ok(vec![None, None, None]), // All keys will wait
+        );
+
+        // Use timeout to cancel the read after a short duration
+        let result = timeout(Duration::from_millis(100), read_future).await;
+
+        // Verify the read was cancelled
+        assert!(result.is_err());
+
+        // Give some time for cleanup to complete
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // When the read is cancelled, the registrations are cleaned up
+        // so the pending count should be 0
+        assert_eq!(0, notify_read.count_pending.load(Ordering::Relaxed));
+
+        // Verify all pending maps are empty (cleanup was performed)
         for pending in &notify_read.pending {
             assert!(pending.lock().is_empty());
         }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1427,7 +1427,10 @@ impl AuthorityState {
         // tx could be reverted when epoch ends, so we must be careful not to return a
         // result here after the epoch ends.
         epoch_store
-            .within_alive_epoch(self.notify_read_effects(certificate))
+            .within_alive_epoch(self.notify_read_effects(
+                "AuthorityState::wait_for_certificate_execution",
+                certificate,
+            ))
             .await
             .map_err(|_| IotaError::EpochEnded(epoch_store.epoch()))
             .and_then(|r| r)
@@ -1557,10 +1560,11 @@ impl AuthorityState {
 
     pub async fn notify_read_effects(
         &self,
+        task_name: &'static str,
         certificate: &VerifiedCertificate,
     ) -> IotaResult<TransactionEffects> {
         self.get_transaction_cache_reader()
-            .try_notify_read_executed_effects(&[*certificate.digest()])
+            .try_notify_read_executed_effects(task_name, &[*certificate.digest()])
             .await
             .map(|mut r| r.pop().expect("must return correct number of effects"))
     }
@@ -6132,7 +6136,10 @@ impl RandomnessRoundReceiver {
                 RANDOMNESS_STATE_UPDATE_EXECUTION_TIMEOUT,
                 authority_state
                     .get_transaction_cache_reader()
-                    .try_notify_read_executed_effects(&[digest]),
+                    .try_notify_read_executed_effects(
+                        "RandomnessRoundReceiver::notify_read_executed_effects_first",
+                        &[digest],
+                    ),
             )
             .await;
             let result = match result {
@@ -6150,7 +6157,10 @@ impl RandomnessRoundReceiver {
                     // Continue waiting as long as necessary in non-debug builds.
                     authority_state
                         .get_transaction_cache_reader()
-                        .try_notify_read_executed_effects(&[digest])
+                        .try_notify_read_executed_effects(
+                            "RandomnessRoundReceiver::notify_read_executed_effects_second",
+                            &[digest],
+                        )
                         .await
                 }
             };

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1841,12 +1841,16 @@ impl AuthorityPerEpochStore {
     ) -> IotaResult<Vec<GlobalStateHash>> {
         let tables = self.tables()?;
         self.checkpoint_state_notify_read
-            .read(checkpoints, |checkpoints| {
-                tables
-                    .state_hash_by_checkpoint
-                    .multi_get(checkpoints)
-                    .map_err(Into::into)
-            })
+            .read(
+                "notify_read_checkpoint_state_hasher",
+                checkpoints,
+                |checkpoints| {
+                    tables
+                        .state_hash_by_checkpoint
+                        .multi_get(checkpoints)
+                        .map_err(Into::into)
+                },
+            )
             .await
     }
 

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -376,7 +376,7 @@ pub async fn enqueue_all_and_execute_all(
     );
     let mut output = Vec::new();
     for cert in certificates {
-        let effects = authority.notify_read_effects(&cert).await?;
+        let effects = authority.notify_read_effects("", &cert).await?;
         output.push(effects);
     }
     Ok(output)

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -485,7 +485,7 @@ impl ValidatorService {
                 let digests_to_watch = [tx_digest];
                 tokio::select! {
                     biased;
-                    effects_digests = cache.notify_read_executed_effects_digests(&digests_to_watch) => {
+                    effects_digests = cache.notify_read_executed_effects_digests("ValidatorService::notify_read_executed_effects_digests", &digests_to_watch) => {
                         Either::Left(effects_digests)
                     }
                     dropped_error = epoch_store.notify_read_dropped_digests(tx_digest) => {

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -579,11 +579,11 @@ impl CheckpointExecutor {
         finish_stage!(pipeline_handle, ExecuteTransactions);
 
         {
-            let _metrics_scope = iota_metrics::monitored_scope(
-                "CheckpointExecutor::notify_read_executed_effects_digests",
-            );
             self.transaction_cache_reader
-                .notify_read_executed_effects_digests(&unexecuted_tx_digests)
+                .notify_read_executed_effects_digests(
+                    "CheckpointExecutor::notify_read_executed_effects_digests",
+                    &unexecuted_tx_digests,
+                )
                 .await;
         }
 
@@ -966,7 +966,10 @@ impl CheckpointExecutor {
         );
 
         self.transaction_cache_reader
-            .notify_read_executed_effects_digests(&[*change_epoch_tx.digest()])
+            .notify_read_executed_effects_digests(
+                "CheckpointExecutor::notify_read_advance_epoch_tx",
+                &[*change_epoch_tx.digest()],
+            )
             .await;
     }
 

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -22,7 +22,11 @@ use std::{
 };
 
 use diffy::create_patch;
-use iota_common::{debug_fatal, fatal, random::get_rng, sync::notify_read::NotifyRead};
+use iota_common::{
+    debug_fatal, fatal,
+    random::get_rng,
+    sync::notify_read::{CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME, NotifyRead},
+};
 use iota_metrics::{MonitoredFutureExt, monitored_future, monitored_scope};
 use iota_network::default_iota_network_config;
 use iota_sdk_types::{
@@ -692,7 +696,7 @@ impl CheckpointStore {
         type ReadResult = Result<Vec<Option<VerifiedCheckpoint>>, TypedStoreError>;
 
         notify_read
-            .read(&[seq], |seqs| {
+            .read("notify_read_checkpoint_watermark", &[seq], |seqs| {
                 let seq = seqs[0];
                 let Some(highest) = get_watermark() else {
                     return Ok(vec![None]) as ReadResult;
@@ -1369,7 +1373,10 @@ impl CheckpointBuilder {
                 .await?;
             let root_effects = self
                 .effects_store
-                .try_notify_read_executed_effects(&root_digests)
+                .try_notify_read_executed_effects(
+                    CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME,
+                    &root_digests,
+                )
                 .in_monitored_scope("CheckpointNotifyRead")
                 .await?;
 
@@ -3694,6 +3701,7 @@ mod tests {
     impl TransactionCacheRead for HashMap<TransactionDigest, TransactionEffects> {
         fn try_notify_read_executed_effects(
             &self,
+            _: &str,
             digests: &[TransactionDigest],
         ) -> BoxFuture<'_, IotaResult<Vec<TransactionEffects>>> {
             std::future::ready(Ok(digests
@@ -3705,6 +3713,7 @@ mod tests {
 
         fn try_notify_read_executed_effects_digests(
             &self,
+            _: &str,
             digests: &[TransactionDigest],
         ) -> BoxFuture<'_, IotaResult<Vec<TransactionEffectsDigest>>> {
             std::future::ready(Ok(digests

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -65,65 +65,73 @@ fn notify_read_input_objects_impl<'a>(
 ) -> BoxFuture<'a, Vec<()>> {
     async move {
         object_notify_read
-            .read::<std::convert::Infallible>(input_and_receiving_keys, |keys| {
-                let mut results = vec![None; keys.len()];
+            .read::<std::convert::Infallible>(
+                "notify_read_input_objects",
+                input_and_receiving_keys,
+                |keys| {
+                    let mut results = vec![None; keys.len()];
 
-                let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
-                    .iter()
-                    .enumerate()
-                    .filter(|(idx, key)| {
-                        if key.is_cancelled() {
-                            // Shared objects in canceled transactions are always available.
-                            results[*idx] = Some(());
-                            false
-                        } else {
-                            true
-                        }
-                    })
-                    .partition(|(_, key)| key.version().is_some());
-                let versioned_object_keys: Vec<_> = keys_with_version
-                    .iter()
-                    .map(|(_, key)| ObjectKey(key.id(), key.version().unwrap()))
-                    .collect();
-                ObjectCacheRead::multi_get_objects_by_key(cache, &versioned_object_keys)
-                    .into_iter()
-                    .zip(keys_with_version.iter())
-                    .for_each(|(o, (idx, input_key))| match o {
-                        Some(_) => results[*idx] = Some(()),
-                        None => {
-                            if receiving_keys.contains(input_key) {
-                                // There could be a more recent version of this object, and the
-                                // object at the specified version could have already been pruned.
-                                // In such a case `has_key` will be false, but since this is a
-                                // receiving object we should mark it as available if we can
-                                // determine that an object with a version greater than or equal to
-                                // the specified version exists or was deleted. We will then let
-                                // mark it as available to let the transaction through so it can
-                                // fail at execution.
-                                let is_available =
-                                    ObjectCacheRead::get_object(cache, &input_key.id())
-                                        .map(|obj| obj.version() >= input_key.version().unwrap())
-                                        .unwrap_or(false);
-                                if is_available {
+                    let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
+                        .iter()
+                        .enumerate()
+                        .filter(|(idx, key)| {
+                            if key.is_cancelled() {
+                                // Shared objects in canceled transactions are always available.
+                                results[*idx] = Some(());
+                                false
+                            } else {
+                                true
+                            }
+                        })
+                        .partition(|(_, key)| key.version().is_some());
+                    let versioned_object_keys: Vec<_> = keys_with_version
+                        .iter()
+                        .map(|(_, key)| ObjectKey(key.id(), key.version().unwrap()))
+                        .collect();
+                    ObjectCacheRead::multi_get_objects_by_key(cache, &versioned_object_keys)
+                        .into_iter()
+                        .zip(keys_with_version.iter())
+                        .for_each(|(o, (idx, input_key))| match o {
+                            Some(_) => results[*idx] = Some(()),
+                            None => {
+                                if receiving_keys.contains(input_key) {
+                                    // There could be a more recent version of this object, and the
+                                    // object at the specified version could have already been
+                                    // pruned. In such a case
+                                    // `has_key` will be false, but since this is a
+                                    // receiving object we should mark it as available if we can
+                                    // determine that an object with a version greater than or equal
+                                    // to the specified version
+                                    // exists or was deleted. We will then let
+                                    // mark it as available to let the transaction through so it can
+                                    // fail at execution.
+                                    let is_available =
+                                        ObjectCacheRead::get_object(cache, &input_key.id())
+                                            .map(|obj| {
+                                                obj.version() >= input_key.version().unwrap()
+                                            })
+                                            .unwrap_or(false);
+                                    if is_available {
+                                        results[*idx] = Some(());
+                                    }
+                                } else if cache
+                                    .get_last_shared_object_deletion_info(&input_key.id(), *epoch)
+                                    .is_some()
+                                {
+                                    // If the shared object was deleted, mark it as
+                                    // available so the transaction can proceed.
                                     results[*idx] = Some(());
                                 }
-                            } else if cache
-                                .get_last_shared_object_deletion_info(&input_key.id(), *epoch)
-                                .is_some()
-                            {
-                                // If the shared object was deleted, mark it as
-                                // available so the transaction can proceed.
-                                results[*idx] = Some(());
                             }
+                        });
+                    keys_without_version.iter().for_each(|(idx, key)| {
+                        if cache.get_package_object(&key.id()).is_some() {
+                            results[*idx] = Some(());
                         }
                     });
-                keys_without_version.iter().for_each(|(idx, key)| {
-                    if cache.get_package_object(&key.id()).is_some() {
-                        results[*idx] = Some(());
-                    }
-                });
-                Ok(results)
-            })
+                    Ok(results)
+                },
+            )
             .await
             .unwrap()
     }
@@ -986,16 +994,18 @@ pub trait TransactionCacheRead: Send + Sync {
 
     fn try_notify_read_executed_effects_digests<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffectsDigest>>>;
 
     /// Non-fallible version of `try_notify_read_executed_effects_digests`.
     fn notify_read_executed_effects_digests<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, Vec<TransactionEffectsDigest>> {
         Box::pin(async move {
-            self.try_notify_read_executed_effects_digests(digests)
+            self.try_notify_read_executed_effects_digests(task_name, digests)
                 .await
                 .expect("storage access failed")
         })
@@ -1014,11 +1024,12 @@ pub trait TransactionCacheRead: Send + Sync {
     /// the database.
     fn try_notify_read_executed_effects<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffects>>> {
         async move {
             let effects_digests = self
-                .try_notify_read_executed_effects_digests(digests)
+                .try_notify_read_executed_effects_digests(task_name, digests)
                 .await?;
             self.try_multi_get_effects(&effects_digests)?
                 .into_iter()
@@ -1037,10 +1048,11 @@ pub trait TransactionCacheRead: Send + Sync {
     /// effects may have been pruned, use `try_notify_read_executed_effects`.
     fn notify_read_executed_effects_for_testing<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, Vec<TransactionEffects>> {
         Box::pin(async move {
-            self.try_notify_read_executed_effects(digests)
+            self.try_notify_read_executed_effects(task_name, digests)
                 .await
                 .unwrap_or_else(|e| panic!("effects must exist: {e}"))
         })

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -2049,10 +2049,11 @@ impl TransactionCacheRead for WritebackCache {
     #[instrument(level = "trace", skip_all)]
     fn try_notify_read_executed_effects_digests<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffectsDigest>>> {
         self.executed_effects_digests_notify_read
-            .read(digests, |digests| {
+            .read(task_name, digests, |digests| {
                 self.try_multi_get_executed_effects_digests(digests)
             })
             .boxed()

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -265,7 +265,7 @@ impl LocalAuthorityClient {
                     .await?;
                 // let certificate = certificate.verify(epoch_store.committee())?;
                 state.enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store);
-                let effects = state.notify_read_effects(&certificate).await?;
+                let effects = state.notify_read_effects("", &certificate).await?;
                 state.sign_effects(effects, &epoch_store)?
             }
         }

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -100,7 +100,7 @@ pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>) 
         WAIT_FOR_TX_TIMEOUT,
         state
             .get_transaction_cache_reader()
-            .try_notify_read_executed_effects(&[digest]),
+            .try_notify_read_executed_effects("", &[digest]),
     )
     .await
     {
@@ -118,7 +118,7 @@ pub async fn wait_for_all_txes(digests: Vec<TransactionDigest>, state: Arc<Autho
         WAIT_FOR_TX_TIMEOUT,
         state
             .get_transaction_cache_reader()
-            .try_notify_read_executed_effects(&digests),
+            .try_notify_read_executed_effects("", &digests),
     )
     .await
     {

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -1113,8 +1113,11 @@ where
         let qd = quorum_driver.clone();
         Ok(async move {
             let digests = [tx_digest];
-            let effects_await = epoch_store
-                .within_alive_epoch(cache_reader.try_notify_read_executed_effects(&digests));
+            let effects_await =
+                epoch_store.within_alive_epoch(cache_reader.try_notify_read_executed_effects(
+                    "TransactionOrchestrator::notify_read_submit_with_qd",
+                    &digests,
+                ));
             // let-and-return necessary to satisfy borrow checker.
             let res = match select(ticket, effects_await.boxed()).await {
                 Either::Left((quorum_driver_response, _)) => Ok(quorum_driver_response),
@@ -1164,7 +1167,10 @@ where
             LOCAL_EXECUTION_TIMEOUT,
             validator_state
                 .get_transaction_cache_reader()
-                .try_notify_read_executed_effects_digests(&[tx_digest]),
+                .try_notify_read_executed_effects_digests(
+                    "TransactionOrchestrator::notify_read_wait_for_local_execution",
+                    &[tx_digest],
+                ),
         )
         .instrument(trace_span!("local_execution"))
         .await

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4615,7 +4615,10 @@ async fn test_shared_object_transaction_ok() {
     authority.execute_for_test(&certificate);
 
     // Ensure transaction effects are available.
-    authority.notify_read_effects(&certificate).await.unwrap();
+    authority
+        .notify_read_effects("", &certificate)
+        .await
+        .unwrap();
 
     // Ensure shared object sequence number increased.
     let shared_object_version = authority.get_object(&shared_object_id).unwrap().version();

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -267,7 +267,7 @@ pub async fn do_cert_with_shared_objects(
     send_consensus(authority, cert).await;
     authority
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[*cert.digest()])
+        .notify_read_executed_effects_for_testing("", &[*cert.digest()])
         .await
         .pop()
         .unwrap()
@@ -444,7 +444,7 @@ async fn test_execution_with_dependencies() {
         .collect();
     authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&digests)
+        .notify_read_executed_effects_for_testing("", &digests)
         .await;
 }
 
@@ -507,7 +507,7 @@ async fn test_per_object_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .get_transaction_cache_reader()
-            .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
+            .notify_read_executed_effects_for_testing("", &[*create_counter_cert.digest()])
             .await
             .pop()
             .unwrap();
@@ -521,7 +521,7 @@ async fn test_per_object_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
+        .notify_read_executed_effects_for_testing("", &[*create_counter_cert.digest()])
         .await
         .pop()
         .unwrap();
@@ -632,7 +632,7 @@ async fn test_txn_age_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .get_transaction_cache_reader()
-            .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
+            .notify_read_executed_effects_for_testing("", &[*create_counter_cert.digest()])
             .await
             .pop()
             .unwrap();
@@ -646,7 +646,7 @@ async fn test_txn_age_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
+        .notify_read_executed_effects_for_testing("", &[*create_counter_cert.digest()])
         .await
         .pop()
         .unwrap();

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -271,7 +271,7 @@ impl GasPriceFeedbackTester {
 
         self.authority_state
             .get_transaction_cache_reader()
-            .notify_read_executed_effects_for_testing(&transaction_digests)
+            .notify_read_executed_effects_for_testing("", &transaction_digests)
             .await
     }
 

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -213,7 +213,10 @@ where
             _ = tokio::time::sleep(tx_finalization_delay) => {
                 trace!(?tx_digest, "Waking up to finalize transaction");
             }
-            _ = cache_read.try_notify_read_executed_effects_digests(&digests) => {
+            _ = cache_read.try_notify_read_executed_effects_digests(
+                "ValidatorTxFinalizer::notify_read_executed_effects_digests",
+                &digests,
+            ) => {
                 trace!(?tx_digest, "Transaction already finalized");
                 return Ok(false);
             }

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -69,7 +69,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     // A small delay is needed for post processing operations following the
@@ -115,7 +115,7 @@ async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
         .iota_node
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     Ok(())
@@ -488,7 +488,7 @@ async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     let info = fullnode
@@ -598,7 +598,7 @@ async fn do_test_full_node_sync_flood() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&digests)
+        .notify_read_executed_effects_for_testing("", &digests)
         .await;
 }
 
@@ -784,7 +784,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
     fullnode.state().get_executed_transaction_and_effects(digest, kv_store).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {digest:?} that was executed with WaitForEffectsCert: {e:?}"));
@@ -1114,7 +1114,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
 
     node.state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     loop {
@@ -1133,7 +1133,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
         transfer_coin(&test_cluster.wallet).await?;
     node.state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest_after_restore])
+        .notify_read_executed_effects_for_testing("", &[digest_after_restore])
         .await;
     Ok(())
 }

--- a/crates/iota-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/iota-e2e-tests/tests/shared_objects_tests.rs
@@ -140,7 +140,7 @@ async fn shared_object_deletion_multiple_times() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&digests)
+        .notify_read_executed_effects_for_testing("", &digests)
         .await;
 }
 
@@ -196,7 +196,7 @@ async fn shared_object_deletion_multiple_times_cert_racing() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&digests)
+        .notify_read_executed_effects_for_testing("", &digests)
         .await;
 }
 
@@ -311,7 +311,7 @@ async fn shared_object_deletion_multi_certs() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[inc_tx_a_digest, inc_tx_b_digest])
+        .notify_read_executed_effects_for_testing("", &[inc_tx_a_digest, inc_tx_b_digest])
         .await;
 }
 

--- a/crates/iota-e2e-tests/tests/simulator_tests.rs
+++ b/crates/iota-e2e-tests/tests/simulator_tests.rs
@@ -139,6 +139,6 @@ async fn test_net_determinism() {
         .iota_node
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -71,7 +71,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     handle
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     // Transaction Orchestrator proactivcely executes txn locally
@@ -437,7 +437,7 @@ async fn test_cached_response_for_executed_transaction() -> Result<(), anyhow::E
     handle
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     let (second, executed_locally) = execute_with_orchestrator(

--- a/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
@@ -39,7 +39,7 @@ async fn test_validator_tx_finalizer_fastpath_tx() {
             node.with_async(|n| async {
                 n.state()
                     .get_transaction_cache_reader()
-                    .notify_read_executed_effects_digests(&tx_digests)
+                    .notify_read_executed_effects_digests("", &tx_digests)
                     .await;
             })
             .await;
@@ -77,7 +77,7 @@ async fn test_validator_tx_finalizer_consensus_tx() {
             node.with_async(|n| async {
                 n.state()
                     .get_transaction_cache_reader()
-                    .notify_read_executed_effects_digests(&tx_digests)
+                    .notify_read_executed_effects_digests("", &tx_digests)
                     .await;
             })
             .await;

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1762,7 +1762,10 @@ impl IotaNode {
             std::time::Duration::from_secs(timeout),
             state
                 .get_transaction_cache_reader()
-                .try_notify_read_executed_effects_digests(&digests),
+                .try_notify_read_executed_effects_digests(
+                    "IotaNode::notify_read_executed_effects_digests",
+                    &digests,
+                ),
         )
         .await
         .is_err()


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.52.3, v1.53.2)
- Port commit:
  - [MystenLabs/sui@5ed5e63](https://github.com/MystenLabs/sui/commit/5ed5e636a1b26bc5a9c1da8aac22eb740554896f)
- Description:

`NotifyRead::read` now takes a task name and, while any key is still pending, a background task warns every 10s listing the outstanding keys and elapsed time. The task name also opens a `monitored_scope`, so each call site gets its own metric. `debug_fatal!` if the checkpoint builder's read is stuck for 60s or more.

## Links to any relevant issues

Part of #12269

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
