### PR TITLE
ci: bind bump/deny/choco workflow inputs via env before shell

### DIFF
--- a/.github/workflows/_cargo_deny.yml
+++ b/.github/workflows/_cargo_deny.yml
@@ -18,11 +18,15 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check bans licenses sources --hide-inclusion-graph
+      - env:
+          MANIFEST_PATH: ${{ inputs.manifest-path || './Cargo.toml' }}
+        run: cargo deny --manifest-path "$MANIFEST_PATH" check bans licenses sources --hide-inclusion-graph
 
   advisories:
     name: cargo deny (advisories)
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check advisories --hide-inclusion-graph
+      - env:
+          MANIFEST_PATH: ${{ inputs.manifest-path || './Cargo.toml' }}
+        run: cargo deny --manifest-path "$MANIFEST_PATH" check advisories --hide-inclusion-graph

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -45,7 +45,10 @@ jobs:
           git checkout ${{ github.sha }} -- scripts/bump_version.sh
 
       - name: Run bump_version.sh
-        run: scripts/bump_version.sh "${{ inputs.bump }}" "${{ inputs.prerelease }}"
+        env:
+          BUMP: ${{ inputs.bump }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: scripts/bump_version.sh "$BUMP" "$PRERELEASE"
 
       - name: Revert bump_version.sh to base branch version
         run: git checkout HEAD -- scripts/bump_version.sh 2>/dev/null || git rm -f scripts/bump_version.sh

--- a/.github/workflows/choco_publish.yml
+++ b/.github/workflows/choco_publish.yml
@@ -21,14 +21,19 @@ jobs:
       - name: Set artifact name
         id: artifact
         shell: bash
-        run: echo "artifact_name=iota-${{ inputs.iota_tag }}-windows-x86_64" >> $GITHUB_OUTPUT
+        env:
+          IOTA_TAG: ${{ inputs.iota_tag }}
+        run: echo "artifact_name=iota-${IOTA_TAG}-windows-x86_64" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download Windows artifact
         shell: bash
+        env:
+          IOTA_TAG: ${{ inputs.iota_tag }}
+          ARTIFACT_NAME: ${{ steps.artifact.outputs.artifact_name }}
         run: |
           mkdir ./tmp
-          curl -L -o ./tmp/${{ steps.artifact.outputs.artifact_name }}.tgz https://github.com/iotaledger/iota/releases/download/${{ inputs.iota_tag }}/${{ steps.artifact.outputs.artifact_name }}.tgz
+          curl -L -o "./tmp/${ARTIFACT_NAME}.tgz" "https://github.com/iotaledger/iota/releases/download/${IOTA_TAG}/${ARTIFACT_NAME}.tgz"
 
       - name: Extract Windows artifact
         shell: bash
@@ -43,16 +48,20 @@ jobs:
 
       - name: Publish Windows iota binary to Chocolatey
         shell: bash
+        env:
+          IOTA_TAG: ${{ inputs.iota_tag }}
+          ARTIFACT_NAME: ${{ steps.artifact.outputs.artifact_name }}
+          TMP_BUILD_DIR: ${{ env.TMP_BUILD_DIR }}
         run: |
           choco install checksum
-          export iota_sha=$(checksum -t sha256 ${{ env.TMP_BUILD_DIR }}/iota.exe)
+          export iota_sha=$(checksum -t sha256 "${TMP_BUILD_DIR}/iota.exe")
           # It is not allowed to have a 'v' in the choco version
-          export choco_version=$(echo "${{ inputs.iota_tag }}" | sed s/'^v'//)
+          export choco_version=$(echo "${IOTA_TAG}" | sed s/'^v'//)
           cd chocolatey
 
           cat <<EOF >>VERIFICATION.txt
           IOTA Binary verification steps
-          1. Download https://github.com/iotaledger/iota/releases/download/${{ inputs.iota_tag }}/${{ steps.artifact.outputs.artifact_name }}.tgz
+          1. Download https://github.com/iotaledger/iota/releases/download/${IOTA_TAG}/${ARTIFACT_NAME}.tgz
           2. Extract iota.exe
           3. Verify binary: checksum.exe -t sha256 iota.exe: ${iota_sha}
           4. Verify file 'LICENSE.txt': https://github.com/iotaledger/iota/blob/develop/LICENSE


### PR DESCRIPTION
## Summary
- Bind `inputs.bump` / `inputs.prerelease` through `env:` before `bump_version.sh`.
- Bind `inputs.manifest-path` through `env:` before `cargo deny` in `_cargo_deny.yml`.
- Bind `inputs.iota_tag` (and related step outputs) through `env:` before Chocolatey publish shell steps.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

Closes #12566

## Test plan
- [ ] Version bump workflow still runs bump_version.sh with configured bump/prerelease
- [ ] cargo deny reusable workflow still checks the configured manifest path
- [ ] Chocolatey publish still downloads/tags from the configured iota_tag