### PR TITLE
feat(node): Add devnet to download-formal-snapshot

### DIFF
--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -16,7 +16,6 @@ use iota_core::{
     authority_aggregator::AuthorityAggregatorBuilder,
     authority_client::{validator::ValidatorAPI, validator_peer::ValidatorPeerAPI},
 };
-use iota_protocol_config::Chain;
 use iota_replay::{ReplayToolCommand, execute_replay_command};
 use iota_sdk::{IotaClient, IotaClientBuilder, rpc_types::IotaTransactionBlockResponseOptions};
 use iota_sdk_types::{Address, ObjectId, SenderSignedTransaction, TransactionDigest};
@@ -50,6 +49,14 @@ pub enum Verbosity {
     Grouped,
     Concise,
     Verbose,
+}
+
+/// Networks that publish snapshots downloadable with this tool.
+#[derive(Debug, Copy, Clone, ValueEnum)]
+pub enum Network {
+    Mainnet,
+    Testnet,
+    Devnet,
 }
 
 #[derive(Parser)]
@@ -217,7 +224,7 @@ pub enum ToolCommand {
         /// If `--snapshot-bucket` is not specified, the value of this flag is
         /// used to construct the default bucket name.
         #[arg(long, default_value = "mainnet")]
-        network: Chain,
+        network: Network,
         /// Snapshot bucket name. If not specified, defaults are
         /// based on value of `--network` flag.
         #[arg(long, conflicts_with = "no_sign_request")]
@@ -613,33 +620,32 @@ impl ToolCommand {
                 });
                 let snapshot_bucket =
                     snapshot_bucket.or_else(|| match (network, no_sign_request) {
-                        (Chain::Mainnet, false) => Some(
+                        (Network::Mainnet, false) => Some(
                             env::var("MAINNET_FORMAL_SIGNED_BUCKET")
                                 .unwrap_or("iota-mainnet-formal".to_string()),
                         ),
-                        (Chain::Mainnet, true) => env::var("MAINNET_FORMAL_UNSIGNED_BUCKET").ok(),
-                        (Chain::Testnet, true) => env::var("TESTNET_FORMAL_UNSIGNED_BUCKET").ok(),
-                        (Chain::Testnet, _) => Some(
+                        (Network::Mainnet, true) => env::var("MAINNET_FORMAL_UNSIGNED_BUCKET").ok(),
+                        (Network::Testnet, false) => Some(
                             env::var("TESTNET_FORMAL_SIGNED_BUCKET")
                                 .unwrap_or("iota-testnet-formal".to_string()),
                         ),
-                        (Chain::Unknown, _) => {
-                            panic!("Cannot generate default snapshot bucket for unknown network");
-                        }
+                        (Network::Testnet, true) => env::var("TESTNET_FORMAL_UNSIGNED_BUCKET").ok(),
+                        (Network::Devnet, false) => Some(
+                            env::var("DEVNET_FORMAL_SIGNED_BUCKET")
+                                .unwrap_or("iota-devnet-formal".to_string()),
+                        ),
+                        (Network::Devnet, true) => env::var("DEVNET_FORMAL_UNSIGNED_BUCKET").ok(),
                     });
 
                 let aws_endpoint = env::var("AWS_SNAPSHOT_ENDPOINT").ok().or_else(|| {
-                    if no_sign_request {
-                        if network == Chain::Mainnet {
-                            Some("https://formal-snapshot.mainnet.iota.cafe".to_string())
-                        } else if network == Chain::Testnet {
-                            Some("https://formal-snapshot.testnet.iota.cafe".to_string())
-                        } else {
-                            None
+                    no_sign_request.then(|| {
+                        match network {
+                            Network::Mainnet => "https://formal-snapshot.mainnet.iota.cafe",
+                            Network::Testnet => "https://formal-snapshot.testnet.iota.cafe",
+                            Network::Devnet => "https://formal-snapshot.devnet.iota.cafe",
                         }
-                    } else {
-                        None
-                    }
+                        .to_string()
+                    })
                 });
 
                 let snapshot_bucket_type = if no_sign_request {

--- a/docs/content/operator/common/snapshots.mdx
+++ b/docs/content/operator/common/snapshots.mdx
@@ -200,7 +200,7 @@ The following steps can be used to restore a node from a Formal snapshot:
 
    - `--epoch` / `--latest`: Pin a specific snapshot epoch, or always grab the most recent one.
    - `--genesis`: The path to the location of the network's `genesis.blob`.
-   - `--network`: Network to download snapshot for. Defaults to "mainnet".
+   - `--network`: Network to download the snapshot for: `mainnet`, `testnet`, or `devnet`. Defaults to `mainnet`.
    - `--path`: Path to snapshot directory on local filesystem.
    - `--skip-grpc-indexes`: Skips building the gRPC index store during the restore. By default it is built from the same object stream that restores the state, so a full node started with the gRPC API enabled opens it in place instead of re-indexing the whole restored state on first start. Skip it only if the node will never serve the gRPC API.
    - `--disable-progress-bar`: Reports progress as a status line logged once per second instead of drawing progress bars.

--- a/docs/site/src/components/FormalSnapshotPicker/index.tsx
+++ b/docs/site/src/components/FormalSnapshotPicker/index.tsx
@@ -5,7 +5,7 @@ import SnapshotEpochPicker, {
 } from '@site/src/components/SnapshotEpochPicker';
 import { EpochSelection, Network } from '@site/src/hooks/useFormalSnapshotEpochs';
 
-const NETWORKS = ['mainnet', 'testnet'] as const;
+const NETWORKS = ['mainnet', 'testnet', 'devnet'] as const;
 
 const SETUPS = ['binary', 'docker'] as const;
 type Setup = (typeof SETUPS)[number];


### PR DESCRIPTION
# Description of change

- Add a `Network` enum (`mainnet`, `testnet`, `devnet`) in `iota-tool` and use it for the `--network` flag of `download-formal-snapshot` instead of the protocol-config `Chain`, removing the unreachable unknown-network panic.
- Wire the devnet defaults like the other networks.
- Add devnet to the formal snapshot picker in the docs.

## Links to any relevant issues

fixes #12420

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes


### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): `iota-tool download-formal-snapshot` now supports `--network devnet` for restoring a devnet node from a formal snapshot.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
