### PR TITLE
refactor(starfish): make consensus gRPC inbound bounds the plain default

### DIFF
--- a/crates/iota-core/src/consensus_manager/starfish_manager.rs
+++ b/crates/iota-core/src/consensus_manager/starfish_manager.rs
@@ -129,24 +129,6 @@ impl ConsensusManagerTrait for StarfishManager {
             .find(|(_, a)| a.protocol_key == own_protocol_key)
             .expect("Own authority should be among the consensus authorities!");
 
-        // Apply the protective consensus gRPC resource limits by default,
-        // filling only the bounds left unconfigured so explicit node config is
-        // respected. A node can opt out via the environment variable without a
-        // redeploy; these are local operational parameters, so heterogeneous
-        // values across validators are safe.
-        let parameters = {
-            let mut p = parameters;
-            if matches!(
-                std::env::var("CONSENSUS_GRPC_PROTECTIVE_LIMITS").as_deref(),
-                Ok("0") | Ok("false")
-            ) {
-                info!("Consensus gRPC protective limits disabled for validator {own_index}");
-            } else {
-                p.tonic.apply_protective();
-            }
-            p
-        };
-
         // Allow DAG visualizer port to be set via environment variable.
         // The port is used as-is (no offset) — in Docker each validator has its
         // own container so port collisions aren't a concern.

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -648,7 +648,7 @@ pub struct AdmissionParameters {
     /// Max concurrent commit fetches per peer
     /// (`fetch_commits` + `fetch_commits_and_transactions`).
     ///
-    /// If unspecified, this will default to `commit_sync_parallel_fetches`.
+    /// If unspecified, this will default to 8.
     #[serde(default = "AdmissionParameters::default_max_commit_fetches_per_peer")]
     pub max_commit_fetches_per_peer: u32,
 }

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -525,15 +525,17 @@ pub struct TonicParameters {
     /// Maximum number of concurrent HTTP/2 streams a peer may open on a single
     /// connection. Bounds per-connection request fan-out.
     ///
-    /// `0` (the default) disables the limit, leaving the transport default.
-    #[serde(default)]
+    /// If unspecified, this will default to 64. `0` disables the limit, leaving
+    /// the transport default.
+    #[serde(default = "TonicParameters::default_max_concurrent_streams")]
     pub max_concurrent_streams: u32,
 
     /// Server-side fallback deadline for requests that omit a `grpc-timeout`
     /// header. The long-lived block-subscription stream is always exempt.
     ///
-    /// A zero duration (the default) disables the fallback deadline.
-    #[serde(default)]
+    /// If unspecified, this will default to 120s. A zero duration disables the
+    /// fallback deadline.
+    #[serde(default = "TonicParameters::default_request_timeout")]
     pub request_timeout: Duration,
 
     /// Hard size limit for inbound (decoded) requests. Consensus requests are
@@ -541,8 +543,9 @@ pub struct TonicParameters {
     /// `message_size_limit`. A smaller inbound bound shrinks the memory a
     /// single in-flight request can pin before its handler runs.
     ///
-    /// `0` (the default) falls back to `message_size_limit`.
-    #[serde(default)]
+    /// If unspecified, this will default to 1MiB. `0` falls back to
+    /// `message_size_limit`.
+    #[serde(default = "TonicParameters::default_max_inbound_message_size")]
     pub max_inbound_message_size: usize,
 
     /// Per-peer, per-RPC admission caps for the inbound consensus server.
@@ -554,8 +557,9 @@ pub struct TonicParameters {
     /// request is disconnected once it expires; the stream itself stays exempt
     /// from `request_timeout`.
     ///
-    /// A zero duration (the default) disables the deadline.
-    #[serde(default)]
+    /// If unspecified, this will default to 30s. A zero duration disables the
+    /// deadline.
+    #[serde(default = "TonicParameters::default_subscribe_request_timeout")]
     pub subscribe_request_timeout: Duration,
 }
 
@@ -576,36 +580,20 @@ impl TonicParameters {
         64 << 20
     }
 
-    /// Fills the inbound resource bounds that are still at their inert
-    /// defaults with the protective preset (sized for ~100-validator
-    /// committees). Bounds an operator configured explicitly are kept, as are
-    /// the transport settings the preset does not cover (keepalive, buffers,
-    /// `message_size_limit`). A bound explicitly configured to its inert value
-    /// still receives the preset; running without a bound requires disabling
-    /// the preset itself (`CONSENSUS_GRPC_PROTECTIVE_LIMITS=0`).
-    pub fn apply_protective(&mut self) {
-        if self.max_concurrent_streams == 0 {
-            self.max_concurrent_streams = 64;
-        }
-        if self.request_timeout.is_zero() {
-            self.request_timeout = Duration::from_secs(120);
-        }
-        if self.max_inbound_message_size == 0 {
-            self.max_inbound_message_size = 1 << 20;
-        }
-        if self.admission.is_inert() {
-            self.admission = AdmissionParameters::protective();
-        }
-        if self.subscribe_request_timeout.is_zero() {
-            self.subscribe_request_timeout = Duration::from_secs(30);
-        }
+    fn default_max_concurrent_streams() -> u32 {
+        64
     }
 
-    /// The inert defaults with the protective bounds applied.
-    pub fn protective() -> Self {
-        let mut params = Self::default();
-        params.apply_protective();
-        params
+    fn default_request_timeout() -> Duration {
+        Duration::from_secs(120)
+    }
+
+    fn default_max_inbound_message_size() -> usize {
+        1 << 20
+    }
+
+    fn default_subscribe_request_timeout() -> Duration {
+        Duration::from_secs(30)
     }
 }
 
@@ -616,11 +604,11 @@ impl Default for TonicParameters {
             connection_buffer_size: TonicParameters::default_connection_buffer_size(),
             excessive_message_size: TonicParameters::default_excessive_message_size(),
             message_size_limit: TonicParameters::default_message_size_limit(),
-            max_concurrent_streams: 0,
-            request_timeout: Duration::ZERO,
-            max_inbound_message_size: 0,
+            max_concurrent_streams: TonicParameters::default_max_concurrent_streams(),
+            request_timeout: TonicParameters::default_request_timeout(),
+            max_inbound_message_size: TonicParameters::default_max_inbound_message_size(),
             admission: AdmissionParameters::default(),
-            subscribe_request_timeout: Duration::ZERO,
+            subscribe_request_timeout: TonicParameters::default_subscribe_request_timeout(),
         }
     }
 }
@@ -633,51 +621,64 @@ impl Default for TonicParameters {
 /// non-protocol parameters — heterogeneous values across authorities are safe,
 /// so they can be rolled out and tuned per node.
 ///
-/// `0` (the default for every cap) disables admission for that group. At node
-/// start the protective preset fills the caps when all of them are left at
-/// `0`; a caps block with any explicitly configured value is kept as-is, and
-/// `CONSENSUS_GRPC_PROTECTIVE_LIMITS=0` disables the preset entirely. Preset
-/// values, sized for ~100-validator committees and the local synchronizer
-/// fan-out toward one server: subscriptions 2, header fetches 32, transaction
-/// fetches 16, commit fetches `commit_sync_parallel_fetches` (8).
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+/// The defaults are sized for ~100-validator committees and the local
+/// synchronizer fan-out toward one server. `0` disables admission for that
+/// group.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AdmissionParameters {
     /// Max concurrent block-subscription streams per peer.
-    #[serde(default)]
+    ///
+    /// If unspecified, this will default to 2.
+    #[serde(default = "AdmissionParameters::default_max_subscriptions_per_peer")]
     pub max_subscriptions_per_peer: u32,
 
     /// Max concurrent header fetches per peer
     /// (`fetch_block_headers` + `fetch_latest_block_headers`).
-    #[serde(default)]
+    ///
+    /// If unspecified, this will default to 32.
+    #[serde(default = "AdmissionParameters::default_max_header_fetches_per_peer")]
     pub max_header_fetches_per_peer: u32,
 
     /// Max concurrent transaction fetches per peer (`fetch_transactions`).
-    #[serde(default)]
+    ///
+    /// If unspecified, this will default to 16.
+    #[serde(default = "AdmissionParameters::default_max_transaction_fetches_per_peer")]
     pub max_transaction_fetches_per_peer: u32,
 
     /// Max concurrent commit fetches per peer
     /// (`fetch_commits` + `fetch_commits_and_transactions`).
-    #[serde(default)]
+    ///
+    /// If unspecified, this will default to `commit_sync_parallel_fetches`.
+    #[serde(default = "AdmissionParameters::default_max_commit_fetches_per_peer")]
     pub max_commit_fetches_per_peer: u32,
 }
 
 impl AdmissionParameters {
-    /// Preset sized for ~100-validator committees and the local synchronizer
-    /// fan-out toward one server.
-    pub fn protective() -> Self {
-        Self {
-            max_subscriptions_per_peer: 2,
-            max_header_fetches_per_peer: 32,
-            max_transaction_fetches_per_peer: 16,
-            max_commit_fetches_per_peer: Parameters::default_commit_sync_parallel_fetches() as u32,
-        }
+    fn default_max_subscriptions_per_peer() -> u32 {
+        2
     }
 
-    /// True when every cap is `0`, i.e. admission control is disabled.
-    pub fn is_inert(&self) -> bool {
-        self.max_subscriptions_per_peer == 0
-            && self.max_header_fetches_per_peer == 0
-            && self.max_transaction_fetches_per_peer == 0
-            && self.max_commit_fetches_per_peer == 0
+    fn default_max_header_fetches_per_peer() -> u32 {
+        32
+    }
+
+    fn default_max_transaction_fetches_per_peer() -> u32 {
+        16
+    }
+
+    fn default_max_commit_fetches_per_peer() -> u32 {
+        Parameters::default_commit_sync_parallel_fetches() as u32
+    }
+}
+
+impl Default for AdmissionParameters {
+    fn default() -> Self {
+        Self {
+            max_subscriptions_per_peer: AdmissionParameters::default_max_subscriptions_per_peer(),
+            max_header_fetches_per_peer: AdmissionParameters::default_max_header_fetches_per_peer(),
+            max_transaction_fetches_per_peer:
+                AdmissionParameters::default_max_transaction_fetches_per_peer(),
+            max_commit_fetches_per_peer: AdmissionParameters::default_max_commit_fetches_per_peer(),
+        }
     }
 }

--- a/crates/starfish/config/tests/parameters_test.rs
+++ b/crates/starfish/config/tests/parameters_test.rs
@@ -10,84 +10,54 @@ fn parameters_snapshot_matches() {
 }
 
 #[test]
-fn protective_preset_enables_bounds_and_default_stays_inert() {
-    let protective = starfish_config::TonicParameters::protective();
-    assert_eq!(protective.max_concurrent_streams, 64);
-    assert_eq!(
-        protective.request_timeout,
-        std::time::Duration::from_secs(120)
-    );
-    assert_eq!(protective.max_inbound_message_size, 1 << 20);
-    assert_eq!(protective.admission.max_subscriptions_per_peer, 2);
-    assert_eq!(protective.admission.max_header_fetches_per_peer, 32);
-    assert_eq!(protective.admission.max_transaction_fetches_per_peer, 16);
-    assert!(protective.admission.max_commit_fetches_per_peer > 0);
-    assert_eq!(
-        protective.subscribe_request_timeout,
-        std::time::Duration::from_secs(30)
-    );
-
-    // The config defaults stay inert; the preset is applied at node start.
-    let inert = starfish_config::TonicParameters::default();
-    assert_eq!(inert.max_concurrent_streams, 0);
-    assert!(inert.request_timeout.is_zero());
-    assert_eq!(inert.max_inbound_message_size, 0);
-    assert_eq!(inert.admission.max_header_fetches_per_peer, 0);
-    assert!(inert.subscribe_request_timeout.is_zero());
-}
-
-#[test]
-fn apply_protective_preserves_operator_transport_fields() {
-    // Operator-customised transport settings that must survive the preset.
-    let mut tonic = starfish_config::TonicParameters {
-        keepalive_interval: std::time::Duration::from_secs(11),
-        connection_buffer_size: 9 << 20,
-        excessive_message_size: 5 << 20,
-        message_size_limit: 7 << 20,
-        ..Default::default()
-    };
-
-    tonic.apply_protective();
-
-    // Protective bounds applied.
+fn default_enables_inbound_bounds() {
+    let tonic = starfish_config::TonicParameters::default();
     assert_eq!(tonic.max_concurrent_streams, 64);
+    assert_eq!(tonic.request_timeout, std::time::Duration::from_secs(120));
     assert_eq!(tonic.max_inbound_message_size, 1 << 20);
+    assert_eq!(tonic.admission.max_subscriptions_per_peer, 2);
     assert_eq!(tonic.admission.max_header_fetches_per_peer, 32);
-    // Operator transport settings preserved (not reset to defaults).
-    assert_eq!(tonic.keepalive_interval, std::time::Duration::from_secs(11));
-    assert_eq!(tonic.connection_buffer_size, 9 << 20);
-    assert_eq!(tonic.excessive_message_size, 5 << 20);
-    assert_eq!(tonic.message_size_limit, 7 << 20);
-}
-
-#[test]
-fn apply_protective_preserves_operator_set_bounds() {
-    let mut tonic = starfish_config::TonicParameters {
-        max_concurrent_streams: 128,
-        request_timeout: std::time::Duration::from_secs(30),
-        max_inbound_message_size: 4 << 20,
-        admission: starfish_config::AdmissionParameters {
-            max_header_fetches_per_peer: 5,
-            ..Default::default()
-        },
-        subscribe_request_timeout: std::time::Duration::from_secs(3),
-        ..Default::default()
-    };
-
-    tonic.apply_protective();
-
-    // Explicitly configured bounds win over the preset.
-    assert_eq!(tonic.max_concurrent_streams, 128);
-    assert_eq!(tonic.request_timeout, std::time::Duration::from_secs(30));
-    assert_eq!(tonic.max_inbound_message_size, 4 << 20);
+    assert_eq!(tonic.admission.max_transaction_fetches_per_peer, 16);
+    assert!(tonic.admission.max_commit_fetches_per_peer > 0);
     assert_eq!(
         tonic.subscribe_request_timeout,
-        std::time::Duration::from_secs(3)
+        std::time::Duration::from_secs(30)
     );
-    // An admission block with any explicitly configured cap is kept as-is,
-    // not mixed with preset values.
-    assert_eq!(tonic.admission.max_header_fetches_per_peer, 5);
-    assert_eq!(tonic.admission.max_subscriptions_per_peer, 0);
+}
+
+#[test]
+fn operator_config_overrides_defaults() {
+    let parameters: starfish_config::Parameters = serde_yaml::from_str(
+        r#"
+tonic:
+  max_concurrent_streams: 128
+  max_inbound_message_size: 4194304
+  admission:
+    max_header_fetches_per_peer: 5
+    max_subscriptions_per_peer: 0
+"#,
+    )
+    .unwrap();
+    let defaults = starfish_config::Parameters::default();
+
+    assert_eq!(parameters.tonic.max_concurrent_streams, 128);
+    assert_eq!(parameters.tonic.max_inbound_message_size, 4 << 20);
+    assert_eq!(parameters.tonic.admission.max_header_fetches_per_peer, 5);
+    // A cap set to `0` disables admission for that group.
+    assert_eq!(parameters.tonic.admission.max_subscriptions_per_peer, 0);
+    // Unspecified fields keep their defaults, per field rather than per block.
+    assert_eq!(
+        parameters.tonic.admission.max_transaction_fetches_per_peer,
+        defaults.tonic.admission.max_transaction_fetches_per_peer
+    );
+    assert_eq!(
+        parameters.tonic.request_timeout,
+        defaults.tonic.request_timeout
+    );
+    assert_eq!(
+        parameters.tonic.keepalive_interval,
+        defaults.tonic.keepalive_interval
+    );
 }
 
 #[test]

--- a/crates/starfish/config/tests/parameters_test.rs
+++ b/crates/starfish/config/tests/parameters_test.rs
@@ -10,22 +10,6 @@ fn parameters_snapshot_matches() {
 }
 
 #[test]
-fn default_enables_inbound_bounds() {
-    let tonic = starfish_config::TonicParameters::default();
-    assert_eq!(tonic.max_concurrent_streams, 64);
-    assert_eq!(tonic.request_timeout, std::time::Duration::from_secs(120));
-    assert_eq!(tonic.max_inbound_message_size, 1 << 20);
-    assert_eq!(tonic.admission.max_subscriptions_per_peer, 2);
-    assert_eq!(tonic.admission.max_header_fetches_per_peer, 32);
-    assert_eq!(tonic.admission.max_transaction_fetches_per_peer, 16);
-    assert!(tonic.admission.max_commit_fetches_per_peer > 0);
-    assert_eq!(
-        tonic.subscribe_request_timeout,
-        std::time::Duration::from_secs(30)
-    );
-}
-
-#[test]
 fn operator_config_overrides_defaults() {
     let parameters: starfish_config::Parameters = serde_yaml::from_str(
         r#"

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -36,18 +36,18 @@ tonic:
   connection_buffer_size: 33554432
   excessive_message_size: 16777216
   message_size_limit: 67108864
-  max_concurrent_streams: 0
+  max_concurrent_streams: 64
   request_timeout:
-    secs: 0
+    secs: 120
     nanos: 0
-  max_inbound_message_size: 0
+  max_inbound_message_size: 1048576
   admission:
-    max_subscriptions_per_peer: 0
-    max_header_fetches_per_peer: 0
-    max_transaction_fetches_per_peer: 0
-    max_commit_fetches_per_peer: 0
+    max_subscriptions_per_peer: 2
+    max_header_fetches_per_peer: 32
+    max_transaction_fetches_per_peer: 16
+    max_commit_fetches_per_peer: 8
   subscribe_request_timeout:
-    secs: 0
+    secs: 30
     nanos: 0
 fast_commit_sync_batch_size: 1000
 commit_sync_gap_threshold: 1000


### PR DESCRIPTION
# Description of change

Follow-up to #12198 (PR #12199), which turned the consensus gRPC inbound bounds on by default while keeping `CONSENSUS_GRPC_PROTECTIVE_LIMITS` as a transitional opt-out. Default-on is stable in production, so the transitional machinery goes away and the bounds get a single always-on representation instead of an inert-vs-protective duality.

- Drop the `CONSENSUS_GRPC_PROTECTIVE_LIMITS` opt-out read in the consensus manager.
- Fold the values into the plain defaults of `TonicParameters` / `AdmissionParameters`, removing the all-zero default and the `apply_protective` / `protective()` / `is_inert` indirection.
- Give each bound a named serde default, so a partially specified `tonic` block falls back to the bound rather than to the field type's zero.
- Update the parameters snapshot and the config tests that asserted the default stays inert.

Net −63 lines. The consumption sites are untouched and keep their existing "`0` disables this bound" reading.

**Defaults now carried by the config.** Same values the preset already applied at node start, so a node running defaults behaves identically:

| Bound | Default |
| --- | --- |
| `max_concurrent_streams` | 64 |
| `request_timeout` | 120s |
| `max_inbound_message_size` | 1MiB |
| `subscribe_request_timeout` | 30s |
| `admission.max_subscriptions_per_peer` | 2 |
| `admission.max_header_fetches_per_peer` | 32 |
| `admission.max_transaction_fetches_per_peer` | 16 |
| `admission.max_commit_fetches_per_peer` | 8 |

**Operator-visible changes.** All three only affect a node whose config touches these fields:

- Disabling a bound is now per bound (`0` under `consensus-config.parameters.tonic`) instead of global via the env var.
- `tonic.admission` is no longer all-or-nothing. `apply_protective` kept a caps block verbatim if any one cap was set, leaving the other three at `0`; unspecified caps now take their defaults.
- A config that explicitly pins the old all-zero values gets those bounds disabled, where before it received the preset.

Local, non-protocol parameters only — no protocol version bump, and heterogeneous values across validators remain safe.

## Links to any relevant issues

Fixes #12200

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): The consensus gRPC per-peer admission control and inbound resource bounds are now plain configuration defaults; `CONSENSUS_GRPC_PROTECTIVE_LIMITS` is removed. Set the individual bound to `0` under `consensus-config.parameters.tonic` to disable it.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
