### PR TITLE
fix(iota-e2e-tests): deflake the gRPC response headers test

### DIFF
--- a/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/header.rs
+++ b/crates/iota-e2e-tests/tests/grpc/v1/ledger_service/header.rs
@@ -11,15 +11,13 @@ use iota_grpc_types::{
 use iota_macros::sim_test;
 
 use crate::{
-    utils::setup_grpc_test_with_builder,
+    utils::setup_grpc_test,
     v1::header::{parse_u64_header, verify_iota_headers},
 };
 
 #[sim_test]
 async fn test_response_headers() {
-    let (test_cluster, client) =
-        setup_grpc_test_with_builder(|builder| builder.with_epoch_duration_ms(2000), None, None)
-            .await;
+    let (test_cluster, client) = setup_grpc_test(None, None).await;
 
     let mut ledger_client = client.ledger_service_client();
 
@@ -53,7 +51,10 @@ async fn test_response_headers() {
 
     // Test get_epoch
     {
-        test_cluster.wait_for_epoch(Some(2)).await;
+        // Two epoch changes are needed: after the first one the latest checkpoint
+        // is still the end-of-epoch checkpoint of epoch 0.
+        test_cluster.force_new_epoch().await;
+        test_cluster.force_new_epoch().await;
 
         let request = GetEpochRequest::default().with_epoch(1);
         let response = ledger_client


### PR DESCRIPTION
# Description of change

`grpc::v1::ledger_service::header::test_response_headers` fails intermittently in the nightly simtest job (most recently [run 31133123498](https://github.com/iotaledger/iota/actions/runs/31133123498/job/92726436999), and previously on 2026-07-22 and 2026-07-23) with `assertion left == right failed: epoch should be 0, got 1`.

The test ran with a 2s epoch, waited for checkpoint 2, and then asserted that the `x-iota-epoch` response header is 0. That header reports the epoch of the fullnode's *highest executed* checkpoint, which is the same value `TestCluster::wait_for_checkpoint` polls — and that wait only guarantees `>= 2`, with no upper bound. When fullnode state sync stalls at startup (`Received no new synced checkpoints for 5s`, `crates/iota-core/src/checkpoints/checkpoint_executor/utils.rs:90`), the fullnode executes checkpoints 1 through 15 in a single burst, so the first observation `>= 2` is already past the end of epoch 0 and the header correctly reports epoch 1. The 5s stall exceeds the whole 2s epoch, so no choice of epoch duration avoids this.

- Drop the `with_epoch_duration_ms(2000)` override so epoch 0 cannot expire on its own, using the shared `setup_grpc_test` helper.
- Drive the epoch changes explicitly with `TestCluster::force_new_epoch` instead of waiting on the epoch timer, as the rest of the e2e suite does. Two calls are needed: after the first, the latest checkpoint is still the end-of-epoch checkpoint of epoch 0, so the later `epoch >= 1` assertions would not hold.
- Assertions themselves are unchanged.

## Links to any relevant issues

Fixes the `test_response_headers` failure in the nightly simtest job.

## How the change has been tested

Reproduced and verified locally with the deterministic simulator (aarch64 macOS), running the test binary directly across many seeds:

- Before the change: 56 failures out of 1220 seeds (4.6%), all the same assertion. Example failing seed `7295364221338941294`; example passing seed `1`.
- After the change: all 56 previously-failing seeds pass, and a 3000-seed sweep produced zero failures.
- The later blocks of the test (`get_objects`, `get_transactions`, `get_checkpoint`, `stream_checkpoints`) keep their `epoch >= 1` assertions satisfied across the full sweep.
- Runtime cost: ~1.5s to ~2.2s per iteration.

Reproduce with:

```sh
SIMTEST_STATIC_INIT_MOVE=$(pwd)/examples/move/basics cargo simtest -p iota-e2e-tests -E 'test(v1::ledger_service::header::test_response_headers)' --no-run
MSIM_TEST_SEED=7295364221338941294 MSIM_TEST_NUM=1 ./target/simulator/deps/grpc-<hash> --exact v1::ledger_service::header::test_response_headers
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes