### PR TITLE
feat(graphql): Support fallback for tx by affected address queries

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.move
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transaction queries filtered by affected address under
+// pruning, with no historical fallback configured. Covers:
+// - `Query.transactionBlocks(filter: { affectedAddress })`
+// - `Address.transactionBlocks` with the `AFFECTED` relation
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A B --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public struct Foo has key, store { id: UID, v: u64 }
+
+    public entry fun send(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, recipient)
+    }
+}
+
+//# run Test::M::send --sender A --args @B
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run Test::M::send --sender A --args @B
+
+//# run Test::M::send --sender A --args @B
+
+//# run Test::M::send --sender A --args @B
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: paginating forward starts at the earliest transaction that affected the
+# address, which has been pruned — no fallback, so the request errors with
+# DATA_PRUNED.
+{
+  transactionBlocks(filter: { affectedAddress: "@{A}" }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# B: paginating backward starts at the most recent transactions, which are
+# still in the database. The cursors printed here are the inputs for the
+# window in D.
+{
+  transactionBlocks(last: 3, filter: { affectedAddress: "@{B}" }) {
+    pageInfo { startCursor endCursor hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# C: the AFFECTED relation on Address paginates the same way.
+{
+  address(address: "@{B}") {
+    transactionBlocks(last: 2, relation: AFFECTED) {
+      pageInfo { hasPreviousPage hasNextPage }
+      nodes { digest }
+    }
+  }
+}
+
+//# run-graphql --cursors {"c":10,"t":6,"i":false} {"c":10,"t":8,"i":false}
+# D: both cursors set — the window between the first and the last of the
+# recent transactions. Only the middle transaction is inside the window
+# (cursors are exclusive). Both page flags are true because transactions
+# exist at the cursor positions, outside the window.
+{
+  transactionBlocks(filter: { affectedAddress: "@{B}" }, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":10,"t":2,"i":false}
+# E: paginating backward from a cursor in the pruned range — no fallback, so
+# the request errors with DATA_PRUNED.
+{
+  transactionBlocks(last: 2, filter: { affectedAddress: "@{B}" }, before: "@{cursor_0}") {
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":10,"t":2,"i":false}
+# F: paginating forward from a cursor in the pruned range — no fallback, so
+# the request errors with DATA_PRUNED.
+{
+  transactionBlocks(filter: { affectedAddress: "@{B}" }, after: "@{cursor_0}") {
+    nodes { digest }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.move
@@ -106,3 +106,12 @@ module Test::M {
     nodes { digest }
   }
 }
+
+//# run-graphql --cursors {"c":1,"t":1,"i":false}
+# G: the cursor is viewed at a checkpoint that has been pruned from the
+# `checkpoints` table, so the request errors with DATA_PRUNED.
+{
+  transactionBlocks(filter: { affectedAddress: "@{B}" }, after: "@{cursor_0}") {
+    nodes { digest }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 22 tasks
+processed 23 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -10,13 +10,23 @@ task 1, lines 11-18:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5099600, storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 5099600
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
 
 task 2, line 20:
 //# run Test::M::send --sender A --args @B
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
 
 task 3, line 22:
 //# create-checkpoint
@@ -24,7 +34,7 @@ Checkpoint created: 1
 
 task 4, line 24:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, line 26:
 //# create-checkpoint
@@ -32,7 +42,7 @@ Checkpoint created: 3
 
 task 6, line 28:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, line 30:
 //# create-checkpoint
@@ -40,7 +50,7 @@ Checkpoint created: 5
 
 task 8, line 32:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 9, line 34:
 //# create-checkpoint
@@ -50,19 +60,34 @@ task 10, line 36:
 //# run Test::M::send --sender A --args @B
 created: object(10,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
 
 task 11, line 38:
 //# run Test::M::send --sender A --args @B
 created: object(11,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
 
 task 12, line 40:
 //# run Test::M::send --sender A --args @B
 created: object(12,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
 
 task 13, line 42:
 //# create-checkpoint
@@ -196,6 +221,29 @@ Response: {
   "errors": [
     {
       "message": "Requested data has been pruned: transaction 2 has been pruned (min available: 6)",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 22, lines 110-117:
+//# run-graphql --cursors {"c":1,"t":1,"i":false}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: checkpoint 1 has been pruned",
       "locations": [
         {
           "line": 4,

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.snap
@@ -1,0 +1,213 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 22 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-18:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5099600, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 20:
+//# run Test::M::send --sender A --args @B
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 24:
+//# advance-epoch
+Epoch advanced: 0
+
+task 5, line 26:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 6, line 28:
+//# advance-epoch
+Epoch advanced: 1
+
+task 7, line 30:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 8, line 32:
+//# advance-epoch
+Epoch advanced: 2
+
+task 9, line 34:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 10, line 36:
+//# run Test::M::send --sender A --args @B
+created: object(10,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 11, line 38:
+//# run Test::M::send --sender A --args @B
+created: object(11,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 12, line 40:
+//# run Test::M::send --sender A --args @B
+created: object(12,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2257200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 13, line 42:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 14, line 44:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 15, line 46:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 16, lines 48-56:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: DB may be missing earliest history for address 0x8cca4e1ce0ba5904cea61df9242da2f7d29e3ef328fb7ec07c086b3bf47ca61a due to pruning",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 17, lines 58-67:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "AdhXLxRHeWpRMVc5eQUZ3D4t9vFbQUnre9uQYp4Jidyj"
+        },
+        {
+          "digest": "DqfAehDoUapzpCYwh6HjJDhGWj6TAxsDZeYg7MfdTxEM"
+        },
+        {
+          "digest": "4r2EosDh4SAmuDk5qEMm19z8Yqi7kPtNTLxdmPdtuJwr"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJjIjoxMCwidCI6OCwiaSI6ZmFsc2V9",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "eyJjIjoxMCwidCI6NiwiaSI6ZmFsc2V9"
+      }
+    }
+  }
+}
+
+task 18, lines 69-78:
+//# run-graphql
+Response: {
+  "data": {
+    "address": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "DqfAehDoUapzpCYwh6HjJDhGWj6TAxsDZeYg7MfdTxEM"
+          },
+          {
+            "digest": "4r2EosDh4SAmuDk5qEMm19z8Yqi7kPtNTLxdmPdtuJwr"
+          }
+        ],
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": true
+        }
+      }
+    }
+  }
+}
+
+task 19, lines 80-90:
+//# run-graphql --cursors {"c":10,"t":6,"i":false} {"c":10,"t":8,"i":false}
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "DqfAehDoUapzpCYwh6HjJDhGWj6TAxsDZeYg7MfdTxEM"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 20, lines 92-99:
+//# run-graphql --cursors {"c":10,"t":2,"i":false}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: transaction 2 has been pruned (min available: 6)",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 21, lines 101-108:
+//# run-graphql --cursors {"c":10,"t":2,"i":false}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: transaction 2 has been pruned (min available: 6)",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -147,6 +147,26 @@ impl TransactionBlockFilter {
         self.at_checkpoint
     }
 
+    /// Returns the affected address when `affected_address` is the only
+    /// filter set.
+    pub(crate) fn only_affected_address(&self) -> Option<IotaAddress> {
+        if self.function.is_some()
+            || self.kind.is_some()
+            || self.sent_address.is_some()
+            || self.recv_address.is_some()
+            || self.input_object.is_some()
+            || self.changed_object.is_some()
+            || self.wrapped_or_deleted_object.is_some()
+            || self.transaction_ids.is_some()
+            || self.after_checkpoint.is_some()
+            || self.at_checkpoint.is_some()
+            || self.before_checkpoint.is_some()
+        {
+            return None;
+        }
+        self.affected_address
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.before_checkpoint == Some(UInt53::from(0))
             || matches!(

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -16,7 +16,7 @@ use iota_indexer::{
     apis::ReadApi,
     models::transactions::{OptimisticTransaction, StoredTransaction},
     read::TransactionRead,
-    schema::transactions,
+    schema::{checkpoints, transactions},
 };
 use iota_json_rpc_api::ReadApiServer;
 use iota_sdk_types::{
@@ -416,6 +416,18 @@ impl TransactionBlock {
             .await;
         }
 
+        // For the only-`affectedAddress` case, we support fallback.
+        // `scan_limit` is ignored here
+        if let Some(address) = filter.only_affected_address() {
+            return Self::paginate_by_affected_address_with_fallback(
+                db,
+                page,
+                address,
+                checkpoint_viewed_at,
+            )
+            .await;
+        }
+
         use transactions::dsl as tx;
         let (prev, next, transactions, tx_bounds): (
             bool,
@@ -543,6 +555,83 @@ impl TransactionBlock {
         if !page.is_from_front() {
             results.reverse();
         }
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = ScanConnection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            let inner = TransactionBlockInner::try_from(stored)?;
+            conn.edges.push(Edge::new(
+                cursor,
+                TransactionBlock {
+                    inner,
+                    checkpoint_viewed_at,
+                },
+            ));
+        }
+        Ok(conn)
+    }
+
+    /// Paginates the transactions that affect `address`, with fallback
+    /// support when part of the history has been pruned from Postgres.
+    async fn paginate_by_affected_address_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        address: IotaAddress,
+        checkpoint_viewed_at: u64,
+    ) -> Result<ScanConnection<String, TransactionBlock>, Error> {
+        use checkpoints::dsl;
+        // Exclusive upperbound, we cannot return newer data than
+        // `checkpoint_viewed_at`.
+        let tx_hi: i64 = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    dsl::checkpoints
+                        .select(dsl::network_total_transactions)
+                        .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
+                })
+            })
+            .await?;
+
+        // Page cursors are inclusive, we need to convert them to exclusive
+        let cursor = if page.is_from_front() {
+            // Cannot do -1 when cursor=0
+            page.after()
+                .and_then(|c| c.tx_sequence_number.checked_sub(1))
+        } else {
+            Some(match page.before() {
+                Some(c) => (tx_hi as u64).min(c.tx_sequence_number.saturating_add(1)),
+                None => tx_hi as u64,
+            })
+        };
+
+        let mut results = db
+            .inner
+            .query_stored_transactions_by_affected_addresses_with_fallback(
+                address.into(),
+                cursor,
+                page.limit() + 2,
+                !page.is_from_front(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !page.is_from_front() {
+            results.reverse();
+        }
+
+        // Initial fetch above honored only the start cursor. We filter the result to
+        // also honor the end cursor and the `tx_hi`
+        results.retain(|tx| {
+            let tx_seq = tx.tx_sequence_number as u64;
+            tx.tx_sequence_number < tx_hi
+                && page.after().is_none_or(|c| c.tx_sequence_number <= tx_seq)
+                && page.before().is_none_or(|c| tx_seq <= c.tx_sequence_number)
+        });
 
         let (prev, next, results) = page.paginate_results(
             results.first().map(|f| f.cursor(checkpoint_viewed_at)),

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -10,7 +10,7 @@ use std::{
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
 use cursor::TxLookup;
-use diesel::{ExpressionMethods, QueryDsl};
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{
     apis::ReadApi,
@@ -595,12 +595,15 @@ impl TransactionBlock {
                         .select(dsl::network_total_transactions)
                         .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
                 })
+                .optional()
             })
-            .await?;
+            .await?
+            .ok_or_else(|| {
+                Error::DataPruned(format!("checkpoint {checkpoint_viewed_at} has been pruned"))
+            })?;
 
         // Page cursors are inclusive, we need to convert them to exclusive
         let cursor = if page.is_from_front() {
-            // Cannot do -1 when cursor=0
             page.after()
                 .and_then(|c| c.tx_sequence_number.checked_sub(1))
         } else {

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -668,18 +668,10 @@ impl HistoricalFallbackReader {
     pub(crate) async fn paginate_transaction_digests_by_address(
         &self,
         address: Address,
-        cursor: Option<TransactionDigest>,
+        cursor: Option<TransactionSequenceNumber>,
         limit: usize,
         oldest_first: bool,
     ) -> IndexerResult<Vec<TransactionDigest>> {
-        let cursor = match cursor {
-            Some(digest) => match self.cursor_cache.get(&digest) {
-                Some(tx_sequence_number) => Some(tx_sequence_number),
-                None => Some(self.resolve_transaction_sequence_number(digest).await?),
-            },
-            None => None,
-        };
-
         let pairs = self
             .client
             .transaction_digests_by_address(address, cursor, limit, oldest_first)
@@ -694,11 +686,23 @@ impl HistoricalFallbackReader {
             .collect())
     }
 
+    /// Resolves the `tx_sequence_number` of the given cursor digest, through
+    /// the cursor cache or the checkpoint data in the fallback storage.
+    pub(crate) async fn resolve_cursor_tx_sequence_number(
+        &self,
+        digest: TransactionDigest,
+    ) -> IndexerResult<TransactionSequenceNumber> {
+        match self.cursor_cache.get(&digest) {
+            Some(tx_sequence_number) => Ok(tx_sequence_number),
+            None => self.resolve_transaction_sequence_number(digest).await,
+        }
+    }
+
     /// Fetches a paginated list of transactions that affect a given address.
     pub(crate) async fn transactions_by_address(
         &self,
         address: Address,
-        cursor: Option<TransactionDigest>,
+        cursor: Option<TransactionSequenceNumber>,
         limit: usize,
         oldest_first: bool,
     ) -> IndexerResult<Vec<Option<StoredTransaction>>> {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1366,45 +1366,37 @@ impl IndexerReader {
 
     /// Fetches a paginated list of transactions that affect a given address,
     /// using the fallback storage if the database is pruned.
-    async fn query_transactions_by_affected_addresses_with_fallback(
+    pub async fn query_stored_transactions_by_affected_addresses_with_fallback(
         &self,
         address: Address,
-        cursor: Option<TransactionDigest>,
+        cursor_tx_seq: Option<u64>,
         limit: usize,
         is_descending: bool,
-        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
-    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+    ) -> IndexerResult<Vec<StoredTransaction>> {
         let watermark = self.affected_addresses_tx_watermark();
 
-        // fast path: cursor is known to KV (cached) and in pruned territory
-        // (below watermark). Serve directly from KV until pagination crosses
-        // into the unpruned DB range.
-        if let Some((cursor, kv_reader)) = cursor.zip(self.fallback_reader()).filter(|(c, kv)| {
-            kv.cursor_cache
-                .get(c)
-                .is_some_and(|s| (s as i64) < watermark)
-        }) {
-            let stored_txs = kv_reader
-                .transactions_by_address(address, Some(cursor), limit, !is_descending)
+        // fast path: the cursor is in pruned territory (below the watermark).
+        // Serve directly from KV until pagination crosses into the unpruned
+        // DB range.
+        if let Some((cursor_tx_seq, kv_reader)) = cursor_tx_seq
+            .zip(self.fallback_reader())
+            .filter(|(c, _)| (*c as i64) < watermark)
+        {
+            return Ok(kv_reader
+                .transactions_by_address(address, Some(cursor_tx_seq), limit, !is_descending)
                 .await?
                 .into_iter()
                 .flatten()
-                .collect();
-
-            return self
-                .stored_transaction_to_transaction_block(stored_txs, options)
-                .await;
+                .collect());
         };
 
         let db_res = self
             .db()
-            .query_transactions_by_affected_addresses(address, cursor, limit, is_descending)
+            .query_transactions_by_affected_addresses(address, cursor_tx_seq, limit, is_descending)
             .await;
 
         let Some(kv_reader) = self.fallback_reader() else {
-            return self
-                .stored_transaction_to_transaction_block(db_res?, options)
-                .await;
+            return db_res;
         };
 
         let (mut rows, id_db_pruned) = match db_res {
@@ -1419,20 +1411,9 @@ impl IndexerReader {
             // Continue pagination from the last DB row, or from the original
             // cursor if the DB returned nothing. Avoids restarting KV from the
             // top of history and re-fetching rows the user already saw.
-            let kv_cursor = if let Some(tx) = rows.last() {
-                let digest =
-                    TransactionDigest::from_bytes(&tx.transaction_digest).map_err(|e| {
-                        IndexerError::PersistentStorageDataCorruption(format!(
-                            "failed to decode transaction digest: {:?} with err: {e:?}",
-                            tx.transaction_digest
-                        ))
-                    })?;
-                kv_reader
-                    .cursor_cache
-                    .insert(digest, tx.tx_sequence_number as u64);
-                Some(digest)
-            } else {
-                cursor
+            let kv_cursor = match rows.last() {
+                Some(tx) => Some(tx.tx_sequence_number as u64),
+                None => cursor_tx_seq,
             };
 
             let kv_rows = kv_reader
@@ -1442,6 +1423,60 @@ impl IndexerReader {
                 .flatten();
             rows.extend(kv_rows);
         }
+
+        Ok(rows)
+    }
+
+    /// Fetches a paginated list of transactions that affect a given address,
+    /// using the fallback storage if the database is pruned.
+    async fn query_transactions_by_affected_addresses_with_fallback(
+        &self,
+        address: Address,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let cursor_tx_seq = match cursor {
+            None => None,
+            Some(digest) => {
+                Some(
+                    match self
+                        .db()
+                        .resolve_cursor_tx_digest_to_seq_num_maybe(digest)
+                        .await?
+                    {
+                        Some(tx_seq) => tx_seq as u64,
+                        // The digest is not in Postgres: resolve it through the
+                        // fallback (which checks its cursor cache first).
+                        None => match self.fallback_reader() {
+                            Some(kv_reader) => {
+                                kv_reader.resolve_cursor_tx_sequence_number(digest).await?
+                            }
+                            None if self.affected_addresses_tx_watermark() > 0 => {
+                                return Err(IndexerError::DataPruned(format!(
+                                    "unable to resolve cursor digest: {digest} potentially pruned"
+                                )));
+                            }
+                            None => {
+                                return Err(IndexerError::InvalidArgument(format!(
+                                    "cursor with digest {digest} not found"
+                                )));
+                            }
+                        },
+                    },
+                )
+            }
+        };
+
+        let rows = self
+            .query_stored_transactions_by_affected_addresses_with_fallback(
+                address,
+                cursor_tx_seq,
+                limit,
+                is_descending,
+            )
+            .await?;
 
         self.stored_transaction_to_transaction_block(rows, options)
             .await
@@ -3604,51 +3639,36 @@ impl<'a> DBReader<'a> {
     ///
     /// # Errors
     ///
-    /// * [`IndexerError::DataPruned`] — signals the caller to fall back to the
-    ///   historical store. Two triggers:
-    ///   * `cursor` resolves to a sequence number below the pruning
-    ///     min_available_tx.
-    ///   * `cursor = None && is_descending = false && min_available_tx > 0`:
-    ///     the DB cannot tell whether the address has pre-watermark history.
-    /// * [`IndexerError::InvalidArgument`]: the cursor is invalid (digest
-    ///   absent from `tx_digests` AND the database is not pruned).
+    /// [`IndexerError::DataPruned`] — signals the caller to fall back to the
+    /// historical store. Two triggers:
+    /// * the first transaction of the page is below the pruning
+    ///   min_available_tx.
+    /// * `cursor_tx_seq = None && is_descending = false && min_available_tx >
+    ///   0`: the DB cannot tell whether the address has pre-watermark history.
     async fn query_transactions_by_affected_addresses(
         &self,
         addr: Address,
-        cursor: Option<TransactionDigest>,
+        cursor_tx_seq: Option<u64>,
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
         let min_available_tx = self.main_reader.affected_addresses_tx_watermark();
 
-        let cursor_tx_seq = if let Some(cursor) = cursor {
-            match self
-                .resolve_cursor_tx_digest_to_seq_num_maybe(cursor)
-                .await?
-            {
-                Some(tx_seq) => {
-                    self.main_reader.ensure_data_not_pruned_for_tx(
-                        tx_seq,
-                        IndexerReader::TRANSACTIONS_BY_ADDRESS_TABLES,
-                    )?;
-                    Some(tx_seq)
-                }
-                None if min_available_tx > 0 => {
-                    return Err(IndexerError::DataPruned(format!(
-                        "unable to resolve cursor digest: {cursor} potentially pruned"
-                    )));
-                }
-                None => {
-                    return Err(IndexerError::InvalidArgument(format!(
-                        "cursor with digest {cursor} not found"
-                    )));
-                }
-            }
-        } else {
-            None
-        };
+        if let Some(cursor_tx_seq) = cursor_tx_seq {
+            // The page starts right after/before cursor in the pagination direction.
+            // The cursor row itself is allowed to be pruned.
+            let page_start = if is_descending {
+                cursor_tx_seq.saturating_sub(1)
+            } else {
+                cursor_tx_seq.saturating_add(1)
+            };
+            self.main_reader.ensure_data_not_pruned_for_tx(
+                page_start as i64,
+                IndexerReader::TRANSACTIONS_BY_ADDRESS_TABLES,
+            )?;
+        }
 
-        if !is_descending && cursor.is_none() && min_available_tx > 0 {
+        if !is_descending && cursor_tx_seq.is_none() && min_available_tx > 0 {
             return Err(IndexerError::DataPruned(format!(
                 "DB may be missing earliest history for address {addr} due to pruning"
             )));


### PR DESCRIPTION
# Description of change

Enable GraphQL fallback to the archival KV store when listing transactions that affect a given address.

Covered paths:

- `Query.transactionBlocks(filter: { affectedAddress })`
- `Address.transactionBlocks` with the `AFFECTED` relation

Notes:

- The query is served by a new `IndexerReader::query_stored_transactions_by_affected_addresses_with_fallback`, extracted from the JSON-RPC `FromOrToAddress` fallback.
- Converting a sequence number (used by graphql) back to a digest is not easily possible, that's why a small refactor of iota-indexer was done to use tx sequence numbers in the core functions.
- The check rejecting cursors below the pruning watermark now looks at the first transaction of the page instead of the cursor row (which is never returned), this also fixes JSON-RPC handling of cursors right at the watermark.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11937

## How the change has been tested

- New e2e test `crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.move` (no fallback configured): paginating forward from the pruned earliest history and from cursors in the pruned range errors with `DATA_PRUNED`; paginating backward serves the unpruned range; a cursor window starting exactly at the watermark resolves; the `AFFECTED` relation paginates the same way.
- The KV-served paths (fast path, whole page from KV, descending top-up across the watermark, cursor cache) cannot be covered by the e2e tests and will be manually tested in followup issues.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: `Query.transactionBlocks(filter: { affectedAddress })` and `Address.transactionBlocks` with the `AFFECTED` relation resolve pruned history from the archival store when the historical fallback is configured, and report `DATA_PRUNED` otherwise.
