### PR TITLE
upstream(iota-execution): port execution timings

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1893,7 +1893,7 @@ impl AuthorityState {
         let move_authenticators = transaction.move_authenticators();
 
         #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
-        let (inner_temp_store, _, mut effects, execution_error_opt) = if move_authenticators
+        let (inner_temp_store, _, mut effects, _, execution_error_opt) = if move_authenticators
             .is_empty()
         {
             // No Move authentication required, proceed to execute the transaction directly.
@@ -2252,7 +2252,7 @@ impl AuthorityState {
             .expect("Creating an executor should not fail here");
 
         let expensive_checks = false;
-        let (inner_temp_store, _, effects, execution_error) = executor
+        let (inner_temp_store, _, effects, _timings, execution_error) = executor
             .execute_transaction_to_effects(
                 self.get_backing_store().as_ref(),
                 protocol_config,

--- a/crates/iota-genesis-common/src/lib.rs
+++ b/crates/iota-genesis-common/src/lib.rs
@@ -78,22 +78,23 @@ pub fn execute_genesis_transaction(
     let (kind, signer, mut gas_data) = transaction.execution_parts();
     gas_data.objects = vec![];
     let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
-    let (inner_temp_store, _, effects, _execution_error) = executor.execute_transaction_to_effects(
-        &InMemoryStorage::new(Vec::new()),
-        protocol_config,
-        metrics,
-        expensive_checks,
-        &certificate_deny_set,
-        &epoch_data.epoch_id(),
-        epoch_data.epoch_start_timestamp(),
-        input_objects,
-        gas_data,
-        IotaGasStatus::new_unmetered(),
-        kind,
-        signer,
-        genesis_digest,
-        &mut None,
-    );
+    let (inner_temp_store, _, effects, _timings, _execution_error) = executor
+        .execute_transaction_to_effects(
+            &InMemoryStorage::new(Vec::new()),
+            protocol_config,
+            metrics,
+            expensive_checks,
+            &certificate_deny_set,
+            &epoch_data.epoch_id(),
+            epoch_data.epoch_start_timestamp(),
+            input_objects,
+            gas_data,
+            IotaGasStatus::new_unmetered(),
+            kind,
+            signer,
+            genesis_digest,
+            &mut None,
+        );
     assert!(inner_temp_store.input_objects.is_empty());
     assert!(inner_temp_store.mutable_inputs.is_empty());
     assert!(effects.mutated().is_empty());

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -788,7 +788,8 @@ impl LocalExec {
 
         let move_authenticators = tx_info.sender_signed_data.move_authenticators();
 
-        let (inner_store, gas_status, effects, result) = if move_authenticators.is_empty() {
+        let (inner_store, gas_status, effects, _timings, result) = if move_authenticators.is_empty()
+        {
             // Standard path: no MoveAuthenticator
             executor.execute_transaction_to_effects(
                 &self,
@@ -1047,7 +1048,7 @@ impl LocalExec {
 
         let move_authenticators = sender_signed_data.move_authenticators();
 
-        let (_, _, effects, exec_res) = if move_authenticators.is_empty() {
+        let (_, _, effects, _timings, exec_res) = if move_authenticators.is_empty() {
             // Standard path: no MoveAuthenticator
             let input_objects = store
                 .read_input_objects_for_transaction(&Transaction::new(sender_signed_data.clone()));

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -222,7 +222,7 @@ impl SingleValidator {
         )
         .unwrap();
         let (kind, signer, gas_data) = executable.transaction().execution_parts();
-        let (inner_temp_store, _, effects, _) =
+        let (inner_temp_store, _, effects, _timings, _) =
             self.epoch_store.executor().execute_transaction_to_effects(
                 &store,
                 self.epoch_store.protocol_config(),

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -651,7 +651,7 @@ mod test {
         gas_data.objects = vec![];
         let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
 
-        let (_inner_temp_store, _, effects, _execution_error) = executor
+        let (_inner_temp_store, _, effects, _timings, _execution_error) = executor
             .execute_transaction_to_effects(
                 &InMemoryStorage::new(Vec::new()),
                 &protocol_config,

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    time::Duration,
+};
 
 use iota_sdk_types::{
     Argument, Event, ObjectData, ObjectDigest, ObjectId, ObjectReference, Owner, TransactionDigest,
@@ -168,6 +171,12 @@ impl ExecutionResultsV1 {
         }
     }
 }
+
+pub enum ExecutionTiming {
+    Success(Duration),
+    Abort(Duration),
+}
+pub type ResultWithTimings<R, E> = Result<(R, Vec<ExecutionTiming>), (E, Vec<ExecutionTiming>)>;
 
 /// If a transaction digest shows up in this list, when executing such
 /// transaction, we will always return `ExecutionError::CertificateDenied`

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -548,6 +548,7 @@ pub mod advance_epoch_result_injection {
     use crate::{
         committee::EpochId,
         error::{ExecutionError, ExecutionErrorKind},
+        execution::ResultWithTimings,
     };
 
     thread_local! {
@@ -565,14 +566,14 @@ pub mod advance_epoch_result_injection {
     /// for testing. If the override is set, the result will be an execution
     /// error, otherwise the original result will be returned.
     pub fn maybe_modify_result(
-        result: Result<(), ExecutionError>,
+        result: ResultWithTimings<(), ExecutionError>,
         current_epoch: EpochId,
-    ) -> Result<(), ExecutionError> {
+    ) -> ResultWithTimings<(), ExecutionError> {
         if let Some((start, end)) = OVERRIDE.with(|o| *o.borrow()) {
             if current_epoch >= start && current_epoch < end {
-                return Err::<(), ExecutionError>(ExecutionError::new(
-                    ExecutionErrorKind::FunctionNotFound,
-                    None,
+                return Err((
+                    ExecutionError::new(ExecutionErrorKind::FunctionNotFound, None),
+                    vec![],
                 ));
             }
         }

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -375,7 +375,7 @@ pub(super) fn execute_with_move_authenticators(
         })
         .collect::<Vec<_>>();
 
-    let (inner_temp_store, _, effects, execution_result) = env
+    let (inner_temp_store, _, effects, _timings, execution_result) = env
         .executor
         .authenticate_then_execute_transaction_to_effects(
             store,

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -144,22 +144,24 @@ impl EpochState {
 
         let transaction = transaction.data().transaction();
         let (kind, signer, gas_data) = transaction.execution_parts();
-        Ok(self.executor.execute_transaction_to_effects(
-            store.backing_store(),
-            &self.protocol_config,
-            self.limits_metrics.clone(),
-            false,           // enable_expensive_checks
-            &HashSet::new(), // certificate_deny_set
-            &self.epoch_start_state.epoch(),
-            self.epoch_start_state.epoch_start_timestamp_ms(),
-            checked_input_objects,
-            gas_data,
-            gas_status,
-            kind,
-            signer,
-            tx_digest,
-            &mut None,
-        ))
+        let (inner_temp_store, gas_status, effects, _timings, result) =
+            self.executor.execute_transaction_to_effects(
+                store.backing_store(),
+                &self.protocol_config,
+                self.limits_metrics.clone(),
+                false,           // enable_expensive_checks
+                &HashSet::new(), // certificate_deny_set
+                &self.epoch_start_state.epoch(),
+                self.epoch_start_state.epoch_start_timestamp_ms(),
+                checked_input_objects,
+                gas_data,
+                gas_status,
+                kind,
+                signer,
+                tx_digest,
+                &mut None,
+            );
+        Ok((inner_temp_store, gas_status, effects, result))
     }
 
     /// Simulate a transaction without committing changes.

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -37,7 +37,10 @@ mod checked {
         committee::EpochId,
         effects::TransactionEffects,
         error::{ExecutionError, ExecutionErrorKind},
-        execution::{ExecutionResults, ExecutionResultsV1, SharedInput, is_certificate_denied},
+        execution::{
+            ExecutionResults, ExecutionResultsV1, ExecutionTiming, ResultWithTimings, SharedInput,
+            is_certificate_denied,
+        },
         execution_config_utils::to_binary_config,
         gas::{IotaGasStatus, IotaGasStatusAPI},
         gas_coin::GAS,
@@ -98,6 +101,7 @@ mod checked {
         InnerTemporaryStore,
         IotaGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         let input_objects = input_objects.into_inner();
@@ -199,12 +203,13 @@ mod checked {
         InnerTemporaryStore,
         IotaGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         let is_epoch_change = transaction_kind.is_end_of_epoch();
         let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
 
-        let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
+        let (gas_cost_summary, execution_result, timings) = execute_transaction::<Mode>(
             &mut temporary_store,
             transaction_kind,
             &mut gas_charger,
@@ -267,6 +272,7 @@ mod checked {
             inner,
             gas_charger.into_gas_status(),
             effects,
+            timings,
             execution_result,
         )
     }
@@ -322,6 +328,7 @@ mod checked {
         InnerTemporaryStore,
         IotaGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         // Preparation
@@ -734,7 +741,8 @@ mod checked {
                 authenticator_move_call,
                 trace_builder_opt,
             )
-            .and_then(|ok_result| {
+            .map_err(|(e, _)| e)
+            .and_then(|(ok_result, _timings)| {
                 temporary_store.check_move_authenticator_results_consistency()?;
                 Ok(ok_result)
             })
@@ -771,7 +779,8 @@ mod checked {
             &mut gas_charger,
             pt,
             &mut None,
-        )?;
+        )
+        .map_err(|(e, _)| e)?;
         temporary_store.update_object_version_and_prev_tx();
         Ok(temporary_store.into_inner())
     }
@@ -807,6 +816,7 @@ mod checked {
     ) -> (
         GasCostSummary,
         Result<Mode::ExecutionResults, ExecutionError>,
+        Vec<ExecutionTiming>,
     ) {
         gas_charger.smash_gas(temporary_store);
 
@@ -828,53 +838,65 @@ mod checked {
         // fails we must still ensure an effect is committed and all objects
         // versions incremented
         let result = gas_charger.charge_input_objects(temporary_store);
-        let mut result = result.and_then(|()| {
-            run_inputs_checks(
-                protocol_config,
-                deny_cert,
-                contains_deleted_input,
-                cancelled_objects,
-            )?;
+        let result: ResultWithTimings<Mode::ExecutionResults, ExecutionError> =
+            result.map_err(|e| (e, vec![])).and_then(
+                |()| -> ResultWithTimings<Mode::ExecutionResults, ExecutionError> {
+                    run_inputs_checks(
+                        protocol_config,
+                        deny_cert,
+                        contains_deleted_input,
+                        cancelled_objects,
+                    )
+                    .map_err(|e| (e, vec![]))?;
 
-            // If the pre-execution succeeded, proceed with the main execution loop
-            // else propagate the pre-execution error
-            let mut execution_result = pre_execution_result_opt.unwrap_or(Ok(())).and_then(|_| {
-                execution_loop::<Mode>(
-                    temporary_store,
-                    transaction_kind,
-                    tx_ctx,
-                    move_vm,
-                    gas_charger,
-                    protocol_config,
-                    metrics.clone(),
-                    trace_builder_opt,
-                )
-            });
+                    // If the pre-execution succeeded, proceed with the main execution loop
+                    // else propagate the pre-execution error
+                    let mut execution_result = pre_execution_result_opt
+                        .unwrap_or(Ok(()))
+                        .map_err(|e| (e, vec![]))
+                        .and_then(|_| {
+                            execution_loop::<Mode>(
+                                temporary_store,
+                                transaction_kind,
+                                tx_ctx,
+                                move_vm,
+                                gas_charger,
+                                protocol_config,
+                                metrics.clone(),
+                                trace_builder_opt,
+                            )
+                        });
 
-            let meter_check = check_meter_limit(
-                temporary_store,
-                gas_charger,
-                protocol_config,
-                metrics.clone(),
+                    let meter_check = check_meter_limit(
+                        temporary_store,
+                        gas_charger,
+                        protocol_config,
+                        metrics.clone(),
+                    );
+                    if let Err(e) = meter_check {
+                        execution_result = Err((e, vec![]));
+                    }
+
+                    if execution_result.is_ok() {
+                        let gas_check = check_written_objects_limit(
+                            temporary_store,
+                            gas_charger,
+                            protocol_config,
+                            metrics,
+                        );
+                        if let Err(e) = gas_check {
+                            execution_result = Err((e, vec![]));
+                        }
+                    }
+
+                    execution_result
+                },
             );
-            if let Err(e) = meter_check {
-                execution_result = Err(e);
-            }
 
-            if execution_result.is_ok() {
-                let gas_check = check_written_objects_limit(
-                    temporary_store,
-                    gas_charger,
-                    protocol_config,
-                    metrics,
-                );
-                if let Err(e) = gas_check {
-                    execution_result = Err(e);
-                }
-            }
-
-            execution_result
-        });
+        let (mut result, timings) = match result {
+            Ok((r, t)) => (Ok(r), t),
+            Err((e, t)) => (Err(e), t),
+        };
 
         let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
         // For advance epoch transaction, we need to provide epoch rewards and rebates
@@ -901,7 +923,7 @@ mod checked {
             result = Err(e);
         }
 
-        (cost_summary, result)
+        (cost_summary, result, timings)
     }
 
     /// When enabled by the protocol config, report a failure of the Move
@@ -1216,7 +1238,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<Mode::ExecutionResults, ExecutionError> {
+    ) -> ResultWithTimings<Mode::ExecutionResults, ExecutionError> {
         let result = match transaction_kind {
             TransactionKind::Genesis(GenesisTransaction { objects, events }) => {
                 if tx_ctx.borrow().epoch() != 0 {
@@ -1240,7 +1262,7 @@ mod checked {
                     },
                 ));
 
-                Ok(Mode::empty_results())
+                Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ConsensusCommitPrologueV1(prologue) => {
                 setup_consensus_commit(
@@ -1254,7 +1276,7 @@ mod checked {
                     trace_builder_opt,
                 )
                 .expect("ConsensusCommitPrologueV1 cannot fail");
-                Ok(Mode::empty_results())
+                Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::Programmable(pt) => {
                 programmable_transactions::execution::execute::<Mode>(
@@ -1286,8 +1308,9 @@ mod checked {
                                 protocol_config,
                                 metrics,
                                 trace_builder_opt,
-                            )?;
-                            return Ok(Mode::empty_results());
+                            )
+                            .map_err(|e| (e, vec![]))?;
+                            return Ok((Mode::empty_results(), vec![]));
                         }
                         EndOfEpochTransactionKind::ChangeEpochV2(change_epoch_v2) => {
                             assert_eq!(i, len - 1);
@@ -1301,8 +1324,9 @@ mod checked {
                                 protocol_config,
                                 metrics,
                                 trace_builder_opt,
-                            )?;
-                            return Ok(Mode::empty_results());
+                            )
+                            .map_err(|e| (e, vec![]))?;
+                            return Ok((Mode::empty_results(), vec![]));
                         }
                         EndOfEpochTransactionKind::ChangeEpochV3(change_epoch_v3) => {
                             assert_eq!(i, len - 1);
@@ -1316,8 +1340,9 @@ mod checked {
                                 protocol_config,
                                 metrics,
                                 trace_builder_opt,
-                            )?;
-                            return Ok(Mode::empty_results());
+                            )
+                            .map_err(|e| (e, vec![]))?;
+                            return Ok((Mode::empty_results(), vec![]));
                         }
                         EndOfEpochTransactionKind::ChangeEpochV4(change_epoch_v4) => {
                             assert_eq!(i, len - 1);
@@ -1331,8 +1356,9 @@ mod checked {
                                 protocol_config,
                                 metrics,
                                 trace_builder_opt,
-                            )?;
-                            return Ok(Mode::empty_results());
+                            )
+                            .map_err(|e| (e, vec![]))?;
+                            return Ok((Mode::empty_results(), vec![]));
                         }
                         _ => unimplemented!(
                             "a new EndOfEpochTransactionKind enum variant was added and needs to be handled"
@@ -1348,9 +1374,12 @@ mod checked {
                 // Deprecated: Authenticator state (JWK) is deprecated and
                 // was never enabled. These transaction kinds are retained
                 // only for BCS enum variant compatibility.
-                return Err(ExecutionError::new(
-                    ExecutionErrorKind::VmInvariantViolation,
-                    Some("AuthenticatorState transactions are deprecated and were never created on IOTA".into()),
+                return Err((
+                    ExecutionError::new(
+                        ExecutionErrorKind::VmInvariantViolation,
+                        Some("AuthenticatorState transactions are deprecated and were never created on IOTA".into()),
+                    ),
+                    vec![],
                 ));
             }
             TransactionKind::RandomnessStateUpdate(randomness_state_update) => {
@@ -1363,14 +1392,17 @@ mod checked {
                     protocol_config,
                     metrics,
                     trace_builder_opt,
-                )?;
-                Ok(Mode::empty_results())
+                )
+                .map_err(|e| (e, vec![]))?;
+                Ok((Mode::empty_results(), vec![]))
             }
             _ => unimplemented!(
                 "a new TransactionKind enum variant was added and needs to be handled"
             ),
         }?;
-        temporary_store.check_execution_results_consistency()?;
+        temporary_store
+            .check_execution_results_consistency()
+            .map_err(|e| (e, vec![]))?;
         Ok(result)
     }
 
@@ -1593,10 +1625,10 @@ mod checked {
         #[cfg(msim)]
         let result = maybe_modify_result(result, params.epoch);
 
-        if result.is_err() {
+        if let Err(err) = &result {
             tracing::error!(
                 "Failed to execute advance epoch transaction. Switching to safe mode. Error: {:?}. Input objects: {:?}. Tx params: {:?}",
-                result.as_ref().err(),
+                err.0,
                 temporary_store.objects(),
                 params,
             );
@@ -1857,6 +1889,7 @@ mod checked {
                     publish_pt,
                     trace_builder_opt,
                 )
+                .map_err(|(e, _)| e)
                 .expect("System Package Publish must succeed");
             } else {
                 let mut new_package = Object::new_system_package(
@@ -1926,6 +1959,8 @@ mod checked {
             pt,
             trace_builder_opt,
         )
+        .map_err(|(e, _)| e)?;
+        Ok(())
     }
 
     /// The function constructs a transaction that invokes
@@ -1976,6 +2011,8 @@ mod checked {
             pt,
             trace_builder_opt,
         )
+        .map_err(|(e, _)| e)?;
+        Ok(())
     }
 
     /// Construct a PTB with a single move call. This calls the authenticator

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -40,12 +40,12 @@ mod checked {
     };
     use move_binary_format::{
         CompiledModule,
-        errors::{Location, PartialVMError, PartialVMResult, VMError, VMResult},
+        errors::{Location, PartialVMError, VMError, VMResult},
         file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
     };
     use move_core_types::{
         account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
-        resolver::ModuleResolver, vm_status::StatusCode,
+        vm_status::StatusCode,
     };
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::{
@@ -53,7 +53,7 @@ mod checked {
         native_extensions::NativeContextExtensions,
         session::{LoadedFunctionInstantiation, SerializedReturnValues},
     };
-    use move_vm_types::{data_store::DataStore, loaded_data::runtime_types::Type};
+    use move_vm_types::loaded_data::runtime_types::Type;
     use tracing::instrument;
 
     use crate::{
@@ -66,7 +66,7 @@ mod checked {
         },
         gas_charger::GasCharger,
         gas_meter::IotaGasMeter,
-        programmable_transactions::linkage_view::LinkageView,
+        programmable_transactions::{data_store::IotaDataStore, linkage_view::LinkageView},
         type_resolver::TypeTagResolver,
     };
 
@@ -1690,101 +1690,6 @@ mod checked {
             contents,
             protocol_config,
         )
-    }
-
-    // Implementation of the `DataStore` trait for the Move VM.
-    // When used during execution it may have a list of new packages that have
-    // just been published in the current context. Those are used for module/type
-    // resolution when executing module init.
-    // It may be created with an empty slice of packages either when no
-    // publish/upgrade are performed or when a type is requested not during
-    // execution.
-    pub(crate) struct IotaDataStore<'state, 'a> {
-        linkage_view: &'a LinkageView<'state>,
-        new_packages: &'a [MovePackage],
-    }
-
-    impl<'state, 'a> IotaDataStore<'state, 'a> {
-        pub(crate) fn new(
-            linkage_view: &'a LinkageView<'state>,
-            new_packages: &'a [MovePackage],
-        ) -> Self {
-            Self {
-                linkage_view,
-                new_packages,
-            }
-        }
-
-        fn get_module(&self, module_id: &ModuleId) -> Option<&Vec<u8>> {
-            for package in self.new_packages {
-                if package.id != ObjectId::from(module_id.address().into_bytes()) {
-                    continue;
-                }
-
-                let module = package.get_module(&identifier_core_to_sdk(module_id.name()));
-
-                if module.is_some() {
-                    return module;
-                }
-            }
-            None
-        }
-    }
-
-    // TODO: `DataStore` will be reworked and this is likely to disappear.
-    //       Leaving this comment around until then as testament to better days to
-    // come...
-    impl DataStore for IotaDataStore<'_, '_> {
-        fn link_context(&self) -> AccountAddress {
-            self.linkage_view.link_context()
-        }
-
-        fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId> {
-            self.linkage_view.relocate(module_id).map_err(|err| {
-                PartialVMError::new(StatusCode::LINKER_ERROR)
-                    .with_message(format!("Error relocating {module_id}: {err:?}"))
-            })
-        }
-
-        fn defining_module(
-            &self,
-            runtime_id: &ModuleId,
-            struct_: &IdentStr,
-        ) -> PartialVMResult<ModuleId> {
-            self.linkage_view
-                .defining_module(runtime_id, struct_)
-                .map_err(|err| {
-                    PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
-                        "Error finding defining module for {runtime_id}::{struct_}: {err:?}"
-                    ))
-                })
-        }
-
-        fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
-            if let Some(bytes) = self.get_module(module_id) {
-                return Ok(bytes.clone());
-            }
-            match self.linkage_view.get_module(module_id) {
-                Ok(Some(bytes)) => Ok(bytes),
-                Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
-                    .with_message(format!("Cannot find {module_id:?} in data cache"))
-                    .finish(Location::Undefined)),
-                Err(err) => {
-                    let msg = format!("Unexpected storage error: {err:?}");
-                    Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(msg)
-                            .finish(Location::Undefined),
-                    )
-                }
-            }
-        }
-
-        fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {
-            // we cannot panic here because during execution and publishing this is
-            // currently called from the publish flow in the Move runtime
-            Ok(())
-        }
     }
 
     enum EitherError {

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/data_store.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/data_store.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_sdk_types::{ObjectId, move_package::MovePackage};
+use iota_types::iota_sdk_types_conversions::identifier_core_to_sdk;
+use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+    resolver::ModuleResolver, vm_status::StatusCode,
+};
+use move_vm_types::data_store::DataStore;
+
+use crate::programmable_transactions::linkage_view::LinkageView;
+
+// Implementation of the `DataStore` trait for the Move VM.
+// When used during execution it may have a list of new packages that have
+// just been published in the current context. Those are used for module/type
+// resolution when executing module init.
+// It may be created with an empty slice of packages either when no
+// publish/upgrade are performed or when a type is requested not during
+// execution.
+pub(crate) struct IotaDataStore<'state, 'a> {
+    linkage_view: &'a LinkageView<'state>,
+    new_packages: &'a [MovePackage],
+}
+
+impl<'state, 'a> IotaDataStore<'state, 'a> {
+    pub(crate) fn new(
+        linkage_view: &'a LinkageView<'state>,
+        new_packages: &'a [MovePackage],
+    ) -> Self {
+        Self {
+            linkage_view,
+            new_packages,
+        }
+    }
+
+    fn get_module(&self, module_id: &ModuleId) -> Option<&Vec<u8>> {
+        for package in self.new_packages {
+            if package.id != ObjectId::from(module_id.address().into_bytes()) {
+                continue;
+            }
+
+            let module = package.get_module(&identifier_core_to_sdk(module_id.name()));
+
+            if module.is_some() {
+                return module;
+            }
+        }
+        None
+    }
+}
+
+// TODO: `DataStore` will be reworked and this is likely to disappear.
+//       Leaving this comment around until then as testament to better days to
+// come...
+impl DataStore for IotaDataStore<'_, '_> {
+    fn link_context(&self) -> AccountAddress {
+        self.linkage_view.link_context()
+    }
+
+    fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId> {
+        self.linkage_view.relocate(module_id).map_err(|err| {
+            PartialVMError::new(StatusCode::LINKER_ERROR)
+                .with_message(format!("Error relocating {module_id}: {err:?}"))
+        })
+    }
+
+    fn defining_module(
+        &self,
+        runtime_id: &ModuleId,
+        struct_: &IdentStr,
+    ) -> PartialVMResult<ModuleId> {
+        self.linkage_view
+            .defining_module(runtime_id, struct_)
+            .map_err(|err| {
+                PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
+                    "Error finding defining module for {runtime_id}::{struct_}: {err:?}"
+                ))
+            })
+    }
+
+    fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
+        if let Some(bytes) = self.get_module(module_id) {
+            return Ok(bytes.clone());
+        }
+        match self.linkage_view.get_module(module_id) {
+            Ok(Some(bytes)) => Ok(bytes),
+            Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+                .with_message(format!("Cannot find {module_id:?} in data cache"))
+                .finish(Location::Undefined)),
+            Err(err) => {
+                let msg = format!("Unexpected storage error: {err:?}");
+                Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(msg)
+                        .finish(Location::Undefined),
+                )
+            }
+        }
+    }
+
+    fn publish_module(&mut self, _module_id: &ModuleId, _blob: Vec<u8>) -> VMResult<()> {
+        // we cannot panic here because during execution and publishing this is
+        // currently called from the publish flow in the Move runtime
+        Ok(())
+    }
+}

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -12,6 +12,7 @@ mod checked {
         fmt,
         rc::Rc,
         sync::Arc,
+        time::Instant,
     };
 
     use iota_move_natives::object_runtime::ObjectRuntime;
@@ -28,6 +29,7 @@ mod checked {
         },
         coin::Coin,
         error::{ExecutionError, ExecutionErrorKind, IotaError, command_argument_error},
+        execution::{ExecutionTiming, ResultWithTimings},
         execution_config_utils::to_binary_config,
         id::RESOLVED_IOTA_ID,
         iota_sdk_types_conversions::type_tag_core_to_sdk,
@@ -96,6 +98,36 @@ mod checked {
         gas_charger: &mut GasCharger,
         pt: ProgrammableTransaction,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
+    ) -> ResultWithTimings<Mode::ExecutionResults, ExecutionError> {
+        let mut timings = vec![];
+        let result = execute_inner::<Mode>(
+            &mut timings,
+            protocol_config,
+            metrics,
+            vm,
+            state_view,
+            tx_context,
+            gas_charger,
+            pt,
+            trace_builder_opt,
+        );
+
+        match result {
+            Ok(result) => Ok((result, timings)),
+            Err(e) => Err((e, timings)),
+        }
+    }
+
+    pub fn execute_inner<Mode: ExecutionMode>(
+        timings: &mut Vec<ExecutionTiming>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        vm: &MoveVM,
+        state_view: &mut dyn ExecutionState,
+        tx_context: Rc<RefCell<TxContext>>,
+        gas_charger: &mut GasCharger,
+        pt: ProgrammableTransaction,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> Result<Mode::ExecutionResults, ExecutionError> {
         let ProgrammableTransaction { inputs, commands } = pt;
         let mut context = ExecutionContext::new(
@@ -110,6 +142,7 @@ mod checked {
         // execute commands
         let mut mode_results = Mode::empty_results();
         for (idx, command) in commands.into_iter().enumerate() {
+            let start = Instant::now();
             if let Err(err) =
                 execute_command::<Mode>(&mut context, &mut mode_results, command, trace_builder_opt)
             {
@@ -120,8 +153,10 @@ mod checked {
                 // modified
                 drop(context);
                 state_view.save_loaded_runtime_objects(loaded_runtime_objects);
+                timings.push(ExecutionTiming::Abort(start.elapsed()));
                 return Err(err.with_command_index(idx as u64));
             };
+            timings.push(ExecutionTiming::Success(start.elapsed()));
         }
 
         // Save loaded objects table in case we fail in post execution

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -77,7 +77,7 @@ mod checked {
             ensure_serialized_size,
         },
         gas_charger::GasCharger,
-        programmable_transactions::{context::*, package_metadata::*},
+        programmable_transactions::{context::*, data_store::IotaDataStore, package_metadata::*},
     };
 
     /// Executes a `ProgrammableTransaction` in the specified `ExecutionMode`,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/mod.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod context;
+pub mod data_store;
 pub mod execution;
 pub mod linkage_view;
 pub mod package_metadata;

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -18,7 +18,7 @@ use iota_types::{
     committee::EpochId,
     effects::TransactionEffects,
     error::ExecutionError,
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionTiming, TypeLayoutStore},
     gas::IotaGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     layout_resolver::LayoutResolver,
@@ -55,6 +55,7 @@ pub trait Executor {
         InnerTemporaryStore,
         IotaGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     );
 
@@ -119,6 +120,7 @@ pub trait Executor {
         InnerTemporaryStore,
         IotaGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     );
 

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -28,7 +28,7 @@ use iota_types::{
     committee::EpochId,
     effects::TransactionEffects,
     error::{ExecutionError, IotaError, IotaResult},
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionTiming, TypeLayoutStore},
     gas::IotaGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     layout_resolver::LayoutResolver,
@@ -94,6 +94,7 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         IotaGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
         execute_transaction_to_effects::<execution_mode::Normal>(
@@ -137,7 +138,7 @@ impl executor::Executor for Executor {
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        if skip_all_checks {
+        let (inner_temp_store, gas_status, effects, _timings, result) = if skip_all_checks {
             execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
                 store,
                 input_objects,
@@ -173,7 +174,8 @@ impl executor::Executor for Executor {
                 certificate_deny_set,
                 &mut None,
             )
-        }
+        };
+        (inner_temp_store, gas_status, effects, result)
     }
 
     fn authenticate_then_execute_transaction_to_effects(
@@ -208,6 +210,7 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         IotaGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
         authenticate_then_execute_transaction_to_effects::<execution_mode::Normal>(


### PR DESCRIPTION
[run-ci]

# Description of change

Foundation for further static PTB changes in https://github.com/iotaledger/iota/pull/12564.
- **Pure plumbing** — timings are computed and **discarded by every caller** (`_timings`); nothing enters `TransactionEffects` or consensus → no behavioral, protocol, or consensus change. 
- **Prerequisite for #10831** (static PTB): that code was written on top of a timings-aware execution layer, so landing this first lets #10831 port 1:1 instead of carrying an IOTA-specific timings strip.
- The consumer (congestion-control execution-time estimator) is **not** ported — out of scope.

**Upstream commit**

| Upstream hash | Description |
|---|---|
| `6210d3b51ec5f85224664646ac26ca454187459e` | Execution layer reports timings of each executed command |

**Downstream adaptations (IOTA divergences from the upstream patch)**

| Area | Upstream | IOTA |
|---|---|---|
| Execution cuts | touches `v0/v1/v2` dispatch + adapters | only `latest` is live → those hunks skipped |
| `maybe_modify_result_legacy` | added for old cuts | not needed → single `maybe_modify_result` moved to `ResultWithTimings` |
| Genesis call site | `iota-genesis-builder` | moved to `iota-genesis-common` |
| `authenticate_then_execute_transaction_to_effects` | absent upstream | IOTA-only path threaded with real timings (trait + impl + adapter + `iota-vm-sdk` call site) |
| `advance_epoch` | single fn | threaded through our `advance_epoch_impl` + `advance_epoch_v1..v4` |

## Links to any relevant issues

Fixes #12579 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)