### PR TITLE
feat(graphql): Support fallback for transactions filtered by transaction IDs

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.move
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transactions filtered by transaction IDs under pruning,
+// with no historical fallback configured. Covers:
+// - `Query.transactionBlocks(filter: { transactionIds })` for pruned and
+//   unpruned digests
+// - pagination over the selected transactions
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public struct Foo has key, store { id: UID, v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: a pruned digest and an unpruned digest requested together. Without a
+# fallback the pruned transaction is dropped from the result, and only the
+# unpruned one is returned.
+{
+  transactionBlocks(filter: { transactionIds: ["@{digest_2}", "@{digest_9}"] }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# B: the three unpruned transactions, ordered by sequence number.
+{
+  transactionBlocks(filter: { transactionIds: ["@{digest_9}", "@{digest_10}", "@{digest_11}"] }) {
+    pageInfo { startCursor endCursor }
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# C: forward page limited to two transactions.
+{
+  transactionBlocks(filter: { transactionIds: ["@{digest_9}", "@{digest_10}", "@{digest_11}"] }, first: 2) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# D: backward page limited to two transactions.
+{
+  transactionBlocks(filter: { transactionIds: ["@{digest_9}", "@{digest_10}", "@{digest_11}"] }, last: 2) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.snap
@@ -1,0 +1,178 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 19 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 12-19:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 5236400
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 21:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, line 23:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 25:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, line 27:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 6, line 29:
+//# advance-epoch
+Epoch advanced: 2
+
+task 7, line 31:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 8, line 33:
+//# advance-epoch
+Epoch advanced: 3
+
+task 9, line 35:
+//# run Test::M::create --sender A
+created: object(9,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 10, line 37:
+//# run Test::M::create --sender A
+created: object(10,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 11, line 39:
+//# run Test::M::create --sender A
+created: object(11,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 12, line 41:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 13, line 43:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 14, line 45:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 15, lines 47-55:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        }
+      ]
+    }
+  }
+}
+
+task 16, lines 57-64:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        },
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        },
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJjIjo5LCJ0Ijo4LCJpIjpmYWxzZX0",
+        "startCursor": "eyJjIjo5LCJ0Ijo2LCJpIjpmYWxzZX0"
+      }
+    }
+  }
+}
+
+task 17, lines 66-73:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        },
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 18, lines 75-82:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        },
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -167,6 +167,26 @@ impl TransactionBlockFilter {
         self.affected_address
     }
 
+    /// Returns the transaction digests when `transactionIds` is the only
+    /// filter set.
+    pub(crate) fn only_transaction_ids(&self) -> Option<&Vec<Digest>> {
+        let no_other_filters = self.function.is_none()
+            && self.kind.is_none()
+            && self.sent_address.is_none()
+            && self.recv_address.is_none()
+            && self.affected_address.is_none()
+            && self.input_object.is_none()
+            && self.changed_object.is_none()
+            && self.wrapped_or_deleted_object.is_none()
+            && self.after_checkpoint.is_none()
+            && self.at_checkpoint.is_none()
+            && self.before_checkpoint.is_none();
+
+        no_other_filters
+            .then_some(self.transaction_ids.as_ref())
+            .flatten()
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.before_checkpoint == Some(UInt53::from(0))
             || matches!(

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -428,6 +428,18 @@ impl TransactionBlock {
             .await;
         }
 
+        // For the only-`transactionIds` case, we support fallback.
+        // `scan_limit` is ignored here
+        if let Some(transaction_ids) = filter.only_transaction_ids() {
+            return Self::paginate_by_transaction_ids_with_fallback(
+                db,
+                page,
+                transaction_ids,
+                checkpoint_viewed_at,
+            )
+            .await;
+        }
+
         use transactions::dsl as tx;
         let (prev, next, transactions, tx_bounds): (
             bool,
@@ -635,6 +647,61 @@ impl TransactionBlock {
                 && page.after().is_none_or(|c| c.tx_sequence_number <= tx_seq)
                 && page.before().is_none_or(|c| tx_seq <= c.tx_sequence_number)
         });
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = ScanConnection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            let inner = TransactionBlockInner::try_from(stored)?;
+            conn.edges.push(Edge::new(
+                cursor,
+                TransactionBlock {
+                    inner,
+                    checkpoint_viewed_at,
+                },
+            ));
+        }
+        Ok(conn)
+    }
+
+    /// Paginates transactions selected by digest, with fallback support.
+    async fn paginate_by_transaction_ids_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        transaction_ids: &[Digest],
+        checkpoint_viewed_at: u64,
+    ) -> Result<ScanConnection<String, TransactionBlock>, Error> {
+        let digests: Vec<TransactionDigest> = transaction_ids.iter().map(|d| (*d).into()).collect();
+
+        let mut results: Vec<StoredTransaction> = db
+            .inner
+            .multi_get_transactions_with_fallback(&digests)
+            .await
+            .map_err(Error::from)?
+            .into_iter()
+            .filter_map(|tx| match tx {
+                TransactionRead::Checkpointed(stored) => Some(stored),
+                // Optimistic transactions are not yet in a checkpoint, so they
+                // have no `tx_sequence_number` to order and paginate.
+                TransactionRead::Optimistic(_) => None,
+            })
+            .collect();
+
+        // The fetch above returns every requested transaction. Keep only the
+        // ones visible at `checkpoint_viewed_at` and inside the inclusive
+        // cursors range, to satisfy requirements of `page.paginate_results`.
+        results.retain(|tx| {
+            let tx_seq = tx.tx_sequence_number as u64;
+            tx.checkpoint_sequence_number as u64 <= checkpoint_viewed_at
+                && page.after().is_none_or(|c| c.tx_sequence_number <= tx_seq)
+                && page.before().is_none_or(|c| tx_seq <= c.tx_sequence_number)
+        });
+        results.sort_by_key(|tx| tx.tx_sequence_number);
 
         let (prev, next, results) = page.paginate_results(
             results.first().map(|f| f.cursor(checkpoint_viewed_at)),


### PR DESCRIPTION
# Description of change

`Query.transactionBlocks(filter: { transactionIds })` now uses the fallback KV store. It gets the requested transactions with `multi_get_transactions_with_fallback`, keeps the ones that are visible at the viewed checkpoint and inside the cursor range, and returns them ordered by `tx_sequence_number`.

This makes it work the same way as the parts that already use the fallback:
- JSON-RPC `iota_multiGetTransactionBlocks` and `iota_getTransactionBlock`
- the GraphQL `transactionBlock(digest)` query

When `transactionIds` is used together with other filters, it still reads only from Postgres, same as the other fallback cases.

## Links to any relevant issues

fixes #12589

## How the change has been tested

- New e2e test `crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.move`, with no fallback set up: when a pruned digest and an unpruned digest are asked for together, only the unpruned one comes back, and paging (forward and backward) works.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: `Query.transactionBlocks(filter: { transactionIds })` can now read pruned transactions from the fallback KV store when it is configured.