### PR TITLE
refactor(iota-localnet,iota-swarm): make swarm config assembly fallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6777,7 +6777,6 @@ dependencies = [
  "iota-keys",
  "iota-macros",
  "iota-metrics",
- "iota-names",
  "iota-protocol-config",
  "iota-sdk",
  "iota-sdk-crypto",

--- a/crates/iota-localnet/Cargo.toml
+++ b/crates/iota-localnet/Cargo.toml
@@ -28,7 +28,6 @@ iota-faucet.workspace = true
 iota-graphql-rpc = { workspace = true, optional = true }
 iota-indexer = { workspace = true, optional = true }
 iota-keys.workspace = true
-iota-names.workspace = true
 iota-sdk.workspace = true
 iota-sdk-crypto.workspace = true
 iota-sdk-types.workspace = true

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -1134,7 +1134,7 @@ async fn genesis(
         .with_rpc_addr(iota_config::node::default_json_rpc_address())
         .with_genesis(genesis.clone())
         .with_admin_interface_address(admin_interface_address_with_port)
-        .build_from_parts(&mut OsRng, network_config.validator_configs(), genesis);
+        .try_build_from_parts(&mut OsRng, network_config.validator_configs(), genesis)?;
 
     let fullnode_config_path = iota_config_dir.join(IOTA_FULLNODE_CONFIG);
     fullnode_config.save(&fullnode_config_path)?;
@@ -1157,21 +1157,30 @@ async fn genesis(
                 .with_admin_interface_address(admin_interface_address_with_port)
                 .with_json_rpc_address(([0, 0, 0, 0], 9000))
                 .with_genesis(genesis.clone())
-                .build_from_parts(&mut OsRng, network_config.validator_configs(), genesis);
+                .try_build_from_parts(&mut OsRng, network_config.validator_configs(), genesis)?;
             ssfn_nodes.push(ssfn_config.clone());
             ssfn_config.save(&path)?;
             prepend_note(&path, SSFN_CONFIG_NOTE)?;
         }
 
-        let ssfn_seed_peers: Vec<SeedPeer> = ssfn_nodes
+        let ssfn_seed_peers = ssfn_nodes
             .iter()
-            .map(|config| SeedPeer {
-                peer_id: Some(anemo::PeerId(
-                    config.network_key_pair().public().0.to_bytes(),
-                )),
-                address: config.p2p_config.external_address.clone().unwrap(),
+            .enumerate()
+            .map(|(index, config)| {
+                let address = config.p2p_config.external_address.clone().ok_or_else(|| {
+                    anyhow!(
+                        "state sync fullnode {index} has no `p2p-config.external-address`, which \
+                         the validators need to derive their seed peers"
+                    )
+                })?;
+                Ok(SeedPeer {
+                    peer_id: Some(anemo::PeerId(
+                        config.network_key_pair().public().0.to_bytes(),
+                    )),
+                    address,
+                })
             })
-            .collect();
+            .collect::<Result<Vec<SeedPeer>, anyhow::Error>>()?;
 
         for (i, mut validator) in network_config
             .into_validator_configs()

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -32,17 +32,16 @@ use iota_indexer::{
     test_utils::{IndexerTypeConfig, start_test_indexer},
 };
 use iota_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
-use iota_names::config::IotaNamesConfig;
 use iota_sdk::iota_client_config::{IotaClientConfig, IotaEnv};
 use iota_sdk_crypto::simple::SimpleKeypair;
 use iota_sdk_types::Address;
 use iota_swarm::memory::Swarm;
 use iota_swarm_config::{
-    genesis_config::{GenesisConfig, ValidatorGenesisConfigBuilder},
+    genesis_config::GenesisConfig,
     network_config::{NetworkConfig, NetworkConfigLight},
     network_config_builder::ConfigBuilder,
-    node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder},
-    node_config_override::{NodeConfigOverride, OverrideScope, check_validator_override_scopes},
+    node_config_builder::FullnodeConfigBuilder,
+    node_config_override::{NodeConfigOverride, OverrideScope},
 };
 use rand::rngs::OsRng;
 use tempfile::tempdir;
@@ -494,17 +493,6 @@ async fn start(
         node_config_overrides.splice(0..0, with_grpc_overrides(input)?);
     }
 
-    // Fullnode settings the branches below feed into the swarm builder,
-    // mirrored so the throwaway config used for override validation matches
-    // the config the overrides will be applied to.
-    let mut fullnode_iota_names_config = None;
-    let mut fullnode_enable_grpc_api = false;
-    let mut fullnode_grpc_api_config = None;
-    // Real validator configs when the network is loaded from disk; empty in
-    // force-regenesis mode, where they only exist at build time.
-    let mut validator_configs_for_validation: Vec<NodeConfig> = Vec::new();
-    let num_validators;
-
     let mut swarm_builder = Swarm::builder();
 
     if disable_fullnode_pruning {
@@ -516,7 +504,6 @@ async fn start(
     if force_regenesis {
         let committee_size = NonZeroUsize::new(committee_size.unwrap_or(DEFAULT_COMMITTEE_SIZE))
             .ok_or_else(|| anyhow!("Committee size must be at least 1."))?;
-        num_validators = committee_size.get();
 
         swarm_builder = swarm_builder.committee_size(committee_size);
         let genesis_config = GenesisConfig::custom_genesis(1, 100);
@@ -575,7 +562,6 @@ async fn start(
                 "Cannot open IOTA network config file at {network_config_path:?}"
             ))
         })?;
-        num_validators = validator_configs.len();
         let first_validator_config = validator_configs.first().ok_or(anyhow!(
             "IOTA network config file must contain at least one validator config"
         ))?;
@@ -622,11 +608,6 @@ async fn start(
                 migration_tx_data_path.eq(&fullnode_migration_tx_data_path),
                 "Fullnode must use the same migration blob as validators in IOTA network config"
             );
-            fullnode_iota_names_config = iota_names_config.clone();
-            fullnode_enable_grpc_api = enable_grpc_api;
-            if enable_grpc_api {
-                fullnode_grpc_api_config = grpc_api_config.clone();
-            }
             swarm_builder = swarm_builder.with_fullnode_db_path(db_path);
 
             if let Some(iota_names_config) = iota_names_config {
@@ -647,7 +628,6 @@ async fn start(
             }
         }
 
-        validator_configs_for_validation = validator_configs.clone();
         let network_config = NetworkConfig {
             validator_configs,
             account_keys,
@@ -683,34 +663,8 @@ async fn start(
     let fullnode_data_ingestion_required = with_indexer.is_some();
     #[cfg(not(feature = "indexer"))]
     let fullnode_data_ingestion_required = false;
-    #[cfg(feature = "indexer")]
-    let fullnode_data_ingestion_dir = data_ingestion_dir.clone();
-    #[cfg(not(feature = "indexer"))]
-    let fullnode_data_ingestion_dir = None;
 
-    // Reject bad overrides here: the swarm builder panics instead of erroring,
-    // and it runs on a blocking task where that is even less legible.
-    if !node_config_overrides.is_empty() {
-        let fullnode_config = (!no_full_node).then(|| {
-            throwaway_fullnode_config(
-                &config_path,
-                fullnode_iota_names_config,
-                fullnode_data_ingestion_dir,
-                disable_fullnode_pruning,
-                fullnode_enable_grpc_api || fullnode_grpc_required,
-                fullnode_grpc_api_config,
-            )
-        });
-        validate_node_config_overrides(
-            &node_config_overrides,
-            &config_path,
-            &validator_configs_for_validation,
-            fullnode_config,
-            fullnode_grpc_required,
-            fullnode_data_ingestion_required,
-            num_validators,
-        )?;
-    }
+    check_fullnode_override_scopes(&node_config_overrides, !no_full_node)?;
 
     swarm_builder = swarm_builder.with_node_config_overrides(node_config_overrides);
 
@@ -730,7 +684,19 @@ async fn start(
             .with_fullnode_rpc_addr(fullnode_url);
     }
 
-    let mut swarm = tokio::task::spawn_blocking(move || swarm_builder.build()).await?;
+    let mut swarm = tokio::task::spawn_blocking(move || swarm_builder.try_build()).await??;
+    match swarm.fullnodes().next() {
+        Some(fullnode) => check_service_requirements(
+            &fullnode.config(),
+            fullnode_grpc_required,
+            fullnode_data_ingestion_required,
+        )?,
+        None => ensure!(
+            !fullnode_grpc_required && !fullnode_data_ingestion_required,
+            "The indexer and GraphQL services need a fullnode to talk to; do not pass \
+             --with-indexer or --with-graphql together with --no-full-node."
+        ),
+    }
     swarm.launch().await?;
     // Let nodes connect to one another
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
@@ -763,32 +729,29 @@ async fn start(
     }
 
     #[cfg(feature = "indexer")]
-    let data_ingestion_dir = swarm
-        .fullnodes()
-        .next()
-        .and_then(|node| {
-            node.config()
-                .checkpoint_executor_config
-                .data_ingestion_dir
-                .clone()
-        })
-        .or(data_ingestion_dir);
+    let data_ingestion_dir = swarm.fullnodes().next().and_then(|node| {
+        node.config()
+            .checkpoint_executor_config
+            .data_ingestion_dir
+            .clone()
+    });
 
     #[cfg(feature = "indexer")]
     let pg_address = format!("postgres://{pg_user}:{pg_password}@{pg_host}:{pg_port}/{pg_db_name}");
 
-    // The indexer and GraphQL services talk to the fullnode via gRPC; it is
-    // enabled by default for them, so `None` here means an override disabled
-    // it (or there is no fullnode).
+    // The indexer and GraphQL services talk to the fullnode via gRPC.
+    // `check_service_requirements` ran before launch, so the address is
+    // set whenever one of them is enabled.
     #[cfg(feature = "indexer")]
-    let fullnode_grpc_url =
-        fullnode_grpc_address.map(|grpc_address| format!("http://{grpc_address}"));
+    let fullnode_grpc_url = || {
+        fullnode_grpc_address
+            .map(|grpc_address| format!("http://{grpc_address}"))
+            .ok_or_else(|| anyhow!(GRPC_REQUIRED))
+    };
 
     #[cfg(feature = "indexer")]
     if let Some(input) = with_indexer {
-        let fullnode_grpc_url = fullnode_grpc_url
-            .clone()
-            .ok_or_else(|| anyhow!(GRPC_REQUIRED))?;
+        let fullnode_grpc_url = fullnode_grpc_url()?;
         let indexer_address = parse_host_port(input, DEFAULT_INDEXER_PORT)
             .map_err(|_| anyhow!("Invalid indexer host and port"))?;
         tracing::info!("Starting the indexer service at {indexer_address}");
@@ -832,7 +795,7 @@ async fn start(
 
     #[cfg(feature = "indexer")]
     if let Some(input) = with_graphql {
-        let fullnode_grpc_url = fullnode_grpc_url.ok_or_else(|| anyhow!(GRPC_REQUIRED))?;
+        let fullnode_grpc_url = fullnode_grpc_url()?;
         let graphql_address = parse_host_port(input, DEFAULT_GRAPHQL_PORT)
             .map_err(|_| anyhow!("Invalid graphql host and port"))?;
         tracing::info!("Starting the GraphQL service at {graphql_address}");
@@ -1097,7 +1060,10 @@ async fn genesis(
     builder = if let Some(validators) = validator_info {
         builder.with_validators(validators)
     } else {
-        builder.committee_size(NonZeroUsize::new(committee_size).unwrap())
+        builder.committee_size(
+            NonZeroUsize::new(committee_size)
+                .ok_or_else(|| anyhow!("Committee size must be at least 1."))?,
+        )
     };
 
     if let Some(address) = admin_interface_address_with_port {
@@ -1263,108 +1229,43 @@ fn with_grpc_overrides(input: String) -> Result<[NodeConfigOverride; 2], anyhow:
     ])
 }
 
-/// Build the throwaway fullnode config that override validation runs against.
-///
-/// The single construction site for that config: every fullnode setting
-/// `start` feeds into the swarm builder must be passed in here too.
-fn throwaway_fullnode_config(
-    config_directory: &Path,
-    iota_names_config: Option<IotaNamesConfig>,
-    data_ingestion_dir: Option<PathBuf>,
-    disable_pruning: bool,
-    enable_grpc_api: bool,
-    grpc_api_config: Option<GrpcApiConfig>,
-) -> NodeConfig {
-    let mut builder = FullnodeConfigBuilder::new()
-        .with_config_directory(config_directory.to_path_buf())
-        .with_iota_names_config(iota_names_config)
-        .with_data_ingestion_dir(data_ingestion_dir)
-        .with_disable_pruning(disable_pruning)
-        .with_enable_grpc_api(enable_grpc_api);
-    if let Some(grpc_api_config) = grpc_api_config {
-        builder = builder.with_grpc_api_config(grpc_api_config);
+/// Fails if a fullnode-scoped override is given for a network without a
+/// fullnode.
+fn check_fullnode_override_scopes(
+    node_config_overrides: &[NodeConfigOverride],
+    has_fullnode: bool,
+) -> Result<(), anyhow::Error> {
+    for config_override in node_config_overrides {
+        ensure!(
+            has_fullnode || config_override.scope != OverrideScope::Fullnode,
+            "`{config_override}` is fullnode-scoped, but this network has no fullnode"
+        );
     }
-    builder.build_from_parts(&mut OsRng, &[], Genesis::new_empty())
+    Ok(())
 }
 
-/// Check that each override applies cleanly to a throwaway config of every
-/// node its scope covers.
-///
-/// `validator_configs` are the real validator configs when the network is
-/// loaded from disk (a freshly built throwaway config stands in for missing
-/// entries); `fullnode_config` is the throwaway config for the fullnode
-/// (`None` with `--no-full-node`); the two `fullnode_*_required` flags mark
-/// what the indexer and GraphQL services need the fullnode config to keep.
-fn validate_node_config_overrides(
-    node_config_overrides: &[NodeConfigOverride],
-    config_directory: &Path,
-    validator_configs: &[NodeConfig],
-    mut fullnode_config: Option<NodeConfig>,
+/// Check that the built fullnode config keeps what the enabled services
+/// need: the indexer and GraphQL talk to the fullnode via gRPC, and the
+/// indexer ingests checkpoints from its data-ingestion directory.
+fn check_service_requirements(
+    fullnode_config: &NodeConfig,
     fullnode_grpc_required: bool,
     fullnode_data_ingestion_required: bool,
-    num_validators: usize,
 ) -> Result<(), anyhow::Error> {
-    check_validator_override_scopes(node_config_overrides, num_validators)?;
     ensure!(
-        fullnode_config.is_some()
-            || node_config_overrides
-                .iter()
-                .all(|config_override| config_override.scope != OverrideScope::Fullnode),
-        "Cannot use fullnode-scoped node config overrides without a fullnode."
+        !fullnode_grpc_required || fullnode_config.enable_grpc_api,
+        GRPC_REQUIRED
     );
-
-    for config_override in node_config_overrides {
-        if let Some(fullnode_config) = fullnode_config.as_mut() {
-            if config_override.applies_to_fullnode() {
-                config_override.apply_to(fullnode_config)?;
-            }
-        }
-    }
-    if let Some(fullnode_config) = &fullnode_config {
-        ensure!(
-            !fullnode_grpc_required || fullnode_config.enable_grpc_api,
-            GRPC_REQUIRED
-        );
-        ensure!(
-            !fullnode_data_ingestion_required
-                || fullnode_config
-                    .checkpoint_executor_config
-                    .data_ingestion_dir
-                    .is_some(),
-            "The indexer ingests checkpoints from the fullnode's data-ingestion directory; do \
-            not clear `checkpoint-executor-config.data-ingestion-dir` together with \
-            --with-indexer."
-        );
-    }
-
-    // Each validator receives a different subset of the overrides, so check
-    // every validator's config.
-    let throwaway_validator_config = (validator_configs.len() < num_validators).then(|| {
-        ValidatorConfigBuilder::new()
-            .with_config_directory(config_directory.to_path_buf())
-            .build_without_genesis(ValidatorGenesisConfigBuilder::new().build(&mut OsRng))
-    });
-    for index in 0..num_validators {
-        let mut validator_config = match validator_configs.get(index) {
-            Some(config) => config.clone(),
-            None => throwaway_validator_config
-                .as_ref()
-                .expect("throwaway config is built when real configs are missing")
-                .clone(),
-        };
-        for config_override in node_config_overrides {
-            if config_override.applies_to_validator(index) {
-                config_override.apply_to(&mut validator_config)?;
-            }
-        }
-        // The fullnode derives its seed peers from the validators' external
-        // addresses; the swarm builder panics without them.
-        ensure!(
-            fullnode_config.is_none() || validator_config.p2p_config.external_address.is_some(),
-            "the node config overrides clear `p2p-config.external-address` on a validator, which \
-            the fullnode needs to derive its seed peers"
-        );
-    }
+    ensure!(
+        !fullnode_data_ingestion_required
+            || fullnode_config
+                .checkpoint_executor_config
+                .data_ingestion_dir
+                .is_some(),
+        "The indexer ingests checkpoints from the fullnode's data-ingestion directory; do \
+        not clear `checkpoint-executor-config.data-ingestion-dir` together with \
+        --with-indexer."
+    );
     Ok(())
 }
 
@@ -1408,272 +1309,96 @@ pub fn parse_host_port(
 mod tests {
     use super::*;
 
-    fn plain_fullnode_config(config_directory: &Path) -> Option<NodeConfig> {
-        Some(throwaway_fullnode_config(
-            config_directory,
-            None,
-            None,
-            false,
-            false,
-            None,
-        ))
-    }
-
-    fn grpc_enabled_fullnode_config(config_directory: &Path) -> Option<NodeConfig> {
-        Some(throwaway_fullnode_config(
-            config_directory,
-            None,
-            None,
-            false,
-            true,
-            None,
-        ))
-    }
-
-    #[test]
-    fn consensus_config_override_scopes() {
-        let dir = tempdir().unwrap();
-        // Validator scopes may set the validator-only section...
-        for input in [
-            "validator-0:consensus-config.db-retention-epochs=2",
-            "validator:consensus-config.db-retention-epochs=2",
-        ] {
-            let config_override = input.parse().unwrap();
-            validate_node_config_overrides(
-                &[config_override],
-                dir.path(),
-                &[],
-                plain_fullnode_config(dir.path()),
-                false,
-                false,
-                1,
-            )
-            .unwrap_or_else(|err| panic!("{input}: {err}"));
-        }
-
-        // ...scopes that cover the fullnode may not.
-        for input in [
-            "fullnode:consensus-config.db-retention-epochs=2",
-            "all:consensus-config.db-retention-epochs=2",
-        ] {
-            let config_override = input.parse().unwrap();
-            let err = validate_node_config_overrides(
-                &[config_override],
-                dir.path(),
-                &[],
-                plain_fullnode_config(dir.path()),
-                false,
-                false,
-                1,
-            )
-            .unwrap_err()
-            .to_string();
-            assert!(err.contains("validator"), "{input}: unhelpful error: {err}");
-        }
-
-        // Without a fullnode, `all:` only ever reaches validators.
-        let config_override = "all:consensus-config.db-retention-epochs=2"
-            .parse()
-            .unwrap();
-        validate_node_config_overrides(&[config_override], dir.path(), &[], None, false, false, 1)
-            .unwrap();
-    }
-
     #[test]
     fn fullnode_scoped_override_without_a_fullnode_fails() {
-        let dir = tempdir().unwrap();
-        let config_override = "fullnode:enable-index-processing=false".parse().unwrap();
+        let config_override: NodeConfigOverride =
+            "fullnode:enable-index-processing=false".parse().unwrap();
         assert!(
-            validate_node_config_overrides(
-                &[config_override],
-                dir.path(),
-                &[],
-                None,
-                false,
-                false,
-                1
-            )
-            .is_err()
+            check_fullnode_override_scopes(std::slice::from_ref(&config_override), false).is_err()
         );
+        check_fullnode_override_scopes(&[config_override], true).unwrap();
+
+        // `all:` reaches the validators, so it stays allowed either way.
+        let all_scoped: NodeConfigOverride = "all:enable-index-processing=false".parse().unwrap();
+        check_fullnode_override_scopes(std::slice::from_ref(&all_scoped), false).unwrap();
+    }
+
+    fn built_fullnode_config(
+        config_directory: &Path,
+        enable_grpc_api: bool,
+        data_ingestion_dir: Option<PathBuf>,
+    ) -> NodeConfig {
+        FullnodeConfigBuilder::new()
+            .with_config_directory(config_directory.to_path_buf())
+            .with_enable_grpc_api(enable_grpc_api)
+            .with_data_ingestion_dir(data_ingestion_dir)
+            .build_from_parts(&mut OsRng, &[], Genesis::new_empty())
     }
 
     #[test]
-    fn validator_p2p_external_address_must_survive_the_overrides() {
+    fn check_service_requirements_rejects_a_disabled_grpc_api() {
         let dir = tempdir().unwrap();
-        let clear: NodeConfigOverride = "all:p2p-config.external-address=null".parse().unwrap();
-        assert!(
-            validate_node_config_overrides(
-                std::slice::from_ref(&clear),
-                dir.path(),
-                &[],
-                plain_fullnode_config(dir.path()),
-                false,
-                false,
-                1
-            )
-            .is_err()
-        );
+        let mut fullnode_config = built_fullnode_config(dir.path(), true, None);
+        check_service_requirements(&fullnode_config, true, false).unwrap();
 
-        // Only the final state counts: a later override may restore it.
-        let restore = "all:p2p-config.external-address='/ip4/127.0.0.1/udp/8084'"
-            .parse()
+        fullnode_config.enable_grpc_api = false;
+        let err = check_service_requirements(&fullnode_config, true, false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("enable-grpc-api"), "{err}");
+        // Without the indexer or GraphQL, the same config is fine.
+        check_service_requirements(&fullnode_config, false, false).unwrap();
+    }
+
+    #[test]
+    fn check_service_requirements_rejects_a_cleared_data_ingestion_dir() {
+        let dir = tempdir().unwrap();
+        let mut fullnode_config =
+            built_fullnode_config(dir.path(), false, Some(dir.path().join("ingestion")));
+        check_service_requirements(&fullnode_config, false, true).unwrap();
+
+        fullnode_config
+            .checkpoint_executor_config
+            .data_ingestion_dir = None;
+        let err = check_service_requirements(&fullnode_config, false, true)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("data-ingestion-dir"), "{err}");
+        // Without the indexer, the same config is fine.
+        check_service_requirements(&fullnode_config, false, false).unwrap();
+    }
+
+    #[test]
+    fn overriding_the_grpc_api_off_fails_the_grpc_requirement() {
+        let dir = tempdir().unwrap();
+        let mut fullnode_config = built_fullnode_config(dir.path(), true, None);
+        "fullnode:enable-grpc-api=false"
+            .parse::<NodeConfigOverride>()
+            .unwrap()
+            .apply_to(&mut fullnode_config)
             .unwrap();
-        validate_node_config_overrides(
-            &[clear, restore],
-            dir.path(),
-            &[],
-            plain_fullnode_config(dir.path()),
-            false,
-            false,
-            1,
-        )
-        .unwrap();
+
+        let err = check_service_requirements(&fullnode_config, true, false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("enable-grpc-api"), "{err}");
     }
 
     #[test]
-    fn validator_index_overrides_validate_independently() {
+    fn overriding_the_data_ingestion_dir_to_null_fails_the_indexer_requirement() {
         let dir = tempdir().unwrap();
-        // validator-0 creates the whole section; validator-1 patches a single
-        // field of a section that does not exist on validator 1.
-        let overrides = [
-            "validator-0:firewall-config={remote-fw-url: 'http://127.0.0.1:65000', \
-             destination-port: 65000}"
-                .parse()
-                .unwrap(),
-            "validator-1:firewall-config.destination-port=65001"
-                .parse()
-                .unwrap(),
-        ];
-        assert!(
-            validate_node_config_overrides(
-                &overrides,
-                dir.path(),
-                &[],
-                plain_fullnode_config(dir.path()),
-                false,
-                false,
-                2
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn index_and_all_validator_overrides_compose() {
-        let dir = tempdir().unwrap();
-        // With one validator, validator 0 receives both overrides in order.
-        let overrides = [
-            "validator-0:firewall-config={remote-fw-url: 'http://127.0.0.1:65000', \
-             destination-port: 65000}"
-                .parse()
-                .unwrap(),
-            "validator:firewall-config.destination-port=65001"
-                .parse()
-                .unwrap(),
-        ];
-        validate_node_config_overrides(
-            &overrides,
-            dir.path(),
-            &[],
-            plain_fullnode_config(dir.path()),
-            false,
-            false,
-            1,
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn validation_uses_the_real_validator_configs() {
-        let dir = tempdir().unwrap();
-        let mut validator_config = ValidatorConfigBuilder::new()
-            .with_config_directory(dir.path().to_path_buf())
-            .build_without_genesis(ValidatorGenesisConfigBuilder::new().build(&mut OsRng));
-        let set_firewall: NodeConfigOverride =
-            "firewall-config={remote-fw-url: 'http://127.0.0.1:65000', destination-port: 65000}"
-                .parse()
-                .unwrap();
-        set_firewall.apply_to(&mut validator_config).unwrap();
-
-        // A dotted edit applies cleanly to the real config even though the
-        // section does not exist on a freshly generated one.
-        let edit = "validator:firewall-config.destination-port=65001"
-            .parse()
+        let mut fullnode_config =
+            built_fullnode_config(dir.path(), false, Some(dir.path().join("ingestion")));
+        "fullnode:checkpoint-executor-config.data-ingestion-dir=null"
+            .parse::<NodeConfigOverride>()
+            .unwrap()
+            .apply_to(&mut fullnode_config)
             .unwrap();
-        validate_node_config_overrides(
-            &[edit],
-            dir.path(),
-            std::slice::from_ref(&validator_config),
-            plain_fullnode_config(dir.path()),
-            false,
-            false,
-            1,
-        )
-        .unwrap();
 
-        // Clearing the gRPC config of a gRPC-enabled validator is rejected
-        // here instead of panicking in the swarm builder.
-        let enable: NodeConfigOverride = "enable-grpc-api=true".parse().unwrap();
-        enable.apply_to(&mut validator_config).unwrap();
-        let clear = "validator:grpc-api-config=null".parse().unwrap();
-        assert!(
-            validate_node_config_overrides(
-                &[clear],
-                dir.path(),
-                &[validator_config],
-                plain_fullnode_config(dir.path()),
-                false,
-                false,
-                1,
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn disabling_a_required_grpc_api_fails() {
-        let dir = tempdir().unwrap();
-        let config_override = "fullnode:enable-grpc-api=false".parse().unwrap();
-        assert!(
-            validate_node_config_overrides(
-                &[config_override],
-                dir.path(),
-                &[],
-                grpc_enabled_fullnode_config(dir.path()),
-                true,
-                false,
-                1
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn clearing_a_required_data_ingestion_dir_fails() {
-        let dir = tempdir().unwrap();
-        let fullnode_config = Some(throwaway_fullnode_config(
-            dir.path(),
-            None,
-            Some(dir.path().join("ingestion")),
-            false,
-            false,
-            None,
-        ));
-        let config_override = "fullnode:checkpoint-executor-config.data-ingestion-dir=null"
-            .parse()
-            .unwrap();
-        assert!(
-            validate_node_config_overrides(
-                &[config_override],
-                dir.path(),
-                &[],
-                fullnode_config,
-                false,
-                true,
-                1
-            )
-            .is_err()
-        );
+        let err = check_service_requirements(&fullnode_config, false, true)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("data-ingestion-dir"), "{err}");
     }
 
     #[test]
@@ -1681,7 +1406,7 @@ mod tests {
         let dir = tempdir().unwrap();
         for (input, expected) in [("[::1]:50051", "[::1]:50051"), ("50051", "0.0.0.0:50051")] {
             let overrides = with_grpc_overrides(input.to_string()).unwrap();
-            let mut config = plain_fullnode_config(dir.path()).unwrap();
+            let mut config = built_fullnode_config(dir.path(), false, None);
             for config_override in &overrides {
                 config_override.apply_to(&mut config).unwrap();
             }

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -88,6 +88,69 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
+async fn test_genesis_rejects_a_zero_committee_size() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+
+    let err = LocalnetCommand::Genesis {
+        working_dir: Some(tmp_dir.path().to_path_buf()),
+        write_config: None,
+        force: false,
+        from_config: None,
+        epoch_duration_ms: None,
+        benchmark_ips: None,
+        with_faucet: false,
+        committee_size: 0,
+        num_additional_gas_accounts: None,
+        chain_start_timestamp_ms: None,
+        admin_interface_address: None,
+    }
+    .execute()
+    .await
+    .unwrap_err();
+
+    let err = format!("{err:#}");
+    assert!(err.contains("Committee size must be at least 1."), "{err}");
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+#[sim_test]
+async fn test_start_reports_a_failing_node_config_override() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+
+    let err = LocalnetCommand::Start {
+        #[cfg(feature = "indexer")]
+        data_ingestion_dir: None,
+        config_dir: Some(tmp_dir.path().to_path_buf()),
+        no_full_node: false,
+        disable_fullnode_pruning: false,
+        // One character off, so the override fails when it is applied to
+        // the built config.
+        node_config_override: vec!["fullnode:enable-index-processng=false".parse()?],
+        force_regenesis: false,
+        with_faucet: None,
+        faucet_amount: None,
+        faucet_coin_count: None,
+        with_grpc: None,
+        fullnode_rpc_port: 9000,
+        committee_size: None,
+        epoch_duration_ms: None,
+        #[cfg(feature = "indexer")]
+        indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
+    }
+    .execute()
+    .await
+    .unwrap_err();
+
+    let err = format!("{err:#}");
+    assert!(err.contains("enable-index-processng"), "{err}");
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+#[sim_test]
 async fn test_start() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
     let working_dir = tmp_dir.path();

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -4,6 +4,7 @@
 
 use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf};
 
+use anyhow::anyhow;
 use fastcrypto::{
     encoding::{Encoding, Hex},
     traits::KeyPair,
@@ -443,12 +444,37 @@ impl FullnodeConfigBuilder {
         self
     }
 
+    /// Build the fullnode config against the given validator configs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Self::try_build_from_parts`] returns an error.
     pub fn build_from_parts<R: rand::RngCore + rand::CryptoRng>(
         self,
         rng: &mut R,
         validator_configs: &[NodeConfig],
         genesis: iota_config::node::Genesis,
     ) -> NodeConfig {
+        self.try_build_from_parts(rng, validator_configs, genesis)
+            .unwrap_or_else(|err| panic!("{err:#}"))
+    }
+
+    /// Build the fullnode config against the given validator configs.
+    ///
+    /// Fails if a validator config has no `p2p-config.external-address`,
+    /// which the fullnode's seed peers are derived from.
+    ///
+    /// # Panics
+    ///
+    /// Panics on failures the config cannot be built without: creating the
+    /// temporary config directory, allocating a local port, or parsing a
+    /// generated network address.
+    pub fn try_build_from_parts<R: rand::RngCore + rand::CryptoRng>(
+        self,
+        rng: &mut R,
+        validator_configs: &[NodeConfig],
+        genesis: iota_config::node::Genesis,
+    ) -> anyhow::Result<NodeConfig> {
         // Take advantage of ValidatorGenesisConfigBuilder to build the keypairs and
         // addresses, even though this is a fullnode.
         let validator_config = ValidatorGenesisConfigBuilder::new().build(rng);
@@ -470,13 +496,23 @@ impl FullnodeConfigBuilder {
         let p2p_config = {
             let seed_peers = validator_configs
                 .iter()
-                .map(|config| SeedPeer {
-                    peer_id: Some(anemo::PeerId(
-                        config.network_key_pair().public().0.to_bytes(),
-                    )),
-                    address: config.p2p_config.external_address.clone().unwrap(),
+                .enumerate()
+                .map(|(index, config)| {
+                    let address = config.p2p_config.external_address.clone().ok_or_else(|| {
+                        anyhow!(
+                            "validator {index} has no `p2p-config.external-address`, which the \
+                             fullnode needs to derive its seed peers: either its config never set \
+                             one or a node config override cleared it"
+                        )
+                    })?;
+                    Ok(SeedPeer {
+                        peer_id: Some(anemo::PeerId(
+                            config.network_key_pair().public().0.to_bytes(),
+                        )),
+                        address,
+                    })
                 })
-                .collect();
+                .collect::<anyhow::Result<Vec<_>>>()?;
 
             P2pConfig {
                 listen_address: self.p2p_listen_address.unwrap_or_else(|| {
@@ -503,11 +539,13 @@ impl FullnodeConfigBuilder {
             }
         };
 
-        let json_rpc_address = self.rpc_addr.unwrap_or_else(|| {
-            let rpc_port = self
-                .rpc_port
-                .unwrap_or_else(|| local_ip_utils::get_available_port(&ip));
-            format!("{ip}:{rpc_port}").parse().unwrap()
+        let json_rpc_address = self.json_rpc_address.unwrap_or_else(|| {
+            self.rpc_addr.unwrap_or_else(|| {
+                let rpc_port = self
+                    .rpc_port
+                    .unwrap_or_else(|| local_ip_utils::get_available_port(&ip));
+                format!("{ip}:{rpc_port}").parse().unwrap()
+            })
         });
 
         let grpc_api_config = self.grpc_api_config.or_else(|| {
@@ -534,7 +572,7 @@ impl FullnodeConfigBuilder {
             pruning_config.set_num_epochs_to_retain(u64::MAX);
         };
 
-        NodeConfig {
+        Ok(NodeConfig {
             authority_key_pair: AuthorityKeyPairWithPath::new(validator_config.authority_key_pair),
             account_key_pair: KeyPairWithPath::new(validator_config.account_key_pair),
             protocol_key_pair: KeyPairWithPath::new(network_to_simple_keypair(
@@ -551,11 +589,11 @@ impl FullnodeConfigBuilder {
                 .unwrap_or(validator_config.network_address),
             metrics_address: self
                 .metrics_address
-                .unwrap_or(local_ip_utils::new_local_tcp_socket_for_testing()),
+                .unwrap_or_else(local_ip_utils::new_local_tcp_socket_for_testing),
             admin_interface_address: self
                 .admin_interface_address
-                .unwrap_or(local_ip_utils::new_local_tcp_socket_for_testing()),
-            json_rpc_address: self.json_rpc_address.unwrap_or(json_rpc_address),
+                .unwrap_or_else(local_ip_utils::new_local_tcp_socket_for_testing),
+            json_rpc_address,
             consensus_config: None,
             enable_index_processing: default_enable_index_processing(),
             genesis,
@@ -602,21 +640,45 @@ impl FullnodeConfigBuilder {
             grpc_api_config,
             chain_override_for_testing: self.chain_override,
             validator_client_monitor_config: None,
-        }
+        })
     }
 
+    /// Build the fullnode config against the given network config.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Self::try_build`] returns an error.
     pub fn build<R: rand::RngCore + rand::CryptoRng>(
         self,
         rng: &mut R,
         network_config: &NetworkConfig,
     ) -> NodeConfig {
+        self.try_build(rng, network_config)
+            .unwrap_or_else(|err| panic!("{err:#}"))
+    }
+
+    /// Build the fullnode config against the given network config.
+    ///
+    /// Fails if a validator config has no `p2p-config.external-address`,
+    /// which the fullnode's seed peers are derived from.
+    ///
+    /// # Panics
+    ///
+    /// Panics on failures the config cannot be built without: creating the
+    /// temporary config directory, allocating a local port, or parsing a
+    /// generated network address.
+    pub fn try_build<R: rand::RngCore + rand::CryptoRng>(
+        self,
+        rng: &mut R,
+        network_config: &NetworkConfig,
+    ) -> anyhow::Result<NodeConfig> {
         let genesis = self
             .genesis
             .as_ref()
             .or_else(|| network_config.get_validator_genesis())
             .cloned()
             .unwrap_or_else(|| iota_config::node::Genesis::new(network_config.genesis.clone()));
-        self.build_from_parts(rng, network_config.validator_configs(), genesis)
+        self.try_build_from_parts(rng, network_config.validator_configs(), genesis)
     }
 }
 
@@ -629,4 +691,25 @@ fn get_key_path(key_pair: &AuthorityKeyPair) -> String {
     // being unique.
     key_path.truncate(12);
     key_path
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::OsRng;
+
+    use super::*;
+
+    #[test]
+    fn fullnode_build_needs_validator_p2p_external_addresses() {
+        let mut validator = ValidatorConfigBuilder::new()
+            .build_without_genesis(ValidatorGenesisConfigBuilder::new().build(&mut OsRng));
+        validator.p2p_config.external_address = None;
+
+        let err = FullnodeConfigBuilder::new()
+            .try_build_from_parts(&mut OsRng, &[validator], Genesis::new_empty())
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("validator 0"), "{err}");
+        assert!(err.contains("seed peers"), "{err}");
+    }
 }

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures::future::try_join_all;
 use iota_config::{
     ExecutionCacheConfig, IOTA_GENESIS_FILENAME, NodeConfig,
@@ -415,13 +415,16 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
     ///
     /// - A `validator-<N>` override names a validator the network does not
     ///   have.
-    /// - An override does not apply to a node in the initial network.
+    /// - An override fails to apply to a built config.
+    /// - The network has a fullnode and a validator config has no
+    ///   `p2p-config.external-address`.
     ///
     /// # Panics
     ///
-    /// Panics on failures the swarm cannot run without, including
-    /// creating its temporary directory, saving the genesis blob, and
-    /// building the genesis (see [`ConfigBuilder::build`]).
+    /// Panics on failures the swarm cannot run without: creating its
+    /// temporary directory, saving the genesis blob, parsing a generated
+    /// network address, and building the genesis (e.g. on invalid
+    /// genesis parameters or a validator below the minimum stake).
     pub fn try_build(self) -> Result<Swarm> {
         let dir = if let Some(dir) = self.dir {
             SwarmDirectory::Persistent(dir)
@@ -539,7 +542,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                     .iter()
                     .filter(|config_override| config_override.applies_to_validator(index)),
                 validator,
-            )?;
+            )
+            .with_context(|| {
+                format!("failed to apply node config overrides to validator {index}")
+            })?;
         }
 
         let mut nodes: HashMap<_, _> = network_config
@@ -610,13 +616,16 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                     builder = builder.with_rpc_port(rpc_port);
                 }
             }
-            let mut config = builder.build(&mut OsRng, &network_config);
+            let mut config = builder
+                .try_build(&mut OsRng, &network_config)
+                .context("failed to build the fullnode config")?;
             apply_node_config_overrides(
                 self.node_config_overrides
                     .iter()
                     .filter(|config_override| config_override.applies_to_fullnode()),
                 &mut config,
-            )?;
+            )
+            .with_context(|| format!("failed to apply node config overrides to fullnode {idx}"))?;
             info!(
                 "SwarmBuilder configuring full node with name {}",
                 config.authority_public_key()
@@ -931,6 +940,45 @@ mod test {
     }
 
     #[test]
+    fn clearing_validator_external_addresses_fails_the_swarm_build() {
+        // The fullnode derives its seed peers from the validators' external
+        // addresses; clearing them must fail the build.
+        let err = Swarm::builder()
+            .with_fullnode_count(1)
+            .with_node_config_overrides(vec![
+                "validator:p2p-config.external-address=null"
+                    .parse()
+                    .unwrap(),
+            ])
+            .try_build()
+            .unwrap_err();
+        // The seed-peer error, not the override echoed back by an
+        // apply-time failure.
+        assert!(format!("{err:#}").contains("seed peers"), "{err:#}");
+
+        // Only the final state counts: a later override may restore it.
+        let swarm = Swarm::builder()
+            .with_fullnode_count(1)
+            .with_node_config_overrides(vec![
+                "validator:p2p-config.external-address=null"
+                    .parse()
+                    .unwrap(),
+                "validator:p2p-config.external-address='/ip4/127.0.0.1/udp/8084'"
+                    .parse()
+                    .unwrap(),
+            ])
+            .try_build()
+            .unwrap();
+        let fullnode = swarm.fullnodes().next().unwrap();
+        assert_eq!(
+            fullnode.config().p2p_config.seed_peers[0]
+                .address
+                .to_string(),
+            "/ip4/127.0.0.1/udp/8084"
+        );
+    }
+
+    #[test]
     fn overrides_apply_per_validator_independently() {
         // validator-0 creates the whole section; the dotted edit fails on
         // validator 1, where the section does not exist.
@@ -952,6 +1000,36 @@ mod test {
         // required fields unset.
         let err = format!("{err:#}");
         assert!(err.contains("validator-1:"), "{err}");
+        assert!(err.contains("remote-fw-url"), "{err}");
+    }
+
+    #[test]
+    fn validator_override_failures_name_the_validator() {
+        // A `validator:` scope carries no index, so only the error context
+        // can say which validator rejected the override.
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut network_config = ConfigBuilder::new(dir.path())
+            .committee_size(NonZeroUsize::new(2).unwrap())
+            .build();
+        "firewall-config={remote-fw-url: 'http://127.0.0.1:65000', destination-port: 65000}"
+            .parse::<NodeConfigOverride>()
+            .unwrap()
+            .apply_to(&mut network_config.validator_configs[0])
+            .unwrap();
+
+        let err = Swarm::builder()
+            .with_network_config(network_config)
+            .with_node_config_overrides(vec![
+                "validator:firewall-config.destination-port=65001"
+                    .parse()
+                    .unwrap(),
+            ])
+            .try_build()
+            .unwrap_err();
+        // Validator 0 has the section; validator 1 does not, so the dotted
+        // edit leaves its required fields unset there.
+        let err = format!("{err:#}");
+        assert!(err.contains("validator 1"), "{err}");
         assert!(err.contains("remote-fw-url"), "{err}");
     }
 

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -197,6 +197,12 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    /// Use the given network config instead of generating one.
+    ///
+    /// Settings that only feed `ConfigBuilder` (the rng, the committee,
+    /// the validator configs it generates) are ignored; the fullnode
+    /// settings, the node config overrides, and the address-verification
+    /// cooldown still apply.
     pub fn with_network_config(mut self, network_config: NetworkConfig) -> Self {
         assert!(self.network_config.is_none() && self.genesis_config.is_none());
         self.network_config = Some(network_config);
@@ -384,11 +390,6 @@ impl<R> SwarmBuilder<R> {
     /// the given order, after all other configuration. Nodes spawned on the
     /// built [`Swarm`] later get them too, except `validator-<N>` scoped
     /// overrides, which refer to positions in the initial network config.
-    ///
-    /// # Panics
-    ///
-    /// [`SwarmBuilder::build`] and later spawns panic on an override that
-    /// fails to apply; validate overrides from user input first.
     pub fn with_node_config_overrides(
         mut self,
         node_config_overrides: Vec<NodeConfigOverride>,
@@ -400,7 +401,28 @@ impl<R> SwarmBuilder<R> {
 
 impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
     /// Create the configured Swarm.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`SwarmBuilder::try_build`] returns an error.
     pub fn build(self) -> Swarm {
+        self.try_build().unwrap_or_else(|err| panic!("{err:#}"))
+    }
+
+    /// Create the configured Swarm.
+    ///
+    /// # Errors
+    ///
+    /// - A `validator-<N>` override names a validator the network does not
+    ///   have.
+    /// - An override does not apply to a node in the initial network.
+    ///
+    /// # Panics
+    ///
+    /// Panics on failures the swarm cannot run without, including
+    /// creating its temporary directory, saving the genesis blob, and
+    /// building the genesis (see [`ConfigBuilder::build`]).
+    pub fn try_build(self) -> Result<Swarm> {
         let dir = if let Some(dir) = self.dir {
             SwarmDirectory::Persistent(dir)
         } else {
@@ -408,6 +430,21 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
         };
 
         let ingest_data = self.data_ingestion_dir.clone();
+
+        // Reject an out-of-range validator scope before the expensive
+        // genesis build; other override failures surface only later, when
+        // the overrides are applied to the built configs.
+        let num_validators = match (&self.network_config, &self.committee) {
+            (Some(network_config), _) => network_config.validator_configs.len(),
+            (None, CommitteeConfig::Size(size)) => size.get(),
+            (None, CommitteeConfig::Validators(validators)) => validators.len(),
+            (None, CommitteeConfig::AccountKeys(keys)) => keys.len(),
+            // `ConfigBuilder::build` uses the key count when keys are given.
+            (None, CommitteeConfig::Deterministic((size, keys))) => {
+                keys.as_ref().map_or(size.get(), Vec::len)
+            }
+        };
+        check_validator_override_scopes(&self.node_config_overrides, num_validators)?;
 
         let mut network_config = self.network_config.unwrap_or_else(|| {
             let mut config_builder = ConfigBuilder::new(dir.as_ref());
@@ -490,18 +527,19 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             }
         }
 
+        // Re-check against the built count; the prediction above only
+        // exists to fail fast before the genesis build.
         check_validator_override_scopes(
             &self.node_config_overrides,
             network_config.validator_configs.len(),
-        )
-        .unwrap_or_else(|err| panic!("{err:#}"));
+        )?;
         for (index, validator) in network_config.validator_configs.iter_mut().enumerate() {
             apply_node_config_overrides(
                 self.node_config_overrides
                     .iter()
                     .filter(|config_override| config_override.applies_to_validator(index)),
                 validator,
-            );
+            )?;
         }
 
         let mut nodes: HashMap<_, _> = network_config
@@ -560,40 +598,38 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 fullnode_config_builder.with_grpc_api_config(grpc_config.clone());
         }
 
-        if self.fullnode_count > 0 {
-            (0..self.fullnode_count).for_each(|idx| {
-                let mut builder = fullnode_config_builder.clone();
-                if idx == 0 {
-                    // Only the first fullnode is used as the rpc fullnode, we can only use the
-                    // same address once.
-                    if let Some(rpc_addr) = self.fullnode_rpc_addr {
-                        builder = builder.with_rpc_addr(rpc_addr);
-                    }
-                    if let Some(rpc_port) = self.fullnode_rpc_port {
-                        builder = builder.with_rpc_port(rpc_port);
-                    }
+        for idx in 0..self.fullnode_count {
+            let mut builder = fullnode_config_builder.clone();
+            if idx == 0 {
+                // Only the first fullnode is used as the rpc fullnode, we can only use the
+                // same address once.
+                if let Some(rpc_addr) = self.fullnode_rpc_addr {
+                    builder = builder.with_rpc_addr(rpc_addr);
                 }
-                let mut config = builder.build(&mut OsRng, &network_config);
-                apply_node_config_overrides(
-                    self.node_config_overrides
-                        .iter()
-                        .filter(|config_override| config_override.applies_to_fullnode()),
-                    &mut config,
-                );
-                info!(
-                    "SwarmBuilder configuring full node with name {}",
-                    config.authority_public_key()
-                );
-                nodes.insert(config.authority_public_key(), Node::new(config));
-            });
+                if let Some(rpc_port) = self.fullnode_rpc_port {
+                    builder = builder.with_rpc_port(rpc_port);
+                }
+            }
+            let mut config = builder.build(&mut OsRng, &network_config);
+            apply_node_config_overrides(
+                self.node_config_overrides
+                    .iter()
+                    .filter(|config_override| config_override.applies_to_fullnode()),
+                &mut config,
+            )?;
+            info!(
+                "SwarmBuilder configuring full node with name {}",
+                config.authority_public_key()
+            );
+            nodes.insert(config.authority_public_key(), Node::new(config));
         }
-        Swarm {
+        Ok(Swarm {
             dir,
             network_config,
             nodes,
             fullnode_config_builder,
             node_config_overrides: self.node_config_overrides,
-        }
+        })
     }
 }
 
@@ -708,6 +744,11 @@ impl Swarm {
     /// Start a node from `config` and add it to the swarm.
     ///
     /// The swarm's node config overrides are applied to the config first.
+    ///
+    /// # Panics
+    ///
+    /// Panics on an override that fails to apply and on a node that fails to
+    /// start.
     pub async fn spawn_new_node(&mut self, mut config: NodeConfig) -> IotaNodeHandle {
         self.apply_node_config_overrides_for_spawn(&mut config);
         let name = config.authority_public_key();
@@ -735,7 +776,8 @@ impl Swarm {
                 }
             }),
             config,
-        );
+        )
+        .unwrap_or_else(|err| panic!("{err:#}"));
     }
 
     pub fn get_fullnode_config_builder(&self) -> FullnodeConfigBuilder {
@@ -746,12 +788,11 @@ impl Swarm {
 fn apply_node_config_overrides<'a>(
     overrides: impl Iterator<Item = &'a NodeConfigOverride>,
     config: &mut NodeConfig,
-) {
+) -> Result<()> {
     for config_override in overrides {
-        config_override
-            .apply_to(config)
-            .unwrap_or_else(|err| panic!("{err:#}"));
+        config_override.apply_to(config)?;
     }
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -789,6 +830,11 @@ impl AsRef<Path> for SwarmDirectory {
 #[cfg(test)]
 mod test {
     use std::num::NonZeroUsize;
+
+    use iota_config::IOTA_GENESIS_FILENAME;
+    use iota_swarm_config::{
+        network_config_builder::ConfigBuilder, node_config_override::NodeConfigOverride,
+    };
 
     use super::Swarm;
 
@@ -861,6 +907,153 @@ mod test {
         );
         // Validator-scoped overrides do not apply to a fullnode.
         assert!(config.enable_soft_locking);
+    }
+
+    #[test]
+    fn try_build_rejects_a_consensus_override_that_reaches_the_fullnode() {
+        // `all:` applies cleanly to the validators and must still fail on
+        // the fullnode, which has no consensus config.
+        let err = Swarm::builder()
+            .with_fullnode_count(1)
+            .with_node_config_overrides(vec![
+                "all:consensus-config.db-retention-epochs=2"
+                    .parse()
+                    .unwrap(),
+            ])
+            .try_build()
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("all:consensus-config.db-retention-epochs=2"),
+            "{err}"
+        );
+        assert!(err.contains("on a fullnode"), "{err}");
+    }
+
+    #[test]
+    fn overrides_apply_per_validator_independently() {
+        // validator-0 creates the whole section; the dotted edit fails on
+        // validator 1, where the section does not exist.
+        let err = Swarm::builder()
+            .committee_size(NonZeroUsize::new(2).unwrap())
+            .with_node_config_overrides(vec![
+                "validator-0:firewall-config={remote-fw-url: 'http://127.0.0.1:65000', \
+                 destination-port: 65000}"
+                    .parse()
+                    .unwrap(),
+                "validator-1:firewall-config.destination-port=65001"
+                    .parse()
+                    .unwrap(),
+            ])
+            .try_build()
+            .unwrap_err();
+        // The failure names the validator-1 override: the section validator-0
+        // created does not exist there, so the dotted edit leaves its
+        // required fields unset.
+        let err = format!("{err:#}");
+        assert!(err.contains("validator-1:"), "{err}");
+        assert!(err.contains("remote-fw-url"), "{err}");
+    }
+
+    #[test]
+    fn try_build_rejects_an_out_of_range_validator_scope_before_the_genesis_build() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let err = Swarm::builder()
+            .dir(dir.path())
+            .committee_size(NonZeroUsize::new(2).unwrap())
+            .with_node_config_overrides(vec![
+                "validator-2:enable-soft-locking=false".parse().unwrap(),
+            ])
+            .try_build()
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("validator-2:enable-soft-locking=false"),
+            "{err}"
+        );
+        assert!(err.contains("only 2 validators"), "{err}");
+        // The genesis blob is saved right after the genesis build, so its
+        // absence pins that the scope is checked before that build.
+        assert!(!dir.path().join(IOTA_GENESIS_FILENAME).exists());
+    }
+
+    #[test]
+    fn try_build_rejects_an_out_of_range_validator_scope_for_a_supplied_network_config() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let network_config = ConfigBuilder::new(dir.path())
+            .committee_size(NonZeroUsize::new(1).unwrap())
+            .build();
+        let err = Swarm::builder()
+            .with_network_config(network_config)
+            .with_node_config_overrides(vec![
+                "validator-1:enable-soft-locking=false".parse().unwrap(),
+            ])
+            .try_build()
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("validator-1:enable-soft-locking=false"),
+            "{err}"
+        );
+        assert!(err.contains("only 1 validator"), "{err}");
+    }
+
+    #[test]
+    fn validator_scopes_may_set_the_consensus_config() {
+        let swarm = Swarm::builder()
+            .with_node_config_overrides(vec![
+                "validator:consensus-config.db-retention-epochs=2"
+                    .parse()
+                    .unwrap(),
+                "validator-0:consensus-config.db-pruner-period-secs=60"
+                    .parse()
+                    .unwrap(),
+            ])
+            .try_build()
+            .unwrap();
+        let consensus_config = swarm.config().validator_configs()[0]
+            .consensus_config
+            .as_ref()
+            .unwrap();
+        assert_eq!(consensus_config.db_retention_epochs, Some(2));
+        assert_eq!(consensus_config.db_pruner_period_secs, Some(60));
+    }
+
+    #[test]
+    fn overrides_apply_to_a_supplied_network_config() {
+        // The localnet feeds a network config loaded from disk; overrides
+        // apply to those configs, not to freshly generated ones.
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut network_config = ConfigBuilder::new(dir.path())
+            .committee_size(NonZeroUsize::new(1).unwrap())
+            .build();
+        "firewall-config={remote-fw-url: 'http://127.0.0.1:65000', destination-port: 65000}"
+            .parse::<NodeConfigOverride>()
+            .unwrap()
+            .apply_to(&mut network_config.validator_configs[0])
+            .unwrap();
+
+        let swarm = Swarm::builder()
+            .with_network_config(network_config)
+            .with_fullnode_count(1)
+            .with_node_config_overrides(vec![
+                "validator:firewall-config.destination-port=65001"
+                    .parse()
+                    .unwrap(),
+                "fullnode:enable-index-processing=false".parse().unwrap(),
+            ])
+            .try_build()
+            .unwrap();
+        assert_eq!(
+            swarm.config().validator_configs()[0]
+                .firewall_config
+                .as_ref()
+                .unwrap()
+                .destination_port,
+            65001
+        );
+        let fullnode = swarm.fullnodes().next().unwrap();
+        assert!(!fullnode.config().enable_index_processing);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description of change

Removes the duplicated override-validation policy in `iota-localnet`; first step of the node-config layering plan.

- Add `SwarmBuilder::try_build() -> anyhow::Result<Swarm>`; `build()` becomes `try_build().unwrap_or_else(|err| panic!(...))`, so existing call sites are untouched. The validator-scope bound check and override application return errors instead of panicking; an out-of-range `validator-<N>` scope fails before the genesis build when the validator count is already known (the predicted count matches `ConfigBuilder`, using the key count when validator keys are supplied), and the bound is re-checked against the built validator count. Override-apply errors name the validator index.
- Add `FullnodeConfigBuilder::try_build` / `try_build_from_parts`: a validator config without `p2p-config.external-address` (which the fullnode's seed peers are derived from) is a clean error naming both possible causes — the file never set one or an override cleared it — instead of an `unwrap`; the panicking forms delegate to them, and the `iota-localnet genesis` fullnode and state-sync-fullnode configs are built through the fallible form.
- `iota-localnet start` calls `try_build` and deletes `validate_node_config_overrides` with its throwaway config assembly — overrides are validated by the build itself, on the real configs, so the validation can no longer drift from what the build does.
- Two rules the build cannot express stay in `iota-localnet`: fullnode-scoped overrides need a fullnode (the swarm accepts them for nodes spawned later — a path no in-repo caller currently combines with overrides — and with `fullnode_count` 0 the build never validates fullnode-scoped overrides, which is why localnet rejects them up front), and the indexer/GraphQL service requirements (fullnode gRPC API, data-ingestion directory) are checked against the built fullnode config before `launch()`, failing rather than skipping when the services are requested without a fullnode.
- Behavior changes: an override that used to panic the build now fails it with a clean error; in force-regenesis mode a bad override value is reported only after the full genesis build, while out-of-range scopes still fail fast; the service requirements are checked on every start (previously only when overrides were passed) and also moved after the build; `genesis --committee-size 0` is a clean error instead of an abort.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] CLI: an override that only the real node config rejects now fails `iota-localnet start` with a clean error naming the node at fault, instead of panicking.