### PR TITLE
feat(iota-execution,simulacrum): execute the on-chain deny-rule transaction kinds

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/create.move
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/create.move
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// The TransactionDenyRulesCreate end-of-epoch transaction kind creates the
+// shared TransactionDenyRules object at its reserved address 0xDE9, with all
+// deny tables empty and all switches off.
+
+//# init --simulator --deny-rule-governance true
+
+//# view-object 0xDE9
+
+//# advance-epoch --create-deny-rules-object
+
+//# view-object 0xDE9
+
+//# view-object 2,0

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/create.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/create.snap
@@ -1,0 +1,97 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
+---
+processed 5 tasks
+
+task 1, line 10:
+//# view-object 0xDE9
+No object at id 0x0000000000000000000000000000000000000000000000000000000000000de9
+
+task 2, line 12:
+//# advance-epoch --create-deny-rules-object
+Epoch advanced: 1
+
+task 3, line 14:
+//# view-object 0xDE9
+Owner: Shared(2)
+Version: 2
+Contents: iota::transaction_deny_rules::TransactionDenyRules {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: 0x0000000000000000000000000000000000000000000000000000000000000de9,
+        },
+    },
+    inner: iota::versioned::Versioned {
+        id: iota::object::UID {
+            id: iota::object::ID {
+                bytes: _,
+            },
+        },
+        version: 1u64,
+    },
+}
+
+task 4, line 16:
+//# view-object 2,0
+Owner: Object(_)
+Version: 2
+Contents: iota::dynamic_field::Field<u64, iota::transaction_deny_rules::TransactionDenyRulesInnerV1> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    name: 1u64,
+    value: iota::transaction_deny_rules::TransactionDenyRulesInnerV1 {
+        version: 1u64,
+        denied_addresses: iota::linked_table::LinkedTable<address, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<address> {
+                vec: vector[],
+            },
+            tail: std::option::Option<address> {
+                vec: vector[],
+            },
+        },
+        denied_objects: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        denied_packages: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        package_publish_disabled: false,
+        package_upgrade_disabled: false,
+        shared_object_disabled: false,
+        user_transaction_disabled: false,
+        receiving_objects_disabled: false,
+        move_authenticator_disabled: false,
+    },
+}

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/persists_across_epochs.move
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/persists_across_epochs.move
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// The TransactionDenyRules object and its accumulated state survive epoch
+// changes, and updates keep working in later epochs.
+
+//# init --simulator --deny-rule-governance true
+
+//# advance-epoch --create-deny-rules-object
+
+//# update-deny-rules --added-addresses 0xAA --package-publish-disabled
+
+//# advance-epoch
+
+// The denied address and the switch survived the epoch change.
+
+//# view-object 1,0
+
+//# update-deny-rules --added-addresses 0xBB --removed-addresses 0xAA
+
+// Still one denied address (0xAA replaced by 0xBB); the switch was cleared by
+// the second update.
+
+//# view-object 1,0

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/persists_across_epochs.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/persists_across_epochs.snap
@@ -1,0 +1,174 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
+---
+processed 7 tasks
+
+task 1, line 9:
+//# advance-epoch --create-deny-rules-object
+Epoch advanced: 1
+
+task 2, line 11:
+//# update-deny-rules --added-addresses 0xAA --package-publish-disabled
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKoAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==" }
+created: object(2,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9, object(1,0)
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, lines 13-15:
+//# advance-epoch
+Epoch advanced: 2
+
+task 4, line 17:
+//# view-object 1,0
+Owner: Object(_)
+Version: 3
+Contents: iota::dynamic_field::Field<u64, iota::transaction_deny_rules::TransactionDenyRulesInnerV1> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: 1u64,
+    value: iota::transaction_deny_rules::TransactionDenyRulesInnerV1 {
+        version: 1u64,
+        denied_addresses: iota::linked_table::LinkedTable<address, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 1u64,
+            head: std::option::Option<address> {
+                vec: vector[
+                    _,
+                ],
+            },
+            tail: std::option::Option<address> {
+                vec: vector[
+                    _,
+                ],
+            },
+        },
+        denied_objects: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        denied_packages: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        package_publish_disabled: true,
+        package_upgrade_disabled: false,
+        shared_object_disabled: false,
+        user_transaction_disabled: false,
+        receiving_objects_disabled: false,
+        move_authenticator_disabled: false,
+    },
+}
+
+task 5, lines 19-22:
+//# update-deny-rules --added-addresses 0xBB --removed-addresses 0xAA
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AgAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKoAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" }
+created: object(5,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9, object(1,0)
+deleted: object(2,0)
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 6, line 24:
+//# view-object 1,0
+Owner: Object(_)
+Version: 4
+Contents: iota::dynamic_field::Field<u64, iota::transaction_deny_rules::TransactionDenyRulesInnerV1> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: 1u64,
+    value: iota::transaction_deny_rules::TransactionDenyRulesInnerV1 {
+        version: 1u64,
+        denied_addresses: iota::linked_table::LinkedTable<address, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 1u64,
+            head: std::option::Option<address> {
+                vec: vector[
+                    _,
+                ],
+            },
+            tail: std::option::Option<address> {
+                vec: vector[
+                    _,
+                ],
+            },
+        },
+        denied_objects: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        denied_packages: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        package_publish_disabled: false,
+        package_upgrade_disabled: false,
+        shared_object_disabled: false,
+        user_transaction_disabled: false,
+        receiving_objects_disabled: false,
+        move_authenticator_disabled: false,
+    },
+}

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/switches.move
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/switches.move
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Each update pins all six global switches to the values carried by the
+// transaction: switches set by one update are cleared by the next one that
+// does not carry them.
+
+//# init --simulator --deny-rule-governance true
+
+//# advance-epoch --create-deny-rules-object
+
+//# update-deny-rules --package-publish-disabled --shared-object-disabled --move-authenticator-disabled
+
+//# view-object 1,0
+
+// The next update carries different switches; the previous ones are cleared.
+
+//# update-deny-rules --user-transaction-disabled
+
+//# view-object 1,0

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/switches.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/switches.snap
@@ -1,0 +1,158 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+task 1, line 10:
+//# advance-epoch --create-deny-rules-object
+Epoch advanced: 1
+
+task 2, line 12:
+//# update-deny-rules --package-publish-disabled --shared-object-disabled --move-authenticator-disabled
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AQAAAAAAAAAAAAAAAAABAAEAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" }
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9, object(1,0)
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, lines 14-16:
+//# view-object 1,0
+Owner: Object(_)
+Version: 3
+Contents: iota::dynamic_field::Field<u64, iota::transaction_deny_rules::TransactionDenyRulesInnerV1> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: 1u64,
+    value: iota::transaction_deny_rules::TransactionDenyRulesInnerV1 {
+        version: 1u64,
+        denied_addresses: iota::linked_table::LinkedTable<address, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<address> {
+                vec: vector[],
+            },
+            tail: std::option::Option<address> {
+                vec: vector[],
+            },
+        },
+        denied_objects: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        denied_packages: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        package_publish_disabled: true,
+        package_upgrade_disabled: false,
+        shared_object_disabled: true,
+        user_transaction_disabled: false,
+        receiving_objects_disabled: false,
+        move_authenticator_disabled: true,
+    },
+}
+
+task 4, line 18:
+//# update-deny-rules --user-transaction-disabled
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" }
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9, object(1,0)
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 5, line 20:
+//# view-object 1,0
+Owner: Object(_)
+Version: 4
+Contents: iota::dynamic_field::Field<u64, iota::transaction_deny_rules::TransactionDenyRulesInnerV1> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: 1u64,
+    value: iota::transaction_deny_rules::TransactionDenyRulesInnerV1 {
+        version: 1u64,
+        denied_addresses: iota::linked_table::LinkedTable<address, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<address> {
+                vec: vector[],
+            },
+            tail: std::option::Option<address> {
+                vec: vector[],
+            },
+        },
+        denied_objects: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        denied_packages: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        package_publish_disabled: false,
+        package_upgrade_disabled: false,
+        shared_object_disabled: false,
+        user_transaction_disabled: true,
+        receiving_objects_disabled: false,
+        move_authenticator_disabled: false,
+    },
+}

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/tolerant_delta.move
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/tolerant_delta.move
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Re-applying a delta is a no-op: adding an already denied entry or removing
+// an absent one is tolerated, and the update transaction still succeeds and
+// emits its event.
+
+//# init --simulator --deny-rule-governance true
+
+//# advance-epoch --create-deny-rules-object
+
+//# update-deny-rules --added-addresses 0xAA --added-packages 0x2B
+
+// The exact same delta again: both adds are already present.
+
+//# update-deny-rules --added-addresses 0xAA --added-packages 0x2B
+
+// Removing entries that were never added is tolerated too.
+
+//# update-deny-rules --removed-addresses 0xBB --removed-objects 0x1A
+
+// One denied address and one denied package, from the first update.
+
+//# view-object 1,0

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/tolerant_delta.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/tolerant_delta.snap
@@ -1,0 +1,118 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+task 1, line 10:
+//# advance-epoch --create-deny-rules-object
+Epoch advanced: 1
+
+task 2, lines 12-14:
+//# update-deny-rules --added-addresses 0xAA --added-packages 0x2B
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKoAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACsAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAA" }
+created: object(2,0), object(2,1)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9, object(1,0)
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, lines 16-18:
+//# update-deny-rules --added-addresses 0xAA --added-packages 0x2B
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKoAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACsAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAA" }
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 4, lines 20-22:
+//# update-deny-rules --removed-addresses 0xBB --removed-objects 0x1A
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAA" }
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 5, line 24:
+//# view-object 1,0
+Owner: Object(_)
+Version: 3
+Contents: iota::dynamic_field::Field<u64, iota::transaction_deny_rules::TransactionDenyRulesInnerV1> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: 1u64,
+    value: iota::transaction_deny_rules::TransactionDenyRulesInnerV1 {
+        version: 1u64,
+        denied_addresses: iota::linked_table::LinkedTable<address, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 1u64,
+            head: std::option::Option<address> {
+                vec: vector[
+                    _,
+                ],
+            },
+            tail: std::option::Option<address> {
+                vec: vector[
+                    _,
+                ],
+            },
+        },
+        denied_objects: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        denied_packages: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 1u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[
+                    iota::object::ID {
+                        bytes: _,
+                    },
+                ],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[
+                    iota::object::ID {
+                        bytes: _,
+                    },
+                ],
+            },
+        },
+        package_publish_disabled: false,
+        package_upgrade_disabled: false,
+        shared_object_disabled: false,
+        user_transaction_disabled: false,
+        receiving_objects_disabled: false,
+        move_authenticator_disabled: false,
+    },
+}

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/update_before_create.move
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/update_before_create.move
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// A TransactionDenyRulesUpdate transaction cannot be built before the
+// TransactionDenyRules object has been created at the end of an epoch.
+
+//# init --simulator --deny-rule-governance true
+
+//# update-deny-rules --added-addresses 0xAA

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/update_before_create.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/update_before_create.snap
@@ -1,0 +1,9 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
+---
+processed 2 tasks
+
+task 1, line 9:
+//# update-deny-rules --added-addresses 0xAA
+Error: the TransactionDenyRules object has not been created yet; advance-epoch --create-deny-rules-object creates it

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/updates_accumulate.move
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/updates_accumulate.move
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// TransactionDenyRulesUpdate transactions apply add/remove deltas that
+// accumulate in the TransactionDenyRules object across updates.
+
+//# init --simulator --deny-rule-governance true
+
+//# advance-epoch --create-deny-rules-object
+
+// First delta: two addresses, one object, two packages.
+
+//# update-deny-rules --added-addresses 0xAA,0xBB --added-objects 0x1A --added-packages 0x2B,0x2C
+
+// Second delta: remove one address, the object and one package, add a new
+// address.
+
+//# update-deny-rules --added-addresses 0xCC --removed-addresses 0xAA --removed-objects 0x1A --removed-packages 0x2B
+
+// The inner object: two denied addresses, no denied objects, one denied
+// package left.
+
+//# view-object 1,0
+
+// One of the surviving table entries from the first delta.
+
+//# view-object 2,0
+
+// The entry added by the second delta.
+
+//# view-object 3,0

--- a/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/updates_accumulate.snap
+++ b/crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/updates_accumulate.snap
@@ -1,0 +1,158 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 818
+---
+processed 7 tasks
+
+task 1, lines 9-11:
+//# advance-epoch --create-deny-rules-object
+Epoch advanced: 1
+
+task 2, lines 13-16:
+//# update-deny-rules --added-addresses 0xAA,0xBB --added-objects 0x1A --added-packages 0x2B,0x2C
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuwABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABoAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAArAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAAAAAgAAAAAAAAABAAAAAAAAAAIAAAAAAAAA" }
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9, object(1,0)
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, lines 18-21:
+//# update-deny-rules --added-addresses 0xCC --removed-addresses 0xAA --removed-objects 0x1A --removed-packages 0x2B
+events: Event { package_id: ObjectId("iota"), module: Identifier("transaction_deny_rules"), sender: Address("_"), type_: StructTag { address: Address("iota"), module: Identifier("transaction_deny_rules"), name: Identifier("TransactionDenyRulesUpdated"), type_params: [] }, contents: "AQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMwBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKoAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAAAAAAIAAAAAAAAAAAAAAAAAAAABAAAAAAAAAA==" }
+created: object(3,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000de9, object(1,0), object(2,0), object(2,4)
+deleted: object(2,1), object(2,2), object(2,3)
+gas summary:
+├── Computation Cost: 0
+├── Computation Cost Burned: 0
+├── Storage Cost: 0
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 4, lines 23-25:
+//# view-object 1,0
+Owner: Object(_)
+Version: 4
+Contents: iota::dynamic_field::Field<u64, iota::transaction_deny_rules::TransactionDenyRulesInnerV1> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    name: 1u64,
+    value: iota::transaction_deny_rules::TransactionDenyRulesInnerV1 {
+        version: 1u64,
+        denied_addresses: iota::linked_table::LinkedTable<address, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 2u64,
+            head: std::option::Option<address> {
+                vec: vector[
+                    _,
+                ],
+            },
+            tail: std::option::Option<address> {
+                vec: vector[
+                    _,
+                ],
+            },
+        },
+        denied_objects: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[],
+            },
+        },
+        denied_packages: iota::linked_table::LinkedTable<iota::object::ID, bool> {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 1u64,
+            head: std::option::Option<iota::object::ID> {
+                vec: vector[
+                    iota::object::ID {
+                        bytes: _,
+                    },
+                ],
+            },
+            tail: std::option::Option<iota::object::ID> {
+                vec: vector[
+                    iota::object::ID {
+                        bytes: _,
+                    },
+                ],
+            },
+        },
+        package_publish_disabled: false,
+        package_upgrade_disabled: false,
+        shared_object_disabled: false,
+        user_transaction_disabled: false,
+        receiving_objects_disabled: false,
+        move_authenticator_disabled: false,
+    },
+}
+
+task 5, lines 27-29:
+//# view-object 2,0
+Owner: Object(_)
+Version: 4
+Contents: iota::dynamic_field::Field<address, iota::linked_table::Node<address, bool>> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    name: _,
+    value: iota::linked_table::Node<address, bool> {
+        prev: std::option::Option<address> {
+            vec: vector[],
+        },
+        next: std::option::Option<address> {
+            vec: vector[
+                _,
+            ],
+        },
+        value: true,
+    },
+}
+
+task 6, line 31:
+//# view-object 3,0
+Owner: Object(_)
+Version: 4
+Contents: iota::dynamic_field::Field<address, iota::linked_table::Node<address, bool>> {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    name: _,
+    value: iota::linked_table::Node<address, bool> {
+        prev: std::option::Option<address> {
+            vec: vector[
+                _,
+            ],
+        },
+        next: std::option::Option<address> {
+            vec: vector[],
+        },
+        value: true,
+    },
+}

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -449,7 +449,7 @@ mod ingestion_tests {
         assert!(err.is_none());
 
         sim.create_checkpoint(); // checkpoint 1
-        sim.advance_epoch(); // checkpoint 2 and epoch 1
+        sim.advance_epoch(false); // checkpoint 2 and epoch 1
 
         let (transaction, _) = sim.transfer_txn(transfer_recipient);
         let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -32,11 +32,11 @@ fn get_or_init_shared_extended_api_simulacrum_env() -> &'static SimulacrumTestSe
 
             execute_simulacrum_transactions(&mut sim, 15);
             add_checkpoints(&mut sim, 300);
-            sim.advance_epoch();
+            sim.advance_epoch(false);
 
             execute_simulacrum_transactions(&mut sim, 10);
             add_checkpoints(&mut sim, 300);
-            sim.advance_epoch();
+            sim.advance_epoch(false);
 
             execute_simulacrum_transactions(&mut sim, 5);
             add_checkpoints(&mut sim, 300);

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -691,6 +691,20 @@ mod checked {
                 }
             }
             InputObjectKind::SharedMoveObject {
+                id: ObjectId::TRANSACTION_DENY_RULES,
+                ..
+            } => {
+                // The deny rules object is written only by system
+                // transactions and has no user-callable readers.
+                if system_transaction {
+                    return Ok(());
+                } else {
+                    return Err(UserInputError::InaccessibleSystemObject {
+                        object_id: ObjectId::TRANSACTION_DENY_RULES,
+                    });
+                }
+            }
+            InputObjectKind::SharedMoveObject {
                 initial_shared_version: input_initial_shared_version,
                 ..
             } => {

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -71,6 +71,10 @@ pub struct IotaInitArgs {
     pub default_gas_price: Option<u64>,
     #[clap(long = "move-auth")]
     pub move_auth: Option<bool>,
+    /// Enable the deny-rule governance feature flags (`deny_rule_governance`
+    /// and `deny_rule_governance_on_chain`).
+    #[clap(long = "deny-rule-governance")]
+    pub deny_rule_governance: Option<bool>,
     #[arg(long)]
     pub flavor: Option<Flavor>,
     /// The number of epochs to keep in the database. Epochs outside of this
@@ -266,6 +270,44 @@ pub struct CreateCheckpointCommand {
 #[derive(Debug, clap::Parser)]
 pub struct AdvanceEpochCommand {
     pub count: Option<u64>,
+    /// Include a `TransactionDenyRulesCreate` kind in the end-of-epoch
+    /// transaction. Simulator mode only.
+    #[arg(long)]
+    pub create_deny_rules_object: bool,
+}
+
+/// Executes a `TransactionDenyRulesUpdate` system transaction applying the
+/// given add/remove delta and switch states. The deny-rules object must have
+/// been created first (`advance-epoch --create-deny-rules-object`).
+#[derive(Debug, clap::Parser)]
+pub struct UpdateDenyRulesCommand {
+    /// Consensus round recorded in the update payload.
+    #[arg(long)]
+    pub round: Option<u64>,
+    #[arg(long, value_delimiter = ',')]
+    pub added_addresses: Vec<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub removed_addresses: Vec<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub added_objects: Vec<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub removed_objects: Vec<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub added_packages: Vec<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub removed_packages: Vec<String>,
+    #[arg(long)]
+    pub package_publish_disabled: bool,
+    #[arg(long)]
+    pub package_upgrade_disabled: bool,
+    #[arg(long)]
+    pub shared_object_disabled: bool,
+    #[arg(long)]
+    pub user_transaction_disabled: bool,
+    #[arg(long)]
+    pub receiving_objects_disabled: bool,
+    #[arg(long)]
+    pub move_authenticator_disabled: bool,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -291,6 +333,7 @@ pub enum IotaSubcommand<ExtraValueArgs: ParsableValue, ExtraRunArgs: Parser> {
     AdvanceEpoch(AdvanceEpochCommand),
     AdvanceClock(AdvanceClockCommand),
     SetRandomState(SetRandomStateCommand),
+    UpdateDenyRules(UpdateDenyRulesCommand),
     ViewCheckpoint,
     RunGraphql(RunGraphqlCommand),
     Bench(RunCommand<ExtraValueArgs>, ExtraRunArgs),
@@ -342,6 +385,9 @@ impl<ExtraValueArgs: ParsableValue, ExtraRunArgs: Parser> clap::FromArgMatches
             Some(("set-random-state", matches)) => {
                 IotaSubcommand::SetRandomState(SetRandomStateCommand::from_arg_matches(matches)?)
             }
+            Some(("update-deny-rules", matches)) => {
+                IotaSubcommand::UpdateDenyRules(UpdateDenyRulesCommand::from_arg_matches(matches)?)
+            }
             Some(("view-checkpoint", _)) => IotaSubcommand::ViewCheckpoint,
             Some(("run-graphql", matches)) => {
                 IotaSubcommand::RunGraphql(RunGraphqlCommand::from_arg_matches(matches)?)
@@ -388,6 +434,7 @@ impl<ExtraValueArgs: ParsableValue, ExtraRunArgs: Parser> clap::CommandFactory
             .subcommand(AdvanceEpochCommand::command().name("advance-epoch"))
             .subcommand(AdvanceClockCommand::command().name("advance-clock"))
             .subcommand(SetRandomStateCommand::command().name("set-random-state"))
+            .subcommand(UpdateDenyRulesCommand::command().name("update-deny-rules"))
             .subcommand(clap::Command::new("view-checkpoint"))
             .subcommand(RunGraphqlCommand::command().name("run-graphql"))
             .subcommand(

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -89,7 +89,12 @@ pub trait TransactionalAdapter: Send + Sync + ReadStore {
         duration: std::time::Duration,
     ) -> anyhow::Result<TransactionEffects>;
 
-    async fn advance_epoch(&mut self) -> anyhow::Result<()>;
+    /// Returns the effects of the end-of-epoch transaction when the executor
+    /// exposes them (the simulator does, the validator setup does not).
+    async fn advance_epoch(
+        &mut self,
+        create_deny_rules_object: bool,
+    ) -> anyhow::Result<Option<TransactionEffects>>;
 
     async fn request_gas(
         &mut self,
@@ -206,10 +211,17 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         unimplemented!("advance_clock not supported")
     }
 
-    async fn advance_epoch(&mut self) -> anyhow::Result<()> {
+    async fn advance_epoch(
+        &mut self,
+        create_deny_rules_object: bool,
+    ) -> anyhow::Result<Option<TransactionEffects>> {
+        anyhow::ensure!(
+            !create_deny_rules_object,
+            "--create-deny-rules-object is only supported in simulator mode"
+        );
         self.validator.reconfigure_for_testing().await;
         self.fullnode.reconfigure_for_testing().await;
-        Ok(())
+        Ok(None)
     }
 
     async fn request_gas(
@@ -442,9 +454,14 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         Ok(Simulacrum::advance_clock(self, duration))
     }
 
-    async fn advance_epoch(&mut self) -> anyhow::Result<()> {
-        Simulacrum::advance_epoch(self);
-        Ok(())
+    async fn advance_epoch(
+        &mut self,
+        create_deny_rules_object: bool,
+    ) -> anyhow::Result<Option<TransactionEffects>> {
+        Ok(Some(Simulacrum::advance_epoch(
+            self,
+            create_deny_rules_object,
+        )))
     }
 
     async fn request_gas(

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -30,16 +30,17 @@ use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_sdk_types::{
     Address, Argument, CheckpointContentsDigest, CheckpointDigest, Command, ConsensusCommitDigest,
     Event, ExecutionStatus, GasPayment, Identifier, MoveAuthenticatorV1, ObjectData, ObjectId,
-    ObjectReference, ProgrammableTransaction, RandomnessRound, Transaction, TransactionDigest,
-    TransactionEffects, TransactionEvents, TransactionExpiration, TransactionKind, TransactionV1,
-    TypeTag, UserSignature, Version, checkpoint::CheckpointContents, gas::GasCostSummary,
-    move_package::MovePackage,
+    ObjectReference, ProgrammableTransaction, RandomnessRound, Transaction,
+    TransactionDenyRulesUpdate, TransactionDigest, TransactionEffects, TransactionEvents,
+    TransactionExpiration, TransactionKind, TransactionV1, TypeTag, UserSignature, Version,
+    checkpoint::CheckpointContents, gas::GasCostSummary, move_package::MovePackage,
 };
 use iota_storage::{
     key_value_store::TransactionKeyValueStore, key_value_store_metrics::KeyValueStoreMetrics,
 };
 use iota_swarm_config::genesis_config::AccountConfig;
 use iota_types::{
+    IOTA_TRANSACTION_DENY_RULES_OBJECT_ID,
     base_types::{IOTA_ADDRESS_LENGTH, VersionNumber},
     committee::EpochId,
     crypto::{AccountKeyPair, get_authority_key_pair, get_key_pair_from_rng},
@@ -114,6 +115,7 @@ const WELL_KNOWN_OBJECTS: &[ObjectId] = &[
     ObjectId::CLOCK,
     ObjectId::DENY_LIST,
     ObjectId::RANDOMNESS_STATE,
+    ObjectId::TRANSACTION_DENY_RULES,
 ];
 // TODO use the file name as a seed
 const RNG_SEED: [u8; 32] = [
@@ -208,6 +210,7 @@ impl AdapterInitConfig {
             reference_gas_price,
             default_gas_price,
             move_auth,
+            deny_rule_governance,
             flavor,
             epochs_to_keep,
             data_ingestion_path,
@@ -238,6 +241,10 @@ impl AdapterInitConfig {
             protocol_config.set_enable_move_authentication_for_testing(enable);
             protocol_config.set_enable_move_authentication_for_sponsor_for_testing(enable);
             protocol_config.set_pre_consensus_sponsor_only_move_authentication_for_testing(enable);
+        }
+        if let Some(enable) = deny_rule_governance {
+            protocol_config.set_deny_rule_governance_for_testing(enable);
+            protocol_config.set_deny_rule_governance_on_chain_for_testing(enable);
         }
         if custom_validator_account && !simulator {
             panic!("Can only set custom validator account in simulator mode");
@@ -710,9 +717,31 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 let latest_chk = self.executor.try_get_latest_checkpoint_sequence_number()?;
                 Ok(Some(format!("Checkpoint created: {latest_chk}")))
             }
-            IotaSubcommand::AdvanceEpoch(AdvanceEpochCommand { count }) => {
+            IotaSubcommand::AdvanceEpoch(AdvanceEpochCommand {
+                count,
+                create_deny_rules_object,
+            }) => {
                 for _ in 0..count.unwrap_or(1) {
-                    self.executor.advance_epoch().await?;
+                    let effects = self
+                        .executor
+                        .advance_epoch(create_deny_rules_object)
+                        .await?;
+                    // Enumerate the objects the create produced so tests can
+                    // `view-object` them. Scoped to the flag to leave the fake
+                    // ids of all other tests untouched.
+                    if create_deny_rules_object {
+                        if let Some(effects) = effects {
+                            let mut created_ids: Vec<_> = effects
+                                .created()
+                                .iter()
+                                .map(|(object_ref, _)| object_ref.object_id)
+                                .collect();
+                            created_ids.sort_by_key(|id| self.get_object_sorting_key(id));
+                            for id in created_ids {
+                                self.enumerate_fake(id);
+                            }
+                        }
+                    }
                 }
                 let epoch = self.try_get_latest_epoch_id()?;
                 Ok(Some(format!("Epoch advanced: {epoch}")))
@@ -741,6 +770,62 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
 
                 self.execute_txn(tx.into()).await?;
                 Ok(None)
+            }
+            IotaSubcommand::UpdateDenyRules(cmd) => {
+                fn parse_entries<T: std::str::FromStr + Ord>(
+                    items: Vec<String>,
+                ) -> anyhow::Result<std::collections::BTreeSet<T>>
+                where
+                    T::Err: std::fmt::Display,
+                {
+                    items
+                        .into_iter()
+                        .map(|item| {
+                            // Accept short hex (e.g. `0xaa`) by left-padding to
+                            // the full 32-byte width.
+                            let hex = item.strip_prefix("0x").unwrap_or(&item);
+                            format!("0x{hex:0>64}")
+                                .parse::<T>()
+                                .map_err(|e| anyhow!("invalid deny list entry `{item}`: {e}"))
+                        })
+                        .collect()
+                }
+
+                let epoch = self.try_get_latest_epoch_id()?;
+                let deny_rules_obj_initial_shared_version = self
+                    .get_object(&IOTA_TRANSACTION_DENY_RULES_OBJECT_ID, None)
+                    .map_err(|_| {
+                        anyhow!(
+                            "the TransactionDenyRules object has not been created yet; \
+                             advance-epoch --create-deny-rules-object creates it"
+                        )
+                    })?
+                    .owner
+                    .into_opt_shared()
+                    .ok_or_else(|| anyhow!("TransactionDenyRules object must be shared"))?;
+
+                let tx = VerifiedTransaction::new_transaction_deny_rules_update(
+                    TransactionDenyRulesUpdate {
+                        epoch,
+                        round: cmd.round.unwrap_or_default(),
+                        added_addresses: parse_entries(cmd.added_addresses)?,
+                        removed_addresses: parse_entries(cmd.removed_addresses)?,
+                        added_objects: parse_entries(cmd.added_objects)?,
+                        removed_objects: parse_entries(cmd.removed_objects)?,
+                        added_packages: parse_entries(cmd.added_packages)?,
+                        removed_packages: parse_entries(cmd.removed_packages)?,
+                        package_publish_disabled: cmd.package_publish_disabled,
+                        package_upgrade_disabled: cmd.package_upgrade_disabled,
+                        shared_object_disabled: cmd.shared_object_disabled,
+                        user_transaction_disabled: cmd.user_transaction_disabled,
+                        receiving_objects_disabled: cmd.receiving_objects_disabled,
+                        move_authenticator_disabled: cmd.move_authenticator_disabled,
+                        deny_rules_obj_initial_shared_version,
+                    },
+                );
+
+                let summary = self.execute_txn(tx.into()).await?;
+                Ok(self.object_summary_output(&summary, /* summarize */ false))
             }
             IotaSubcommand::ViewObject(ViewObjectCommand { id: fake_id }) => {
                 let obj = get_obj!(fake_id);
@@ -2709,6 +2794,18 @@ async fn init_sim_executor(
     // Create the simulator with the specific account configs, which also crates
     // objects
 
+    // The simulator resolves its `ProtocolConfig` from the protocol version alone,
+    // so feature flags toggled on `protocol_config` would not reach it. Scope a
+    // thread-local override around the (synchronous) construction so the genesis
+    // epoch picks the flags up; `Simulacrum::advance_epoch` then carries the
+    // config over to later epochs.
+    let config_override = protocol_config.deny_rule_governance().then(|| {
+        ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_deny_rule_governance_for_testing(true);
+            config.set_deny_rule_governance_on_chain_for_testing(true);
+            config
+        })
+    });
     let (sim, read_replica) = PersistedStore::new_sim_replica_with_protocol_version_and_accounts(
         rng,
         DEFAULT_CHAIN_START_TIMESTAMP,
@@ -2718,6 +2815,7 @@ async fn init_sim_executor(
         reference_gas_price,
         None,
     );
+    drop(config_override);
 
     sim.set_data_ingestion_path(data_ingestion_path.clone());
 

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -22,9 +22,9 @@ use iota_sdk_types::{
     Event, GasPayment, GenesisObject, GenesisTransaction, Identifier, Input, MakeMoveVector,
     MergeCoins, MoveAuthenticator, MoveCall, MoveStruct, ObjectDigest, ObjectId, ObjectReference,
     Owner, ProgrammableTransaction, Publish, RandomnessRound, RandomnessStateUpdate,
-    SenderSignedTransaction, SharedObjectReference, SplitCoins, Transaction, TransactionDigest,
-    TransactionExpiration, TransactionKind, TransactionV1, TransferObjects, TypeTag, Upgrade,
-    UserSignature, Version,
+    SenderSignedTransaction, SharedObjectReference, SplitCoins, Transaction,
+    TransactionDenyRulesUpdate, TransactionDigest, TransactionExpiration, TransactionKind,
+    TransactionV1, TransferObjects, TypeTag, Upgrade, UserSignature, Version,
     crypto::{Intent, IntentMessage, IntentScope, SimpleSignature},
 };
 use itertools::Either;
@@ -2467,6 +2467,10 @@ impl VerifiedTransaction {
 
     pub fn new_end_of_epoch_transaction(txns: Vec<EndOfEpochTransactionKind>) -> Self {
         TransactionKind::EndOfEpoch(txns).pipe(Self::new_system_transaction)
+    }
+
+    pub fn new_transaction_deny_rules_update(update: TransactionDenyRulesUpdate) -> Self {
+        TransactionKind::TransactionDenyRulesUpdate(update).pipe(Self::new_system_transaction)
     }
 
     fn new_system_transaction(system_transaction: TransactionKind) -> Self {

--- a/crates/iota-types/src/transaction_deny_rules.rs
+++ b/crates/iota-types/src/transaction_deny_rules.rs
@@ -10,6 +10,8 @@ use crate::{
 };
 
 pub const TRANSACTION_DENY_RULES_MODULE_NAME: &IdentStr = ident_str!("transaction_deny_rules");
+pub const TRANSACTION_DENY_RULES_MODULE: Identifier =
+    Identifier::from_static("transaction_deny_rules");
 pub const TRANSACTION_DENY_RULES_UPDATE_FUNCTION_NAME: Identifier =
     Identifier::from_static("update");
 pub const TRANSACTION_DENY_RULES_CREATE_FUNCTION_NAME: Identifier =

--- a/crates/simulacrum-server/src/rest_api.rs
+++ b/crates/simulacrum-server/src/rest_api.rs
@@ -225,7 +225,7 @@ pub async fn advance_epoch(
 
     let old_epoch = simulacrum.get_highest_verified_checkpoint().data().epoch;
 
-    simulacrum.advance_epoch();
+    simulacrum.advance_epoch(false);
 
     let new_epoch = simulacrum.get_highest_verified_checkpoint().data().epoch;
 

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -45,9 +45,30 @@ pub struct EpochState {
 impl EpochState {
     pub fn new(system_state: IotaSystemState) -> Self {
         let epoch_start_state = system_state.into_epoch_start_state();
-        let committee = epoch_start_state.get_iota_committee();
         let protocol_config =
             ProtocolConfig::get_for_version(epoch_start_state.protocol_version(), Chain::Unknown);
+        Self::new_impl(protocol_config, epoch_start_state)
+    }
+
+    /// Like [`Self::new`], but reuses the given `protocol_config` instead of
+    /// resolving it from the protocol version, keeping any feature flags
+    /// customized for testing.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the config's version does not match the system state's
+    /// protocol version.
+    pub fn new_with_config(protocol_config: ProtocolConfig, system_state: IotaSystemState) -> Self {
+        let epoch_start_state = system_state.into_epoch_start_state();
+        assert_eq!(
+            protocol_config.version,
+            epoch_start_state.protocol_version()
+        );
+        Self::new_impl(protocol_config, epoch_start_state)
+    }
+
+    fn new_impl(protocol_config: ProtocolConfig, epoch_start_state: EpochStartSystemState) -> Self {
+        let committee = epoch_start_state.get_iota_committee();
         let registry = prometheus_filtered::Registry::new();
         let limits_metrics = Arc::new(LimitsMetrics::new(&registry));
         let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(&registry));

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -292,12 +292,18 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     /// created.
     ///
     /// NOTE: This function does not currently support updating the protocol
-    /// version or the system packages
+    /// version or the system packages.
+    ///
+    /// With `create_deny_rules_object`, the end-of-epoch transaction also
+    /// creates the `TransactionDenyRules` object (requires the
+    /// `deny_rule_governance_on_chain` feature flag).
+    ///
+    /// Returns the effects of the end-of-epoch transaction.
     ///
     /// # Panics
     ///
     /// Panics if the end-of-epoch transaction cannot be executed or fails.
-    pub fn advance_epoch(&self) {
+    pub fn advance_epoch(&self, create_deny_rules_object: bool) -> TransactionEffects {
         let inner = self.inner.read().unwrap();
         let current_epoch = inner.epoch_state.epoch();
         let next_epoch = current_epoch + 1;
@@ -325,9 +331,13 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let scores = vec![MAX_SCORE; committee_size];
 
         let next_epoch_system_package_bytes: Vec<SystemPackage> = vec![];
+        let mut kinds = Vec::new();
+        if create_deny_rules_object {
+            kinds.push(EndOfEpochTransactionKind::TransactionDenyRulesCreate);
+        }
         // Mirror the node's kind selection: the framework's `advance_epoch`
         // expects the V4 argument shape when the flag is enabled.
-        let kinds = vec![if pass_validator_scores {
+        kinds.push(if pass_validator_scores {
             EndOfEpochTransactionKind::new_change_epoch_v4(
                 next_epoch,
                 next_epoch_protocol_version.as_u64(),
@@ -355,7 +365,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
                 next_epoch_system_package_bytes,
                 vec![],
             )
-        }];
+        });
 
         let tx = VerifiedTransaction::new_end_of_epoch_transaction(kinds);
         let (effects, execution_error) = self
@@ -368,7 +378,17 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
         let (checkpoint, contents, new_epoch_state) = {
             let mut inner = self.inner.write().unwrap();
-            let new_epoch_state = EpochState::new(inner.store.get_system_state());
+            let system_state = inner.store.get_system_state();
+            // On same-version epoch changes, carry the current protocol config
+            // over instead of re-resolving it from the version, so feature
+            // flags customized for testing survive the epoch change.
+            let prev_protocol_config = inner.epoch_state.protocol_config();
+            let new_epoch_state =
+                if system_state.protocol_version() == prev_protocol_config.version.as_u64() {
+                    EpochState::new_with_config(prev_protocol_config.clone(), system_state)
+                } else {
+                    EpochState::new(system_state)
+                };
             let end_of_epoch_data = EndOfEpochData {
                 next_epoch_committee: new_epoch_state.committee().committee_members(),
                 next_epoch_protocol_version: next_epoch_protocol_version.as_u64(),
@@ -402,6 +422,8 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         // Finally, update the epoch state
         let mut inner = self.inner.write().unwrap();
         inner.epoch_state = new_epoch_state;
+
+        effects
     }
 
     /// Execute a function with read access to the store.
@@ -1004,13 +1026,41 @@ mod tests {
     }
 
     #[test]
+    fn advance_epoch_creates_deny_rules_object() {
+        let _guard =
+            iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+                config.set_deny_rule_governance_for_testing(true);
+                config.set_deny_rule_governance_on_chain_for_testing(true);
+                config
+            });
+        let sim = Simulacrum::new();
+
+        assert!(sim.with_store(|store| {
+            store
+                .get_object(&iota_types::IOTA_TRANSACTION_DENY_RULES_OBJECT_ID)
+                .is_none()
+        }));
+
+        sim.advance_epoch(true);
+
+        let object = sim
+            .with_store(|store| {
+                store
+                    .get_object(&iota_types::IOTA_TRANSACTION_DENY_RULES_OBJECT_ID)
+                    .cloned()
+            })
+            .expect("the TransactionDenyRules object must exist after the create");
+        assert!(object.owner().is_shared());
+    }
+
+    #[test]
     fn simple_epoch() {
         let steps = 10;
         let sim = Simulacrum::new();
 
         let start_epoch = sim.with_store(|store| store.get_highest_checkpoint().unwrap().epoch);
         for i in 0..steps {
-            sim.advance_epoch();
+            sim.advance_epoch(false);
             sim.advance_clock(Duration::from_millis(1));
             sim.create_checkpoint();
             println!("{i}");

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -20,8 +20,8 @@ mod checked {
         Address, Argument, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4, Command,
         EndOfEpochTransactionKind, ExecutionStatus, GasPayment, GenesisTransaction, Identifier,
         MoveAuthenticator, ObjectId, ProgrammableTransaction, RandomnessStateUpdate,
-        SharedObjectReference, SystemPackage, TransactionDigest, TransactionEffects,
-        TransactionKind, Version, gas::GasCostSummary,
+        SharedObjectReference, SystemPackage, TransactionDenyRulesUpdate, TransactionDigest,
+        TransactionEffects, TransactionKind, Version, gas::GasCostSummary,
     };
     #[cfg(msim)]
     use iota_types::iota_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -51,6 +51,10 @@ mod checked {
         storage::{BackingStore, Storage},
         transaction::{
             CallArg, CancelledObjects, CheckedInputObjects, InputObjects, TransactionKindExt,
+        },
+        transaction_deny_rules::{
+            TRANSACTION_DENY_RULES_CREATE_FUNCTION_NAME, TRANSACTION_DENY_RULES_MODULE,
+            TRANSACTION_DENY_RULES_UPDATE_FUNCTION_NAME,
         },
     };
     use move_binary_format::CompiledModule;
@@ -1287,10 +1291,13 @@ mod checked {
                 )
             }
             TransactionKind::EndOfEpoch(txns) => {
-                let builder = ProgrammableTransactionBuilder::new();
+                // Non-change-epoch kinds accumulate commands into the builder;
+                // the change-epoch kind is always last and executes the built
+                // transaction as part of advancing the epoch.
+                let mut builder = ProgrammableTransactionBuilder::new();
                 let len = txns.len();
 
-                if let Some((i, tx)) = txns.into_iter().enumerate().next() {
+                for (i, tx) in txns.into_iter().enumerate() {
                     match tx {
                         EndOfEpochTransactionKind::ChangeEpoch(change_epoch) => {
                             assert_eq!(i, len - 1);
@@ -1353,16 +1360,11 @@ mod checked {
                             return Ok(Mode::empty_results());
                         }
                         EndOfEpochTransactionKind::TransactionDenyRulesCreate => {
-                            // Execution of the create arrives with the on-chain
-                            // deny rule governance wiring; nothing injects this
-                            // kind until then.
-                            return Err(ExecutionError::new(
-                                ExecutionErrorKind::VmInvariantViolation,
-                                Some(
-                                    "TransactionDenyRulesCreate cannot be executed at this protocol version"
-                                        .into(),
-                                ),
-                            ));
+                            assert!(
+                                protocol_config.deny_rule_governance_on_chain(),
+                                "unexpected TransactionDenyRulesCreate: on-chain deny rule governance is not enabled"
+                            );
+                            builder = setup_transaction_deny_rules_create(builder)?;
                         }
                         _ => unimplemented!(
                             "a new EndOfEpochTransactionKind enum variant was added and needs to be handled"
@@ -1396,16 +1398,22 @@ mod checked {
                 )?;
                 Ok(Mode::empty_results())
             }
-            TransactionKind::TransactionDenyRulesUpdate(_) => {
-                // Execution of the update arrives with the on-chain deny rule
-                // governance wiring; nothing injects this kind until then.
-                Err(ExecutionError::new(
-                    ExecutionErrorKind::VmInvariantViolation,
-                    Some(
-                        "TransactionDenyRulesUpdate cannot be executed at this protocol version"
-                            .into(),
-                    ),
-                ))
+            TransactionKind::TransactionDenyRulesUpdate(update) => {
+                assert!(
+                    protocol_config.deny_rule_governance_on_chain(),
+                    "unexpected TransactionDenyRulesUpdate: on-chain deny rule governance is not enabled"
+                );
+                setup_transaction_deny_rules_update(
+                    update,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                    trace_builder_opt,
+                )?;
+                Ok(Mode::empty_results())
             }
             _ => unimplemented!(
                 "a new TransactionKind enum variant was added and needs to be handled"
@@ -2004,6 +2012,89 @@ mod checked {
             assert_invariant!(
                 res.is_ok(),
                 "Unable to generate randomness_state_update transaction!"
+            );
+            builder.finish()
+        };
+        programmable_transactions::execution::execute::<execution_mode::System>(
+            protocol_config,
+            metrics,
+            move_vm,
+            temporary_store,
+            tx_ctx,
+            gas_charger,
+            pt,
+            trace_builder_opt,
+        )
+    }
+
+    /// Appends the `transaction_deny_rules::create` call to the end-of-epoch
+    /// transaction being built. If the built transaction later fails and epoch
+    /// advancement falls back to safe mode, the creation is dropped with it
+    /// and must be re-injected at a later epoch end while the object is
+    /// absent.
+    fn setup_transaction_deny_rules_create(
+        mut builder: ProgrammableTransactionBuilder,
+    ) -> Result<ProgrammableTransactionBuilder, ExecutionError> {
+        let res = builder.move_call(
+            ObjectId::FRAMEWORK,
+            TRANSACTION_DENY_RULES_MODULE,
+            TRANSACTION_DENY_RULES_CREATE_FUNCTION_NAME,
+            vec![],
+            vec![],
+        );
+        assert_invariant!(
+            res.is_ok(),
+            "Unable to generate transaction_deny_rules create transaction!"
+        );
+        Ok(builder)
+    }
+
+    /// Executes a `TransactionDenyRulesUpdate` system transaction: a single
+    /// call to `transaction_deny_rules::update` applying the payload's
+    /// add/remove delta and switch states.
+    fn setup_transaction_deny_rules_update(
+        update: TransactionDenyRulesUpdate,
+        temporary_store: &mut TemporaryStore<'_>,
+        tx_ctx: Rc<RefCell<TxContext>>,
+        move_vm: &Arc<MoveVM>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> Result<(), ExecutionError> {
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            // Argument order must match `transaction_deny_rules::update`. The
+            // set-typed delta lists BCS-encode identically to the `vector`
+            // parameters the Move function takes.
+            let res = builder.move_call(
+                ObjectId::FRAMEWORK,
+                TRANSACTION_DENY_RULES_MODULE,
+                TRANSACTION_DENY_RULES_UPDATE_FUNCTION_NAME,
+                vec![],
+                vec![
+                    CallArg::Shared(SharedObjectReference::new(
+                        ObjectId::TRANSACTION_DENY_RULES,
+                        update.deny_rules_obj_initial_shared_version,
+                        true,
+                    )),
+                    CallArg::pure(&update.added_addresses),
+                    CallArg::pure(&update.removed_addresses),
+                    CallArg::pure(&update.added_objects),
+                    CallArg::pure(&update.removed_objects),
+                    CallArg::pure(&update.added_packages),
+                    CallArg::pure(&update.removed_packages),
+                    CallArg::pure(&update.package_publish_disabled),
+                    CallArg::pure(&update.package_upgrade_disabled),
+                    CallArg::pure(&update.shared_object_disabled),
+                    CallArg::pure(&update.user_transaction_disabled),
+                    CallArg::pure(&update.receiving_objects_disabled),
+                    CallArg::pure(&update.move_authenticator_disabled),
+                ],
+            );
+            assert_invariant!(
+                res.is_ok(),
+                "Unable to generate transaction_deny_rules update transaction!"
             );
             builder.finish()
         };


### PR DESCRIPTION
# Description of change

Part of #12498, stacked on #12540. Makes the execution layer execute the on-chain deny-rule transaction kinds that #12540 wired inert.

- `TransactionDenyRulesCreate` (end-of-epoch kind): calls `transaction_deny_rules::create`, creating the shared `TransactionDenyRules` object at its reserved address `0xDE9`. Rides the epoch-change transaction, so a safe-mode fallback drops it together with the epoch change and it gets re-injected at the next epoch end.
- `TransactionDenyRulesUpdate` (system transaction kind): calls `transaction_deny_rules::update`, applying the add/remove delta and pinning the six global switches.
- Both kinds assert the `deny_rule_governance_on_chain` feature flag; the end-of-epoch loop now supports kinds preceding the final change-epoch kind.
- `iota-transaction-checks`: user transactions cannot use the `TransactionDenyRules` object as input (same rule as the `AuthenticatorState`/`Random` system objects).
- Test infrastructure:
  - `simulacrum`: `advance_epoch` can inject the create kind and returns the end-of-epoch effects; the protocol config is carried over across same-version epoch changes so feature flags customized for testing survive.
  - transactional-test-runner: `--deny-rule-governance` init flag, `advance-epoch --create-deny-rules-object`, and a new `update-deny-rules` subcommand.

## Links to any relevant issues

Closes #12503.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New transactional tests in `crates/iota-adapter-transactional-tests/tests/transaction_deny_rules/` cover creation (object absent before, shared at `0xDE9` with empty tables and all switches off after), delta accumulation across updates (table sizes and entry children asserted via `view-object`), tolerant no-op deltas (re-adding present entries and removing absent ones changes nothing, the event is still emitted), switch pinning (switches set by one update are cleared by the next), persistence across epoch changes, and updating before creation (clean error). A simulacrum unit test pins the create end to end. Clippy clean across all touched crates; `cargo +nightly fmt` applied.

