### PR TITLE
chore(indexer): remove deprecated objects snapshot CLI flags

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -235,10 +235,6 @@ To view help information:
 cargo run --bin iota-indexer -- help
 ```
 
-#### Deprecated flags
-
-`--objects-snapshot-min-checkpoint-lag` / `--objects-snapshot-sleep-duration` (and the `OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG` env var) are deprecated and will be removed in v1.31.0. The `objects_snapshot` pipeline has been removed; these flags are now no-ops.
-
 ### Experimental Features
 
 #### Historic Fallback (REST KV Store)

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -270,8 +270,6 @@ pub enum Command {
         #[command(flatten)]
         ingestion_config: IngestionConfig,
         #[command(flatten)]
-        snapshot_config: SnapshotLagConfig,
-        #[command(flatten)]
         pruning_options: PruningOptions,
         #[arg(long)]
         reset_db: bool,
@@ -439,29 +437,6 @@ impl RetentionConfig {
         }
 
         overrides
-    }
-}
-
-#[derive(Args, Default, Debug, Clone)]
-pub struct SnapshotLagConfig {
-    /// DEPRECATED: will be removed in v1.31.0. The objects_snapshot pipeline
-    /// has been removed. This flag is a no-op.
-    #[arg(
-        long = "objects-snapshot-min-checkpoint-lag",
-        env = "OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG"
-    )]
-    pub snapshot_min_lag: Option<usize>,
-
-    /// DEPRECATED: will be removed in v1.31.0. The objects_snapshot pipeline
-    /// has been removed. This flag is a no-op.
-    #[arg(long = "objects-snapshot-sleep-duration")]
-    pub sleep_duration: Option<u64>,
-}
-
-impl SnapshotLagConfig {
-    /// Returns `true` if any deprecated flag was explicitly provided.
-    pub fn is_set(&self) -> bool {
-        self.snapshot_min_lag.is_some() || self.sleep_duration.is_some()
     }
 }
 

--- a/crates/iota-indexer/src/main.rs
+++ b/crates/iota-indexer/src/main.rs
@@ -74,7 +74,6 @@ async fn main() -> Result<(), IndexerError> {
     match opts.command {
         Command::Indexer {
             ingestion_config,
-            snapshot_config,
             pruning_options,
             reset_db,
         } => {
@@ -91,15 +90,6 @@ async fn main() -> Result<(), IndexerError> {
                 if retention_config.is_some() {
                     check_prunable_tables_valid(&mut pool_conn).await?;
                 }
-            }
-
-            if snapshot_config.is_set() {
-                warn!(
-                    "the --objects-snapshot-min-checkpoint-lag / --objects-snapshot-sleep-duration arguments \
-                     (and the OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG env var) are deprecated. \
-                     These arguments will be removed in v1.31.0. \
-                     The objects_snapshot pipeline has been removed; these flags are now no-ops."
-                );
             }
 
             let store = PgIndexerStore::new(connection_pool, indexer_metrics.clone());

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -300,7 +300,6 @@ acc1: object(0,0), acc2: object(0,1)
 --custom-validator-account: creates a custom validator account. This is only allowed in simulator mode.
 --reference-gas-price <REFERENCE_GAS_PRICE>: Defines a reference gas price for transactions. Only valid in simulator mode.
 --default-gas-price <DEFAULT_GAS_PRICE>: sSets the default gas price for transactions. If not specified, the default is `1_000`.
---objects-snapshot-min-checkpoint-lag <OBJECT_SNAPSHOT_MIN_CHECKPOINT_LAG>: defines the minimum checkpoint lag for object snapshots. This affects when state snapshots are taken during execution
 --flavor <FLAVOR>: Specifies the Move compiler flavor (e.g., Iota).
 The --flavor option in the init command specifies the Move language flavor that will be used in the environment. This option determines the syntax and semantics applied to Move programs and packages in the test adapter(Core or Iota).
 --addresses <NAMED_ADDRESSES>: Maps custom named addresses to specific numerical addresses for the Move environment.


### PR DESCRIPTION
# Description of change

- Remove the deprecated `--objects-snapshot-min-checkpoint-lag` / `--objects-snapshot-sleep-duration` CLI flags and the `OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG` env var from `iota-indexer`, together with the `SnapshotLagConfig` struct and the startup deprecation warning. They became no-ops when the `objects_snapshot` pipeline was removed (#11709) and were scheduled for removal in v1.31.0.
- Drop the stale mention of `--objects-snapshot-min-checkpoint-lag` from the transactional test runner docs; the flag itself was already removed in #11709.

## Links to any relevant issues

fixes #11713

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: Removed the deprecated `--objects-snapshot-min-checkpoint-lag` / `--objects-snapshot-sleep-duration` CLI flags and the `OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG` env var which currently were no-ops.

#### Breaking Changes Rollout

Affected Crates:

- iota-indexer

Required User Actions:

- Operators who still pass these flags (or set the env var) must remove them from their deployment configuration before upgrading to v1.31.0; the indexer will otherwise fail to parse its arguments on startup.