### PR TITLE
fix(graphql): update Checkpoint::paginate comment for the fallback

### DIFF
--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -399,8 +399,8 @@ impl Checkpoint {
     /// If the `Page<Cursor>` is set, then this function will defer to the
     /// `checkpoint_viewed_at` in the cursor if they are consistent.
     ///
-    /// Specifying cursor or requesting epoch from the pruned range will result
-    /// in an error.
+    /// A cursor or epoch in the pruned range is served from the fallback KV
+    /// store when configured, otherwise the request errors.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,


### PR DESCRIPTION
# Description of change

The doc comment on `Checkpoint::paginate` said that a cursor or epoch in the pruned range always returns an error. This is not true anymore: when the fallback KV store is configured, they are read from it. Updated the comment to say so.

Doc comment only, no behavior change.

## Links to any relevant issues

fixes #12590