### PR TITLE
refactor: remove the `Signature` alias of `SimpleSignature`

### DIFF
--- a/crates/iota-cluster-test/src/wallet_client.rs
+++ b/crates/iota-cluster-test/src/wallet_client.rs
@@ -4,8 +4,11 @@
 
 use iota_keys::keystore::AccountKeystore;
 use iota_sdk::{IotaClient, IotaClientBuilder, wallet_context::WalletContext};
-use iota_sdk_types::{Address, crypto::Intent};
-use iota_types::{crypto::Signature, transaction::TransactionData};
+use iota_sdk_types::{
+    Address,
+    crypto::{Intent, SimpleSignature},
+};
+use iota_types::transaction::TransactionData;
 use tracing::{Instrument, info, info_span};
 
 use super::Cluster;
@@ -52,7 +55,7 @@ impl WalletClient {
         &self.fullnode_client
     }
 
-    pub fn sign(&self, txn_data: &TransactionData, desc: &str) -> Signature {
+    pub fn sign(&self, txn_data: &TransactionData, desc: &str) -> SimpleSignature {
         self.get_wallet()
             .config()
             .keystore()

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -29,7 +29,7 @@ use iota_types::{
     crypto::{
         AggregateAuthoritySignature, AuthorityKeyPair, AuthorityPublicKeyBytes,
         AuthorityQuorumSignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo, KeypairTraits,
-        Signature, Signer, get_key_pair,
+        Signer, get_key_pair,
     },
     effects::{
         IDOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsExtForTesting,
@@ -179,7 +179,7 @@ fn get_registry() -> Result<Registry> {
     let kp3 = Secp256r1PrivateKey::generate(StdRng::from_seed([0; 32]));
 
     // ... and the user signature which does
-    let sig: Signature = kp1.sign(b"hello world");
+    let sig: SimpleSignature = kp1.sign(b"hello world");
     tracer.trace_value(&mut samples, &sig).unwrap();
 
     let multisig_pk = MultiSigPublicKey::new(

--- a/crates/iota-core/src/unit_tests/auth_unit_test_utils.rs
+++ b/crates/iota-core/src/unit_tests/auth_unit_test_utils.rs
@@ -6,9 +6,10 @@ use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use iota_move_build::{BuildConfig, CompiledPackage};
 use iota_sdk_crypto::Signer;
-use iota_sdk_types::{Address, ObjectId, ObjectReference, Owner, TransactionDigest};
+use iota_sdk_types::{
+    Address, ObjectId, ObjectReference, Owner, TransactionDigest, crypto::SimpleSignature,
+};
 use iota_types::{
-    crypto::Signature,
     effects::TransactionEffectsAPI,
     error::IotaResult,
     move_package::UpgradePolicy,
@@ -69,7 +70,7 @@ pub fn build_test_modules_with_dep_addr(
 pub async fn publish_package_on_single_authority(
     path: &Path,
     sender: Address,
-    sender_key: &impl Signer<Signature>,
+    sender_key: &impl Signer<SimpleSignature>,
     gas_payment: ObjectReference,
     dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectId)>,
     dep_ids: Vec<ObjectId>,
@@ -122,7 +123,7 @@ pub async fn publish_package_on_single_authority(
 pub async fn upgrade_package_on_single_authority(
     path: &Path,
     sender: Address,
-    sender_key: &impl Signer<Signature>,
+    sender_key: &impl Signer<SimpleSignature>,
     gas_payment: ObjectReference,
     package_id: ObjectId,
     upgrade_cap: ObjectReference,

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -18,7 +18,7 @@ use iota_protocol_config::Chain::Unknown;
 use iota_sdk_types::{
     Address, ExecutionError, ExecutionStatus, Identifier, ObjectId, ObjectReference,
     SenderSignedTransaction, StakeUnit, TransactionDigest,
-    crypto::{Intent, IntentMessage, IntentScope},
+    crypto::{Intent, IntentMessage, IntentScope, SimpleSignature},
 };
 #[cfg(msim)]
 use iota_simulator::configs::constant_latency_ms;
@@ -27,8 +27,7 @@ use iota_types::{
     committee::Committee,
     crypto::{
         AccountKeyPair, AuthorityKeyPair, AuthoritySignInfo, AuthoritySignature,
-        IotaAuthoritySignature, KeypairTraits, Signature, Signer, get_key_pair,
-        get_key_pair_from_rng,
+        IotaAuthoritySignature, KeypairTraits, Signer, get_key_pair, get_key_pair_from_rng,
     },
     effects::{
         SignedTransactionEffects, TestEffectsBuilder, TransactionEffects,
@@ -109,7 +108,7 @@ pub fn set_local_client_config(
 
 pub fn create_object_move_transaction(
     src: Address,
-    secret: &impl iota_sdk_crypto::Signer<Signature>,
+    secret: &impl iota_sdk_crypto::Signer<SimpleSignature>,
     dest: Address,
     value: u64,
     package_id: ObjectId,
@@ -142,7 +141,7 @@ pub fn create_object_move_transaction(
 
 pub fn delete_object_move_transaction(
     src: Address,
-    secret: &impl iota_sdk_crypto::Signer<Signature>,
+    secret: &impl iota_sdk_crypto::Signer<SimpleSignature>,
     object_ref: ObjectReference,
     framework_obj_id: ObjectId,
     gas_object_ref: ObjectReference,
@@ -167,7 +166,7 @@ pub fn delete_object_move_transaction(
 
 pub fn set_object_move_transaction(
     src: Address,
-    secret: &impl iota_sdk_crypto::Signer<Signature>,
+    secret: &impl iota_sdk_crypto::Signer<SimpleSignature>,
     object_ref: ObjectReference,
     value: u64,
     framework_obj_id: ObjectId,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -29,14 +29,14 @@ use iota_sdk_types::{
     ConsensusDeterminedVersionAssignments, Digest, EpochId, ExecutionError, ExecutionStatus,
     GasPayment, Identifier, MoveStruct, ObjectData, ObjectDigest, ObjectId, ObjectReference, Owner,
     ProgrammableTransaction, SharedObjectReference, StructTag, TransactionDigest, TransactionKind,
-    TypeTag, Version, VersionAssignment,
+    TypeTag, Version, VersionAssignment, crypto::SimpleSignature,
 };
 use iota_types::{
     base_types::{AuthorityName, TxContext, dbg_addr, dbg_object_id, random_object_ref},
     committee::Committee,
     crypto::{
-        AccountKeyPair, AuthorityKeyPair, AuthorityPublicKey, IotaSignature, Signature,
-        get_key_pair, random_committee_key_pairs_of_size,
+        AccountKeyPair, AuthorityKeyPair, AuthorityPublicKey, IotaSignature, get_key_pair,
+        random_committee_key_pairs_of_size,
     },
     dynamic_field::{DynamicFieldInfo, DynamicFieldType},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEffectsExt},
@@ -1185,7 +1185,8 @@ async fn test_handle_transfer_transaction_bad_signature() {
     *bad_signature_transfer_transaction
         .data_mut_for_testing()
         .tx_signatures_mut_for_testing() = vec![
-        Signature::new_secure(&transfer_transaction.data().intent_message(), &unknown_key).into(),
+        SimpleSignature::new_secure(&transfer_transaction.data().intent_message(), &unknown_key)
+            .into(),
     ];
 
     assert!(

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -13,11 +13,11 @@ use iota_protocol_config::{Chain, OverrideGuard, ProtocolConfig, ProtocolVersion
 use iota_sdk_types::{
     Address, ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, GenesisTransaction,
     Identifier, SenderSignedTransaction, SharedObjectReference, TransactionKind,
-    crypto::IntentScope,
+    crypto::{IntentScope, SimpleSignature},
 };
 use iota_types::{
     base_types::{dbg_addr, random_object_ref},
-    crypto::{AccountKeyPair, IotaSignature, Signature, get_key_pair},
+    crypto::{AccountKeyPair, IotaSignature, get_key_pair},
     error::{IotaError, UserInputError},
     messages_grpc::HandleSoftBundleCertificatesRequestV1,
     transaction::TransactionDataAPI,
@@ -72,7 +72,7 @@ async fn test_handle_transfer_transaction_bad_signature() {
         |mut_tx| {
             let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
             let data = mut_tx.data_mut_for_testing();
-            let signature = Signature::new_secure(&data.intent_message(), &unknown_key);
+            let signature = SimpleSignature::new_secure(&data.intent_message(), &unknown_key);
             *data.tx_signatures_mut_for_testing() = vec![signature.into()];
         },
         |err| {
@@ -802,7 +802,7 @@ async fn test_handle_certificate_errors() {
     let mut absent_sig_tx = transfer_transaction.clone();
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
     let data = absent_sig_tx.data_mut_for_testing();
-    let signature = Signature::new_secure(&data.intent_message(), &unknown_key);
+    let signature = SimpleSignature::new_secure(&data.intent_message(), &unknown_key);
     *data.tx_signatures_mut_for_testing() = vec![signature.into()];
     let ct = CertifiedTransaction::new(
         data.clone(),

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -29,7 +29,8 @@ use iota_protocol_config::{PerObjectCongestionControlMode, ProtocolConfig};
 use iota_sdk_types::{
     Address, Argument, ExecutionError, Identifier, MoveAuthenticatorV1, MoveLocation, ObjectId,
     ObjectReference, Owner, ProgrammableTransaction, SharedObjectReference, SignatureScheme,
-    TypeTag, UserSignature, crypto::Intent,
+    TypeTag, UserSignature,
+    crypto::{Intent, SimpleSignature},
 };
 use iota_test_transaction_builder::publish_package;
 use iota_types::{
@@ -2837,7 +2838,7 @@ impl TestEnvironment {
     /// `SimpleSignature` and the abstract-account object reference.
     fn move_authenticator_from_ed25519_sig(
         aa_obj_ref: ObjectReference,
-        signature: iota_sdk_types::crypto::SimpleSignature,
+        signature: SimpleSignature,
     ) -> anyhow::Result<UserSignature> {
         let hex_encoded_signature: String = Hex::encode(signature.to_bytes())
             .chars()

--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -2834,10 +2834,10 @@ impl TestEnvironment {
     }
 
     /// Build a `UserSignature::MoveAuthenticator` from a raw ed25519
-    /// `Signature` and the abstract-account object reference.
+    /// `SimpleSignature` and the abstract-account object reference.
     fn move_authenticator_from_ed25519_sig(
         aa_obj_ref: ObjectReference,
-        signature: iota_types::crypto::Signature,
+        signature: iota_sdk_types::crypto::SimpleSignature,
     ) -> anyhow::Result<UserSignature> {
         let hex_encoded_signature: String = Hex::encode(signature.to_bytes())
             .chars()

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -40,10 +40,9 @@ use iota_json_rpc_types::{
 };
 use iota_metrics::init_metrics;
 use iota_move_build::BuildConfig;
-use iota_sdk_types::TransactionDigest;
+use iota_sdk_types::{TransactionDigest, crypto::SimpleSignature};
 use iota_types::{
-    crypto::{Signature, SimpleKeypair},
-    quorum_driver_types::ExecuteTransactionRequestType,
+    crypto::SimpleKeypair, quorum_driver_types::ExecuteTransactionRequestType,
     utils::to_sender_signed_transaction,
 };
 use jsonrpsee::{
@@ -391,7 +390,7 @@ pub async fn execute_tx_and_wait_for_indexer_checkpoint(
     indexer_client: &HttpClient,
     store: &PgIndexerStore,
     tx_bytes: TransactionBlockBytes,
-    keypair: &impl Signer<Signature>,
+    keypair: &impl Signer<SimpleSignature>,
 ) -> TransactionDigest {
     let digest = execute_tx_must_succeed(indexer_client, tx_bytes, keypair).await;
     indexer_wait_for_transaction(digest, store, indexer_client).await;
@@ -401,7 +400,7 @@ pub async fn execute_tx_and_wait_for_indexer_checkpoint(
 pub async fn execute_tx_must_succeed(
     indexer_client: &HttpClient,
     tx_bytes: TransactionBlockBytes,
-    keypair: &impl Signer<Signature>,
+    keypair: &impl Signer<SimpleSignature>,
 ) -> TransactionDigest {
     let txn = to_sender_signed_transaction(tx_bytes.to_data().unwrap(), keypair);
     let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -15,10 +15,12 @@ use iota_json_rpc_types::{
 };
 use iota_keys::keystore::AccountKeystore;
 use iota_sdk_crypto::Signer;
-use iota_sdk_types::{Address, Identifier, ObjectId, ObjectReference, StructTag, TypeTag};
+use iota_sdk_types::{
+    Address, Identifier, ObjectId, ObjectReference, StructTag, TypeTag, crypto::SimpleSignature,
+};
 use iota_types::{
     balance::Supply,
-    crypto::{AccountKeyPair, Signature, SimpleKeypair, get_key_pair},
+    crypto::{AccountKeyPair, SimpleKeypair, get_key_pair},
     parse_iota_struct_tag,
     quorum_driver_types::ExecuteTransactionRequestType,
     utils::to_sender_signed_transaction,
@@ -785,7 +787,7 @@ async fn create_trusted_coins(
 pub async fn execute_move_call(
     client: &HttpClient,
     address: Address,
-    account_keypair: &impl Signer<Signature>,
+    account_keypair: &impl Signer<SimpleSignature>,
     package_object_id: ObjectId,
     module: String,
     function: String,

--- a/crates/iota-keys/src/keystore.rs
+++ b/crates/iota-keys/src/keystore.rs
@@ -20,10 +20,10 @@ use iota_sdk_crypto::{
 };
 use iota_sdk_types::{
     Address, SignatureScheme,
-    crypto::{Intent, IntentMessage},
+    crypto::{Intent, IntentMessage, SimpleSignature},
 };
 use iota_types::crypto::{
-    EncodeDecodeBase64, IotaSignature, PublicKey, Signature, SimpleKeypair, enum_dispatch,
+    EncodeDecodeBase64, IotaSignature, PublicKey, SimpleKeypair, enum_dispatch,
     get_key_pair_from_rng,
 };
 use rand::{SeedableRng, rngs::StdRng};
@@ -56,14 +56,18 @@ pub trait AccountKeystore: Send + Sync {
     fn keys(&self) -> Vec<&StoredKey>;
     fn get_key(&self, address: &Address) -> Result<&StoredKey, anyhow::Error>;
 
-    fn sign_hashed(&self, address: &Address, msg: &[u8]) -> Result<Signature, signature::Error>;
+    fn sign_hashed(
+        &self,
+        address: &Address,
+        msg: &[u8],
+    ) -> Result<SimpleSignature, signature::Error>;
 
     fn sign_secure<T>(
         &self,
         address: &Address,
         msg: &T,
         intent: Intent,
-    ) -> Result<Signature, signature::Error>
+    ) -> Result<SimpleSignature, signature::Error>
     where
         T: Serialize;
     fn addresses(&self) -> Vec<Address> {
@@ -342,13 +346,17 @@ pub struct AliasedKey {
 }
 
 impl AccountKeystore for FileBasedKeystore {
-    fn sign_hashed(&self, address: &Address, msg: &[u8]) -> Result<Signature, signature::Error> {
+    fn sign_hashed(
+        &self,
+        address: &Address,
+        msg: &[u8],
+    ) -> Result<SimpleSignature, signature::Error> {
         let stored_key = self.keys.get(address).ok_or_else(|| {
             signature::Error::from_source(format!("Cannot find key for address: [{address}]"))
         })?;
 
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(Signature::new_hashed(msg, keypair)),
+            StoredKey::KeyPair(keypair) => Ok(SimpleSignature::new_hashed(msg, keypair)),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_hashed is not supported for account type",
             )),
@@ -362,7 +370,7 @@ impl AccountKeystore for FileBasedKeystore {
         address: &Address,
         msg: &T,
         intent: Intent,
-    ) -> Result<Signature, signature::Error>
+    ) -> Result<SimpleSignature, signature::Error>
     where
         T: Serialize,
     {
@@ -372,7 +380,7 @@ impl AccountKeystore for FileBasedKeystore {
 
         let intent_msg = &IntentMessage::new(intent, msg);
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(Signature::new_secure(intent_msg, keypair)),
+            StoredKey::KeyPair(keypair) => Ok(SimpleSignature::new_secure(intent_msg, keypair)),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_secure is not supported for account type",
             )),
@@ -731,13 +739,17 @@ pub struct InMemKeystore {
 }
 
 impl AccountKeystore for InMemKeystore {
-    fn sign_hashed(&self, address: &Address, msg: &[u8]) -> Result<Signature, signature::Error> {
+    fn sign_hashed(
+        &self,
+        address: &Address,
+        msg: &[u8],
+    ) -> Result<SimpleSignature, signature::Error> {
         let stored_key = self.keys.get(address).ok_or_else(|| {
             signature::Error::from_source(format!("Cannot find key for address: [{address}]"))
         })?;
 
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(Signature::new_hashed(msg, keypair)),
+            StoredKey::KeyPair(keypair) => Ok(SimpleSignature::new_hashed(msg, keypair)),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_hashed is not supported for account type",
             )),
@@ -751,7 +763,7 @@ impl AccountKeystore for InMemKeystore {
         address: &Address,
         msg: &T,
         intent: Intent,
-    ) -> Result<Signature, signature::Error>
+    ) -> Result<SimpleSignature, signature::Error>
     where
         T: Serialize,
     {
@@ -761,7 +773,7 @@ impl AccountKeystore for InMemKeystore {
 
         let intent_msg = &IntentMessage::new(intent, msg);
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(Signature::new_secure(intent_msg, keypair)),
+            StoredKey::KeyPair(keypair) => Ok(SimpleSignature::new_secure(intent_msg, keypair)),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_secure is not supported for account type",
             )),

--- a/crates/iota-ledger/src/lib.rs
+++ b/crates/iota-ledger/src/lib.rs
@@ -14,9 +14,9 @@ pub use crate::api::errors::LedgerError;
 mod api;
 use iota_sdk_types::{
     Address,
-    crypto::{Intent, IntentMessage},
+    crypto::{Intent, IntentMessage, SimpleSignature},
 };
-use iota_types::{crypto::Signature, object::Object};
+use iota_types::object::Object;
 
 pub use crate::api::{get_public_key::PublicKeyResult, get_version::Version};
 use crate::{
@@ -29,7 +29,7 @@ pub struct Ledger {
 }
 
 pub struct SignedTransaction {
-    pub signature: Signature,
+    pub signature: SimpleSignature,
     pub address: Address,
 }
 
@@ -184,7 +184,7 @@ impl Ledger {
         signature_bytes.extend_from_slice(key_response.public_key.as_ref());
 
         Ok(SignedTransaction {
-            signature: Signature::from_bytes(&signature_bytes)
+            signature: SimpleSignature::from_bytes(&signature_bytes)
                 .map_err(|_| LedgerError::Serialization)?,
             address: Address::from_bytes(key_response.address)
                 .map_err(|_| LedgerError::Serialization)?,

--- a/crates/iota-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/iota-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -21,9 +21,11 @@ use iota_json_rpc_types::{
 };
 use iota_sdk::{IotaClient, IotaClientBuilder};
 use iota_sdk_crypto::ToFromBech32;
-use iota_sdk_types::{Address, ObjectId, ObjectReference, TransactionDigest};
+use iota_sdk_types::{
+    Address, ObjectId, ObjectReference, TransactionDigest, crypto::SimpleSignature,
+};
 use iota_types::{
-    crypto::{AccountKeyPair, IotaSignature, Signature, SimpleKeypair, get_key_pair},
+    crypto::{AccountKeyPair, IotaSignature, SimpleKeypair, get_key_pair},
     quorum_driver_types::ExecuteTransactionRequestType,
     transaction::{TransactionData, TransactionEnvelope},
 };
@@ -791,7 +793,7 @@ pub(crate) async fn sign_and_execute(
     txn_data: TransactionData,
     request_type: ExecuteTransactionRequestType,
 ) -> IotaTransactionBlockResponse {
-    let signature = Signature::new_secure(&txn_data.intent_message(), keypair);
+    let signature = SimpleSignature::new_secure(&txn_data.intent_message(), keypair);
 
     let transaction_response = match client
         .quorum_driver_api()

--- a/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
+++ b/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
@@ -19,7 +19,7 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::IotaTransactionBlockResponseOptions,
     types::{
-        crypto::{IotaSignature, PublicKey, Signature, SimpleKeypair, get_key_pair_from_rng},
+        crypto::{IotaSignature, PublicKey, SimpleKeypair, get_key_pair_from_rng},
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         transaction::{TransactionData, TransactionDataAPI},
     },
@@ -28,7 +28,7 @@ use iota_sdk_crypto::{
     Signer as _, ToFromBase64, ToFromBech32, ed25519::Ed25519PrivateKey,
     secp256k1::Secp256k1PrivateKey, secp256r1::Secp256r1PrivateKey,
 };
-use iota_sdk_types::{Address, UserSignature};
+use iota_sdk_types::{Address, UserSignature, crypto::SimpleSignature};
 use rand::{SeedableRng, rngs::StdRng};
 use utils::request_tokens_from_faucet;
 
@@ -146,7 +146,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let digest = hasher.finalize().digest;
 
     // use SimpleKeypair to sign the digest.
-    let iota_sig: Signature = ikp_determ_0.sign(&digest);
+    let iota_sig: SimpleSignature = ikp_determ_0.sign(&digest);
 
     // if you would like to verify the signature locally before submission, use this
     // function. if it fails to verify locally, the transaction will fail to

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -38,7 +38,7 @@ use iota_sdk_crypto::{
 };
 use iota_sdk_types::{
     Address, SignatureScheme,
-    crypto::{Intent, IntentMessage, IntentScope},
+    crypto::{Intent, IntentMessage, IntentScope, SimpleSignature},
 };
 use rand::{
     SeedableRng,
@@ -591,22 +591,13 @@ pub fn get_key_pair_from_bytes<KP: KeypairTraits>(bytes: &[u8]) -> IotaResult<KP
     Ok(sk.into())
 }
 
-// Account Signatures
-//
-
-// User signatures over transactions. Sourced from the SDK so the node shares a
-// single definition with clients; node-only behaviour (signing and
-// intent-message verification) lives in the [`IotaSignature`] extension trait
-// below.
-pub use iota_sdk_types::SimpleSignature as Signature;
-
-/// An all-zero ed25519 [`Signature`] placeholder, used for system transactions
-/// (which are not signed) and in tests where the signature content is
-/// irrelevant.
-pub fn zero_ed25519_signature() -> Signature {
+/// An all-zero ed25519 [`SimpleSignature`] placeholder, used for system
+/// transactions (which are not signed) and in tests where the signature
+/// content is irrelevant.
+pub fn zero_ed25519_signature() -> SimpleSignature {
     // `flag || signature || public key`, all zero; the leading zero byte selects
     // the ed25519 scheme.
-    Signature::from_bytes([0u8; 1 + Ed25519Signature::LENGTH + Ed25519PublicKey::LENGTH])
+    SimpleSignature::from_bytes([0u8; 1 + Ed25519Signature::LENGTH + Ed25519PublicKey::LENGTH])
         .expect("zero-filled ed25519 signature has the expected length")
 }
 
@@ -633,15 +624,14 @@ pub trait IotaPublicKey: VerifyingKey {
     const SIGNATURE_SCHEME: SignatureScheme;
 }
 
-/// Node-only behaviour layered on top of the SDK [`Signature`]
-/// (`iota_sdk_types::SimpleSignature`): construction from a signer and
-/// intent-message verification.
+/// Node-only behaviour layered on top of the SDK [`SimpleSignature`]:
+/// construction from a signer and intent-message verification.
 pub trait IotaSignature: Sized {
     /// Signs a message that is already in hashed form.
     fn new_hashed(
         hashed_msg: &[u8],
-        secret: &impl iota_sdk_crypto::Signer<Signature>,
-    ) -> Signature {
+        secret: &impl iota_sdk_crypto::Signer<SimpleSignature>,
+    ) -> SimpleSignature {
         secret.sign(hashed_msg)
     }
 
@@ -649,8 +639,8 @@ pub trait IotaSignature: Sized {
     #[instrument(level = "trace", skip_all)]
     fn new_secure<T>(
         value: &IntentMessage<T>,
-        secret: &impl iota_sdk_crypto::Signer<Signature>,
-    ) -> Signature
+        secret: &impl iota_sdk_crypto::Signer<SimpleSignature>,
+    ) -> SimpleSignature
     where
         T: Serialize,
     {
@@ -670,7 +660,7 @@ pub trait IotaSignature: Sized {
         T: Serialize;
 }
 
-impl IotaSignature for Signature {
+impl IotaSignature for SimpleSignature {
     #[instrument(level = "trace", skip_all)]
     fn verify_secure<T>(&self, value: &IntentMessage<T>, author: Address) -> Result<(), IotaError>
     where

--- a/crates/iota-types/src/signature.rs
+++ b/crates/iota-types/src/signature.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::{Address, UserSignature, crypto::IntentMessage};
+use iota_sdk_types::{
+    Address, UserSignature,
+    crypto::{IntentMessage, SimpleSignature},
+};
 use serde::Serialize;
 
 use crate::error::IotaResult;
@@ -57,8 +60,8 @@ impl AuthenticatorTrait for UserSignature {
 }
 
 /// This ports the wrapper trait to the verify_secure defined on
-/// [`crate::crypto::Signature`].
-impl AuthenticatorTrait for crate::crypto::Signature {
+/// [`SimpleSignature`].
+impl AuthenticatorTrait for SimpleSignature {
     #[tracing::instrument(level = "trace", skip_all)]
     fn verify_claims<T>(
         &self,

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -26,7 +26,7 @@ use iota_sdk_types::{
     SenderSignedTransaction, SharedObjectReference, SplitCoins, TransactionDigest,
     TransactionExpiration, TransactionKind, TransactionV1, TransferObjects, TypeTag, Upgrade,
     UserSignature, Version,
-    crypto::{Intent, IntentMessage, IntentScope},
+    crypto::{Intent, IntentMessage, IntentScope, SimpleSignature},
 };
 use itertools::Either;
 use nonempty::{NonEmpty, nonempty};
@@ -40,8 +40,8 @@ use crate::{
     committee::{Committee, EpochId},
     crypto::{
         AuthoritySignInfo, AuthoritySignInfoTrait, AuthoritySignature,
-        AuthorityStrongQuorumSignInfo, DefaultHash, EmptySignInfo, IotaSignature, Signature,
-        Signer, zero_ed25519_signature,
+        AuthorityStrongQuorumSignInfo, DefaultHash, EmptySignInfo, IotaSignature, Signer,
+        zero_ed25519_signature,
     },
     execution::SharedInput,
     message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope},
@@ -1848,12 +1848,12 @@ pub trait SenderSignedTransactionAPI {
     /// signature.
     fn new_from_sender_signature(
         tx_data: TransactionData,
-        tx_signature: Signature,
+        tx_signature: SimpleSignature,
     ) -> SenderSignedTransaction;
 
     /// Adds a signature. Does not check the validity of the signature or
     /// perform any de-dup checks.
-    fn add_signature(&mut self, new_signature: Signature);
+    fn add_signature(&mut self, new_signature: SimpleSignature);
 
     /// Returns a mapping from the address each signature commits to, to the
     /// signature itself.
@@ -1933,12 +1933,12 @@ pub trait SenderSignedTransactionAPI {
 impl SenderSignedTransactionAPI for SenderSignedTransaction {
     fn new_from_sender_signature(
         tx_data: TransactionData,
-        tx_signature: Signature,
+        tx_signature: SimpleSignature,
     ) -> SenderSignedTransaction {
         Self::new(tx_data, vec![tx_signature.into()])
     }
 
-    fn add_signature(&mut self, new_signature: Signature) {
+    fn add_signature(&mut self, new_signature: SimpleSignature) {
         self.0.signatures.push(new_signature.into());
     }
 
@@ -2323,30 +2323,30 @@ impl<S> Envelope<SenderSignedTransaction, S> {
 impl TransactionEnvelope {
     pub fn from_data_and_signer(
         data: TransactionData,
-        signers: Vec<&impl iota_sdk_crypto::Signer<Signature>>,
+        signers: Vec<&impl iota_sdk_crypto::Signer<SimpleSignature>>,
     ) -> Self {
         let signatures = {
             let intent_msg = data.intent_message();
             signers
                 .into_iter()
-                .map(|s| Signature::new_secure(&intent_msg, s))
+                .map(|s| SimpleSignature::new_secure(&intent_msg, s))
                 .collect()
         };
         Self::from_data(data, signatures)
     }
 
     // TODO: Rename this function and above to make it clearer.
-    pub fn from_data(data: TransactionData, signatures: Vec<Signature>) -> Self {
+    pub fn from_data(data: TransactionData, signatures: Vec<SimpleSignature>) -> Self {
         Self::from_user_sig_data(data, signatures.into_iter().map(|s| s.into()).collect())
     }
 
     pub fn signature_from_signer(
         data: TransactionData,
         intent: Intent,
-        signer: &impl iota_sdk_crypto::Signer<Signature>,
-    ) -> Signature {
+        signer: &impl iota_sdk_crypto::Signer<SimpleSignature>,
+    ) -> SimpleSignature {
         let intent_msg = IntentMessage::new(intent, data);
-        Signature::new_secure(&intent_msg, signer)
+        SimpleSignature::new_secure(&intent_msg, signer)
     }
 
     pub fn from_user_sig_data(data: TransactionData, signatures: Vec<UserSignature>) -> Self {

--- a/crates/iota-types/src/unit_tests/base_types_tests.rs
+++ b/crates/iota-types/src/unit_tests/base_types_tests.rs
@@ -15,7 +15,7 @@ use iota_protocol_config::ProtocolConfig;
 use iota_sdk_crypto::ToFromBytes as _;
 use iota_sdk_types::{
     Digest, Owner, TransactionDigest,
-    crypto::{Intent, IntentMessage, IntentScope},
+    crypto::{Intent, IntentMessage, IntentScope, SimpleSignature},
 };
 use move_binary_format::file_format;
 
@@ -24,7 +24,7 @@ use crate::{
     base_types::TypeTag,
     crypto::{
         AccountKeyPair, AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature,
-        IotaSignature, Signature,
+        IotaSignature,
         bcs_signable_test::{Bar, Foo},
         get_key_pair,
     },
@@ -55,7 +55,7 @@ fn test_signatures() {
     let foox = IntentMessage::new(Intent::iota_transaction(), Foo("hellox".into()));
     let bar = IntentMessage::new(Intent::iota_transaction(), Bar("hello".into()));
 
-    let s = Signature::new_secure(&foo, &sec1);
+    let s = SimpleSignature::new_secure(&foo, &sec1);
     assert!(s.verify_secure(&foo, addr1).is_ok());
     assert!(s.verify_secure(&foo, addr2).is_err());
     assert!(s.verify_secure(&foox, addr1).is_err());
@@ -78,11 +78,12 @@ fn test_signatures() {
 fn test_signatures_serde() {
     let (_, sec1): (_, AccountKeyPair) = get_key_pair();
     let foo = Foo("hello".into());
-    let s = Signature::new_secure(&IntentMessage::new(Intent::iota_transaction(), foo), &sec1);
+    let s =
+        SimpleSignature::new_secure(&IntentMessage::new(Intent::iota_transaction(), foo), &sec1);
 
     let serialized = bcs::to_bytes(&s).unwrap();
     println!("{serialized:?}");
-    let deserialized: Signature = bcs::from_bytes(&serialized).unwrap();
+    let deserialized: SimpleSignature = bcs::from_bytes(&serialized).unwrap();
     assert_eq!(deserialized.to_bytes(), s.to_bytes());
 }
 

--- a/crates/iota-types/src/unit_tests/crypto_tests.rs
+++ b/crates/iota-types/src/unit_tests/crypto_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk_crypto::{ToFromBech32, ToFromBytes as _};
+use iota_sdk_types::crypto::SimpleSignature;
 use proptest::{collection, prelude::*};
 
 use super::*;
@@ -120,7 +121,7 @@ proptest! {
         let _pk = PublicKey::try_from_bytes(SignatureScheme::Bls12381, &bytes);
         let _pk = PublicKey::try_from_bytes(SignatureScheme::Ed25519, &bytes);
         let _pk = PublicKey::try_from_bytes(SignatureScheme::Secp256k1, &bytes);
-        let _sig = Signature::from_bytes(&bytes);
+        let _sig = SimpleSignature::from_bytes(&bytes);
     }
 
     #[test]

--- a/crates/iota-types/src/unit_tests/intent_tests.rs
+++ b/crates/iota-types/src/unit_tests/intent_tests.rs
@@ -5,7 +5,10 @@
 use fastcrypto::traits::KeyPair;
 use iota_sdk_types::{
     ObjectId,
-    crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion, PersonalMessage},
+    crypto::{
+        Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion, PersonalMessage,
+        SimpleSignature,
+    },
 };
 
 use crate::{
@@ -13,7 +16,7 @@ use crate::{
     committee::EpochId,
     crypto::{
         AccountKeyPair, AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature,
-        IotaSignature, Signature, get_key_pair,
+        IotaSignature, get_key_pair,
     },
     object::Object,
     transaction::{
@@ -47,7 +50,7 @@ fn test_personal_message_intent() {
     assert_eq!(&intent_bcs[3..], &p_message_bcs);
 
     // Let's ensure we can sign and verify intents.
-    let s = Signature::new_secure(&IntentMessage::new(intent, p_message), &sec1);
+    let s = SimpleSignature::new_secure(&IntentMessage::new(intent, p_message), &sec1);
     let verification = s.verify_secure(&IntentMessage::new(intent, p_message_2), addr1);
     assert!(verification.is_ok())
 }
@@ -71,7 +74,7 @@ fn test_authority_signature_intent() {
         gas_price * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         gas_price,
     );
-    let signature = Signature::new_secure(&data.intent_message(), &sender_key);
+    let signature = SimpleSignature::new_secure(&data.intent_message(), &sender_key);
     let tx = TransactionEnvelope::from_data(data, vec![signature]);
     let tx1 = tx.clone();
     assert!(

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -15,7 +15,7 @@ use iota_sdk_crypto::{
 };
 use iota_sdk_types::{
     Address, ExecutionStatus, GasPayment, Owner, SharedObjectReference, SignatureScheme, StructTag,
-    TransactionEventsDigest, gas::GasCostSummary,
+    TransactionEventsDigest, crypto::SimpleSignature, gas::GasCostSummary,
 };
 use roaring::RoaringBitmap;
 
@@ -716,10 +716,10 @@ fn test_user_signature_committed_in_signed_transactions() {
 fn signature_from_signer(
     data: TransactionData,
     intent: Intent,
-    signer: &impl iota_sdk_crypto::Signer<Signature>,
-) -> Signature {
+    signer: &impl iota_sdk_crypto::Signer<SimpleSignature>,
+) -> SimpleSignature {
     let intent_msg = IntentMessage::new(intent, data);
-    Signature::new_secure(&intent_msg, signer)
+    SimpleSignature::new_secure(&intent_msg, signer)
 }
 
 #[test]

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -10,8 +10,8 @@ use std::{
 
 use fastcrypto::traits::{AggregateAuthenticator, KeyPair};
 use iota_sdk_crypto::{
-    ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey, secp256r1::Secp256r1PrivateKey,
-    simple::SimpleKeypair,
+    Signer, ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey,
+    secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair,
 };
 use iota_sdk_types::{
     Address, ExecutionStatus, GasPayment, Owner, SharedObjectReference, SignatureScheme, StructTag,
@@ -716,7 +716,7 @@ fn test_user_signature_committed_in_signed_transactions() {
 fn signature_from_signer(
     data: TransactionData,
     intent: Intent,
-    signer: &impl iota_sdk_crypto::Signer<SimpleSignature>,
+    signer: &impl Signer<SimpleSignature>,
 ) -> SimpleSignature {
     let intent_msg = IntentMessage::new(intent, data);
     SimpleSignature::new_secure(&intent_msg, signer)

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -41,14 +41,12 @@ use iota_sdk_crypto::{
 use iota_sdk_types::{
     Address, SenderSignedTransaction, SignatureScheme, Transaction,
     crypto::{
-        Intent, IntentMessage, PasskeyAuthenticator, PublicKey as SdkPublicKey, UserSignature,
+        Intent, IntentMessage, PasskeyAuthenticator, PublicKey as SdkPublicKey, SimpleSignature,
+        UserSignature,
     },
 };
 use iota_types::{
-    crypto::{
-        DefaultHash, EncodeDecodeBase64, PublicKey, Signature, SimpleKeypair,
-        get_authority_key_pair,
-    },
+    crypto::{DefaultHash, EncodeDecodeBase64, PublicKey, SimpleKeypair, get_authority_key_pair},
     error::IotaResult,
     move_authenticator::MoveAuthenticatorExt,
     multisig::{MultiSig, MultiSigPublicKey, MultisigMember, ThresholdUnit, WeightUnit},
@@ -845,7 +843,7 @@ impl KeyToolCommand {
                     StoredKey::KeyPair(kp) => kp,
                     _ => bail!("Not a keypair"),
                 };
-                let signature: Signature = ikp.sign(&bytes);
+                let signature: SimpleSignature = ikp.sign(&bytes);
                 let iota_signature = signature.to_base64();
                 let public_key = PublicKey::from(ikp).encode_base64();
                 let public_key_hex = Hex::encode_with_format(PublicKey::from(ikp).as_ref());

--- a/crates/iota/src/signing.rs
+++ b/crates/iota/src/signing.rs
@@ -11,12 +11,10 @@ use iota_ledger_signer::LedgerSigner;
 use iota_sdk::wallet_context::WalletContext;
 use iota_sdk_types::{
     Address, MoveAuthenticatorV1, ObjectId, Owner, SharedObjectReference, TypeTag, UserSignature,
-    Version, crypto::Intent,
+    Version,
+    crypto::{Intent, SimpleSignature},
 };
-use iota_types::{
-    crypto::Signature,
-    transaction::{CallArg, TransactionData},
-};
+use iota_types::transaction::{CallArg, TransactionData};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -154,7 +152,7 @@ pub(crate) fn sign_secure<T>(
     address: &Address,
     msg: &T,
     intent: Intent,
-) -> Result<Signature>
+) -> Result<SimpleSignature>
 where
     T: Serialize,
 {

--- a/crates/iota/src/unit_tests/keytool_tests.rs
+++ b/crates/iota/src/unit_tests/keytool_tests.rs
@@ -15,12 +15,11 @@ use iota_sdk_crypto::{
 use iota_sdk_types::{
     Address, Ed25519PublicKey, Ed25519Signature, ObjectDigest, ObjectId, ObjectReference,
     SignatureScheme, Version,
-    crypto::{Intent, IntentScope, PublicKey, PublicKeyExt as _, UserSignature},
+    crypto::{Intent, IntentScope, PublicKey, PublicKeyExt as _, SimpleSignature, UserSignature},
 };
 use iota_types::{
     crypto::{
-        AuthorityKeyPair, EncodeDecodeBase64, Signature, SimpleKeypair, get_key_pair,
-        get_key_pair_from_rng,
+        AuthorityKeyPair, EncodeDecodeBase64, SimpleKeypair, get_key_pair, get_key_pair_from_rng,
     },
     transaction::{TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData, TransactionDataAPI},
 };
@@ -86,7 +85,7 @@ async fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
             Intent::iota_transaction(),
         )?;
         match sig {
-            Signature::Ed25519 { .. } => {
+            SimpleSignature::Ed25519 { .. } => {
                 // signature contains corresponding flag
                 assert_eq!(
                     *sig.to_bytes().first().unwrap(),
@@ -95,14 +94,14 @@ async fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
                 // keystore stores pubkey with corresponding flag
                 assert!(pk.flag() == SignatureScheme::Ed25519.to_u8())
             }
-            Signature::Secp256k1 { .. } => {
+            SimpleSignature::Secp256k1 { .. } => {
                 assert_eq!(
                     *sig.to_bytes().first().unwrap(),
                     SignatureScheme::Secp256k1.to_u8()
                 );
                 assert!(pk.flag() == SignatureScheme::Secp256k1.to_u8())
             }
-            Signature::Secp256r1 { .. } => {
+            SimpleSignature::Secp256r1 { .. } => {
                 assert_eq!(
                     *sig.to_bytes().first().unwrap(),
                     SignatureScheme::Secp256r1.to_u8()


### PR DESCRIPTION
# Description of change

Follow-up to #12034 / #10724: drop the transitional `Signature` name so the SDK type is used under its own name everywhere.

- Remove the `pub use iota_sdk_types::SimpleSignature as Signature` re-export from `iota_types::crypto`; every consumer imports `iota_sdk_types::crypto::SimpleSignature` directly.
- Rename the remaining `Signature` mentions in signatures of the `IotaSignature` / `SenderSignedTransactionAPI` traits, `TransactionEnvelope` constructors, and doc comments.

## Serialization / wire compatibility

No change: this only removes a type alias — the underlying type is the same SDK `SimpleSignature`, so BCS bytes and digests are untouched.

## Links to any relevant issues

- #10724
- #12034

## How the change has been tested

- [x] `cargo check --workspace --all-targets`, `cargo ci-clippy`, and `cargo +nightly fmt --check` — clean.
- [x] Unit tests: `iota-types --lib` (202) and `iota-core --lib` `transaction_tests` (19) — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)