### PR TITLE
feat(consensus): add per-author strong-vote blame metrics to Starfish-Speed

### DIFF
--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -986,7 +986,8 @@ impl Core {
         }
 
         // Strong-vote payload metrics: distribution of the `missing` set size,
-        // and per-leader counter when the payload is a blame (non-empty).
+        // and per-leader and per-missing-author counters when the payload is a
+        // blame (non-empty).
         if let Some(sv) = strong_vote.as_ref() {
             let node_metrics = &self.context.metrics.node_metrics;
             node_metrics
@@ -1002,6 +1003,13 @@ impl Core {
                     .strong_blames_emitted_for_leader
                     .with_label_values(&[leader])
                     .inc();
+                for missing_author in sv.missing.iter() {
+                    let hostname = &self.context.committee.authority(missing_author).hostname;
+                    node_metrics
+                        .strong_vote_missing_by_author
+                        .with_label_values(&[hostname])
+                        .inc();
+                }
             }
         }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1671,6 +1671,15 @@ impl Core {
                 .strong_blames_received_from_voter
                 .with_label_values(&[voter])
                 .inc();
+            for missing_author in strong_vote.missing.iter() {
+                let hostname = &self.context.committee.authority(missing_author).hostname;
+                self.context
+                    .metrics
+                    .node_metrics
+                    .strong_blames_received_for_author
+                    .with_label_values(&[hostname])
+                    .inc();
+            }
             dag_state.record_strong_vote_complaint(
                 block.author(),
                 leader_round,

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -359,6 +359,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) strong_blames_received_from_voter: IntCounterVec,
     pub(crate) adaptive_ack_excluded_authorities: IntGauge,
     pub(crate) adaptive_ack_acks_dropped: IntCounter,
+    pub(crate) strong_vote_missing_by_author: IntCounterVec,
 }
 
 impl NodeMetrics {
@@ -1439,6 +1440,13 @@ impl NodeMetrics {
             adaptive_ack_acks_dropped: register_int_counter_with_registry!(
                 "adaptive_ack_acks_dropped",
                 "Total pending acknowledgments skipped because their author was in the adaptive-ack exclusion set at proposal time. Skipped refs remain pending and may be included later if the author leaves the exclusion set.",
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            strong_vote_missing_by_author: register_int_counter_vec_with_registry!(
+                "strong_vote_missing_by_author",
+                "Number of times an authority's transactions were not locally available when a strong-vote payload was built, labeled by that authority. Observed only when consensus_starfish_speed is enabled.",
+                &["author"],
                 registry;
                 MetricLevel::Warn,
             ).unwrap(),

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -360,6 +360,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) adaptive_ack_excluded_authorities: IntGauge,
     pub(crate) adaptive_ack_acks_dropped: IntCounter,
     pub(crate) strong_vote_missing_by_author: IntCounterVec,
+    pub(crate) strong_blames_received_for_author: IntCounterVec,
 }
 
 impl NodeMetrics {
@@ -1446,6 +1447,13 @@ impl NodeMetrics {
             strong_vote_missing_by_author: register_int_counter_vec_with_registry!(
                 "strong_vote_missing_by_author",
                 "Number of times an authority's transactions were not locally available when a strong-vote payload was built, labeled by that authority. Observed only when consensus_starfish_speed is enabled.",
+                &["author"],
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            strong_blames_received_for_author: register_int_counter_vec_with_registry!(
+                "strong_blames_received_for_author",
+                "Number of times an authority appeared in the `missing` set of a strong blame received against this node (when acting as leader), labeled by that authority. Observed only when consensus_starfish_speed is enabled.",
                 &["author"],
                 registry;
                 MetricLevel::Warn,

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -21097,6 +21097,186 @@
           ],
           "title": "Adaptive-ack acks dropped",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate at which each authority's transactions were not locally available when this node built a strong-vote payload, by that authority.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 853
+          },
+          "id": 421,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by(author) (rate(consensus_strong_vote_missing_by_author[5m]))",
+              "legendFormat": "{{author}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Strong-vote missing (by author)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Rate at which each authority appeared in the `missing` set of a strong blame received against this node as leader, by that authority.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 853
+          },
+          "id": 422,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by(author) (rate(consensus_strong_blames_received_for_author[5m]))",
+              "legendFormat": "{{author}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Strong blames received (by author)",
+          "type": "timeseries"
         }
       ],
       "title": "StarfishSpeed",


### PR DESCRIPTION
# Description of change

Adds two metrics, both labelled by the authority whose transactions were unavailable:

- `strong_vote_missing_by_author` — counts authorities named in the `missing` set of a strong-vote payload this node builds, so `host` is the voter.
- `strong_blames_received_for_author` — counts authorities named in the `missing` set of a blame received while this node is leader, so `host` is the leader.

`strong_vote_missing_authorities` records only the size of that set, so nothing currently identifies which authorities it names.

Also adds the matching panels to the `StarfishSpeed` row of the local Starfish dashboard. Both counters are only written when `consensus_starfish_speed` is enabled.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
