### PR TITLE
upstream: Porting core-protocol related upstream changes in range mainnet-1.52.3 to mainnet-1.53.2

### DIFF
--- a/crates/iota-common/Cargo.toml
+++ b/crates/iota-common/Cargo.toml
@@ -26,7 +26,7 @@ iota-macros.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # external dependencies
 tempfile.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
 
 # internal dependencies
 iota-metrics.workspace = true

--- a/crates/iota-common/src/logging.rs
+++ b/crates/iota-common/src/logging.rs
@@ -23,19 +23,76 @@ pub fn crash_on_debug() -> bool {
     *CRASH_ON_DEBUG
 }
 
+#[cfg(msim)]
+pub mod intercept_debug_fatal {
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    pub struct DebugFatalCallback {
+        pub pattern: String,
+        pub callback: Arc<dyn Fn() + Send + Sync>,
+    }
+
+    thread_local! {
+        static INTERCEPT_DEBUG_FATAL: Mutex<Option<DebugFatalCallback>> = Mutex::new(None);
+    }
+
+    pub fn register_callback(message: &str, f: impl Fn() + Send + Sync + 'static) {
+        INTERCEPT_DEBUG_FATAL.with(|m| {
+            *m.lock().unwrap() = Some(DebugFatalCallback {
+                pattern: message.to_string(),
+                callback: Arc::new(f),
+            });
+        });
+    }
+
+    pub fn get_callback() -> Option<DebugFatalCallback> {
+        INTERCEPT_DEBUG_FATAL.with(|m| m.lock().unwrap().clone())
+    }
+}
+
+#[macro_export]
+macro_rules! register_debug_fatal_handler {
+    ($message:literal, $f:expr) => {
+        #[cfg(msim)]
+        $crate::logging::intercept_debug_fatal::register_callback($message, $f);
+
+        #[cfg(not(msim))]
+        {
+            // silence unused variable warnings from the body of the callback
+            let _ = $f;
+        }
+    };
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[macro_export]
 macro_rules! debug_fatal {
     ($($arg:tt)*) => {{
-        if $crate::logging::crash_on_debug() {
-            $crate::fatal!($($arg)*);
-        } else {
-            let stacktrace = std::backtrace::Backtrace::capture();
-            tracing::error!(debug_fatal = true, stacktrace = ?stacktrace, $($arg)*);
-            let location = concat!(file!(), ':', line!());
-            if let Some(metrics) = iota_metrics::get_metrics() {
-                metrics.system_invariant_violations.with_label_values(&[location]).inc();
+        loop {
+            #[cfg(msim)]
+            {
+                if let Some(cb) = $crate::logging::intercept_debug_fatal::get_callback() {
+                    tracing::error!($($arg)*);
+                    let msg = format!($($arg)*);
+                    if msg.contains(&cb.pattern) {
+                        (cb.callback)();
+                    }
+                    break;
+                }
             }
+
+            if $crate::logging::crash_on_debug() {
+                $crate::fatal!($($arg)*);
+            } else {
+                let stacktrace = std::backtrace::Backtrace::capture();
+                tracing::error!(debug_fatal = true, stacktrace = ?stacktrace, $($arg)*);
+                let location = concat!(file!(), ':', line!());
+                if let Some(metrics) = iota_metrics::get_metrics() {
+                    metrics.system_invariant_violations.with_label_values(&[location]).inc();
+                }
+            }
+            break;
         }
     }};
 }

--- a/crates/iota-common/src/sync/notify_read.rs
+++ b/crates/iota-common/src/sync/notify_read.rs
@@ -3,21 +3,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{HashMap, hash_map::DefaultHasher},
+    collections::{HashMap, HashSet, hash_map::DefaultHasher},
     error::Error,
     future::Future,
     hash::{Hash, Hasher},
     mem,
     pin::Pin,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::future::{Either, join_all};
+use iota_metrics::spawn_monitored_task;
 use parking_lot::{Mutex, MutexGuard};
-use tokio::sync::oneshot;
+use tokio::{
+    sync::oneshot,
+    time::{Instant, interval_at},
+};
+use tracing::warn;
+
+use crate::debug_fatal;
 
 type Registrations<V> = Vec<oneshot::Sender<V>>;
+
+/// Wrapper that ensures a spawned task is aborted when dropped
+struct TaskAbortOnDrop {
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl TaskAbortOnDrop {
+    fn new(handle: tokio::task::JoinHandle<()>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for TaskAbortOnDrop {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Interval duration for logging waiting keys when reads take too long
+const LONG_WAIT_LOG_INTERVAL_SECS: u64 = 10;
+
+pub const CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME: &str =
+    "CheckpointBuilder::notify_read_executed_effects";
 
 pub struct NotifyRead<K, V> {
     pending: Vec<Mutex<HashMap<K, Registrations<V>>>>,
@@ -119,24 +157,90 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone + Unpin, V: Clone + Unpin> NotifyRead<K, V> {
+impl<K: Eq + Hash + Clone + Unpin + std::fmt::Debug + Send + Sync + 'static, V: Clone + Unpin>
+    NotifyRead<K, V>
+{
     pub async fn read<E: Error>(
         &self,
+        task_name: &'static str,
         keys: &[K],
         fetch: impl FnOnce(&[K]) -> Result<Vec<Option<V>>, E>,
     ) -> Result<Vec<V>, E> {
+        let _metrics_scope = iota_metrics::monitored_scope(task_name);
         let registrations = self.register_all(keys);
 
         let results = fetch(keys)?;
 
-        let results = results
-            .into_iter()
-            .zip(registrations)
-            .map(|(a, r)| match a {
-                // Note that Some() clause also drops registration that is already fulfilled
-                Some(ready) => Either::Left(futures::future::ready(ready)),
-                None => Either::Right(r),
+        // Track which keys are still waiting
+        let waiting_keys: HashSet<K> = keys
+            .iter()
+            .zip(results.iter())
+            .filter(|&(_key, result)| result.is_none())
+            .map(|(key, _result)| key.clone())
+            .collect();
+        let has_waiting_keys = !waiting_keys.is_empty();
+        let waiting_keys = Arc::new(Mutex::new(waiting_keys));
+
+        // Spawn logging task if there are waiting keys
+        let _log_handle_guard = if has_waiting_keys {
+            let waiting_keys_clone = waiting_keys.clone();
+            let start_time = Instant::now();
+            let task_name = task_name.to_string();
+
+            let handle = spawn_monitored_task!(async move {
+                // Only start logging after the first interval.
+                let start = Instant::now() + Duration::from_secs(LONG_WAIT_LOG_INTERVAL_SECS);
+                let mut interval =
+                    interval_at(start, Duration::from_secs(LONG_WAIT_LOG_INTERVAL_SECS));
+
+                loop {
+                    interval.tick().await;
+                    let current_waiting = waiting_keys_clone.lock();
+                    if current_waiting.is_empty() {
+                        break;
+                    }
+                    let keys_vec: Vec<_> = current_waiting.iter().cloned().collect();
+                    drop(current_waiting); // Release lock before logging
+
+                    let elapsed_secs = start_time.elapsed().as_secs();
+
+                    warn!(
+                        "[{task_name}] Still waiting for {elapsed_secs}s for {} keys: {keys_vec:?}",
+                        keys_vec.len(),
+                    );
+
+                    if task_name == CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME && elapsed_secs >= 60 {
+                        debug_fatal!("{task_name} is stuck");
+                    }
+                }
             });
+            Some(TaskAbortOnDrop::new(handle))
+        } else {
+            None
+        };
+
+        let results =
+            results
+                .into_iter()
+                .zip(registrations)
+                .zip(keys.iter())
+                .map(|((a, r), key)| match a {
+                    // Note that Some() clause also drops registration that is already fulfilled
+                    Some(ready) => Either::Left(futures::future::ready(ready)),
+                    None => {
+                        let waiting_keys = waiting_keys.clone();
+                        let key = key.clone();
+                        Either::Right(async move {
+                            let result = r.await;
+                            // Remove this key from the waiting set
+                            waiting_keys.lock().remove(&key);
+                            result
+                        })
+                    }
+                });
+
+        // The logging task will be automatically aborted when _log_handle_guard is
+        // dropped
 
         Ok(join_all(results).await)
     }
@@ -185,7 +289,10 @@ impl<K: Eq + Hash + Clone, V: Clone> Default for NotifyRead<K, V> {
 
 #[cfg(test)]
 mod tests {
+    use std::{convert::Infallible, sync::Arc};
+
     use futures::future::join_all;
+    use tokio::time::timeout;
 
     use super::*;
 
@@ -202,6 +309,36 @@ mod tests {
         assert_eq!(0, notify_read.count_pending.load(Ordering::Relaxed));
         assert_eq!(reads, vec![1, 2]);
         // ensure cleanup is done correctly
+        for pending in &notify_read.pending {
+            assert!(pending.lock().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    pub async fn test_notify_read_cancellation() {
+        let notify_read = Arc::new(NotifyRead::<u64, u64>::new());
+
+        // Start a read that will wait indefinitely
+        let read_future = notify_read.read::<Infallible>(
+            "test_task",
+            &[1, 2, 3],
+            |_keys| Ok(vec![None, None, None]), // All keys will wait
+        );
+
+        // Use timeout to cancel the read after a short duration
+        let result = timeout(Duration::from_millis(100), read_future).await;
+
+        // Verify the read was cancelled
+        assert!(result.is_err());
+
+        // Give some time for cleanup to complete
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // When the read is cancelled, the registrations are cleaned up
+        // so the pending count should be 0
+        assert_eq!(0, notify_read.count_pending.load(Ordering::Relaxed));
+
+        // Verify all pending maps are empty (cleanup was performed)
         for pending in &notify_read.pending {
             assert!(pending.lock().is_empty());
         }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1421,7 +1421,10 @@ impl AuthorityState {
         // tx could be reverted when epoch ends, so we must be careful not to return a
         // result here after the epoch ends.
         epoch_store
-            .within_alive_epoch(self.notify_read_effects(certificate))
+            .within_alive_epoch(self.notify_read_effects(
+                "AuthorityState::wait_for_certificate_execution",
+                certificate,
+            ))
             .await
             .map_err(|_| IotaError::EpochEnded(epoch_store.epoch()))
             .and_then(|r| r)
@@ -1551,10 +1554,11 @@ impl AuthorityState {
 
     pub async fn notify_read_effects(
         &self,
+        task_name: &'static str,
         certificate: &VerifiedCertificate,
     ) -> IotaResult<TransactionEffects> {
         self.get_transaction_cache_reader()
-            .try_notify_read_executed_effects(&[*certificate.digest()])
+            .try_notify_read_executed_effects(task_name, &[*certificate.digest()])
             .await
             .map(|mut r| r.pop().expect("must return correct number of effects"))
     }
@@ -6107,7 +6111,10 @@ impl RandomnessRoundReceiver {
                 RANDOMNESS_STATE_UPDATE_EXECUTION_TIMEOUT,
                 authority_state
                     .get_transaction_cache_reader()
-                    .try_notify_read_executed_effects(&[digest]),
+                    .try_notify_read_executed_effects(
+                        "RandomnessRoundReceiver::notify_read_executed_effects_first",
+                        &[digest],
+                    ),
             )
             .await;
             let result = match result {
@@ -6125,7 +6132,10 @@ impl RandomnessRoundReceiver {
                     // Continue waiting as long as necessary in non-debug builds.
                     authority_state
                         .get_transaction_cache_reader()
-                        .try_notify_read_executed_effects(&[digest])
+                        .try_notify_read_executed_effects(
+                            "RandomnessRoundReceiver::notify_read_executed_effects_second",
+                            &[digest],
+                        )
                         .await
                 }
             };

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -15,7 +15,6 @@ use std::{
     vec,
 };
 
-use anyhow::bail;
 use arc_swap::{ArcSwap, Guard};
 use async_trait::async_trait;
 use authority_per_epoch_store::TxLockGuard;
@@ -159,7 +158,7 @@ use crate::{
     },
     authority_client::NetworkAuthorityClient,
     checkpoint_progress_tracker::CheckpointProgressTracker,
-    checkpoints::CheckpointStore,
+    checkpoints::{CheckpointBuilderError, CheckpointBuilderResult, CheckpointStore},
     congestion_tracker::CongestionTracker,
     consensus_adapter::ConsensusAdapter,
     epoch::committee_store::CommitteeStore,
@@ -3778,11 +3777,7 @@ impl AuthorityState {
                 "Performing state consistency check for epoch {}",
                 cur_epoch_store.epoch()
             );
-            self.expensive_check_is_consistent_state(
-                state_hasher,
-                cur_epoch_store,
-                cfg!(debug_assertions), // panic in debug mode only
-            );
+            self.expensive_check_is_consistent_state(state_hasher, cur_epoch_store);
         }
 
         if expensive_safety_check_config.enable_secondary_index_checks() {
@@ -3799,7 +3794,6 @@ impl AuthorityState {
         &self,
         state_hasher: Arc<GlobalStateHasher>,
         cur_epoch_store: &AuthorityPerEpochStore,
-        panic: bool,
     ) {
         let live_object_set_hash = state_hasher.digest_live_object_set();
 
@@ -3814,23 +3808,16 @@ impl AuthorityState {
 
         let is_inconsistent = root_state_hash != live_object_set_hash;
         if is_inconsistent {
-            if panic {
-                panic!(
-                    "Inconsistent state detected: root state hash: {root_state_hash:?}, live object set hash: {live_object_set_hash:?}"
-                );
-            } else {
-                error!(
-                    "Inconsistent state detected: root state hash: {:?}, live object set hash: {:?}",
-                    root_state_hash, live_object_set_hash
-                );
-            }
+            debug_fatal!(
+                "Inconsistent state detected: root state hash: {:?}, live object set hash: {:?}",
+                root_state_hash,
+                live_object_set_hash
+            );
         } else {
             info!("State consistency check passed");
         }
 
-        if !panic {
-            state_hasher.set_inconsistent_state(is_inconsistent);
-        }
+        state_hasher.set_inconsistent_state(is_inconsistent);
     }
 
     pub fn current_epoch_for_testing(&self) -> EpochId {
@@ -4155,7 +4142,7 @@ impl AuthorityState {
         match self.read_object_at_version(object_id, obj_ref.version)? {
             Some((object, layout)) => Ok(PastObjectRead::VersionFound(obj_ref, object, layout)),
             None => {
-                error!(
+                debug_fatal!(
                     "Object with in parent_entry is missing from object store, datastore is \
                      inconsistent",
                 );
@@ -5179,7 +5166,7 @@ impl AuthorityState {
 
             let new_ref = new_object.object_ref();
             if new_ref != system_package_ref {
-                error!(
+                debug_fatal!(
                     "Framework mismatch -- binary: {new_ref:?}\n  upgrade: {system_package_ref:?}"
                 );
                 return None;
@@ -5390,7 +5377,7 @@ impl AuthorityState {
         checkpoint: CheckpointSequenceNumber,
         epoch_start_timestamp_ms: CheckpointTimestamp,
         scores: Vec<u64>,
-    ) -> anyhow::Result<(
+    ) -> CheckpointBuilderResult<(
         IotaSystemState,
         Option<SystemEpochInfoEvent>,
         TransactionEffects,
@@ -5423,7 +5410,7 @@ impl AuthorityState {
             .get_system_package_bytes(next_epoch_system_packages.clone(), &binary_config)
             .await
         else {
-            error!(
+            debug_fatal!(
                 "upgraded system packages {:?} are not locally available, cannot create \
                 ChangeEpochTx. validator binary must be upgraded to the correct version!",
                 next_epoch_system_packages
@@ -5437,7 +5424,7 @@ impl AuthorityState {
             //   packages, reconfigure, and most likely shut down in the new epoch (this
             //   validator likely doesn't support the new protocol version, or else it
             //   should have had the packages.)
-            bail!("missing system packages: cannot form ChangeEpochTx");
+            return Err(CheckpointBuilderError::SystemPackagesMissing);
         };
 
         // Use ChangeEpochV3 or ChangeEpochV4 when the feature flags are enabled and
@@ -5575,7 +5562,7 @@ impl AuthorityState {
             .try_is_tx_already_executed(tx_digest)?
         {
             warn!("change epoch tx has already been executed via state sync");
-            bail!("change epoch tx has already been executed via state sync",);
+            return Err(CheckpointBuilderError::ChangeEpochTxAlreadyExecuted);
         }
 
         let execution_guard = self.execution_lock_for_executable_transaction(&executable_tx)?;
@@ -5615,11 +5602,7 @@ impl AuthorityState {
         // able to deliver to the transaction to CheckpointExecutor after it is
         // included in a certified checkpoint.
         self.get_state_sync_store()
-            .try_insert_transaction_and_effects(&tx, &effects)
-            .map_err(|err| {
-                let err: anyhow::Error = err.into();
-                err
-            })?;
+            .try_insert_transaction_and_effects(&tx, &effects)?;
 
         info!(
             "Effects summary of the change epoch transaction: {:?}",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1841,12 +1841,16 @@ impl AuthorityPerEpochStore {
     ) -> IotaResult<Vec<GlobalStateHash>> {
         let tables = self.tables()?;
         self.checkpoint_state_notify_read
-            .read(checkpoints, |checkpoints| {
-                tables
-                    .state_hash_by_checkpoint
-                    .multi_get(checkpoints)
-                    .map_err(Into::into)
-            })
+            .read(
+                "notify_read_checkpoint_state_hasher",
+                checkpoints,
+                |checkpoints| {
+                    tables
+                        .state_hash_by_checkpoint
+                        .multi_get(checkpoints)
+                        .map_err(Into::into)
+                },
+            )
             .await
     }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1370,10 +1370,14 @@ impl AuthorityPerEpochStore {
             .set(tokio::sync::Mutex::new(randomness_manager))
             .is_err()
         {
-            error!("BUG: `set_randomness_manager` called more than once; this should never happen");
+            debug_fatal!(
+                "BUG: `set_randomness_manager` called more than once; this should never happen"
+            );
         }
         if self.randomness_reporter.set(reporter).is_err() {
-            error!("BUG: `set_randomness_manager` called more than once; this should never happen");
+            debug_fatal!(
+                "BUG: `set_randomness_manager` called more than once; this should never happen"
+            );
         }
         result
     }

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -212,6 +212,23 @@ impl AuthorityStore {
         }
     }
 
+    // NB: This must only be called at time of reconfiguration. We take the
+    // execution lock write guard as an argument to ensure that this is the
+    // case.
+    pub fn clear_object_per_epoch_marker_table(
+        &self,
+        _execution_guard: &ExecutionLockWriteGuard<'_>,
+    ) -> IotaResult<()> {
+        // We can safely delete all entries in the per epoch marker table since this is
+        // only called at epoch boundaries (during reconfiguration). Therefore
+        // any entries that currently exist can be removed. Because of this we
+        // can use the `schedule_delete_all` method.
+        Ok(self
+            .perpetual_tables
+            .object_per_epoch_marker_table
+            .schedule_delete_all()?)
+    }
+
     pub async fn open_with_committee_for_testing(
         perpetual_tables: Arc<AuthorityPerpetualTables>,
         committee: &Committee,

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -376,7 +376,7 @@ pub async fn enqueue_all_and_execute_all(
     );
     let mut output = Vec::new();
     for cert in certificates {
-        let effects = authority.notify_read_effects(&cert).await?;
+        let effects = authority.notify_read_effects("", &cert).await?;
         output.push(effects);
     }
     Ok(output)

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -485,7 +485,7 @@ impl ValidatorService {
                 let digests_to_watch = [tx_digest];
                 tokio::select! {
                     biased;
-                    effects_digests = cache.notify_read_executed_effects_digests(&digests_to_watch) => {
+                    effects_digests = cache.notify_read_executed_effects_digests("ValidatorService::notify_read_executed_effects_digests", &digests_to_watch) => {
                         Either::Left(effects_digests)
                     }
                     dropped_error = epoch_store.notify_read_dropped_digests(tx_digest) => {

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -579,11 +579,11 @@ impl CheckpointExecutor {
         finish_stage!(pipeline_handle, ExecuteTransactions);
 
         {
-            let _metrics_scope = iota_metrics::monitored_scope(
-                "CheckpointExecutor::notify_read_executed_effects_digests",
-            );
             self.transaction_cache_reader
-                .notify_read_executed_effects_digests(&unexecuted_tx_digests)
+                .notify_read_executed_effects_digests(
+                    "CheckpointExecutor::notify_read_executed_effects_digests",
+                    &unexecuted_tx_digests,
+                )
                 .await;
         }
 
@@ -966,7 +966,10 @@ impl CheckpointExecutor {
         );
 
         self.transaction_cache_reader
-            .notify_read_executed_effects_digests(&[*change_epoch_tx.digest()])
+            .notify_read_executed_effects_digests(
+                "CheckpointExecutor::notify_read_advance_epoch_tx",
+                &[*change_epoch_tx.digest()],
+            )
             .await;
     }
 

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -23,7 +23,6 @@ use std::{
 
 use diffy::create_patch;
 use iota_common::{debug_fatal, fatal, random::get_rng, sync::notify_read::NotifyRead};
-use iota_macros::fail_point;
 use iota_metrics::{MonitoredFutureExt, monitored_future, monitored_scope};
 use iota_network::default_iota_network_config;
 use iota_sdk_types::{
@@ -996,6 +995,23 @@ struct BuiltCheckpoint {
     full_contents: Option<FullCheckpointContents>,
 }
 
+#[derive(Debug)]
+pub enum CheckpointBuilderError {
+    ChangeEpochTxAlreadyExecuted,
+    SystemPackagesMissing,
+    Retry(anyhow::Error),
+}
+
+impl<IotaError: std::error::Error + Send + Sync + 'static> From<IotaError>
+    for CheckpointBuilderError
+{
+    fn from(e: IotaError) -> Self {
+        Self::Retry(e.into())
+    }
+}
+
+pub type CheckpointBuilderResult<T = ()> = Result<T, CheckpointBuilderError>;
+
 pub struct CheckpointBuilder {
     state: Arc<AuthorityState>,
     store: Arc<CheckpointStore>,
@@ -1085,13 +1101,29 @@ impl CheckpointBuilder {
         }
         info!("Starting CheckpointBuilder");
         loop {
-            self.maybe_build_checkpoints().await;
+            match self.maybe_build_checkpoints().await {
+                Ok(()) => {}
+                err @ Err(
+                    CheckpointBuilderError::ChangeEpochTxAlreadyExecuted
+                    | CheckpointBuilderError::SystemPackagesMissing,
+                ) => {
+                    info!("CheckpointBuilder stopping: {:?}", err);
+                    return;
+                }
+                Err(CheckpointBuilderError::Retry(inner)) => {
+                    let msg = format!("{inner:?}");
+                    debug_fatal!("Error while making checkpoint, will retry in 1s: {}", msg);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    self.metrics.checkpoint_errors.inc();
+                    continue;
+                }
+            }
 
             self.notify.notified().await;
         }
     }
 
-    async fn maybe_build_checkpoints(&mut self) {
+    async fn maybe_build_checkpoints(&mut self) -> CheckpointBuilderResult {
         let _scope = monitored_scope("BuildCheckpoints");
 
         // Collect info about the most recently built checkpoint.
@@ -1189,36 +1221,28 @@ impl CheckpointBuilder {
                 "Making checkpoint with commit height range"
             );
 
-            match self
+            let seq = self
                 .make_checkpoint(std::mem::take(&mut grouped_pending_checkpoints))
-                .await
-            {
-                Ok(seq) => {
-                    // Count only on success; a failed build retries the same
-                    // group and would otherwise double-count it.
-                    self.metrics
-                        .commits_per_checkpoint
-                        .observe(commits_in_checkpoint as f64);
-                    // Advance the window anchor to the highest checkpoint just
-                    // built (a single call may emit several when chunked).
-                    last_seq = Some(seq);
-                    self.last_built.send_if_modified(|cur| {
-                        // when rebuilding checkpoints at startup, seq can be for an old checkpoint
-                        if seq > *cur {
-                            *cur = seq;
-                            true
-                        } else {
-                            false
-                        }
-                    });
+                .await?;
+
+            // Count only on success; a failed build retries the same
+            // group and would otherwise double-count it.
+            self.metrics
+                .commits_per_checkpoint
+                .observe(commits_in_checkpoint as f64);
+            // Advance the window anchor to the highest checkpoint just
+            // built (a single call may emit several when chunked).
+            last_seq = Some(seq);
+            self.last_built.send_if_modified(|cur| {
+                // when rebuilding checkpoints at startup, seq can be for an old checkpoint
+                if seq > *cur {
+                    *cur = seq;
+                    true
+                } else {
+                    false
                 }
-                Err(e) => {
-                    error!("Error while making checkpoint, will retry in 1s: {:?}", e);
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    self.metrics.checkpoint_errors.inc();
-                    return;
-                }
-            }
+            });
+
             // Ensure that the task can be cancelled at end of epoch, even if no other await
             // yields execution.
             tokio::task::yield_now().await;
@@ -1227,6 +1251,8 @@ impl CheckpointBuilder {
             "Waiting for more checkpoints from consensus after processing {last_height:?}; {} pending checkpoints left unprocessed until next interval",
             grouped_pending_checkpoints.len(),
         );
+
+        Ok(())
     }
 
     #[instrument(level = "debug", skip_all, fields(last_height = pendings.last().unwrap().details().checkpoint_height
@@ -1234,7 +1260,7 @@ impl CheckpointBuilder {
     async fn make_checkpoint(
         &self,
         pendings: Vec<PendingCheckpoint>,
-    ) -> anyhow::Result<CheckpointSequenceNumber> {
+    ) -> CheckpointBuilderResult<CheckpointSequenceNumber> {
         let _scope = monitored_scope("CheckpointBuilder::make_checkpoint");
         let last_details = pendings.last().unwrap().details().clone();
 
@@ -1526,8 +1552,9 @@ impl CheckpointBuilder {
         &self,
         transactions_effects_and_sizes: Vec<(TransactionEnvelope, TransactionEffects, usize)>,
         signatures: Vec<Vec<UserSignature>>,
-    ) -> anyhow::Result<Vec<Vec<(TransactionEnvelope, TransactionEffects, Vec<UserSignature>)>>>
-    {
+    ) -> CheckpointBuilderResult<
+        Vec<Vec<(TransactionEnvelope, TransactionEffects, Vec<UserSignature>)>>,
+    > {
         let _guard = monitored_scope("CheckpointBuilder::split_checkpoint_chunks");
         let mut chunks = Vec::new();
         let mut chunk = Vec::new();
@@ -1610,7 +1637,7 @@ impl CheckpointBuilder {
         all_effects: Vec<TransactionEffects>,
         details: &PendingCheckpointInfo,
         all_roots: &HashSet<TransactionDigest>,
-    ) -> anyhow::Result<NonEmpty<BuiltCheckpoint>> {
+    ) -> CheckpointBuilderResult<NonEmpty<BuiltCheckpoint>> {
         let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
 
         let total = all_effects.len();
@@ -1948,7 +1975,7 @@ impl CheckpointBuilder {
         signatures: &mut Vec<Vec<UserSignature>>,
         checkpoint: CheckpointSequenceNumber,
         scores: Vec<u64>,
-    ) -> anyhow::Result<(IotaSystemState, Option<SystemEpochInfoEvent>)> {
+    ) -> CheckpointBuilderResult<(IotaSystemState, Option<SystemEpochInfoEvent>)> {
         let (system_state, system_epoch_info_event, effects) = self
             .state
             .create_and_execute_advance_epoch_tx(
@@ -2367,9 +2394,9 @@ impl CheckpointSignatureAggregator {
                     format!("{digest} (total stake: {total_stake})")
                 })
                 .collect::<Vec<String>>();
-            error!(
-                checkpoint_seq = self.summary.sequence_number,
-                "Split brain detected in checkpoint signature aggregation! Remaining stake: {:?}, Digests by stake: {:?}",
+            debug_fatal!(
+                "Split brain detected in checkpoint signature aggregation for checkpoint {:?}. Remaining stake: {:?}, Digests by stake: {:?}",
+                self.summary.sequence_number,
                 self.signatures_by_digest.uncommitted_stake(),
                 digests_by_stake_messages,
             );
@@ -2562,8 +2589,6 @@ async fn diagnose_split_brain(
     let mut file = File::create(checkpoint_fork_file_path).unwrap();
     write!(file, "{fork_logs_text}").unwrap();
     debug!("{}", fork_logs_text);
-
-    fail_point!("split_brain_reached");
 }
 
 pub trait CheckpointServiceNotify {

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -22,7 +22,11 @@ use std::{
 };
 
 use diffy::create_patch;
-use iota_common::{debug_fatal, fatal, random::get_rng, sync::notify_read::NotifyRead};
+use iota_common::{
+    debug_fatal, fatal,
+    random::get_rng,
+    sync::notify_read::{CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME, NotifyRead},
+};
 use iota_metrics::{MonitoredFutureExt, monitored_future, monitored_scope};
 use iota_network::default_iota_network_config;
 use iota_sdk_types::{
@@ -682,7 +686,7 @@ impl CheckpointStore {
         type ReadResult = Result<Vec<Option<VerifiedCheckpoint>>, TypedStoreError>;
 
         notify_read
-            .read(&[seq], |seqs| {
+            .read("notify_read_checkpoint_watermark", &[seq], |seqs| {
                 let seq = seqs[0];
                 let Some(highest) = get_watermark() else {
                     return Ok(vec![None]) as ReadResult;
@@ -1336,7 +1340,10 @@ impl CheckpointBuilder {
                 .await?;
             let root_effects = self
                 .effects_store
-                .try_notify_read_executed_effects(&root_digests)
+                .try_notify_read_executed_effects(
+                    CHECKPOINT_BUILDER_NOTIFY_READ_TASK_NAME,
+                    &root_digests,
+                )
                 .in_monitored_scope("CheckpointNotifyRead")
                 .await?;
 
@@ -3662,6 +3669,7 @@ mod tests {
     impl TransactionCacheRead for HashMap<TransactionDigest, TransactionEffects> {
         fn try_notify_read_executed_effects(
             &self,
+            _: &str,
             digests: &[TransactionDigest],
         ) -> BoxFuture<'_, IotaResult<Vec<TransactionEffects>>> {
             std::future::ready(Ok(digests
@@ -3673,6 +3681,7 @@ mod tests {
 
         fn try_notify_read_executed_effects_digests(
             &self,
+            _: &str,
             digests: &[TransactionDigest],
         ) -> BoxFuture<'_, IotaResult<Vec<TransactionEffectsDigest>>> {
             std::future::ready(Ok(digests

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -18,6 +18,7 @@ use fastcrypto::{
 };
 use fastcrypto_tbls::{dkg_v1, dkg_v1::Output, nodes, nodes::PartyId};
 use futures::{StreamExt, stream::FuturesUnordered};
+use iota_common::debug_fatal;
 use iota_macros::fail_point_if;
 use iota_network::randomness;
 use iota_sdk_types::RandomnessRound;
@@ -641,7 +642,9 @@ impl RandomnessManager {
             return Ok(());
         }
         let Some((_, party_id)) = self.authority_info.get(authority) else {
-            error!("random beacon: received DKG Message from unknown authority: {authority:?}");
+            debug_fatal!(
+                "random beacon: received DKG Message from unknown authority: {authority:?}"
+            );
             return Ok(());
         };
         if *party_id != msg.sender() {

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -65,65 +65,73 @@ fn notify_read_input_objects_impl<'a>(
 ) -> BoxFuture<'a, Vec<()>> {
     async move {
         object_notify_read
-            .read::<std::convert::Infallible>(input_and_receiving_keys, |keys| {
-                let mut results = vec![None; keys.len()];
+            .read::<std::convert::Infallible>(
+                "notify_read_input_objects",
+                input_and_receiving_keys,
+                |keys| {
+                    let mut results = vec![None; keys.len()];
 
-                let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
-                    .iter()
-                    .enumerate()
-                    .filter(|(idx, key)| {
-                        if key.is_cancelled() {
-                            // Shared objects in canceled transactions are always available.
-                            results[*idx] = Some(());
-                            false
-                        } else {
-                            true
-                        }
-                    })
-                    .partition(|(_, key)| key.version().is_some());
-                let versioned_object_keys: Vec<_> = keys_with_version
-                    .iter()
-                    .map(|(_, key)| ObjectKey(key.id(), key.version().unwrap()))
-                    .collect();
-                ObjectCacheRead::multi_get_objects_by_key(cache, &versioned_object_keys)
-                    .into_iter()
-                    .zip(keys_with_version.iter())
-                    .for_each(|(o, (idx, input_key))| match o {
-                        Some(_) => results[*idx] = Some(()),
-                        None => {
-                            if receiving_keys.contains(input_key) {
-                                // There could be a more recent version of this object, and the
-                                // object at the specified version could have already been pruned.
-                                // In such a case `has_key` will be false, but since this is a
-                                // receiving object we should mark it as available if we can
-                                // determine that an object with a version greater than or equal to
-                                // the specified version exists or was deleted. We will then let
-                                // mark it as available to let the transaction through so it can
-                                // fail at execution.
-                                let is_available =
-                                    ObjectCacheRead::get_object(cache, &input_key.id())
-                                        .map(|obj| obj.version() >= input_key.version().unwrap())
-                                        .unwrap_or(false);
-                                if is_available {
+                    let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
+                        .iter()
+                        .enumerate()
+                        .filter(|(idx, key)| {
+                            if key.is_cancelled() {
+                                // Shared objects in canceled transactions are always available.
+                                results[*idx] = Some(());
+                                false
+                            } else {
+                                true
+                            }
+                        })
+                        .partition(|(_, key)| key.version().is_some());
+                    let versioned_object_keys: Vec<_> = keys_with_version
+                        .iter()
+                        .map(|(_, key)| ObjectKey(key.id(), key.version().unwrap()))
+                        .collect();
+                    ObjectCacheRead::multi_get_objects_by_key(cache, &versioned_object_keys)
+                        .into_iter()
+                        .zip(keys_with_version.iter())
+                        .for_each(|(o, (idx, input_key))| match o {
+                            Some(_) => results[*idx] = Some(()),
+                            None => {
+                                if receiving_keys.contains(input_key) {
+                                    // There could be a more recent version of this object, and the
+                                    // object at the specified version could have already been
+                                    // pruned. In such a case
+                                    // `has_key` will be false, but since this is a
+                                    // receiving object we should mark it as available if we can
+                                    // determine that an object with a version greater than or equal
+                                    // to the specified version
+                                    // exists or was deleted. We will then let
+                                    // mark it as available to let the transaction through so it can
+                                    // fail at execution.
+                                    let is_available =
+                                        ObjectCacheRead::get_object(cache, &input_key.id())
+                                            .map(|obj| {
+                                                obj.version() >= input_key.version().unwrap()
+                                            })
+                                            .unwrap_or(false);
+                                    if is_available {
+                                        results[*idx] = Some(());
+                                    }
+                                } else if cache
+                                    .get_last_shared_object_deletion_info(&input_key.id(), *epoch)
+                                    .is_some()
+                                {
+                                    // If the shared object was deleted, mark it as
+                                    // available so the transaction can proceed.
                                     results[*idx] = Some(());
                                 }
-                            } else if cache
-                                .get_last_shared_object_deletion_info(&input_key.id(), *epoch)
-                                .is_some()
-                            {
-                                // If the shared object was deleted, mark it as
-                                // available so the transaction can proceed.
-                                results[*idx] = Some(());
                             }
+                        });
+                    keys_without_version.iter().for_each(|(idx, key)| {
+                        if cache.get_package_object(&key.id()).is_some() {
+                            results[*idx] = Some(());
                         }
                     });
-                keys_without_version.iter().for_each(|(idx, key)| {
-                    if cache.get_package_object(&key.id()).is_some() {
-                        results[*idx] = Some(());
-                    }
-                });
-                Ok(results)
-            })
+                    Ok(results)
+                },
+            )
             .await
             .unwrap()
     }
@@ -986,16 +994,18 @@ pub trait TransactionCacheRead: Send + Sync {
 
     fn try_notify_read_executed_effects_digests<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffectsDigest>>>;
 
     /// Non-fallible version of `try_notify_read_executed_effects_digests`.
     fn notify_read_executed_effects_digests<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, Vec<TransactionEffectsDigest>> {
         Box::pin(async move {
-            self.try_notify_read_executed_effects_digests(digests)
+            self.try_notify_read_executed_effects_digests(task_name, digests)
                 .await
                 .expect("storage access failed")
         })
@@ -1014,11 +1024,12 @@ pub trait TransactionCacheRead: Send + Sync {
     /// the database.
     fn try_notify_read_executed_effects<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffects>>> {
         async move {
             let effects_digests = self
-                .try_notify_read_executed_effects_digests(digests)
+                .try_notify_read_executed_effects_digests(task_name, digests)
                 .await?;
             self.try_multi_get_effects(&effects_digests)?
                 .into_iter()
@@ -1037,10 +1048,11 @@ pub trait TransactionCacheRead: Send + Sync {
     /// effects may have been pruned, use `try_notify_read_executed_effects`.
     fn notify_read_executed_effects_for_testing<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, Vec<TransactionEffects>> {
         Box::pin(async move {
-            self.try_notify_read_executed_effects(digests)
+            self.try_notify_read_executed_effects(task_name, digests)
                 .await
                 .unwrap_or_else(|e| panic!("effects must exist: {e}"))
         })

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1258,7 +1258,7 @@ impl WritebackCache {
         self.cache_latest_object_by_id(object_id, LatestObjectCacheEntry::NonExistent, ticket);
     }
 
-    fn clear_state_end_of_epoch_impl(&self, _execution_guard: &ExecutionLockWriteGuard<'_>) {
+    fn clear_state_end_of_epoch_impl(&self, execution_guard: &ExecutionLockWriteGuard<'_>) {
         info!("clearing state at end of epoch");
         assert!(
             self.dirty.pending_transaction_writes.is_empty(),
@@ -1267,6 +1267,10 @@ impl WritebackCache {
         self.dirty.clear();
         info!("clearing old transaction locks");
         self.object_locks.clear();
+        info!("clearing object per epoch marker table");
+        self.store
+            .clear_object_per_epoch_marker_table(execution_guard)
+            .expect("db error");
     }
 
     fn revert_state_update_impl(&self, tx: &TransactionDigest) -> IotaResult {

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -2053,10 +2053,11 @@ impl TransactionCacheRead for WritebackCache {
     #[instrument(level = "trace", skip_all)]
     fn try_notify_read_executed_effects_digests<'a>(
         &'a self,
+        task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffectsDigest>>> {
         self.executed_effects_digests_notify_read
-            .read(digests, |digests| {
+            .read(task_name, digests, |digests| {
                 self.try_multi_get_executed_effects_digests(digests)
             })
             .boxed()

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -317,6 +317,10 @@ fn make_owner_key(owner: Address, object: &Object) -> Option<(OwnerIndexKey, Own
     Some((key, info))
 }
 
+fn default_table_options() -> typed_store::rocks::DBOptions {
+    typed_store::rocks::default_db_options().disable_write_throttling()
+}
+
 /// RocksDB tables for the GrpcIndexesStore
 ///
 /// Anytime a new table is added, or an existing one has its schema changed,
@@ -343,6 +347,7 @@ struct IndexStoreTables {
     /// the event that the node was running with indexes enabled, then run
     /// for a period of time with indexes disabled, and then run with them
     /// enabled again so that the tables can be reinitialized.
+    #[default_options_override_fn = "default_table_options"]
     watermark: DBMap<Watermark, CheckpointSequenceNumber>,
 
     /// Deprecated: per-epoch metadata moved to the CheckpointStore's
@@ -356,6 +361,7 @@ struct IndexStoreTables {
     ///
     /// Only contains entries for transactions which have yet to be pruned from
     /// the main database.
+    #[default_options_override_fn = "default_table_options"]
     transaction_checkpoints: DBMap<TransactionDigest, CheckpointSequenceNumber>,
 
     /// An index of object ownership.
@@ -367,6 +373,7 @@ struct IndexStoreTables {
     /// Full `StructTag` stored in value for collision filtering & API
     /// responses. Bounded by the live object set (one entry per
     /// address-owned object).
+    #[default_options_override_fn = "default_table_options"]
     owner: DBMap<OwnerIndexKey, OwnerIndexInfo>,
 
     /// An index of dynamic fields (children objects).
@@ -374,10 +381,12 @@ struct IndexStoreTables {
     /// Allows an efficient iterator to list all of the dynamic fields owned by
     /// a particular ObjectId. Only the key is stored; field metadata is loaded
     /// on demand from the object store.
+    #[default_options_override_fn = "default_table_options"]
     dynamic_field: DBMap<DynamicFieldKey, ()>,
 
     /// Coin info with regulated coin metadata.
     /// Bounded by the live object set (one entry per coin type).
+    #[default_options_override_fn = "default_table_options"]
     coin: DBMap<CoinIndexKey, CoinIndexInfo>,
 
     /// An index of Package versions.
@@ -386,6 +395,7 @@ struct IndexStoreTables {
     /// Allows efficient listing of all versions of a package, including
     /// upgraded user packages that have different storage IDs.
     /// Bounded by the live object set (one entry per package version).
+    #[default_options_override_fn = "default_table_options"]
     package_version: DBMap<PackageVersionKey, PackageVersionInfo>,
     // NOTE: Authors and Reviewers before adding any new tables ensure that they are either:
     // - bounded in size by the live object set

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -265,7 +265,7 @@ impl LocalAuthorityClient {
                     .await?;
                 // let certificate = certificate.verify(epoch_store.committee())?;
                 state.enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store);
-                let effects = state.notify_read_effects(&certificate).await?;
+                let effects = state.notify_read_effects("", &certificate).await?;
                 state.sign_effects(effects, &epoch_store)?
             }
         }

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -100,7 +100,7 @@ pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>) 
         WAIT_FOR_TX_TIMEOUT,
         state
             .get_transaction_cache_reader()
-            .try_notify_read_executed_effects(&[digest]),
+            .try_notify_read_executed_effects("", &[digest]),
     )
     .await
     {
@@ -118,7 +118,7 @@ pub async fn wait_for_all_txes(digests: Vec<TransactionDigest>, state: Arc<Autho
         WAIT_FOR_TX_TIMEOUT,
         state
             .get_transaction_cache_reader()
-            .try_notify_read_executed_effects(&digests),
+            .try_notify_read_executed_effects("", &digests),
     )
     .await
     {

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -1113,8 +1113,11 @@ where
         let qd = quorum_driver.clone();
         Ok(async move {
             let digests = [tx_digest];
-            let effects_await = epoch_store
-                .within_alive_epoch(cache_reader.try_notify_read_executed_effects(&digests));
+            let effects_await =
+                epoch_store.within_alive_epoch(cache_reader.try_notify_read_executed_effects(
+                    "TransactionOrchestrator::notify_read_submit_with_qd",
+                    &digests,
+                ));
             // let-and-return necessary to satisfy borrow checker.
             let res = match select(ticket, effects_await.boxed()).await {
                 Either::Left((quorum_driver_response, _)) => Ok(quorum_driver_response),
@@ -1164,7 +1167,10 @@ where
             LOCAL_EXECUTION_TIMEOUT,
             validator_state
                 .get_transaction_cache_reader()
-                .try_notify_read_executed_effects_digests(&[tx_digest]),
+                .try_notify_read_executed_effects_digests(
+                    "TransactionOrchestrator::notify_read_wait_for_local_execution",
+                    &[tx_digest],
+                ),
         )
         .instrument(trace_span!("local_execution"))
         .await

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4615,7 +4615,10 @@ async fn test_shared_object_transaction_ok() {
     authority.execute_for_test(&certificate);
 
     // Ensure transaction effects are available.
-    authority.notify_read_effects(&certificate).await.unwrap();
+    authority
+        .notify_read_effects("", &certificate)
+        .await
+        .unwrap();
 
     // Ensure shared object sequence number increased.
     let shared_object_version = authority.get_object(&shared_object_id).unwrap().version();

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -268,7 +268,7 @@ pub async fn do_cert_with_shared_objects(
     send_consensus(authority, cert).await;
     authority
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[*cert.digest()])
+        .notify_read_executed_effects_for_testing("", &[*cert.digest()])
         .await
         .pop()
         .unwrap()
@@ -445,7 +445,7 @@ async fn test_execution_with_dependencies() {
         .collect();
     authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&digests)
+        .notify_read_executed_effects_for_testing("", &digests)
         .await;
 }
 
@@ -508,7 +508,7 @@ async fn test_per_object_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .get_transaction_cache_reader()
-            .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
+            .notify_read_executed_effects_for_testing("", &[*create_counter_cert.digest()])
             .await
             .pop()
             .unwrap();
@@ -522,7 +522,7 @@ async fn test_per_object_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
+        .notify_read_executed_effects_for_testing("", &[*create_counter_cert.digest()])
         .await
         .pop()
         .unwrap();
@@ -633,7 +633,7 @@ async fn test_txn_age_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .get_transaction_cache_reader()
-            .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
+            .notify_read_executed_effects_for_testing("", &[*create_counter_cert.digest()])
             .await
             .pop()
             .unwrap();
@@ -647,7 +647,7 @@ async fn test_txn_age_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[*create_counter_cert.digest()])
+        .notify_read_executed_effects_for_testing("", &[*create_counter_cert.digest()])
         .await
         .pop()
         .unwrap();

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -273,7 +273,7 @@ impl GasPriceFeedbackTester {
 
         self.authority_state
             .get_transaction_cache_reader()
-            .notify_read_executed_effects_for_testing(&transaction_digests)
+            .notify_read_executed_effects_for_testing("", &transaction_digests)
             .await
     }
 

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -213,7 +213,10 @@ where
             _ = tokio::time::sleep(tx_finalization_delay) => {
                 trace!(?tx_digest, "Waking up to finalize transaction");
             }
-            _ = cache_read.try_notify_read_executed_effects_digests(&digests) => {
+            _ = cache_read.try_notify_read_executed_effects_digests(
+                "ValidatorTxFinalizer::notify_read_executed_effects_digests",
+                &digests,
+            ) => {
                 trace!(?tx_digest, "Transaction already finalized");
                 return Ok(false);
             }

--- a/crates/iota-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/iota-e2e-tests/tests/checkpoint_tests.rs
@@ -10,7 +10,8 @@ use std::{
     time::Duration,
 };
 
-use iota_macros::{register_fail_point, register_fail_point_if, sim_test};
+use iota_common::register_debug_fatal_handler;
+use iota_macros::{register_fail_point_if, sim_test};
 use iota_test_transaction_builder::make_transfer_iota_transaction;
 use iota_types::messages_checkpoint::CheckpointSummaryExt;
 use test_cluster::TestClusterBuilder;
@@ -59,14 +60,19 @@ async fn test_checkpoint_split_brain() {
             panic_timeout: None,
         });
     }
+
     let committee_size = 9;
     // count number of nodes that have reached split brain condition
     let count_split_brain_nodes: Arc<Mutex<AtomicUsize>> = Default::default();
     let count_clone = count_split_brain_nodes.clone();
-    register_fail_point("split_brain_reached", move || {
-        let counter = count_clone.lock().unwrap();
-        counter.fetch_add(1, Ordering::Relaxed);
-    });
+
+    register_debug_fatal_handler!(
+        "Split brain detected in checkpoint signature aggregation",
+        move || {
+            let counter = count_clone.lock().unwrap();
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+    );
 
     register_fail_point_if("cp_execution_nondeterminism", || true);
 

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -67,7 +67,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     // A small delay is needed for post processing operations following the
@@ -113,7 +113,7 @@ async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
         .iota_node
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     Ok(())
@@ -486,7 +486,7 @@ async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     let info = fullnode
@@ -596,7 +596,7 @@ async fn do_test_full_node_sync_flood() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&digests)
+        .notify_read_executed_effects_for_testing("", &digests)
         .await;
 }
 
@@ -783,7 +783,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
     fullnode.state().get_executed_transaction_and_effects(digest, kv_store).await
         .unwrap_or_else(|e| panic!("Fullnode does not know about the txn {digest:?} that was executed with WaitForEffectsCert: {e:?}"));

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -56,9 +56,16 @@ fn test_protocol_overrides_2() {
 #[cfg(msim)]
 mod sim_only_tests {
 
-    use std::{path::PathBuf, sync::Arc};
+    use std::{
+        path::PathBuf,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use fastcrypto::encoding::Base64;
+    use iota_common::register_debug_fatal_handler;
     use iota_core::authority::framework_injection;
     use iota_framework::BuiltInFramework;
     use iota_json_rpc_api::WriteApiClient;
@@ -697,6 +704,14 @@ mod sim_only_tests {
             .build()
             .await;
 
+        let framework_mismatch_counter = Arc::new(AtomicUsize::new(0));
+        register_debug_fatal_handler!("Framework mismatch -- ", {
+            let counter = framework_mismatch_counter.clone();
+            move || {
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
         // We must stop the validators before overriding the system modules, otherwise
         // the validators may start running before the override and hence send
         // capabilities indicating that they only support the genesis system
@@ -732,6 +747,9 @@ mod sim_only_tests {
             );
             assert_eq!(committee.epoch, 2);
         });
+
+        // The debug_fatal was hit
+        assert_eq!(framework_mismatch_counter.load(Ordering::Relaxed), 1);
     }
 
     // Test that protocol version upgrade does not complete when there is no quorum

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -466,6 +466,9 @@ async fn test_create_advance_epoch_tx_race() {
     // proceeded with reconfiguration.
     sleep(Duration::from_secs(1)).await;
     reconfig_delay_tx.send(()).unwrap();
+
+    // wait for reconfiguration to complete
+    test_cluster.wait_for_epoch(None).await;
 }
 
 #[sim_test]

--- a/crates/iota-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/iota-e2e-tests/tests/shared_objects_tests.rs
@@ -141,7 +141,7 @@ async fn shared_object_deletion_multiple_times() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&digests)
+        .notify_read_executed_effects_for_testing("", &digests)
         .await;
 }
 
@@ -198,7 +198,7 @@ async fn shared_object_deletion_multiple_times_cert_racing() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&digests)
+        .notify_read_executed_effects_for_testing("", &digests)
         .await;
 }
 
@@ -314,7 +314,7 @@ async fn shared_object_deletion_multi_certs() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[inc_tx_a_digest, inc_tx_b_digest])
+        .notify_read_executed_effects_for_testing("", &[inc_tx_a_digest, inc_tx_b_digest])
         .await;
 }
 

--- a/crates/iota-e2e-tests/tests/simulator_tests.rs
+++ b/crates/iota-e2e-tests/tests/simulator_tests.rs
@@ -139,6 +139,6 @@ async fn test_net_determinism() {
         .iota_node
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -72,7 +72,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     handle
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     // Transaction Orchestrator proactivcely executes txn locally
@@ -446,7 +446,7 @@ async fn test_cached_response_for_executed_transaction() -> Result<(), anyhow::E
     handle
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects_for_testing(&[digest])
+        .notify_read_executed_effects_for_testing("", &[digest])
         .await;
 
     let (second, executed_locally) = execute_with_orchestrator(

--- a/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
@@ -40,7 +40,7 @@ async fn test_validator_tx_finalizer_fastpath_tx() {
             node.with_async(|n| async {
                 n.state()
                     .get_transaction_cache_reader()
-                    .notify_read_executed_effects_digests(&tx_digests)
+                    .notify_read_executed_effects_digests("", &tx_digests)
                     .await;
             })
             .await;
@@ -79,7 +79,7 @@ async fn test_validator_tx_finalizer_consensus_tx() {
             node.with_async(|n| async {
                 n.state()
                     .get_transaction_cache_reader()
-                    .notify_read_executed_effects_digests(&tx_digests)
+                    .notify_read_executed_effects_digests("", &tx_digests)
                     .await;
             })
             .await;

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -88,7 +88,7 @@ CheckpointSummary { epoch: 0, sequence_number: 4, network_total_transactions: 4,
 
 task 10, line 44:
 //# advance-epoch 6
-Epoch advanced: 5
+Epoch advanced: 6
 
 task 11, line 46:
 //# view-checkpoint
@@ -156,7 +156,7 @@ CheckpointSummary { epoch: 6, sequence_number: 11, network_total_transactions: 1
 
 task 18, lines 75-78:
 //# advance-epoch
-Epoch advanced: 6
+Epoch advanced: 7
 
 task 19, lines 80-95:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/checkpoints.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/checkpoints.snap
@@ -16,7 +16,7 @@ Checkpoint created: 2
 
 task 3, line 18:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 4, lines 20-35:
 //# run-graphql
@@ -61,7 +61,7 @@ Checkpoint created: 6
 
 task 8, line 43:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 9, line 45:
 //# create-checkpoint

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.snap
@@ -28,7 +28,7 @@ Checkpoint created: 2
 
 task 5, line 44:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 46-62:
 //# run-graphql
@@ -103,7 +103,7 @@ Checkpoint created: 6
 
 task 13, line 76:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 14, line 78:
 //# run Test::M1::create --args 0 @A --sender A
@@ -137,11 +137,11 @@ Checkpoint created: 10
 
 task 20, line 90:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 21, line 92:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 22, lines 94-158:
 //# run-graphql --cursors {"t":3,"i":false,"c":4} {"t":7,"i":false,"c":8} {"t":11,"i":false,"c":12}

--- a/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.snap
@@ -40,7 +40,7 @@ Checkpoint created: 1
 
 task 5, line 29:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 31-33:
 //# programmable --sender C --inputs 10000000000 @C
@@ -64,7 +64,7 @@ Checkpoint created: 3
 
 task 9, line 39:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, line 41:
 //# view-object 3,1

--- a/crates/iota-graphql-e2e-tests/tests/datetime/datetime.snap
+++ b/crates/iota-graphql-e2e-tests/tests/datetime/datetime.snap
@@ -33,7 +33,7 @@ Checkpoint created: 7
 
 task 15, line 42:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 16, lines 44-46:
 //# create-checkpoint
@@ -45,7 +45,7 @@ Checkpoint created: 10
 
 task 20, line 54:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 21, lines 56-67:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 11:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 13-15:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, lines 22-24:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, lines 25-29:
 //# programmable --sender C --inputs 10000000000 @C
@@ -53,7 +53,7 @@ Checkpoint created: 5
 
 task 9, lines 32-33:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 10, lines 34-73:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 9:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 11-13:
 //# programmable --sender C --inputs 10000000000 @C
@@ -101,7 +101,7 @@ Checkpoint created: 4
 
 task 9, line 69:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, line 71:
 //# create-checkpoint

--- a/crates/iota-graphql-e2e-tests/tests/epoch/system_state.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/system_state.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 13:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 15-17:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, line 23:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, line 25:
 //# create-checkpoint
@@ -44,7 +44,7 @@ Checkpoint created: 5
 
 task 8, line 27:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 9, lines 29-31:
 //# programmable --sender C --inputs 10000000000 @C
@@ -60,7 +60,7 @@ Checkpoint created: 7
 
 task 11, line 35:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 12, line 37:
 //# run 0x3::iota_system::request_withdraw_stake --args object(0x5) object(4,0) --sender C
@@ -76,7 +76,7 @@ Checkpoint created: 9
 
 task 14, line 41:
 //# advance-epoch
-Epoch advanced: 4
+Epoch advanced: 5
 
 task 15, lines 43-45:
 //# programmable --sender C --inputs 10000000000 @C
@@ -92,7 +92,7 @@ Checkpoint created: 11
 
 task 17, line 49:
 //# advance-epoch
-Epoch advanced: 5
+Epoch advanced: 6
 
 task 18, lines 51-61:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/objects/filter_by_type.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/filter_by_type.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 10:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 12-14:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, line 21:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, lines 23-38:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.snap
@@ -54,7 +54,7 @@ Checkpoint created: 1
 
 task 5, line 42:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 44-70:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/prune/backward_history_pruning.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/backward_history_pruning.snap
@@ -54,7 +54,7 @@ Checkpoint created: 2
 
 task 9, line 55:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 10, lines 57-59:
 //# programmable --sender A --inputs @A object(4,0)
@@ -81,7 +81,7 @@ Checkpoint created: 5
 
 task 14, line 68:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 15, lines 70-84:
 //# run-graphql
@@ -126,7 +126,7 @@ Checkpoint created: 7
 
 task 18, line 92:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 19, lines 94-96:
 //# programmable --sender A --inputs @A
@@ -142,7 +142,7 @@ Checkpoint created: 9
 
 task 21, line 100:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 22, lines 102-110:
 //# run-graphql --wait-for-checkpoint-pruned 4

--- a/crates/iota-graphql-e2e-tests/tests/prune/prune.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/prune.snap
@@ -21,7 +21,7 @@ Checkpoint created: 1
 
 task 4, line 32:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, line 34:
 //# run Test::M1::create --args 1 @A
@@ -35,7 +35,7 @@ Checkpoint created: 3
 
 task 7, line 38:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 8, line 40:
 //# run Test::M1::create --args 2 @A
@@ -49,7 +49,7 @@ Checkpoint created: 5
 
 task 10, line 44:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 11, lines 46-56:
 //# run-graphql --wait-for-checkpoint-pruned 4

--- a/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.snap
@@ -30,7 +30,7 @@ Checkpoint created: 1
 
 task 4, line 20:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, lines 22-46:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/transactions/system.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/system.snap
@@ -1455,7 +1455,7 @@ Response: {
 
 task 6, line 188:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 7, lines 190-277:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/validator/validator.snap
+++ b/crates/iota-graphql-e2e-tests/tests/validator/validator.snap
@@ -8,7 +8,7 @@ A: object(0,0)
 
 task 1, line 9:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 2, line 11:
 //# create-checkpoint
@@ -50,7 +50,7 @@ Checkpoint created: 3
 
 task 9, line 50:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, lines 52-66:
 //# run-graphql
@@ -169,7 +169,7 @@ Checkpoint created: 5
 
 task 27, lines 100-102:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 28, lines 104-120:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/validator/validator_iip8.snap
+++ b/crates/iota-graphql-e2e-tests/tests/validator/validator_iip8.snap
@@ -8,7 +8,7 @@ A: object(0,0)
 
 task 1, line 9:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 2, line 11:
 //# create-checkpoint
@@ -50,7 +50,7 @@ Checkpoint created: 3
 
 task 9, line 50:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, lines 52-66:
 //# run-graphql
@@ -169,7 +169,7 @@ Checkpoint created: 5
 
 task 27, lines 100-102:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 28, lines 104-120:
 //# run-graphql

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1678,7 +1678,10 @@ impl IotaNode {
             std::time::Duration::from_secs(timeout),
             state
                 .get_transaction_cache_reader()
-                .try_notify_read_executed_effects_digests(&digests),
+                .try_notify_read_executed_effects_digests(
+                    "IotaNode::notify_read_executed_effects_digests",
+                    &digests,
+                ),
         )
         .await
         .is_err()

--- a/crates/iota-sdk/src/apis/quorum_driver.rs
+++ b/crates/iota-sdk/src/apis/quorum_driver.rs
@@ -18,7 +18,6 @@ use crate::{
     error::{Error, IotaRpcResult},
 };
 
-const WAIT_FOR_LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(60);
 const WAIT_FOR_LOCAL_EXECUTION_MIN_INTERVAL: Duration = Duration::from_millis(100);
 const WAIT_FOR_LOCAL_EXECUTION_MAX_INTERVAL: Duration = Duration::from_secs(2);
 
@@ -72,7 +71,13 @@ impl QuorumDriverApi {
 
         // JSON-RPC ignores WaitForLocalExecution, so simulate it by polling for the
         // transaction.
-        let mut poll_response = tokio::time::timeout(WAIT_FOR_LOCAL_EXECUTION_TIMEOUT, async {
+        let wait_for_local_execution_timeout: Duration = if cfg!(msim) {
+            // In simtests, fullnodes can stop receiving checkpoints for > 30s.
+            Duration::from_secs(120)
+        } else {
+            Duration::from_secs(60)
+        };
+        let mut poll_response = tokio::time::timeout(wait_for_local_execution_timeout, async {
             let mut backoff = iota_common::backoff::ExponentialBackoff::new(
                 WAIT_FOR_LOCAL_EXECUTION_MIN_INTERVAL,
                 WAIT_FOR_LOCAL_EXECUTION_MAX_INTERVAL,

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -43,7 +43,7 @@ use iota_swarm_config::{
     network_config_builder::ConfigBuilder,
 };
 use iota_types::{
-    base_types::{AuthorityName, VersionNumber},
+    base_types::{AuthorityName, EpochId, VersionNumber},
     committee::Committee,
     crypto::AuthoritySignature,
     effects::TransactionEffects,
@@ -574,6 +574,10 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
 
     fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         Ok(self.with_store(|store| store.get_highest_checkpoint().unwrap()))
+    }
+
+    fn try_get_latest_epoch_id(&self) -> iota_types::storage::error::Result<EpochId> {
+        Ok(self.inner.read().unwrap().epoch_state.epoch())
     }
 
     fn try_get_highest_verified_checkpoint(

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -1296,7 +1296,6 @@ where
     /// Writes a range delete tombstone to delete all entries in the db map.
     /// The effect of this write is visible immediately, i.e. you won't see
     /// old values when you do a lookup or scan.
-    #[cfg(msim)]
     #[instrument(level = "trace", skip_all, err)]
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let Some(last_key) = self

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -379,6 +379,8 @@ impl DBOptions {
     pub fn disable_write_throttling(mut self) -> DBOptions {
         self.options.set_soft_pending_compaction_bytes_limit(0);
         self.options.set_hard_pending_compaction_bytes_limit(0);
+        self.options.set_level_zero_slowdown_writes_trigger(512);
+        self.options.set_level_zero_stop_writes_trigger(1024);
         self
     }
 }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -427,16 +427,10 @@ async fn test_delete_range() {
     assert!(db.contains_key(&100).expect("Failed to query legal key"));
 }
 
-// `schedule_delete_all` is only compiled under the simulator, so its tests are
-// too. They use `msim::sim_test` directly rather than `iota_macros::sim_test`,
-// which expands to a path in `iota-simulator` — a crate typed-store cannot
-// depend on without a dependency cycle. A plain `#[tokio::test]` would not do:
-// under the simulator it expands to a test marked `#[ignore]`.
-#[cfg(msim)]
 mod delete_all {
     use super::*;
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn deletes_every_entry() {
         let tmp_dir = iota_common::tempdir();
         let db: DBMap<i32, String> = open_map(tmp_dir.path(), None);
@@ -462,7 +456,7 @@ mod delete_all {
         );
     }
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn deletes_a_single_entry() {
         let tmp_dir = iota_common::tempdir();
         let db: DBMap<i32, String> = open_map(tmp_dir.path(), None);
@@ -474,7 +468,7 @@ mod delete_all {
         assert!(db.is_empty());
     }
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn deletes_an_all_ones_last_key() {
         let tmp_dir = iota_common::tempdir();
         let db: DBMap<u64, String> = open_map(tmp_dir.path(), None);
@@ -490,7 +484,7 @@ mod delete_all {
         assert!(db.is_empty());
     }
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn deletes_an_empty_key() {
         let tmp_dir = iota_common::tempdir();
         // A unit key serializes to no bytes at all, so the last key is the
@@ -505,7 +499,7 @@ mod delete_all {
         assert!(db.is_empty());
     }
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn deletes_signed_keys() {
         let tmp_dir = iota_common::tempdir();
         let db: DBMap<i32, String> = open_map(tmp_dir.path(), None);
@@ -521,7 +515,7 @@ mod delete_all {
         assert!(db.is_empty());
     }
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn deletes_variable_length_keys() {
         let tmp_dir = iota_common::tempdir();
         let db: DBMap<String, String> = open_map(tmp_dir.path(), None);
@@ -536,7 +530,7 @@ mod delete_all {
         assert!(db.is_empty());
     }
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn deletes_entries_already_on_disk() {
         let tmp_dir = iota_common::tempdir();
         let db: DBMap<i32, String> = open_map(tmp_dir.path(), None);
@@ -553,7 +547,7 @@ mod delete_all {
         assert!(db.is_empty());
     }
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn succeeds_on_an_empty_map() {
         let tmp_dir = iota_common::tempdir();
         let db: DBMap<i32, String> = open_map(tmp_dir.path(), None);
@@ -563,7 +557,7 @@ mod delete_all {
         assert!(db.is_empty());
     }
 
-    #[msim::sim_test]
+    #[tokio::test]
     async fn leaves_other_column_families_intact() {
         let tmp_dir = iota_common::tempdir();
         let rocks = open_rocksdb(tmp_dir.path(), &["First_CF", "Second_CF"]);

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -250,7 +250,6 @@ where
         Ok(())
     }
 
-    #[cfg(msim)]
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let mut locked = self.rows.write().unwrap();
         locked.clear();

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -46,7 +46,6 @@ where
     ///
     /// Not atomic with respect to concurrent writers: an entry inserted while
     /// the call is in flight may survive it.
-    #[cfg(msim)]
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError>;
 
     /// Returns true if the map is empty, otherwise false.


### PR DESCRIPTION
# Description of change

This PR contains a batch of core-protocol related upstream changes. The changes have been individually reviewed before squash-merging. None of them modify protocol parameters, so a new protocol version is not necessary.

## Links to any relevant issues

List of included PRs:
- #12273
- #12281 
- #12419 
- #12514
- #12513 
- #12537 

Closes #12269 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)


