### PR TITLE
upstream(core): Pin system package lookups to voted versions when constructing ChangeEpochTx

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5106,35 +5106,60 @@ impl AuthorityState {
     ///   authority can satisfy that upgrade, in which case the contents are
     ///   included in the output.
     ///
-    /// If the current version of the framework can't be loaded, the binary does
+    /// If a needed version of the framework can't be loaded, the binary does
     /// not contain the bytes for that framework ID, or the resulting
     /// package fails the digest check, `None` is returned indicating that
     /// this authority cannot run the upgrade that the network voted on.
+    ///
+    /// All object lookups are pinned to the versions in `system_packages`
+    /// instead of using the latest versions, so that the result is
+    /// deterministic even if the change epoch transaction that performs the
+    /// upgrade has already been executed locally (e.g. via state sync). In
+    /// that case the reconstructed change epoch transaction is byte-identical
+    /// to the executed one, and the caller detects it as already executed.
     async fn get_system_package_bytes(
         &self,
         system_packages: Vec<ObjectReference>,
         binary_config: &BinaryConfig,
     ) -> Option<Vec<SystemPackage>> {
-        let ids: Vec<_> = system_packages
-            .iter()
-            .map(|object_ref| object_ref.object_id)
-            .collect();
-        let objects = self.get_objects(&ids);
+        let object_store = self.get_object_cache_reader();
 
         let mut res = Vec::with_capacity(system_packages.len());
-        for (system_package_ref, object) in system_packages.into_iter().zip(objects.iter()) {
-            let prev_transaction = match object {
-                Some(cur_object) if cur_object.object_ref() == system_package_ref => {
-                    // Skip this one because it doesn't need to be upgraded.
-                    info!(
-                        "Framework {} does not need updating",
+        for system_package_ref in system_packages {
+            if object_store
+                .get_object_by_key(&system_package_ref.object_id, system_package_ref.version)
+                .is_some_and(|object| object.object_ref() == system_package_ref)
+            {
+                // Skip this one because it doesn't need to be upgraded.
+                info!(
+                    "Framework {} does not need updating",
+                    system_package_ref.object_id
+                );
+                continue;
+            }
+
+            // The digest in `system_package_ref` commits to a package built on top of the
+            // predecessor version's `previous_transaction` (see `compare_system_package`),
+            // so it must be re-derived from that version. A ref at
+            // `OBJECT_START_VERSION` is a freshly created package with no predecessor.
+            let prev_transaction = if system_package_ref.version == OBJECT_START_VERSION {
+                TransactionDigest::GENESIS_MARKER
+            } else {
+                let prev_version = system_package_ref
+                    .version
+                    .previous()
+                    .expect("version is greater than OBJECT_START_VERSION");
+                let Some(prev_object) =
+                    object_store.get_object_by_key(&system_package_ref.object_id, prev_version)
+                else {
+                    error!(
+                        "Framework {} not available locally at version {prev_version:?}, cannot \
+                         derive upgrade to {system_package_ref:?}",
                         system_package_ref.object_id
                     );
-                    continue;
-                }
-
-                Some(cur_object) => cur_object.previous_transaction,
-                None => TransactionDigest::GENESIS_MARKER,
+                    return None;
+                };
+                prev_object.previous_transaction
             };
 
             #[cfg(msim)]


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.78.0, latest)
- Port commit:
  - [MystenLabs/sui@3bd67c2](https://github.com/MystenLabs/sui/commit/3bd67c24ac28ac753a57c3e7e7abaa5dd7a68642)
- Description:

Fix race condition in building system packages by using a fixed input version.

If the change epoch tx was already executed (e.g. via state sync), deriving the voted package digest from the latest package version fails, since its `previous_transaction` now points at the change epoch tx. Pinning lookups to the voted versions makes the rebuilt tx byte-identical, so the existing already-executed check handles it instead of a spurious debug_fatal.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes