### PR TITLE
upstream: [execution] Port sui-adapter basic package cache

### DIFF
--- a/iota-execution/latest/iota-adapter/src/data_store/cached_data_store.rs
+++ b/iota-execution/latest/iota-adapter/src/data_store/cached_data_store.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+
+use iota_sdk_types::{ObjectId, move_package::MovePackage};
+use iota_types::error::IotaResult;
+
+use crate::data_store::PackageStore;
+
+pub struct CachedPackageStore<'state> {
+    pub package_store: Box<dyn PackageStore + 'state>,
+    pub package_cache: RefCell<BTreeMap<ObjectId, Option<Rc<MovePackage>>>>,
+    pub max_cache_size: usize,
+}
+
+impl<'state> CachedPackageStore<'state> {
+    pub const DEFAULT_MAX_CACHE_SIZE: usize = 200;
+    pub fn new(package_store: Box<dyn PackageStore + 'state>) -> Self {
+        Self {
+            package_store,
+            package_cache: RefCell::new(BTreeMap::new()),
+            max_cache_size: Self::DEFAULT_MAX_CACHE_SIZE,
+        }
+    }
+
+    pub fn get_package(&self, id: &ObjectId) -> IotaResult<Option<Rc<MovePackage>>> {
+        if let Some(pkg) = self.package_cache.borrow().get(id).cloned() {
+            return Ok(pkg);
+        }
+
+        if self.package_cache.borrow().len() >= self.max_cache_size {
+            self.package_cache.borrow_mut().clear();
+        }
+
+        let pkg = self.package_store.get_package(id)?;
+        self.package_cache.borrow_mut().insert(*id, pkg.clone());
+        Ok(pkg)
+    }
+}
+
+impl PackageStore for CachedPackageStore<'_> {
+    fn get_package(&self, id: &ObjectId) -> IotaResult<Option<Rc<MovePackage>>> {
+        self.get_package(id)
+    }
+}

--- a/iota-execution/latest/iota-adapter/src/data_store/iota_data_store.rs
+++ b/iota-execution/latest/iota-adapter/src/data_store/iota_data_store.rs
@@ -2,8 +2,10 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::rc::Rc;
+
 use iota_sdk_types::{ObjectId, move_package::MovePackage};
-use iota_types::iota_sdk_types_conversions::identifier_core_to_sdk;
+use iota_types::{error::IotaResult, iota_sdk_types_conversions::identifier_core_to_sdk};
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
@@ -11,7 +13,7 @@ use move_core_types::{
 };
 use move_vm_types::data_store::DataStore;
 
-use crate::programmable_transactions::linkage_view::LinkageView;
+use crate::data_store::{PackageStore, linkage_view::LinkageView};
 
 // Implementation of the `DataStore` trait for the Move VM.
 // When used during execution it may have a list of new packages that have
@@ -105,5 +107,16 @@ impl DataStore for IotaDataStore<'_, '_> {
         // we cannot panic here because during execution and publishing this is
         // currently called from the publish flow in the Move runtime
         Ok(())
+    }
+}
+
+impl PackageStore for IotaDataStore<'_, '_> {
+    fn get_package(&self, id: &ObjectId) -> IotaResult<Option<Rc<MovePackage>>> {
+        for package in self.new_packages {
+            if package.id() == *id {
+                return Ok(Some(Rc::new(package.clone())));
+            }
+        }
+        self.linkage_view.get_package(id)
     }
 }

--- a/iota-execution/latest/iota-adapter/src/data_store/linkage_view.rs
+++ b/iota-execution/latest/iota-adapter/src/data_store/linkage_view.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
+// Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet, hash_map::Entry},
+    rc::Rc,
     str::FromStr,
 };
 
@@ -14,8 +15,8 @@ use iota_sdk_types::{
 };
 use iota_types::{
     error::{ExecutionError, IotaError, IotaResult},
+    iota_sdk_types_conversions::identifier_core_to_sdk,
     move_package::MovePackageExt,
-    storage::{BackingPackageStore, PackageObject, get_module},
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -24,15 +25,16 @@ use move_core_types::{
     resolver::{LinkageResolver, ModuleResolver},
 };
 
-use crate::execution_value::IotaResolver;
+use crate::data_store::PackageStore;
 
 /// Exposes module and linkage resolution to the Move runtime.  The first by
 /// delegating to `resolver` and the second via linkage information that is
 /// loaded from a move package.
 pub struct LinkageView<'state> {
     /// Interface to resolve packages, modules and resources directly from the
-    /// store.
-    resolver: Box<dyn IotaResolver + 'state>,
+    /// store, and possibly from other sources (e.g., packages just
+    /// published).
+    resolver: Box<dyn PackageStore + 'state>,
     /// Information used to change module and type identities during linkage.
     linkage_info: Option<LinkageInfo>,
     /// Cache containing the type origin information from every package that has
@@ -61,11 +63,11 @@ pub struct LinkageInfo {
 pub struct SavedLinkage(LinkageInfo);
 
 impl<'state> LinkageView<'state> {
-    /// Creates a new `LinkageView` instance with the provided `IotaResolver`.
+    /// Creates a new `LinkageView` instance with the provided `PackageStore`.
     /// This instance is responsible for resolving and linking types across
     /// different contexts. It initializes internal caches for type origins
     /// and past contexts.
-    pub fn new(resolver: Box<dyn IotaResolver + 'state>) -> Self {
+    pub fn new(resolver: Box<dyn PackageStore + 'state>) -> Self {
         Self {
             resolver,
             linkage_info: None,
@@ -273,7 +275,7 @@ impl<'state> LinkageView<'state> {
         }
 
         let storage_id = ObjectId::new(self.relocate(runtime_id)?.address().into_bytes());
-        let Some(package) = self.resolver.get_package_object(&storage_id)? else {
+        let Some(package) = self.resolver.get_package(&storage_id)? else {
             invariant_violation!("Missing dependent package in store: {storage_id}",)
         };
 
@@ -281,7 +283,7 @@ impl<'state> LinkageView<'state> {
             module_name,
             datatype_name,
             package,
-        } in package.move_package().type_origin_table()
+        } in package.type_origin_table()
         {
             if module_name == runtime_id.name().as_str() && datatype_name == struct_.as_str() {
                 self.add_type_origin(runtime_id.clone(), struct_.to_owned(), *package)?;
@@ -294,7 +296,7 @@ impl<'state> LinkageView<'state> {
 
         invariant_violation!(
             "{runtime_id}::{struct_} not found in type origin table in {storage_id} (v{})",
-            package.move_package().version(),
+            package.version(),
         )
     }
 }
@@ -329,18 +331,23 @@ impl LinkageResolver for LinkageView<'_> {
     }
 }
 
-// Remaining implementations delegated to state_view ************************
-
 impl ModuleResolver for LinkageView<'_> {
     type Error = IotaError;
 
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        get_module(self, id)
+        Ok(self
+            .get_package(&ObjectId::new(id.address().into_bytes()))?
+            .and_then(|package| {
+                package
+                    .serialized_module_map()
+                    .get(&identifier_core_to_sdk(id.name()))
+                    .cloned()
+            }))
     }
 }
 
-impl BackingPackageStore for LinkageView<'_> {
-    fn get_package_object(&self, package_id: &ObjectId) -> IotaResult<Option<PackageObject>> {
-        self.resolver.get_package_object(package_id)
+impl PackageStore for LinkageView<'_> {
+    fn get_package(&self, package_id: &ObjectId) -> IotaResult<Option<Rc<MovePackage>>> {
+        self.resolver.get_package(package_id)
     }
 }

--- a/iota-execution/latest/iota-adapter/src/data_store/mod.rs
+++ b/iota-execution/latest/iota-adapter/src/data_store/mod.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod cached_data_store;
+pub mod iota_data_store;
+pub mod linkage_view;
+
+use std::rc::Rc;
+
+use iota_sdk_types::{ObjectId, move_package::MovePackage};
+use iota_types::{error::IotaResult, storage::BackingPackageStore};
+
+// A unifying trait that allows us to load move packages that may not be objects
+// just yet (e.g., if they were published in the current transaction). Note that
+// this needs to load `MovePackage`s and not `MovePackageObject`s.
+pub trait PackageStore {
+    fn get_package(&self, id: &ObjectId) -> IotaResult<Option<Rc<MovePackage>>>;
+}
+
+impl<T: BackingPackageStore> PackageStore for T {
+    fn get_package(&self, id: &ObjectId) -> IotaResult<Option<Rc<MovePackage>>> {
+        Ok(self
+            .get_package_object(id)?
+            .map(|x| Rc::new(x.move_package().clone())))
+    }
+}

--- a/iota-execution/latest/iota-adapter/src/lib.rs
+++ b/iota-execution/latest/iota-adapter/src/lib.rs
@@ -6,6 +6,7 @@
 extern crate iota_types;
 
 pub mod adapter;
+pub mod data_store;
 pub mod error;
 pub mod execution_engine;
 pub mod execution_mode;

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -35,7 +35,7 @@ mod checked {
         metrics::LimitsMetrics,
         move_package::{MovePackageExt, derive_package_metadata_id},
         object::{MoveStructExt, Object, ObjectInner},
-        storage::{BackingPackageStore, DenyListResult, PackageObject},
+        storage::DenyListResult,
         transaction::CallArg,
     };
     use move_binary_format::{
@@ -58,6 +58,10 @@ mod checked {
 
     use crate::{
         adapter::new_native_extensions,
+        data_store::{
+            PackageStore, cached_data_store::CachedPackageStore, iota_data_store::IotaDataStore,
+            linkage_view::LinkageView,
+        },
         error::convert_vm_error,
         execution_mode::ExecutionMode,
         execution_value::{
@@ -66,7 +70,6 @@ mod checked {
         },
         gas_charger::GasCharger,
         gas_meter::IotaGasMeter,
-        programmable_transactions::{data_store::IotaDataStore, linkage_view::LinkageView},
         type_resolver::TypeTagResolver,
     };
 
@@ -158,7 +161,9 @@ mod checked {
         where
             'a: 'state,
         {
-            let mut linkage_view = LinkageView::new(Box::new(state_view.as_iota_resolver()));
+            let mut linkage_view = LinkageView::new(Box::new(CachedPackageStore::new(Box::new(
+                state_view.as_iota_resolver(),
+            ))));
             let mut input_object_map = BTreeMap::new();
             let inputs = inputs
                 .into_iter()
@@ -318,7 +323,7 @@ mod checked {
             let package = package_for_linkage(&self.linkage_view, package_id)
                 .map_err(|e| self.convert_vm_error(e))?;
 
-            self.linkage_view.set_linkage(package.move_package())
+            self.linkage_view.set_linkage(&package)
         }
 
         /// Load a type using the context's current session.
@@ -1260,13 +1265,13 @@ mod checked {
     /// context.  Produces an error if the object at that ID does not exist,
     /// or is not a package.
     fn package_for_linkage(
-        linkage_view: &LinkageView,
+        package_store: &dyn PackageStore,
         package_id: ObjectId,
-    ) -> VMResult<PackageObject> {
+    ) -> VMResult<Rc<MovePackage>> {
         use move_binary_format::errors::PartialVMError;
         use move_core_types::vm_status::StatusCode;
 
-        match linkage_view.get_package_object(&package_id) {
+        match package_store.get_package(&package_id) {
             Ok(Some(package)) => Ok(package),
             Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
                 .with_message(format!("Cannot find link context {package_id} in store"))
@@ -1300,13 +1305,11 @@ mod checked {
 
         // Set the defining package as the link context while loading the
         // struct
-        let original_address = linkage_view
-            .set_linkage(package.move_package())
-            .map_err(|e| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(e.to_string())
-                    .finish(Location::Undefined)
-            })?;
+        let original_address = linkage_view.set_linkage(&package).map_err(|e| {
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message(e.to_string())
+                .finish(Location::Undefined)
+        })?;
 
         let runtime_id = ModuleId::new(
             original_address,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -73,6 +73,7 @@ mod checked {
 
     use crate::{
         adapter::substitute_package_id,
+        data_store::iota_data_store::IotaDataStore,
         execution_mode::ExecutionMode,
         execution_value::{
             CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
@@ -81,7 +82,6 @@ mod checked {
         gas_charger::GasCharger,
         programmable_transactions::{
             context::*,
-            data_store::IotaDataStore,
             package_metadata::*,
             trace_utils::{
                 trace_move_call_end, trace_move_call_start, trace_ptb_summary, trace_split_coins,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/mod.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/mod.rs
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod context;
-pub mod data_store;
 pub mod execution;
-pub mod linkage_view;
 pub mod package_metadata;
 pub mod trace_utils;

--- a/iota-execution/latest/iota-adapter/src/type_layout_resolver.rs
+++ b/iota-execution/latest/iota-adapter/src/type_layout_resolver.rs
@@ -12,7 +12,10 @@ use iota_types::{
 use move_core_types::annotated_value as A;
 use move_vm_runtime::move_vm::MoveVM;
 
-use crate::programmable_transactions::{context::load_type_from_struct, linkage_view::LinkageView};
+use crate::{
+    data_store::{cached_data_store::CachedPackageStore, linkage_view::LinkageView},
+    programmable_transactions::context::load_type_from_struct,
+};
 
 /// Retrieve a `MoveStructLayout` from a `Type`.
 /// Invocation into the `Session` to leverage the `LinkageView` implementation
@@ -28,7 +31,9 @@ struct NullIotaResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
-        let linkage_view = LinkageView::new(Box::new(NullIotaResolver(state_view)));
+        let linkage_view = LinkageView::new(Box::new(CachedPackageStore::new(Box::new(
+            NullIotaResolver(state_view),
+        ))));
         Self { vm, linkage_view }
     }
 }


### PR DESCRIPTION
# Description of change

Adds a per-transaction cache for `MovePackage`s in the adapter, bounded at 200 packages (dropped wholesale when full). Reorganizes the data-store code into its own `data_store/` directory and introduces the `PackageStore` trait that `LinkageView`, `IotaDataStore` and the new `CachedPackageStore` all implement.

- `LinkageView` now resolves through `PackageStore` (`Rc<MovePackage>`) instead of `BackingPackageStore` (`PackageObject`).
- `programmable_transactions/{data_store,linkage_view}.rs` move to `data_store/{iota_data_store,linkage_view}.rs`.
- No protocol or consensus behavior change — packages resolve identically, just cached.

**Stacked on #12529** — the `IotaDataStore` extraction it ports is a prerequisite. Review that one first.

## Upstream commits

| Commit | Upstream PR | Description |
|---|---|---|
| `4a38dd7f73ef4677a030074be6c0bd8a24a14181` | #22099 | [sui-adapter] Add basic package cache |

### Skipped

| Commit | Upstream PR | Reason |
|---|---|---|
| `5357e92b0cde849f67684de41cae695499db61a0` | #22206 | Already ported by @jkrvivian in #11677 (`789c8dce30`), present in the target branch |

### Downstream adaptations

| Area | Upstream | Here | Why |
|---|---|---|---|
| Package/ID types | `iota_types::move_package::MovePackage`, `ObjectID` | `iota_sdk_types::{move_package::MovePackage, ObjectId}` + `MovePackageExt` | IOTA moved these types to `iota-rust-sdk` |
| `LinkageView::get_module` | `serialized_module_map().get(name.as_str())` | `.get(&identifier_core_to_sdk(id.name()))` | SDK module map is keyed by the SDK `Identifier` |
| `IotaDataStore::get_module` | iterates all new packages | keeps IOTA's `package.id` guard + `identifier_core_to_sdk` | pre-existing IOTA behavior, carried forward unchanged |
| `package_for_linkage` | renamed to `get_package`, resolves via `&data_store` | name and error messages kept, still resolves via `linkage_view` | the rename and the data-store switch belong to #22092, which is wont-merge |

`PackageStore` itself comes from upstream #22092 (wont-merge), but `4a38dd7f`'s new `data_store/mod.rs` carries the trait definition, so nothing from that commit was pulled in beyond the `package_for_linkage` signature the conversion forces.

Upstream note: #22099 was reverted (#22154) and relanded as #22178. The reland additionally wraps `LinkageInfo` in a `RefCell` and touches `static_programmable_transactions`, which belongs to the static-PTB line (#10831) and doesn't exist here — so this ports `4a38dd7f`, whose `LinkageView` shape matches ours.

## Links to any relevant issues

Closes #10833

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo check --all-targets` on `iota-adapter-latest`/`iota-core`/`iota-node`, `cargo ci-clippy`, `cargo machete`, `cargo ci-license`, `cargo +nightly fmt --all` — all clean. `iota-adapter-transactional-tests`: 323/323 pass (covers publish, upgrade, linkage, transitive linkage, type-origin resolution — the paths the cache sits on). `iota-core --lib`: 739 pass, 2 skipped.

No new tests added: the commit is a caching layer plus a module move with no new behavior, and the existing linkage/upgrade suites already exercise every path through `PackageStore`.
