### PR TITLE
feat(iota-core,iota-protocol-config): inject deny-rule delta updates at the commit boundary (#12506)

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3269,38 +3269,31 @@ impl AuthorityState {
         self.execution_lock.write().await
     }
 
-    /// Fails reconfiguration when the deny-rules state walked from the object
-    /// for the next epoch diverged from the closing epoch's mirror. Between
-    /// commits the two are in lockstep and the epoch boundary is such a
-    /// barrier, so a mismatch means one of them is corrupted; the object is
-    /// authoritative. Nodes that did not run consensus for the closing epoch
-    /// (fullnodes, validators joining at this boundary) execute the injected
-    /// updates without a mirror, so they are exempt.
+    /// Reports a mirror that diverged from the object at the epoch boundary,
+    /// where the two must agree. Reporting is the remedy: reconfiguration
+    /// re-seeds the mirror from the object, so failing here would only pin the
+    /// node to the diverged state. Nodes outside the closing committee hold no
+    /// mirror and are exempt.
     pub(crate) fn check_transaction_deny_rules_consistency(
         &self,
         cur_epoch_store: &AuthorityPerEpochStore,
         epoch_start_configuration: &EpochStartConfiguration,
-    ) -> IotaResult<()> {
+    ) {
         if self.is_fullnode(cur_epoch_store) {
-            return Ok(());
+            return;
         }
         if let Some(walked_deny_rules) = epoch_start_configuration.transaction_deny_rules_state() {
             let mirrored_deny_rules = cur_epoch_store.get_mirrored_transaction_deny_rules();
             if *walked_deny_rules != *mirrored_deny_rules {
                 debug_fatal!(
                     "TransactionDenyRules object diverged from the mirrored state at the end of \
-                     epoch {} (walked: {walked_deny_rules:?}, mirrored: {mirrored_deny_rules:?})",
+                     epoch {}; continuing from the object (walked: {walked_deny_rules:?}, \
+                     mirrored: {mirrored_deny_rules:?})",
                     cur_epoch_store.epoch(),
                 );
                 cur_epoch_store.metrics.deny_rule_mirror_divergence.set(1);
-                return Err(IotaError::GenericAuthority {
-                    error: "TransactionDenyRules object diverged from the mirrored state at the \
-                            epoch boundary"
-                        .to_string(),
-                });
             }
         }
-        Ok(())
     }
 
     #[instrument(level = "error", skip_all)]
@@ -3377,7 +3370,7 @@ impl AuthorityState {
             expensive_safety_check_config,
             epoch_supply_change,
         )?;
-        self.check_transaction_deny_rules_consistency(cur_epoch_store, &epoch_start_configuration)?;
+        self.check_transaction_deny_rules_consistency(cur_epoch_store, &epoch_start_configuration);
 
         self.get_reconfig_api()
             .try_set_epoch_start_configuration(&epoch_start_configuration)?;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3273,10 +3273,11 @@ impl AuthorityState {
     /// where the two must agree. Reporting is the remedy: reconfiguration
     /// re-seeds the mirror from the object, so failing here would only pin the
     /// node to the diverged state. An object the closing epoch had but the
-    /// walk no longer finds is also reported — objects cannot be deleted, so
-    /// the local store lost it, and a committee member without it stops
-    /// injecting updates while its peers continue. Nodes outside the closing
-    /// committee hold no mirror and are exempt.
+    /// walk no longer finds is fatal instead — objects cannot be deleted, so
+    /// the local store lost it, there is nothing to re-seed from, and a
+    /// committee member continuing without it would stop injecting updates
+    /// while its peers continue. Nodes outside the closing committee hold no
+    /// mirror and are exempt.
     pub(crate) fn check_transaction_deny_rules_consistency(
         &self,
         cur_epoch_store: &AuthorityPerEpochStore,
@@ -3292,12 +3293,12 @@ impl AuthorityState {
                 .transaction_deny_rules_obj_initial_shared_version()
                 .is_some()
             {
-                debug_fatal!(
+                fatal!(
                     "TransactionDenyRules object existed in epoch {} but is missing from the \
-                     state walked for the next epoch",
+                     state walked for the next epoch — the local store is corrupted; restore or \
+                     state-sync before rejoining",
                     cur_epoch_store.epoch(),
                 );
-                cur_epoch_store.metrics.deny_rule_mirror_divergence.set(1);
             }
             return;
         };

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3272,10 +3272,12 @@ impl AuthorityState {
     /// Reports a mirror that diverged from the object at the epoch boundary,
     /// where the two must agree. Reporting is the remedy: reconfiguration
     /// re-seeds the mirror from the object, so failing here would only pin
-    /// the node to the diverged state. A missing object is fatal instead —
-    /// objects cannot be deleted, so the local store lost it and there is
-    /// nothing to re-seed from. Nodes outside the closing committee hold no
-    /// mirror and are exempt.
+    /// the node to the diverged state. A missing object is fatal instead.
+    /// Objects cannot be deleted, so the local store lost it and there is
+    /// nothing to re-seed from. Nodes outside the closing committee are
+    /// exempt. So is an epoch this node's consensus did not close. A
+    /// checkpoint catch-up leaves the mirror legitimately behind until the
+    /// re-seed.
     pub(crate) fn check_transaction_deny_rules_consistency(
         &self,
         cur_epoch_store: &AuthorityPerEpochStore,
@@ -3300,6 +3302,20 @@ impl AuthorityState {
             }
             return;
         };
+        // RejectAllTx proves this node's consensus processed every commit of
+        // the epoch, so the mirror is complete. Otherwise the tail came from
+        // synced checkpoints and the mirror's lag carries no signal.
+        if cur_epoch_store
+            .get_reconfig_state_read_lock_guard()
+            .should_accept_tx()
+        {
+            info!(
+                "skipping the deny-rule mirror comparison: consensus did not close epoch {} on \
+                 this node",
+                cur_epoch_store.epoch(),
+            );
+            return;
+        }
         let mirrored_deny_rules = cur_epoch_store.get_mirrored_transaction_deny_rules();
         if *walked_deny_rules != *mirrored_deny_rules {
             debug_fatal!(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3272,8 +3272,11 @@ impl AuthorityState {
     /// Reports a mirror that diverged from the object at the epoch boundary,
     /// where the two must agree. Reporting is the remedy: reconfiguration
     /// re-seeds the mirror from the object, so failing here would only pin the
-    /// node to the diverged state. Nodes outside the closing committee hold no
-    /// mirror and are exempt.
+    /// node to the diverged state. An object the closing epoch had but the
+    /// walk no longer finds is also reported — objects cannot be deleted, so
+    /// the local store lost it, and a committee member without it stops
+    /// injecting updates while its peers continue. Nodes outside the closing
+    /// committee hold no mirror and are exempt.
     pub(crate) fn check_transaction_deny_rules_consistency(
         &self,
         cur_epoch_store: &AuthorityPerEpochStore,
@@ -3282,17 +3285,31 @@ impl AuthorityState {
         if self.is_fullnode(cur_epoch_store) {
             return;
         }
-        if let Some(walked_deny_rules) = epoch_start_configuration.transaction_deny_rules_state() {
-            let mirrored_deny_rules = cur_epoch_store.get_mirrored_transaction_deny_rules();
-            if *walked_deny_rules != *mirrored_deny_rules {
+        let Some(walked_deny_rules) = epoch_start_configuration.transaction_deny_rules_state()
+        else {
+            if cur_epoch_store
+                .epoch_start_config()
+                .transaction_deny_rules_obj_initial_shared_version()
+                .is_some()
+            {
                 debug_fatal!(
-                    "TransactionDenyRules object diverged from the mirrored state at the end of \
-                     epoch {}; continuing from the object (walked: {walked_deny_rules:?}, \
-                     mirrored: {mirrored_deny_rules:?})",
+                    "TransactionDenyRules object existed in epoch {} but is missing from the \
+                     state walked for the next epoch",
                     cur_epoch_store.epoch(),
                 );
                 cur_epoch_store.metrics.deny_rule_mirror_divergence.set(1);
             }
+            return;
+        };
+        let mirrored_deny_rules = cur_epoch_store.get_mirrored_transaction_deny_rules();
+        if *walked_deny_rules != *mirrored_deny_rules {
+            debug_fatal!(
+                "TransactionDenyRules object diverged from the mirrored state at the end of \
+                 epoch {}; continuing from the object (walked: {walked_deny_rules:?}, mirrored: \
+                 {mirrored_deny_rules:?})",
+                cur_epoch_store.epoch(),
+            );
+            cur_epoch_store.metrics.deny_rule_mirror_divergence.set(1);
         }
     }
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3269,6 +3269,40 @@ impl AuthorityState {
         self.execution_lock.write().await
     }
 
+    /// Fails reconfiguration when the deny-rules state walked from the object
+    /// for the next epoch diverged from the closing epoch's mirror. Between
+    /// commits the two are in lockstep and the epoch boundary is such a
+    /// barrier, so a mismatch means one of them is corrupted; the object is
+    /// authoritative. Nodes that did not run consensus for the closing epoch
+    /// (fullnodes, validators joining at this boundary) execute the injected
+    /// updates without a mirror, so they are exempt.
+    pub(crate) fn check_transaction_deny_rules_consistency(
+        &self,
+        cur_epoch_store: &AuthorityPerEpochStore,
+        epoch_start_configuration: &EpochStartConfiguration,
+    ) -> IotaResult<()> {
+        if self.is_fullnode(cur_epoch_store) {
+            return Ok(());
+        }
+        if let Some(walked_deny_rules) = epoch_start_configuration.transaction_deny_rules_state() {
+            let mirrored_deny_rules = cur_epoch_store.get_mirrored_transaction_deny_rules();
+            if *walked_deny_rules != *mirrored_deny_rules {
+                debug_fatal!(
+                    "TransactionDenyRules object diverged from the mirrored state at the end of \
+                     epoch {} (walked: {walked_deny_rules:?}, mirrored: {mirrored_deny_rules:?})",
+                    cur_epoch_store.epoch(),
+                );
+                cur_epoch_store.metrics.deny_rule_mirror_divergence.set(1);
+                return Err(IotaError::GenericAuthority {
+                    error: "TransactionDenyRules object diverged from the mirrored state at the \
+                            epoch boundary"
+                        .to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     #[instrument(level = "error", skip_all)]
     pub async fn reconfigure(
         &self,
@@ -3343,6 +3377,8 @@ impl AuthorityState {
             expensive_safety_check_config,
             epoch_supply_change,
         )?;
+        self.check_transaction_deny_rules_consistency(cur_epoch_store, &epoch_start_configuration)?;
+
         self.get_reconfig_api()
             .try_set_epoch_start_configuration(&epoch_start_configuration)?;
         // When state snapshots are published, a RocksDB checkpoint of the

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3271,12 +3271,10 @@ impl AuthorityState {
 
     /// Reports a mirror that diverged from the object at the epoch boundary,
     /// where the two must agree. Reporting is the remedy: reconfiguration
-    /// re-seeds the mirror from the object, so failing here would only pin the
-    /// node to the diverged state. An object the closing epoch had but the
-    /// walk no longer finds is fatal instead — objects cannot be deleted, so
-    /// the local store lost it, there is nothing to re-seed from, and a
-    /// committee member continuing without it would stop injecting updates
-    /// while its peers continue. Nodes outside the closing committee hold no
+    /// re-seeds the mirror from the object, so failing here would only pin
+    /// the node to the diverged state. A missing object is fatal instead —
+    /// objects cannot be deleted, so the local store lost it and there is
+    /// nothing to re-seed from. Nodes outside the closing committee hold no
     /// mirror and are exempt.
     pub(crate) fn check_transaction_deny_rules_consistency(
         &self,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -32,8 +32,9 @@ use iota_protocol_config::{
 };
 use iota_sdk_types::{
     Address, CanceledTransaction, CheckpointTimestamp, DenyRuleSet, ObjectId, ObjectReference,
-    RandomnessRound, SenderSignedTransaction, TransactionDigest, TransactionEffects,
-    TransactionEffectsDigest, TransactionKind, UserSignature, Version, VersionAssignment,
+    RandomnessRound, SenderSignedTransaction, TransactionDenyRulesUpdate, TransactionDigest,
+    TransactionEffects, TransactionEffectsDigest, TransactionKind, UserSignature, Version,
+    VersionAssignment,
     checkpoint::{CheckpointContents, CheckpointSummary},
 };
 use iota_storage::mutex_table::{MutexGuard, MutexTable};
@@ -925,6 +926,14 @@ pub struct AuthorityEpochTables {
     /// generation overwrites an older one from the same authority.
     deny_rule_proposals: DBMap<AuthorityName, TransactionDenyRuleProposal>,
 
+    /// The deny rule state last written to the `TransactionDenyRules` object
+    /// by injected updates, as of the last flushed commit. Single row keyed by
+    /// `()`; written atomically with the flush batch so a restart resumes with
+    /// the mirror exactly at the flush position (unflushed commits are
+    /// re-processed by consensus replay). Absent until the first injection of
+    /// the epoch.
+    mirrored_deny_rules: DBMap<(), DenyRuleSet>,
+
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
     override_protocol_upgrade_buffer_stake: DBMap<u64, u64>,
@@ -1285,10 +1294,8 @@ impl AuthorityPerEpochStore {
                 .safe_iter()
                 .collect::<Result<BTreeMap<_, _>, _>>()
                 .expect("AuthorityEpochTables should contain valid deny rule proposals");
-        let mirrored_deny_rules = epoch_start_configuration
-            .transaction_deny_rules_state()
-            .cloned()
-            .unwrap_or_default();
+        let mirrored_deny_rules =
+            Self::initial_mirrored_deny_rules(&tables, &epoch_start_configuration)?;
         let active_transaction_deny_rules = ArcSwap::from_pointee(union_deny_rule_sets(
             Self::compute_active_transaction_deny_rules(&cached_deny_rule_proposals, &committee),
             &mirrored_deny_rules,
@@ -3112,6 +3119,26 @@ impl AuthorityPerEpochStore {
         self.mirrored_transaction_deny_rules.load_full()
     }
 
+    /// The mirrored deny rule state to start from when the epoch store opens.
+    /// A persisted row (mid-epoch restart) wins over the epoch-start seed: it
+    /// carries the advances from every flushed injection, and consensus
+    /// replay re-applies only the unflushed tail. On a fresh epoch the row is
+    /// absent and the seed is the object state at the boundary.
+    fn initial_mirrored_deny_rules(
+        tables: &AuthorityEpochTables,
+        epoch_start_configuration: &EpochStartConfiguration,
+    ) -> IotaResult<DenyRuleSet> {
+        Ok(tables
+            .mirrored_deny_rules
+            .get(&())?
+            .or_else(|| {
+                epoch_start_configuration
+                    .transaction_deny_rules_state()
+                    .cloned()
+            })
+            .unwrap_or_default())
+    }
+
     /// Recomputes the active deny rule set from the current proposals and
     /// swaps it in. Returns true when the active set changed. Production
     /// recomputes through `ConsensusOutputQuarantine::push_consensus_output`;
@@ -4228,6 +4255,121 @@ impl AuthorityPerEpochStore {
         consensus_round * 2
     }
 
+    /// Injects `TransactionDenyRulesUpdate` system transactions bringing the
+    /// on-chain object to the current proposal aggregate: additions always,
+    /// removals only once enough of the committee has announced this epoch
+    /// and the round floor has passed. A diff larger than
+    /// `deny_rule_update_max_entries_per_tx` is split into disjoint chunks of
+    /// the sorted diff — deterministic on every validator — each carrying the
+    /// absolute switch states, so application is order-free and a re-sent
+    /// chunk is a no-op. Advances the mirrored state to the injected target
+    /// in the same commit output that persists it.
+    pub(crate) fn add_deny_rule_update_transactions(
+        &self,
+        output: &mut ConsensusCommitOutput,
+        transactions: &mut VecDeque<VerifiedExecutableTransaction>,
+        consensus_commit_info: &ConsensusCommitInfo,
+    ) -> IotaResult<()> {
+        if !self.protocol_config().deny_rule_governance_on_chain() {
+            return Ok(());
+        }
+        // Mirroring starts the epoch after the object is created: without the
+        // object there is nothing to update.
+        let Some(initial_shared_version) = self
+            .epoch_start_config()
+            .transaction_deny_rules_obj_initial_shared_version()
+        else {
+            return Ok(());
+        };
+
+        // The aggregate from every recorded proposal, this commit's included.
+        let mut proposals = self
+            .consensus_quarantine
+            .read()
+            .current_deny_rule_proposals();
+        proposals.extend(
+            output
+                .deny_rule_proposals()
+                .iter()
+                .map(|(authority, proposal)| (*authority, proposal.clone())),
+        );
+        let aggregate = Self::compute_active_transaction_deny_rules(&proposals, self.committee());
+        let mirror = self.mirrored_transaction_deny_rules.load_full();
+
+        // Removals wait until enough of the committee has re-announced its
+        // configuration this epoch, so entries do not drop out just because
+        // announcements are still arriving. Additions apply immediately.
+        let announced_stake: StakeUnit = proposals
+            .keys()
+            .map(|authority| self.committee().weight(authority))
+            .sum();
+        let removals_unlocked = announced_stake >= self.committee().quorum_threshold()
+            && consensus_commit_info.round
+                >= self.protocol_config().deny_rule_removal_grace_round_floor();
+        self.metrics
+            .deny_rule_removals_unlocked
+            .set(removals_unlocked as i64);
+
+        let (chunks, target) = compute_deny_rule_update_chunks(
+            &aggregate,
+            &mirror,
+            removals_unlocked,
+            self.protocol_config().deny_rule_update_max_entries_per_tx() as usize,
+            self.epoch(),
+            consensus_commit_info.round,
+            initial_shared_version,
+        );
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        let chunk_count = chunks.len();
+
+        let mut all_scheduled = true;
+        for chunk in chunks {
+            let transaction = VerifiedExecutableTransaction::new_system(
+                VerifiedTransaction::new_transaction_deny_rules_update(chunk),
+                self.epoch(),
+            );
+            match self.process_consensus_system_transaction(&transaction) {
+                ConsensusTransactionResult::Scheduled {
+                    transaction,
+                    start_time: _,
+                } => {
+                    transactions.push_front(transaction);
+                }
+                ConsensusTransactionResult::IgnoredSystem => {
+                    all_scheduled = false;
+                }
+                _ => unreachable!(
+                    "process_consensus_system_transaction returned unexpected ConsensusTransactionResult."
+                ),
+            }
+            output.record_consensus_message_processed(SequencedConsensusTransactionKey::System(
+                *transaction.digest(),
+            ));
+        }
+        // A skipped chunk (epoch closing) leaves the object behind the
+        // aggregate; keeping the mirror behind too makes the next commit
+        // re-derive the same delta, and the tolerant Move ops absorb any
+        // chunk that did execute.
+        if all_scheduled {
+            self.metrics.deny_rule_updates_injected.inc();
+            self.metrics
+                .deny_rule_update_transactions_injected
+                .inc_by(chunk_count as u64);
+            output.record_mirrored_deny_rules(target.clone());
+            self.mirrored_transaction_deny_rules.store(Arc::new(target));
+            // Re-derive enforcement from the advanced mirror: the recompute in
+            // `push_consensus_output` only runs for commits that record
+            // proposals, so without this a removal that unlocks on a
+            // proposal-free commit would stay enforced until the next
+            // proposal arrives, though the object already dropped it.
+            self.store_active_transaction_deny_rules(&proposals);
+        }
+
+        Ok(())
+    }
+
     // Adds the consensus commit prologue transaction to the beginning of input
     // `transactions` to update the system clock used in all transactions in the
     // current consensus commit. Returns the root of the consensus commit
@@ -4755,6 +4897,15 @@ impl AuthorityPerEpochStore {
                     .await?;
             }
         }
+
+        // Bring the on-chain deny-rules object up to date with the proposal
+        // aggregate before the prologue is prepended, so the prologue stays
+        // the first transaction of the commit.
+        self.add_deny_rule_update_transactions(
+            output,
+            &mut verified_non_randomness_transactions,
+            consensus_commit_info,
+        )?;
 
         // Add the consensus commit prologue transaction to the beginning of
         // `verified_non_randomness_transactions`.
@@ -5909,4 +6060,187 @@ pub(crate) fn union_deny_rule_sets(mut rules: DenyRuleSet, other: &DenyRuleSet) 
     rules.receiving_objects_disabled |= other.receiving_objects_disabled;
     rules.move_authenticator_disabled |= other.move_authenticator_disabled;
     rules
+}
+
+/// Computes the `TransactionDenyRulesUpdate` transactions that bring the
+/// on-chain object from `mirror` to `aggregate`: additions and switch
+/// activations always, entry removals and switch deactivations only when
+/// `removals_unlocked` — until then a mirrored switch stays on even though
+/// the (still incomplete) aggregate no longer carries it. A delta larger
+/// than `max_entries_per_tx` is split into disjoint chunks of the sorted
+/// delta, each carrying the absolute switch states. Returns the chunks
+/// (empty when the object is already up to date) and the state the object
+/// holds once they have executed — the next mirror. Pure function of its
+/// inputs, so every validator derives the same transactions at the same
+/// commit.
+pub(crate) fn compute_deny_rule_update_chunks(
+    aggregate: &DenyRuleSet,
+    mirror: &DenyRuleSet,
+    removals_unlocked: bool,
+    max_entries_per_tx: usize,
+    epoch: EpochId,
+    round: u64,
+    deny_rules_obj_initial_shared_version: Version,
+) -> (Vec<TransactionDenyRulesUpdate>, DenyRuleSet) {
+    let switch = |aggregate_switch: bool, mirror_switch: bool| {
+        if removals_unlocked {
+            aggregate_switch
+        } else {
+            aggregate_switch || mirror_switch
+        }
+    };
+    let mut delta = TransactionDenyRulesUpdate {
+        epoch,
+        round,
+        added_addresses: aggregate
+            .denied_addresses
+            .difference(&mirror.denied_addresses)
+            .copied()
+            .collect(),
+        removed_addresses: BTreeSet::new(),
+        added_objects: aggregate
+            .denied_objects
+            .difference(&mirror.denied_objects)
+            .copied()
+            .collect(),
+        removed_objects: BTreeSet::new(),
+        added_packages: aggregate
+            .denied_packages
+            .difference(&mirror.denied_packages)
+            .copied()
+            .collect(),
+        removed_packages: BTreeSet::new(),
+        package_publish_disabled: switch(
+            aggregate.package_publish_disabled,
+            mirror.package_publish_disabled,
+        ),
+        package_upgrade_disabled: switch(
+            aggregate.package_upgrade_disabled,
+            mirror.package_upgrade_disabled,
+        ),
+        shared_object_disabled: switch(
+            aggregate.shared_object_disabled,
+            mirror.shared_object_disabled,
+        ),
+        user_transaction_disabled: switch(
+            aggregate.user_transaction_disabled,
+            mirror.user_transaction_disabled,
+        ),
+        receiving_objects_disabled: switch(
+            aggregate.receiving_objects_disabled,
+            mirror.receiving_objects_disabled,
+        ),
+        move_authenticator_disabled: switch(
+            aggregate.move_authenticator_disabled,
+            mirror.move_authenticator_disabled,
+        ),
+        deny_rules_obj_initial_shared_version,
+    };
+    if removals_unlocked {
+        delta.removed_addresses = mirror
+            .denied_addresses
+            .difference(&aggregate.denied_addresses)
+            .copied()
+            .collect();
+        delta.removed_objects = mirror
+            .denied_objects
+            .difference(&aggregate.denied_objects)
+            .copied()
+            .collect();
+        delta.removed_packages = mirror
+            .denied_packages
+            .difference(&aggregate.denied_packages)
+            .copied()
+            .collect();
+    }
+
+    // The object state once the delta has executed.
+    let target = DenyRuleSet {
+        denied_addresses: mirror
+            .denied_addresses
+            .union(&delta.added_addresses)
+            .filter(|key| !delta.removed_addresses.contains(key))
+            .copied()
+            .collect(),
+        denied_objects: mirror
+            .denied_objects
+            .union(&delta.added_objects)
+            .filter(|key| !delta.removed_objects.contains(key))
+            .copied()
+            .collect(),
+        denied_packages: mirror
+            .denied_packages
+            .union(&delta.added_packages)
+            .filter(|key| !delta.removed_packages.contains(key))
+            .copied()
+            .collect(),
+        package_publish_disabled: delta.package_publish_disabled,
+        package_upgrade_disabled: delta.package_upgrade_disabled,
+        shared_object_disabled: delta.shared_object_disabled,
+        user_transaction_disabled: delta.user_transaction_disabled,
+        receiving_objects_disabled: delta.receiving_objects_disabled,
+        move_authenticator_disabled: delta.move_authenticator_disabled,
+    };
+
+    let switches_changed = delta.package_publish_disabled != mirror.package_publish_disabled
+        || delta.package_upgrade_disabled != mirror.package_upgrade_disabled
+        || delta.shared_object_disabled != mirror.shared_object_disabled
+        || delta.user_transaction_disabled != mirror.user_transaction_disabled
+        || delta.receiving_objects_disabled != mirror.receiving_objects_disabled
+        || delta.move_authenticator_disabled != mirror.move_authenticator_disabled;
+    let entry_count = delta.added_addresses.len()
+        + delta.removed_addresses.len()
+        + delta.added_objects.len()
+        + delta.removed_objects.len()
+        + delta.added_packages.len()
+        + delta.removed_packages.len();
+    if entry_count == 0 && !switches_changed {
+        return (Vec::new(), target);
+    }
+
+    // Deterministic chunking: cut each (already sorted) delta set into runs,
+    // filling one chunk to the limit before starting the next.
+    let max_entries_per_tx = max_entries_per_tx.max(1);
+    let chunk_count = entry_count.div_ceil(max_entries_per_tx).max(1);
+    let empty = TransactionDenyRulesUpdate {
+        added_addresses: BTreeSet::new(),
+        removed_addresses: BTreeSet::new(),
+        added_objects: BTreeSet::new(),
+        removed_objects: BTreeSet::new(),
+        added_packages: BTreeSet::new(),
+        removed_packages: BTreeSet::new(),
+        ..delta
+    };
+    let mut chunks = vec![empty; chunk_count];
+    let mut slot = 0;
+    {
+        let mut fill =
+            |set: BTreeSet<Address>,
+             select: fn(&mut TransactionDenyRulesUpdate) -> &mut BTreeSet<Address>| {
+                for key in set {
+                    select(&mut chunks[slot / max_entries_per_tx]).insert(key);
+                    slot += 1;
+                }
+            };
+        fill(delta.added_addresses, |chunk| &mut chunk.added_addresses);
+        fill(delta.removed_addresses, |chunk| {
+            &mut chunk.removed_addresses
+        });
+    }
+    {
+        let mut fill =
+            |set: BTreeSet<ObjectId>,
+             select: fn(&mut TransactionDenyRulesUpdate) -> &mut BTreeSet<ObjectId>| {
+                for key in set {
+                    select(&mut chunks[slot / max_entries_per_tx]).insert(key);
+                    slot += 1;
+                }
+            };
+        fill(delta.added_objects, |chunk| &mut chunk.added_objects);
+        fill(delta.removed_objects, |chunk| &mut chunk.removed_objects);
+        fill(delta.added_packages, |chunk| &mut chunk.added_packages);
+        fill(delta.removed_packages, |chunk| &mut chunk.removed_packages);
+    }
+
+    (chunks, target)
 }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -926,12 +926,10 @@ pub struct AuthorityEpochTables {
     /// generation overwrites an older one from the same authority.
     deny_rule_proposals: DBMap<AuthorityName, TransactionDenyRuleProposal>,
 
-    /// The deny rule state last written to the `TransactionDenyRules` object
-    /// by injected updates, as of the last flushed commit. Single row keyed by
-    /// `()`; written atomically with the flush batch so a restart resumes with
-    /// the mirror exactly at the flush position (unflushed commits are
-    /// re-processed by consensus replay). Absent until the first injection of
-    /// the epoch.
+    /// The deny rule state last written to the `TransactionDenyRules` object,
+    /// as of the last flushed commit. Single row keyed by `()`, written in the
+    /// flush batch so a restart resumes at the flush position and consensus
+    /// replays the rest. Absent until the epoch's first injection.
     mirrored_deny_rules: DBMap<(), DenyRuleSet>,
 
     /// Contains a single key, which overrides the value of
@@ -3120,10 +3118,9 @@ impl AuthorityPerEpochStore {
     }
 
     /// The mirrored deny rule state to start from when the epoch store opens.
-    /// A persisted row (mid-epoch restart) wins over the epoch-start seed: it
-    /// carries the advances from every flushed injection, and consensus
-    /// replay re-applies only the unflushed tail. On a fresh epoch the row is
-    /// absent and the seed is the object state at the boundary.
+    /// A persisted row (mid-epoch restart) wins over the epoch-start seed,
+    /// which does not cover advances from flushed commits. On a fresh epoch
+    /// the row is absent and the seed is the object state at the boundary.
     fn initial_mirrored_deny_rules(
         tables: &AuthorityEpochTables,
         epoch_start_configuration: &EpochStartConfiguration,
@@ -4257,17 +4254,14 @@ impl AuthorityPerEpochStore {
 
     /// Injects `TransactionDenyRulesUpdate` system transactions bringing the
     /// on-chain object to the current proposal aggregate: additions always,
-    /// removals only once enough of the committee has announced this epoch
-    /// and the round floor has passed. A diff larger than
+    /// removals only once enough of the committee has announced this epoch and
+    /// the round floor has passed. A diff larger than
     /// `deny_rule_update_max_entries_per_tx` is split into disjoint chunks of
-    /// the sorted diff — deterministic on every validator — each carrying the
-    /// absolute switch states, so application is order-free and a re-sent
-    /// chunk is a no-op. Advances the mirrored state to the injected target
-    /// in the same commit output that persists it. Each scheduled update
-    /// becomes a checkpoint root: user transactions cannot take the deny-rules
-    /// object as an input, so nothing else in the commit depends on an update,
-    /// and one without a root of its own would execute on validators but never
-    /// reach a checkpoint.
+    /// the sorted diff, each carrying the absolute switch states, so a re-sent
+    /// chunk is a no-op. Advances the mirrored state to the injected target in
+    /// the same commit output that persists it. Each scheduled update becomes
+    /// a checkpoint root: nothing else in the commit can depend on the object,
+    /// so an update without a root of its own would never be checkpointed.
     pub(crate) fn add_deny_rule_update_transactions(
         &self,
         output: &mut ConsensusCommitOutput,
@@ -4301,9 +4295,8 @@ impl AuthorityPerEpochStore {
         let aggregate = Self::compute_active_transaction_deny_rules(&proposals, self.committee());
         let mirror = self.mirrored_transaction_deny_rules.load_full();
 
-        // Removals wait until enough of the committee has re-announced its
-        // configuration this epoch, so entries do not drop out just because
-        // announcements are still arriving. Additions apply immediately.
+        // Removals wait for enough of the committee to re-announce, so entries
+        // do not drop out while announcements are still arriving.
         let announced_stake: StakeUnit = proposals
             .keys()
             .map(|authority| self.committee().weight(authority))
@@ -4354,10 +4347,8 @@ impl AuthorityPerEpochStore {
                 *transaction.digest(),
             ));
         }
-        // A skipped chunk (epoch closing) leaves the object behind the
-        // aggregate; keeping the mirror behind too makes the next commit
-        // re-derive the same delta, and the tolerant Move ops absorb any
-        // chunk that did execute.
+        // Holding the mirror back when a chunk was skipped (epoch closing) makes
+        // the next commit re-derive the same delta; re-application is a no-op.
         if all_scheduled {
             self.metrics.deny_rule_updates_injected.inc();
             self.metrics
@@ -4365,11 +4356,9 @@ impl AuthorityPerEpochStore {
                 .inc_by(chunk_count as u64);
             output.record_mirrored_deny_rules(target.clone());
             self.mirrored_transaction_deny_rules.store(Arc::new(target));
-            // Re-derive enforcement from the advanced mirror: the recompute in
-            // `push_consensus_output` only runs for commits that record
-            // proposals, so without this a removal that unlocks on a
-            // proposal-free commit would stay enforced until the next
-            // proposal arrives, though the object already dropped it.
+            // The recompute in `push_consensus_output` only runs for commits
+            // that record proposals, so a removal unlocking on a proposal-free
+            // commit would otherwise stay enforced after the object dropped it.
             self.store_active_transaction_deny_rules(&proposals);
         }
 
@@ -6071,15 +6060,12 @@ pub(crate) fn union_deny_rule_sets(mut rules: DenyRuleSet, other: &DenyRuleSet) 
 
 /// Computes the `TransactionDenyRulesUpdate` transactions that bring the
 /// on-chain object from `mirror` to `aggregate`: additions and switch
-/// activations always, entry removals and switch deactivations only when
-/// `removals_unlocked` — until then a mirrored switch stays on even though
-/// the (still incomplete) aggregate no longer carries it. A delta larger
-/// than `max_entries_per_tx` is split into disjoint chunks of the sorted
-/// delta, each carrying the absolute switch states. Returns the chunks
-/// (empty when the object is already up to date) and the state the object
-/// holds once they have executed — the next mirror. Pure function of its
-/// inputs, so every validator derives the same transactions at the same
-/// commit.
+/// activations always, removals and switch deactivations only when
+/// `removals_unlocked`. A delta larger than `max_entries_per_tx` is split into
+/// disjoint chunks of the sorted delta, each carrying the absolute switch
+/// states. Returns the chunks (empty when the object is up to date) and the
+/// state the object holds once they have executed — the next mirror. Pure, so
+/// every validator derives the same transactions at the same commit.
 pub(crate) fn compute_deny_rule_update_chunks(
     aggregate: &DenyRuleSet,
     mirror: &DenyRuleSet,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -739,13 +739,11 @@ pub struct AuthorityPerEpochStore {
     active_transaction_deny_rules: ArcSwap<DenyRuleSet>,
 
     /// The state the scheduled deny-rule updates bring the
-    /// `TransactionDenyRules` object to: seeded from the object at epoch
-    /// start, advanced when a commit schedules updates — the only
-    /// commit-deterministic point; execution completion is not, and must not
-    /// feed back in. The base the injection diff is computed against. An
-    /// execution failure (an invariant violation — the update is built to
-    /// exclude every expected failure) leaves the object behind this state
-    /// until the epoch boundary re-seeds it.
+    /// `TransactionDenyRules` object to, and the base of the injection diff:
+    /// seeded from the object at epoch start, advanced when a commit
+    /// schedules updates — the only commit-deterministic point; execution
+    /// completion is not and must not feed back in. A failed update leaves
+    /// the object behind until the epoch boundary re-seeds the mirror.
     mirrored_transaction_deny_rules: ArcSwap<DenyRuleSet>,
 
     /// Pre-consensus soft locks for owned objects (P-COOL flow).
@@ -930,11 +928,9 @@ pub struct AuthorityEpochTables {
     /// generation overwrites an older one from the same authority.
     deny_rule_proposals: DBMap<AuthorityName, TransactionDenyRuleProposal>,
 
-    /// The state the scheduled deny-rule updates bring the
-    /// `TransactionDenyRules` object to, as of the last flushed commit.
-    /// Single row keyed by `()`, written in the flush batch so a restart
-    /// resumes at the flush position and consensus replays the rest. Present
-    /// from epoch-store construction whenever the object exists.
+    /// The mirrored deny-rule state as of the last flushed commit, written
+    /// in the flush batch so a restart resumes there and replays the rest.
+    /// Present from epoch-store construction whenever the object exists.
     mirrored_deny_rules: DBMap<(), DenyRuleSet>,
 
     /// Contains a single key, which overrides the value of
@@ -3122,14 +3118,11 @@ impl AuthorityPerEpochStore {
         self.mirrored_transaction_deny_rules.load_full()
     }
 
-    /// The mirrored deny rule state to start from when the epoch store opens.
-    /// A persisted row (mid-epoch restart) wins over the epoch-start seed,
-    /// which does not cover advances from flushed commits. When the object
-    /// exists, a fresh epoch persists the seed as the row immediately, making
-    /// the row's presence an invariant: a row that is absent although commits
-    /// have flushed is a lost row — corruption, not a fresh epoch — and
-    /// continuing from the stale seed would derive updates the node's peers
-    /// do not, so the node fails instead.
+    /// The mirrored deny-rule state to start from when the epoch store
+    /// opens: a persisted row (mid-epoch restart) wins over the epoch-start
+    /// seed. A fresh epoch persists the seed immediately when the object
+    /// exists, so a row absent although commits have flushed is a lost row,
+    /// and the node fails rather than derive updates its peers do not.
     fn initial_mirrored_deny_rules(
         tables: &AuthorityEpochTables,
         epoch_start_configuration: &EpochStartConfiguration,
@@ -4271,15 +4264,12 @@ impl AuthorityPerEpochStore {
     }
 
     /// Injects `TransactionDenyRulesUpdate` system transactions bringing the
-    /// on-chain object to the current proposal aggregate: additions always,
-    /// removals only once enough of the committee has announced this epoch and
-    /// the round floor has passed. A diff larger than
-    /// `deny_rule_update_max_entries_per_tx` is split into disjoint chunks of
-    /// the sorted diff, each carrying the absolute switch states, so a re-sent
-    /// chunk is a no-op. Advances the mirrored state to the injected target in
-    /// the same commit output that persists it. Each scheduled update becomes
-    /// a checkpoint root: nothing else in the commit can depend on the object,
-    /// so an update without a root of its own would never be checkpointed.
+    /// on-chain object to the current proposal aggregate, chunked and gated
+    /// by `compute_deny_rule_update_chunks`. Advances the mirrored state to
+    /// the injected target in the same commit output that persists it. Each
+    /// scheduled update becomes a checkpoint root: nothing else in the commit
+    /// can depend on the object, so an unrooted update would never be
+    /// checkpointed.
     pub(crate) fn add_deny_rule_update_transactions(
         &self,
         output: &mut ConsensusCommitOutput,
@@ -4911,9 +4901,8 @@ impl AuthorityPerEpochStore {
             }
         }
 
-        // Bring the on-chain deny-rules object up to date with the proposal
-        // aggregate before the prologue is prepended, so the prologue stays
-        // the first transaction of the commit.
+        // Inject deny-rule updates before the prologue is prepended, so the
+        // prologue stays the first transaction of the commit.
         self.add_deny_rule_update_transactions(
             output,
             &mut verified_non_randomness_transactions,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -931,7 +931,7 @@ pub struct AuthorityEpochTables {
     /// The mirrored deny-rule state as of the last flushed commit, written
     /// in the flush batch so a restart resumes there and replays the rest.
     /// Present from epoch-store construction whenever the object exists.
-    mirrored_deny_rules: DBMap<(), DenyRuleSet>,
+    flushed_deny_rule_mirror: DBMap<(), DenyRuleSet>,
 
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
@@ -1293,13 +1293,12 @@ impl AuthorityPerEpochStore {
                 .safe_iter()
                 .collect::<Result<BTreeMap<_, _>, _>>()
                 .expect("AuthorityEpochTables should contain valid deny rule proposals");
-        let mirrored_deny_rules =
-            Self::initial_mirrored_deny_rules(&tables, &epoch_start_configuration)?;
+        let deny_rule_mirror = Self::initial_deny_rule_mirror(&tables, &epoch_start_configuration)?;
         let active_transaction_deny_rules = ArcSwap::from_pointee(union_deny_rule_sets(
             Self::compute_active_transaction_deny_rules(&cached_deny_rule_proposals, &committee),
-            &mirrored_deny_rules,
+            &deny_rule_mirror,
         ));
-        let mirrored_transaction_deny_rules = ArcSwap::from_pointee(mirrored_deny_rules);
+        let mirrored_transaction_deny_rules = ArcSwap::from_pointee(deny_rule_mirror);
 
         let committee_size = committee.num_members();
         let report_version = MisbehaviorReportVersion::from_protocol(&protocol_config);
@@ -3123,11 +3122,11 @@ impl AuthorityPerEpochStore {
     /// seed. A fresh epoch persists the seed immediately when the object
     /// exists, so a row absent although commits have flushed is a lost row,
     /// and the node fails rather than derive updates its peers do not.
-    fn initial_mirrored_deny_rules(
+    fn initial_deny_rule_mirror(
         tables: &AuthorityEpochTables,
         epoch_start_configuration: &EpochStartConfiguration,
     ) -> IotaResult<DenyRuleSet> {
-        if let Some(row) = tables.mirrored_deny_rules.get(&())? {
+        if let Some(row) = tables.flushed_deny_rule_mirror.get(&())? {
             return Ok(row);
         }
         let Some(seed) = epoch_start_configuration.transaction_deny_rules_state() else {
@@ -3139,11 +3138,11 @@ impl AuthorityPerEpochStore {
             .is_some()
         {
             fatal!(
-                "mirrored_deny_rules row is missing although commits have flushed — the epoch \
+                "flushed_deny_rule_mirror row is missing although commits have flushed — the epoch \
                  database is corrupted; restore or state-sync before rejoining"
             );
         }
-        tables.mirrored_deny_rules.insert(&(), seed)?;
+        tables.flushed_deny_rule_mirror.insert(&(), seed)?;
         Ok(seed.clone())
     }
 
@@ -4362,7 +4361,7 @@ impl AuthorityPerEpochStore {
             self.metrics
                 .deny_rule_update_transactions_injected
                 .inc_by(chunk_count as u64);
-            output.record_mirrored_deny_rules(target.clone());
+            output.record_flushed_deny_rule_mirror(target.clone());
             self.mirrored_transaction_deny_rules.store(Arc::new(target));
             // The recompute in `push_consensus_output` only runs for commits
             // that record proposals, so a removal unlocking on a proposal-free

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -931,7 +931,7 @@ pub struct AuthorityEpochTables {
     /// The mirrored deny-rule state as of the last flushed commit, written
     /// in the flush batch so a restart resumes there and replays the rest.
     /// Present from epoch-store construction whenever the object exists.
-    flushed_deny_rule_mirror: DBMap<(), DenyRuleSet>,
+    deny_rule_mirror: DBMap<(), DenyRuleSet>,
 
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
@@ -3087,11 +3087,23 @@ impl AuthorityPerEpochStore {
     /// announces its configuration each epoch, so this converges towards the
     /// full committee stake as announcements arrive.
     pub fn announced_deny_rule_stake(&self) -> StakeUnit {
-        self.consensus_quarantine
-            .read()
-            .current_deny_rule_proposals()
+        Self::announced_stake(
+            &self
+                .consensus_quarantine
+                .read()
+                .current_deny_rule_proposals(),
+            self.committee(),
+        )
+    }
+
+    /// The total committee stake behind the given proposals.
+    fn announced_stake(
+        proposals: &BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
+        committee: &Committee,
+    ) -> StakeUnit {
+        proposals
             .keys()
-            .map(|authority| self.committee().weight(authority))
+            .map(|authority| committee.weight(authority))
             .sum()
     }
 
@@ -3126,7 +3138,7 @@ impl AuthorityPerEpochStore {
         tables: &AuthorityEpochTables,
         epoch_start_configuration: &EpochStartConfiguration,
     ) -> IotaResult<DenyRuleSet> {
-        if let Some(row) = tables.flushed_deny_rule_mirror.get(&())? {
+        if let Some(row) = tables.deny_rule_mirror.get(&())? {
             return Ok(row);
         }
         let Some(seed) = epoch_start_configuration.transaction_deny_rules_state() else {
@@ -3138,11 +3150,11 @@ impl AuthorityPerEpochStore {
             .is_some()
         {
             fatal!(
-                "flushed_deny_rule_mirror row is missing although commits have flushed — the epoch \
+                "deny_rule_mirror row is missing although commits have flushed — the epoch \
                  database is corrupted; restore or state-sync before rejoining"
             );
         }
-        tables.flushed_deny_rule_mirror.insert(&(), seed)?;
+        tables.deny_rule_mirror.insert(&(), seed)?;
         Ok(seed.clone())
     }
 
@@ -4299,15 +4311,17 @@ impl AuthorityPerEpochStore {
                 .iter()
                 .map(|(authority, proposal)| (*authority, proposal.clone())),
         );
+        // No proposals means an empty aggregate and zero announced stake.
+        // The diff can produce no chunk from that.
+        if proposals.is_empty() {
+            return Ok(());
+        }
         let aggregate = Self::compute_active_transaction_deny_rules(&proposals, self.committee());
         let mirror = self.mirrored_transaction_deny_rules.load_full();
 
         // Removals wait for enough of the committee to re-announce, so entries
         // do not drop out while announcements are still arriving.
-        let announced_stake: StakeUnit = proposals
-            .keys()
-            .map(|authority| self.committee().weight(authority))
-            .sum();
+        let announced_stake = Self::announced_stake(&proposals, self.committee());
         let removals_unlocked = announced_stake >= self.committee().quorum_threshold()
             && consensus_commit_info.round
                 >= self.protocol_config().deny_rule_removal_grace_round_floor();
@@ -4361,7 +4375,7 @@ impl AuthorityPerEpochStore {
             self.metrics
                 .deny_rule_update_transactions_injected
                 .inc_by(chunk_count as u64);
-            output.record_flushed_deny_rule_mirror(target.clone());
+            output.record_deny_rule_mirror(target.clone());
             self.mirrored_transaction_deny_rules.store(Arc::new(target));
             // The recompute in `push_consensus_output` only runs for commits
             // that record proposals, so a removal unlocking on a proposal-free

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3119,21 +3119,34 @@ impl AuthorityPerEpochStore {
 
     /// The mirrored deny rule state to start from when the epoch store opens.
     /// A persisted row (mid-epoch restart) wins over the epoch-start seed,
-    /// which does not cover advances from flushed commits. On a fresh epoch
-    /// the row is absent and the seed is the object state at the boundary.
+    /// which does not cover advances from flushed commits. When the object
+    /// exists, a fresh epoch persists the seed as the row immediately, making
+    /// the row's presence an invariant: a row that is absent although commits
+    /// have flushed is a lost row — corruption, not a fresh epoch — and
+    /// continuing from the stale seed would derive updates the node's peers
+    /// do not, so the node fails instead.
     fn initial_mirrored_deny_rules(
         tables: &AuthorityEpochTables,
         epoch_start_configuration: &EpochStartConfiguration,
     ) -> IotaResult<DenyRuleSet> {
-        Ok(tables
-            .mirrored_deny_rules
-            .get(&())?
-            .or_else(|| {
-                epoch_start_configuration
-                    .transaction_deny_rules_state()
-                    .cloned()
-            })
-            .unwrap_or_default())
+        if let Some(row) = tables.mirrored_deny_rules.get(&())? {
+            return Ok(row);
+        }
+        let Some(seed) = epoch_start_configuration.transaction_deny_rules_state() else {
+            return Ok(DenyRuleSet::default());
+        };
+        if tables
+            .last_consensus_stats
+            .get(&LAST_CONSENSUS_STATS_ADDR)?
+            .is_some()
+        {
+            fatal!(
+                "mirrored_deny_rules row is missing although commits have flushed — the epoch \
+                 database is corrupted; restore or state-sync before rejoining"
+            );
+        }
+        tables.mirrored_deny_rules.insert(&(), seed)?;
+        Ok(seed.clone())
     }
 
     /// Recomputes the active deny rule set from the current proposals and

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -738,10 +738,14 @@ pub struct AuthorityPerEpochStore {
     /// boundary before any announcement of the new epoch lands.
     active_transaction_deny_rules: ArcSwap<DenyRuleSet>,
 
-    /// The deny rule state last written to the `TransactionDenyRules` object,
-    /// as far as this validator knows: seeded from the object at epoch start,
-    /// advanced on each injected update. The base the injection diff is
-    /// computed against.
+    /// The state the scheduled deny-rule updates bring the
+    /// `TransactionDenyRules` object to: seeded from the object at epoch
+    /// start, advanced when a commit schedules updates — the only
+    /// commit-deterministic point; execution completion is not, and must not
+    /// feed back in. The base the injection diff is computed against. An
+    /// execution failure (an invariant violation — the update is built to
+    /// exclude every expected failure) leaves the object behind this state
+    /// until the epoch boundary re-seeds it.
     mirrored_transaction_deny_rules: ArcSwap<DenyRuleSet>,
 
     /// Pre-consensus soft locks for owned objects (P-COOL flow).
@@ -926,10 +930,11 @@ pub struct AuthorityEpochTables {
     /// generation overwrites an older one from the same authority.
     deny_rule_proposals: DBMap<AuthorityName, TransactionDenyRuleProposal>,
 
-    /// The deny rule state last written to the `TransactionDenyRules` object,
-    /// as of the last flushed commit. Single row keyed by `()`, written in the
-    /// flush batch so a restart resumes at the flush position and consensus
-    /// replays the rest. Absent until the epoch's first injection.
+    /// The state the scheduled deny-rule updates bring the
+    /// `TransactionDenyRules` object to, as of the last flushed commit.
+    /// Single row keyed by `()`, written in the flush batch so a restart
+    /// resumes at the flush position and consensus replays the rest. Present
+    /// from epoch-store construction whenever the object exists.
     mirrored_deny_rules: DBMap<(), DenyRuleSet>,
 
     /// Contains a single key, which overrides the value of
@@ -3111,8 +3116,8 @@ impl AuthorityPerEpochStore {
         self.active_transaction_deny_rules.load_full()
     }
 
-    /// Returns the deny rule state last known to be written to the
-    /// `TransactionDenyRules` object.
+    /// Returns the state the scheduled deny-rule updates bring the
+    /// `TransactionDenyRules` object to.
     pub fn get_mirrored_transaction_deny_rules(&self) -> Arc<DenyRuleSet> {
         self.mirrored_transaction_deny_rules.load_full()
     }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -4263,11 +4263,16 @@ impl AuthorityPerEpochStore {
     /// the sorted diff — deterministic on every validator — each carrying the
     /// absolute switch states, so application is order-free and a re-sent
     /// chunk is a no-op. Advances the mirrored state to the injected target
-    /// in the same commit output that persists it.
+    /// in the same commit output that persists it. Each scheduled update
+    /// becomes a checkpoint root: user transactions cannot take the deny-rules
+    /// object as an input, so nothing else in the commit depends on an update,
+    /// and one without a root of its own would execute on validators but never
+    /// reach a checkpoint.
     pub(crate) fn add_deny_rule_update_transactions(
         &self,
         output: &mut ConsensusCommitOutput,
         transactions: &mut VecDeque<VerifiedExecutableTransaction>,
+        roots: &mut BTreeSet<TransactionKey>,
         consensus_commit_info: &ConsensusCommitInfo,
     ) -> IotaResult<()> {
         if !self.protocol_config().deny_rule_governance_on_chain() {
@@ -4335,6 +4340,7 @@ impl AuthorityPerEpochStore {
                     transaction,
                     start_time: _,
                 } => {
+                    roots.insert(transaction.key());
                     transactions.push_front(transaction);
                 }
                 ConsensusTransactionResult::IgnoredSystem => {
@@ -4904,6 +4910,7 @@ impl AuthorityPerEpochStore {
         self.add_deny_rule_update_transactions(
             output,
             &mut verified_non_randomness_transactions,
+            non_randomness_roots,
             consensus_commit_info,
         )?;
 

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -108,10 +108,10 @@ pub(crate) struct ConsensusCommitOutput {
     // `last_consensus_stats`.
     deny_rule_proposals: BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
 
-    // The mirrored deny rule state after this commit's injected updates, when
-    // this commit injected any. Flushed to `mirrored_deny_rules` atomically
-    // with `last_consensus_stats`.
-    mirrored_deny_rules: Option<DenyRuleSet>,
+    // The mirror state reached by this commit's injected updates, when it
+    // injected any. Written to `flushed_deny_rule_mirror` atomically with
+    // `last_consensus_stats`.
+    flushed_deny_rule_mirror: Option<DenyRuleSet>,
 }
 
 impl ConsensusCommitOutput {
@@ -280,8 +280,8 @@ impl ConsensusCommitOutput {
     }
 
     /// Records the mirror state reached by this commit's injected updates.
-    pub fn record_mirrored_deny_rules(&mut self, rules: DenyRuleSet) {
-        self.mirrored_deny_rules = Some(rules);
+    pub fn record_flushed_deny_rule_mirror(&mut self, rules: DenyRuleSet) {
+        self.flushed_deny_rule_mirror = Some(rules);
     }
 
     pub fn write_to_batch(
@@ -423,8 +423,8 @@ impl ConsensusCommitOutput {
         )?;
 
         batch.insert_batch(&tables.deny_rule_proposals, self.deny_rule_proposals)?;
-        if let Some(mirrored) = self.mirrored_deny_rules {
-            batch.insert_batch(&tables.mirrored_deny_rules, [((), mirrored)])?;
+        if let Some(mirror) = self.flushed_deny_rule_mirror {
+            batch.insert_batch(&tables.flushed_deny_rule_mirror, [((), mirror)])?;
         }
 
         Ok(())

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -107,6 +107,11 @@ pub(crate) struct ConsensusCommitOutput {
     // commit. Flushed to `deny_rule_proposals` atomically with
     // `last_consensus_stats`.
     deny_rule_proposals: BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
+
+    // The mirrored deny rule state after this commit's injected updates, when
+    // this commit injected any. Flushed to `mirrored_deny_rules` atomically
+    // with `last_consensus_stats`.
+    mirrored_deny_rules: Option<DenyRuleSet>,
 }
 
 impl ConsensusCommitOutput {
@@ -267,6 +272,18 @@ impl ConsensusCommitOutput {
         }
     }
 
+    /// The deny rule proposals recorded during this commit so far.
+    pub(super) fn deny_rule_proposals(
+        &self,
+    ) -> &BTreeMap<AuthorityName, TransactionDenyRuleProposal> {
+        &self.deny_rule_proposals
+    }
+
+    /// Records the mirror state reached by this commit's injected updates.
+    pub fn record_mirrored_deny_rules(&mut self, rules: DenyRuleSet) {
+        self.mirrored_deny_rules = Some(rules);
+    }
+
     pub fn write_to_batch(
         self,
         epoch_store: &AuthorityPerEpochStore,
@@ -406,6 +423,9 @@ impl ConsensusCommitOutput {
         )?;
 
         batch.insert_batch(&tables.deny_rule_proposals, self.deny_rule_proposals)?;
+        if let Some(mirrored) = self.mirrored_deny_rules {
+            batch.insert_batch(&tables.mirrored_deny_rules, [((), mirrored)])?;
+        }
 
         Ok(())
     }

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -109,9 +109,9 @@ pub(crate) struct ConsensusCommitOutput {
     deny_rule_proposals: BTreeMap<AuthorityName, TransactionDenyRuleProposal>,
 
     // The mirror state reached by this commit's injected updates, when it
-    // injected any. Written to `flushed_deny_rule_mirror` atomically with
+    // injected any. Written to `deny_rule_mirror` atomically with
     // `last_consensus_stats`.
-    flushed_deny_rule_mirror: Option<DenyRuleSet>,
+    deny_rule_mirror: Option<DenyRuleSet>,
 }
 
 impl ConsensusCommitOutput {
@@ -280,8 +280,8 @@ impl ConsensusCommitOutput {
     }
 
     /// Records the mirror state reached by this commit's injected updates.
-    pub fn record_flushed_deny_rule_mirror(&mut self, rules: DenyRuleSet) {
-        self.flushed_deny_rule_mirror = Some(rules);
+    pub fn record_deny_rule_mirror(&mut self, rules: DenyRuleSet) {
+        self.deny_rule_mirror = Some(rules);
     }
 
     pub fn write_to_batch(
@@ -423,8 +423,8 @@ impl ConsensusCommitOutput {
         )?;
 
         batch.insert_batch(&tables.deny_rule_proposals, self.deny_rule_proposals)?;
-        if let Some(mirror) = self.flushed_deny_rule_mirror {
-            batch.insert_batch(&tables.flushed_deny_rule_mirror, [((), mirror)])?;
+        if let Some(mirror) = self.deny_rule_mirror {
+            batch.insert_batch(&tables.deny_rule_mirror, [((), mirror)])?;
         }
 
         Ok(())

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -117,6 +117,24 @@ pub enum EpochStartConfiguration {
 }
 
 impl EpochStartConfiguration {
+    /// Test-only: stamps the deny-rules object fields onto a V3 config, as
+    /// `new` does when the object exists at the epoch boundary.
+    #[cfg(test)]
+    pub fn set_transaction_deny_rules_for_testing(
+        &mut self,
+        initial_shared_version: Version,
+        state: DenyRuleSet,
+    ) {
+        match self {
+            Self::V3(config) => {
+                config.transaction_deny_rules_obj_initial_shared_version =
+                    Some(initial_shared_version);
+                config.transaction_deny_rules_state = Some(state);
+            }
+            _ => panic!("only a V3 config carries deny-rules fields"),
+        }
+    }
+
     pub fn new(
         system_state: EpochStartSystemState,
         epoch_digest: CheckpointDigest,

--- a/crates/iota-core/src/epoch/epoch_metrics.rs
+++ b/crates/iota-core/src/epoch/epoch_metrics.rs
@@ -138,9 +138,8 @@ pub struct EpochMetrics {
     /// passed.
     pub deny_rule_removals_unlocked: IntGauge,
 
-    /// Set to 1 when the `TransactionDenyRules` object diverged from the
-    /// mirrored state at an epoch boundary — a corruption signal that fails
-    /// reconfiguration.
+    /// Set to 1, and never cleared, when the `TransactionDenyRules` object
+    /// diverged from the mirrored state at an epoch boundary.
     pub deny_rule_mirror_divergence: IntGauge,
 }
 

--- a/crates/iota-core/src/epoch/epoch_metrics.rs
+++ b/crates/iota-core/src/epoch/epoch_metrics.rs
@@ -4,7 +4,10 @@
 
 use std::sync::Arc;
 
-use prometheus_filtered::{IntGauge, MetricLevel, Registry, register_int_gauge_with_registry};
+use prometheus_filtered::{
+    IntCounter, IntGauge, MetricLevel, Registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry,
+};
 
 pub struct EpochMetrics {
     /// The current epoch ID. This is updated only when the AuthorityState
@@ -121,6 +124,24 @@ pub struct EpochMetrics {
 
     /// The number of shared object assignments in the quarantine.
     pub shared_object_assignments_size: IntGauge,
+
+    /// The number of consensus commits that injected deny-rule update
+    /// transactions.
+    pub deny_rule_updates_injected: IntCounter,
+
+    /// The number of injected deny-rule update transactions (one per chunk
+    /// of the delta).
+    pub deny_rule_update_transactions_injected: IntCounter,
+
+    /// Whether deny-rule removals are currently unlocked: enough of the
+    /// committee has announced this epoch and the grace round floor has
+    /// passed.
+    pub deny_rule_removals_unlocked: IntGauge,
+
+    /// Set to 1 when the `TransactionDenyRules` object diverged from the
+    /// mirrored state at an epoch boundary — a corruption signal that fails
+    /// reconfiguration.
+    pub deny_rule_mirror_divergence: IntGauge,
 }
 
 impl EpochMetrics {
@@ -254,6 +275,31 @@ impl EpochMetrics {
             shared_object_assignments_size: register_int_gauge_with_registry!(
                 "shared_object_assignments_size",
                 "The number of shared object assignments in the quarantine",
+                registry
+            )
+            .unwrap(),
+            deny_rule_updates_injected: register_int_counter_with_registry!(
+                "deny_rule_updates_injected",
+                "The number of consensus commits that injected deny-rule update transactions",
+                registry
+            )
+            .unwrap(),
+            deny_rule_update_transactions_injected: register_int_counter_with_registry!(
+                "deny_rule_update_transactions_injected",
+                "The number of injected deny-rule update transactions",
+                registry
+            )
+            .unwrap(),
+            deny_rule_removals_unlocked: register_int_gauge_with_registry!(
+                "deny_rule_removals_unlocked",
+                "Whether deny-rule removals are currently unlocked",
+                registry
+            )
+            .unwrap(),
+            deny_rule_mirror_divergence: register_int_gauge_with_registry!(
+                "deny_rule_mirror_divergence",
+                "Set to 1 when the TransactionDenyRules object diverged from the mirrored state \
+                 at an epoch boundary",
                 registry
             )
             .unwrap(),

--- a/crates/iota-core/src/epoch/epoch_metrics.rs
+++ b/crates/iota-core/src/epoch/epoch_metrics.rs
@@ -133,9 +133,8 @@ pub struct EpochMetrics {
     /// of the delta).
     pub deny_rule_update_transactions_injected: IntCounter,
 
-    /// Whether deny-rule removals are currently unlocked: enough of the
-    /// committee has announced this epoch and the grace round floor has
-    /// passed.
+    /// Whether deny-rule removals are unlocked: enough announced stake this
+    /// epoch and the grace round floor passed.
     pub deny_rule_removals_unlocked: IntGauge,
 
     /// Set to 1, and never cleared, when the `TransactionDenyRules` object

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1054,10 +1054,12 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
     let commit_info = ConsensusCommitInfo::new_for_test(1, 0, false);
     let mut output = ConsensusCommitOutput::default();
     let mut transactions = VecDeque::new();
+    let mut roots = std::collections::BTreeSet::new();
     store
-        .add_deny_rule_update_transactions(&mut output, &mut transactions, &commit_info)
+        .add_deny_rule_update_transactions(&mut output, &mut transactions, &mut roots, &commit_info)
         .unwrap();
     assert!(transactions.is_empty());
+    assert!(roots.is_empty());
 
     // Reopen with the object present at the epoch boundary, as the epoch
     // after its creation starts.
@@ -1086,8 +1088,9 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
     // first commit injects the full aggregate.
     let mut output = ConsensusCommitOutput::default();
     let mut transactions = VecDeque::new();
+    let mut roots = std::collections::BTreeSet::new();
     store
-        .add_deny_rule_update_transactions(&mut output, &mut transactions, &commit_info)
+        .add_deny_rule_update_transactions(&mut output, &mut transactions, &mut roots, &commit_info)
         .unwrap();
     assert_eq!(transactions.len(), 1);
     let TransactionKind::TransactionDenyRulesUpdate(update) =
@@ -1104,6 +1107,13 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
         *store.get_mirrored_transaction_deny_rules(),
         rules_denying_address(address)
     );
+    // Nothing else in a commit can depend on the deny-rules object, so the
+    // update only reaches a checkpoint if it is a root of its own.
+    assert_eq!(
+        roots,
+        [transactions[0].key()].into_iter().collect(),
+        "the injected update must be registered as a checkpoint root"
+    );
 
     // The advanced mirror is persisted with the same commit output.
     output.set_default_commit_stats_for_testing();
@@ -1114,10 +1124,12 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
     // The next commit finds the object up to date and injects nothing.
     let mut output = ConsensusCommitOutput::default();
     let mut transactions = VecDeque::new();
+    let mut roots = std::collections::BTreeSet::new();
     store
-        .add_deny_rule_update_transactions(&mut output, &mut transactions, &commit_info)
+        .add_deny_rule_update_transactions(&mut output, &mut transactions, &mut roots, &commit_info)
         .unwrap();
     assert!(transactions.is_empty());
+    assert!(roots.is_empty());
 
     // Withdrawing the proposal makes a later — proposal-free — commit inject
     // the removal; the mirror and the enforced active set must both drop the
@@ -1132,8 +1144,9 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
     );
     let mut output = ConsensusCommitOutput::default();
     let mut transactions = VecDeque::new();
+    let mut roots = std::collections::BTreeSet::new();
     store
-        .add_deny_rule_update_transactions(&mut output, &mut transactions, &commit_info)
+        .add_deny_rule_update_transactions(&mut output, &mut transactions, &mut roots, &commit_info)
         .unwrap();
     assert_eq!(transactions.len(), 1);
     let TransactionKind::TransactionDenyRulesUpdate(update) =
@@ -1150,6 +1163,76 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
         *store.get_active_transaction_deny_rules(),
         DenyRuleSet::default()
     );
+    assert_eq!(roots, [transactions[0].key()].into_iter().collect());
+}
+
+/// Every chunk of a split delta becomes its own checkpoint root: a chunk that
+/// executes but reaches no checkpoint would leave the object behind on every
+/// node that follows checkpoints rather than consensus.
+#[tokio::test]
+async fn every_injected_deny_rule_chunk_becomes_a_checkpoint_root() {
+    use std::collections::{BTreeSet, VecDeque};
+
+    use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+
+    use crate::consensus_handler::ConsensusCommitInfo;
+
+    let mut protocol_config =
+        ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    protocol_config.set_deny_rule_governance_for_testing(true);
+    protocol_config.set_deny_rule_governance_on_chain_for_testing(true);
+    // One entry per transaction, so the four denied addresses below split
+    // across four chunks.
+    protocol_config.set_deny_rule_update_max_entries_per_tx_for_testing(1);
+    protocol_config.set_deny_rule_removal_grace_round_floor_for_testing(0);
+    let authority_state = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config.clone())
+        .build()
+        .await;
+    let store = authority_state.epoch_store_for_testing();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(move |_, _| protocol_config.clone());
+    let me = store.name;
+    let rules = DenyRuleSet {
+        denied_addresses: (0..4u8).map(|i| Address::new([i; 32])).collect(),
+        ..Default::default()
+    };
+    flush_deny_rule_proposal(&store, deny_proposal(me, 1, rules));
+
+    let mut epoch_start_configuration = (*store.epoch_start_configuration).clone();
+    epoch_start_configuration
+        .set_transaction_deny_rules_for_testing(Version::from_u64(3), DenyRuleSet::default());
+    store.release_db_handles();
+    let store = AuthorityPerEpochStore::new(
+        store.name,
+        store.committee().clone(),
+        &store.parent_path,
+        store.db_options.clone(),
+        store.metrics.clone(),
+        epoch_start_configuration,
+        authority_state.get_backing_package_store().clone(),
+        store.execution_component.metrics(),
+        store.signature_verifier.metrics.clone(),
+        &ExpensiveSafetyCheckConfig::default(),
+        store.chain,
+        0,
+    )
+    .unwrap();
+
+    let mut output = ConsensusCommitOutput::default();
+    let mut transactions = VecDeque::new();
+    let mut roots = BTreeSet::new();
+    store
+        .add_deny_rule_update_transactions(
+            &mut output,
+            &mut transactions,
+            &mut roots,
+            &ConsensusCommitInfo::new_for_test(1, 0, false),
+        )
+        .unwrap();
+
+    assert_eq!(transactions.len(), 4);
+    let injected: BTreeSet<_> = transactions.iter().map(|tx| tx.key()).collect();
+    assert_eq!(roots, injected);
 }
 
 /// The epoch-boundary consistency guard fails reconfiguration only on a node

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1303,3 +1303,33 @@ async fn deny_rule_mirror_guard_reports_divergence() {
     );
     authority_state.check_transaction_deny_rules_consistency(&store, &diverged);
 }
+
+/// Objects cannot be deleted, so a walk finding no object after the closing
+/// epoch had one means the local store lost it — reported like a divergence.
+#[tokio::test]
+#[should_panic(expected = "missing from the state walked")]
+async fn deny_rule_mirror_guard_reports_a_missing_object() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let next_without_object = (*store.epoch_start_configuration).clone();
+    let mut with_object = (*store.epoch_start_configuration).clone();
+    with_object
+        .set_transaction_deny_rules_for_testing(Version::from_u64(3), DenyRuleSet::default());
+    store.release_db_handles();
+    let closing_store = AuthorityPerEpochStore::new(
+        store.name,
+        store.committee().clone(),
+        &store.parent_path,
+        store.db_options.clone(),
+        store.metrics.clone(),
+        with_object,
+        authority_state.get_backing_package_store().clone(),
+        store.execution_component.metrics(),
+        store.signature_verifier.metrics.clone(),
+        &ExpensiveSafetyCheckConfig::default(),
+        store.chain,
+        0,
+    )
+    .unwrap();
+    authority_state.check_transaction_deny_rules_consistency(&closing_store, &next_without_object);
+}

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1235,10 +1235,9 @@ async fn every_injected_deny_rule_chunk_becomes_a_checkpoint_root() {
     assert_eq!(roots, injected);
 }
 
-/// The epoch-boundary consistency guard fails reconfiguration only on a node
-/// that kept a mirror through the closing epoch: matching states pass, and a
-/// node outside the closing committee (a fullnode) is exempt even when its
-/// seed lags the object.
+/// The guard only compares on a node that kept a mirror through the closing
+/// epoch: matching states pass, and a node outside the closing committee is
+/// exempt even when its seed lags the object.
 #[tokio::test]
 async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
     let authority_state = TestAuthorityBuilder::new().build().await;
@@ -1249,16 +1248,10 @@ async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
     // configuration without the object.
     let mut matching = (*store.epoch_start_configuration).clone();
     matching.set_transaction_deny_rules_for_testing(Version::from_u64(3), DenyRuleSet::default());
-    assert!(
-        authority_state
-            .check_transaction_deny_rules_consistency(&store, &matching)
-            .is_ok()
-    );
-    assert!(
-        authority_state
-            .check_transaction_deny_rules_consistency(&store, &store.epoch_start_configuration)
-            .is_ok()
-    );
+    // `debug_fatal!` aborts test configurations, so returning is the assertion.
+    authority_state.check_transaction_deny_rules_consistency(&store, &matching);
+    authority_state
+        .check_transaction_deny_rules_consistency(&store, &store.epoch_start_configuration);
 
     // A node that was not in the closing epoch's committee has no mirror to
     // compare: reopen the store under a foreign committee and diverge the
@@ -1293,19 +1286,14 @@ async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
     )
     .unwrap();
     assert!(authority_state.is_fullnode(&fullnode_store));
-    assert!(
-        authority_state
-            .check_transaction_deny_rules_consistency(&fullnode_store, &diverged)
-            .is_ok()
-    );
+    authority_state.check_transaction_deny_rules_consistency(&fullnode_store, &diverged);
 }
 
-/// A committee member whose mirror diverged from the walked object state must
-/// not reconfigure onto it. `debug_fatal!` panics in debug builds; release
-/// builds log, set the metric, and fail reconfiguration with an error.
+/// A diverged mirror is reported: `debug_fatal!` aborts test configurations,
+/// so a divergence introduced by a bug fails the suite.
 #[tokio::test]
 #[should_panic(expected = "diverged from the mirrored state")]
-async fn deny_rule_mirror_guard_fails_on_divergence() {
+async fn deny_rule_mirror_guard_reports_divergence() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
     let mut diverged = (*store.epoch_start_configuration).clone();
@@ -1313,5 +1301,5 @@ async fn deny_rule_mirror_guard_fails_on_divergence() {
         Version::from_u64(3),
         rules_denying_address(Address::new([9u8; 32])),
     );
-    let _ = authority_state.check_transaction_deny_rules_consistency(&store, &diverged);
+    authority_state.check_transaction_deny_rules_consistency(&store, &diverged);
 }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1027,7 +1027,7 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
 
     use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use iota_sdk_types::TransactionKind;
-    use iota_types::transaction::TransactionDataAPI;
+    use iota_types::transaction::TransactionAPI;
 
     use crate::consensus_handler::ConsensusCommitInfo;
 

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -969,7 +969,7 @@ fn deny_rule_update_chunks_split_deterministically() {
 /// atomically with each injecting commit — not from the epoch-start seed,
 /// which is stale once injections have advanced the object.
 #[tokio::test]
-async fn restart_recovers_the_flushed_deny_rule_mirror() {
+async fn restart_recovers_the_deny_rule_mirror() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
     let address = Address::new([7u8; 32]);
@@ -983,7 +983,7 @@ async fn restart_recovers_the_flushed_deny_rule_mirror() {
     // An injecting commit persists the advanced mirror with its results.
     let mirror = rules_denying_address(address);
     let mut output = ConsensusCommitOutput::default();
-    output.record_flushed_deny_rule_mirror(mirror.clone());
+    output.record_deny_rule_mirror(mirror.clone());
     output.set_default_commit_stats_for_testing();
     let mut batch = store.db_batch_for_test();
     output.write_to_batch(&store, &mut batch).unwrap();
@@ -1240,6 +1240,8 @@ async fn every_injected_deny_rule_chunk_becomes_a_checkpoint_root() {
 async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
+    // Close the epoch so the comparisons below run rather than being exempt.
+    store.get_reconfig_state_write_lock_guard().close_all_tx();
     let walked = rules_denying_address(Address::new([9u8; 32]));
 
     // Matching states (both default) pass for a committee member, as does a
@@ -1291,7 +1293,7 @@ async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
 /// immediately, so a row absent although commits have flushed is a lost
 /// row: the store refuses to open rather than start from the stale seed.
 #[tokio::test]
-#[should_panic(expected = "flushed_deny_rule_mirror row is missing")]
+#[should_panic(expected = "deny_rule_mirror row is missing")]
 async fn lost_mirror_row_after_flushed_commits_fails_the_reopen() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
@@ -1317,11 +1319,11 @@ async fn lost_mirror_row_after_flushed_commits_fails_the_reopen() {
     )
     .unwrap();
     let tables = store.tables().unwrap();
-    assert!(tables.flushed_deny_rule_mirror.get(&()).unwrap().is_some());
+    assert!(tables.deny_rule_mirror.get(&()).unwrap().is_some());
 
     // Flush a commit, then lose the row.
     flush_deny_rule_proposal(&store, deny_proposal(store.name, 1, DenyRuleSet::default()));
-    tables.flushed_deny_rule_mirror.remove(&()).unwrap();
+    tables.deny_rule_mirror.remove(&()).unwrap();
     drop(tables);
     store.release_db_handles();
     let _ = AuthorityPerEpochStore::new(
@@ -1340,13 +1342,34 @@ async fn lost_mirror_row_after_flushed_commits_fails_the_reopen() {
     );
 }
 
+/// A validator that crosses the boundary by executing synced checkpoints
+/// never closes the epoch in its own consensus. Its mirror legitimately
+/// lags the object and the re-seed repairs it. The guard must not report
+/// that lag as a divergence.
+#[tokio::test]
+async fn deny_rule_mirror_guard_exempts_an_epoch_consensus_did_not_close() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    // The reconfig state stays at its default: the epoch was never closed.
+    let mut diverged = (*store.epoch_start_configuration).clone();
+    diverged.set_transaction_deny_rules_for_testing(
+        Version::from_u64(3),
+        rules_denying_address(Address::new([9u8; 32])),
+    );
+    // `debug_fatal!` aborts test configurations, so returning is the assertion.
+    authority_state.check_transaction_deny_rules_consistency(&store, &diverged);
+    assert_eq!(store.metrics.deny_rule_mirror_divergence.get(), 0);
+}
+
 /// A diverged mirror is reported: `debug_fatal!` aborts test configurations,
-/// so a divergence introduced by a bug fails the suite.
+/// so a divergence introduced by a bug fails the suite. The epoch is closed
+/// first so the comparison runs.
 #[tokio::test]
 #[should_panic(expected = "diverged from the mirrored state")]
 async fn deny_rule_mirror_guard_reports_divergence() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
+    store.get_reconfig_state_write_lock_guard().close_all_tx();
     let mut diverged = (*store.epoch_start_configuration).clone();
     diverged.set_transaction_deny_rules_for_testing(
         Version::from_u64(3),

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1305,10 +1305,11 @@ async fn deny_rule_mirror_guard_reports_divergence() {
 }
 
 /// Objects cannot be deleted, so a walk finding no object after the closing
-/// epoch had one means the local store lost it — reported like a divergence.
+/// epoch had one means the local store lost it. Unlike a readable divergence
+/// there is nothing to re-seed from, so this fail-stops in every build.
 #[tokio::test]
 #[should_panic(expected = "missing from the state walked")]
-async fn deny_rule_mirror_guard_reports_a_missing_object() {
+async fn deny_rule_mirror_guard_fails_on_a_missing_object() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
     let next_without_object = (*store.epoch_start_configuration).clone();

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1041,9 +1041,8 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
         .with_protocol_config(protocol_config.clone())
         .build()
         .await;
-    // The builder's config override is dropped when `build` returns; the
-    // reopened epoch store below re-derives its config, so keep the override
-    // alive for the whole test.
+    // The builder's config override drops when `build` returns; keep one
+    // alive for the reopened epoch store below.
     let _guard = ProtocolConfig::apply_overrides_for_testing(move |_, _| protocol_config.clone());
     let store = authority_state.epoch_store_for_testing();
     let me = store.name;
@@ -1131,10 +1130,9 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
     assert!(transactions.is_empty());
     assert!(roots.is_empty());
 
-    // Withdrawing the proposal makes a later — proposal-free — commit inject
-    // the removal; the mirror and the enforced active set must both drop the
-    // entry in that same commit, not wait for the next proposal to trigger a
-    // recompute.
+    // Withdrawing the proposal makes a later, proposal-free commit inject
+    // the removal; the mirror and the enforced active set must drop the
+    // entry in that same commit, not at the next proposal-driven recompute.
     flush_deny_rule_proposal(&store, deny_proposal(me, 2, DenyRuleSet::default()));
     assert!(
         store
@@ -1290,9 +1288,8 @@ async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
 }
 
 /// With the object present, a fresh epoch persists the mirror seed row
-/// immediately, so a row that is absent although commits have flushed can
-/// only be a lost row: the store refuses to open rather than fall back to
-/// the stale epoch-start seed and derive updates its peers do not.
+/// immediately, so a row absent although commits have flushed is a lost
+/// row: the store refuses to open rather than start from the stale seed.
 #[tokio::test]
 #[should_panic(expected = "mirrored_deny_rules row is missing")]
 async fn lost_mirror_row_after_flushed_commits_fails_the_reopen() {

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use iota_config::node::ExpensiveSafetyCheckConfig;
-use iota_sdk_types::{Address, DenyRuleSet, ObjectId, TransactionDigest};
+use iota_sdk_types::{Address, DenyRuleSet, ObjectId, TransactionDigest, Version};
 use iota_types::{
     base_types::AuthorityName, committee::Committee, crypto::KeypairTraits,
     messages_consensus::TransactionDenyRuleProposal,
@@ -18,7 +18,8 @@ use typed_store::rocks::DBBatch;
 
 use crate::authority::{
     authority_per_epoch_store::{
-        AuthorityPerEpochStore, consensus_quarantine::ConsensusCommitOutput,
+        AuthorityPerEpochStore, compute_deny_rule_update_chunks,
+        consensus_quarantine::ConsensusCommitOutput,
     },
     test_authority_builder::TestAuthorityBuilder,
 };
@@ -824,4 +825,410 @@ async fn restart_seed_restores_persisted_deny_rules() {
     let active = reopened.get_active_transaction_deny_rules();
     assert!(active.denied_addresses.contains(&address));
     assert!(active.user_transaction_disabled);
+}
+
+/// `compute_deny_rule_update_chunks` decision table: no diff yields no
+/// chunks; additions and switch activations apply while removals are still
+/// locked; entry removals and switch deactivations wait for the unlock.
+#[test]
+fn deny_rule_update_chunks_respect_removal_grace() {
+    let staying = Address::new([1u8; 32]);
+    let leaving = Address::new([2u8; 32]);
+    let arriving = Address::new([3u8; 32]);
+    let mirror = DenyRuleSet {
+        denied_addresses: [staying, leaving].into(),
+        user_transaction_disabled: true,
+        ..Default::default()
+    };
+    let aggregate = DenyRuleSet {
+        denied_addresses: [staying, arriving].into(),
+        shared_object_disabled: true,
+        ..Default::default()
+    };
+    let version = Version::from_u64(5);
+
+    // Object already up to date: nothing to inject, in either grace state.
+    for unlocked in [false, true] {
+        let (chunks, target) =
+            compute_deny_rule_update_chunks(&mirror, &mirror, unlocked, 1000, 7, 42, version);
+        assert!(chunks.is_empty());
+        assert_eq!(target, mirror);
+    }
+
+    // Removals locked: the arriving address and the newly active switch go
+    // out, but the leaving address stays and the mirrored switch stays on.
+    let (chunks, target) =
+        compute_deny_rule_update_chunks(&aggregate, &mirror, false, 1000, 7, 42, version);
+    assert_eq!(chunks.len(), 1);
+    let chunk = &chunks[0];
+    assert_eq!(chunk.epoch, 7);
+    assert_eq!(chunk.round, 42);
+    assert_eq!(chunk.deny_rules_obj_initial_shared_version, version);
+    assert_eq!(chunk.added_addresses, [arriving].into());
+    assert!(chunk.removed_addresses.is_empty());
+    assert!(chunk.shared_object_disabled);
+    assert!(chunk.user_transaction_disabled);
+    assert_eq!(target.denied_addresses, [staying, leaving, arriving].into());
+    assert!(target.shared_object_disabled);
+    assert!(target.user_transaction_disabled);
+
+    // Removals unlocked: the full diff applies and the object reaches the
+    // aggregate exactly.
+    let (chunks, target) =
+        compute_deny_rule_update_chunks(&aggregate, &mirror, true, 1000, 7, 42, version);
+    assert_eq!(chunks.len(), 1);
+    let chunk = &chunks[0];
+    assert_eq!(chunk.added_addresses, [arriving].into());
+    assert_eq!(chunk.removed_addresses, [leaving].into());
+    assert!(chunk.shared_object_disabled);
+    assert!(!chunk.user_transaction_disabled);
+    assert_eq!(target, aggregate);
+
+    // A switch deactivation alone is also held back until the unlock.
+    let switch_off = DenyRuleSet {
+        denied_addresses: mirror.denied_addresses.clone(),
+        ..Default::default()
+    };
+    let (chunks, target) =
+        compute_deny_rule_update_chunks(&switch_off, &mirror, false, 1000, 7, 42, version);
+    assert!(chunks.is_empty());
+    assert_eq!(target, mirror);
+    let (chunks, _) =
+        compute_deny_rule_update_chunks(&switch_off, &mirror, true, 1000, 7, 42, version);
+    assert_eq!(chunks.len(), 1);
+    assert!(!chunks[0].user_transaction_disabled);
+}
+
+/// A delta larger than the per-transaction limit splits into disjoint chunks
+/// that reassemble to the full diff, each within the limit and carrying the
+/// same switch states — and the split is deterministic.
+#[test]
+fn deny_rule_update_chunks_split_deterministically() {
+    let mirror = DenyRuleSet {
+        denied_packages: (0..2u8).map(|i| ObjectId::new([100 + i; 32])).collect(),
+        ..Default::default()
+    };
+    let aggregate = DenyRuleSet {
+        denied_addresses: (0..5u8).map(|i| Address::new([i; 32])).collect(),
+        denied_objects: (0..3u8).map(|i| ObjectId::new([50 + i; 32])).collect(),
+        user_transaction_disabled: true,
+        ..Default::default()
+    };
+    let version = Version::from_u64(5);
+
+    // 5 added addresses + 3 added objects + 2 removed packages = 10 entries.
+    let (chunks, target) =
+        compute_deny_rule_update_chunks(&aggregate, &mirror, true, 3, 7, 42, version);
+    assert_eq!(chunks.len(), 4);
+    assert_eq!(target, aggregate);
+
+    let mut added_addresses = std::collections::BTreeSet::new();
+    let mut added_objects = std::collections::BTreeSet::new();
+    let mut removed_packages = std::collections::BTreeSet::new();
+    for chunk in &chunks {
+        let entries = chunk.added_addresses.len()
+            + chunk.removed_addresses.len()
+            + chunk.added_objects.len()
+            + chunk.removed_objects.len()
+            + chunk.added_packages.len()
+            + chunk.removed_packages.len();
+        assert!(entries <= 3);
+        // Disjointness: no entry may appear in two chunks.
+        for key in &chunk.added_addresses {
+            assert!(added_addresses.insert(*key));
+        }
+        for key in &chunk.added_objects {
+            assert!(added_objects.insert(*key));
+        }
+        for key in &chunk.removed_packages {
+            assert!(removed_packages.insert(*key));
+        }
+        assert!(chunk.removed_addresses.is_empty());
+        assert!(chunk.removed_objects.is_empty());
+        assert!(chunk.added_packages.is_empty());
+        // Every chunk carries the absolute switch states and target object.
+        assert!(chunk.user_transaction_disabled);
+        assert_eq!(chunk.epoch, 7);
+        assert_eq!(chunk.round, 42);
+        assert_eq!(chunk.deny_rules_obj_initial_shared_version, version);
+    }
+    assert_eq!(added_addresses, aggregate.denied_addresses);
+    assert_eq!(added_objects, aggregate.denied_objects);
+    assert_eq!(removed_packages, mirror.denied_packages);
+
+    // Same inputs, same chunks.
+    let (again, _) = compute_deny_rule_update_chunks(&aggregate, &mirror, true, 3, 7, 42, version);
+    assert_eq!(chunks, again);
+
+    // A zero limit is clamped to one entry per transaction.
+    let (chunks, _) = compute_deny_rule_update_chunks(&aggregate, &mirror, true, 0, 7, 42, version);
+    assert_eq!(chunks.len(), 10);
+}
+
+/// A mid-epoch restart resumes from the persisted mirror row — written
+/// atomically with each injecting commit — not from the epoch-start seed,
+/// which is stale once injections have advanced the object.
+#[tokio::test]
+async fn restart_recovers_persisted_mirrored_deny_rules() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let address = Address::new([7u8; 32]);
+
+    // Fresh epoch: no persisted row, the mirror starts from the seed.
+    assert_eq!(
+        *store.get_mirrored_transaction_deny_rules(),
+        DenyRuleSet::default()
+    );
+
+    // An injecting commit persists the advanced mirror with its results.
+    let mirror = rules_denying_address(address);
+    let mut output = ConsensusCommitOutput::default();
+    output.record_mirrored_deny_rules(mirror.clone());
+    output.set_default_commit_stats_for_testing();
+    let mut batch = store.db_batch_for_test();
+    output.write_to_batch(&store, &mut batch).unwrap();
+    batch.write().unwrap();
+
+    // Reopen over the same epoch DB, as a restart does.
+    store.release_db_handles();
+    let reopened = AuthorityPerEpochStore::new(
+        store.name,
+        store.committee().clone(),
+        &store.parent_path,
+        store.db_options.clone(),
+        store.metrics.clone(),
+        (*store.epoch_start_configuration).clone(),
+        authority_state.get_backing_package_store().clone(),
+        store.execution_component.metrics(),
+        store.signature_verifier.metrics.clone(),
+        &ExpensiveSafetyCheckConfig::default(),
+        store.chain,
+        0,
+    )
+    .unwrap();
+
+    assert_eq!(*reopened.get_mirrored_transaction_deny_rules(), mirror);
+    // The recovered mirror flows back into enforcement.
+    assert!(
+        reopened
+            .get_active_transaction_deny_rules()
+            .denied_addresses
+            .contains(&address)
+    );
+}
+
+/// Injection at the commit boundary: with the flag on and the object present,
+/// a recorded proposal makes the next commit inject a
+/// `TransactionDenyRulesUpdate`, advance the mirror in lockstep, and go quiet
+/// once the object is up to date. Without the object nothing is injected.
+#[tokio::test]
+async fn commit_injects_deny_rule_updates_and_advances_mirror() {
+    use std::collections::VecDeque;
+
+    use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+    use iota_sdk_types::TransactionKind;
+    use iota_types::transaction::TransactionDataAPI;
+
+    use crate::consensus_handler::ConsensusCommitInfo;
+
+    let mut protocol_config =
+        ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    protocol_config.set_deny_rule_governance_for_testing(true);
+    protocol_config.set_deny_rule_governance_on_chain_for_testing(true);
+    protocol_config.set_deny_rule_update_max_entries_per_tx_for_testing(1000);
+    protocol_config.set_deny_rule_removal_grace_round_floor_for_testing(0);
+    let authority_state = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config.clone())
+        .build()
+        .await;
+    // The builder's config override is dropped when `build` returns; the
+    // reopened epoch store below re-derives its config, so keep the override
+    // alive for the whole test.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(move |_, _| protocol_config.clone());
+    let store = authority_state.epoch_store_for_testing();
+    let me = store.name;
+    let address = Address::new([1u8; 32]);
+    flush_deny_rule_proposal(&store, deny_proposal(me, 1, rules_denying_address(address)));
+
+    // The object does not exist this epoch: nothing to update.
+    let commit_info = ConsensusCommitInfo::new_for_test(1, 0, false);
+    let mut output = ConsensusCommitOutput::default();
+    let mut transactions = VecDeque::new();
+    store
+        .add_deny_rule_update_transactions(&mut output, &mut transactions, &commit_info)
+        .unwrap();
+    assert!(transactions.is_empty());
+
+    // Reopen with the object present at the epoch boundary, as the epoch
+    // after its creation starts.
+    let initial_shared_version = Version::from_u64(3);
+    let mut epoch_start_configuration = (*store.epoch_start_configuration).clone();
+    epoch_start_configuration
+        .set_transaction_deny_rules_for_testing(initial_shared_version, DenyRuleSet::default());
+    store.release_db_handles();
+    let store = AuthorityPerEpochStore::new(
+        store.name,
+        store.committee().clone(),
+        &store.parent_path,
+        store.db_options.clone(),
+        store.metrics.clone(),
+        epoch_start_configuration,
+        authority_state.get_backing_package_store().clone(),
+        store.execution_component.metrics(),
+        store.signature_verifier.metrics.clone(),
+        &ExpensiveSafetyCheckConfig::default(),
+        store.chain,
+        0,
+    )
+    .unwrap();
+
+    // The single validator holds all stake and the grace floor is 0, so the
+    // first commit injects the full aggregate.
+    let mut output = ConsensusCommitOutput::default();
+    let mut transactions = VecDeque::new();
+    store
+        .add_deny_rule_update_transactions(&mut output, &mut transactions, &commit_info)
+        .unwrap();
+    assert_eq!(transactions.len(), 1);
+    let TransactionKind::TransactionDenyRulesUpdate(update) =
+        transactions[0].data().transaction().kind()
+    else {
+        panic!("expected a deny-rules update transaction");
+    };
+    assert_eq!(update.added_addresses, [address].into());
+    assert_eq!(
+        update.deny_rules_obj_initial_shared_version,
+        initial_shared_version
+    );
+    assert_eq!(
+        *store.get_mirrored_transaction_deny_rules(),
+        rules_denying_address(address)
+    );
+
+    // The advanced mirror is persisted with the same commit output.
+    output.set_default_commit_stats_for_testing();
+    let mut batch = store.db_batch_for_test();
+    output.write_to_batch(&store, &mut batch).unwrap();
+    batch.write().unwrap();
+
+    // The next commit finds the object up to date and injects nothing.
+    let mut output = ConsensusCommitOutput::default();
+    let mut transactions = VecDeque::new();
+    store
+        .add_deny_rule_update_transactions(&mut output, &mut transactions, &commit_info)
+        .unwrap();
+    assert!(transactions.is_empty());
+
+    // Withdrawing the proposal makes a later — proposal-free — commit inject
+    // the removal; the mirror and the enforced active set must both drop the
+    // entry in that same commit, not wait for the next proposal to trigger a
+    // recompute.
+    flush_deny_rule_proposal(&store, deny_proposal(me, 2, DenyRuleSet::default()));
+    assert!(
+        store
+            .get_active_transaction_deny_rules()
+            .denied_addresses
+            .contains(&address)
+    );
+    let mut output = ConsensusCommitOutput::default();
+    let mut transactions = VecDeque::new();
+    store
+        .add_deny_rule_update_transactions(&mut output, &mut transactions, &commit_info)
+        .unwrap();
+    assert_eq!(transactions.len(), 1);
+    let TransactionKind::TransactionDenyRulesUpdate(update) =
+        transactions[0].data().transaction().kind()
+    else {
+        panic!("expected a deny-rules update transaction");
+    };
+    assert_eq!(update.removed_addresses, [address].into());
+    assert_eq!(
+        *store.get_mirrored_transaction_deny_rules(),
+        DenyRuleSet::default()
+    );
+    assert_eq!(
+        *store.get_active_transaction_deny_rules(),
+        DenyRuleSet::default()
+    );
+}
+
+/// The epoch-boundary consistency guard fails reconfiguration only on a node
+/// that kept a mirror through the closing epoch: matching states pass, and a
+/// node outside the closing committee (a fullnode) is exempt even when its
+/// seed lags the object.
+#[tokio::test]
+async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let walked = rules_denying_address(Address::new([9u8; 32]));
+
+    // Matching states (both default) pass for a committee member, as does a
+    // configuration without the object.
+    let mut matching = (*store.epoch_start_configuration).clone();
+    matching.set_transaction_deny_rules_for_testing(Version::from_u64(3), DenyRuleSet::default());
+    assert!(
+        authority_state
+            .check_transaction_deny_rules_consistency(&store, &matching)
+            .is_ok()
+    );
+    assert!(
+        authority_state
+            .check_transaction_deny_rules_consistency(&store, &store.epoch_start_configuration)
+            .is_ok()
+    );
+
+    // A node that was not in the closing epoch's committee has no mirror to
+    // compare: reopen the store under a foreign committee and diverge the
+    // walked state — the guard must not fire.
+    let mut diverged = (*store.epoch_start_configuration).clone();
+    diverged.set_transaction_deny_rules_for_testing(Version::from_u64(3), walked);
+    // The simple test committee is seeded like the test authority's own keys,
+    // so drop this node's name explicitly to get a committee it is not in.
+    let (simple_committee, _keys) = Committee::new_simple_test_committee();
+    let foreign_committee = Committee::new_for_testing_with_normalized_voting_power(
+        0,
+        simple_committee
+            .members()
+            .filter(|(name, _)| *name != store.name)
+            .map(|(name, stake)| (*name, *stake))
+            .collect(),
+    );
+    store.release_db_handles();
+    let fullnode_store = AuthorityPerEpochStore::new(
+        store.name,
+        std::sync::Arc::new(foreign_committee),
+        &store.parent_path,
+        store.db_options.clone(),
+        store.metrics.clone(),
+        (*store.epoch_start_configuration).clone(),
+        authority_state.get_backing_package_store().clone(),
+        store.execution_component.metrics(),
+        store.signature_verifier.metrics.clone(),
+        &ExpensiveSafetyCheckConfig::default(),
+        store.chain,
+        0,
+    )
+    .unwrap();
+    assert!(authority_state.is_fullnode(&fullnode_store));
+    assert!(
+        authority_state
+            .check_transaction_deny_rules_consistency(&fullnode_store, &diverged)
+            .is_ok()
+    );
+}
+
+/// A committee member whose mirror diverged from the walked object state must
+/// not reconfigure onto it. `debug_fatal!` panics in debug builds; release
+/// builds log, set the metric, and fail reconfiguration with an error.
+#[tokio::test]
+#[should_panic(expected = "diverged from the mirrored state")]
+async fn deny_rule_mirror_guard_fails_on_divergence() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let mut diverged = (*store.epoch_start_configuration).clone();
+    diverged.set_transaction_deny_rules_for_testing(
+        Version::from_u64(3),
+        rules_denying_address(Address::new([9u8; 32])),
+    );
+    let _ = authority_state.check_transaction_deny_rules_consistency(&store, &diverged);
 }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -14,7 +14,7 @@ use iota_types::{
     messages_consensus::TransactionDenyRuleProposal,
 };
 use tokio::time::timeout;
-use typed_store::rocks::DBBatch;
+use typed_store::{Map, rocks::DBBatch};
 
 use crate::authority::{
     authority_per_epoch_store::{
@@ -1048,7 +1048,6 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
     let store = authority_state.epoch_store_for_testing();
     let me = store.name;
     let address = Address::new([1u8; 32]);
-    flush_deny_rule_proposal(&store, deny_proposal(me, 1, rules_denying_address(address)));
 
     // The object does not exist this epoch: nothing to update.
     let commit_info = ConsensusCommitInfo::new_for_test(1, 0, false);
@@ -1083,6 +1082,7 @@ async fn commit_injects_deny_rule_updates_and_advances_mirror() {
         0,
     )
     .unwrap();
+    flush_deny_rule_proposal(&store, deny_proposal(me, 1, rules_denying_address(address)));
 
     // The single validator holds all stake and the grace floor is 0, so the
     // first commit injects the full aggregate.
@@ -1196,7 +1196,6 @@ async fn every_injected_deny_rule_chunk_becomes_a_checkpoint_root() {
         denied_addresses: (0..4u8).map(|i| Address::new([i; 32])).collect(),
         ..Default::default()
     };
-    flush_deny_rule_proposal(&store, deny_proposal(me, 1, rules));
 
     let mut epoch_start_configuration = (*store.epoch_start_configuration).clone();
     epoch_start_configuration
@@ -1217,6 +1216,7 @@ async fn every_injected_deny_rule_chunk_becomes_a_checkpoint_root() {
         0,
     )
     .unwrap();
+    flush_deny_rule_proposal(&store, deny_proposal(me, 1, rules));
 
     let mut output = ConsensusCommitOutput::default();
     let mut transactions = VecDeque::new();
@@ -1287,6 +1287,60 @@ async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
     .unwrap();
     assert!(authority_state.is_fullnode(&fullnode_store));
     authority_state.check_transaction_deny_rules_consistency(&fullnode_store, &diverged);
+}
+
+/// With the object present, a fresh epoch persists the mirror seed row
+/// immediately, so a row that is absent although commits have flushed can
+/// only be a lost row: the store refuses to open rather than fall back to
+/// the stale epoch-start seed and derive updates its peers do not.
+#[tokio::test]
+#[should_panic(expected = "mirrored_deny_rules row is missing")]
+async fn lost_mirror_row_after_flushed_commits_fails_the_reopen() {
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let mut with_object = (*store.epoch_start_configuration).clone();
+    with_object
+        .set_transaction_deny_rules_for_testing(Version::from_u64(3), DenyRuleSet::default());
+
+    // Fresh epoch with the object: the constructor writes the seed row.
+    store.release_db_handles();
+    let store = AuthorityPerEpochStore::new(
+        store.name,
+        store.committee().clone(),
+        &store.parent_path,
+        store.db_options.clone(),
+        store.metrics.clone(),
+        with_object.clone(),
+        authority_state.get_backing_package_store().clone(),
+        store.execution_component.metrics(),
+        store.signature_verifier.metrics.clone(),
+        &ExpensiveSafetyCheckConfig::default(),
+        store.chain,
+        0,
+    )
+    .unwrap();
+    let tables = store.tables().unwrap();
+    assert!(tables.mirrored_deny_rules.get(&()).unwrap().is_some());
+
+    // Flush a commit, then lose the row.
+    flush_deny_rule_proposal(&store, deny_proposal(store.name, 1, DenyRuleSet::default()));
+    tables.mirrored_deny_rules.remove(&()).unwrap();
+    drop(tables);
+    store.release_db_handles();
+    let _ = AuthorityPerEpochStore::new(
+        store.name,
+        store.committee().clone(),
+        &store.parent_path,
+        store.db_options.clone(),
+        store.metrics.clone(),
+        with_object,
+        authority_state.get_backing_package_store().clone(),
+        store.execution_component.metrics(),
+        store.signature_verifier.metrics.clone(),
+        &ExpensiveSafetyCheckConfig::default(),
+        store.chain,
+        0,
+    );
 }
 
 /// A diverged mirror is reported: `debug_fatal!` aborts test configurations,

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -969,7 +969,7 @@ fn deny_rule_update_chunks_split_deterministically() {
 /// atomically with each injecting commit — not from the epoch-start seed,
 /// which is stale once injections have advanced the object.
 #[tokio::test]
-async fn restart_recovers_persisted_mirrored_deny_rules() {
+async fn restart_recovers_the_flushed_deny_rule_mirror() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
     let address = Address::new([7u8; 32]);
@@ -983,7 +983,7 @@ async fn restart_recovers_persisted_mirrored_deny_rules() {
     // An injecting commit persists the advanced mirror with its results.
     let mirror = rules_denying_address(address);
     let mut output = ConsensusCommitOutput::default();
-    output.record_mirrored_deny_rules(mirror.clone());
+    output.record_flushed_deny_rule_mirror(mirror.clone());
     output.set_default_commit_stats_for_testing();
     let mut batch = store.db_batch_for_test();
     output.write_to_batch(&store, &mut batch).unwrap();
@@ -1291,7 +1291,7 @@ async fn deny_rule_mirror_guard_exempts_nodes_outside_the_committee() {
 /// immediately, so a row absent although commits have flushed is a lost
 /// row: the store refuses to open rather than start from the stale seed.
 #[tokio::test]
-#[should_panic(expected = "mirrored_deny_rules row is missing")]
+#[should_panic(expected = "flushed_deny_rule_mirror row is missing")]
 async fn lost_mirror_row_after_flushed_commits_fails_the_reopen() {
     let authority_state = TestAuthorityBuilder::new().build().await;
     let store = authority_state.epoch_store_for_testing();
@@ -1317,11 +1317,11 @@ async fn lost_mirror_row_after_flushed_commits_fails_the_reopen() {
     )
     .unwrap();
     let tables = store.tables().unwrap();
-    assert!(tables.mirrored_deny_rules.get(&()).unwrap().is_some());
+    assert!(tables.flushed_deny_rule_mirror.get(&()).unwrap().is_some());
 
     // Flush a commit, then lose the row.
     flush_deny_rule_proposal(&store, deny_proposal(store.name, 1, DenyRuleSet::default()));
-    tables.mirrored_deny_rules.remove(&()).unwrap();
+    tables.flushed_deny_rule_mirror.remove(&()).unwrap();
     drop(tables);
     store.release_db_handles();
     let _ = AuthorityPerEpochStore::new(

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -8104,6 +8104,8 @@ async fn advance_epoch_tx_creates_deny_rules_object_under_flag(
     if enabled {
         protocol_config.set_deny_rule_governance_for_testing(true);
         protocol_config.set_deny_rule_governance_on_chain_for_testing(true);
+        protocol_config.set_deny_rule_update_max_entries_per_tx_for_testing(1000);
+        protocol_config.set_deny_rule_removal_grace_round_floor_for_testing(0);
     }
     let authority = TestAuthorityBuilder::new()
         .with_protocol_config(protocol_config)

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1525,6 +1525,8 @@
                 "debug_print_stack_trace_base_cost": {
                   "u64": "52"
                 },
+                "deny_rule_removal_grace_round_floor": null,
+                "deny_rule_update_max_entries_per_tx": null,
                 "dynamic_field_add_child_object_cost_base": {
                   "u64": "100"
                 },

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1449,6 +1449,18 @@ pub struct ProtocolConfig {
     /// validators in any epoch to go above this.
     max_committee_members_count: Option<u64>,
 
+    /// Maximum number of added plus removed entries one injected
+    /// `TransactionDenyRulesUpdate` transaction may carry; a larger diff is
+    /// split into multiple transactions in the same commit. Set together with
+    /// the `deny_rule_governance` feature flags.
+    deny_rule_update_max_entries_per_tx: Option<u64>,
+
+    /// Consensus round before which removals are never injected into the
+    /// `TransactionDenyRules` object, so validators can re-announce their
+    /// rules after an epoch change before unsupported entries are dropped.
+    /// Set together with the `deny_rule_governance` feature flags.
+    deny_rule_removal_grace_round_floor: Option<u64>,
+
     /// Configures the garbage collection depth for consensus. When is unset or
     /// `0` then the garbage collection is disabled.
     consensus_gc_depth: Option<u32>,
@@ -2105,6 +2117,14 @@ impl ProtocolConfig {
                 || ret.feature_flags.deny_rule_governance,
             "deny_rule_governance_on_chain requires deny_rule_governance"
         );
+        // The injection cannot chunk updates or gate removals without its
+        // knobs.
+        assert!(
+            !ret.feature_flags.deny_rule_governance_on_chain
+                || (ret.deny_rule_update_max_entries_per_tx.is_some()
+                    && ret.deny_rule_removal_grace_round_floor.is_some()),
+            "deny_rule_governance_on_chain requires deny_rule_update_max_entries_per_tx and deny_rule_removal_grace_round_floor"
+        );
 
         ret
     }
@@ -2625,6 +2645,8 @@ impl ProtocolConfig {
             max_accumulated_txn_cost_per_object_in_mysticeti_commit: Some(10),
 
             max_committee_members_count: None,
+            deny_rule_update_max_entries_per_tx: None,
+            deny_rule_removal_grace_round_floor: None,
 
             consensus_gc_depth: None,
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2127,13 +2127,11 @@ impl ProtocolConfig {
         );
         // A deny-rule update chunk must always execute, or the object falls
         // permanently behind the mirrored state on every validator at once.
-        // Each entry is a `LinkedTable` child object, so chunks are bounded by
-        // the system-transaction object limits — and, tighter, by
-        // `max_event_emit_size` (the update event carries every entry, ~32
-        // bytes each) and by the object-runtime store entries touched when
-        // removals re-link nodes. Those last two cannot be expressed as an
-        // entry count here; the constant keeps a wide margin below them
-        // (tightest is roughly 5000 entries for a removal-only chunk).
+        // The binding limits are `max_event_emit_size` (the update event
+        // carries every entry, ~32 bytes each) and the object-runtime store
+        // entries touched when removals re-link `LinkedTable` nodes — neither
+        // expressible as an entry count here, so the constant keeps a wide
+        // margin below them (tightest is roughly 5000 entries).
         const DENY_RULE_UPDATE_MAX_ENTRIES_PER_TX_CEILING: u64 = 2048;
         assert!(
             ret.deny_rule_update_max_entries_per_tx

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2125,6 +2125,32 @@ impl ProtocolConfig {
                     && ret.deny_rule_removal_grace_round_floor.is_some()),
             "deny_rule_governance_on_chain requires deny_rule_update_max_entries_per_tx and deny_rule_removal_grace_round_floor"
         );
+        // A deny-rule update chunk must always execute, or the object falls
+        // permanently behind the mirrored state on every validator at once.
+        // Each entry is a `LinkedTable` child object, so chunks are bounded by
+        // the system-transaction object limits — and, tighter, by
+        // `max_event_emit_size` (the update event carries every entry, ~32
+        // bytes each) and by the object-runtime store entries touched when
+        // removals re-link nodes. Those last two cannot be expressed as an
+        // entry count here; the constant keeps a wide margin below them
+        // (tightest is roughly 5000 entries for a removal-only chunk).
+        const DENY_RULE_UPDATE_MAX_ENTRIES_PER_TX_CEILING: u64 = 2048;
+        assert!(
+            ret.deny_rule_update_max_entries_per_tx
+                .is_none_or(|max_entries| {
+                    max_entries > 0
+                        && max_entries <= DENY_RULE_UPDATE_MAX_ENTRIES_PER_TX_CEILING
+                        && [
+                            ret.max_num_new_move_object_ids_system_tx,
+                            ret.max_num_deleted_move_object_ids_system_tx,
+                            ret.object_runtime_max_num_cached_objects_system_tx,
+                            ret.object_runtime_max_num_store_entries_system_tx,
+                        ]
+                        .iter()
+                        .all(|limit| limit.is_none_or(|limit| max_entries <= limit))
+                }),
+            "deny_rule_update_max_entries_per_tx must be positive, at most {DENY_RULE_UPDATE_MAX_ENTRIES_PER_TX_CEILING}, and within the system transaction object limits"
+        );
 
         ret
     }
@@ -3841,6 +3867,51 @@ mod test {
                 .unwrap()
                 == &true
         );
+    }
+
+    /// A chunk limit above the executability ceiling would fail execution on
+    /// every validator at once, so the configuration is rejected at startup
+    /// rather than at the flip.
+    #[test]
+    #[should_panic(expected = "deny_rule_update_max_entries_per_tx must be positive")]
+    fn deny_rule_chunk_limit_above_the_ceiling_is_rejected() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_deny_rule_governance_for_testing(true);
+            config.set_deny_rule_governance_on_chain_for_testing(true);
+            config.set_deny_rule_removal_grace_round_floor_for_testing(0);
+            config.set_deny_rule_update_max_entries_per_tx_for_testing(2048 + 1);
+            config
+        });
+        let _ = ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    }
+
+    /// A zero chunk limit would make every delta unsplittable; the pure
+    /// chunking function clamps it, but the configuration is still invalid.
+    #[test]
+    #[should_panic(expected = "deny_rule_update_max_entries_per_tx must be positive")]
+    fn deny_rule_chunk_limit_of_zero_is_rejected() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_deny_rule_governance_for_testing(true);
+            config.set_deny_rule_governance_on_chain_for_testing(true);
+            config.set_deny_rule_removal_grace_round_floor_for_testing(0);
+            config.set_deny_rule_update_max_entries_per_tx_for_testing(0);
+            config
+        });
+        let _ = ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    }
+
+    /// The value the flip is expected to ship stays inside the limits.
+    #[test]
+    fn deny_rule_chunk_limit_within_system_tx_object_id_limit_is_accepted() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_deny_rule_governance_for_testing(true);
+            config.set_deny_rule_governance_on_chain_for_testing(true);
+            config.set_deny_rule_removal_grace_round_floor_for_testing(0);
+            config.set_deny_rule_update_max_entries_per_tx_for_testing(1000);
+            config
+        });
+        let config = ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+        assert_eq!(config.deny_rule_update_max_entries_per_tx(), 1000);
     }
 
     #[test]

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -245,6 +245,10 @@ impl AdapterInitConfig {
         if let Some(enable) = deny_rule_governance {
             protocol_config.set_deny_rule_governance_for_testing(enable);
             protocol_config.set_deny_rule_governance_on_chain_for_testing(enable);
+            if enable {
+                protocol_config.set_deny_rule_update_max_entries_per_tx_for_testing(1000);
+                protocol_config.set_deny_rule_removal_grace_round_floor_for_testing(0);
+            }
         }
         if custom_validator_account && !simulator {
             panic!("Can only set custom validator account in simulator mode");
@@ -2800,9 +2804,13 @@ async fn init_sim_executor(
     // epoch picks the flags up; `Simulacrum::advance_epoch` then carries the
     // config over to later epochs.
     let config_override = protocol_config.deny_rule_governance().then(|| {
-        ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        let max_entries = protocol_config.deny_rule_update_max_entries_per_tx();
+        let grace_floor = protocol_config.deny_rule_removal_grace_round_floor();
+        ProtocolConfig::apply_overrides_for_testing(move |_, mut config| {
             config.set_deny_rule_governance_for_testing(true);
             config.set_deny_rule_governance_on_chain_for_testing(true);
+            config.set_deny_rule_update_max_entries_per_tx_for_testing(max_entries);
+            config.set_deny_rule_removal_grace_round_floor_for_testing(grace_floor);
             config
         })
     });

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -1031,6 +1031,8 @@ mod tests {
             iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
                 config.set_deny_rule_governance_for_testing(true);
                 config.set_deny_rule_governance_on_chain_for_testing(true);
+                config.set_deny_rule_update_max_entries_per_tx_for_testing(1000);
+                config.set_deny_rule_removal_grace_round_floor_for_testing(0);
                 config
             });
         let sim = Simulacrum::new();
@@ -1068,6 +1070,8 @@ mod tests {
             iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
                 config.set_deny_rule_governance_for_testing(true);
                 config.set_deny_rule_governance_on_chain_for_testing(true);
+                config.set_deny_rule_update_max_entries_per_tx_for_testing(1000);
+                config.set_deny_rule_removal_grace_round_floor_for_testing(0);
                 config
             });
         let sim = Simulacrum::new();

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -1129,10 +1129,9 @@ mod tests {
         assert!(!walked.user_transaction_disabled);
     }
 
-    /// A chunk at the `deny_rule_update_max_entries_per_tx` ceiling asserted
-    /// in `ProtocolConfig::get_for_version` executes successfully — all
-    /// additions and all removals, which stress different limits (new object
-    /// ids and event size vs the store entries touched by re-linking).
+    /// A chunk at the `deny_rule_update_max_entries_per_tx` ceiling executes:
+    /// all additions and all removals, which stress different limits (new
+    /// object ids and event size vs the store entries touched by re-linking).
     #[test]
     fn deny_rule_update_executes_at_the_chunk_ceiling() {
         use std::collections::BTreeSet;

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -1129,6 +1129,85 @@ mod tests {
         assert!(!walked.user_transaction_disabled);
     }
 
+    /// A chunk at the `deny_rule_update_max_entries_per_tx` ceiling asserted
+    /// in `ProtocolConfig::get_for_version` executes successfully — all
+    /// additions and all removals, which stress different limits (new object
+    /// ids and event size vs the store entries touched by re-linking).
+    #[test]
+    fn deny_rule_update_executes_at_the_chunk_ceiling() {
+        use std::collections::BTreeSet;
+
+        use iota_sdk_types::TransactionDenyRulesUpdate;
+        use iota_types::transaction_deny_rules::{
+            get_transaction_deny_rules, get_transaction_deny_rules_obj_initial_shared_version,
+        };
+
+        const CEILING: u64 = 2048;
+
+        let _guard =
+            iota_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+                config.set_deny_rule_governance_for_testing(true);
+                config.set_deny_rule_governance_on_chain_for_testing(true);
+                config.set_deny_rule_update_max_entries_per_tx_for_testing(CEILING);
+                config.set_deny_rule_removal_grace_round_floor_for_testing(0);
+                config
+            });
+        let sim = Simulacrum::new();
+        sim.advance_epoch(true);
+
+        let initial_shared_version = sim
+            .with_store(|store| get_transaction_deny_rules_obj_initial_shared_version(store))
+            .unwrap()
+            .expect("object must exist after the create");
+
+        let addresses: BTreeSet<Address> = (0..CEILING)
+            .map(|i| {
+                let mut bytes = [0u8; 32];
+                bytes[..8].copy_from_slice(&i.to_be_bytes());
+                Address::new(bytes)
+            })
+            .collect();
+        let update = |round, added_addresses, removed_addresses| {
+            VerifiedTransaction::new_transaction_deny_rules_update(TransactionDenyRulesUpdate {
+                epoch: 1,
+                round,
+                added_addresses,
+                removed_addresses,
+                added_objects: BTreeSet::new(),
+                removed_objects: BTreeSet::new(),
+                added_packages: BTreeSet::new(),
+                removed_packages: BTreeSet::new(),
+                package_publish_disabled: false,
+                package_upgrade_disabled: false,
+                shared_object_disabled: false,
+                user_transaction_disabled: false,
+                receiving_objects_disabled: false,
+                move_authenticator_disabled: false,
+                deny_rules_obj_initial_shared_version: initial_shared_version,
+            })
+        };
+
+        let (_, error) = sim
+            .execute_transaction(update(0, addresses.clone(), BTreeSet::new()).into())
+            .unwrap();
+        assert!(error.is_none());
+        let walked = sim
+            .with_store(|store| get_transaction_deny_rules(store))
+            .unwrap()
+            .expect("object must exist");
+        assert_eq!(walked.denied_addresses.len(), CEILING as usize);
+
+        let (_, error) = sim
+            .execute_transaction(update(1, BTreeSet::new(), addresses).into())
+            .unwrap();
+        assert!(error.is_none());
+        let walked = sim
+            .with_store(|store| get_transaction_deny_rules(store))
+            .unwrap()
+            .expect("object must exist");
+        assert!(walked.denied_addresses.is_empty());
+    }
+
     #[test]
     fn simple_epoch() {
         let steps = 10;


### PR DESCRIPTION
# Description of change

Part of #12498, stacked on #12576. Every consensus commit brings the on-chain `TransactionDenyRules` object up to date with the stake-aggregated deny rule set, by injecting `TransactionDenyRulesUpdate` system transactions at the commit boundary.

- **Diff + chunking** (`compute_deny_rule_update_chunks`, pure function): the delta from the mirrored object state to the current proposal aggregate. Additions and switch activations apply immediately; entry removals and switch *deactivations* wait for the availability grace — announced stake ≥ 2f+1 and commit round ≥ `deny_rule_removal_grace_round_floor` — so nothing mirrored drops out at the start of an epoch just because announcements are still arriving. A delta larger than `deny_rule_update_max_entries_per_tx` splits into disjoint chunks of the sorted diff, each carrying the absolute switch states, so application is order-free and a re-sent chunk is a no-op.
- **Injection** (`add_deny_rule_update_transactions`): runs in `process_consensus_transactions` right before the prologue adder (the prologue stays first) and before shared-object version assignment, overlaying this commit's freshly recorded proposals onto the quarantined ones. Every scheduled chunk is registered as a **checkpoint root**: user transactions cannot take the deny-rules object as an input, so nothing else in a commit depends on an update, and one without a root of its own would execute on validators but never reach a checkpoint — leaving fullnodes (which follow checkpoints) with a permanently stale object. The mirror advances to the injected target only when every chunk was scheduled; an ignored chunk (epoch closing) leaves it behind so the next commit re-derives the same delta. Enforcement is re-derived from the advanced mirror in the same commit, so a removal that unlocks on a proposal-free commit stops being enforced as soon as the object drops it.
- **Mirror recovery**: the mirror is persisted in a `deny_rule_mirror` epoch-table row inside the same atomic batch as the commit's other results; the seed row is written at epoch-store construction whenever the object exists, so a mid-epoch restart resumes from the row (consensus replay re-advances the unflushed tail) and a row absent after commits have flushed is decidably a lost row — the store refuses to open rather than fall back to the stale boundary seed and derive updates its peers do not. At reconfiguration the state walked from the object for the next epoch is compared against the closing epoch's mirror. A mismatch is reported (`debug_fatal!`, sticky `deny_rule_mirror_divergence` metric) and reconfiguration **continues**: the next epoch re-seeds its mirror from the authoritative object, which is the repair — failing would pin the node to the diverged state and crash-loop it at the same boundary. An object the closing epoch had but the walk no longer finds is **fatal** instead: objects cannot be deleted, so the local store lost it, there is nothing to re-seed from, and a committee member continuing without it would stop injecting while its peers continue. Nodes that did not run consensus for the closing epoch — fullnodes, validators joining at the boundary — hold no mirror and are exempt from the comparison. So is an epoch this node's consensus did not close through the `RejectAllTx` reconfig transition. A validator that crosses the boundary by executing synced checkpoints legitimately lags the object until the re-seed. The mirror deliberately advances at scheduling time, the only commit-deterministic point — execution completion is not consensus-deterministic and never feeds back into diffing; a (by construction excluded) execution failure therefore surfaces at the boundary and the next epoch deterministically re-derives the unapplied delta.
- **Protocol knobs**: `deny_rule_update_max_entries_per_tx` and `deny_rule_removal_grace_round_floor`, unset at every version (config snapshots unchanged, values land with the #12507 flip), with a startup assert coupling them to `deny_rule_governance_on_chain`. The chunk limit is additionally asserted positive, at most a constant ceiling of 2048, and within the system-transaction object limits: every entry is a `LinkedTable` child object, and the tightest execution bounds sit well below the object-id limits — the update event carries every entry (~32 bytes each) against `max_event_emit_size` (250 KiB ⇒ ~8000 entries), and removals re-link nodes against `object_runtime_max_num_store_entries_system_tx` (16000 ⇒ ~5000 removals). A chunk the config accepts but execution rejects would fail on every validator at once and leave the object permanently behind the mirror.
- **Metrics**: `deny_rule_updates_injected`, `deny_rule_update_transactions_injected`, `deny_rule_removals_unlocked`, `deny_rule_mirror_divergence`.
- **GraphQL**: no schema change — the `TransactionDenyRulesUpdateTransaction` output type exists since #12540, and `TransactionBlockKindInput` has no per-kind variant for any injected system transaction, so the update is filterable via the existing `SystemTx` value (matching the gRPC filter's `System` mapping).

### Links to any relevant issues

Fixes #12506.

### How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New tests: `deny_rule_update_chunks_respect_removal_grace` (decision table: no-change / additions during grace / removals and switch-offs held until unlock), `deny_rule_update_chunks_split_deterministically` (disjoint chunks reassemble to the full diff, all within the limit, deterministic, zero-limit clamped), `commit_injects_deny_rule_updates_and_advances_mirror` (the adder end to end: no object → no-op; inject → persist → quiesce; withdrawal → removal injected with mirror and enforcement dropping the entry in the same commit; injected updates registered as roots), `every_injected_deny_rule_chunk_becomes_a_checkpoint_root` (a split delta roots each chunk), `restart_recovers_the_deny_rule_mirror` (real epoch-store reopen resumes from the persisted row and feeds it back into enforcement), the boundary-guard tests `deny_rule_mirror_guard_reports_divergence` / `deny_rule_mirror_guard_fails_on_a_missing_object` / `deny_rule_mirror_guard_exempts_nodes_outside_the_committee` / `deny_rule_mirror_guard_exempts_an_epoch_consensus_did_not_close`, `lost_mirror_row_after_flushed_commits_fails_the_reopen` (the seed-row invariant makes an absent row decidable), protocol-config ceiling tests (over-ceiling and zero rejected, 1000 accepted), and `deny_rule_update_executes_at_the_chunk_ceiling` (simulacrum executes all-additions and all-removals chunks of 2048 entries through the real execution path). Full-pipeline injection through the consensus handler, checkpoints, and reconfiguration is covered by the #12577 simtest battery (PR #12635, stacked above). Existing deny-governance batteries, protocol-config snapshots, clippy, and `cargo +nightly fmt` pass.

