### PR TITLE
fix(simulacrum): stop epoch changes from silently falling into safe mode

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -294,6 +294,10 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ///
     /// NOTE: This function does not currently support updating the protocol
     /// version or the system packages
+    ///
+    /// # Panics
+    ///
+    /// Panics if the end-of-epoch transaction cannot be executed or fails.
     pub fn advance_epoch(&self) {
         let inner = self.inner.read().unwrap();
         let current_epoch = inner.epoch_state.epoch();
@@ -304,25 +308,64 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             .epoch_rolling_gas_cost_summary()
             .clone();
         let epoch_start_timestamp_ms = inner.store.get_clock().timestamp_ms();
+        let pass_validator_scores = inner
+            .epoch_state
+            .protocol_config()
+            .pass_validator_scores_to_advance_epoch();
+        let adjust_rewards_by_score = inner
+            .epoch_state
+            .protocol_config()
+            .adjust_rewards_by_score();
+        let committee_size = inner.epoch_state.committee().num_members();
         drop(inner);
 
+        // One full score per validator, so rewards stay unadjusted. This
+        // mirrors the node's default when locally calculated scores are not
+        // passed. Must match MAX_SCORE in validator_set.move.
+        const MAX_SCORE: u64 = u16::MAX as u64 + 1;
+        let scores = vec![MAX_SCORE; committee_size];
+
         let next_epoch_system_package_bytes: Vec<SystemPackage> = vec![];
-        let kinds = vec![EndOfEpochTransactionKind::new_change_epoch_v3(
-            next_epoch,
-            next_epoch_protocol_version.as_u64(),
-            gas_cost_summary.storage_cost,
-            gas_cost_summary.computation_cost,
-            gas_cost_summary.computation_cost_burned,
-            gas_cost_summary.storage_rebate,
-            gas_cost_summary.non_refundable_storage_fee,
-            epoch_start_timestamp_ms,
-            next_epoch_system_package_bytes,
-            vec![],
-        )];
+        // Mirror the node's kind selection: the framework's `advance_epoch`
+        // expects the V4 argument shape when the flag is enabled.
+        let kinds = vec![if pass_validator_scores {
+            EndOfEpochTransactionKind::new_change_epoch_v4(
+                next_epoch,
+                next_epoch_protocol_version.as_u64(),
+                gas_cost_summary.storage_cost,
+                gas_cost_summary.computation_cost,
+                gas_cost_summary.computation_cost_burned,
+                gas_cost_summary.storage_rebate,
+                gas_cost_summary.non_refundable_storage_fee,
+                epoch_start_timestamp_ms,
+                next_epoch_system_package_bytes,
+                vec![],
+                scores,
+                adjust_rewards_by_score,
+            )
+        } else {
+            EndOfEpochTransactionKind::new_change_epoch_v3(
+                next_epoch,
+                next_epoch_protocol_version.as_u64(),
+                gas_cost_summary.storage_cost,
+                gas_cost_summary.computation_cost,
+                gas_cost_summary.computation_cost_burned,
+                gas_cost_summary.storage_rebate,
+                gas_cost_summary.non_refundable_storage_fee,
+                epoch_start_timestamp_ms,
+                next_epoch_system_package_bytes,
+                vec![],
+            )
+        }];
 
         let tx = VerifiedTransaction::new_end_of_epoch_transaction(kinds);
-        self.execute_transaction(tx.into())
+        let (effects, execution_error) = self
+            .execute_transaction(tx.into())
             .expect("advancing the epoch cannot fail");
+        assert!(
+            execution_error.is_none(),
+            "the end-of-epoch transaction failed: {execution_error:?}, {effects:?}"
+        );
 
         let (checkpoint, contents, new_epoch_state) = {
             let mut inner = self.inner.write().unwrap();


### PR DESCRIPTION
# Description of change

`Simulacrum::advance_epoch` still built `EndOfEpochTransactionKind::ChangeEpochV3`, but the framework's `iota_system::advance_epoch` now has the V4 argument shape (`scores`, `adjust_rewards_by_score`). Every simulated epoch change therefore failed with an arity mismatch and fell back to safe mode, invisibly: the engine only logs the failure and simulacrum ignored execution errors in the effects — no simulated epoch change actually distributed rewards.

- Mirror the node's change-epoch kind selection: `ChangeEpochV4` when `pass_validator_scores_to_advance_epoch` is enabled, `ChangeEpochV3` otherwise.
- Pass one full score (`MAX_SCORE`) per validator — the node's default when locally calculated scores are not passed. The scores length is asserted by `validator_set::compute_adjusted_reward_distribution` regardless of `adjust_rewards_by_score`, and full scores leave rewards unadjusted either way.
- Assert that the end-of-epoch transaction succeeded, so future regressions fail loudly instead of silently.

## Links to any relevant issues

Fixes #12558.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

No new test: the new assert is the regression guard — without the fix, the existing `simple_epoch` simulacrum test panics on it (the end-of-epoch transaction aborts in `validator_set::compute_adjusted_reward_distribution` with `EInvalidScoresData`). With the fix, all simulacrum unit tests pass and epoch changes execute for real. Snapshots of pg-gated suites that advance epochs (GraphQL e2e, indexer) may need regeneration, since simulated epoch changes now actually execute.
