### PR TITLE
fix(consensus): bound peer-controlled memory growth in ingest

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -28,7 +28,7 @@ use crate::{
         ShardWithProofAPI, SignedBlockHeader, TransactionsCommitment, VerifiedBlock,
         VerifiedOwnShard, VerifiedTransactions,
     },
-    block_verifier::BlockVerifier,
+    block_verifier::{BlockVerifier, max_shard_bytes},
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
     commit_syncer::CommitSyncType,
     commit_vote_monitor::CommitVoteMonitor,
@@ -376,6 +376,8 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             serialized_shards.truncate(self.context.parameters.max_shards_per_bundle);
         }
 
+        let max_shard_bytes = max_shard_bytes(&self.context);
+
         let mut verified_shards: Vec<ShardWithProof> = vec![];
         for serialized_shard in &serialized_shards {
             let shard: ShardWithProof = bcs::from_bytes(serialized_shard)
@@ -410,6 +412,23 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 let e = ConsensusError::TooBigShardRoundInABundle {
                     shard_round: shard.round(),
                     block_round,
+                };
+                self.context
+                    .metrics
+                    .node_metrics
+                    .bundles_with_invalid_parts
+                    .with_label_values(&[peer_hostname, "shard", e.name()])
+                    .inc();
+                self.misbehavior_store.record_faulty_block(peer, peer, &e);
+                info!("Invalid shard from {}: {}", peer, e);
+                return Err(e);
+            }
+
+            if shard.shard().len() > max_shard_bytes {
+                let e = ConsensusError::SerializedShardTooLarge {
+                    peer,
+                    size: shard.shard().len(),
+                    limit: max_shard_bytes,
                 };
                 self.context
                     .metrics
@@ -811,9 +830,38 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             );
         }
 
+        // 5b. Drop the primary block when a different header is already accepted
+        // for its slot: two signed headers from the author's own stream for one
+        // slot are provable equivocation, so charge the author. The rest of the
+        // bundle is still processed; a same-slot header sitting in the block
+        // manager's suspender is caught by the equivalent cap there.
+        let primary_block_equivocates = !primary_block_far_future
+            && self
+                .dag_state
+                .read()
+                .contains_other_block_header_at_slot(&block_ref);
+        if primary_block_equivocates {
+            let e = ConsensusError::BlockHeaderEquivocation {
+                authority: peer,
+                round: block_ref.round,
+            };
+            self.misbehavior_store.record_faulty_block(peer, peer, &e);
+            self.context
+                .metrics
+                .node_metrics
+                .dropped_slot_cap_headers_total
+                .with_label_values(&[
+                    self.context.authority_hostname(peer),
+                    DataSource::BlockStreaming.as_str(),
+                ])
+                .inc();
+            info!("Dropped streamed block {block_ref} from peer {peer}: {e}");
+        }
+        let primary_block_dropped = primary_block_far_future || primary_block_equivocates;
+
         // 6. Collect shards from a bundle and check their proofs. Skipped for a
-        // far-future primary block so its shards never reach the reconstructor.
-        let verified_shards = if primary_block_far_future {
+        // dropped primary block so its shards never reach the reconstructor.
+        let verified_shards = if primary_block_dropped {
             Vec::new()
         } else {
             let serialized_shards =
@@ -841,8 +889,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .await;
 
         // 9. Prepare transaction messages for shard reconstructor and send them.
-        // Skipped for a far-future primary block (no shards were collected).
-        if !primary_block_far_future {
+        // Skipped for a dropped primary block (no shards were collected).
+        if !primary_block_dropped {
             let transaction_messages = TransactionMessage::create_transaction_messages(
                 &verified_blocks[0],
                 &verified_shards,
@@ -876,8 +924,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .observe(missing_ancestors.len() as f64);
 
         // 11. Add the block to dag, add its missing ancestors to the set. A
-        // far-future block was dropped above and is not forwarded to the core.
-        if !primary_block_far_future {
+        // block dropped above is not forwarded to the core.
+        if !primary_block_dropped {
             let (missing_block_ancestors, missing_block_committed_transactions) = self
                 .core_dispatcher
                 .add_blocks(verified_blocks, DataSource::BlockStreaming)
@@ -903,8 +951,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // 12. Add our shard from the received block and its proof to the dag_state
-        // only if it contains transactions and the block is not far-future.
-        if let Some(shard_for_core) = shard_for_core.filter(|_| !primary_block_far_future) {
+        // only if it contains transactions and the block was not dropped.
+        if let Some(shard_for_core) = shard_for_core.filter(|_| !primary_block_dropped) {
             let serialized_shard_for_core: Bytes = bcs::to_bytes(&shard_for_core)
                 .map_err(ConsensusError::SerializationFailure)?
                 .into();
@@ -1153,7 +1201,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     continue;
                 }
 
-                let missing_headers = dag_state.get_cached_block_headers_in_range(
+                let missing_headers = dag_state.get_cached_block_headers_in_range_one_per_round(
                     authority,
                     highest_accepted_round + 1,
                     lowest_missing_round,
@@ -1996,6 +2044,112 @@ mod tests {
                 .get(),
             1,
             "the dropped far-future block is counted"
+        );
+    }
+
+    /// A second streamed block for a slot we already accepted a header for is
+    /// provable equivocation by its author: the block is dropped before shard
+    /// extraction, its payload and own shard never reach the core, and the
+    /// author is charged.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_subscribed_block_bundle_drops_slot_equivocation() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
+        let (tx_message_sender, mut tx_message_receiver) = mpsc::channel(100);
+        let network_client = Arc::new(FakeNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+        let header_synchronizer = HeaderSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            false,
+            None,
+            Arc::new(MisbehaviorStore::new(&context)),
+        );
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+        let authority_service = Arc::new(AuthorityService::new(
+            context.clone(),
+            block_verifier,
+            commit_vote_monitor,
+            header_synchronizer,
+            transactions_synchronizer,
+            core_dispatcher.clone(),
+            rx_block_broadcast,
+            dag_state.clone(),
+            store,
+            misbehavior_store.clone(),
+            tx_message_sender,
+            cordial_knowledge,
+        ));
+        let mut encoder = create_encoder(&context);
+
+        // Authority 0 already has an accepted header at round 1; the streamed
+        // block below is a different header for the same slot.
+        let peer = context.committee.to_authority_index(0).unwrap();
+        let accepted = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder)
+                .set_ancestors(vec![BlockRef::new(
+                    GENESIS_ROUND,
+                    AuthorityIndex::new_for_test(1),
+                    BlockHeaderDigest::MIN,
+                )])
+                .build(),
+        );
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
+        );
+        assert_ne!(accepted.reference(), input_block.reference());
+        dag_state
+            .write()
+            .accept_block_header(accepted, DataSource::BlockBundleStream);
+
+        let bundle = SerializedBlockBundle::try_from(input_block).unwrap();
+        authority_service
+            .handle_subscribed_block_bundle(peer, bundle, &mut encoder)
+            .await
+            .unwrap();
+
+        assert!(
+            tx_message_receiver.try_recv().is_err(),
+            "an equivocating bundle must not feed the shard reconstructor"
+        );
+        assert!(
+            core_dispatcher.get_blocks().is_empty(),
+            "the equivocating block must not be forwarded to the core"
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_slot_cap_headers_total
+                .with_label_values(&[
+                    context.authority_hostname(peer),
+                    DataSource::BlockStreaming.as_str(),
+                ])
+                .get(),
+            1,
+        );
+        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[peer.value()];
+        assert_eq!(
+            counts.faulty_blocks_provable, 1,
+            "two signed headers for one slot are provable equivocation"
         );
     }
 
@@ -4259,5 +4413,105 @@ mod tests {
             TransactionsCommitment::default(),
         );
         check_shard_transaction_author(&valid_shard, peer, &context).unwrap();
+    }
+
+    /// A shard longer than the maximum honest shard length is refused at
+    /// ingress and charged to the relaying peer; one at exactly that length
+    /// passes the length gate and is only rejected by its Merkle proof.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_extract_shards_rejects_oversized_shard() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
+        let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let network_client = Arc::new(FakeNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+        let header_synchronizer = HeaderSynchronizer::start(
+            network_client,
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            false,
+            None,
+            Arc::new(MisbehaviorStore::new(&context)),
+        );
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+        let authority_service = AuthorityService::new(
+            context.clone(),
+            block_verifier,
+            commit_vote_monitor,
+            header_synchronizer,
+            transactions_synchronizer,
+            core_dispatcher,
+            rx_block_broadcast,
+            dag_state,
+            store,
+            misbehavior_store.clone(),
+            tx_message_sender,
+            cordial_knowledge,
+        );
+
+        let max_shard_bytes = {
+            let limit = crate::block_verifier::serialized_transactions_size_limit(&context);
+            let shard_bytes = (limit + 4).div_ceil(context.committee.info_length());
+            shard_bytes + (shard_bytes % 2)
+        };
+        let peer = context.committee.to_authority_index(1).unwrap();
+        let carrier_ref = BlockRef::new(5, peer, BlockHeaderDigest::default());
+        let shard_ref = BlockRef::new(4, peer, BlockHeaderDigest::default());
+        let shard_of_len = |len: usize| {
+            let shard = crate::block_header::ShardWithProof::new(
+                vec![0u8; len],
+                vec![],
+                shard_ref,
+                TransactionsCommitment::default(),
+            );
+            vec![Bytes::from(bcs::to_bytes(&shard).unwrap())]
+        };
+
+        let result = authority_service.extract_shards_from_bundle(
+            peer,
+            &context.committee.authority(peer).hostname.clone(),
+            shard_of_len(max_shard_bytes + 1),
+            carrier_ref,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(ConsensusError::SerializedShardTooLarge { limit, peer: err_peer, .. })
+                    if limit == max_shard_bytes && err_peer == peer
+            ),
+            "an oversized shard must be refused, got {result:?}"
+        );
+        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[peer.value()];
+        assert_eq!(counts.faulty_blocks_unprovable, 1);
+
+        // At exactly the maximum length the size gate passes, so the shard is
+        // only rejected by the following proof check.
+        let result = authority_service.extract_shards_from_bundle(
+            peer,
+            &context.committee.authority(peer).hostname.clone(),
+            shard_of_len(max_shard_bytes),
+            carrier_ref,
+        );
+        assert!(
+            matches!(result, Err(ConsensusError::IncorrectShardProof { .. })),
+            "a maximum-length shard must pass the size gate, got {result:?}"
+        );
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -830,11 +830,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             );
         }
 
-        // 5b. Drop the primary block when a different header is already accepted
-        // for its slot: two signed headers from the author's own stream for one
-        // slot are provable equivocation, so charge the author. The rest of the
-        // bundle is still processed; a same-slot header sitting in the block
-        // manager's suspender is caught by the equivalent cap there.
+        // 5b. Two signed headers from the author's own stream for one slot are
+        // provable equivocation, so drop the block before its shards and payload
+        // are processed, and charge the author. A same-slot header still only
+        // suspended is caught by the equivalent cap in the block manager.
         let primary_block_equivocates = !primary_block_far_future
             && self
                 .dag_state
@@ -855,12 +854,19 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     DataSource::BlockStreaming.as_str(),
                 ])
                 .inc();
-            info!("Dropped streamed block {block_ref} from peer {peer}: {e}");
+            warn!(
+                "Peer {peer} equivocated: dropping streamed block {block_ref}, its slot already \
+                 holds a header with a different digest"
+            );
         }
+        // The block is not accepted for either reason, so the steps below skip it.
         let primary_block_dropped = primary_block_far_future || primary_block_equivocates;
 
         // 6. Collect shards from a bundle and check their proofs. Skipped for a
-        // dropped primary block so its shards never reach the reconstructor.
+        // dropped primary block so its shards never reach the reconstructor. The
+        // bundled headers still go through: they are signed by their authors and
+        // already verified, while a shard's proof is checked only against the
+        // commitment carried inside the shard itself.
         let verified_shards = if primary_block_dropped {
             Vec::new()
         } else {

--- a/crates/starfish/core/src/block_manager/block_suspender.rs
+++ b/crates/starfish/core/src/block_manager/block_suspender.rs
@@ -488,6 +488,18 @@ impl BlockSuspender {
     pub(crate) fn suspended_blocks_refs(&self) -> BTreeSet<BlockRef> {
         self.suspended_headers.keys().cloned().collect()
     }
+
+    /// Whether a suspended header exists at `block_ref`'s slot with a digest
+    /// different from `block_ref`'s.
+    pub(crate) fn contains_other_header_at_slot(&self, block_ref: &BlockRef) -> bool {
+        self.suspended_headers
+            .range(
+                BlockRef::new(block_ref.round, block_ref.author, BlockHeaderDigest::MIN)
+                    ..=BlockRef::new(block_ref.round, block_ref.author, BlockHeaderDigest::MAX),
+            )
+            .any(|(existing, _)| existing != block_ref)
+    }
+
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.suspended_headers.is_empty()

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -30,6 +30,7 @@ use crate::{
     block_manager::block_suspender::BlockSuspender,
     context::Context,
     dag_state::{DagState, DataSource},
+    error::ConsensusError,
 };
 
 /// Combine headers accepted via the regular path with headers unsuspended by
@@ -208,6 +209,7 @@ impl BlockManager {
         let blocks = drop_far_future(&self.context, &self.dag_state, blocks, source, |b| {
             b.round()
         });
+        let blocks = self.drop_over_slot_cap(blocks, source, |b| b.reference());
 
         let block_headers: Vec<_> = blocks
             .iter()
@@ -256,6 +258,7 @@ impl BlockManager {
             drop_far_future(&self.context, &self.dag_state, block_headers, source, |h| {
                 h.round()
             });
+        let block_headers = self.drop_over_slot_cap(block_headers, source, |h| h.reference());
 
         // Headers are added through synchronizer, commit syncer and cordial
         // dissemination.
@@ -595,6 +598,71 @@ impl BlockManager {
             .collect::<Vec<_>>();
         filtered.sort_by_key(|h| h.round());
         filtered
+    }
+
+    /// Drops items whose slot already holds a header with a different digest,
+    /// be it accepted, suspended, or earlier in this batch. Only
+    /// peer-controlled sources are filtered, the rest pass through unchanged.
+    ///
+    /// A drop means two headers of one slot passed signature verification, so
+    /// the author is charged a provable fault.
+    fn drop_over_slot_cap<T>(
+        &self,
+        items: Vec<T>,
+        source: DataSource,
+        ref_of: impl Fn(&T) -> BlockRef,
+    ) -> Vec<T> {
+        if !source.is_subject_to_slot_cap() {
+            return items;
+        }
+        let dag_state = self.dag_state.read();
+        let misbehavior_store = dag_state.misbehavior_store().clone();
+        let mut admitted_by_slot: BTreeMap<(Round, AuthorityIndex), BlockHeaderDigest> =
+            BTreeMap::new();
+        items
+            .into_iter()
+            .filter(|item| {
+                let block_ref = ref_of(item);
+                let slot = (block_ref.round, block_ref.author);
+                let admit = match admitted_by_slot.get(&slot) {
+                    Some(admitted_digest) => *admitted_digest == block_ref.digest,
+                    None => {
+                        let other_exists = dag_state
+                            .contains_other_block_header_at_slot(&block_ref)
+                            || self
+                                .block_suspender
+                                .contains_other_header_at_slot(&block_ref);
+                        if !other_exists {
+                            admitted_by_slot.insert(slot, block_ref.digest);
+                        }
+                        !other_exists
+                    }
+                };
+                if !admit {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .dropped_slot_cap_headers_total
+                        .with_label_values(&[
+                            self.context.authority_hostname(block_ref.author),
+                            source.as_str(),
+                        ])
+                        .inc();
+                    // No relaying peer is known at this level; passing the
+                    // author as the peer leaves the author's provable fault as
+                    // the only charge.
+                    misbehavior_store.record_faulty_block(
+                        block_ref.author,
+                        block_ref.author,
+                        &ConsensusError::BlockHeaderEquivocation {
+                            authority: block_ref.author,
+                            round: block_ref.round,
+                        },
+                    );
+                }
+                admit
+            })
+            .collect()
     }
 }
 
@@ -1385,7 +1453,7 @@ mod tests {
         // One round past the ceiling: dropped for every far-future-bounded source.
         for source in [
             DataSource::BlockBundleStream,
-            DataSource::HeaderSynchronizer,
+            DataSource::HeaderSynchronizerRequested,
         ] {
             let store = Arc::new(MemStore::new());
             let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
@@ -1660,5 +1728,175 @@ mod tests {
         );
         // Suspender state is still cleaned up by the cascade.
         assert!(block_manager.block_suspender.is_empty());
+    }
+
+    /// A second header for an (author, round) slot is dropped for capped
+    /// sources — whether the first copy is accepted, suspended, or earlier in
+    /// the same batch — while an exact duplicate passes through to the regular
+    /// dedup.
+    #[tokio::test]
+    async fn slot_cap_drops_second_header_for_slot() {
+        use gc_eviction_helpers::*;
+
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let misbehavior_store = dag_state.read().misbehavior_store().clone();
+        let mut block_manager = BlockManager::new(context.clone(), dag_state);
+        let faults = |authority: u8| {
+            let crate::misbehavior_store::MisbehaviorCounts::V1(counts) =
+                &misbehavior_store.snapshot_totals()[authority as usize];
+            (
+                counts.faulty_blocks_provable,
+                counts.faulty_blocks_unprovable,
+            )
+        };
+        let slot_cap_drops = |source: DataSource| {
+            context
+                .metrics
+                .node_metrics
+                .dropped_slot_cap_headers_total
+                .with_label_values(&[
+                    context.authority_hostname(AuthorityIndex::new_for_test(1)),
+                    source.as_str(),
+                ])
+                .get()
+        };
+
+        // Two headers for slot (author 1, round 50), different digests, both
+        // with the same missing ancestor. The first is suspended; the second
+        // is dropped by the cap even though nothing is accepted yet.
+        let missing_ancestor = block_ref(30, 0);
+        let first = header(50, 1, vec![missing_ancestor]);
+        let equivocation = {
+            let mut ancestors = vec![missing_ancestor];
+            ancestors.push(block_ref(30, 2));
+            header(50, 1, ancestors)
+        };
+        assert_ne!(first.reference(), equivocation.reference());
+
+        let (accepted, _) = block_manager
+            .try_accept_block_headers(vec![first.clone()], DataSource::BlockBundleStream);
+        assert!(accepted.is_empty());
+        assert!(
+            block_manager
+                .suspended_blocks_refs()
+                .contains(&first.reference())
+        );
+
+        let (accepted, missing) = block_manager
+            .try_accept_block_headers(vec![equivocation.clone()], DataSource::BlockBundleStream);
+        assert!(accepted.is_empty());
+        assert!(
+            missing.is_empty(),
+            "a dropped header's ancestors must not be queued to fetch"
+        );
+        assert!(
+            !block_manager
+                .suspended_blocks_refs()
+                .contains(&equivocation.reference()),
+            "the second header for the slot must not grow the suspender"
+        );
+        assert_eq!(slot_cap_drops(DataSource::BlockBundleStream), 1);
+        assert_eq!(
+            faults(1),
+            (1, 0),
+            "two verified headers for one slot are the author's provable fault, \
+             and no relaying peer is charged for it"
+        );
+
+        // A repeat of the suspended header is neither a drop nor a fault.
+        let (accepted, _) =
+            block_manager.try_accept_block_headers(vec![first], DataSource::BlockStreaming);
+        assert!(accepted.is_empty());
+        assert_eq!(slot_cap_drops(DataSource::BlockStreaming), 0);
+        assert_eq!(faults(1), (1, 0));
+
+        // Same-batch case at a fresh slot: two different digests in one call,
+        // only the first survives.
+        let batch_first = header(60, 1, vec![block_ref(59, 0)]);
+        let batch_second = header(60, 1, vec![block_ref(59, 2)]);
+        let (accepted, _) = block_manager.try_accept_block_headers(
+            vec![batch_first.clone(), batch_second.clone()],
+            DataSource::BlockBundleStream,
+        );
+        assert!(accepted.is_empty());
+        assert!(
+            block_manager
+                .suspended_blocks_refs()
+                .contains(&batch_first.reference())
+        );
+        assert!(
+            !block_manager
+                .suspended_blocks_refs()
+                .contains(&batch_second.reference())
+        );
+        assert_eq!(slot_cap_drops(DataSource::BlockBundleStream), 2);
+        assert_eq!(faults(1), (2, 0));
+        assert_eq!(faults(0), (0, 0), "only the equivocating author is charged");
+    }
+
+    /// A header the cap dropped is still accepted when it arrives from an
+    /// exempt source: as a requested ref via the header synchronizer, or from
+    /// certified catch-up.
+    #[tokio::test]
+    async fn slot_cap_exempts_requested_and_certified_sources() {
+        use gc_eviction_helpers::*;
+
+        for exempt_source in [
+            DataSource::HeaderSynchronizerRequested,
+            DataSource::CommitSyncer,
+        ] {
+            let (context, _) = Context::new_for_test(4);
+            let context = Arc::new(context);
+            let store = Arc::new(MemStore::new());
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            let mut block_manager = BlockManager::new(context.clone(), dag_state.clone());
+
+            let missing_ancestor = block_ref(30, 0);
+            let first = header(50, 1, vec![missing_ancestor]);
+            let equivocation = header(50, 1, vec![missing_ancestor, block_ref(30, 2)]);
+
+            block_manager.try_accept_block_headers(vec![first], DataSource::BlockBundleStream);
+            let (_, _) =
+                block_manager.try_accept_block_headers(vec![equivocation.clone()], exempt_source);
+            assert!(
+                block_manager
+                    .suspended_blocks_refs()
+                    .contains(&equivocation.reference()),
+                "{} must bypass the slot cap",
+                exempt_source.as_str()
+            );
+        }
+    }
+
+    /// Fetch-response gap-fill headers run under their own source and are
+    /// subject to the cap, unlike the requested refs.
+    #[tokio::test]
+    async fn slot_cap_applies_to_header_synchronizer_additional() {
+        use gc_eviction_helpers::*;
+
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let mut block_manager = BlockManager::new(context, dag_state);
+
+        let missing_ancestor = block_ref(30, 0);
+        let first = header(50, 1, vec![missing_ancestor]);
+        let equivocation = header(50, 1, vec![missing_ancestor, block_ref(30, 2)]);
+
+        block_manager.try_accept_block_headers(vec![first], DataSource::BlockBundleStream);
+        block_manager.try_accept_block_headers(
+            vec![equivocation.clone()],
+            DataSource::HeaderSynchronizerAdditional,
+        );
+        assert!(
+            !block_manager
+                .suspended_blocks_refs()
+                .contains(&equivocation.reference()),
+            "gap-fill extras must be subject to the slot cap"
+        );
     }
 }

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -13,6 +13,7 @@ use crate::{
         genesis_block_headers,
     },
     context::Context,
+    encoder::shard_bytes,
     error::{ConsensusError, ConsensusResult},
     transaction::TransactionVerifier,
 };
@@ -342,6 +343,17 @@ pub(crate) fn serialized_transactions_size_limit(context: &Context) -> usize {
         .saturating_add(MAX_BCS_LENGTH_PREFIX_BYTES)
 }
 
+/// Upper bound on the length of a shard encoding a transaction payload that
+/// passes `check_transactions`. `usize::MAX` when the protocol payload limits
+/// are disabled, as no finite shard length is implied then.
+pub(crate) fn max_shard_bytes(context: &Context) -> usize {
+    let payload_limit = serialized_transactions_size_limit(context);
+    if payload_limit == usize::MAX {
+        return usize::MAX;
+    }
+    shard_bytes(payload_limit, context.committee.info_length())
+}
+
 #[cfg(test)]
 pub(crate) struct NoopBlockVerifier;
 
@@ -411,6 +423,30 @@ pub(crate) mod test {
         let expected = uleb128_len(max_count) + max_count * (uleb128_len(tx_size) + tx_size);
         assert_eq!(serialized.len(), expected);
         assert!(serialized.len() <= serialized_transactions_size_limit(&context));
+    }
+
+    /// Pins `max_shard_bytes` to what the encoder actually produces for a
+    /// maximal payload, so a change to the encoder's chunking is caught here
+    /// rather than by shards being refused at ingress.
+    #[tokio::test]
+    async fn max_shard_bytes_bounds_maximal_shard() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let payload_limit = serialized_transactions_size_limit(&context);
+        let info_length = context.committee.info_length();
+        let parity_length = context.committee.parity_length();
+
+        let mut encoder = crate::encoder::create_encoder(&context);
+        let shards = encoder
+            .encode_serialized_data(
+                &bytes::Bytes::from(vec![0u8; payload_limit]),
+                info_length,
+                parity_length,
+            )
+            .unwrap();
+
+        let longest = shards.iter().map(|shard| shard.len()).max().unwrap();
+        assert_eq!(longest, max_shard_bytes(&context));
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -954,11 +954,13 @@ impl ConnectionKnowledge {
     /// to send to the peer.
     pub fn create_bundle(&mut self, block: VerifiedBlock) -> BlockBundle {
         let block_round = block.round();
-        // Try to update ancestors as they may still be pending updates.
-        // These headers will also be updated via cordial knowledge messages and may be
-        // sent again in the future. We consider this overhead negligible.
+        // The global knowledge updates for these ancestors may still be in flight,
+        // so record them here to have them available for this bundle: each becomes
+        // the header disseminated as an additional header for its slot. For an
+        // equivocating author this overrides a header recorded for that slot
+        // earlier, which is fine, as that one is still obtainable by reference.
         for ancestor_block_ref in block.ancestors() {
-            self.handle_new_header(*ancestor_block_ref);
+            self.set_referenced_header(*ancestor_block_ref);
         }
         // 1. Own headers and shards for round up to round_upper_bound_exclusive should
         //    be marked as known
@@ -1087,16 +1089,29 @@ impl ConnectionKnowledge {
         }
     }
 
-    /// Handles adding a new header to the set of potentially unknown headers
+    /// Handles adding a new header to the set of potentially unknown headers.
+    /// Keeps at most one header per slot, since a bundle carries only one: the
+    /// receiver drops additional headers of a slot as spam protection. An
+    /// equivocating header a peer needs is obtained by reference instead.
     fn handle_new_header(&mut self, block_ref: BlockRef) {
         let round = block_ref.round;
         let authority = block_ref.author.value();
 
-        // Insert the block into the set for that (authority, round)
-        self.headers_not_known[authority]
-            .entry(round)
-            .or_default()
-            .insert(block_ref);
+        let refs_at_slot = self.headers_not_known[authority].entry(round).or_default();
+        if refs_at_slot.is_empty() {
+            refs_at_slot.insert(block_ref);
+        }
+    }
+
+    /// Records `block_ref` as the header to offer for its slot, replacing any
+    /// header tracked there. Used for the ancestors of a block we are about to
+    /// send: the peer needs them to accept it.
+    fn set_referenced_header(&mut self, block_ref: BlockRef) {
+        let refs_at_slot = self.headers_not_known[block_ref.author.value()]
+            .entry(block_ref.round)
+            .or_default();
+        refs_at_slot.clear();
+        refs_at_slot.insert(block_ref);
     }
 
     /// Handles adding a new shard to the set of potentially unknown shards.
@@ -1359,6 +1374,82 @@ mod tests {
                 assert_eq!(shards.len(), final_round as usize);
             }
         }
+    }
+
+    /// When an author equivocates, the header offered for that slot is the one
+    /// the block we are sending references, not whichever reached us first.
+    #[tokio::test]
+    async fn test_referenced_ancestor_wins_the_slot() {
+        telemetry_subscribers::init_for_testing();
+
+        let validators = 4;
+        let our_index = AuthorityIndex::new_for_test(0);
+        let to_whom_index = AuthorityIndex::new_for_test(1);
+        let equivocating_index = AuthorityIndex::new_for_test(2);
+        let (context, _key_pairs) = Context::new_for_test(validators);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let cordial_knowledge = CordialKnowledge::start(context, dag_state.clone());
+        let connection_knowledge = cordial_knowledge.connection_knowledges[to_whom_index].clone();
+
+        // Only the equivocating author's headers are useful to this peer, so the
+        // bundle content is unambiguous.
+        connection_knowledge.write().process_one_message(
+            ConnectionKnowledgeMessage::UsefulAuthors {
+                useful_headers_to_peer: BTreeMap::from([(equivocating_index, GENESIS_ROUND)]),
+                useful_shards_to_peer: BTreeMap::new(),
+                useful_headers_from_peer: BTreeMap::new(),
+                useful_shards_from_peer: vec![None; validators],
+            },
+        );
+
+        // Two headers for slot (equivocating author, round 1), distinguished by
+        // timestamp so their digests differ. Both are accepted, as they would be
+        // when one arrives by stream and the other by a requested fetch.
+        let first_arrival = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(1, equivocating_index.value() as u8)
+                .set_timestamp_ms(1000)
+                .build(),
+        );
+        let referenced = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(1, equivocating_index.value() as u8)
+                .set_timestamp_ms(2000)
+                .build(),
+        );
+        assert_ne!(first_arrival.reference(), referenced.reference());
+        for header in [&first_arrival, &referenced] {
+            dag_state
+                .write()
+                .accept_block_header(header.clone(), DataSource::Test);
+        }
+
+        // The slot is filled by arrival order first.
+        connection_knowledge
+            .write()
+            .process_one_message(ConnectionKnowledgeMessage::NewHeader {
+                block_ref: first_arrival.reference(),
+            });
+
+        // Our own block references the other header of that slot, so the peer
+        // needs that one to accept the block.
+        let own_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new(2, our_index.value() as u8)
+                .set_ancestors(vec![referenced.reference()])
+                .build(),
+        );
+        let BlockBundle {
+            verified_headers, ..
+        } = connection_knowledge.write().create_bundle(own_block);
+
+        assert_eq!(
+            verified_headers
+                .iter()
+                .map(|header| header.reference())
+                .collect::<Vec<_>>(),
+            vec![referenced.reference()],
+            "the bundle must offer the referenced header, not the first-arrived one"
+        );
     }
 
     /// Test that connection knowledge correctly takes additional parts for

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -65,9 +65,9 @@ pub(crate) enum DataSource {
     /// Block headers received in bundles via block bundle streaming.
     BlockBundleStream,
 
-    /// Block headers fetched by the live/periodic header synchronizer
-    /// component.
-    HeaderSynchronizer,
+    /// Block headers the live/periodic header synchronizer requested by
+    /// reference and the peer returned.
+    HeaderSynchronizerRequested,
 
     /// Block headers loaded from persistent storage during node recovery.
     Recover,
@@ -89,6 +89,12 @@ pub(crate) enum DataSource {
     /// Transactions received via fast commit synchronization.
     FastCommitSyncer,
 
+    /// Block headers a header-sync response volunteered beyond the refs we
+    /// requested (the server's gap-fill below our requested rounds). These were
+    /// not asked for by digest, so they are subject to the one-header-per-slot
+    /// cap.
+    HeaderSynchronizerAdditional,
+
     /// Data added during testing.
     /// Only used in test code.
     #[cfg(test)]
@@ -103,7 +109,8 @@ impl DataSource {
         match self {
             DataSource::BlockStreaming
             | DataSource::BlockBundleStream
-            | DataSource::HeaderSynchronizer => true,
+            | DataSource::HeaderSynchronizerRequested
+            | DataSource::HeaderSynchronizerAdditional => true,
             DataSource::TransactionSynchronizer
             | DataSource::ShardReconstructor
             | DataSource::Recover
@@ -124,7 +131,8 @@ impl DataSource {
         match self {
             DataSource::BlockStreaming
             | DataSource::BlockBundleStream
-            | DataSource::HeaderSynchronizer => true,
+            | DataSource::HeaderSynchronizerRequested
+            | DataSource::HeaderSynchronizerAdditional => true,
             DataSource::TransactionSynchronizer
             | DataSource::ShardReconstructor
             | DataSource::Recover
@@ -143,14 +151,40 @@ impl DataSource {
             DataSource::TransactionSynchronizer => "Transactions synchronizer",
             DataSource::ShardReconstructor => "Shard reconstructor",
             DataSource::BlockBundleStream => "Block headers in streaming",
-            DataSource::HeaderSynchronizer => "Header synchronizer",
+            DataSource::HeaderSynchronizerRequested => "Header synchronizer requested",
             DataSource::Recover => "Recover",
             DataSource::OwnBlock => "Own block",
             DataSource::BlockStreaming => "Block streaming",
             DataSource::CommitSyncer => "Commit syncer",
             DataSource::FastCommitSyncer => "Fast commit syncer",
+            DataSource::HeaderSynchronizerAdditional => "Header synchronizer additional",
             #[cfg(test)]
             DataSource::Test => "Test",
+        }
+    }
+
+    /// Whether headers from this source are subject to the one-header-per-slot
+    /// cap. Only the live ingress paths, whose content a peer chooses freely,
+    /// are capped. The rest are exempt for different reasons: headers requested
+    /// by digest cannot be inflated by the peer serving them, and refusing a
+    /// requested ancestor would stall linearization; commit-sync headers arrive
+    /// with a commit carrying a quorum of votes; recovery reads our own store
+    /// and our own proposals are already one per slot by construction; and the
+    /// transaction sources carry no headers at all.
+    pub(crate) fn is_subject_to_slot_cap(&self) -> bool {
+        match self {
+            DataSource::BlockStreaming
+            | DataSource::BlockBundleStream
+            | DataSource::HeaderSynchronizerAdditional => true,
+            DataSource::HeaderSynchronizerRequested
+            | DataSource::TransactionSynchronizer
+            | DataSource::ShardReconstructor
+            | DataSource::Recover
+            | DataSource::OwnBlock
+            | DataSource::CommitSyncer
+            | DataSource::FastCommitSyncer => false,
+            #[cfg(test)]
+            DataSource::Test => false,
         }
     }
 }
@@ -1533,6 +1567,25 @@ impl DagState {
         self.get_recent_block_headers_at_slot(slot)
     }
 
+    /// Whether an accepted header exists at `block_ref`'s slot with a digest
+    /// different from `block_ref`'s — i.e. an equivocation for that slot.
+    pub(crate) fn contains_other_block_header_at_slot(&self, block_ref: &BlockRef) -> bool {
+        self.recent_headers_refs_by_authority[block_ref.author]
+            .range((
+                Included(BlockRef::new(
+                    block_ref.round,
+                    block_ref.author,
+                    BlockHeaderDigest::MIN,
+                )),
+                Included(BlockRef::new(
+                    block_ref.round,
+                    block_ref.author,
+                    BlockHeaderDigest::MAX,
+                )),
+            ))
+            .any(|existing| existing != block_ref)
+    }
+
     /// Returns headers from `recent_block_headers` at `round`. The caller must
     /// pass `round > last_commit_round()` so the lookup stays inside the
     /// not-yet-committed portion of the DAG.
@@ -1734,6 +1787,54 @@ impl DagState {
                 BlockHeaderDigest::MIN,
             )),
         )) {
+            let block_header = self
+                .recent_block_headers
+                .get(block_ref)
+                .expect("Block header should exist in recent block headers");
+            block_headers.push(block_header.clone());
+            if block_headers.len() >= limit {
+                break;
+            }
+        }
+        block_headers
+    }
+
+    /// Returns cached block headers from the specified authority within a given
+    /// round range, at most one per round: where the authority has several
+    /// headers in a round, the one with the lowest digest. Block headers
+    /// returned are limited to `start_round` <= round < `end_round`, up to
+    /// `limit` entries. NOTE: Only cached block headers are returned; storage
+    /// is not checked.
+    pub(crate) fn get_cached_block_headers_in_range_one_per_round(
+        &self,
+        authority: AuthorityIndex,
+        start_round: Round,
+        end_round: Round,
+        limit: usize,
+    ) -> Vec<VerifiedBlockHeader> {
+        if start_round >= end_round || limit == 0 {
+            return vec![];
+        }
+
+        let mut block_headers: Vec<VerifiedBlockHeader> = vec![];
+        for block_ref in self.recent_headers_refs_by_authority[authority].range((
+            Included(BlockRef::new(
+                start_round,
+                authority,
+                BlockHeaderDigest::MIN,
+            )),
+            Excluded(BlockRef::new(
+                end_round,
+                AuthorityIndex::MIN,
+                BlockHeaderDigest::MIN,
+            )),
+        )) {
+            if block_headers
+                .last()
+                .is_some_and(|last| last.round() == block_ref.round)
+            {
+                continue;
+            }
             let block_header = self
                 .recent_block_headers
                 .get(block_ref)
@@ -3673,6 +3774,52 @@ mod test {
         );
         assert_eq!(cached_block_headers.len(), 1);
         assert_eq!(cached_block_headers[0].round(), 10);
+    }
+
+    /// `get_cached_block_headers_in_range_one_per_round` returns one header
+    /// per round when the authority equivocated, and the limit counts kept
+    /// headers, so equivocations don't crowd out later rounds.
+    #[tokio::test]
+    async fn test_get_cached_block_headers_one_per_round() {
+        let (mut context, _) = Context::new_for_test(4);
+        context.parameters.dag_state_cached_rounds = 10;
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store);
+
+        // Authority 1 equivocates at rounds 10 and 11; rounds 12 and 13 hold a
+        // single header each. Distinct ancestors give distinct digests.
+        for (round, versions) in [(10u32, 3u8), (11, 2), (12, 1), (13, 1)] {
+            for version in 0..versions {
+                let block_header = VerifiedBlockHeader::new_for_test(
+                    TestBlockHeader::new(round, 1)
+                        .set_ancestors(vec![BlockRef::new(
+                            round - 1,
+                            AuthorityIndex::new_for_test(version),
+                            BlockHeaderDigest::MIN,
+                        )])
+                        .build(),
+                );
+                dag_state.accept_block_header(block_header, DataSource::Test);
+            }
+        }
+        let authority = context.committee.to_authority_index(1).unwrap();
+
+        let headers =
+            dag_state.get_cached_block_headers_in_range_one_per_round(authority, 9, 20, 10);
+        assert_eq!(
+            headers.iter().map(|h| h.round()).collect::<Vec<_>>(),
+            vec![10, 11, 12, 13],
+        );
+
+        // The limit counts kept headers: with limit 3 the scan still reaches
+        // round 12 past the equivocations.
+        let headers =
+            dag_state.get_cached_block_headers_in_range_one_per_round(authority, 9, 20, 3);
+        assert_eq!(
+            headers.iter().map(|h| h.round()).collect::<Vec<_>>(),
+            vec![10, 11, 12],
+        );
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -98,6 +98,14 @@ impl ShardEncoder for TrivialEncoder {
     }
 }
 
+/// Length of every shard encoding a payload of `payload_bytes`, which is the
+/// payload split `info_length` ways with room for the u32 length prefix,
+/// rounded up to satisfy the encoder's alignment requirement.
+pub(crate) fn shard_bytes(payload_bytes: usize, info_length: usize) -> usize {
+    let shard_bytes = (payload_bytes + 4).div_ceil(info_length);
+    shard_bytes + (shard_bytes % 2)
+}
+
 /// Creates shards from serialized transactions, padding as necessary to
 /// ensure each shard is of equal length. The number of shards created is
 /// equal to `info_length`.
@@ -108,13 +116,7 @@ fn create_shards_from_serialized_transactions(
     let bytes_length = serialized.len();
     let mut statements_with_len: Vec<u8> = (bytes_length as u32).to_le_bytes().to_vec();
     statements_with_len.extend_from_slice(serialized);
-    // increase the length by 4 for u32
-    let mut shard_bytes = (bytes_length + 4).div_ceil(info_length);
-
-    // Ensure shard_bytes meets alignment requirements.
-    if !shard_bytes.is_multiple_of(2) {
-        shard_bytes += 1;
-    }
+    let shard_bytes = shard_bytes(bytes_length, info_length);
 
     let length_with_padding = shard_bytes * info_length;
     statements_with_len.resize(length_with_padding, 0);

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -403,6 +403,28 @@ pub(crate) enum ConsensusError {
         actual: &'static str,
         starfish_speed: bool,
     },
+
+    #[error("Authority {authority} equivocated: signed a second block header for round {round}")]
+    BlockHeaderEquivocation {
+        authority: AuthorityIndex,
+        round: Round,
+    },
+
+    #[error(
+        "Fetch response from {peer} contains unrequested header (author {author}, round {round}) outside the request's gap-fill window"
+    )]
+    UnrequestedHeaderOutOfWindow {
+        peer: AuthorityIndex,
+        author: AuthorityIndex,
+        round: Round,
+    },
+
+    #[error("Peer {peer} sent a shard that is too large: {size} > {limit}")]
+    SerializedShardTooLarge {
+        peer: AuthorityIndex,
+        size: usize,
+        limit: usize,
+    },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -42,6 +42,7 @@ use crate::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
         VerifiedBlockHeader,
     },
+    block_manager::drop_far_future,
     block_verifier::BlockVerifier,
     commit_syncer::fast::{FastSyncPauseSource, paused_by_fast_sync},
     commit_vote_monitor::CommitVoteMonitor,
@@ -646,6 +647,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                             if let Err(err) = Self::process_fetched_headers_from_authority(blocks,
                                 peer_index,
                                 blocks_guard,
+                                highest_rounds,
                                 core_dispatcher.clone(),
                                 dag_state.clone(),
                                 block_verifier.clone(),
@@ -688,6 +690,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         mut serialized_headers: Vec<Bytes>,
         peer_index: AuthorityIndex,
         requested_blocks_guard: BlocksGuard,
+        highest_rounds: Vec<Round>,
         core_dispatcher: Arc<D>,
         dag_state: Arc<RwLock<DagState>>,
         block_verifier: Arc<V>,
@@ -768,24 +771,98 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 .join(", "),
         );
 
-        // A peer may volunteer validly-signed headers we never requested, so
-        // bound the response here; the block manager applies the same bound
-        // downstream when these headers are accepted.
-        let block_headers = crate::block_manager::drop_far_future(
+        // Partition the response. Refs we asked for are admitted unconditionally:
+        // we named them by digest, so they are needed by definition. Anything
+        // else is the server's gap-fill, legitimate only for an author we
+        // requested from, at a round strictly between the frontier we sent and
+        // the highest round we requested for that author. The bound is the
+        // highest rather than the lowest requested round because the server may
+        // truncate an oversized request and derive its gap-fill window from the
+        // surviving refs.
+        let mut max_requested_rounds: Vec<Option<Round>> = vec![None; context.committee.size()];
+        for block_ref in &requested_blocks_guard.block_refs {
+            let entry = &mut max_requested_rounds[block_ref.author];
+            *entry = Some(entry.map_or(block_ref.round, |round| round.max(block_ref.round)));
+        }
+
+        let mut requested_headers = Vec::new();
+        let mut additional_headers = Vec::new();
+        let mut out_of_window: Option<BlockRef> = None;
+        for header in block_headers {
+            let block_ref = header.reference();
+            if requested_blocks_guard.block_refs.contains(&block_ref) {
+                requested_headers.push(header);
+                continue;
+            }
+            let in_window = max_requested_rounds[block_ref.author].is_some_and(|max_round| {
+                highest_rounds[block_ref.author] < block_ref.round && block_ref.round < max_round
+            });
+            if !in_window {
+                out_of_window.get_or_insert(block_ref);
+            }
+            additional_headers.push(header);
+        }
+
+        // Both sides derive the gap-fill window from the same request inputs,
+        // so an out-of-window header cannot come from an honest server — and
+        // the unrequested part of the response is exactly what we cannot
+        // verify by digest, so none of it is accepted.
+        if let Some(block_ref) = out_of_window {
+            let e = ConsensusError::UnrequestedHeaderOutOfWindow {
+                peer: peer_index,
+                author: block_ref.author,
+                round: block_ref.round,
+            };
+            misbehavior_store.record_faulty_block(peer_index, peer_index, &e);
+            metrics
+                .synchronizer_fetch_window_violations
+                .with_label_values(&[peer_hostname.as_str(), sync_method])
+                .inc();
+            warn!(
+                "Dropping {} unrequested headers fetched from peer {peer_index} {peer_hostname}: {e}",
+                additional_headers.len()
+            );
+            additional_headers.clear();
+        }
+
+        let requested_headers = drop_far_future(
             &context,
             &dag_state,
-            block_headers,
-            DataSource::HeaderSynchronizer,
+            requested_headers,
+            DataSource::HeaderSynchronizerRequested,
+            |header| header.round(),
+        );
+        let additional_headers = drop_far_future(
+            &context,
+            &dag_state,
+            additional_headers,
+            DataSource::HeaderSynchronizerAdditional,
             |header| header.round(),
         );
 
-        // Now send them to core for processing. Ignore the returned missing blocks as
-        // we don't want this mechanism to keep feedback looping on fetching
-        // more blocks. The periodic synchronization will take care of that.
-        let (missing_blocks, missing_committed_txns) = core_dispatcher
-            .add_block_headers(block_headers, DataSource::HeaderSynchronizer)
-            .await
-            .map_err(|_| ConsensusError::Shutdown)?;
+        // Now send them to core for processing — additional headers first, as
+        // they sit below the requested ones and connect them to our frontier.
+        // They go in under their own source so the block manager's per-slot cap
+        // applies to them but never to the requested refs. Ignore the returned
+        // missing blocks as we don't want this mechanism to keep feedback
+        // looping on fetching more blocks. The periodic synchronization will
+        // take care of that.
+        let mut missing_blocks = BTreeSet::new();
+        let mut missing_committed_txns = BTreeMap::new();
+        for (headers, source) in [
+            (additional_headers, DataSource::HeaderSynchronizerAdditional),
+            (requested_headers, DataSource::HeaderSynchronizerRequested),
+        ] {
+            if headers.is_empty() {
+                continue;
+            }
+            let (blocks, committed_txns) = core_dispatcher
+                .add_block_headers(headers, source)
+                .await
+                .map_err(|_| ConsensusError::Shutdown)?;
+            missing_blocks.extend(blocks);
+            missing_committed_txns.extend(committed_txns);
+        }
 
         // now release all the locked blocks as they have been fetched, verified &
         // processed
@@ -1221,13 +1298,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
 
                 // Now process the returned results
                 let mut total_fetched = 0;
-                for (blocks_guard, serialized_fetched_block_headers, peer) in results {
+                for (blocks_guard, serialized_fetched_block_headers, peer, highest_rounds) in
+                    results
+                {
                     total_fetched += serialized_fetched_block_headers.len();
 
                     if let Err(err) = Self::process_fetched_headers_from_authority(
                         serialized_fetched_block_headers,
                         peer,
                         blocks_guard,
+                        highest_rounds,
                         core_dispatcher.clone(),
                         dag_state.clone(),
                         block_verifier.clone(),
@@ -1299,7 +1379,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         network_client: Arc<C>,
         missing_block_headers_refs: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
         dag_state: Arc<RwLock<DagState>>,
-    ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex)> {
+    ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex, Vec<Round>)> {
         // Step 1: Map authorities to missing block headers refs that they are aware of
         let mut authority_to_block_headers_refs: HashMap<AuthorityIndex, Vec<BlockRef>> =
             HashMap::new();
@@ -1525,7 +1605,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                     match response {
                         Ok(fetched_block_headers) => {
                             info!("Fetched {} block headers from peer {}", fetched_block_headers.len(), peer_hostname);
-                            results.push((blocks_guard, fetched_block_headers, peer_index));
+                            results.push((blocks_guard, fetched_block_headers, peer_index, highest_rounds));
 
                             // no more pending requests are left, just break the loop
                             if request_futures.is_empty() {
@@ -1613,7 +1693,7 @@ mod tests {
         CommitDigest, CommitIndex,
         authority_service::COMMIT_LAG_MULTIPLIER,
         block_header::{
-            BlockHeaderDigest, BlockRef, Round, TestBlockHeader, VerifiedBlock,
+            BlockHeaderDigest, BlockRef, GENESIS_ROUND, Round, TestBlockHeader, VerifiedBlock,
             VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
         },
         block_verifier::NoopBlockVerifier,
@@ -3031,7 +3111,7 @@ mod tests {
             assert_eq!(results.len(), 3);
 
             // 6) Results in order: peers 2 and 3 (known), then peer 1 (random)
-            let peers: Vec<_> = results.iter().map(|(_, _, peer)| *peer).collect();
+            let peers: Vec<_> = results.iter().map(|(_, _, peer, _)| *peer).collect();
             assert_eq!(
                 peers,
                 vec![
@@ -3042,7 +3122,7 @@ mod tests {
             );
 
             // 7) Verify the returned bytes correspond to that block
-            for (_, bytes, _) in &results {
+            for (_, bytes, _, _) in &results {
                 let expected = missing_vbh.serialized().clone();
                 assert_eq!(bytes, &vec![expected]);
             }
@@ -3189,7 +3269,7 @@ mod tests {
         assert_eq!(results.len(), 4, "Expected 2 known + 2 random fetches");
 
         // 7) First fetch from peer 3 (knowledge-based)
-        let (_guard3, bytes3, peer3) = &results[0];
+        let (_guard3, bytes3, peer3, _) = &results[0];
         assert_eq!(*peer3, AuthorityIndex::new_for_test(3));
         let expected2 = all_verified_block_headers
             [known_number_block_headers..2 * known_number_block_headers]
@@ -3199,7 +3279,7 @@ mod tests {
         assert_eq!(bytes3, &expected2);
 
         // 8) Second fetch from peer 1 (additional random)
-        let (_guard1, bytes1, peer1) = &results[1];
+        let (_guard1, bytes1, peer1, _) = &results[1];
         assert_eq!(*peer1, AuthorityIndex::new_for_test(1));
         let expected1 = all_verified_block_headers
             [0..context.parameters.max_headers_per_header_sync_fetch]
@@ -3209,7 +3289,7 @@ mod tests {
         assert_eq!(bytes1, &expected1);
 
         // 9) Third fetch from peer 4 (additional random)
-        let (_guard4, bytes4, peer4) = &results[2];
+        let (_guard4, bytes4, peer4, _) = &results[2];
         assert_eq!(*peer4, AuthorityIndex::new_for_test(4));
         let expected4 =
             all_verified_block_headers[context.parameters.max_headers_per_header_sync_fetch
@@ -3220,7 +3300,7 @@ mod tests {
         assert_eq!(bytes4, &expected4);
 
         // 10) Fourth fetch from peer 5 (fallback after peer 2 timeout)
-        let (_guard5, bytes5, peer5) = &results[3];
+        let (_guard5, bytes5, peer5, _) = &results[3];
         assert_eq!(*peer5, AuthorityIndex::new_for_test(5));
         let expected5 = all_verified_block_headers[0..known_number_block_headers]
             .iter()
@@ -3301,6 +3381,7 @@ mod tests {
             expected_serialized_block_headers.clone(),
             peer_index,
             blocks_guard, // The guard is consumed here
+            vec![GENESIS_ROUND; context.committee.size()],
             core_dispatcher.clone(),
             dag_state.clone(),
             block_verifier.clone(),
@@ -3344,6 +3425,7 @@ mod tests {
             expected_serialized_block_headers,
             peer_index,
             blocks_guard_second,
+            vec![GENESIS_ROUND; context.committee.size()],
             core_dispatcher.clone(),
             dag_state.clone(),
             block_verifier,
@@ -3431,6 +3513,7 @@ mod tests {
             serialized,
             peer_index,
             blocks_guard,
+            vec![GENESIS_ROUND; context.committee.size()],
             core_dispatcher.clone(),
             dag_state.clone(),
             block_verifier,
@@ -3456,9 +3539,194 @@ mod tests {
                 .metrics
                 .node_metrics
                 .dropped_far_future_headers_total
-                .with_label_values(&[DataSource::HeaderSynchronizer.as_str()])
+                .with_label_values(&[DataSource::HeaderSynchronizerRequested.as_str()])
                 .get(),
             1
         );
+    }
+
+    /// Unrequested headers inside the gap-fill window are admitted; the window
+    /// upper bound is the highest requested round per author.
+    #[tokio::test]
+    async fn test_process_fetched_headers_admits_in_window_extras() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (commands_sender, _commands_receiver) =
+            monitored_mpsc::channel("consensus_synchronizer_commands", 1000);
+        let network_client = Arc::new(MockNetworkClient::default());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+
+        // Requested: authority 1 at rounds 10 and 50. Extra: authority 1 at
+        // round 30 — between the sent frontier (5) and the *highest* requested
+        // round, so it must be admitted even though it is above the lowest.
+        let requested_low = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(10, 1).build());
+        let requested_high = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(50, 1).build());
+        let extra = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(30, 1).build());
+        let refs = [requested_low.reference(), requested_high.reference()]
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let serialized = vec![
+            requested_low.serialized().clone(),
+            requested_high.serialized().clone(),
+            extra.serialized().clone(),
+        ];
+
+        let peer_index = AuthorityIndex::new_for_test(2);
+        let inflight_blocks_map = InflightBlockHeadersMap::new();
+        let blocks_guard = inflight_blocks_map
+            .lock_headers(refs.clone(), peer_index, SyncMethod::Live)
+            .expect("Failed to lock blocks");
+        let verified_cache = Arc::new(parking_lot::Mutex::new(lru::LruCache::new(
+            NonZero::new(1000).unwrap(),
+        )));
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+
+        let result = HeaderSynchronizer::<
+            MockNetworkClient,
+            NoopBlockVerifier,
+            MockCoreThreadDispatcher,
+        >::process_fetched_headers_from_authority(
+            serialized,
+            peer_index,
+            blocks_guard,
+            vec![5; context.committee.size()],
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier,
+            verified_cache,
+            commit_vote_monitor,
+            transactions_synchronizer,
+            context.clone(),
+            commands_sender,
+            "live",
+            misbehavior_store,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let added = core_dispatcher.get_and_drain_block_headers().await;
+        let added_refs = added.iter().map(|b| b.reference()).collect::<BTreeSet<_>>();
+        assert!(added_refs.contains(&extra.reference()));
+        assert!(refs.iter().all(|r| added_refs.contains(r)));
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .synchronizer_fetch_window_violations
+                .with_label_values(&[
+                    context.committee.authority(peer_index).hostname.as_str(),
+                    "live",
+                ])
+                .get(),
+            0
+        );
+    }
+
+    /// An unrequested header outside the gap-fill window discredits every
+    /// unrequested header in the response: all extras are dropped, the peer is
+    /// charged, and the requested refs are still processed.
+    #[tokio::test]
+    async fn test_process_fetched_headers_rejects_out_of_window_extras() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (commands_sender, _commands_receiver) =
+            monitored_mpsc::channel("consensus_synchronizer_commands", 1000);
+        let network_client = Arc::new(MockNetworkClient::default());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+
+        // Requested: authority 1 at round 50. Extras: one above the highest
+        // requested round for authority 1, one from an authority we did not
+        // request from at all, and one legitimately in-window — the violation
+        // must take the in-window one down with it.
+        let requested = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(50, 1).build());
+        let extra_above = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(60, 1).build());
+        let extra_unrequested_author =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(30, 3).build());
+        let extra_in_window =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(30, 1).build());
+        let refs = [requested.reference()].into_iter().collect::<BTreeSet<_>>();
+        let serialized = vec![
+            requested.serialized().clone(),
+            extra_above.serialized().clone(),
+            extra_unrequested_author.serialized().clone(),
+            extra_in_window.serialized().clone(),
+        ];
+
+        let peer_index = AuthorityIndex::new_for_test(2);
+        let inflight_blocks_map = InflightBlockHeadersMap::new();
+        let blocks_guard = inflight_blocks_map
+            .lock_headers(refs, peer_index, SyncMethod::Live)
+            .expect("Failed to lock blocks");
+        let verified_cache = Arc::new(parking_lot::Mutex::new(lru::LruCache::new(
+            NonZero::new(1000).unwrap(),
+        )));
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+
+        let result = HeaderSynchronizer::<
+            MockNetworkClient,
+            NoopBlockVerifier,
+            MockCoreThreadDispatcher,
+        >::process_fetched_headers_from_authority(
+            serialized,
+            peer_index,
+            blocks_guard,
+            vec![5; context.committee.size()],
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier,
+            verified_cache,
+            commit_vote_monitor,
+            transactions_synchronizer,
+            context.clone(),
+            commands_sender,
+            "live",
+            misbehavior_store.clone(),
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let added = core_dispatcher.get_and_drain_block_headers().await;
+        assert_eq!(
+            added.iter().map(|b| b.reference()).collect::<Vec<_>>(),
+            vec![requested.reference()],
+            "only the requested ref may be processed after a window violation"
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .synchronizer_fetch_window_violations
+                .with_label_values(&[
+                    context.committee.authority(peer_index).hostname.as_str(),
+                    "live",
+                ])
+                .get(),
+            1
+        );
+        let crate::misbehavior_store::MisbehaviorCounts::V1(counts) =
+            &misbehavior_store.snapshot_totals()[peer_index.value()];
+        assert_eq!(counts.faulty_blocks_unprovable, 1);
     }
 }

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -361,6 +361,9 @@ pub(crate) struct NodeMetrics {
     pub(crate) adaptive_ack_acks_dropped: IntCounter,
     pub(crate) strong_vote_missing_by_author: IntCounterVec,
     pub(crate) strong_blames_received_for_author: IntCounterVec,
+    pub(crate) dropped_slot_cap_headers_total: IntCounterVec,
+    pub(crate) synchronizer_fetch_window_violations: IntCounterVec,
+    pub(crate) shard_reconstructor_dropped_shards: IntCounterVec,
 }
 
 impl NodeMetrics {
@@ -1455,6 +1458,27 @@ impl NodeMetrics {
                 "strong_blames_received_for_author",
                 "Number of times an authority appeared in the `missing` set of a strong blame received against this node (when acting as leader), labeled by that authority. Observed only when consensus_starfish_speed is enabled.",
                 &["author"],
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            dropped_slot_cap_headers_total: register_int_counter_vec_with_registry!(
+                "dropped_slot_cap_headers_total",
+                "Number of block headers dropped because their (author, round) slot already holds a header with a different digest, by author and source",
+                &["authority", "source"],
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            synchronizer_fetch_window_violations: register_int_counter_vec_with_registry!(
+                "synchronizer_fetch_window_violations",
+                "Number of header-sync responses whose unrequested headers fell outside the request's gap-fill window; all unrequested headers of such responses are dropped",
+                &["peer", "type"],
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            shard_reconstructor_dropped_shards: register_int_counter_vec_with_registry!(
+                "shard_reconstructor_dropped_shards",
+                "Number of shards dropped by the reconstructor's admission rules, by reason: the relaying peer already contributed a shard in the slot, or the slot already holds the maximum number of accumulators",
+                &["reason"],
                 registry;
                 MetricLevel::Warn,
             ).unwrap(),

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -305,7 +305,9 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::MalformedShard(_)
         | ConsensusError::TooBigHeaderRoundInABundle { .. }
         | ConsensusError::TooBigShardRoundInABundle { .. }
-        | ConsensusError::IncorrectShardProof { .. } => FaultType::Unprovable,
+        | ConsensusError::IncorrectShardProof { .. }
+        | ConsensusError::UnrequestedHeaderOutOfWindow { .. }
+        | ConsensusError::SerializedShardTooLarge { .. } => FaultType::Unprovable,
 
         // Checks that run only after the author's signature is verified, so the
         // signed header itself proves the author produced a block that violates
@@ -327,7 +329,8 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::TransactionTooLarge { .. }
         | ConsensusError::TooManyTransactions { .. }
         | ConsensusError::TooManyTransactionBytes { .. }
-        | ConsensusError::InvalidTransaction(_) => FaultType::Provable,
+        | ConsensusError::InvalidTransaction(_)
+        | ConsensusError::BlockHeaderEquivocation { .. } => FaultType::Provable,
 
         // Not attributable as misbehavior from a signed block alone: subjective
         // rejections, commit-chain and commit-sync inconsistencies, fetch-shape

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -103,7 +103,8 @@ pub struct ShardAccumulator {
     transaction_ref: TransactionRef,
     /// Block digest of the source block (present for V1, absent for V2)
     block_digest: Option<BlockHeaderDigest>,
-    /// Collected shards, indexed by their shard index
+    /// Collected shards, one slot per authority, indexed by the authority index
+    /// of the peer that relayed the shard.
     collected_shards: Vec<Option<Shard>>,
     /// Number of collected data shards
     number_shards: usize,
@@ -158,12 +159,20 @@ impl ShardAccumulator {
 
     /// We use Codec to decode the transaction data from collected shards. Once
     /// reconstructed, we encode and verify that the transaction commitment
-    /// was computed correctly
-    fn decode_by_codec(&self, codec: &mut Codec) -> ConsensusResult<VerifiedTransactions> {
+    /// was computed correctly. Consumes the accumulator, so the collected
+    /// shards move into the decoder rather than being copied.
+    fn decode_by_codec(self, codec: &mut Codec) -> ConsensusResult<VerifiedTransactions> {
+        let Self {
+            transaction_ref,
+            block_digest,
+            collected_shards,
+            ..
+        } = self;
+
         let transactions = codec.decoder.decode_shards(
             codec.info_length,
             codec.parity_length,
-            self.collected_shards.clone(),
+            collected_shards,
         )?;
 
         let serialized =
@@ -175,18 +184,21 @@ impl ShardAccumulator {
             &codec.context.clone(),
             &mut codec.encoder,
         )?;
-        if computed_commitment != self.transaction_ref.transactions_commitment {
-            return Err(ConsensusError::TransactionCommitmentMismatch {
-                transaction_ref: self.transaction_ref,
-            });
+        if computed_commitment != transaction_ref.transactions_commitment {
+            return Err(ConsensusError::TransactionCommitmentMismatch { transaction_ref });
         }
 
         Ok(VerifiedTransactions::new(
             transactions,
-            self.transaction_ref,
-            self.block_digest,
+            transaction_ref,
+            block_digest,
             serialized,
         ))
+    }
+
+    /// Whether a shard is already collected at the given index.
+    fn contains_shard_at_index(&self, shard_index: usize) -> bool {
+        self.collected_shards[shard_index].is_some()
     }
 }
 
@@ -206,21 +218,16 @@ impl ShardAccumulator {
 /// the direct primary-block route, where the full payload is verified against
 /// the author.
 fn record_reconstruction_verification_failure(
-    context: &Context,
     dag_state: &RwLock<DagState>,
     misbehavior_store: &MisbehaviorStore,
-    shard_accumulator: &ShardAccumulator,
+    tx_ref: TransactionRef,
+    relayers: Vec<AuthorityIndex>,
     err: &ConsensusError,
 ) {
-    let tx_ref = shard_accumulator.transaction_ref;
     let author = tx_ref.author;
     let authored = dag_state
         .read()
         .contains_verified_block_headers_for_transaction_refs(&[tx_ref])[0];
-    let relayers: Vec<_> = shard_accumulator
-        .collected_shard_indices()
-        .filter_map(|i| context.committee.to_authority_index(i))
-        .collect();
     misbehavior_store.record_faulty_transactions(author, authored, relayers);
     error!(
         "Reconstructed transactions for {:?} failed verification: {:?}",
@@ -233,19 +240,11 @@ fn record_reconstruction_verification_failure(
 /// the peer-supplied shards, not the author, so no author fault is recorded
 /// even when a verified header for the ref exists.
 fn record_reconstruction_commitment_mismatch(
-    context: &Context,
     misbehavior_store: &MisbehaviorStore,
-    shard_accumulator: &ShardAccumulator,
+    tx_ref: TransactionRef,
+    relayers: Vec<AuthorityIndex>,
 ) {
-    let relayers: Vec<_> = shard_accumulator
-        .collected_shard_indices()
-        .filter_map(|i| context.committee.to_authority_index(i))
-        .collect();
-    misbehavior_store.record_faulty_transactions(
-        shard_accumulator.transaction_ref.author,
-        false,
-        relayers,
-    );
+    misbehavior_store.record_faulty_transactions(tx_ref.author, false, relayers);
 }
 
 /// Data structure containing both encoder and decoder
@@ -433,48 +432,49 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                     rx.recv().await
                 } {
                     metrics.node_metrics.reconstruction_jobs_started.inc();
+                    // Read what the failure paths attribute with before decoding
+                    // consumes the accumulator.
+                    let tx_ref = shard_accumulator.transaction_ref;
+                    let relayers: Vec<_> = shard_accumulator
+                        .collected_shard_indices()
+                        .filter_map(|i| context.committee.to_authority_index(i))
+                        .collect();
                     let result = match shard_accumulator.decode_by_codec(&mut codec) {
                         // With at least one honest relayer the commitment is
                         // genuine and proof-valid shards decode to the committed
                         // payload, so a decode failure requires info_length
                         // colluding relayers (or a codec bug).
                         Err(err) => {
-                            error!(
-                                "Failed to reconstruct transactions for {:?}: {:?}",
-                                shard_accumulator.transaction_ref, err
-                            );
+                            error!("Failed to reconstruct transactions for {tx_ref:?}: {err:?}");
                             // A commitment mismatch means the reconstructed bytes
                             // aren't the ones the author committed to; the shards,
                             // and thus the mismatch, come from peers, so charge
                             // only the peers that relayed shards, never the author.
                             if matches!(err, ConsensusError::TransactionCommitmentMismatch { .. }) {
                                 record_reconstruction_commitment_mismatch(
-                                    &context,
                                     &misbehavior_store,
-                                    &shard_accumulator,
+                                    tx_ref,
+                                    relayers,
                                 );
                             }
-                            Err(shard_accumulator.transaction_ref)
+                            Err(tx_ref)
                         }
                         Ok(verified_transactions) => match block_verifier
                             .check_and_verify_transactions(&verified_transactions.transactions())
                         {
                             Ok(()) => {
-                                debug!(
-                                    "Successfully reconstructed transactions for {:?}",
-                                    shard_accumulator.transaction_ref
-                                );
+                                debug!("Successfully reconstructed transactions for {tx_ref:?}");
                                 Ok(verified_transactions)
                             }
                             Err(err) => {
                                 record_reconstruction_verification_failure(
-                                    &context,
                                     &dag_state,
                                     &misbehavior_store,
-                                    &shard_accumulator,
+                                    tx_ref,
+                                    relayers,
                                     &err,
                                 );
-                                Err(shard_accumulator.transaction_ref)
+                                Err(tx_ref)
                             }
                         },
                     };
@@ -680,17 +680,87 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         let total_length = self.total_length;
 
         match msg {
-            TransactionMessage::Shard(shard_msg) => match self.shard_accumulators.entry(tx_ref) {
-                Entry::Vacant(v) => {
-                    v.insert(ShardAccumulator::new_with_shard(shard_msg, total_length));
+            TransactionMessage::Shard(shard_msg) => {
+                // Relaying two shards for one slot is the peer's own fault;
+                // exceeding the accumulator limit is not, as others may have
+                // filled the slot.
+                // TODO: charge the peer for the former once every validator
+                // runs the per-slot header cap.
+                let slot_start = TransactionRef {
+                    round: tx_ref.round,
+                    author: tx_ref.author,
+                    transactions_commitment: TransactionsCommitment::MIN,
+                };
+                let slot_end = TransactionRef {
+                    round: tx_ref.round,
+                    author: tx_ref.author,
+                    transactions_commitment: TransactionsCommitment::MAX,
+                };
+                let mut accumulators_in_slot = 0usize;
+                let mut peer_in_other_accumulator = false;
+                for (existing_ref, accumulator) in
+                    self.shard_accumulators.range(slot_start..=slot_end)
+                {
+                    accumulators_in_slot += 1;
+                    if *existing_ref != tx_ref
+                        && accumulator.contains_shard_at_index(shard_msg.shard_index)
+                    {
+                        peer_in_other_accumulator = true;
+                    }
                 }
-                Entry::Occupied(mut o) => {
-                    o.get_mut().update_with_shard(shard_msg);
+
+                // One shard per (relaying peer, slot), across all accumulators:
+                // an honest peer holds exactly one shard per slot, so a peer
+                // whose index already appears in another accumulator of the
+                // slot has spent the contribution it was entitled to.
+                if peer_in_other_accumulator {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .shard_reconstructor_dropped_shards
+                        .with_label_values(&["peer_already_in_slot"])
+                        .inc();
+                    debug!(
+                        "Dropping shard for {tx_ref:?}: peer index {} already contributed a shard in this slot",
+                        shard_msg.shard_index
+                    );
+                    return Ok(());
                 }
-            },
+
+                match self.shard_accumulators.entry(tx_ref) {
+                    Entry::Vacant(v) => {
+                        // With one shard per (peer, slot), a slot holding
+                        // `parity_length + 1` accumulators has too few
+                        // uncommitted peers left for any further commitment to
+                        // ever gather `info_length` contributors — a new
+                        // accumulator would be dead weight by construction.
+                        let max_accumulators_per_slot = self.context.committee.parity_length() + 1;
+                        if accumulators_in_slot >= max_accumulators_per_slot {
+                            self.context
+                                .metrics
+                                .node_metrics
+                                .shard_reconstructor_dropped_shards
+                                .with_label_values(&["slot_full"])
+                                .inc();
+                            debug!(
+                                "Dropping shard for {tx_ref:?}: slot already holds {accumulators_in_slot} accumulators"
+                            );
+                            return Ok(());
+                        }
+                        v.insert(ShardAccumulator::new_with_shard(shard_msg, total_length));
+                    }
+                    Entry::Occupied(mut o) => {
+                        o.get_mut().update_with_shard(shard_msg);
+                    }
+                }
+            }
 
             TransactionMessage::FullTransaction(tx_ref) => {
                 self.processed_transactions.insert(tx_ref);
+                // The full payload arrived through the direct path, so a
+                // partially filled accumulator for it can never be needed
+                // again — release it instead of waiting for round eviction.
+                self.shard_accumulators.remove(&tx_ref);
                 return Ok(());
             }
         }
@@ -761,7 +831,7 @@ mod tests {
         core::ReasonToCreateBlock,
         core_thread::{CoreError, CoreThreadDispatcher},
         dag_state::{DagState, DataSource},
-        encoder::create_encoder,
+        encoder::{ShardEncoder, create_encoder},
         misbehavior_store::MisbehaviorCounts,
         shard_reconstructor::{
             ShardMessage, ShardReconstructor, ShardReconstructorHandle, TransactionMessage,
@@ -1568,6 +1638,328 @@ mod tests {
                 "Each peer that relayed a shard must be charged unprovably"
             );
         }
+    }
+
+    /// Encodes a distinct payload for `slot` and returns its commitment plus
+    /// the full shard set, so tests can build several commitments in one slot.
+    fn encode_payload_for_slot(
+        context: &Arc<Context>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
+        marker: u8,
+    ) -> (TransactionsCommitment, Vec<Shard>) {
+        let serialized = Transaction::serialize(&[Transaction::new(vec![marker; 16])]).unwrap();
+        let commitment =
+            TransactionsCommitment::compute_transactions_commitment(&serialized, context, encoder)
+                .unwrap();
+        let shards = encoder
+            .encode_serialized_data(
+                &serialized,
+                context.committee.info_length(),
+                context.committee.parity_length(),
+            )
+            .unwrap();
+        (commitment, shards)
+    }
+
+    /// A peer gets one shard per (author, round) slot across all accumulators:
+    /// its shard for a second commitment in the slot is dropped whether that
+    /// would create a new accumulator or join one another peer created. The
+    /// first commitment still reconstructs from `info_length` distinct peers.
+    #[tokio::test]
+    async fn test_shard_admission_one_shard_per_peer_per_slot() {
+        telemetry_subscribers::init_for_testing();
+
+        let h = TestHarness::new(10);
+        let context = h.context.clone();
+        let tx = h.tx.clone();
+        let mut encoder = create_encoder(&context);
+        let info_length = context.committee.info_length();
+
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build()).reference();
+        let (first_commitment, first_shards) = encode_payload_for_slot(&context, &mut encoder, 1);
+        let (second_commitment, second_shards) = encode_payload_for_slot(&context, &mut encoder, 2);
+
+        // Peer 0 contributes to the first commitment, creating its accumulator.
+        tx.send(vec![TransactionMessage::Shard(ShardMessage {
+            transaction_ref: TransactionRef::new(block_ref, first_commitment),
+            block_digest: Some(block_ref.digest),
+            shard: first_shards[0].clone(),
+            shard_index: 0,
+        })])
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Peer 0's shard for a second commitment in the same slot is dropped —
+        // it would create a second accumulator.
+        tx.send(vec![TransactionMessage::Shard(ShardMessage {
+            transaction_ref: TransactionRef::new(block_ref, second_commitment),
+            block_digest: Some(block_ref.digest),
+            shard: second_shards[0].clone(),
+            shard_index: 0,
+        })])
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["peer_already_in_slot"])
+                .get(),
+            1,
+        );
+
+        // Peer 1 creates the second commitment's accumulator, then peer 0 tries
+        // to join it — also dropped, this time through the occupied arm.
+        tx.send(vec![TransactionMessage::Shard(ShardMessage {
+            transaction_ref: TransactionRef::new(block_ref, second_commitment),
+            block_digest: Some(block_ref.digest),
+            shard: second_shards[1].clone(),
+            shard_index: 1,
+        })])
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        tx.send(vec![TransactionMessage::Shard(ShardMessage {
+            transaction_ref: TransactionRef::new(block_ref, second_commitment),
+            block_digest: Some(block_ref.digest),
+            shard: second_shards[0].clone(),
+            shard_index: 0,
+        })])
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["peer_already_in_slot"])
+                .get(),
+            2,
+        );
+
+        // The first commitment still reconstructs: peers 2..info_length+1 are
+        // free to contribute, so it reaches `info_length` shards.
+        let rest: Vec<_> = (2..=info_length)
+            .map(|i| {
+                TransactionMessage::Shard(ShardMessage {
+                    transaction_ref: TransactionRef::new(block_ref, first_commitment),
+                    block_digest: Some(block_ref.digest),
+                    shard: first_shards[i].clone(),
+                    shard_index: i,
+                })
+            })
+            .collect();
+        tx.send(rest).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(600)).await;
+
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
+        assert_eq!(
+            fetched.len(),
+            1,
+            "the first commitment must still reconstruct from info_length distinct peers"
+        );
+        assert_eq!(
+            fetched[0].transaction_ref().transactions_commitment,
+            first_commitment
+        );
+
+        h.handle.stop().await.unwrap();
+    }
+
+    /// Two commitments in one slot, each backed by a disjoint set of
+    /// `info_length` peers, both reconstruct: the per-peer rule never fires for
+    /// peers that relay only their own single shard.
+    #[tokio::test]
+    async fn test_two_commitments_in_slot_from_disjoint_peers_both_reconstruct() {
+        telemetry_subscribers::init_for_testing();
+
+        let h = TestHarness::new(10);
+        let context = h.context.clone();
+        let tx = h.tx.clone();
+        let mut encoder = create_encoder(&context);
+        let info_length = context.committee.info_length();
+        assert!(
+            2 * info_length <= context.committee.size(),
+            "the committee must be large enough for two disjoint peer sets"
+        );
+
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build()).reference();
+        let (first_commitment, first_shards) = encode_payload_for_slot(&context, &mut encoder, 1);
+        let (second_commitment, second_shards) = encode_payload_for_slot(&context, &mut encoder, 2);
+
+        // Peers 0..info_length back the first commitment, peers
+        // info_length..2*info_length back the second.
+        let mut batch = Vec::new();
+        for (i, shard) in first_shards.iter().enumerate().take(info_length) {
+            batch.push(TransactionMessage::Shard(ShardMessage {
+                transaction_ref: TransactionRef::new(block_ref, first_commitment),
+                block_digest: Some(block_ref.digest),
+                shard: shard.clone(),
+                shard_index: i,
+            }));
+        }
+        for (i, shard) in second_shards
+            .iter()
+            .enumerate()
+            .take(2 * info_length)
+            .skip(info_length)
+        {
+            batch.push(TransactionMessage::Shard(ShardMessage {
+                transaction_ref: TransactionRef::new(block_ref, second_commitment),
+                block_digest: Some(block_ref.digest),
+                shard: shard.clone(),
+                shard_index: i,
+            }));
+        }
+        tx.send(batch).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(800)).await;
+
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
+        let commitments: BTreeSet<_> = fetched
+            .iter()
+            .map(|vt| vt.transaction_ref().transactions_commitment)
+            .collect();
+        assert_eq!(
+            commitments,
+            BTreeSet::from([first_commitment, second_commitment]),
+            "both commitments backed by disjoint peer sets must reconstruct"
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["peer_already_in_slot"])
+                .get(),
+            0,
+            "honest single-shard-per-peer traffic must never be dropped"
+        );
+
+        h.handle.stop().await.unwrap();
+    }
+
+    /// A slot admits at most `parity_length + 1` accumulators; past that any
+    /// further commitment is dead weight by construction and is dropped.
+    #[tokio::test]
+    async fn test_shard_admission_caps_accumulators_per_slot() {
+        telemetry_subscribers::init_for_testing();
+
+        let h = TestHarness::new(10);
+        let context = h.context.clone();
+        let tx = h.tx.clone();
+        let mut encoder = create_encoder(&context);
+        let max_accumulators = context.committee.parity_length() + 1;
+        assert!(max_accumulators < context.committee.size());
+
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build()).reference();
+
+        // Peer i creates accumulator i, one distinct commitment each, filling
+        // the slot exactly to the cap.
+        for peer in 0..max_accumulators {
+            let (commitment, shards) = encode_payload_for_slot(&context, &mut encoder, peer as u8);
+            tx.send(vec![TransactionMessage::Shard(ShardMessage {
+                transaction_ref: TransactionRef::new(block_ref, commitment),
+                block_digest: Some(block_ref.digest),
+                shard: shards[peer].clone(),
+                shard_index: peer,
+            })])
+            .await
+            .unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["slot_full"])
+                .get(),
+            0,
+            "filling the slot exactly to the cap must admit every accumulator"
+        );
+
+        // One more distinct commitment, from a peer that has not contributed to
+        // the slot yet, is refused.
+        let next_peer = max_accumulators;
+        let (commitment, shards) = encode_payload_for_slot(&context, &mut encoder, next_peer as u8);
+        tx.send(vec![TransactionMessage::Shard(ShardMessage {
+            transaction_ref: TransactionRef::new(block_ref, commitment),
+            block_digest: Some(block_ref.digest),
+            shard: shards[next_peer].clone(),
+            shard_index: next_peer,
+        })])
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["slot_full"])
+                .get(),
+            1,
+        );
+
+        h.handle.stop().await.unwrap();
+    }
+
+    /// The full payload arriving directly releases a partially filled
+    /// accumulator for that ref instead of leaving it to round eviction.
+    #[tokio::test]
+    async fn test_full_transaction_releases_pending_accumulator() {
+        telemetry_subscribers::init_for_testing();
+
+        let h = TestHarness::new(10);
+        let context = h.context.clone();
+        let tx = h.tx.clone();
+        let mut encoder = create_encoder(&context);
+        let info_length = context.committee.info_length();
+
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build()).reference();
+        let (commitment, shards) = encode_payload_for_slot(&context, &mut encoder, 1);
+        let transaction_ref = TransactionRef::new(block_ref, commitment);
+
+        // Fewer than info_length shards, so the accumulator stays pending.
+        let batch: Vec<_> = (0..info_length - 1)
+            .map(|i| {
+                TransactionMessage::Shard(ShardMessage {
+                    transaction_ref,
+                    block_digest: Some(block_ref.digest),
+                    shard: shards[i].clone(),
+                    shard_index: i,
+                })
+            })
+            .collect();
+        tx.send(batch).await.unwrap();
+
+        // The gauge is refreshed on the eviction tick (once per second).
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+        assert_eq!(
+            context.metrics.node_metrics.shard_accumulators.get(),
+            1,
+            "a partially filled accumulator is pending"
+        );
+
+        tx.send(vec![TransactionMessage::FullTransaction(transaction_ref)])
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+        assert_eq!(
+            context.metrics.node_metrics.shard_accumulators.get(),
+            0,
+            "the pending accumulator is released once the full payload arrives"
+        );
+
+        h.handle.stop().await.unwrap();
     }
 
     /// A failed reconstruction must not leak its queue entry: the ref is

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -4389,7 +4389,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Round gap of accepted block headers from Header synchronizer",
+          "description": "Round gap of accepted block headers from the header synchronizer, both requested and additional",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -4456,7 +4456,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rate(consensus_accepted_block_headers_round_gap_bucket{source=\"Header synchronizer\"}[5m])) by (le)",
+              "expr": "sum(rate(consensus_accepted_block_headers_round_gap_bucket{source=~\"Header synchronizer.*\"}[5m])) by (le)",
               "format": "heatmap",
               "fullMetaSearch": false,
               "includeNullMetadata": true,


### PR DESCRIPTION
# Description of change

Bounds two in-memory structures in Starfish ingest that grew under inputs a peer
fully controls, so growth is limited by protocol rules rather than by GC timing.

Header side:

- At most one accepted header per `(author, round)` slot on the live ingress paths.
  Suspended headers count too, so equivocations naming missing ancestors cannot
  accumulate in the block suspender. Headers requested by digest, certified
  catch-up and our own blocks stay exempt — refusing a requested ancestor would
  stall linearization.
- Unrequested headers in a header-sync response are admitted only inside the
  gap-fill window the request defines. A response that breaks it loses all of its
  unrequested headers and the serving peer is charged; both sides derive the
  window from the same request inputs.
- When serving, one header per slot in gap-fill and in cordial-knowledge offers,
  so equivocations no longer crowd out headers a requester needs. The header
  offered for a slot is the one the block being sent references, since that is
  the one the peer needs to accept it.

Shard side:

- One shard per `(relaying peer, slot)` across all accumulators, and at most
  `parity_length + 1` accumulators per slot: beyond that, too few peers remain
  uncommitted for any further commitment to reach `info_length` shards. An honest
  peer holds one shard per slot, so neither rule is reachable by honest traffic.
- Shards are kept keyed by index instead of a vector sized to the committee, and a
  directly received payload releases its pending accumulator immediately.

Beyond what the issue reports: a relayed shard's length was bounded only by the gRPC
decode limit, so each accumulator entry could hold far more than an honest shard. A
shard longer than the maximum honest length is now rejected at ingress, against a
bound derived from the encoder's own chunking.

New counters: `dropped_slot_cap_headers_total`,
`synchronizer_fetch_window_violations`, `shard_reconstructor_dropped_shards`.

## Links to any relevant issues

fixes iotaledger/iota-private#445

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo nextest run -p starfish-core` (425 passed) and `cargo simtest -p
starfish-simtests` (30 passed), plus `cargo clippy -p starfish-core --all-targets
--all-features -- -D warnings`.


