### PR TITLE
fix(iota-rest-kv): skip BigTable request when there are no keys to fetch

### DIFF
--- a/crates/iota-rest-kv/src/bigtable.rs
+++ b/crates/iota-rest-kv/src/bigtable.rs
@@ -332,6 +332,12 @@ impl KvStoreClient {
             .filter_map(|(index, key)| key.as_ref().map(|k| (k.clone(), index)))
             .collect::<HashMap<Vec<u8>, usize>>();
 
+        // With no keys to look up, `multi_get` would read the whole table
+        // instead of nothing, so return the empty result without calling it.
+        if key_to_index.is_empty() {
+            return Ok(results);
+        }
+
         let start = Instant::now();
         for row in client
             .multi_get(
@@ -668,5 +674,22 @@ mod tests {
             _ => None,
         });
         assert!(matches!(result, Err(ApiError::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn fetch_from_bigtable_with_only_missing_keys_does_not_query_the_store() {
+        // When all keys are missing, the result must be all-None and no
+        // request should be sent (an empty multi_get scans the whole table).
+        // The test client points at a closed port, so any request would fail this test.
+        let client = KvStoreClient::new_for_tests();
+        let results = client
+            .fetch_from_bigtable(
+                CHECKPOINTS_TABLE,
+                vec![None, None, None],
+                CHECKPOINT_SUMMARY_COLUMN_QUALIFIER,
+            )
+            .await
+            .expect("missing keys must resolve without querying the store");
+        assert_eq!(results, vec![None, None, None]);
     }
 }


### PR DESCRIPTION
## Description of change

`fetch_from_bigtable` issued a `multi_get` even when there were no keys to look up — which happens when all requested keys are already resolved as absent before the fetch. Return the empty result directly and skip the unnecessary BigTable request.

Adds a regression test (using the closed-port test client) that the empty-key path resolves without reaching the store.

## How the change has been tested

- New unit test `fetch_from_bigtable_with_only_missing_keys_does_not_query_the_store`
- `cargo test -p iota-rest-kv`, `cargo clippy`, `cargo +nightly fmt`