### PR TITLE
feat(iota-core,iota-node): make deny rule announcements mandatory and track announced stake

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3062,6 +3062,19 @@ impl AuthorityPerEpochStore {
             .remove(authority)
     }
 
+    /// The total stake of committee members with a recorded deny rule
+    /// proposal this epoch, empty proposals included. Every committee member
+    /// announces its configuration each epoch, so this converges towards the
+    /// full committee stake as announcements arrive.
+    pub fn announced_deny_rule_stake(&self) -> StakeUnit {
+        self.consensus_quarantine
+            .read()
+            .current_deny_rule_proposals()
+            .keys()
+            .map(|authority| self.committee().weight(authority))
+            .sum()
+    }
+
     /// Whether `proposal` is newer than the recorded proposal (if any) from
     /// the same authority and should therefore be recorded.
     pub fn should_record_deny_rule_proposal(&self, proposal: &TransactionDenyRuleProposal) -> bool {

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -557,6 +557,32 @@ fn compute_active_transaction_deny_rules_applies_stake_thresholds() {
     assert!(!active.package_upgrade_disabled);
 }
 
+/// `announced_deny_rule_stake` sums the committee stake behind recorded
+/// proposals: empty proposals count as announcements, non-members weigh 0.
+#[tokio::test]
+async fn announced_deny_rule_stake_counts_recorded_proposals() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+
+    assert_eq!(store.announced_deny_rule_stake(), 0);
+
+    // A non-member's recorded proposal contributes no stake.
+    flush_deny_rule_proposal(
+        &store,
+        deny_proposal(AuthorityName::ZERO, 1, DenyRuleSet::default()),
+    );
+    assert_eq!(store.announced_deny_rule_stake(), 0);
+
+    // An empty proposal is an announcement: the single-validator test
+    // committee holds all stake.
+    flush_deny_rule_proposal(&store, deny_proposal(me, 1, DenyRuleSet::default()));
+    assert_eq!(
+        store.announced_deny_rule_stake(),
+        store.committee().total_votes()
+    );
+}
+
 /// A proposal replaces the recorded one from the same authority only when its
 /// generation is strictly newer, both across commits
 /// (`should_record_deny_rule_proposal`) and within one commit

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -100,7 +100,7 @@ use iota_network::{
 use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
 use iota_protocol_config::{ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{
-    DenyRuleSet, RandomnessRound,
+    RandomnessRound,
     crypto::{Intent, IntentMessage, IntentScope},
 };
 use iota_snapshot::uploader::StateSnapshotUploader;
@@ -1847,33 +1847,26 @@ impl IotaNode {
 
                 // Announce the local deny rules. Recorded proposals are
                 // epoch-scoped, so this re-announces on every epoch change.
-                // An empty set is still submitted when a non-empty proposal
-                // is recorded this epoch: in the full-state model that
-                // withdraws the earlier rules after an operator cleared the
-                // local config and restarted.
+                // The empty set is announced too: every committee member
+                // attests its configuration each epoch, so silence means
+                // offline rather than "no rules".
                 if config.deny_rule_governance() {
                     let proposed_rules = self.config.transaction_deny_config.to_deny_rule_set();
                     let recorded = cur_epoch_store.recorded_deny_rule_proposal(&self.state.name);
-                    let should_submit = proposed_rules != DenyRuleSet::default()
-                        || recorded
-                            .as_ref()
-                            .is_some_and(|p| p.proposed_rules != DenyRuleSet::default());
-                    if should_submit {
-                        let transaction = ConsensusTransaction::new_transaction_deny_rule_proposal(
-                            TransactionDenyRuleProposal::new(
-                                self.state.name,
-                                proposed_rules,
-                                recorded.map(|p| p.generation),
-                            ),
-                        );
-                        info!(
-                            tracking_id = ?transaction.get_tracking_id(),
-                            "submitting deny rule proposal to consensus"
-                        );
-                        components
-                            .consensus_adapter
-                            .submit(transaction, None, &cur_epoch_store)?;
-                    }
+                    let transaction = ConsensusTransaction::new_transaction_deny_rule_proposal(
+                        TransactionDenyRuleProposal::new(
+                            self.state.name,
+                            proposed_rules,
+                            recorded.map(|p| p.generation),
+                        ),
+                    );
+                    info!(
+                        tracking_id = ?transaction.get_tracking_id(),
+                        "submitting deny rule proposal to consensus"
+                    );
+                    components
+                        .consensus_adapter
+                        .submit(transaction, None, &cur_epoch_store)?;
                 }
             } else if self.state.is_active_validator(&cur_epoch_store)
                 && cur_epoch_store


### PR DESCRIPTION
# Description of change

Part of #12498, stacked on #12560. Aggregation-input changes ahead of the on-chain mirroring:

- `monitor_reconfiguration` now always announces the local deny rules under the `deny_rule_governance` flag — the empty set is an explicit per-epoch attestation, so silence means offline rather than "no rules".
- New `announced_deny_rule_stake` on the epoch store: the committee stake behind recorded proposals (empty ones included). Consumed by the removal grace in the delta-injection PR, which only allows removals from the on-chain object once announced stake reaches 2f+1.

No aggregated-set cap is included: active entries already require f+1 supporting stake and per-proposal size is bounded by the consensus transaction limit; whether a bound is wanted is resolved with #12507.

## Links to any relevant issues

Fixes #12504.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New unit test `announced_deny_rule_stake_counts_recorded_proposals` (empty proposals count as announcements, non-members weigh zero). Existing deny-governance batteries pass; clippy and `cargo +nightly fmt` clean.