### PR TITLE
feat(indexer): Add request metrics for historical fallback KV store

### DIFF
--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -288,6 +288,20 @@ impl HttpRestKVClient {
     }
 
     async fn fetch_batch(&self, request: MultiGetRequest) -> IndexerResult<Vec<Option<Bytes>>> {
+        let item_type = request.item_type;
+        self.metrics.record_request(item_type);
+
+        let result = self.fetch_batch_inner(request).await;
+        if result.is_err() {
+            self.metrics.record_request_error(item_type);
+        }
+        result
+    }
+
+    async fn fetch_batch_inner(
+        &self,
+        request: MultiGetRequest,
+    ) -> IndexerResult<Vec<Option<Bytes>>> {
         let url = self.base_url.join(&request.item_type.to_string())?;
 
         trace!(
@@ -347,6 +361,27 @@ impl HttpRestKVClient {
             IndexerError::HistoricalFallbackInput("limit must be greater than 0".into())
         })?;
 
+        let item_type = key.item_type();
+        self.metrics.record_request(item_type);
+
+        let result = self.paginate_inner(key, cursor, limit, reversed).await;
+        if result.is_err() {
+            self.metrics.record_request_error(item_type);
+        }
+        result
+    }
+
+    async fn paginate_inner<C, T>(
+        &self,
+        key: Key,
+        cursor: Option<C>,
+        limit: NonZeroUsize,
+        reversed: bool,
+    ) -> IndexerResult<Vec<T>>
+    where
+        C: Display,
+        T: for<'de> Deserialize<'de>,
+    {
         let (item_type, encoded_key) = key.to_path_elements();
         let mut url = self.base_url.join(&format!("{item_type}/{encoded_key}"))?;
 
@@ -454,6 +489,20 @@ impl HttpRestKVClient {
     }
 
     async fn fetch_objects_before_version_batch(
+        &self,
+        request: MultiGetRequest,
+    ) -> IndexerResult<Vec<Option<Bytes>>> {
+        let item_type = request.item_type;
+        self.metrics.record_request(item_type);
+
+        let result = self.fetch_objects_before_version_batch_inner(request).await;
+        if result.is_err() {
+            self.metrics.record_request_error(item_type);
+        }
+        result
+    }
+
+    async fn fetch_objects_before_version_batch_inner(
         &self,
         request: MultiGetRequest,
     ) -> IndexerResult<Vec<Option<Bytes>>> {

--- a/crates/iota-indexer/src/historical_fallback/metrics.rs
+++ b/crates/iota-indexer/src/historical_fallback/metrics.rs
@@ -13,6 +13,8 @@ pub struct HistoricalFallbackClientMetrics {
     pub(crate) cache_misses: IntCounterVec,
     pub(crate) cache_object_before_version_hits: IntCounter,
     pub(crate) cache_object_before_version_misses: IntCounter,
+    pub(crate) requests: IntCounterVec,
+    pub(crate) request_errors: IntCounterVec,
 }
 
 impl HistoricalFallbackClientMetrics {
@@ -44,6 +46,20 @@ impl HistoricalFallbackClientMetrics {
                 registry,
             )
             .unwrap(),
+            requests: register_int_counter_vec_with_registry!(
+                "historical_fallback_requests",
+                "Historical fallback requests to the KV store",
+                &["resource"],
+                registry,
+            )
+            .unwrap(),
+            request_errors: register_int_counter_vec_with_registry!(
+                "historical_fallback_request_errors",
+                "Historical fallback requests to the KV store that failed",
+                &["resource"],
+                registry,
+            )
+            .unwrap(),
         }
     }
 
@@ -65,5 +81,17 @@ impl HistoricalFallbackClientMetrics {
 
     pub(crate) fn record_cache_object_before_version_miss(&self) {
         self.cache_object_before_version_misses.inc();
+    }
+
+    pub(crate) fn record_request(&self, item_type: ItemType) {
+        self.requests
+            .with_label_values(&[&item_type.to_string()])
+            .inc();
+    }
+
+    pub(crate) fn record_request_error(&self, item_type: ItemType) {
+        self.request_errors
+            .with_label_values(&[&item_type.to_string()])
+            .inc();
     }
 }


### PR DESCRIPTION
# Description of change

Add Prometheus metrics for the requests the historical fallback client sends to the archival KV store:

- `historical_fallback_requests` — requests to the KV store, labeled by `resource` (`tx`, `fx`, `cs`, `cc`, `ob`, `txa`, ...).
- `historical_fallback_request_errors` — requests that failed, with the same label.

Counted per HTTP request, cache hits are not counted. The counters are exposed for both indexer JSON-RPC and GraphQL, next to the existing `historical_fallback_cache_*` metrics.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/11940

## How the change has been tested

Manual smoke test against the testnet archival KV store and a pruned testnet indexer database:

- Queries for pruned checkpoints and transactions by affected address increment `historical_fallback_requests` for each resource type involved.
- Repeating the same query is served from the cache and does not increment the request count.
- With the KV store unreachable, the failing query increments `historical_fallback_request_errors`.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
