### PR TITLE
upstream(core): Move self-signed effects equivocation check from execution path to effects signing

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -255,6 +255,10 @@ pub struct AuthorityMetrics {
     execute_certificate_latency_shared_object: Histogram,
 
     internal_execution_latency: Histogram,
+    /// Number of times the validator refused to report effects (signed or
+    /// unsigned, labeled by RPC surface) because it had previously signed
+    /// different effects for the same transaction.
+    signed_effects_equivocation_prevented: IntCounterVec,
     execution_load_input_objects_latency: Histogram,
     prepare_certificate_latency: Histogram,
     commit_certificate_latency: Histogram,
@@ -487,6 +491,13 @@ impl AuthorityMetrics {
                 registry,
             )
                 .unwrap(),
+            signed_effects_equivocation_prevented: register_int_counter_vec_with_registry!(
+                "authority_state_signed_effects_equivocation_prevented",
+                "Number of times the validator refused to report effects that differ from previously signed effects for the same transaction, by RPC surface",
+                &["surface"],
+                registry,
+            )
+            .unwrap(),
             execution_load_input_objects_latency: register_histogram_with_registry!(
                 "authority_state_execution_load_input_objects_latency",
                 "Latency of loading input objects for execution",
@@ -1473,14 +1484,6 @@ impl AuthorityState {
 
         let (tx_input_objects, per_authenticator_inputs) =
             self.read_objects_for_execution(tx_guard.as_lock_guard(), transaction, epoch_store)?;
-
-        // If no expected_effects_digest was provided, try to get it from storage.
-        // We could be re-executing a previously executed but uncommitted transaction,
-        // perhaps after restarting with a new binary. In this situation, if
-        // we have published an effects signature, we must be sure not to
-        // equivocate.
-        let expected_effects_digest =
-            expected_effects_digest.or(epoch_store.get_signed_effects_digest(tx_digest)?);
 
         self.process_transaction(
             tx_guard,
@@ -4508,6 +4511,47 @@ impl AuthorityState {
         }
     }
 
+    /// A client aggregating effects signatures towards a quorum assumes
+    /// finality once it collects 2f+1 of them, so within an epoch this
+    /// validator must never assert two different effects for the same
+    /// transaction on any RPC surface, signed or unsigned. Executed effects
+    /// can change across a restart if an uncommitted transaction is
+    /// re-executed with divergent results (e.g. by a new binary), so every
+    /// effects-reporting path calls this before returning effects, and
+    /// refuses to contradict a signature that may already be in a client's
+    /// hands.
+    pub fn check_effects_against_previously_signed(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        tx_digest: &TransactionDigest,
+        effects_digest: &TransactionEffectsDigest,
+        surface: &'static str,
+    ) -> IotaResult<()> {
+        if let Some(previously_signed_digest) = epoch_store.get_signed_effects_digest(tx_digest)? {
+            if previously_signed_digest != *effects_digest {
+                self.metrics
+                    .signed_effects_equivocation_prevented
+                    .with_label_values(&[surface])
+                    .inc();
+                error!(
+                    ?tx_digest,
+                    ?previously_signed_digest,
+                    executed_digest = ?effects_digest,
+                    surface,
+                    "refusing to report effects that differ from previously signed effects"
+                );
+                return Err(IotaError::GenericAuthority {
+                    error: format!(
+                        "Refusing to report effects for transaction {tx_digest}: effects digest \
+                         {effects_digest} differs from previously signed effects digest \
+                         {previously_signed_digest}"
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn sign_effects(
         &self,
@@ -4515,6 +4559,14 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<VerifiedSignedTransactionEffects> {
         let tx_digest = *effects.transaction_digest();
+
+        self.check_effects_against_previously_signed(
+            epoch_store,
+            &tx_digest,
+            &effects.digest(),
+            "sign_effects",
+        )?;
+
         let signed_effects = match epoch_store.get_effects_signature(&tx_digest)? {
             Some(sig) => {
                 debug_assert!(sig.epoch == epoch_store.epoch());

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -684,9 +684,9 @@ pub struct AuthorityPerEpochStore {
 
     /// In-memory cache of signed effects digests. Populated from disk at
     /// startup, updated on insert, and pruned on checkpoint finalization.
-    /// `get_signed_effects_digest` is called on every transaction; this
-    /// avoids a disk read on the hot path where the vast majority of
-    /// lookups return `None`. Writes still go to disk for crash recovery.
+    /// Consulted when reporting effects over RPC to refuse reporting
+    /// effects that differ from previously signed effects. Writes still go
+    /// to disk for crash recovery.
     signed_effects_digests_cache: DashMap<TransactionDigest, TransactionEffectsDigest>,
 
     /// Cancellation token used to signal epoch termination to all in-flight
@@ -799,10 +799,11 @@ pub struct AuthorityEpochTables {
     effects_signatures: DBMap<TransactionDigest, AuthoritySignInfo>,
 
     /// When we sign a TransactionEffects, we must record the digest of the
-    /// effects in order to detect and prevent equivocation when
-    /// re-executing a transaction that may not have been committed to disk.
+    /// effects in order to refuse to sign different effects for the same
+    /// transaction later, e.g. after a re-execution of an uncommitted
+    /// transaction produced divergent results.
     /// Entries are removed from this table after the transaction in question
-    /// has been committed to disk.
+    /// has been committed to a checkpoint.
     signed_effects_digests: DBMap<TransactionDigest, TransactionEffectsDigest>,
 
     /// Signatures of transaction certificates that are executed locally.
@@ -1675,6 +1676,26 @@ impl AuthorityPerEpochStore {
         effects_digest: &TransactionEffectsDigest,
         effects_signature: &AuthoritySignInfo,
     ) -> IotaResult {
+        // The entry guard serializes concurrent signers of the same transaction, so at
+        // most one effects digest can ever be recorded per transaction within an
+        // epoch.
+        match self.signed_effects_digests_cache.entry(*tx_digest) {
+            dashmap::mapref::entry::Entry::Occupied(entry) => {
+                if entry.get() != effects_digest {
+                    return Err(IotaError::GenericAuthority {
+                        error: format!(
+                            "Refusing to report effects for transaction {tx_digest}: effects \
+                             digest {effects_digest} differs from previously signed effects \
+                             digest {}",
+                            entry.get()
+                        ),
+                    });
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(*effects_digest);
+            }
+        }
         let tables = self.tables()?;
         let mut batch = tables.effects_signatures.batch();
         batch.insert_batch(&tables.effects_signatures, [(tx_digest, effects_signature)])?;
@@ -1683,8 +1704,6 @@ impl AuthorityPerEpochStore {
             [(tx_digest, effects_digest)],
         )?;
         batch.write()?;
-        self.signed_effects_digests_cache
-            .insert(*tx_digest, *effects_digest);
         Ok(())
     }
 

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -214,6 +214,14 @@ impl ValidatorService {
 
         let build_executed = |effects: TransactionEffects| -> TxStatusUpdate {
             let effects_digest = effects.digest();
+            if let Err(error) = state.check_effects_against_previously_signed(
+                epoch_store,
+                &tx_digest,
+                &effects_digest,
+                "submit_tx",
+            ) {
+                return TxStatusUpdate::Rejected { error };
+            }
             TxStatusUpdate::Executed {
                 effects_digest,
                 details: Some(Self::build_executed_data(state, &effects)),
@@ -467,7 +475,7 @@ impl ValidatorService {
         match cache.try_get_executed_effects(&tx_digest) {
             Ok(Some(effects)) => {
                 return (
-                    Self::build_executed_update(state, effects, include_details),
+                    Self::build_executed_update(state, epoch_store, effects, include_details),
                     Weight::one(),
                 );
             }
@@ -515,6 +523,14 @@ impl ValidatorService {
                         Weight::zero(),
                     );
                 };
+                if let Err(error) = state.check_effects_against_previously_signed(
+                    epoch_store,
+                    &tx_digest,
+                    &effects_digest,
+                    "get_tx_status",
+                ) {
+                    return (TxStatusUpdate::Rejected { error }, Weight::zero());
+                }
                 let details = if include_details {
                     match cache.try_get_executed_effects(&tx_digest) {
                         Ok(Some(effects)) => Some(Self::build_executed_data(state, &effects)),
@@ -556,10 +572,19 @@ impl ValidatorService {
     /// including full details.
     fn build_executed_update(
         state: &Arc<AuthorityState>,
+        epoch_store: &AuthorityPerEpochStore,
         effects: TransactionEffects,
         include_details: bool,
     ) -> TxStatusUpdate {
         let effects_digest = effects.digest();
+        if let Err(error) = state.check_effects_against_previously_signed(
+            epoch_store,
+            effects.transaction_digest(),
+            &effects_digest,
+            "get_tx_status",
+        ) {
+            return TxStatusUpdate::Rejected { error };
+        }
         let details = if include_details {
             Some(Self::build_executed_data(state, &effects))
         } else {

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -29,18 +29,19 @@ use iota_sdk_types::{
     ConsensusDeterminedVersionAssignments, Digest, EpochId, ExecutionError, ExecutionStatus,
     GasPayment, Identifier, MoveStruct, ObjectData, ObjectDigest, ObjectId, ObjectReference, Owner,
     ProgrammableTransaction, SharedObjectReference, StructTag, Transaction, TransactionDigest,
-    TransactionEffects, TransactionExpiration, TransactionKind, TransactionV1, TypeTag, Version,
-    VersionAssignment, crypto::SimpleSignature,
+    TransactionEffects, TransactionEffectsDigest, TransactionExpiration, TransactionKind,
+    TransactionV1, TypeTag, Version, VersionAssignment,
+    crypto::{Intent, IntentScope, SimpleSignature},
 };
 use iota_types::{
     base_types::{AuthorityName, TxContext, dbg_addr, dbg_object_id, random_object_ref},
     committee::Committee,
     crypto::{
-        AccountKeyPair, AuthorityKeyPair, AuthorityPublicKey, IotaSignature, get_key_pair,
-        random_committee_key_pairs_of_size,
+        AccountKeyPair, AuthorityKeyPair, AuthorityPublicKey, AuthoritySignInfo, IotaSignature,
+        get_key_pair, random_committee_key_pairs_of_size,
     },
     dynamic_field::{DynamicFieldInfo, DynamicFieldType},
-    effects::{TransactionEffectsAPI, TransactionEffectsExt},
+    effects::{TestEffectsBuilder, TransactionEffectsAPI, TransactionEffectsExt},
     epoch_data::EpochData,
     error::{IotaError, IotaResult, UserInputError},
     executable_transaction::VerifiedExecutableTransaction,
@@ -8195,4 +8196,93 @@ fn rules_denying(
         denied_addresses: [address].into(),
         ..Default::default()
     }
+}
+
+#[tokio::test]
+async fn test_effects_equivocation_prevented_at_signing_not_execution() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let recipient = dbg_addr(2);
+    let object_id = ObjectId::random();
+    let gas_object_id = ObjectId::random();
+    let authority_state =
+        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas_object = authority_state.get_object(&gas_object_id).unwrap();
+
+    let transfer_transaction = init_transfer_transaction(
+        &authority_state,
+        sender,
+        &sender_key,
+        recipient,
+        object.object_ref(),
+        gas_object.object_ref(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+
+    let epoch_store = authority_state.epoch_store_for_testing();
+    let executable = VerifiedExecutableTransaction::new_from_checkpoint(
+        transfer_transaction,
+        epoch_store.epoch(),
+        1,
+    );
+    let tx_digest = *executable.digest();
+
+    // Simulate having previously signed different effects for this transaction, as
+    // could happen if a divergent re-execution occurs after signed effects were
+    // returned to a client but before the transaction was committed to a
+    // checkpoint.
+    let previously_signed_digest = TransactionEffectsDigest::random();
+    let previously_signed_sig = AuthoritySignInfo::new(
+        epoch_store.epoch(),
+        &TestEffectsBuilder::new(executable.data()).build(),
+        Intent::iota_app(IntentScope::TransactionEffects),
+        authority_state.name,
+        &*authority_state.secret,
+    );
+    epoch_store
+        .insert_effects_digest_and_signature(
+            &tx_digest,
+            &previously_signed_digest,
+            &previously_signed_sig,
+        )
+        .unwrap();
+
+    // Execution must not consult previously signed effects: it succeeds even
+    // though the resulting effects differ from the previously signed digest.
+    let (effects, execution_error) = authority_state
+        .try_execute_immediately(&executable, None, &epoch_store)
+        .unwrap();
+    assert!(execution_error.is_none());
+    assert_ne!(effects.digest(), previously_signed_digest);
+
+    // Signing must refuse to contradict the previously signed effects.
+    let err = authority_state
+        .get_signed_effects_and_maybe_resign(&tx_digest, &epoch_store)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        IotaError::GenericAuthority { ref error }
+            if error.contains("differs from previously signed effects digest")
+    ));
+
+    // Recording a conflicting digest for the same transaction is rejected.
+    let err = epoch_store
+        .insert_effects_digest_and_signature(&tx_digest, &effects.digest(), &previously_signed_sig)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        IotaError::GenericAuthority { ref error }
+            if error.contains("differs from previously signed effects digest")
+    ));
+
+    // Re-recording the same digest remains idempotent.
+    epoch_store
+        .insert_effects_digest_and_signature(
+            &tx_digest,
+            &previously_signed_digest,
+            &previously_signed_sig,
+        )
+        .unwrap();
 }

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -11,23 +11,24 @@ use iota_protocol_config::{Chain, OverrideGuard, ProtocolConfig};
 // Additional imports for P-COOL tests
 use iota_sdk_types::{
     Address, Argument, Command, Identifier, ObjectId, ProgrammableTransaction, SplitCoins,
-    Transaction, TransactionDigest,
-    crypto::{Intent, IntentMessage, IntentScope::AuthorityCapabilities},
+    Transaction, TransactionDigest, TransactionEffectsDigest,
+    crypto::{Intent, IntentMessage, IntentScope, IntentScope::AuthorityCapabilities},
 };
 // Additional imports for P-COOL tests
 use iota_types::{
     base_types::{AuthorityName, dbg_addr, dbg_object_id, random_object_ref},
     crypto::{
-        AccountKeyPair, AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature,
-        get_authority_key_pair, get_key_pair,
+        AccountKeyPair, AuthorityKeyPair, AuthoritySignInfo, AuthoritySignature,
+        IotaAuthoritySignature, get_authority_key_pair, get_key_pair,
     },
     error::IotaError,
+    executable_transaction::VerifiedExecutableTransaction,
     messages_checkpoint::CheckpointResponse,
     messages_consensus::{AuthorityCapabilitiesV1, SignedAuthorityCapabilitiesV1},
     messages_grpc::{LayoutGenerationOption, TxStatusUpdate},
     object::Object,
     supported_protocol_versions::SupportedProtocolVersions,
-    transaction::TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+    transaction::{TEST_ONLY_GAS_UNIT_FOR_TRANSFER, VerifiedTransaction},
     utils::to_sender_signed_transaction,
 };
 use tokio_stream::StreamExt;
@@ -695,6 +696,103 @@ async fn test_v2_submit_tx_already_executed() {
     }
 }
 
+// Test that the already-executed fast path refuses to report effects that
+// contradict effects the validator previously signed for the same
+// transaction.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_submit_tx_refuses_contradicting_previously_signed() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
+        authority_state.name,
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
+
+    let tx = Transaction::new_transfer(
+        dbg_addr(2),
+        object.object_ref(),
+        sender,
+        gas.object_ref(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx, &sender_key);
+    let tx_digest = *tx.digest();
+
+    let epoch_store = authority_state.epoch_store_for_testing();
+    let executable = VerifiedExecutableTransaction::new_from_checkpoint(
+        VerifiedTransaction::new_unchecked(tx.clone()),
+        epoch_store.epoch(),
+        1,
+    );
+    let (effects, execution_error) = authority_state
+        .try_execute_immediately(&executable, None, &epoch_store)
+        .unwrap();
+    assert!(execution_error.is_none());
+
+    // Record a signed digest that differs from the executed effects,
+    // simulating divergent re-execution after the effects were signed.
+    let previously_signed_digest = TransactionEffectsDigest::random();
+    assert_ne!(previously_signed_digest, effects.digest());
+    let signature = AuthoritySignInfo::new(
+        epoch_store.epoch(),
+        &effects,
+        Intent::iota_app(IntentScope::TransactionEffects),
+        authority_state.name,
+        &*authority_state.secret,
+    );
+    epoch_store
+        .insert_effects_digest_and_signature(&tx_digest, &previously_signed_digest, &signature)
+        .unwrap();
+
+    let response = validator_service
+        .submit_tx(make_v2_submit_request(vec![tx]))
+        .await
+        .expect("submit_tx should succeed");
+
+    let results = collect_v2_stream(response).await;
+    assert_eq!(results.len(), 1);
+    match &results[0].1 {
+        TxStatusUpdate::Rejected { error } => {
+            assert!(
+                matches!(
+                    error,
+                    IotaError::GenericAuthority { error }
+                        if error.contains("differs from previously signed effects digest")
+                ),
+                "Expected equivocation refusal, got {error:?}"
+            );
+        }
+        other => panic!("Expected Rejected, got {other:?}"),
+    }
+}
+
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_v2_submit_tx_multiple_transactions() {
     telemetry_subscribers::init_for_testing();
@@ -1205,6 +1303,190 @@ async fn test_v2_get_tx_status_already_executed_with_details() {
                 details.is_some(),
                 "details should be present when requested"
             );
+        }
+        other => panic!("Expected Executed, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_refuses_contradicting_previously_signed() {
+    // If the validator has signed effects for a transaction, get_tx_status
+    // must never acknowledge a different effects digest for it, even though
+    // the acknowledgment is unsigned. Simulates divergent re-execution by
+    // recording a signed digest that differs from the executed effects.
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
+        authority_state.name,
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
+
+    let tx = Transaction::new_transfer(
+        dbg_addr(2),
+        object.object_ref(),
+        sender,
+        gas.object_ref(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx, &sender_key);
+    let tx_digest = *tx.digest();
+
+    let epoch_store = authority_state.epoch_store_for_testing();
+    let executable = VerifiedExecutableTransaction::new_from_checkpoint(
+        VerifiedTransaction::new_unchecked(tx),
+        epoch_store.epoch(),
+        1,
+    );
+    let (effects, execution_error) = authority_state
+        .try_execute_immediately(&executable, None, &epoch_store)
+        .unwrap();
+    assert!(execution_error.is_none());
+
+    let previously_signed_digest = TransactionEffectsDigest::random();
+    assert_ne!(previously_signed_digest, effects.digest());
+    let signature = AuthoritySignInfo::new(
+        epoch_store.epoch(),
+        &effects,
+        Intent::iota_app(IntentScope::TransactionEffects),
+        authority_state.name,
+        &*authority_state.secret,
+    );
+    epoch_store
+        .insert_effects_digest_and_signature(&tx_digest, &previously_signed_digest, &signature)
+        .unwrap();
+
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![(tx_digest, true)]))
+        .await
+        .expect("get_tx_status should succeed");
+
+    let results = collect_v2_status_stream(response).await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, tx_digest);
+    match &results[0].1 {
+        TxStatusUpdate::Rejected { error } => {
+            assert!(
+                matches!(
+                    error,
+                    IotaError::GenericAuthority { error }
+                        if error.contains("differs from previously signed effects digest")
+                ),
+                "Expected equivocation refusal, got {error:?}"
+            );
+        }
+        other => panic!("Expected Rejected, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_v2_get_tx_status_allows_matching_previously_signed() {
+    // A previously signed digest that matches the executed effects does not
+    // block get_tx_status. The query is registered before execution so that
+    // the wait path serves it, exercising the equivocation check there.
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let object_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[
+            Object::with_id_owner_for_testing(object_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ])
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
+        authority_state.name,
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let rgp = authority_state.reference_gas_price_for_testing().unwrap();
+    let object = authority_state.get_object(&object_id).unwrap();
+    let gas = authority_state.get_object(&gas_id).unwrap();
+
+    let tx = Transaction::new_transfer(
+        dbg_addr(2),
+        object.object_ref(),
+        sender,
+        gas.object_ref(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+    );
+    let tx = to_sender_signed_transaction(tx, &sender_key);
+    let tx_digest = *tx.digest();
+
+    // Register the query before execution so it is served by the wait path.
+    // get_tx_status only spawns the query task; on this single-threaded
+    // runtime it first runs when the test task yields. Blocking on the timer
+    // below hands it the thread: it finds no executed effects yet and parks
+    // on the executed-effects notification, committing it to the wait path
+    // before the transaction executes. With paused time the sleep does not
+    // delay the test; the clock only advances once the query task has parked.
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![(tx_digest, true)]))
+        .await
+        .expect("get_tx_status should succeed");
+    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+    let epoch_store = authority_state.epoch_store_for_testing();
+    let executable = VerifiedExecutableTransaction::new_from_checkpoint(
+        VerifiedTransaction::new_unchecked(tx),
+        epoch_store.epoch(),
+        1,
+    );
+    let (effects, execution_error) = authority_state
+        .try_execute_immediately(&executable, None, &epoch_store)
+        .unwrap();
+    assert!(execution_error.is_none());
+    authority_state
+        .sign_effects(effects.clone(), &epoch_store)
+        .unwrap();
+
+    let results = collect_v2_status_stream(response).await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, tx_digest);
+    match &results[0].1 {
+        TxStatusUpdate::Executed { effects_digest, .. } => {
+            assert_eq!(*effects_digest, effects.digest());
         }
         other => panic!("Expected Executed, got {other:?}"),
     }


### PR DESCRIPTION
## Description of change

- Upstream range: v1.78.0
- Port commit:
  - [MystenLabs/sui@6dfa239](https://github.com/MystenLabs/sui/commit/6dfa239916a9b4ab95924dbc89547e3538790d7f)
- Description:

A validator must never assert two different effects for the same transaction
within an epoch, since clients aggregate effects signatures toward finality.
This was enforced during execution: if re-executing an uncommitted transaction
(e.g. after a restart with a new binary) produced effects differing from
previously signed effects, the validator would panic.

The upstream commit is ported in full as a single commit; it makes two
changes:

1. Move the equivocation check out of the execution path:
   - execution no longer consults previously signed effects, so a divergent
     re-execution no longer panics the node
   - recording a conflicting signed-effects digest for the same transaction is
     rejected atomically in the epoch store
2. Enforce the check at every effects-reporting RPC boundary instead:
   - effects signing refuses to sign effects that differ from those for which
     a signature has already been returned, and reports the refusal via a new
     `signed_effects_equivocation_prevented` metric
   - the unsigned already-executed acknowledgments in the `submit_tx` and
     `get_tx_status` RPCs refuse likewise, since clients aggregate those
     effects digests toward finality as well

Entries in the `signed_effects_digests` table are still cleared on checkpoint
finalization, so the check only applies between transaction execution and
checkpoint finalization.


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
