### PR TITLE
fix(typed-store): review fixes for the tagged map and the column family work

### DIFF
--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -232,6 +232,10 @@ impl Database {
 
     /// Creates a new column family at runtime. Fails if a column family with
     /// this name already exists.
+    ///
+    /// `options` hold until the database is next opened, after which a
+    /// column family the caller does not declare is opened with the
+    /// crate's options instead. Declare it to keep them.
     pub fn create_cf(&self, name: &str, options: &rocksdb::Options) -> Result<(), TypedStoreError> {
         match &self.storage {
             Storage::Rocks(db) => nondeterministic!(db.underlying.create_cf(name, options))

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -1696,7 +1696,12 @@ where
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let from = be_fix_int_ser(&self.tag);
         let to = match prefix_iterator_bounds(&self.tag).1 {
-            Some(to) => to,
+            Some(to) => {
+                if self.is_empty() {
+                    return Ok(());
+                }
+                to
+            }
             // The maximum tag has no following tag to bound the range
             // against, so end it just past the last entry. That read is why a
             // row written in between survives the clear, and why a value that

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -32,7 +32,10 @@ use crate::{
         safe_iter::{SafeIter, SafeRevIter},
     },
     traits::{Map, TableSummary},
-    util::{be_fix_int_ser, iterator_bounds_with_range, prefix_iterator_bounds},
+    util::{
+        be_fix_int_ser, iterator_bounds_with_range, prefix_iterator_bounds,
+        prefix_iterator_bounds_with_range,
+    },
 };
 
 // The throughput floor is used to compute the threshold for when a batch write
@@ -1543,8 +1546,10 @@ where
         lower: K,
         upper: K,
     ) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + '_ {
+        let (lower_bound, upper_bound) =
+            prefix_iterator_bounds_with_range(&self.tag, lower..=upper);
         self.map
-            .safe_range_iter((self.tag, lower)..=(self.tag, upper))
+            .iter_forward_raw(lower_bound, upper_bound)
             .map(|result| result.map(|((_, key), value)| (key, value)))
     }
 
@@ -1554,8 +1559,10 @@ where
         lower: K,
         upper: K,
     ) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + '_ {
+        let (lower_bound, upper_bound) =
+            prefix_iterator_bounds_with_range(&self.tag, lower..=upper);
         self.map
-            .safe_range_iter_reversed((self.tag, lower)..=(self.tag, upper))
+            .iter_reversed_raw(lower_bound, upper_bound)
             .map(|result| result.map(|((_, key), value)| (key, value)))
     }
 }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -61,19 +61,6 @@ impl ColumnFamily {
             ColumnFamily::InMemory(name) => name,
         }
     }
-
-    pub(crate) fn rocks_cf<'a>(
-        &self,
-        rocks_db: &'a RocksDB,
-    ) -> Arc<rocksdb::BoundColumnFamily<'a>> {
-        match &self {
-            ColumnFamily::Rocks(name) => rocks_db
-                .underlying
-                .cf_handle(name)
-                .expect("the column family was deleted unexpectedly"),
-            _ => unreachable!("invariant is checked by the caller"),
-        }
-    }
 }
 
 pub(crate) enum Storage {
@@ -174,7 +161,7 @@ impl Database {
         match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => Ok(db
                 .underlying
-                .get_pinned_cf_opt(&cf.rocks_cf(db), key, readopts)
+                .get_pinned_cf_opt(&rocks_cf(db, cf.name()), key, readopts)
                 .map_err(typed_store_err_from_rocks_err)?
                 .map(GetResult::Rocks)),
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
@@ -201,7 +188,7 @@ impl Database {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => {
                 let keys_vec: Vec<K> = keys.into_iter().collect();
                 let res = db.underlying.batched_multi_get_cf_opt(
-                    &cf.rocks_cf(db),
+                    &rocks_cf(db, cf.name()),
                     keys_vec.iter(),
                     // sorted_input
                     false,
@@ -278,7 +265,7 @@ impl Database {
         let ret = match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
                 .underlying
-                .delete_cf(&cf.rocks_cf(db), key)
+                .delete_cf(&rocks_cf(db, cf.name()), key)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
                 db.delete(cf_name, key.as_ref());
@@ -310,7 +297,7 @@ impl Database {
         let ret = match (&self.storage, cf) {
             (Storage::Rocks(db), ColumnFamily::Rocks(_)) => db
                 .underlying
-                .put_cf(&cf.rocks_cf(db), key, value)
+                .put_cf(&rocks_cf(db, cf.name()), key, value)
                 .map_err(typed_store_err_from_rocks_err),
             (Storage::InMemory(db), ColumnFamily::InMemory(cf_name)) => {
                 db.put(cf_name, key, value);
@@ -521,8 +508,6 @@ pub struct DBMap<K, V> {
     iter_sample_interval: SamplingInterval,
     _metrics_task_cancel_handle: Arc<oneshot::Sender<()>>,
 }
-
-unsafe impl<K: Send, V: Send> Send for DBMap<K, V> {}
 
 impl<K, V> DBMap<K, V> {
     pub(crate) fn new(
@@ -1541,31 +1526,34 @@ where
 /// use tempfile::tempdir;
 /// use typed_store::{Map, rocks::*};
 ///
-/// let db = open_cf_opts(
-///     tempdir().unwrap(),
-///     None,
-///     MetricConf::default(),
-///     &[("shared", rocksdb::Options::default())],
-/// )
-/// .unwrap();
-///
-/// let numbers: TaggedDBMap<u32, String> =
-///     TaggedDBMap::reopen(&db, "shared", 0, &ReadWriteOptions::default(), true).unwrap();
-/// let words: TaggedDBMap<String, u64> =
-///     TaggedDBMap::reopen(&db, "shared", 1, &ReadWriteOptions::default(), true).unwrap();
-///
-/// let mut batch = numbers.batch();
-/// batch
-///     .insert_batch_tagged(&numbers, [(1, "one".to_string())])
-///     .unwrap()
-///     .insert_batch_tagged(&words, [("one".to_string(), 1)])
+/// #[tokio::main(flavor = "current_thread")]
+/// async fn main() {
+///     let db = open_cf_opts(
+///         tempdir().unwrap(),
+///         None,
+///         MetricConf::default(),
+///         &[("shared", rocksdb::Options::default())],
+///     )
 ///     .unwrap();
-/// batch.write().unwrap();
 ///
-/// assert_eq!(numbers.get(&1).unwrap(), Some("one".to_string()));
-/// assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
-/// // Each map sees only its own row.
-/// assert_eq!(numbers.safe_iter().count(), 1);
+///     let numbers: TaggedDBMap<u32, String> =
+///         TaggedDBMap::reopen(&db, "shared", 0, &ReadWriteOptions::default(), false).unwrap();
+///     let words: TaggedDBMap<String, u64> =
+///         TaggedDBMap::reopen(&db, "shared", 1, &ReadWriteOptions::default(), false).unwrap();
+///
+///     let mut batch = numbers.batch();
+///     batch
+///         .insert_batch_tagged(&numbers, [(1, "one".to_string())])
+///         .unwrap()
+///         .insert_batch_tagged(&words, [("one".to_string(), 1)])
+///         .unwrap();
+///     batch.write().unwrap();
+///
+///     assert_eq!(numbers.get(&1).unwrap(), Some("one".to_string()));
+///     assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
+///     // Each map sees only its own row.
+///     assert_eq!(numbers.safe_iter().count(), 1);
+/// }
 /// ```
 pub struct TaggedDBMap<K, V> {
     tag: u8,

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -1112,19 +1112,25 @@ impl DBBatch {
         from: &K,
         to: &K,
     ) -> Result<(), TypedStoreError> {
+        self.schedule_delete_range_raw(db, be_fix_int_ser(from), be_fix_int_ser(to))
+    }
+
+    /// [`Self::schedule_delete_range`] for a range whose bounds are not keys,
+    /// such as a whole key prefix. The bounds are raw bytes ordered like the
+    /// map's keys, i.e. in the `be_fix_int_ser` encoding; `from` is inclusive
+    /// and `to` exclusive.
+    fn schedule_delete_range_raw<K, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        from: Vec<u8>,
+        to: Vec<u8>,
+    ) -> Result<(), TypedStoreError> {
         if !Arc::ptr_eq(&db.db, &self.database) {
             return Err(TypedStoreError::CrossDBBatch);
         }
 
-        let from_buf = be_fix_int_ser(from);
-        let to_buf = be_fix_int_ser(to);
-
         if let StorageWriteBatch::Rocks(b) = &mut self.batch {
-            b.delete_range_cf(
-                &rocks_cf_from_db(&self.database, db.cf_name())?,
-                from_buf,
-                to_buf,
-            );
+            b.delete_range_cf(&rocks_cf_from_db(&self.database, db.cf_name())?, from, to);
         }
         Ok(())
     }
@@ -1524,6 +1530,31 @@ where
     ) -> Result<(), TypedStoreError> {
         batch.delete_batch(&self.map, keys.into_iter().map(|key| (self.tag, key)))?;
         Ok(())
+    }
+
+    /// Deletes every entry of the map with a single range tombstone over the
+    /// tag's key range, leaving the other tags of the column family untouched.
+    pub fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
+        let from = be_fix_int_ser(&self.tag);
+        let to = match prefix_iterator_bounds(&self.tag).1 {
+            Some(to) => to,
+            // The maximum tag has no following tag to bound the range
+            // against, so end it just past the last entry. That read is why a
+            // row written in between survives the clear, and why a value that
+            // does not deserialize fails it.
+            None => match self.iter_reversed().next().transpose()? {
+                Some((last_key, _)) => {
+                    let mut to = be_fix_int_ser(&(self.tag, last_key));
+                    to.push(0);
+                    to
+                }
+                None => return Ok(()),
+            },
+        };
+
+        let mut batch = self.batch();
+        batch.schedule_delete_range_raw(&self.map, from, to)?;
+        batch.write()
     }
 
     /// Forward iterator over all of the map's entries.

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -1078,14 +1078,28 @@ impl DBBatch {
         db: &DBMap<K, V>,
         purged_vals: impl IntoIterator<Item = J>,
     ) -> Result<(), TypedStoreError> {
+        self.delete_batch_raw_keys(
+            db,
+            purged_vals
+                .into_iter()
+                .map(|key| be_fix_int_ser(key.borrow())),
+        )
+    }
+
+    /// [`Self::delete_batch`] for keys already in the column family's
+    /// `be_fix_int_ser` encoding.
+    fn delete_batch_raw_keys<K, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        purged_vals: impl IntoIterator<Item = Vec<u8>>,
+    ) -> Result<(), TypedStoreError> {
         if !Arc::ptr_eq(&db.db, &self.database) {
             return Err(TypedStoreError::CrossDBBatch);
         }
 
         purged_vals
             .into_iter()
-            .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
-                let k_buf = be_fix_int_ser(k.borrow());
+            .try_for_each::<_, Result<_, TypedStoreError>>(|k_buf| {
                 match (&mut self.batch, &db.column_family) {
                     (StorageWriteBatch::Rocks(b), ColumnFamily::Rocks(name)) => {
                         b.delete_cf(&rocks_cf_from_db(&self.database, name)?, k_buf)
@@ -1141,14 +1155,28 @@ impl DBBatch {
         db: &DBMap<K, V>,
         new_vals: impl IntoIterator<Item = (J, U)>,
     ) -> Result<&mut Self, TypedStoreError> {
+        self.insert_batch_raw_keys(
+            db,
+            new_vals
+                .into_iter()
+                .map(|(key, value)| (be_fix_int_ser(key.borrow()), value)),
+        )
+    }
+
+    /// [`Self::insert_batch`] for keys already in the column family's
+    /// `be_fix_int_ser` encoding.
+    fn insert_batch_raw_keys<K, U: Borrow<V>, V: Serialize>(
+        &mut self,
+        db: &DBMap<K, V>,
+        new_vals: impl IntoIterator<Item = (Vec<u8>, U)>,
+    ) -> Result<&mut Self, TypedStoreError> {
         if !Arc::ptr_eq(&db.db, &self.database) {
             return Err(TypedStoreError::CrossDBBatch);
         }
         let mut total = 0usize;
         new_vals
             .into_iter()
-            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
-                let k_buf = be_fix_int_ser(k.borrow());
+            .try_for_each::<_, Result<_, TypedStoreError>>(|(k_buf, v)| {
                 let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
                 total += k_buf.len() + v_buf.len();
                 if db.opts.log_value_hash {
@@ -1180,6 +1208,34 @@ impl DBBatch {
             .with_label_values(&[db.cf_name()])
             .observe(total as f64);
         Ok(self)
+    }
+
+    /// [`Self::insert_batch`] for a map sharing its column family by tag.
+    pub fn insert_batch_tagged<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
+        &mut self,
+        map: &TaggedDBMap<K, V>,
+        new_vals: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<&mut Self, TypedStoreError> {
+        self.insert_batch_raw_keys(
+            &map.map,
+            new_vals
+                .into_iter()
+                .map(|(key, value)| (be_fix_int_ser(&(map.tag, key.borrow())), value)),
+        )
+    }
+
+    /// [`Self::delete_batch`] for a map sharing its column family by tag.
+    pub fn delete_batch_tagged<J: Borrow<K>, K: Serialize, V>(
+        &mut self,
+        map: &TaggedDBMap<K, V>,
+        purged_vals: impl IntoIterator<Item = J>,
+    ) -> Result<(), TypedStoreError> {
+        self.delete_batch_raw_keys(
+            &map.map,
+            purged_vals
+                .into_iter()
+                .map(|key| be_fix_int_ser(&(map.tag, key.borrow()))),
+        )
     }
 }
 
@@ -1476,6 +1532,12 @@ where
     K: Clone + Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
+    /// Drops the tag prefixed to a key of the underlying map, turning its row
+    /// into a row of this map.
+    fn strip_tag(row: Result<((u8, K), V), TypedStoreError>) -> Result<(K, V), TypedStoreError> {
+        row.map(|((_, key), value)| (key, value))
+    }
+
     /// Reopens an open database as a tagged map operating under `cf_name`.
     /// See [`DBMap::reopen`] for the remaining parameters.
     pub fn reopen(
@@ -1496,45 +1558,91 @@ where
         self.map.batch()
     }
 
-    pub fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
-        self.map.get(&(self.tag, key.clone()))
+    /// Reverse counterpart of [`Map::safe_range_iter`]: yields exactly the keys
+    /// of `safe_range_iter(range)` in descending order.
+    pub fn safe_range_iter_reversed(&self, range: impl RangeBounds<K>) -> DbIterator<'_, (K, V)> {
+        let (lower_bound, upper_bound) = prefix_iterator_bounds_with_range(&self.tag, range);
+        Box::new(
+            self.map
+                .iter_reversed_raw(lower_bound, upper_bound)
+                .map(Self::strip_tag),
+        )
     }
+}
 
-    pub fn multi_get(&self, keys: &[K]) -> Result<Vec<Option<V>>, TypedStoreError> {
-        self.map
-            .multi_get(keys.iter().map(|key| (self.tag, key.clone())))
-    }
+impl<'a, K, V> Map<'a, K, V> for TaggedDBMap<K, V>
+where
+    K: Clone + Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    type Error = TypedStoreError;
 
-    pub fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
+    fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
         self.map.contains_key(&(self.tag, key.clone()))
     }
 
-    pub fn insert_batch(
+    fn multi_contains_keys<J>(
         &self,
-        batch: &mut DBBatch,
-        key_val_pairs: impl IntoIterator<Item = (K, V)>,
-    ) -> Result<(), TypedStoreError> {
-        batch.insert_batch(
-            &self.map,
-            key_val_pairs
-                .into_iter()
-                .map(|(key, value)| ((self.tag, key), value)),
-        )?;
-        Ok(())
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<bool>, TypedStoreError>
+    where
+        J: Borrow<K>,
+    {
+        self.map
+            .multi_contains_keys(keys.into_iter().map(|key| (self.tag, key.borrow().clone())))
     }
 
-    pub fn delete_batch(
+    fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
+        self.map.get(&(self.tag, key.clone()))
+    }
+
+    fn multi_get<J>(
         &self,
-        batch: &mut DBBatch,
-        keys: impl IntoIterator<Item = K>,
-    ) -> Result<(), TypedStoreError> {
-        batch.delete_batch(&self.map, keys.into_iter().map(|key| (self.tag, key)))?;
-        Ok(())
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<Option<V>>, TypedStoreError>
+    where
+        J: Borrow<K>,
+    {
+        self.map
+            .multi_get(keys.into_iter().map(|key| (self.tag, key.borrow().clone())))
+    }
+
+    fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
+        self.map.insert(&(self.tag, key.clone()), value)
+    }
+
+    fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
+        self.map.remove(&(self.tag, key.clone()))
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_insert<J, U>(
+        &self,
+        key_val_pairs: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<(), TypedStoreError>
+    where
+        J: Borrow<K>,
+        U: Borrow<V>,
+    {
+        let mut batch = self.batch();
+        batch.insert_batch_tagged(self, key_val_pairs)?;
+        batch.write()
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), TypedStoreError>
+    where
+        J: Borrow<K>,
+    {
+        let mut batch = self.batch();
+        batch.delete_batch_tagged(self, keys)?;
+        batch.write()
     }
 
     /// Deletes every entry of the map with a single range tombstone over the
     /// tag's key range, leaving the other tags of the column family untouched.
-    pub fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
+    #[instrument(level = "trace", skip_all, err)]
+    fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let from = be_fix_int_ser(&self.tag);
         let to = match prefix_iterator_bounds(&self.tag).1 {
             Some(to) => to,
@@ -1542,7 +1650,7 @@ where
             // against, so end it just past the last entry. That read is why a
             // row written in between survives the clear, and why a value that
             // does not deserialize fails it.
-            None => match self.iter_reversed().next().transpose()? {
+            None => match self.safe_range_iter_reversed(..).next().transpose()? {
                 Some((last_key, _)) => {
                     let mut to = be_fix_int_ser(&(self.tag, last_key));
                     to.push(0);
@@ -1557,44 +1665,41 @@ where
         batch.write()
     }
 
-    /// Forward iterator over all of the map's entries.
-    pub fn iter(&self) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + '_ {
-        self.map
-            .safe_iter_with_prefix(&self.tag)
-            .map(|result| result.map(|((_, key), value)| (key, value)))
+    fn is_empty(&self) -> bool {
+        self.safe_iter().next().is_none()
     }
 
-    /// Reverse iterator over all of the map's entries.
-    pub fn iter_reversed(&self) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + '_ {
-        self.map
-            .safe_iter_with_prefix_reversed(&self.tag)
-            .map(|result| result.map(|((_, key), value)| (key, value)))
+    fn safe_iter(&'a self) -> DbIterator<'a, (K, V)> {
+        Box::new(
+            self.map
+                .safe_iter_with_prefix(&self.tag)
+                .map(Self::strip_tag),
+        )
     }
 
-    /// Forward iterator over the map's entries in `lower..=upper`.
-    pub fn range_iter(
-        &self,
-        lower: K,
-        upper: K,
-    ) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + '_ {
-        let (lower_bound, upper_bound) =
-            prefix_iterator_bounds_with_range(&self.tag, lower..=upper);
-        self.map
-            .iter_forward_raw(lower_bound, upper_bound)
-            .map(|result| result.map(|((_, key), value)| (key, value)))
+    fn safe_iter_with_bounds(
+        &'a self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> DbIterator<'a, (K, V)> {
+        let range = (
+            lower_bound.map(Bound::Included).unwrap_or(Bound::Unbounded),
+            upper_bound.map(Bound::Excluded).unwrap_or(Bound::Unbounded),
+        );
+        self.safe_range_iter(range)
     }
 
-    /// Reverse iterator over the map's entries in `lower..=upper`.
-    pub fn range_iter_reversed(
-        &self,
-        lower: K,
-        upper: K,
-    ) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + '_ {
-        let (lower_bound, upper_bound) =
-            prefix_iterator_bounds_with_range(&self.tag, lower..=upper);
-        self.map
-            .iter_reversed_raw(lower_bound, upper_bound)
-            .map(|result| result.map(|((_, key), value)| (key, value)))
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
+        let (lower_bound, upper_bound) = prefix_iterator_bounds_with_range(&self.tag, range);
+        Box::new(
+            self.map
+                .iter_forward_raw(lower_bound, upper_bound)
+                .map(Self::strip_tag),
+        )
+    }
+
+    fn try_catch_up_with_primary(&self) -> Result<(), TypedStoreError> {
+        self.map.try_catch_up_with_primary()
     }
 }
 

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -645,14 +645,10 @@ impl<K, V> DBMap<K, V> {
     }
 
     /// Returns a vector of raw values corresponding to the keys provided.
-    fn multi_get_pinned<J>(
+    fn multi_get_pinned(
         &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<Option<GetResult<'_>>>, TypedStoreError>
-    where
-        J: Borrow<K>,
-        K: Serialize,
-    {
+        keys_bytes: impl IntoIterator<Item = Vec<u8>>,
+    ) -> Result<Vec<Option<GetResult<'_>>>, TypedStoreError> {
         let _timer = self
             .db_metrics
             .op_metrics
@@ -664,7 +660,6 @@ impl<K, V> DBMap<K, V> {
         } else {
             None
         };
-        let keys_bytes = keys.into_iter().map(|k| be_fix_int_ser(k.borrow()));
         let results: Result<Vec<_>, TypedStoreError> = self
             .db
             .multi_get(&self.column_family, keys_bytes, &self.opts.readopts())
@@ -1218,16 +1213,9 @@ impl DBBatch {
     }
 }
 
-impl<'a, K, V> Map<'a, K, V> for DBMap<K, V>
-where
-    K: Serialize + DeserializeOwned,
-    V: Serialize + DeserializeOwned,
-{
-    type Error = TypedStoreError;
-
+impl<K, V> DBMap<K, V> {
     #[instrument(level = "trace", skip_all, err)]
-    fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
-        let key_buf = be_fix_int_ser(key);
+    pub(crate) fn contains_raw_key(&self, key_buf: Vec<u8>) -> Result<bool, TypedStoreError> {
         let readopts = self.opts.readopts();
         Ok(self
             .db
@@ -1239,19 +1227,19 @@ where
     }
 
     #[instrument(level = "trace", skip_all, err)]
-    fn multi_contains_keys<J>(
+    pub(crate) fn multi_contains_raw_keys(
         &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<bool>, Self::Error>
-    where
-        J: Borrow<K>,
-    {
+        keys: impl IntoIterator<Item = Vec<u8>>,
+    ) -> Result<Vec<bool>, TypedStoreError> {
         let values = self.multi_get_pinned(keys)?;
         Ok(values.into_iter().map(|v| v.is_some()).collect())
     }
 
     #[instrument(level = "trace", skip_all, err)]
-    fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
+    pub(crate) fn get_raw_key(&self, key_buf: Vec<u8>) -> Result<Option<V>, TypedStoreError>
+    where
+        V: DeserializeOwned,
+    {
         let _timer = self
             .db_metrics
             .op_metrics
@@ -1263,7 +1251,6 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key);
         let res = self
             .db
             .get(&self.column_family, &key_buf, &self.opts.readopts())?;
@@ -1298,7 +1285,10 @@ where
     }
 
     #[instrument(level = "trace", skip_all, err)]
-    fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
+    pub(crate) fn insert_raw_key(&self, key_buf: Vec<u8>, value: &V) -> Result<(), TypedStoreError>
+    where
+        V: Serialize,
+    {
         let timer = self
             .db_metrics
             .op_metrics
@@ -1310,7 +1300,6 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key);
         let value_buf = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
         self.db_metrics
             .op_metrics
@@ -1343,7 +1332,7 @@ where
     }
 
     #[instrument(level = "trace", skip_all, err)]
-    fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
+    pub(crate) fn remove_raw_key(&self, key_buf: Vec<u8>) -> Result<(), TypedStoreError> {
         let _timer = self
             .db_metrics
             .op_metrics
@@ -1355,7 +1344,6 @@ where
         } else {
             None
         };
-        let key_buf = be_fix_int_ser(key);
         self.db.delete_cf(&self.column_family, key_buf)?;
         self.db_metrics
             .op_metrics
@@ -1368,6 +1356,62 @@ where
                 .report_metrics(self.cf_name());
         }
         Ok(())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    pub(crate) fn multi_get_raw_keys(
+        &self,
+        keys: impl IntoIterator<Item = Vec<u8>>,
+    ) -> Result<Vec<Option<V>>, TypedStoreError>
+    where
+        V: DeserializeOwned,
+    {
+        let results = self.multi_get_pinned(keys)?;
+        let values_parsed: Result<Vec<_>, TypedStoreError> = results
+            .into_iter()
+            .map(|value_byte| match value_byte {
+                Some(data) => Ok(Some(
+                    bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
+                )),
+                None => Ok(None),
+            })
+            .collect();
+
+        values_parsed
+    }
+}
+
+impl<'a, K, V> Map<'a, K, V> for DBMap<K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    type Error = TypedStoreError;
+
+    fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
+        self.contains_raw_key(be_fix_int_ser(key))
+    }
+
+    fn multi_contains_keys<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<bool>, Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        self.multi_contains_raw_keys(keys.into_iter().map(|k| be_fix_int_ser(k.borrow())))
+    }
+
+    fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
+        self.get_raw_key(be_fix_int_ser(key))
+    }
+
+    fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
+        self.insert_raw_key(be_fix_int_ser(key), value)
+    }
+
+    fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
+        self.remove_raw_key(be_fix_int_ser(key))
     }
 
     /// Writes a range delete tombstone to delete all entries in the db map.
@@ -1441,7 +1485,6 @@ where
     }
 
     /// Returns a vector of values corresponding to the keys provided.
-    #[instrument(level = "trace", skip_all, err)]
     fn multi_get<J>(
         &self,
         keys: impl IntoIterator<Item = J>,
@@ -1449,18 +1492,7 @@ where
     where
         J: Borrow<K>,
     {
-        let results = self.multi_get_pinned(keys)?;
-        let values_parsed: Result<Vec<_>, TypedStoreError> = results
-            .into_iter()
-            .map(|value_byte| match value_byte {
-                Some(data) => Ok(Some(
-                    bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
-                )),
-                None => Ok(None),
-            })
-            .collect();
-
-        values_parsed
+        self.multi_get_raw_keys(keys.into_iter().map(|k| be_fix_int_ser(k.borrow())))
     }
 
     /// Convenience method for batch insertion
@@ -1583,13 +1615,13 @@ impl<K, V> TaggedDBMap<K, V> {
 
 impl<'a, K, V> Map<'a, K, V> for TaggedDBMap<K, V>
 where
-    K: Clone + Serialize + DeserializeOwned,
+    K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
     type Error = TypedStoreError;
 
     fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
-        self.map.contains_key(&(self.tag, key.clone()))
+        self.map.contains_raw_key(be_fix_int_ser(&(self.tag, key)))
     }
 
     fn multi_contains_keys<J>(
@@ -1599,12 +1631,14 @@ where
     where
         J: Borrow<K>,
     {
-        self.map
-            .multi_contains_keys(keys.into_iter().map(|key| (self.tag, key.borrow().clone())))
+        self.map.multi_contains_raw_keys(
+            keys.into_iter()
+                .map(|key| be_fix_int_ser(&(self.tag, key.borrow()))),
+        )
     }
 
     fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
-        self.map.get(&(self.tag, key.clone()))
+        self.map.get_raw_key(be_fix_int_ser(&(self.tag, key)))
     }
 
     fn multi_get<J>(
@@ -1614,16 +1648,19 @@ where
     where
         J: Borrow<K>,
     {
-        self.map
-            .multi_get(keys.into_iter().map(|key| (self.tag, key.borrow().clone())))
+        self.map.multi_get_raw_keys(
+            keys.into_iter()
+                .map(|key| be_fix_int_ser(&(self.tag, key.borrow()))),
+        )
     }
 
     fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
-        self.map.insert(&(self.tag, key.clone()), value)
+        self.map
+            .insert_raw_key(be_fix_int_ser(&(self.tag, key)), value)
     }
 
     fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
-        self.map.remove(&(self.tag, key.clone()))
+        self.map.remove_raw_key(be_fix_int_ser(&(self.tag, key)))
     }
 
     #[instrument(level = "trace", skip_all, err)]

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -238,14 +238,7 @@ impl Database {
     /// this name already exists.
     pub fn create_cf(&self, name: &str, options: &rocksdb::Options) -> Result<(), rocksdb::Error> {
         match &self.storage {
-            Storage::Rocks(db) => {
-                db.underlying.create_cf(name, options)?;
-                let mut cf_names = db.cf_names.write().expect("lock should not be poisoned");
-                if !cf_names.iter().any(|cf| cf == name) {
-                    cf_names.push(name.to_string());
-                }
-                Ok(())
-            }
+            Storage::Rocks(db) => db.underlying.create_cf(name, options),
             Storage::InMemory(db) => {
                 db.create_cf(name);
                 Ok(())
@@ -255,14 +248,7 @@ impl Database {
 
     pub fn drop_cf(&self, name: &str) -> Result<(), rocksdb::Error> {
         match &self.storage {
-            Storage::Rocks(db) => {
-                db.underlying.drop_cf(name)?;
-                db.cf_names
-                    .write()
-                    .expect("lock should not be poisoned")
-                    .retain(|cf| cf != name);
-                Ok(())
-            }
+            Storage::Rocks(db) => db.underlying.drop_cf(name),
             Storage::InMemory(db) => {
                 db.drop_cf(name);
                 Ok(())
@@ -367,20 +353,20 @@ impl Database {
         }
     }
 
-    /// Iterate all column families and flush the memtables of every column
-    /// family to SST files on disk.
+    /// Flush the memtables of every column family of the database to SST files
+    /// on disk.
     pub fn flush_all(&self) -> Result<(), TypedStoreError> {
         match &self.storage {
             // See `flush_cf` for why the flushes run off the test thread under
             // the simulator.
             Storage::Rocks(rocks) => nondeterministic!({
-                let cf_names = rocks
-                    .cf_names
-                    .read()
-                    .expect("lock should not be poisoned")
-                    .clone();
-                for cf_name in &cf_names {
-                    if let Some(cf) = rocks.underlying.cf_handle(cf_name) {
+                for cf_name in rocks.cf_names().map_err(|e| {
+                    TypedStoreError::RocksDB(format!(
+                        "Failed to list column families of {}: {e}",
+                        rocks.underlying.path().display()
+                    ))
+                })? {
+                    if let Some(cf) = rocks.underlying.cf_handle(&cf_name) {
                         rocks.underlying.flush_cf(&cf).map_err(|e| {
                             TypedStoreError::RocksDB(format!(
                                 "Failed to flush column family {cf_name}: {e}"
@@ -629,8 +615,8 @@ impl<K, V> DBMap<K, V> {
         self.db.flush_cf(&self.column_family)
     }
 
-    /// Iterate all column families and flush the memtables of every column
-    /// family to SST files on disk.
+    /// Flush the memtables of every column family of the database to SST files
+    /// on disk.
     pub fn flush_all(&self) -> Result<(), TypedStoreError> {
         self.db.flush_all()
     }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -1012,7 +1012,7 @@ impl DBBatch {
             .rocksdb_batch_commit_latency_seconds
             .with_label_values(&[&db_name])
             .start_timer();
-        let batch_size = self.size_in_bytes();
+        let batch_size_bytes = self.size_in_bytes();
 
         let perf_ctx = if self.write_sample_interval.sample() {
             Some(RocksDBPerfContext)
@@ -1024,20 +1024,20 @@ impl DBBatch {
             .op_metrics
             .rocksdb_batch_commit_bytes
             .with_label_values(&[&db_name])
-            .observe(batch_size as f64);
+            .observe(batch_size_bytes as f64);
 
         if perf_ctx.is_some() {
             self.db_metrics
                 .write_perf_ctx_metrics
                 .report_metrics(&db_name);
         }
-        let elapsed = timer.stop_and_record();
-        let threshold_secs = very_slow_batch_write_threshold_secs(batch_size);
-        if elapsed > threshold_secs {
+        let elapsed_secs = timer.stop_and_record();
+        let threshold_secs = very_slow_batch_write_threshold_secs(batch_size_bytes);
+        if elapsed_secs > threshold_secs {
             warn!(
-                ?elapsed,
+                elapsed_secs,
                 threshold_secs,
-                batch_size,
+                batch_size_bytes,
                 ?db_name,
                 "very slow batch write"
             );
@@ -1050,7 +1050,7 @@ impl DBBatch {
                 .op_metrics
                 .rocksdb_very_slow_batch_writes_duration_ms
                 .with_label_values(&[&db_name])
-                .inc_by((elapsed * 1000.0) as u64);
+                .inc_by((elapsed_secs * 1000.0) as u64);
         }
         Ok(())
     }
@@ -1334,9 +1334,9 @@ where
         }
         self.db.put_cf(&self.column_family, key_buf, value_buf)?;
 
-        let elapsed = timer.stop_and_record();
-        if elapsed > 1.0 {
-            warn!(?elapsed, cf = ?self.cf_name(), "very slow insert");
+        let elapsed_secs = timer.stop_and_record();
+        if elapsed_secs > 1.0 {
+            warn!(elapsed_secs, cf = ?self.cf_name(), "very slow insert");
             self.db_metrics
                 .op_metrics
                 .rocksdb_very_slow_puts_count
@@ -1346,7 +1346,7 @@ where
                 .op_metrics
                 .rocksdb_very_slow_puts_duration_ms
                 .with_label_values(&[self.cf_name()])
-                .inc_by((elapsed * 1000.0) as u64);
+                .inc_by((elapsed_secs * 1000.0) as u64);
         }
 
         Ok(())
@@ -1698,9 +1698,11 @@ fn default_hash(value: &[u8]) -> Digest<32> {
     hasher.finalize()
 }
 
-// Kept well below the write rate a healthy disk sustains, so that only
-// genuinely degraded writes are reported.
-const THROUGHPUT_FLOOR_BYTES_PER_SEC: f64 = 32.0 * 1024.0 * 1024.0;
+// The throughput floor is used to compute the threshold for when a batch write
+// is considered "very slow".
+const THROUGHPUT_FLOOR_BYTES_PER_SEC: f64 = 32.0 * 1024.0 * 1024.0; // 32 MiB/s
+
+// A batch write that took less than this is never reported as very slow.
 const MIN_VERY_SLOW_BATCH_WRITE_SECS: f64 = 1.0;
 
 /// Returns the elapsed time above which a batch write of `batch_size_bytes` is

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -70,7 +70,7 @@ impl ColumnFamily {
             ColumnFamily::Rocks(name) => rocks_db
                 .underlying
                 .cf_handle(name)
-                .expect("Map-keying column family should have been checked at DB creation"),
+                .expect("the column family was deleted unexpectedly"),
             _ => unreachable!("invariant is checked by the caller"),
         }
     }
@@ -232,9 +232,10 @@ impl Database {
 
     /// Creates a new column family at runtime. Fails if a column family with
     /// this name already exists.
-    pub fn create_cf(&self, name: &str, options: &rocksdb::Options) -> Result<(), rocksdb::Error> {
+    pub fn create_cf(&self, name: &str, options: &rocksdb::Options) -> Result<(), TypedStoreError> {
         match &self.storage {
-            Storage::Rocks(db) => db.underlying.create_cf(name, options),
+            Storage::Rocks(db) => nondeterministic!(db.underlying.create_cf(name, options))
+                .map_err(typed_store_err_from_rocks_err),
             Storage::InMemory(db) => {
                 db.create_cf(name);
                 Ok(())
@@ -242,9 +243,19 @@ impl Database {
         }
     }
 
-    pub fn drop_cf(&self, name: &str) -> Result<(), rocksdb::Error> {
+    /// Maps on the column family have to be dropped first: a map resolves
+    /// it on every operation and panics once it is gone.
+    pub fn drop_cf(&self, name: &str) -> Result<(), TypedStoreError> {
+        if name == rocksdb::DEFAULT_COLUMN_FAMILY_NAME {
+            // rocksdb refuses this, but not before its wrapper has taken the
+            // handle out of its own map, losing it for the rest of the process.
+            return Err(TypedStoreError::RocksDB(format!(
+                "the {name} column family cannot be dropped"
+            )));
+        }
         match &self.storage {
-            Storage::Rocks(db) => db.underlying.drop_cf(name),
+            Storage::Rocks(db) => nondeterministic!(db.underlying.drop_cf(name))
+                .map_err(typed_store_err_from_rocks_err),
             Storage::InMemory(db) => {
                 db.drop_cf(name);
                 Ok(())
@@ -483,7 +494,7 @@ fn rocks_cf_from_db<'a>(
         Storage::Rocks(rocksdb) => Ok(rocksdb
             .underlying
             .cf_handle(cf_name)
-            .expect("Map-keying column family should have been checked at DB creation")),
+            .expect("the column family was deleted unexpectedly")),
         _ => Err(TypedStoreError::RocksDB(
             "using invalid batch type for the database".to_string(),
         )),
@@ -576,6 +587,9 @@ impl<K, V> DBMap<K, V> {
         let cf_key = opt_cf
             .unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
             .to_owned();
+        if db.cf_handle(&cf_key).is_none() {
+            return Err(TypedStoreError::UnregisteredColumn(cf_key));
+        }
 
         let column_family = match &db.storage {
             Storage::Rocks(_) => ColumnFamily::Rocks(cf_key),

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -1652,6 +1652,9 @@ where
 
     /// Deletes every entry of the map with a single range tombstone over the
     /// tag's key range, leaving the other tags of the column family untouched.
+    ///
+    /// The entries stay on disk until compaction, and until then iteration
+    /// is slowed because of them.
     #[instrument(level = "trace", skip_all, err)]
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let from = be_fix_int_ser(&self.tag);

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -236,6 +236,7 @@ impl Database {
     /// `options` hold until the database is next opened, after which a
     /// column family the caller does not declare is opened with the
     /// crate's options instead. Declare it to keep them.
+    #[instrument(level = "debug", skip(self, options), err)]
     pub fn create_cf(&self, name: &str, options: &rocksdb::Options) -> Result<(), TypedStoreError> {
         match &self.storage {
             Storage::Rocks(db) => nondeterministic!(db.underlying.create_cf(name, options))
@@ -249,6 +250,7 @@ impl Database {
 
     /// Maps on the column family have to be dropped first: a map resolves
     /// it on every operation and panics once it is gone.
+    #[instrument(level = "debug", skip(self), err)]
     pub fn drop_cf(&self, name: &str) -> Result<(), TypedStoreError> {
         if name == rocksdb::DEFAULT_COLUMN_FAMILY_NAME {
             // rocksdb refuses this, but not before its wrapper has taken the
@@ -937,7 +939,7 @@ impl<K, V> DBMap<K, V> {
 /// use tempfile::tempdir;
 /// use typed_store::{Map, metrics::DBMetrics, rocks::*};
 ///
-/// #[tokio::main]
+/// #[tokio::main(flavor = "current_thread")]
 /// async fn main() -> Result<(), Error> {
 ///     let rocks = open_cf_opts(
 ///         tempfile::tempdir().unwrap(),
@@ -1529,16 +1531,48 @@ where
 ///
 /// Tags of existing maps must never change or be reused, or old rows would
 /// be read under the wrong types.
+///
+/// Metrics are labelled by column family, so all the maps of one column
+/// family report together, with no way to tell the tags apart.
+///
+/// # Examples
+///
+/// ```
+/// use tempfile::tempdir;
+/// use typed_store::{Map, rocks::*};
+///
+/// let db = open_cf_opts(
+///     tempdir().unwrap(),
+///     None,
+///     MetricConf::default(),
+///     &[("shared", rocksdb::Options::default())],
+/// )
+/// .unwrap();
+///
+/// let numbers: TaggedDBMap<u32, String> =
+///     TaggedDBMap::reopen(&db, "shared", 0, &ReadWriteOptions::default(), true).unwrap();
+/// let words: TaggedDBMap<String, u64> =
+///     TaggedDBMap::reopen(&db, "shared", 1, &ReadWriteOptions::default(), true).unwrap();
+///
+/// let mut batch = numbers.batch();
+/// batch
+///     .insert_batch_tagged(&numbers, [(1, "one".to_string())])
+///     .unwrap()
+///     .insert_batch_tagged(&words, [("one".to_string(), 1)])
+///     .unwrap();
+/// batch.write().unwrap();
+///
+/// assert_eq!(numbers.get(&1).unwrap(), Some("one".to_string()));
+/// assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
+/// // Each map sees only its own row.
+/// assert_eq!(numbers.safe_iter().count(), 1);
+/// ```
 pub struct TaggedDBMap<K, V> {
     tag: u8,
     map: DBMap<(u8, K), V>,
 }
 
-impl<K, V> TaggedDBMap<K, V>
-where
-    K: Clone + Serialize + DeserializeOwned,
-    V: Serialize + DeserializeOwned,
-{
+impl<K, V> TaggedDBMap<K, V> {
     /// Drops the tag prefixed to a key of the underlying map, turning its row
     /// into a row of this map.
     fn strip_tag(row: Result<((u8, K), V), TypedStoreError>) -> Result<(K, V), TypedStoreError> {
@@ -1567,7 +1601,11 @@ where
 
     /// Reverse counterpart of [`Map::safe_range_iter`]: yields exactly the keys
     /// of `safe_range_iter(range)` in descending order.
-    pub fn safe_range_iter_reversed(&self, range: impl RangeBounds<K>) -> DbIterator<'_, (K, V)> {
+    pub fn safe_range_iter_reversed(&self, range: impl RangeBounds<K>) -> DbIterator<'_, (K, V)>
+    where
+        K: Serialize + DeserializeOwned,
+        V: DeserializeOwned,
+    {
         let (lower_bound, upper_bound) = prefix_iterator_bounds_with_range(&self.tag, range);
         Box::new(
             self.map

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -836,21 +836,6 @@ impl<K, V> DBMap<K, V> {
         }
     }
 
-    /// Reverse counterpart of [`Map::safe_range_iter`]: yields exactly the keys
-    /// of `safe_range_iter(range)` in descending order.
-    ///
-    /// Both directions derive their bounds from the same
-    /// `iterator_bounds_with_range`, so they are guaranteed to cover the
-    /// identical set of keys regardless of the bound inclusivity.
-    pub fn safe_range_iter_reversed(&self, range: impl RangeBounds<K>) -> DbIterator<'_, (K, V)>
-    where
-        K: Serialize + DeserializeOwned,
-        V: DeserializeOwned,
-    {
-        let (lower_bound, upper_bound) = iterator_bounds_with_range(range);
-        self.iter_reversed_raw(lower_bound, upper_bound)
-    }
-
     /// Forward iterator over every entry whose key begins with `prefix`.
     ///
     /// `prefix` is serialized with `be_fix_int_ser` and must form a prefix of
@@ -1447,6 +1432,14 @@ where
         self.iter_forward_raw(lower_bound, upper_bound)
     }
 
+    /// Both directions derive their bounds from the same
+    /// `iterator_bounds_with_range`, so they are guaranteed to cover the
+    /// identical set of keys regardless of the bound inclusivity.
+    fn safe_range_iter_reversed(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
+        let (lower_bound, upper_bound) = iterator_bounds_with_range(range);
+        self.iter_reversed_raw(lower_bound, upper_bound)
+    }
+
     /// Returns a vector of values corresponding to the keys provided.
     #[instrument(level = "trace", skip_all, err)]
     fn multi_get<J>(
@@ -1586,21 +1579,6 @@ impl<K, V> TaggedDBMap<K, V> {
     pub fn batch(&self) -> DBBatch {
         self.map.batch()
     }
-
-    /// Reverse counterpart of [`Map::safe_range_iter`]: yields exactly the keys
-    /// of `safe_range_iter(range)` in descending order.
-    pub fn safe_range_iter_reversed(&self, range: impl RangeBounds<K>) -> DbIterator<'_, (K, V)>
-    where
-        K: Serialize + DeserializeOwned,
-        V: DeserializeOwned,
-    {
-        let (lower_bound, upper_bound) = prefix_iterator_bounds_with_range(&self.tag, range);
-        Box::new(
-            self.map
-                .iter_reversed_raw(lower_bound, upper_bound)
-                .map(Self::strip_tag),
-        )
-    }
 }
 
 impl<'a, K, V> Map<'a, K, V> for TaggedDBMap<K, V>
@@ -1727,6 +1705,15 @@ where
         Box::new(
             self.map
                 .iter_forward_raw(lower_bound, upper_bound)
+                .map(Self::strip_tag),
+        )
+    }
+
+    fn safe_range_iter_reversed(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
+        let (lower_bound, upper_bound) = prefix_iterator_bounds_with_range(&self.tag, range);
+        Box::new(
+            self.map
+                .iter_reversed_raw(lower_bound, upper_bound)
                 .map(Self::strip_tag),
         )
     }

--- a/crates/typed-store/src/database.rs
+++ b/crates/typed-store/src/database.rs
@@ -38,10 +38,6 @@ use crate::{
     },
 };
 
-// The throughput floor is used to compute the threshold for when a batch write
-// is considered "very slow".
-const THROUGHPUT_FLOOR_BYTES_PER_SEC: f64 = 32.0 * 1024.0 * 1024.0;
-
 #[derive(Clone)]
 pub(crate) enum ColumnFamily {
     Rocks(String),
@@ -1036,8 +1032,15 @@ impl DBBatch {
                 .report_metrics(&db_name);
         }
         let elapsed = timer.stop_and_record();
-        if elapsed > very_slow_batch_write_threshold_secs(batch_size) {
-            warn!(?elapsed, batch_size, ?db_name, "very slow batch write");
+        let threshold_secs = very_slow_batch_write_threshold_secs(batch_size);
+        if elapsed > threshold_secs {
+            warn!(
+                ?elapsed,
+                threshold_secs,
+                batch_size,
+                ?db_name,
+                "very slow batch write"
+            );
             self.db_metrics
                 .op_metrics
                 .rocksdb_very_slow_batch_writes_count
@@ -1695,11 +1698,37 @@ fn default_hash(value: &[u8]) -> Digest<32> {
     hasher.finalize()
 }
 
-/// Elapsed time above which a batch write is reported as very slow.
-/// Large batches get time proportional to their size, at a deliberately
-/// conservative throughput floor, while a small write taking that long is a
-/// genuine stall and must be reported.
+// Kept well below the write rate a healthy disk sustains, so that only
+// genuinely degraded writes are reported.
+const THROUGHPUT_FLOOR_BYTES_PER_SEC: f64 = 32.0 * 1024.0 * 1024.0;
+const MIN_VERY_SLOW_BATCH_WRITE_SECS: f64 = 1.0;
+
+/// Returns the elapsed time above which a batch write of `batch_size_bytes` is
+/// reported as very slow: what it would take at
+/// [`THROUGHPUT_FLOOR_BYTES_PER_SEC`], and never less than
+/// [`MIN_VERY_SLOW_BATCH_WRITE_SECS`].
 fn very_slow_batch_write_threshold_secs(batch_size_bytes: usize) -> f64 {
-    const MIN_THRESHOLD_SECS: f64 = 1.0;
-    (batch_size_bytes as f64 / THROUGHPUT_FLOOR_BYTES_PER_SEC).max(MIN_THRESHOLD_SECS)
+    (batch_size_bytes as f64 / THROUGHPUT_FLOOR_BYTES_PER_SEC).max(MIN_VERY_SLOW_BATCH_WRITE_SECS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::very_slow_batch_write_threshold_secs;
+
+    const MIB: usize = 1024 * 1024;
+
+    #[test]
+    fn very_slow_batch_write_threshold_never_below_one_second() {
+        assert_eq!(very_slow_batch_write_threshold_secs(0), 1.0);
+        assert_eq!(very_slow_batch_write_threshold_secs(1), 1.0);
+        assert_eq!(very_slow_batch_write_threshold_secs(MIB), 1.0);
+        assert_eq!(very_slow_batch_write_threshold_secs(32 * MIB), 1.0);
+    }
+
+    #[test]
+    fn very_slow_batch_write_threshold_grows_with_batch_size() {
+        assert_eq!(very_slow_batch_write_threshold_secs(48 * MIB), 1.5);
+        assert_eq!(very_slow_batch_write_threshold_secs(64 * MIB), 2.0);
+        assert_eq!(very_slow_batch_write_threshold_secs(320 * MIB), 10.0);
+    }
 }

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -115,7 +115,7 @@ pub type StoreError = typed_store_error::TypedStoreError;
 ///     #[default_options_override_fn = "custom_fn_name1"]
 ///     table4: DBMap<i32, String>,
 /// }
-/// #[tokio::main]
+/// #[tokio::main(flavor = "current_thread")]
 /// async fn main() -> Result<(), Error> {
 ///     use typed_store::rocks::MetricConf;
 ///     let primary_path = tempfile::tempdir()

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -503,7 +503,7 @@ impl OperationMetrics {
             .unwrap(),
             rocksdb_very_slow_batch_writes_duration_ms: register_int_counter_vec_with_registry!(
                 "rocksdb_very_slow_batch_writes_duration",
-                "Total duration of batch writes that took more than 1 second and were slower than 32 MiB/s",
+                "Total time in milliseconds spent on batch writes that took more than 1 second and were slower than 32 MiB/s",
                 &["db_name"],
                 registry;
                 MetricLevel::Trace,
@@ -519,7 +519,7 @@ impl OperationMetrics {
             .unwrap(),
             rocksdb_very_slow_puts_duration_ms: register_int_counter_vec_with_registry!(
                 "rocksdb_very_slow_puts_duration",
-                "Total duration of puts that took more than 1 second",
+                "Total time in milliseconds spent on puts that took more than 1 second",
                 &["cf_name"],
                 registry;
                 MetricLevel::Trace,

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -495,7 +495,7 @@ impl OperationMetrics {
             .unwrap(),
             rocksdb_very_slow_batch_writes_count: register_int_counter_vec_with_registry!(
                 "rocksdb_num_very_slow_batch_writes",
-                "Number of batch writes that took more than 1 second",
+                "Number of batch writes that took more than 1 second and were slower than 32 MiB/s",
                 &["db_name"],
                 registry;
                 MetricLevel::Trace,
@@ -503,7 +503,7 @@ impl OperationMetrics {
             .unwrap(),
             rocksdb_very_slow_batch_writes_duration_ms: register_int_counter_vec_with_registry!(
                 "rocksdb_very_slow_batch_writes_duration",
-                "Total duration of batch writes that took more than 1 second",
+                "Total duration of batch writes that took more than 1 second and were slower than 32 MiB/s",
                 &["db_name"],
                 registry;
                 MetricLevel::Trace,

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -55,12 +55,13 @@ impl SamplingInterval {
     pub fn new(once_every_duration: Duration, after_num_ops: u64) -> Self {
         let counter = Arc::new(AtomicU64::new(1));
         if !once_every_duration.is_zero() {
-            let counter = counter.clone();
+            let counter = Arc::downgrade(&counter);
             tokio::task::spawn(async move {
-                loop {
+                while let Some(counter) = counter.upgrade() {
                     if counter.load(Ordering::SeqCst) > after_num_ops {
                         counter.store(0, Ordering::SeqCst);
                     }
+                    drop(counter);
                     tokio::time::sleep(once_every_duration).await;
                 }
             });
@@ -1099,5 +1100,47 @@ impl DBMetrics {
         // `init` has run. `get_or_init` ensures the rocksdb metrics are
         // registered at most once even when first reached concurrently.
         ONCE.get_or_init(|| Arc::new(DBMetrics::new(prometheus_filtered::default_registry())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::metrics::SamplingInterval;
+
+    // `RuntimeMetrics` is not provided by the deterministic simulator's tokio
+    // fork. Under the simulator `#[tokio::test]` is turned into an ignored test
+    // anyway, so this turns off nothing that would otherwise run.
+    #[cfg(not(msim))]
+    fn alive_tasks() -> usize {
+        tokio::runtime::Handle::current()
+            .metrics()
+            .num_alive_tasks()
+    }
+
+    /// A timed interval keeps a task resetting its counter, and that task stops
+    /// once the last clone of the interval is dropped.
+    #[cfg(not(msim))]
+    #[tokio::test]
+    async fn a_dropped_interval_stops_its_task() {
+        let tasks_before = alive_tasks();
+        let interval = SamplingInterval::new(Duration::from_millis(10), 0);
+        let clone = interval.clone();
+        assert_eq!(alive_tasks(), tasks_before + 1);
+
+        drop(interval);
+        drop(clone);
+        for _ in 0..100 {
+            if alive_tasks() == tasks_before {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            alive_tasks(),
+            tasks_before,
+            "the task outlived the interval"
+        );
     }
 }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -262,6 +262,9 @@ pub async fn safe_drop_db(path: PathBuf, timeout: Duration) -> Result<(), rocksd
     }
 }
 
+/// Lists what is on disk and adds anything the caller did not declare, because
+/// rocksdb refuses to open a database unless every column family it has is
+/// named.
 fn populate_missing_cfs(
     input_cfs: &[(&str, rocksdb::Options)],
     path: &Path,

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -11,7 +11,7 @@ use std::{
     collections::HashSet,
     ffi::CStr,
     path::{Path, PathBuf},
-    sync::{Arc, RwLock},
+    sync::Arc,
     time::Duration,
 };
 
@@ -53,9 +53,16 @@ mod tests;
 #[derive(Debug)]
 pub(crate) struct RocksDB {
     pub(crate) underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
-    /// Names of all column families opened on this database, kept in sync
-    /// with column families created or dropped at runtime.
-    pub(crate) cf_names: RwLock<Vec<String>>,
+}
+
+impl RocksDB {
+    /// Returns the names of the column families the database has on disk.
+    pub(crate) fn cf_names(&self) -> Result<Vec<String>, rocksdb::Error> {
+        rocksdb::DBWithThreadMode::<MultiThreaded>::list_cf(
+            &rocksdb::Options::default(),
+            self.underlying.path(),
+        )
+    }
 }
 
 impl Drop for RocksDB {
@@ -129,7 +136,6 @@ pub fn open_cf_opts<P: AsRef<Path>>(
         let mut options = db_options.unwrap_or_else(|| default_db_options().options);
         options.create_if_missing(true);
         options.create_missing_column_families(true);
-        let cf_names: Vec<String> = cfs.iter().map(|(name, _)| name.clone()).collect();
         let rocksdb = {
             rocksdb::DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
                 &options,
@@ -142,7 +148,6 @@ pub fn open_cf_opts<P: AsRef<Path>>(
         Ok(Arc::new(Database::new(
             Storage::Rocks(RocksDB {
                 underlying: rocksdb,
-                cf_names: RwLock::new(cf_names),
             }),
             metric_conf,
         )))
@@ -206,11 +211,9 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
                 .map_err(typed_store_err_from_rocks_err)?;
             db
         };
-        let cf_names: Vec<String> = opt_cfs.keys().map(|name| name.to_string()).collect();
         Ok(Arc::new(Database::new(
             Storage::Rocks(RocksDB {
                 underlying: rocksdb,
-                cf_names: RwLock::new(cf_names),
             }),
             metric_conf,
         )))

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -273,10 +273,22 @@ fn populate_missing_cfs(
             .ok()
             .unwrap_or_default();
 
+    let default_db_options = default_db_options();
+    let mut names_default = false;
     for cf_name in existing_cfs {
+        names_default |= cf_name == rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
         if !input_cf_index.contains(&cf_name[..]) {
-            cfs.push((cf_name, rocksdb::Options::default()));
+            cfs.push((cf_name, default_db_options.options.clone()));
         }
+    }
+    // A database that does not exist yet has nothing to list, so the column
+    // family rocksdb always opens has to be named here: its wrapper otherwise
+    // adds it with the rocksdb defaults of its own.
+    if !names_default && !input_cf_index.contains(rocksdb::DEFAULT_COLUMN_FAMILY_NAME) {
+        cfs.push((
+            rocksdb::DEFAULT_COLUMN_FAMILY_NAME.to_owned(),
+            default_db_options.options,
+        ));
     }
     cfs.extend(
         input_cfs

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -78,7 +78,7 @@ pub(crate) fn rocks_cf<'a>(
     rocks_db
         .underlying
         .cf_handle(cf_name)
-        .expect("Map-keying column family should have been checked at DB creation")
+        .expect("the column family was deleted unexpectedly")
 }
 
 // Check if the database is corrupted, and if so, panic.

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1037,7 +1037,7 @@ async fn open_as_secondary_test() {
 }
 
 #[tokio::test]
-async fn test_create_cf_at_runtime() {
+async fn a_column_family_can_be_created_at_runtime() {
     let tmp_dir = iota_common::tempdir();
     let path = tmp_dir.path();
     {
@@ -1106,7 +1106,7 @@ async fn test_create_cf_at_runtime() {
 /// rows surfacing in each other: gets, full scans in both directions,
 /// bounded ranges, and deletes all stay within their map's tag.
 #[tokio::test]
-async fn test_tagged_dbmaps_share_a_column_family() {
+async fn tagged_dbmaps_share_a_column_family() {
     let tmp_dir = iota_common::tempdir();
     let db = open_rocksdb(tmp_dir.path(), &["shared"]);
     let numbers: TaggedDBMap<u32, String> =
@@ -1123,6 +1123,18 @@ async fn test_tagged_dbmaps_share_a_column_family() {
         .insert_batch_tagged(&words, [("one".to_string(), 1), ("two".to_string(), 2)])
         .unwrap();
     batch.write().unwrap();
+
+    // The rows are in the named column family, under the tagged keys, and not
+    // in the default one the maps would fall back to if the name were ignored.
+    let shared = DBMap::<(u8, u32), String>::reopen(
+        &db,
+        Some("shared"),
+        &ReadWriteOptions::default(),
+        false,
+    )
+    .expect("failed to open the shared column family");
+    assert_eq!(shared.get(&(0, 1)).unwrap(), Some("one".to_string()));
+    assert_eq!(shared.safe_iter().count(), 4);
 
     // Point lookups stay within the tag.
     assert_eq!(numbers.get(&1).unwrap(), Some("one".to_string()));

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1152,6 +1152,59 @@ async fn test_tagged_dbmaps_share_a_column_family() {
     assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
 }
 
+/// A bounded range stays within its own tag even when the upper bound is the
+/// maximum key, where making the exclusive rocksdb bound would otherwise carry
+/// into the next tag's key range — while still yielding that maximum key.
+#[tokio::test]
+async fn tagged_range_iter_stays_within_its_tag() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["shared"]);
+    // The neighbouring tag's key must serialize to fewer, all-zero bytes: the
+    // escaped bound is tag 1 followed by zeros, and only a shorter all-zero key
+    // sorts below it.
+    let wide: TaggedDBMap<u64, String> =
+        TaggedDBMap::reopen(&db, "shared", 0, &ReadWriteOptions::default(), false)
+            .expect("failed to open the wide map");
+    let narrow: TaggedDBMap<u8, String> =
+        TaggedDBMap::reopen(&db, "shared", 1, &ReadWriteOptions::default(), false)
+            .expect("failed to open the narrow map");
+
+    let mut batch = wide.batch();
+    wide.insert_batch(
+        &mut batch,
+        [(1, "one".to_string()), (u64::MAX, "max".to_string())],
+    )
+    .unwrap();
+    narrow
+        .insert_batch(&mut batch, [(0, "zero".to_string())])
+        .unwrap();
+    batch.write().unwrap();
+
+    let rows: Vec<_> = wide
+        .range_iter(0, u64::MAX)
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![(1, "one".to_string()), (u64::MAX, "max".to_string())]
+    );
+    let rows: Vec<_> = wide
+        .range_iter_reversed(0, u64::MAX)
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![(u64::MAX, "max".to_string()), (1, "one".to_string())]
+    );
+
+    // The neighbouring tag keeps its row and reaches it through its own range.
+    let rows: Vec<_> = narrow
+        .range_iter(0, u8::MAX)
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(rows, vec![(0, "zero".to_string())]);
+}
+
 fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> {
     let cf_key = opt_cf.unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME);
     DBMap::<K, V>::reopen(

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::RangeBounds;
+use std::ops::{Bound, RangeBounds};
 
 use rstest::rstest;
 use serde::{Serialize, de::DeserializeOwned};
@@ -1107,11 +1107,10 @@ async fn test_tagged_dbmaps_share_a_column_family() {
             .expect("failed to open the words map");
 
     let mut batch = numbers.batch();
-    numbers
-        .insert_batch(&mut batch, [(1, "one".to_string()), (2, "two".to_string())])
-        .unwrap();
-    words
-        .insert_batch(&mut batch, [("one".to_string(), 1), ("two".to_string(), 2)])
+    batch
+        .insert_batch_tagged(&numbers, [(1, "one".to_string()), (2, "two".to_string())])
+        .unwrap()
+        .insert_batch_tagged(&words, [("one".to_string(), 1), ("two".to_string(), 2)])
         .unwrap();
     batch.write().unwrap();
 
@@ -1119,37 +1118,94 @@ async fn test_tagged_dbmaps_share_a_column_family() {
     assert_eq!(numbers.get(&1).unwrap(), Some("one".to_string()));
     assert_eq!(words.get(&"two".to_string()).unwrap(), Some(2));
     assert_eq!(
-        numbers.multi_get(&[1, 2, 3]).unwrap(),
+        numbers.multi_get([1, 2, 3]).unwrap(),
         vec![Some("one".to_string()), Some("two".to_string()), None]
+    );
+    assert_eq!(
+        numbers.multi_contains_keys([1, 3]).unwrap(),
+        vec![true, false]
     );
     assert!(words.contains_key(&"one".to_string()).unwrap());
 
     // Full scans in both directions yield only the map's own rows.
-    let rows: Vec<_> = numbers.iter().collect::<Result<_, _>>().unwrap();
+    let rows: Vec<_> = numbers.safe_iter().collect::<Result<_, _>>().unwrap();
     assert_eq!(rows, vec![(1, "one".to_string()), (2, "two".to_string())]);
-    let rows: Vec<_> = numbers.iter_reversed().collect::<Result<_, _>>().unwrap();
+    let rows: Vec<_> = numbers
+        .safe_range_iter_reversed(..)
+        .collect::<Result<_, _>>()
+        .unwrap();
     assert_eq!(rows, vec![(2, "two".to_string()), (1, "one".to_string())]);
-    let rows: Vec<_> = words.iter().collect::<Result<_, _>>().unwrap();
+    let rows: Vec<_> = words.safe_iter().collect::<Result<_, _>>().unwrap();
     assert_eq!(rows, vec![("one".to_string(), 1), ("two".to_string(), 2)]);
 
-    // Bounded ranges, both directions.
+    // Bounded ranges honour their own inclusivity, in both directions.
     let rows: Vec<_> = numbers
-        .range_iter(2, u32::MAX)
+        .safe_range_iter(2..=u32::MAX)
         .collect::<Result<_, _>>()
         .unwrap();
     assert_eq!(rows, vec![(2, "two".to_string())]);
     let rows: Vec<_> = numbers
-        .range_iter_reversed(u32::MIN, 1)
+        .safe_iter_with_bounds(None, Some(2))
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(rows, vec![(1, "one".to_string())]);
+    let rows: Vec<_> = numbers
+        .safe_range_iter(1..2)
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(rows, vec![(1, "one".to_string())]);
+    let rows: Vec<_> = numbers
+        .safe_range_iter((Bound::Excluded(1), Bound::Included(2)))
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(rows, vec![(2, "two".to_string())]);
+    let rows: Vec<_> = numbers
+        .safe_range_iter_reversed(u32::MIN..=1)
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(rows, vec![(1, "one".to_string())]);
+    let rows: Vec<_> = numbers
+        .safe_range_iter_reversed(..2)
         .collect::<Result<_, _>>()
         .unwrap();
     assert_eq!(rows, vec![(1, "one".to_string())]);
 
+    // Single-key writes stay within the tag as well.
+    numbers.insert(&3, &"three".to_string()).unwrap();
+    assert_eq!(numbers.get(&3).unwrap(), Some("three".to_string()));
+    numbers.remove(&3).unwrap();
+    assert_eq!(numbers.get(&3).unwrap(), None);
+
     // Deletes stay within the tag.
     let mut batch = numbers.batch();
-    numbers.delete_batch(&mut batch, [1, 2]).unwrap();
+    batch.delete_batch_tagged(&numbers, [1, 2]).unwrap();
     batch.write().unwrap();
-    assert!(numbers.iter().next().is_none());
+    assert!(numbers.is_empty());
+    assert!(!words.is_empty());
     assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
+}
+
+/// A tagged batch write refuses a map from another database, as an untagged
+/// one does.
+#[tokio::test]
+async fn tagged_batch_rejects_a_map_from_another_database() {
+    let tmp_dirs = [iota_common::tempdir(), iota_common::tempdir()];
+    let dbs = tmp_dirs.each_ref().map(|dir| {
+        let db = open_rocksdb(dir.path(), &["shared"]);
+        TaggedDBMap::<u32, String>::reopen(&db, "shared", 0, &ReadWriteOptions::default(), false)
+            .expect("failed to open the map")
+    });
+    let [map, other] = &dbs;
+
+    let mut batch = map.batch();
+    assert!(matches!(
+        batch.insert_batch_tagged(other, [(1, "one".to_string())]),
+        Err(TypedStoreError::CrossDBBatch)
+    ));
+    assert!(matches!(
+        batch.delete_batch_tagged(other, [1]),
+        Err(TypedStoreError::CrossDBBatch)
+    ));
 }
 
 /// A bounded range stays within its own tag even when the upper bound is the
@@ -1170,18 +1226,18 @@ async fn tagged_range_iter_stays_within_its_tag() {
             .expect("failed to open the narrow map");
 
     let mut batch = wide.batch();
-    wide.insert_batch(
-        &mut batch,
-        [(1, "one".to_string()), (u64::MAX, "max".to_string())],
-    )
-    .unwrap();
-    narrow
-        .insert_batch(&mut batch, [(0, "zero".to_string())])
+    batch
+        .insert_batch_tagged(
+            &wide,
+            [(1, "one".to_string()), (u64::MAX, "max".to_string())],
+        )
+        .unwrap()
+        .insert_batch_tagged(&narrow, [(0, "zero".to_string())])
         .unwrap();
     batch.write().unwrap();
 
     let rows: Vec<_> = wide
-        .range_iter(0, u64::MAX)
+        .safe_range_iter(0..=u64::MAX)
         .collect::<Result<_, _>>()
         .unwrap();
     assert_eq!(
@@ -1189,7 +1245,7 @@ async fn tagged_range_iter_stays_within_its_tag() {
         vec![(1, "one".to_string()), (u64::MAX, "max".to_string())]
     );
     let rows: Vec<_> = wide
-        .range_iter_reversed(0, u64::MAX)
+        .safe_range_iter_reversed(0..=u64::MAX)
         .collect::<Result<_, _>>()
         .unwrap();
     assert_eq!(
@@ -1199,7 +1255,7 @@ async fn tagged_range_iter_stays_within_its_tag() {
 
     // The neighbouring tag keeps its row and reaches it through its own range.
     let rows: Vec<_> = narrow
-        .range_iter(0, u8::MAX)
+        .safe_range_iter(0..=u8::MAX)
         .collect::<Result<_, _>>()
         .unwrap();
     assert_eq!(rows, vec![(0, "zero".to_string())]);
@@ -1224,16 +1280,17 @@ async fn tagged_schedule_delete_all_clears_only_its_own_tag() {
 
     let mut batch = cleared.batch();
     for map in [&below, &cleared, &above, &last] {
-        map.insert_batch(
-            &mut batch,
-            [(0, "zero".to_string()), (u32::MAX, "max".to_string())],
-        )
-        .unwrap();
+        batch
+            .insert_batch_tagged(
+                map,
+                [(0, "zero".to_string()), (u32::MAX, "max".to_string())],
+            )
+            .unwrap();
     }
     batch.write().unwrap();
 
     let entries = |map: &TaggedDBMap<u32, String>| -> Vec<(u32, String)> {
-        map.iter().collect::<Result<_, _>>().unwrap()
+        map.safe_iter().collect::<Result<_, _>>().unwrap()
     };
     let expected = vec![(0, "zero".to_string()), (u32::MAX, "max".to_string())];
 

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -603,19 +603,60 @@ async fn test_safe_range_iter_exclusive_lower_bound_at_max_with_inclusive_upper(
 
 #[tokio::test]
 async fn test_safe_range_iter_reversed_matches_forward() {
-    use std::ops::Bound::{self, Excluded, Included, Unbounded};
-
     let tmp_dir = iota_common::tempdir();
     let db: DBMap<u32, String> = open_map(tmp_dir.path(), None);
-    // [1, 100) so that bounds like 20 / 50 land on existing keys, exercising the
-    // exclusive-upper "skip the boundary key" path of the reverse seek.
-    for i in 1..100u32 {
-        db.insert(&i, &i.to_string()).unwrap();
-    }
+    fill_for_range_symmetry(&db);
+    assert_reversed_matches_forward(&db);
+}
 
-    let check = |range: (Bound<u32>, Bound<u32>)| {
-        let forward: Vec<_> = db.safe_range_iter(range).map(|r| r.unwrap()).collect();
-        let mut reversed: Vec<_> = db
+/// A tagged map owes the same symmetry, and owes it with the neighbouring tags
+/// populated across the whole key space: its bounds are computed by a different
+/// function from the plain map's, and it is the reverse scan that carries its
+/// upper bound in the seek rather than in the read options.
+#[tokio::test]
+async fn tagged_reversed_scan_matches_forward() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["shared"]);
+    let open = |tag: u8| {
+        TaggedDBMap::<u32, String>::reopen(&db, "shared", tag, &ReadWriteOptions::default(), false)
+            .expect("failed to open the map")
+    };
+    let below = open(0);
+    let map = open(1);
+    let above = open(2);
+
+    for neighbour in [&below, &above] {
+        neighbour
+            .multi_insert([(0, "noise".to_string()), (u32::MAX, "noise".to_string())])
+            .unwrap();
+    }
+    fill_for_range_symmetry(&map);
+
+    assert_reversed_matches_forward(&map);
+}
+
+type RangeOfKeys = (std::ops::Bound<u32>, std::ops::Bound<u32>);
+
+/// Fills a map with `[1, 100)`, so that bounds like 20 and 50 land on existing
+/// keys and exercise the "skip the boundary key" path of the reverse seek.
+fn fill_for_range_symmetry<'a, M: Map<'a, u32, String>>(map: &M)
+where
+    M::Error: std::fmt::Debug,
+{
+    for i in 1..100u32 {
+        map.insert(&i, &i.to_string()).unwrap();
+    }
+}
+
+/// A reverse scan yields exactly what the forward one does, reversed, for every
+/// shape a range can take. Written for any map, so that a tagged map is held to
+/// what a plain one does even though it computes its bounds elsewhere.
+fn assert_reversed_matches_forward<'a, M: Map<'a, u32, String>>(map: &'a M) {
+    use std::ops::Bound::{Excluded, Included, Unbounded};
+
+    let check = |range: RangeOfKeys| {
+        let forward: Vec<_> = map.safe_range_iter(range).map(|r| r.unwrap()).collect();
+        let mut reversed: Vec<_> = map
             .safe_range_iter_reversed(range)
             .map(|r| r.unwrap())
             .collect();
@@ -636,6 +677,8 @@ async fn test_safe_range_iter_reversed_matches_forward() {
     check((Unbounded, Unbounded)); // full table
     check((Included(40), Excluded(40))); // empty
     check((Included(50), Included(50))); // single element
+    check((Included(0), Included(u32::MAX))); // the whole key space
+    check((Excluded(0), Excluded(u32::MAX)));
 }
 
 #[tokio::test]

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1296,6 +1296,40 @@ async fn tagged_ranges_follow_the_key_encoding_rather_than_ord() {
     assert!(signed.safe_range_iter(-1..=1).next().is_none());
 }
 
+/// Clearing a map that holds nothing writes nothing, whatever its tag: a
+/// tombstone would be read past by every iterator of the column family until
+/// compaction drops it.
+#[tokio::test]
+async fn clearing_an_empty_tagged_map_writes_nothing() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["shared"]);
+    let writes_so_far = || match &db.storage {
+        crate::database::Storage::Rocks(rocks) => rocks.underlying.latest_sequence_number(),
+        _ => unreachable!("the database is rocksdb"),
+    };
+    let open = |tag| {
+        TaggedDBMap::<u32, String>::reopen(&db, "shared", tag, &ReadWriteOptions::default(), false)
+            .expect("failed to open the map")
+    };
+
+    // The maximum tag ends its range on the last entry, the others on the tag
+    // that follows, so each takes its own path to the same answer.
+    for tag in [0, u8::MAX] {
+        let map = open(tag);
+        let before = writes_so_far();
+        map.schedule_delete_all().expect("failed to clear the map");
+        assert_eq!(writes_so_far(), before, "tag {tag} wrote over nothing");
+    }
+
+    // And a map that does hold rows still writes its tombstone.
+    let map = open(0);
+    map.insert(&1, &"one".to_string()).unwrap();
+    let before = writes_so_far();
+    map.schedule_delete_all().expect("failed to clear the map");
+    assert!(writes_so_far() > before);
+    assert!(map.is_empty());
+}
+
 /// A tag belongs to its column family, so the same one is free in another.
 #[tokio::test]
 async fn a_tag_is_free_in_another_column_family() {

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1195,6 +1195,102 @@ async fn test_tagged_dbmaps_share_a_column_family() {
     assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
 }
 
+/// Reads `key` from the `[CFOptions "cf_name"]` section of the database's
+/// current OPTIONS file.
+fn cf_option(path: &Path, cf_name: &str, key: &str) -> String {
+    let current = std::fs::read_dir(path)
+        .expect("Failed to read the database directory")
+        .filter_map(|entry| {
+            let name = entry.expect("Failed to read a directory entry").file_name();
+            name.to_str()?.starts_with("OPTIONS-").then_some(name)
+        })
+        .max()
+        .expect("The database has no OPTIONS file");
+    let options = std::fs::read_to_string(path.join(current)).expect("Failed to read the options");
+
+    options
+        .split(&format!("[CFOptions \"{cf_name}\"]"))
+        .nth(1)
+        .expect("The options name no such column family")
+        .lines()
+        .map(str::trim)
+        .take_while(|line| !line.starts_with('['))
+        .find_map(|line| line.strip_prefix(&format!("{key}=")))
+        .unwrap_or_else(|| panic!("The column family has no {key} option"))
+        .to_owned()
+}
+
+/// A column family created at runtime keeps its options when the database is
+/// reopened without declaring it, instead of falling back to the rocksdb
+/// defaults.
+#[tokio::test]
+async fn a_rediscovered_column_family_keeps_its_options() {
+    let tmp_dir = iota_common::tempdir();
+    let path = tmp_dir.path();
+    let declared = |cf: &'static str| {
+        open_cf_opts(
+            path,
+            None,
+            MetricConf::default(),
+            &[(cf, default_db_options().options)],
+        )
+        .expect("Failed to open rocksdb")
+    };
+    {
+        let db = declared("static_cf");
+        db.create_cf("dynamic_cf", &default_db_options().options)
+            .expect("Failed to create column family");
+    }
+
+    // Reopened without naming the runtime column family, so it is rediscovered.
+    let _db = declared("static_cf");
+    assert_eq!(
+        cf_option(path, "dynamic_cf", "bottommost_compression"),
+        cf_option(path, "static_cf", "bottommost_compression"),
+    );
+}
+
+/// The default column family is opened with the crate's options from the start,
+/// rather than with the rocksdb defaults its wrapper would otherwise give it.
+#[tokio::test]
+async fn the_default_column_family_keeps_the_crate_s_options() {
+    let tmp_dir = iota_common::tempdir();
+    let path = tmp_dir.path();
+    let declared = || {
+        open_cf_opts(
+            path,
+            None,
+            MetricConf::default(),
+            &[("static_cf", default_db_options().options)],
+        )
+        .expect("Failed to open rocksdb")
+    };
+
+    // The database is new, so nothing is there to rediscover.
+    let db = declared();
+    let expected = cf_option(path, "static_cf", "bottommost_compression");
+    assert_eq!(
+        cf_option(
+            path,
+            rocksdb::DEFAULT_COLUMN_FAMILY_NAME,
+            "bottommost_compression"
+        ),
+        expected,
+    );
+
+    // And the options do not change when it is rediscovered on the next open.
+    drop(db);
+    let _db = declared();
+    assert_eq!(
+        cf_option(
+            path,
+            rocksdb::DEFAULT_COLUMN_FAMILY_NAME,
+            "bottommost_compression"
+        ),
+        expected,
+    );
+}
+
 /// Opening a map on a column family the database does not have is refused,
 /// rather than yielding a map whose every operation panics.
 #[tokio::test]

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1064,8 +1064,18 @@ async fn test_create_cf_at_runtime() {
             .expect("Failed to insert");
         assert_eq!(map.get(&1).unwrap(), Some("one".to_string()));
 
-        // The dynamically created column family must be covered by flush_all.
+        // The dynamically created column family must be covered by flush_all:
+        // its memtable reaches disk as an SST file of that column family.
+        let sst_files = || {
+            db.live_files()
+                .expect("Failed to list live files")
+                .into_iter()
+                .filter(|file| file.column_family_name == "dynamic_cf")
+                .count()
+        };
+        assert_eq!(sst_files(), 0, "the row must still be in the memtable");
         db.flush_all().expect("Failed to flush");
+        assert_eq!(sst_files(), 1, "flush_all must cover the column family");
     }
     {
         // The column family is rediscovered when reopening the database from
@@ -1183,6 +1193,33 @@ async fn test_tagged_dbmaps_share_a_column_family() {
     assert!(numbers.is_empty());
     assert!(!words.is_empty());
     assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
+}
+
+/// `flush_all` covers the `default` column family, which rocksdb opens for
+/// every database and which no caller declares.
+#[tokio::test]
+async fn flush_all_covers_the_default_column_family() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["static_cf"]);
+    let map = DBMap::<u32, String>::reopen(&db, None, &ReadWriteOptions::default(), false)
+        .expect("Failed to open map on the default column family");
+    map.insert(&1, &"one".to_string())
+        .expect("Failed to insert");
+
+    let sst_files = || {
+        db.live_files()
+            .expect("Failed to list live files")
+            .into_iter()
+            .filter(|file| file.column_family_name == "default")
+            .count()
+    };
+    assert_eq!(sst_files(), 0, "the row must still be in the memtable");
+    db.flush_all().expect("Failed to flush");
+    assert_eq!(
+        sst_files(),
+        1,
+        "flush_all must cover the default column family"
+    );
 }
 
 /// A tagged batch write refuses a map from another database, as an untagged

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1205,6 +1205,56 @@ async fn tagged_range_iter_stays_within_its_tag() {
     assert_eq!(rows, vec![(0, "zero".to_string())]);
 }
 
+/// Clearing a tagged map removes all of its own entries and none of the
+/// entries the other tags keep in the same column family.
+#[tokio::test]
+async fn tagged_schedule_delete_all_clears_only_its_own_tag() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["shared"]);
+    let open = |tag: u8| {
+        TaggedDBMap::<u32, String>::reopen(&db, "shared", tag, &ReadWriteOptions::default(), false)
+            .expect("failed to open the map")
+    };
+    // The cleared tag has an immediate neighbour on either side, and the
+    // maximum tag has no following tag to bound its own range against.
+    let below = open(0);
+    let cleared = open(1);
+    let above = open(2);
+    let last = open(u8::MAX);
+
+    let mut batch = cleared.batch();
+    for map in [&below, &cleared, &above, &last] {
+        map.insert_batch(
+            &mut batch,
+            [(0, "zero".to_string()), (u32::MAX, "max".to_string())],
+        )
+        .unwrap();
+    }
+    batch.write().unwrap();
+
+    let entries = |map: &TaggedDBMap<u32, String>| -> Vec<(u32, String)> {
+        map.iter().collect::<Result<_, _>>().unwrap()
+    };
+    let expected = vec![(0, "zero".to_string()), (u32::MAX, "max".to_string())];
+
+    cleared.schedule_delete_all().unwrap();
+    assert!(entries(&cleared).is_empty());
+    assert_eq!(entries(&below), expected);
+    assert_eq!(entries(&above), expected);
+    assert_eq!(entries(&last), expected);
+
+    // The maximum tag takes the bound from its own last key.
+    last.schedule_delete_all().unwrap();
+    assert!(entries(&last).is_empty());
+    assert_eq!(entries(&below), expected);
+    assert_eq!(entries(&above), expected);
+
+    // Clearing an already empty map is a no-op, at the maximum tag too.
+    cleared.schedule_delete_all().unwrap();
+    last.schedule_delete_all().unwrap();
+    assert_eq!(entries(&below), expected);
+}
+
 fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> {
     let cf_key = opt_cf.unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME);
     DBMap::<K, V>::reopen(

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1207,6 +1207,71 @@ async fn tagged_dbmaps_share_a_column_family() {
     assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
 }
 
+/// Ranges are bounded by the serialized keys, so for a key type whose encoding
+/// does not order the way `Ord` does they cover something else. Pinned here
+/// because it surprises callers; a plain `DBMap` behaves the same way.
+#[tokio::test]
+async fn tagged_ranges_follow_the_key_encoding_rather_than_ord() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["shared"]);
+    let words: TaggedDBMap<String, u32> =
+        TaggedDBMap::reopen(&db, "shared", 0, &ReadWriteOptions::default(), false)
+            .expect("failed to open the words map");
+    let signed: TaggedDBMap<i32, u32> =
+        TaggedDBMap::reopen(&db, "shared", 1, &ReadWriteOptions::default(), false)
+            .expect("failed to open the signed map");
+
+    // A string is serialized with its length first, so the order is by length.
+    words
+        .multi_insert([
+            ("b".to_string(), 0),
+            ("aa".to_string(), 0),
+            ("aaa".to_string(), 0),
+        ])
+        .unwrap();
+    let keys: Vec<_> = words
+        .safe_iter()
+        .map(|row| row.unwrap().0)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        keys,
+        ["b", "aa", "aaa"],
+        "Ord would order these differently"
+    );
+    assert!(
+        words
+            .safe_range_iter("aa".to_string().."b".to_string())
+            .next()
+            .is_none(),
+        "the upper bound serializes below the lower one"
+    );
+
+    // A negative integer is two's complement, so it sorts above the positives.
+    signed.multi_insert([(0, 0), (1, 0), (-1, 0)]).unwrap();
+    let keys: Vec<_> = signed.safe_iter().map(|row| row.unwrap().0).collect();
+    assert_eq!(keys, [0, 1, -1], "Ord would order these differently");
+    assert!(signed.safe_range_iter(-1..=1).next().is_none());
+}
+
+/// A tag belongs to its column family, so the same one is free in another.
+#[tokio::test]
+async fn a_tag_is_free_in_another_column_family() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["shared", "other"]);
+
+    let numbers =
+        TaggedDBMap::<u32, String>::reopen(&db, "shared", 0, &ReadWriteOptions::default(), false)
+            .expect("failed to open the numbers map");
+    let words =
+        TaggedDBMap::<String, u64>::reopen(&db, "other", 0, &ReadWriteOptions::default(), false)
+            .expect("failed to open the words map");
+
+    numbers.insert(&1, &"one".to_string()).unwrap();
+    words.insert(&"one".to_string(), &1).unwrap();
+    assert_eq!(numbers.get(&1).unwrap(), Some("one".to_string()));
+    assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
+}
+
 /// Reads `key` from the `[CFOptions "cf_name"]` section of the database's
 /// current OPTIONS file.
 fn cf_option(path: &Path, cf_name: &str, key: &str) -> String {

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1195,6 +1195,68 @@ async fn test_tagged_dbmaps_share_a_column_family() {
     assert_eq!(words.get(&"one".to_string()).unwrap(), Some(1));
 }
 
+/// Opening a map on a column family the database does not have is refused,
+/// rather than yielding a map whose every operation panics.
+#[tokio::test]
+async fn opening_a_map_on_a_missing_column_family_fails() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["static_cf"]);
+
+    assert!(matches!(
+        DBMap::<u32, String>::reopen(&db, Some("absent"), &ReadWriteOptions::default(), false),
+        Err(TypedStoreError::UnregisteredColumn(cf)) if cf == "absent"
+    ));
+}
+
+/// Dropping the default column family is refused before rocksdb is asked,
+/// because its wrapper would lose the handle on the way to being refused.
+#[tokio::test]
+async fn the_default_column_family_cannot_be_dropped() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["static_cf"]);
+    let map = DBMap::<u32, String>::reopen(&db, None, &ReadWriteOptions::default(), false)
+        .expect("Failed to open map on the default column family");
+
+    assert!(db.drop_cf(rocksdb::DEFAULT_COLUMN_FAMILY_NAME).is_err());
+
+    // The column family is still there, and still usable.
+    assert!(db.cf_handle(rocksdb::DEFAULT_COLUMN_FAMILY_NAME).is_some());
+    map.insert(&1, &"one".to_string())
+        .expect("Failed to insert");
+    assert_eq!(map.get(&1).unwrap(), Some("one".to_string()));
+}
+
+/// A column family can be dropped and created again on one database handle,
+/// and comes back empty.
+#[tokio::test]
+async fn a_dropped_column_family_can_be_created_again() {
+    let tmp_dir = iota_common::tempdir();
+    let db = open_rocksdb(tmp_dir.path(), &["static_cf"]);
+    let options = rocksdb::Options::default();
+    db.create_cf("cycled", &options)
+        .expect("Failed to create column family");
+    {
+        let map =
+            DBMap::<u32, String>::reopen(&db, Some("cycled"), &ReadWriteOptions::default(), false)
+                .expect("Failed to open map");
+        map.insert(&1, &"one".to_string())
+            .expect("Failed to insert");
+    }
+
+    db.drop_cf("cycled").expect("Failed to drop column family");
+    assert!(
+        DBMap::<u32, String>::reopen(&db, Some("cycled"), &ReadWriteOptions::default(), false)
+            .is_err()
+    );
+
+    db.create_cf("cycled", &options)
+        .expect("Failed to create column family again");
+    let map =
+        DBMap::<u32, String>::reopen(&db, Some("cycled"), &ReadWriteOptions::default(), false)
+            .expect("Failed to open map on the recreated column family");
+    assert_eq!(map.get(&1).unwrap(), None);
+}
+
 /// `flush_all` covers the `default` column family, which rocksdb opens for
 /// every database and which no caller declares.
 #[tokio::test]

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -287,6 +287,10 @@ where
         unimplemented!("unimplemented API");
     }
 
+    fn safe_range_iter_reversed(&'a self, _range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)> {
+        unimplemented!("unimplemented API");
+    }
+
     fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -65,6 +65,10 @@ where
     /// inclusivity (e.g. `lo..hi` excludes `hi`, `lo..=hi` includes it).
     fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)>;
 
+    /// Reverse counterpart of [`Self::safe_range_iter`]: yields exactly the
+    /// keys of `safe_range_iter(range)` in descending order.
+    fn safe_range_iter_reversed(&'a self, range: impl RangeBounds<K>) -> DbIterator<'a, (K, V)>;
+
     /// Returns a vector of values corresponding to the keys provided,
     /// non-atomically.
     fn multi_get<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<Vec<Option<V>>, Self::Error>

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -97,6 +97,42 @@ where
     (Some(lower), upper)
 }
 
+/// Computes the raw byte bounds for scanning `range` within the key range of
+/// `prefix`, for keys serialized with [`be_fix_int_ser`].
+///
+/// `range` bounds the part of the key that follows `prefix`; see
+/// [`prefix_iterator_bounds`] for the requirements on `prefix`. The returned
+/// bounds never leave the prefix, including at an inclusive bound on the
+/// maximum key.
+pub(crate) fn prefix_iterator_bounds_with_range<P, K>(
+    prefix: &P,
+    range: impl RangeBounds<K>,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>)
+where
+    P: ?Sized + Serialize,
+    K: Serialize,
+{
+    let prefix_buf = be_fix_int_ser(prefix);
+    let (lower_bound, upper_bound) = iterator_bounds_with_range(range);
+
+    let mut iterator_lower_bound = prefix_buf.clone();
+    if let Some(lower_bound) = lower_bound {
+        iterator_lower_bound.extend_from_slice(&lower_bound);
+    }
+
+    let iterator_upper_bound = match upper_bound {
+        Some(upper_bound) => {
+            let mut key_buf = prefix_buf;
+            key_buf.extend_from_slice(&upper_bound);
+            Some(key_buf)
+        }
+        // An unbounded range ends where the prefix ends.
+        None => prefix_iterator_bounds(prefix).1,
+    };
+
+    (Some(iterator_lower_bound), iterator_upper_bound)
+}
+
 /// Increments the big-endian integer in `v` by one, in place.
 ///
 /// Callers must ensure `v` is not all-`0xFF` (each one checks `is_max` and
@@ -189,4 +225,51 @@ fn test_inclusive_upper_bound_at_max() {
     // Symmetric with the excluded-lower arm at the max.
     let (lower, _) = iterator_bounds_with_range::<u8>((Bound::Excluded(u8::MAX), Bound::Unbounded));
     assert_eq!(lower, Some(vec![0xFF, 0x00]));
+}
+
+#[test]
+fn prefixed_bounds_stay_within_the_prefix() {
+    // An inclusive upper bound at the maximum key must stay inside the prefix.
+    // Computing it over the whole `(prefix, key)` buffer would carry into the
+    // next prefix, whose keys can serialize more compactly and would then be
+    // scanned.
+    fn check_max<K: Serialize + Copy>(max: K) {
+        assert!(
+            is_max(&be_fix_int_ser(&max)),
+            "test value must serialize to all-0xFF"
+        );
+        let (lower, upper) = prefix_iterator_bounds_with_range(&0u8, ..=max);
+        let upper = upper.expect("an inclusive upper bound must be bounded, not None");
+
+        assert_eq!(lower, Some(be_fix_int_ser(&0u8)));
+        assert!(
+            be_fix_int_ser(&(0u8, max)) < upper,
+            "the maximum key of the prefix must stay in range"
+        );
+        assert!(
+            upper <= be_fix_int_ser(&1u8),
+            "the bound must not reach into the next prefix"
+        );
+    }
+    check_max(u8::MAX);
+    check_max(u32::MAX);
+    check_max(u64::MAX);
+
+    // The excluded-lower arm at the maximum is prefixed the same way.
+    let (lower, _) = prefix_iterator_bounds_with_range::<u8, u8>(
+        &0u8,
+        (Bound::Excluded(u8::MAX), Bound::Unbounded),
+    );
+    assert_eq!(lower, Some(vec![0x00, 0xFF, 0x00]));
+
+    // An unbounded range ends where the prefix ends, and at the maximum prefix
+    // it runs to the end of the column family — as for a plain prefix scan.
+    assert_eq!(
+        prefix_iterator_bounds_with_range::<u8, u32>(&0u8, ..),
+        (Some(vec![0x00]), Some(vec![0x01]))
+    );
+    assert_eq!(
+        prefix_iterator_bounds_with_range::<u8, u32>(&u8::MAX, ..),
+        prefix_iterator_bounds(&u8::MAX)
+    );
 }


### PR DESCRIPTION
# Description of change

Address the review of #12448, on top of its branch, one commit per finding.

The bugs found in `TaggedDBMap` itself turned out to be two: a bounded scan
could leave its tag, and clearing a map wrote a tombstone per row. The rest
are pre-existing faults in `typed-store` that `create_cf` made reachable, or
that the review surfaced along the way.

## `TaggedDBMap`

**`fix: keep tagged range scans inside their tag`** — a bounded scan computed
its bounds over the whole `(tag, key)` and then had nowhere to carry the
increment when the upper bound serialized to all-`0xFF`, so the carry ran into
the next tag and the scan returned a neighbour's rows. The bounds are now
computed over the key alone and the tag is prefixed afterwards, so the carry
cannot escape it. `prefix_iterator_bounds_with_range` in `util.rs`, with a test
that a prefixed bound stays inside its prefix.

**`feat: delete a tagged map's entries with one range tombstone`** — clearing a
tagged map deleted row by row. It now covers its tag with a single range
tombstone, the same way a plain `DBMap` covers a column family.

The tombstone runs from the tag to the tag after it, so the maximum tag has no
bound to end on. It reads the last row and ends just past it instead, which is
what `DBMap::schedule_delete_all` does for a whole column family — so the
maximum tag is no worse off than a plain map, and every other tag is better
off. Two things follow from the read, and neither can go without an upper bound
that rocksdb does not have: an insert between the read and the write survives
the clear, and a value that does not deserialize fails it. Left as it is
deliberately; a table meant to be cleared should not sit on the maximum tag.

**`fix: leave a tagged map that holds nothing alone`** and **`docs: say what a
tagged map's clear costs until compaction`** — the tombstone was written even
over an empty map, and it is read past by every iterator of the column family
until compaction drops it, so the neighbouring tags paid for a clear that
deleted nothing. A plain `DBMap` already returned early, and so does a tagged
map now, with the cost said on the method.

**`refactor: reach a tagged map's rows without cloning the key`** — a tagged map
builds the key of the map underneath it, a pair of its tag and the caller's key.
`DBMap` takes a reference, so the pair had to be built to be pointed at, and the
key cloned to build it — on every read, every write and every key of a batch.
`DBMap` now has entry points taking a key already in the column family's
encoding, named as the batch ones already are, and `impl Map for TaggedDBMap` no
longer asks that keys be `Clone`.

**`refactor: implement Map for TaggedDBMap`** — the tagged map carried its own
inherent copies of the `Map` methods, so it could not be used where a plain map
could and its ranges took concrete `Range` types rather than
`impl RangeBounds<K>`. It implements the trait now, and `DBBatch` gained the
tagged batch entry points.

**`test: hold a tagged map to the plain map's range symmetry`** — the battery
that checks a reverse scan against the forward one, across every shape a range
can take, was written for a plain map; a tagged map computes its bounds through
a different function and inherited none of it. `safe_range_iter_reversed` moved
into `Map` so the battery can run over both. The tagged case runs with
neighbouring tags holding the lowest and the highest key of the space.

## Faults `create_cf` made reachable

**`fix: refuse a map on a column family the database lacks`** — `DBMap::reopen`
never checked that its column family exists and always returned a map; every
operation on it then resolved the column family by name and panicked, which the
release profile turns into an immediate abort. It returns `UnregisteredColumn`
now, an error the crate had defined and never used. Dropping the `default`
column family is also refused before rocksdb is asked: rocksdb rejects it too,
but its wrapper first takes the handle out of its own map, leaving the column
family unusable for the rest of the process.

**`fix: open a rediscovered column family with the crate's options`** — a column
family on disk that the caller does not declare was opened with the bare rocksdb
defaults, losing Lz4 with bottommost Zstd, the 16 KiB blocks, the bloom filter
and the pinned filter and index blocks. Before column families could be created
at runtime this only concerned tables dropped from the declaration; now it is
where every runtime-created column family lands on the next open. They get the
crate's options, which is what the secondary open path already did.

The default column family took the same options by a second route, and one the
fix above does not reach: a database that does not exist yet has nothing to
list, so the column family rocksdb always creates was never named, and the
rocksdb wrapper adds it with defaults of its own. It read one way on the first
open of a database and another way on every open after it. It is named now.

**`fix: ask rocksdb which column families to flush`** — `flush_all` iterated a
list captured when the database was opened, so a column family created at
runtime was never flushed, and `default` was missing from the list to begin
with. It asks rocksdb through `list_cf` instead.

## Pre-existing faults

**`fix: stop a sampling interval's task with the interval`** — every
`SamplingInterval` spawned a task to reset its counter and nothing ever stopped
it, so a dropped map left its tasks running for the life of the process. The
task now holds a `Weak` on the counter and returns once the last clone of the
interval is gone.

**`fix: scale the slow-batch-write threshold with batch size`** (in #12448) and
**`fix: clarify and cover the very slow batch write threshold`** — a flat one
second called every large batch very slow. The threshold is what the batch would
take at a throughput floor, never less than a second; the constants say what
they are and the arithmetic has tests.

**`fix: name the units of the slow write logs and metrics`** — the log line and
the metric help strings did not say what unit the numbers were in.

## Cleanups

**`chore: tidy up the tagged map and unbreak the doc tests`** — two doc examples
asked for the default tokio runtime flavor while the crate's dev-dependencies do
not enable `rt-multi-thread`, so `cargo test --doc` failed to build for the whole
crate and every example in it went unchecked. Also gives `TaggedDBMap` an example
of its own and moves the trait bounds of its inherent methods off the impl block.

**`docs: say what populate_missing_cfs is for`** — the function had nothing on
it, and the name does not say that it exists because rocksdb refuses to open a
database unless every column family it has is named.

**`refactor: resolve a column family through one function`** — three places
turned a column family into a rocksdb handle, two of them with the same expect
message word for word. `DBMap` was also declared `Send` by hand, which the
compiler works out on its own and which narrowed the bound rather than widening
it.

## Known, deliberate, not addressed here

- Range bounds follow the serialized bytes rather than `Ord`. Pre-existing and
  crate-wide; unfixable without changing the on-disk key format, so a test pins
  the behaviour instead.
- `DBMap::schedule_delete_all` leaves the last entry, so the two `Map` impls
  disagree about what clearing a map means. Fixed on `develop` by #12497, which
  landed after the point this branch stands on; it arrives here when #12448 is
  rebased before merging.
- Tagged maps cannot be fields of `#[derive(DBMapUtils)]`, so they are outside
  `dump`, `table_summary` and `iota-tool db-tool`. Supporting them is a feature
  of its own.

## Links to any relevant issues

Stacked on #12448 — review that one first; this branch targets its branch.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo clippy -p typed-store --all-targets --all-features -- -D warnings` is
clean, `cargo nextest run -p typed-store` is 80 green and `cargo test -p
typed-store --doc` is 4 green — the latter did not build at all before this
branch. Every fix carries a test that fails without it; the tagged range work is
covered by scans in both directions against neighbouring tags holding the
extremes of the key space.

