### PR TITLE
feat(iota-core,iota-types): wire the deny-rules object lifecycle

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5142,6 +5142,22 @@ impl AuthorityState {
     )> {
         let mut txns = Vec::new();
 
+        // Create the TransactionDenyRules object once: the epoch-start
+        // configuration is identical on every validator, so the whole
+        // committee injects (or skips) the kind together. If this epoch
+        // change falls into safe mode the creation is dropped with it, the
+        // object stays absent, and the next epoch end injects it again.
+        if epoch_store
+            .protocol_config()
+            .deny_rule_governance_on_chain()
+            && epoch_store
+                .epoch_start_config()
+                .transaction_deny_rules_obj_initial_shared_version()
+                .is_none()
+        {
+            txns.push(EndOfEpochTransactionKind::TransactionDenyRulesCreate);
+        }
+
         let next_epoch = epoch_store.epoch() + 1;
 
         let buffer_stake_bps = epoch_store.get_effective_buffer_stake_bps();

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -728,12 +728,20 @@ pub struct AuthorityPerEpochStore {
     /// `Rejected` response instead of waiting for the gRPC deadline.
     dropped_tx_status_cache: super::dropped_tx_status_cache::DroppedTxStatusCache,
 
-    /// The active deny rule set: the stake-weighted aggregate of the recorded
-    /// deny rule proposals. Recomputed via
-    /// `store_active_transaction_deny_rules` in
-    /// `ConsensusOutputQuarantine::push_consensus_output` and seeded from the
-    /// `deny_rule_proposals` table on construction.
+    /// The active deny rule set: the union of the mirrored on-chain state
+    /// and the stake-weighted aggregate of the recorded deny rule proposals.
+    /// Recomputed via `store_active_transaction_deny_rules` in
+    /// `ConsensusOutputQuarantine::push_consensus_output`; seeded on
+    /// construction from the epoch-start object state and the
+    /// `deny_rule_proposals` table, so enforcement carries across the epoch
+    /// boundary before any announcement of the new epoch lands.
     active_transaction_deny_rules: ArcSwap<DenyRuleSet>,
+
+    /// The deny rule state last written to the `TransactionDenyRules` object,
+    /// as far as this validator knows: seeded from the object at epoch start,
+    /// advanced on each injected update. The base the injection diff is
+    /// computed against.
+    mirrored_transaction_deny_rules: ArcSwap<DenyRuleSet>,
 
     /// Pre-consensus soft locks for owned objects (P-COOL flow).
     ///
@@ -1277,9 +1285,15 @@ impl AuthorityPerEpochStore {
                 .safe_iter()
                 .collect::<Result<BTreeMap<_, _>, _>>()
                 .expect("AuthorityEpochTables should contain valid deny rule proposals");
-        let active_transaction_deny_rules = ArcSwap::from_pointee(
+        let mirrored_deny_rules = epoch_start_configuration
+            .transaction_deny_rules_state()
+            .cloned()
+            .unwrap_or_default();
+        let active_transaction_deny_rules = ArcSwap::from_pointee(union_deny_rule_sets(
             Self::compute_active_transaction_deny_rules(&cached_deny_rule_proposals, &committee),
-        );
+            &mirrored_deny_rules,
+        ));
+        let mirrored_transaction_deny_rules = ArcSwap::from_pointee(mirrored_deny_rules);
 
         let committee_size = committee.num_members();
         let report_version = MisbehaviorReportVersion::from_protocol(&protocol_config);
@@ -1328,6 +1342,7 @@ impl AuthorityPerEpochStore {
             signed_effects_digests_cache,
             dropped_tx_status_cache: super::dropped_tx_status_cache::DroppedTxStatusCache::new(),
             active_transaction_deny_rules,
+            mirrored_transaction_deny_rules,
             soft_locks: OnceCell::new(),
             end_of_publish: Mutex::new(end_of_publish),
             pending_consensus_certificates: RwLock::new(pending_consensus_certificates),
@@ -3085,9 +3100,16 @@ impl AuthorityPerEpochStore {
             .is_some_and(|generation| generation >= proposal.generation)
     }
 
-    /// Returns the active deny rule set derived from the recorded proposals.
+    /// Returns the active deny rule set: the union of the mirrored on-chain
+    /// state and the aggregate of the recorded proposals.
     pub fn get_active_transaction_deny_rules(&self) -> Arc<DenyRuleSet> {
         self.active_transaction_deny_rules.load_full()
+    }
+
+    /// Returns the deny rule state last known to be written to the
+    /// `TransactionDenyRules` object.
+    pub fn get_mirrored_transaction_deny_rules(&self) -> Arc<DenyRuleSet> {
+        self.mirrored_transaction_deny_rules.load_full()
     }
 
     /// Recomputes the active deny rule set from the current proposals and
@@ -3107,7 +3129,10 @@ impl AuthorityPerEpochStore {
         &self,
         proposals: &BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
     ) -> bool {
-        let rules = Self::compute_active_transaction_deny_rules(proposals, self.committee());
+        let rules = union_deny_rule_sets(
+            Self::compute_active_transaction_deny_rules(proposals, self.committee()),
+            &self.mirrored_transaction_deny_rules.load(),
+        );
         if **self.active_transaction_deny_rules.load() == rules {
             return false;
         }
@@ -5861,4 +5886,27 @@ impl From<LockDetails> for LockDetailsWrapper {
         // always use latest version.
         LockDetailsWrapper::V1(details)
     }
+}
+
+/// The union of two deny rule sets: an entry or switch is active when it is
+/// active in either. Enforcement combines the mirrored on-chain state with
+/// the current epoch's aggregate this way, so on-chain rules keep applying
+/// before their supporters have re-announced.
+pub(crate) fn union_deny_rule_sets(mut rules: DenyRuleSet, other: &DenyRuleSet) -> DenyRuleSet {
+    rules
+        .denied_addresses
+        .extend(other.denied_addresses.iter().copied());
+    rules
+        .denied_objects
+        .extend(other.denied_objects.iter().copied());
+    rules
+        .denied_packages
+        .extend(other.denied_packages.iter().copied());
+    rules.package_publish_disabled |= other.package_publish_disabled;
+    rules.package_upgrade_disabled |= other.package_upgrade_disabled;
+    rules.shared_object_disabled |= other.shared_object_disabled;
+    rules.user_transaction_disabled |= other.user_transaction_disabled;
+    rules.receiving_objects_disabled |= other.receiving_objects_disabled;
+    rules.move_authenticator_disabled |= other.move_authenticator_disabled;
+    rules
 }

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 use enum_dispatch::enum_dispatch;
 use iota_config::NodeConfig;
-use iota_sdk_types::{CheckpointDigest, Version};
+use iota_sdk_types::{CheckpointDigest, DenyRuleSet, Version};
 use iota_types::{
     deny_list_v1::get_deny_list_obj_initial_shared_version,
     epoch_data::EpochData,
@@ -17,6 +17,9 @@ use iota_types::{
     messages_checkpoint::CheckpointTimestamp,
     randomness_state::get_randomness_state_obj_initial_shared_version,
     storage::ObjectStore,
+    transaction_deny_rules::{
+        get_transaction_deny_rules, get_transaction_deny_rules_obj_initial_shared_version,
+    },
 };
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +30,13 @@ pub trait EpochStartConfigTrait {
     fn flags(&self) -> &[EpochFlag];
     fn randomness_obj_initial_shared_version(&self) -> Version;
     fn coin_deny_list_obj_initial_shared_version(&self) -> Version;
+    /// `None` until the `TransactionDenyRulesCreate` end-of-epoch transaction
+    /// has created the object.
+    fn transaction_deny_rules_obj_initial_shared_version(&self) -> Option<Version>;
+    /// The deny rule state read from the `TransactionDenyRules` object at
+    /// epoch start (`None` while the object does not exist). Seeds the
+    /// enforcement cache and the mirrored on-chain state for the epoch.
+    fn transaction_deny_rules_state(&self) -> Option<&DenyRuleSet>;
 }
 
 // IMPORTANT: Assign explicit values to each variant to ensure that the values
@@ -103,6 +113,7 @@ impl fmt::Display for EpochFlag {
 pub enum EpochStartConfiguration {
     V1(EpochStartConfigurationV1),
     V2(EpochStartConfigurationV2),
+    V3(EpochStartConfigurationV3),
 }
 
 impl EpochStartConfiguration {
@@ -116,15 +127,21 @@ impl EpochStartConfiguration {
             get_randomness_state_obj_initial_shared_version(object_store)?;
         let coin_deny_list_obj_initial_shared_version =
             get_deny_list_obj_initial_shared_version(object_store);
-        Ok(Self::V2(EpochStartConfigurationV2 {
+        let transaction_deny_rules_obj_initial_shared_version =
+            get_transaction_deny_rules_obj_initial_shared_version(object_store)?;
+        let transaction_deny_rules_state = get_transaction_deny_rules(object_store)?;
+        debug_assert_eq!(
+            transaction_deny_rules_obj_initial_shared_version.is_some(),
+            transaction_deny_rules_state.is_some()
+        );
+        Ok(Self::V3(EpochStartConfigurationV3 {
             system_state,
             epoch_digest,
             flags: initial_epoch_flags,
-            // Field retained for serialization compatibility; always None because
-            // authenticator state (JWK/zkLogin) was never enabled on IOTA.
-            authenticator_obj_initial_shared_version: None,
             randomness_obj_initial_shared_version,
             coin_deny_list_obj_initial_shared_version,
+            transaction_deny_rules_obj_initial_shared_version,
+            transaction_deny_rules_state,
         }))
     }
 
@@ -154,6 +171,17 @@ impl EpochStartConfiguration {
                 randomness_obj_initial_shared_version: config.randomness_obj_initial_shared_version,
                 coin_deny_list_obj_initial_shared_version: config
                     .coin_deny_list_obj_initial_shared_version,
+            }),
+            Self::V3(config) => Self::V3(EpochStartConfigurationV3 {
+                system_state: config.system_state.new_at_next_epoch_for_testing(),
+                epoch_digest: config.epoch_digest,
+                flags: config.flags.clone(),
+                randomness_obj_initial_shared_version: config.randomness_obj_initial_shared_version,
+                coin_deny_list_obj_initial_shared_version: config
+                    .coin_deny_list_obj_initial_shared_version,
+                transaction_deny_rules_obj_initial_shared_version: config
+                    .transaction_deny_rules_obj_initial_shared_version,
+                transaction_deny_rules_state: config.transaction_deny_rules_state.clone(),
             }),
             _ => panic!(
                 "This function is only implemented for the latest version of EpochStartConfiguration"
@@ -207,6 +235,14 @@ impl EpochStartConfigTrait for EpochStartConfigurationV1 {
     fn coin_deny_list_obj_initial_shared_version(&self) -> Version {
         self.coin_deny_list_obj_initial_shared_version
     }
+
+    fn transaction_deny_rules_obj_initial_shared_version(&self) -> Option<Version> {
+        None
+    }
+
+    fn transaction_deny_rules_state(&self) -> Option<&DenyRuleSet> {
+        None
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -239,5 +275,56 @@ impl EpochStartConfigTrait for EpochStartConfigurationV2 {
 
     fn coin_deny_list_obj_initial_shared_version(&self) -> Version {
         self.coin_deny_list_obj_initial_shared_version
+    }
+
+    fn transaction_deny_rules_obj_initial_shared_version(&self) -> Option<Version> {
+        None
+    }
+
+    fn transaction_deny_rules_state(&self) -> Option<&DenyRuleSet> {
+        None
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct EpochStartConfigurationV3 {
+    system_state: EpochStartSystemState,
+    epoch_digest: CheckpointDigest,
+    flags: Vec<EpochFlag>,
+    randomness_obj_initial_shared_version: Version,
+    coin_deny_list_obj_initial_shared_version: Version,
+    transaction_deny_rules_obj_initial_shared_version: Option<Version>,
+    /// Present exactly when the initial shared version is: both come from the
+    /// same object at epoch start.
+    transaction_deny_rules_state: Option<DenyRuleSet>,
+}
+
+impl EpochStartConfigTrait for EpochStartConfigurationV3 {
+    fn epoch_digest(&self) -> CheckpointDigest {
+        self.epoch_digest
+    }
+
+    fn epoch_start_state(&self) -> &EpochStartSystemState {
+        &self.system_state
+    }
+
+    fn flags(&self) -> &[EpochFlag] {
+        &self.flags
+    }
+
+    fn randomness_obj_initial_shared_version(&self) -> Version {
+        self.randomness_obj_initial_shared_version
+    }
+
+    fn coin_deny_list_obj_initial_shared_version(&self) -> Version {
+        self.coin_deny_list_obj_initial_shared_version
+    }
+
+    fn transaction_deny_rules_obj_initial_shared_version(&self) -> Option<Version> {
+        self.transaction_deny_rules_obj_initial_shared_version
+    }
+
+    fn transaction_deny_rules_state(&self) -> Option<&DenyRuleSet> {
+        self.transaction_deny_rules_state.as_ref()
     }
 }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -557,6 +557,61 @@ fn compute_active_transaction_deny_rules_applies_stake_thresholds() {
     assert!(!active.package_upgrade_disabled);
 }
 
+/// The enforcement union keeps every mirrored on-chain entry and switch
+/// active regardless of the proposal-derived aggregate, so rules carry
+/// across the epoch boundary before supporters re-announce.
+#[test]
+fn union_deny_rule_sets_keeps_mirrored_state_active() {
+    use crate::authority::authority_per_epoch_store::union_deny_rule_sets;
+
+    // Every list gets a mirrored-only, an aggregate-only, and a shared entry.
+    // Each side contributes three of the six switches.
+    let shared = Address::new([1u8; 32]);
+    let mirrored = DenyRuleSet {
+        denied_addresses: [shared, Address::new([2u8; 32])].into(),
+        denied_objects: [ObjectId::new([3u8; 32])].into(),
+        denied_packages: [ObjectId::new([4u8; 32])].into(),
+        package_publish_disabled: true,
+        shared_object_disabled: true,
+        receiving_objects_disabled: true,
+        ..Default::default()
+    };
+    let aggregate = DenyRuleSet {
+        denied_addresses: [shared, Address::new([5u8; 32])].into(),
+        denied_objects: [ObjectId::new([6u8; 32])].into(),
+        denied_packages: [ObjectId::new([7u8; 32])].into(),
+        package_upgrade_disabled: true,
+        user_transaction_disabled: true,
+        move_authenticator_disabled: true,
+        ..Default::default()
+    };
+
+    let active = union_deny_rule_sets(aggregate, &mirrored);
+    assert_eq!(
+        active.denied_addresses,
+        [shared, Address::new([2u8; 32]), Address::new([5u8; 32])].into()
+    );
+    assert_eq!(
+        active.denied_objects,
+        [ObjectId::new([3u8; 32]), ObjectId::new([6u8; 32])].into()
+    );
+    assert_eq!(
+        active.denied_packages,
+        [ObjectId::new([4u8; 32]), ObjectId::new([7u8; 32])].into()
+    );
+    assert!(active.package_publish_disabled);
+    assert!(active.package_upgrade_disabled);
+    assert!(active.shared_object_disabled);
+    assert!(active.user_transaction_disabled);
+    assert!(active.receiving_objects_disabled);
+    assert!(active.move_authenticator_disabled);
+
+    // An empty aggregate changes nothing. A fresh epoch starts this way.
+    // This also pins the switches the mirror leaves off.
+    let active = union_deny_rule_sets(DenyRuleSet::default(), &mirrored);
+    assert_eq!(active, mirrored);
+}
+
 /// `announced_deny_rule_stake` sums the committee stake behind recorded
 /// proposals: empty proposals count as announcements, non-members weigh 0.
 #[tokio::test]

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -8086,6 +8086,56 @@ async fn authority_with_deny_rule_governance(enabled: bool) -> Arc<AuthorityStat
         .await
 }
 
+/// The end-of-epoch transaction creates the `TransactionDenyRules` object
+/// exactly when on-chain deny rule governance is enabled and the object does
+/// not exist at epoch start.
+#[rstest::rstest]
+#[tokio::test]
+async fn advance_epoch_tx_creates_deny_rules_object_under_flag(
+    #[values(false, true)] enabled: bool,
+) {
+    use iota_sdk_types::gas::GasCostSummary;
+    use iota_types::IOTA_TRANSACTION_DENY_RULES_OBJECT_ID;
+
+    use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
+
+    let mut protocol_config =
+        ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    if enabled {
+        protocol_config.set_deny_rule_governance_for_testing(true);
+        protocol_config.set_deny_rule_governance_on_chain_for_testing(true);
+    }
+    let authority = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config)
+        .build()
+        .await;
+    let epoch_store = authority.epoch_store_for_testing();
+    assert!(
+        epoch_store
+            .epoch_start_config()
+            .transaction_deny_rules_obj_initial_shared_version()
+            .is_none()
+    );
+
+    // One full score for the single-validator test committee.
+    let (_, _, effects) = authority
+        .create_and_execute_advance_epoch_tx(
+            &epoch_store,
+            &GasCostSummary::new(0, 0, 0, 0, 0),
+            1, // checkpoint
+            0, // epoch_start_timestamp_ms
+            vec![u16::MAX as u64 + 1],
+        )
+        .await
+        .expect("advance epoch tx must succeed");
+
+    let created = effects
+        .created()
+        .iter()
+        .any(|(object_ref, _)| object_ref.object_id == IOTA_TRANSACTION_DENY_RULES_OBJECT_ID);
+    assert_eq!(created, enabled);
+}
+
 /// A `TransactionDenyRuleProposal` whose declared authority matches `author` is
 /// recorded through the consensus pipeline and its rules become active for the
 /// next commit; a proposal whose author does not match the consensus block

--- a/crates/iota-types/src/transaction_deny_rules.rs
+++ b/crates/iota-types/src/transaction_deny_rules.rs
@@ -1,12 +1,20 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::{Identifier, Version};
+use std::fmt;
+
+use iota_sdk_types::{Address, DenyRuleSet, Identifier, Version};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{
-    IOTA_FRAMEWORK_ADDRESS, IOTA_TRANSACTION_DENY_RULES_OBJECT_ID, error::IotaResult,
+    IOTA_FRAMEWORK_ADDRESS, IOTA_TRANSACTION_DENY_RULES_OBJECT_ID, MoveTypeTagTrait,
+    collection_types::{LinkedTable, LinkedTableNode},
+    dynamic_field::get_dynamic_field_from_store,
+    error::{IotaError, IotaResult},
+    id::{ID, UID},
     storage::ObjectStore,
+    versioned::Versioned,
 };
 
 pub const TRANSACTION_DENY_RULES_MODULE_NAME: &IdentStr = ident_str!("transaction_deny_rules");
@@ -40,4 +48,125 @@ pub fn get_transaction_deny_rules_obj_initial_shared_version(
                 .into_opt_shared()
                 .expect("TransactionDenyRules object must be shared")
         }))
+}
+
+pub const TRANSACTION_DENY_RULES_INNER_V1: u64 = 1;
+
+/// Rust version of the Move `transaction_deny_rules::TransactionDenyRules`
+/// type.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TransactionDenyRules {
+    pub id: UID,
+    pub inner: Versioned,
+}
+
+/// Rust version of the Move
+/// `transaction_deny_rules::TransactionDenyRulesInnerV1` type.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TransactionDenyRulesInnerV1 {
+    pub version: u64,
+    pub denied_addresses: LinkedTable<Address>,
+    pub denied_objects: LinkedTable<ID>,
+    pub denied_packages: LinkedTable<ID>,
+    pub package_publish_disabled: bool,
+    pub package_upgrade_disabled: bool,
+    pub shared_object_disabled: bool,
+    pub user_transaction_disabled: bool,
+    pub receiving_objects_disabled: bool,
+    pub move_authenticator_disabled: bool,
+}
+
+/// The full deny rule state read back from the `TransactionDenyRules` object,
+/// or `None` while the object has not been created yet.
+///
+/// Each deny list is reconstructed by walking its `LinkedTable` (`head` →
+/// `node.next`) with derived-id child reads, so any node can rebuild the
+/// state from its object store alone. Validators seed enforcement and the
+/// mirrored on-chain state from this at epoch start.
+pub fn get_transaction_deny_rules(
+    object_store: &dyn ObjectStore,
+) -> IotaResult<Option<DenyRuleSet>> {
+    let Some(object) = object_store.try_get_object(&IOTA_TRANSACTION_DENY_RULES_OBJECT_ID)? else {
+        return Ok(None);
+    };
+    let iota_sdk_types::ObjectData::Struct(move_object) = &object.data else {
+        return Err(IotaError::ObjectDeserialization {
+            error: "TransactionDenyRules object must be a Move object".to_string(),
+        });
+    };
+    let rules: TransactionDenyRules = bcs::from_bytes(move_object.contents()).map_err(|err| {
+        IotaError::ObjectDeserialization {
+            error: format!("failed to decode TransactionDenyRules: {err}"),
+        }
+    })?;
+    if rules.inner.version != TRANSACTION_DENY_RULES_INNER_V1 {
+        return Err(IotaError::ObjectDeserialization {
+            error: format!(
+                "unsupported TransactionDenyRules inner version {}",
+                rules.inner.version
+            ),
+        });
+    }
+    let inner: TransactionDenyRulesInnerV1 =
+        get_dynamic_field_from_store(object_store, rules.inner.id.id.bytes, &rules.inner.version)?;
+
+    Ok(Some(DenyRuleSet {
+        denied_addresses: walk_linked_table(object_store, &inner.denied_addresses)?
+            .into_iter()
+            .collect(),
+        denied_objects: walk_linked_table(object_store, &inner.denied_objects)?
+            .into_iter()
+            .map(|id| id.bytes)
+            .collect(),
+        denied_packages: walk_linked_table(object_store, &inner.denied_packages)?
+            .into_iter()
+            .map(|id| id.bytes)
+            .collect(),
+        package_publish_disabled: inner.package_publish_disabled,
+        package_upgrade_disabled: inner.package_upgrade_disabled,
+        shared_object_disabled: inner.shared_object_disabled,
+        user_transaction_disabled: inner.user_transaction_disabled,
+        receiving_objects_disabled: inner.receiving_objects_disabled,
+        move_authenticator_disabled: inner.move_authenticator_disabled,
+    }))
+}
+
+/// Collects a `LinkedTable`'s keys in list order by following the `next`
+/// links, one derived-id child read per entry.
+fn walk_linked_table<K>(
+    object_store: &dyn ObjectStore,
+    table: &LinkedTable<K>,
+) -> IotaResult<Vec<K>>
+where
+    K: MoveTypeTagTrait + Serialize + DeserializeOwned + Clone + fmt::Debug,
+{
+    let mut keys = Vec::with_capacity(table.size as usize);
+    let mut next = table.head.clone();
+    while let Some(key) = next {
+        // A cycle in the links would otherwise never terminate; the walk can
+        // only visit `size` distinct entries.
+        if keys.len() as u64 == table.size {
+            return Err(IotaError::ObjectDeserialization {
+                error: format!(
+                    "LinkedTable {} has more linked entries than its size {}",
+                    table.id, table.size
+                ),
+            });
+        }
+        let node: LinkedTableNode<K, bool> =
+            get_dynamic_field_from_store(object_store, table.id, &key)?;
+        keys.push(key);
+        next = node.next;
+    }
+    if keys.len() as u64 != table.size {
+        return Err(IotaError::ObjectDeserialization {
+            error: format!(
+                "LinkedTable {} links {} entries but its size is {}",
+                table.id,
+                keys.len(),
+                table.size
+            ),
+        });
+    }
+    Ok(keys)
 }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -1053,6 +1053,78 @@ mod tests {
         assert!(object.owner().is_shared());
     }
 
+    /// The full deny rule state read back by walking the object's
+    /// `LinkedTable`s matches the deltas applied through real execution.
+    #[test]
+    fn walked_object_state_matches_applied_deltas() {
+        use std::collections::BTreeSet;
+
+        use iota_sdk_types::TransactionDenyRulesUpdate;
+        use iota_types::transaction_deny_rules::{
+            get_transaction_deny_rules, get_transaction_deny_rules_obj_initial_shared_version,
+        };
+
+        let _guard =
+            iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+                config.set_deny_rule_governance_for_testing(true);
+                config.set_deny_rule_governance_on_chain_for_testing(true);
+                config
+            });
+        let sim = Simulacrum::new();
+        sim.advance_epoch(true);
+
+        let initial_shared_version = sim
+            .with_store(|store| get_transaction_deny_rules_obj_initial_shared_version(store))
+            .unwrap()
+            .expect("object must exist after the create");
+
+        let denied_address = Address::new([0xAA; 32]);
+        let removed_address = Address::new([0xBB; 32]);
+        let denied_package = ObjectId::new([0x2B; 32]);
+        let update = |round, added_addresses: BTreeSet<Address>, removed_addresses| {
+            VerifiedTransaction::new_transaction_deny_rules_update(TransactionDenyRulesUpdate {
+                epoch: 1,
+                round,
+                added_addresses,
+                removed_addresses,
+                added_objects: BTreeSet::new(),
+                removed_objects: BTreeSet::new(),
+                added_packages: [denied_package].into(),
+                removed_packages: BTreeSet::new(),
+                package_publish_disabled: false,
+                package_upgrade_disabled: false,
+                shared_object_disabled: true,
+                user_transaction_disabled: false,
+                receiving_objects_disabled: false,
+                move_authenticator_disabled: false,
+                deny_rules_obj_initial_shared_version: initial_shared_version,
+            })
+        };
+
+        // Two entries in, then one removed again: the walk crosses re-linked
+        // nodes, not just appended ones.
+        let (_, error) = sim
+            .execute_transaction(
+                update(0, [denied_address, removed_address].into(), BTreeSet::new()).into(),
+            )
+            .unwrap();
+        assert!(error.is_none());
+        let (_, error) = sim
+            .execute_transaction(update(1, BTreeSet::new(), [removed_address].into()).into())
+            .unwrap();
+        assert!(error.is_none());
+
+        let walked = sim
+            .with_store(|store| get_transaction_deny_rules(store))
+            .unwrap()
+            .expect("object must exist");
+        assert_eq!(walked.denied_addresses, [denied_address].into());
+        assert!(walked.denied_objects.is_empty());
+        assert_eq!(walked.denied_packages, [denied_package].into());
+        assert!(walked.shared_object_disabled);
+        assert!(!walked.user_transaction_disabled);
+    }
+
     #[test]
     fn simple_epoch() {
         let steps = 10;


### PR DESCRIPTION
# Description of change

Part of #12498, stacked on #12567. Wires the `TransactionDenyRules` object's lifecycle: the node creates it at the end of the first enabled epoch and reads it back at every epoch start.

- **Creation injection**: `create_and_execute_advance_epoch_tx` injects `TransactionDenyRulesCreate` ahead of the change-epoch kind when `deny_rule_governance_on_chain` is on and the object does not exist at epoch start. The predicate reads the epoch-start configuration — identical on every validator — so the whole committee injects or skips together, and a safe-moded epoch change (which drops the creation) leads to re-injection at the next epoch end.
- **Read-back**: `get_transaction_deny_rules` in `iota-types` reconstructs the full deny rule state from any object store by walking each deny list's `LinkedTable` (`head` → `node.next`, one derived-id child read per entry, with cycle and size integrity checks) — a read a plain `Table` cannot support on validators, which lack the fullnode dynamic-field index.
- **`EpochStartConfigurationV3`** carries the object's initial shared version and the walked deny state. Both are computed once per epoch at the boundary and persisted with the configuration, so a mid-epoch restart reloads the identical seed instead of re-walking a store that has advanced.
- **Epoch-store seeding**: the new mirrored-state record (`get_mirrored_transaction_deny_rules`, the base the delta-injection PR diffs against) is seeded from the epoch-start state, and enforcement becomes the union of the mirror and the proposal-derived aggregate — on-chain rules keep applying across the epoch boundary before any supporter re-announces, closing the enforcement lapse of in-memory-only aggregation. The object/mirror boundary guard lands with the mirror advance in the delta-injection PR.

### Links to any relevant issues

Fixes #12505.

### How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New tests: `advance_epoch_tx_creates_deny_rules_object_under_flag` (the injection predicate through real end-of-epoch execution, flag on and off), `walked_object_state_matches_applied_deltas` (create + two delta updates through real execution — including a removal that re-links nodes — then the walk reconstructs the exact state), and `union_deny_rule_sets_keeps_mirrored_state_active` (boundary enforcement semantics). Existing deny-governance batteries pass; clippy and `cargo +nightly fmt` clean.