### PR TITLE
refactor: remove the `MultiSig` and `MultiSigPublicKey` aliases of the SDK multisig types

### DIFF
--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -22,7 +22,10 @@ use iota_sdk_types::{
     TransactionExpiration, TransactionKind, TypeArgumentError, TypeTag, UnchangedSharedKind,
     UserSignature,
     checkpoint::{CheckpointCommitment, CheckpointContents, CheckpointSummary},
-    crypto::{Intent, IntentMessage, PersonalMessage},
+    crypto::{
+        Intent, IntentMessage, MultisigAggregatedSignature, MultisigCommittee, MultisigMember,
+        PersonalMessage,
+    },
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
     validator::ValidatorCommitteeMember,
 };
@@ -39,7 +42,6 @@ use iota_types::{
         CertifiedCheckpointSummary, CheckpointContentsExt, FullCheckpointContents,
     },
     messages_grpc::ObjectInfoRequestKind,
-    multisig::{MultiSig, MultiSigPublicKey, MultisigMember},
     object::{MoveStructExt, ObjectInner},
     storage::DeleteKind,
     transaction::{CallArg, TransactionAPI, TransactionEnvelope},
@@ -181,7 +183,7 @@ fn get_registry() -> Result<Registry> {
     let sig: SimpleSignature = kp1.sign(b"hello world");
     tracer.trace_value(&mut samples, &sig).unwrap();
 
-    let multisig_pk = MultiSigPublicKey::new(
+    let multisig_pk = MultisigCommittee::new(
         vec![
             MultisigMember::new(kp1.public_key(), 1),
             MultisigMember::new(kp2.public_key(), 1),
@@ -201,7 +203,7 @@ fn get_registry() -> Result<Registry> {
     let sig2: SimpleSignature = kp2.sign(&*digest);
     let sig3: SimpleSignature = kp3.sign(&*digest);
 
-    let multi_sig = MultiSig::new(
+    let multi_sig = MultisigAggregatedSignature::new(
         vec![
             sig1.clone().into(),
             sig2.clone().into(),

--- a/crates/iota-e2e-tests/tests/multisig_tests.rs
+++ b/crates/iota-e2e-tests/tests/multisig_tests.rs
@@ -11,14 +11,14 @@ use iota_sdk_crypto::{secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair};
 use iota_sdk_types::{
     Address, UserSignature,
     crypto::{
-        Intent, IntentMessage, PasskeyAuthenticator, PasskeyPublicKey, PublicKey,
-        Secp256r1PublicKey, Secp256r1Signature, SimpleSignature,
+        Intent, IntentMessage, MultisigAggregatedSignature, MultisigCommittee, MultisigMember,
+        PasskeyAuthenticator, PasskeyPublicKey, PublicKey, Secp256r1PublicKey, Secp256r1Signature,
+        SimpleSignature,
     },
 };
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     error::{IotaError, IotaResult},
-    multisig::{MultiSig, MultiSigPublicKey, MultisigMember},
     transaction::TransactionEnvelope,
     utils::{make_upgraded_multisig_tx, multisig_keys},
 };
@@ -123,7 +123,7 @@ async fn create_credential_and_sign_test_tx_with_passkey_multisig(
     let pk1 = kp2.public_key(); // secp256k1
     let pk2 = kp3.public_key(); // secp256r1
 
-    let multisig_pk = MultiSigPublicKey::new(
+    let multisig_pk = MultisigCommittee::new(
         vec![
             MultisigMember::new(pk0, 1),
             MultisigMember::new(pk1, 1),
@@ -201,8 +201,9 @@ async fn create_credential_and_sign_test_tx_with_passkey_multisig(
     )
     .unwrap();
 
-    let multisig =
-        UserSignature::Multisig(MultiSig::new(vec![sig.into()], multisig_pk.clone()).unwrap());
+    let multisig = UserSignature::Multisig(
+        MultisigAggregatedSignature::new(vec![sig.into()], multisig_pk.clone()).unwrap(),
+    );
 
     TransactionEnvelope::from_user_sig_data(tx_data, vec![multisig])
 }
@@ -255,7 +256,7 @@ async fn test_multisig_e2e() {
     let pk1: PublicKey = kp2.public_key().into(); // secp256k1
     let pk2 = kp3.public_key(); // secp256r1
 
-    let multisig_pk = MultiSigPublicKey::new_unchecked(
+    let multisig_pk = MultisigCommittee::new_unchecked(
         vec![
             MultisigMember::new(pk0, 1),
             MultisigMember::new(pk1.clone(), 1),
@@ -349,7 +350,7 @@ async fn test_multisig_e2e() {
     let pk3: PublicKey = Secp256r1PrivateKey::generate(rand::thread_rng())
         .public_key()
         .into();
-    let wrong_multisig_pk = MultiSigPublicKey::new_unchecked(
+    let wrong_multisig_pk = MultisigCommittee::new_unchecked(
         vec![
             MultisigMember::new(pk0, 1),
             MultisigMember::new(pk1, 1),

--- a/crates/iota-test-transaction-builder/src/lib.rs
+++ b/crates/iota-test-transaction-builder/src/lib.rs
@@ -19,11 +19,11 @@ use iota_sdk_transaction_builder::{PTBArgumentList, TransactionBuilder};
 use iota_sdk_types::{
     Address, Identifier, Input, ObjectId, ObjectReference, Owner, ProgrammableTransaction,
     SharedObjectReference, StructTag, Transaction, TransactionDigest, TransactionKind, TypeTag,
-    UserSignature, Version, crypto::SimpleSignature,
+    UserSignature, Version,
+    crypto::{BitmapUnit, MultisigAggregatedSignature, MultisigCommittee, SimpleSignature},
 };
 use iota_types::{
     crypto::{AccountKeyPair, get_key_pair},
-    multisig::{BitmapUnit, MultiSig, MultiSigPublicKey},
     transaction::{
         CallArg, DEFAULT_VALIDATOR_GAS_PRICE, TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
         TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionAPI, TransactionEnvelope,
@@ -416,15 +416,18 @@ impl TestTransactionBuilder {
 
     pub fn build_and_sign_multisig(
         self,
-        multisig_pk: MultiSigPublicKey,
+        multisig_pk: MultisigCommittee,
         signers: &[&dyn Signer<SimpleSignature>],
         bitmap: BitmapUnit,
     ) -> TransactionEnvelope {
         let data = self.build();
         let digest = data.signing_digest();
         let signatures = signers.iter().map(|s| s.sign(&digest).into()).collect();
-        let multisig =
-            UserSignature::Multisig(MultiSig::new_unchecked(signatures, bitmap, multisig_pk));
+        let multisig = UserSignature::Multisig(MultisigAggregatedSignature::new_unchecked(
+            signatures,
+            bitmap,
+            multisig_pk,
+        ));
 
         TransactionEnvelope::from_user_sig_data(data, vec![multisig])
     }

--- a/crates/iota-types/src/multisig.rs
+++ b/crates/iota-types/src/multisig.rs
@@ -4,11 +4,10 @@
 
 pub use enum_dispatch::enum_dispatch;
 use iota_sdk_crypto::{Verifier, multisig::MultisigVerifier};
-pub use iota_sdk_types::crypto::{
-    BitmapUnit, MultisigAggregatedSignature as MultiSig, MultisigCommittee as MultiSigPublicKey,
-    MultisigMember, MultisigMemberSignature, ThresholdUnit, WeightUnit,
+use iota_sdk_types::{
+    Address,
+    crypto::{IntentMessage, MultisigAggregatedSignature},
 };
-use iota_sdk_types::{Address, crypto::IntentMessage};
 use serde::Serialize;
 
 use crate::{
@@ -20,7 +19,7 @@ use crate::{
 #[path = "unit_tests/multisig_tests.rs"]
 mod multisig_tests;
 
-impl AuthenticatorTrait for MultiSig {
+impl AuthenticatorTrait for MultisigAggregatedSignature {
     fn verify_claims<T>(
         &self,
         intent_message: &IntentMessage<T>,

--- a/crates/iota-types/src/unit_tests/multisig_tests.rs
+++ b/crates/iota-types/src/unit_tests/multisig_tests.rs
@@ -5,12 +5,14 @@
 use iota_sdk_crypto::Signer;
 use iota_sdk_types::{
     Address,
-    crypto::{Intent, IntentMessage, PersonalMessage, Secp256k1Signature},
+    crypto::{
+        Intent, IntentMessage, MultisigAggregatedSignature, MultisigCommittee, MultisigMember,
+        MultisigMemberSignature, PersonalMessage, Secp256k1Signature,
+    },
 };
 
 use crate::{
     error::IotaError,
-    multisig::{MultiSig, MultiSigPublicKey, MultisigMember, MultisigMemberSignature},
     signature::{AuthenticatorTrait, VerifyParams},
     utils::multisig_keys,
 };
@@ -24,7 +26,7 @@ fn verify_rejects_signature_pubkey_scheme_mismatch() {
     let (kp1, kp2, _) = multisig_keys();
 
     let multisig_pk =
-        MultiSigPublicKey::new(vec![MultisigMember::new(kp1.public_key(), 1)], 1).unwrap();
+        MultisigCommittee::new(vec![MultisigMember::new(kp1.public_key(), 1)], 1).unwrap();
     let multisig_address: Address = (&multisig_pk).into();
 
     let intent_msg = IntentMessage::new(
@@ -34,7 +36,7 @@ fn verify_rejects_signature_pubkey_scheme_mismatch() {
 
     // Sign with the Secp256k1 key even though the committee member is Ed25519.
     let secp_sig: Secp256k1Signature = kp2.sign(&*intent_msg.signing_digest());
-    let multisig = MultiSig::new_unchecked(
+    let multisig = MultisigAggregatedSignature::new_unchecked(
         vec![MultisigMemberSignature::Secp256k1(secp_sig)],
         0b1,
         multisig_pk,

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -223,9 +223,9 @@ pub fn make_sponsored_regular_sig_tx() -> (TransactionEnvelope, Address, Address
 mod move_authenticator {
     use fastcrypto::hash::HashFunction;
     use iota_sdk_types::{
-        Address, Digest, SenderSignedTransaction, SharedObjectReference, UserSignature,
+        Address, Digest, MoveAuthenticator, MoveAuthenticatorV1, SenderSignedTransaction,
+        SharedObjectReference, UserSignature,
     };
-    pub use iota_sdk_types::{MoveAuthenticator, MoveAuthenticatorV1};
 
     use crate::{
         crypto::DefaultHash,

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -11,7 +11,8 @@ use iota_sdk_crypto::{
 };
 use iota_sdk_types::{
     Address, ObjectId, SenderSignedTransaction, SimpleSignature, Transaction, TransactionKind,
-    UserSignature, crypto::Intent,
+    UserSignature,
+    crypto::{Intent, MultisigAggregatedSignature, MultisigCommittee, MultisigMember},
 };
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -22,7 +23,6 @@ use crate::{
         AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, get_key_pair,
         get_key_pair_from_rng,
     },
-    multisig::{MultiSig, MultiSigPublicKey, MultisigMember},
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionAPI, TransactionEnvelope},
@@ -175,7 +175,7 @@ pub fn make_upgraded_multisig_tx() -> TransactionEnvelope {
     let pk2 = kp2.public_key();
     let pk3 = kp3.public_key();
 
-    let multisig_pk = MultiSigPublicKey::new(
+    let multisig_pk = MultisigCommittee::new(
         vec![
             MultisigMember::new(pk1, 1),
             MultisigMember::new(pk2, 1),
@@ -192,7 +192,8 @@ pub fn make_upgraded_multisig_tx() -> TransactionEnvelope {
     let sig2: SimpleSignature = kp2.sign(&msg);
 
     // Any 2 of 3 signatures verifies ok.
-    let multi_sig1 = MultiSig::new(vec![sig1.into(), sig2.into()], multisig_pk).unwrap();
+    let multi_sig1 =
+        MultisigAggregatedSignature::new(vec![sig1.into(), sig2.into()], multisig_pk).unwrap();
     TransactionEnvelope::new(SenderSignedTransaction::new(
         tx.transaction().clone(),
         vec![UserSignature::Multisig(multi_sig1)],

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -42,15 +42,15 @@ use iota_sdk_crypto::{
 use iota_sdk_types::{
     Address, SenderSignedTransaction, SignatureScheme, Transaction,
     crypto::{
-        Intent, IntentMessage, PasskeyAuthenticator, PublicKey as SdkPublicKey, SimpleSignature,
-        UserSignature,
+        Intent, IntentMessage, MultisigAggregatedSignature, MultisigCommittee, MultisigMember,
+        PasskeyAuthenticator, PublicKey as SdkPublicKey, SimpleSignature, ThresholdUnit,
+        UserSignature, WeightUnit,
     },
 };
 use iota_types::{
     crypto::{DefaultHash, EncodeDecodeBase64, PublicKey, get_authority_key_pair},
     error::IotaResult,
     move_authenticator::MoveAuthenticatorExt,
-    multisig::{MultiSig, MultiSigPublicKey, MultisigMember, ThresholdUnit, WeightUnit},
     signature::{AuthenticatorTrait, VerifyParams},
     transaction::TransactionAPI,
 };
@@ -92,7 +92,7 @@ pub enum KeyToolCommand {
     /// If tx_bytes is passed in, verify the multisig.
     DecodeMultiSig {
         #[arg(long)]
-        multisig: MultiSig,
+        multisig: MultisigAggregatedSignature,
         #[arg(long)]
         tx_bytes: Option<String>,
     },
@@ -344,7 +344,7 @@ pub struct MultiSigAddress {
 #[serde(rename_all = "camelCase")]
 pub struct MultiSigCombinePartialSig {
     multisig_address: Address,
-    multisig_parsed: MultiSig,
+    multisig_parsed: MultisigAggregatedSignature,
     multisig_serialized: String,
 }
 
@@ -762,7 +762,7 @@ impl KeyToolCommand {
             } => {
                 let multisig_pk = multisig_public_key(pks, weights, threshold)?;
                 let address: Address = (&multisig_pk).into();
-                let multisig = MultiSig::new(sigs, multisig_pk)?;
+                let multisig = MultisigAggregatedSignature::new(sigs, multisig_pk)?;
                 let multisig_serialized = Base64::encode(multisig.to_bytes());
                 CommandOutput::MultiSigCombinePartialSig(MultiSigCombinePartialSig {
                     multisig_address: address,
@@ -1148,14 +1148,14 @@ impl Debug for CommandOutput {
 
 impl PrintableResult for CommandOutput {}
 
-/// Build and validate a [`MultiSigPublicKey`] from a list of public keys and
+/// Build and validate a [`MultisigCommittee`] from a list of public keys and
 /// their corresponding weights. The number of keys must match the number of
 /// weights.
 fn multisig_public_key(
     pks: Vec<SdkPublicKey>,
     weights: Vec<WeightUnit>,
     threshold: ThresholdUnit,
-) -> Result<MultiSigPublicKey, anyhow::Error> {
+) -> Result<MultisigCommittee, anyhow::Error> {
     if pks.len() != weights.len() {
         bail!(
             "Number of public keys ({}) does not match number of weights ({})",
@@ -1168,7 +1168,7 @@ fn multisig_public_key(
         .zip(weights)
         .map(|(pk, w)| MultisigMember::new(pk, w))
         .collect();
-    Ok(MultiSigPublicKey::new(members, threshold)?)
+    Ok(MultisigCommittee::new(members, threshold)?)
 }
 
 /// Converts legacy formatted private key to 33 bytes bech32 encoded private key


### PR DESCRIPTION
# Description of change

Follow-up to the SDK type migration (#10724 and the `TransactionData` / `SenderSignedData` / `Signature` alias removals): drop the transitional `MultiSig` and `MultiSigPublicKey` names so the SDK multisig types are used under their own names everywhere.

- Remove the `pub use` re-export from `iota_types::multisig` (`MultisigAggregatedSignature as MultiSig`, `MultisigCommittee as MultiSigPublicKey`, plus the pass-through re-exports of `BitmapUnit`, `MultisigMember`, `MultisigMemberSignature`, `ThresholdUnit`, `WeightUnit`); the module now only holds the `AuthenticatorTrait` impl.
- Every consumer imports the types from `iota_sdk_types::crypto` directly and uses the SDK names.
- The `iota keytool` CLI keeps its own local `MultiSig` names (`DecodedSigOutput::MultiSig`, `MultiSigCombinePartialSig`, user-facing command help) — those are CLI output/UX identifiers, not the removed aliases.

## Serialization / wire compatibility

No change: this only removes type aliases — the underlying SDK types are unchanged, so BCS bytes and digests are untouched.

## Links to any relevant issues

- #10724

## How the change has been tested

- [x] `cargo check --workspace --all-targets` — clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` on the touched crates and `cargo +nightly fmt` — clean.
- [x] Unit tests: `iota-types` multisig tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
