### PR TITLE
fix(iota-graphql-rpc): stop panicking on failed requests in test cluster wait helpers

### DIFF
--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -199,11 +199,17 @@ pub async fn wait_for_graphql_checkpoint_pruned(
 
     tokio::time::timeout(timeout, async {
         loop {
-            let resp = client
+            let resp = match client
                 .execute_to_graphql(query.to_string(), false, vec![], vec![])
                 .await
-                .unwrap()
-                .response_body_json();
+            {
+                Ok(resp) => resp.response_body_json(),
+                Err(e) => {
+                    info!("GraphQL request failed, retrying: {e}");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
 
             let current_checkpoint = &resp["data"]["checkpoint"];
             if current_checkpoint.is_null() {
@@ -300,11 +306,17 @@ async fn wait_for_graphql_checkpoint_catchup(
 
     tokio::time::timeout(timeout, async {
         loop {
-            let resp = client
+            let resp = match client
                 .execute_to_graphql(query.to_string(), false, vec![], vec![])
                 .await
-                .unwrap()
-                .response_body_json();
+            {
+                Ok(resp) => resp.response_body_json(),
+                Err(e) => {
+                    info!("GraphQL request failed, retrying: {e}");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
 
             let current_checkpoint = resp["data"]["availableRange"]["last"].get("sequenceNumber");
             info!("Current checkpoint: {:?}", current_checkpoint);


### PR DESCRIPTION
# Description of change

`wait_for_graphql_checkpoint_catchup` and `wait_for_graphql_checkpoint_pruned` in the GraphQL test cluster unwrapped the result of every request, so a single failed request (e.g. an empty HTTP response while the server is still starting) panicked the whole test.

- Replace the `unwrap()` in both wait helpers with a log-and-retry after 1s, matching the polling loops they already run in.
- The overall `tokio::time::timeout` around each loop still bounds the wait.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/12252

## How the change has been tested

- `consistency/objects_pagination` e2e tests pass locally with `--features pg_integration`.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.