### PR TITLE
feat(iota-data-ingestion): add low-frequency progress logs to workers

### DIFF
--- a/crates/iota-data-ingestion/src/common.rs
+++ b/crates/iota-data-ingestion/src/common.rs
@@ -9,6 +9,10 @@ use iota_grpc_client::{
 };
 use iota_types::{committee::EpochId, messages_checkpoint::CheckpointSequenceNumber};
 
+/// How often the per-checkpoint workers log progress at info level: one line
+/// every this many checkpoints.
+pub const PROGRESS_LOG_INTERVAL: CheckpointSequenceNumber = 1000;
+
 /// Gets epoch id and its first checkpoint sequence number.
 ///
 /// if `None`, returns the current epoch.

--- a/crates/iota-data-ingestion/src/workers/blob.rs
+++ b/crates/iota-data-ingestion/src/workers/blob.rs
@@ -207,6 +207,10 @@ impl Worker for BlobWorker {
         self.upload_blob(bytes, chk_seq_num, Self::file_path(chk_seq_num))
             .await?;
 
+        if chk_seq_num.is_multiple_of(common::PROGRESS_LOG_INTERVAL) {
+            tracing::info!("uploaded checkpoint {chk_seq_num} to the remote store");
+        }
+
         Ok(())
     }
 }

--- a/crates/iota-data-ingestion/src/workers/historical.rs
+++ b/crates/iota-data-ingestion/src/workers/historical.rs
@@ -191,8 +191,9 @@ impl Reducer<RelayWorker> for HistoricalReducer {
                 .await?;
             }
         }
-        self.upload(uploaded_range, self.prepare_data_to_upload(buffer)?)
+        self.upload(uploaded_range.clone(), self.prepare_data_to_upload(buffer)?)
             .await?;
+        tracing::info!("committed checkpoints {uploaded_range:?} to the remote store");
         Ok(())
     }
 

--- a/crates/iota-data-ingestion/src/workers/kv_store.rs
+++ b/crates/iota-data-ingestion/src/workers/kv_store.rs
@@ -29,6 +29,8 @@ use object_store::{DynObjectStore, ObjectStoreExt, path::Path};
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
+use crate::common;
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct KVStoreTaskConfig {
@@ -264,6 +266,11 @@ impl Worker for KVStoreWorker {
             .zip(repeat(checkpoint_summary)),
         )
         .await?;
+
+        if checkpoint_number.is_multiple_of(common::PROGRESS_LOG_INTERVAL) {
+            info!("stored checkpoint {checkpoint_number} in the KV store");
+        }
+
         Ok(())
     }
 }

--- a/crates/iota-kvstore/src/bigtable/worker.rs
+++ b/crates/iota-kvstore/src/bigtable/worker.rs
@@ -11,14 +11,20 @@ use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
 use iota_sdk_types::{Address, Owner, TransactionDigest};
 use iota_types::{
-    effects::TransactionEffectsExt, full_checkpoint_content::CheckpointData,
-    messages_checkpoint::CheckpointContentsExt, transaction::TransactionAPI,
+    effects::TransactionEffectsExt,
+    full_checkpoint_content::CheckpointData,
+    messages_checkpoint::{CheckpointContentsExt, CheckpointSequenceNumber},
+    transaction::TransactionAPI,
 };
 use strum::IntoEnumIterator;
 
 use crate::{
     BigTableClient, KeyValueStoreWriter, TransactionData, client::TransactionSequenceNumber,
 };
+
+/// How often the worker logs progress at info level: one line every this many
+/// checkpoints.
+const PROGRESS_LOG_INTERVAL: CheckpointSequenceNumber = 1000;
 
 /// Represents the available BigTable tables the Client and the KvWorker can
 /// interact with.
@@ -186,6 +192,12 @@ impl Worker for KvWorker {
                 }
             }
         }
+
+        let sequence_number = checkpoint.checkpoint_summary.sequence_number;
+        if sequence_number.is_multiple_of(PROGRESS_LOG_INTERVAL) {
+            tracing::info!("stored checkpoint {sequence_number} in the KV store");
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
# Description of change

Since v1.29.0-alpha (#12344, #12462) the `iota-data-ingestion` services log nothing at info level during normal operation, so operators cannot tell from the logs whether the services are making progress.

Add low-frequency info logs to the workers:

- historical worker: one line per committed batch (one batch per `commit-duration-seconds`)
- blob (live checkpoints), KV store, and BigTable KV workers: one progress line every 1000th checkpoint

## Links to any relevant issues

fixes #12543

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)