### PR TITLE
fix(consensus): bound the wait for the block subscription request

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -548,6 +548,15 @@ pub struct TonicParameters {
     /// Per-peer, per-RPC admission caps for the inbound consensus server.
     #[serde(default)]
     pub admission: AdmissionParameters,
+
+    /// Deadline for receiving the request message that opens a block
+    /// subscription stream. A peer that opens the stream and withholds the
+    /// request is disconnected once it expires; the stream itself stays exempt
+    /// from `request_timeout`.
+    ///
+    /// A zero duration (the default) disables the deadline.
+    #[serde(default)]
+    pub subscribe_request_timeout: Duration,
 }
 
 impl TonicParameters {
@@ -587,6 +596,9 @@ impl TonicParameters {
         if self.admission.is_inert() {
             self.admission = AdmissionParameters::protective();
         }
+        if self.subscribe_request_timeout.is_zero() {
+            self.subscribe_request_timeout = Duration::from_secs(30);
+        }
     }
 
     /// The inert defaults with the protective bounds applied.
@@ -608,6 +620,7 @@ impl Default for TonicParameters {
             request_timeout: Duration::ZERO,
             max_inbound_message_size: 0,
             admission: AdmissionParameters::default(),
+            subscribe_request_timeout: Duration::ZERO,
         }
     }
 }

--- a/crates/starfish/config/tests/parameters_test.rs
+++ b/crates/starfish/config/tests/parameters_test.rs
@@ -22,6 +22,10 @@ fn protective_preset_enables_bounds_and_default_stays_inert() {
     assert_eq!(protective.admission.max_header_fetches_per_peer, 32);
     assert_eq!(protective.admission.max_transaction_fetches_per_peer, 16);
     assert!(protective.admission.max_commit_fetches_per_peer > 0);
+    assert_eq!(
+        protective.subscribe_request_timeout,
+        std::time::Duration::from_secs(30)
+    );
 
     // The config defaults stay inert; the preset is applied at node start.
     let inert = starfish_config::TonicParameters::default();
@@ -29,6 +33,7 @@ fn protective_preset_enables_bounds_and_default_stays_inert() {
     assert!(inert.request_timeout.is_zero());
     assert_eq!(inert.max_inbound_message_size, 0);
     assert_eq!(inert.admission.max_header_fetches_per_peer, 0);
+    assert!(inert.subscribe_request_timeout.is_zero());
 }
 
 #[test]
@@ -65,6 +70,7 @@ fn apply_protective_preserves_operator_set_bounds() {
             max_header_fetches_per_peer: 5,
             ..Default::default()
         },
+        subscribe_request_timeout: std::time::Duration::from_secs(3),
         ..Default::default()
     };
 
@@ -74,6 +80,10 @@ fn apply_protective_preserves_operator_set_bounds() {
     assert_eq!(tonic.max_concurrent_streams, 128);
     assert_eq!(tonic.request_timeout, std::time::Duration::from_secs(30));
     assert_eq!(tonic.max_inbound_message_size, 4 << 20);
+    assert_eq!(
+        tonic.subscribe_request_timeout,
+        std::time::Duration::from_secs(3)
+    );
     // An admission block with any explicitly configured cap is kept as-is,
     // not mixed with preset values.
     assert_eq!(tonic.admission.max_header_fetches_per_peer, 5);
@@ -121,6 +131,10 @@ tonic:
     assert_eq!(
         parameters.tonic.admission.max_commit_fetches_per_peer,
         defaults.tonic.admission.max_commit_fetches_per_peer
+    );
+    assert_eq!(
+        parameters.tonic.subscribe_request_timeout,
+        defaults.tonic.subscribe_request_timeout
     );
 }
 

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -46,6 +46,9 @@ tonic:
     max_header_fetches_per_peer: 0
     max_transaction_fetches_per_peer: 0
     max_commit_fetches_per_peer: 0
+  subscribe_request_timeout:
+    secs: 0
+    nanos: 0
 fast_commit_sync_batch_size: 1000
 commit_sync_gap_threshold: 1000
 enable_fast_commit_syncer: true

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -764,7 +764,24 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         // half-open subscriptions; the permit is held for the stream's lifetime.
         let permit = self.admit(RpcGroup::Subscribe, peer_index)?;
         let mut request_stream = request.into_inner();
-        let first_request = match request_stream.next().await {
+        let subscribe_request_timeout = self.context.parameters.tonic.subscribe_request_timeout;
+        let first_message = if subscribe_request_timeout.is_zero() {
+            request_stream.next().await
+        } else {
+            match tokio::time::timeout(subscribe_request_timeout, request_stream.next()).await {
+                Ok(message) => message,
+                Err(_) => {
+                    debug!(
+                        "subscribe_block_bundles() request from {} not received within {:?}",
+                        peer_index, subscribe_request_timeout
+                    );
+                    return Err(tonic::Status::deadline_exceeded(
+                        "Subscription request not received in time",
+                    ));
+                }
+            }
+        };
+        let first_request = match first_message {
             Some(Ok(r)) => r,
             Some(Err(e)) => {
                 debug!(
@@ -1684,5 +1701,57 @@ mod tests {
             max_fetch_transactions_response_bytes(&context),
             9 * serialized_transactions_size_limit(&context)
         );
+    }
+
+    /// A peer that opens a block subscription stream but never sends the
+    /// request starting it is disconnected once the deadline expires, instead
+    /// of holding a subscription slot and its connection state indefinitely.
+    #[cfg(not(msim))]
+    #[tokio::test]
+    async fn subscribe_without_request_hits_deadline() {
+        use std::time::Duration;
+
+        use futures::stream;
+        use parking_lot::Mutex;
+        use tonic::Request;
+
+        use super::{SubscribeBlockBundlesRequest, TonicManager};
+        use crate::network::test_network::TestService;
+
+        const SUBSCRIBE_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
+
+        let (context, keys) = Context::new_for_test(4);
+        let server_index = context.committee.to_authority_index(0).unwrap();
+        let mut server_context = context.clone().with_authority_index(server_index);
+        server_context.parameters.tonic.subscribe_request_timeout = SUBSCRIBE_REQUEST_TIMEOUT;
+        let mut server = TonicManager::new(Arc::new(server_context), keys[0].0.clone());
+        server
+            .install_service(Arc::new(Mutex::new(TestService::new())))
+            .await;
+
+        let client_context = Arc::new(
+            context
+                .clone()
+                .with_authority_index(context.committee.to_authority_index(1).unwrap()),
+        );
+        let client =
+            TonicManager::<Mutex<TestService>>::new(client_context, keys[1].0.clone()).client();
+
+        let mut raw_client = client
+            .get_client(server_index, Duration::from_secs(5))
+            .await
+            .unwrap();
+        // A request stream that stays open without ever yielding the
+        // subscription request.
+        let request = Request::new(stream::pending::<SubscribeBlockBundlesRequest>());
+        let status = tokio::time::timeout(
+            SUBSCRIBE_REQUEST_TIMEOUT * 10,
+            raw_client.subscribe_block_bundles(request),
+        )
+        .await
+        .expect("server must not wait for the request past the deadline")
+        .expect_err("subscription without a request must be rejected");
+
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
     }
 }


### PR DESCRIPTION
# Description of change

`SubscribeBlockBundles` is exempt from the server-side request timeout so that healthy long-lived subscriptions are not aborted. As a side effect, the handler's wait for the request message that names the starting round had no deadline: a peer could open the stream, send nothing, and hold a subscription slot and its stream state until it disconnected. With the per-peer cap at 2, two such streams block that authority's legitimate subscription indefinitely, and HTTP/2 keepalive does not help — a peer whose application has wedged still answers pings.

- Add `tonic.subscribe_request_timeout`, inert by default and set to 30s by the protective preset, applied only to the wait for the opening request.
- On expiry the handler returns `DeadlineExceeded`, releasing the admission permit and ending the stream. The connection and the timeout exemption for established subscriptions are untouched.

## Links to any relevant issues

Part of iotaledger/iota-private#446

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New end-to-end test opens a subscription stream whose request never arrives and asserts the server answers `DeadlineExceeded`. Full `starfish-core` and `starfish-config` suites pass.
