### PR TITLE
feat(starfish): rank header-synchronizer peers by responsiveness

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -163,13 +163,14 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_enable_starfish_speed_adaptive_acknowledgments")]
     pub enable_starfish_speed_adaptive_acknowledgments: bool,
 
-    /// Prefer more responsive peers when the transactions synchronizer and the
-    /// commit syncer select peers to fetch from. Responses are verified the
-    /// same way regardless, so it cannot affect safety. Enabled by default;
-    /// disabling it restores the previous selection: for the transactions
-    /// synchronizer a uniform random order that excludes the most recently
-    /// failed peers (up to less than f+1 by stake), and for the commit syncer a
-    /// uniform random order.
+    /// Prefer more responsive peers when the transactions synchronizer, the
+    /// commit syncer and the header synchronizer select peers to fetch from.
+    /// Responses are verified the same way regardless, so it cannot affect
+    /// safety. Enabled by default; disabling it restores the previous
+    /// selection: for the transactions synchronizer a uniform random order
+    /// that excludes the most recently failed peers (up to less than f+1 by
+    /// stake), and for the commit syncer and the header synchronizer a uniform
+    /// random order.
     #[serde(default = "Parameters::default_enable_peer_responsiveness_ranking")]
     pub enable_peer_responsiveness_ranking: bool,
 

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -144,7 +144,9 @@ impl SyncMethod {
 /// responsiveness recording needs.
 struct FetchedHeaders {
     serialized_headers: Vec<Bytes>,
-    /// Round trip measured when the response arrived, before verification.
+    /// Round trip measured when the response arrived. The recording site adds
+    /// the verification time on top, so a peer is charged for checking what it
+    /// sent but not for the wait on the other periodic fetches in the batch.
     elapsed: Duration,
     /// Whether the peer was known to hold the requested headers and thus owes
     /// the whole request.
@@ -728,9 +730,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
     /// to Core for processing.
     ///
     /// Records the fetch in the responsiveness tracker once the payload has
-    /// been verified: a verification failure counts as a failure, a success is
-    /// credited with the latency scaled by how many of the requested headers
-    /// were actually delivered.
+    /// been verified: a verification failure or a gap-fill window violation
+    /// counts as a failure, a success is credited with the fetch-plus-verify
+    /// latency scaled by how many of the requested headers were actually
+    /// delivered.
     async fn process_fetched_headers_from_authority(
         fetched: FetchedHeaders,
         peer_index: AuthorityIndex,
@@ -766,6 +769,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         }
 
         // Verify all the fetched block headers
+        let verify_start = Instant::now();
         let block_headers = Handle::current()
             .spawn_blocking({
                 let block_verifier = block_verifier.clone();
@@ -786,15 +790,18 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 }
             })
             .await
-            .expect("Spawn blocking should not fail")
-            .inspect_err(|_| {
-                // A fast response of invalid headers must not earn rank.
-                context.peer_responsiveness.record_failure_with_timeout(
-                    DataSource::HeaderSynchronizerRequested,
-                    peer_index,
-                    FETCH_REQUEST_TIMEOUT,
-                );
-            })?;
+            .expect("Spawn blocking should not fail");
+        // Fetch and verification both count against the peer, matching the
+        // commit syncer.
+        let elapsed = fetched.elapsed + verify_start.elapsed();
+        let block_headers = block_headers.inspect_err(|_| {
+            // A fast response of invalid headers must not earn rank.
+            context.peer_responsiveness.record_failure_with_timeout(
+                DataSource::HeaderSynchronizerRequested,
+                peer_index,
+                FETCH_REQUEST_TIMEOUT,
+            );
+        })?;
 
         // Record commit votes from the verified blocks.
         for block in &block_headers {
@@ -877,24 +884,31 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 additional_headers.len()
             );
             additional_headers.clear();
-        }
-
-        // Credit the fetch now that the payload verified. Only requested
-        // headers count as delivered, so unsolicited extras cannot mask a
-        // shortfall.
-        let factor = if fetched.holds_requested {
-            shortfall_factor(
-                requested_blocks_guard.block_refs.len(),
-                requested_headers.len(),
-            )
+            // A proven violation is charged like a failed fetch: the peer is
+            // dishonest, so its response speed must not earn rank.
+            context.peer_responsiveness.record_failure_with_timeout(
+                DataSource::HeaderSynchronizerRequested,
+                peer_index,
+                FETCH_REQUEST_TIMEOUT,
+            );
         } else {
-            1.0
-        };
-        context.peer_responsiveness.record_success(
-            DataSource::HeaderSynchronizerRequested,
-            peer_index,
-            fetched.elapsed.mul_f64(factor),
-        );
+            // Credit the fetch now that the payload verified. Only requested
+            // headers count as delivered, so unsolicited extras cannot mask a
+            // shortfall.
+            let factor = if fetched.holds_requested {
+                shortfall_factor(
+                    requested_blocks_guard.block_refs.len(),
+                    requested_headers.len(),
+                )
+            } else {
+                1.0
+            };
+            context.peer_responsiveness.record_success(
+                DataSource::HeaderSynchronizerRequested,
+                peer_index,
+                elapsed.mul_f64(factor),
+            );
+        }
 
         let requested_headers = drop_far_future(
             &context,
@@ -4242,13 +4256,13 @@ mod tests {
         );
 
         // Peer 2 is asked for four headers and delivers one of them plus three
-        // valid but unrequested headers, so the response length matches the
+        // valid in-window gap-fill headers, so the response length matches the
         // request while three quarters of it are missing.
         let requested_headers = (30..34)
             .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
             .collect::<Vec<_>>();
-        let extras = (30..33)
-            .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 1).build()))
+        let extras = (10..13)
+            .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
             .collect::<Vec<_>>();
         let mut serialized = vec![requested_headers[0].serialized().clone()];
         serialized.extend(extras.iter().map(|header| header.serialized().clone()));
@@ -4267,10 +4281,39 @@ mod tests {
         let elapsed_ms = fetched.elapsed.as_millis() as f64;
         let result = process(fetched, blocks_guard, padding_peer).await;
         assert!(result.is_ok());
+        let recorded = latency(padding_peer).expect("the delivery is recorded");
+        assert!(
+            (elapsed_ms * 4.0..elapsed_ms * 4.0 + 100.0).contains(&recorded),
+            "one of four requested headers delivered should scale the fetch-plus-verify \
+             latency by four, got {recorded}"
+        );
+
+        // Peer 3 pads its response with a header from an author we did not
+        // request from — a window violation.
+        let requested = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(61, 0).build());
+        let out_of_window = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(20, 3).build());
+        let violating_peer = AuthorityIndex::new_for_test(3);
+        let blocks_guard = inflight_blocks_map
+            .lock_headers(
+                BTreeSet::from([requested.reference()]),
+                violating_peer,
+                SyncMethod::Live,
+            )
+            .expect("the header is free to lock");
+        let result = process(
+            fetched_for_test(vec![
+                requested.serialized().clone(),
+                out_of_window.serialized().clone(),
+            ]),
+            blocks_guard,
+            violating_peer,
+        )
+        .await;
+        assert!(result.is_ok());
         assert_eq!(
-            latency(padding_peer),
-            Some(elapsed_ms * 4.0),
-            "one of four requested headers delivered should scale the latency by four"
+            latency(violating_peer),
+            Some(FETCH_REQUEST_TIMEOUT.as_millis() as f64),
+            "a window violation should be charged like a failed fetch"
         );
     }
 }

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -893,13 +893,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             );
         } else {
             // Credit the fetch now that the payload verified. Only requested
-            // headers count as delivered, so unsolicited extras cannot mask a
-            // shortfall.
+            // headers count as delivered, each ref once, so neither unsolicited
+            // extras nor duplicated copies can mask a shortfall.
             let factor = if fetched.holds_requested {
-                shortfall_factor(
-                    requested_blocks_guard.block_refs.len(),
-                    requested_headers.len(),
-                )
+                let delivered = requested_headers
+                    .iter()
+                    .map(|header| header.reference())
+                    .collect::<BTreeSet<_>>()
+                    .len();
+                shortfall_factor(requested_blocks_guard.block_refs.len(), delivered)
             } else {
                 1.0
             };
@@ -4255,16 +4257,19 @@ mod tests {
             "a peer serving invalid headers should be demoted to the timeout"
         );
 
-        // Peer 2 is asked for four headers and delivers one of them plus three
-        // valid in-window gap-fill headers, so the response length matches the
-        // request while three quarters of it are missing.
+        // Peer 2 is asked for four headers and delivers one of them twice plus
+        // two valid in-window gap-fill headers, so the response length matches
+        // the request while three quarters of it are missing.
         let requested_headers = (30..34)
             .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
             .collect::<Vec<_>>();
-        let extras = (10..13)
+        let extras = (10..12)
             .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
             .collect::<Vec<_>>();
-        let mut serialized = vec![requested_headers[0].serialized().clone()];
+        let mut serialized = vec![
+            requested_headers[0].serialized().clone(),
+            requested_headers[0].serialized().clone(),
+        ];
         serialized.extend(extras.iter().map(|header| header.serialized().clone()));
         let padding_peer = AuthorityIndex::new_for_test(2);
         let blocks_guard = inflight_blocks_map

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -42,7 +42,10 @@ use crate::{
     },
     block_manager::drop_far_future,
     block_verifier::BlockVerifier,
-    commit_syncer::fast::{FastSyncPauseSource, paused_by_fast_sync},
+    commit_syncer::{
+        fast::{FastSyncPauseSource, paused_by_fast_sync},
+        shortfall_factor,
+    },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
@@ -135,6 +138,17 @@ impl SyncMethod {
             SyncMethod::Periodic => MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER,
         }
     }
+}
+
+/// A successful fetch response, carrying what the post-verification
+/// responsiveness recording needs.
+struct FetchedHeaders {
+    serialized_headers: Vec<Bytes>,
+    /// Round trip measured when the response arrived, before verification.
+    elapsed: Duration,
+    /// Whether the peer was known to hold the requested headers and thus owes
+    /// the whole request.
+    holds_requested: bool,
 }
 
 struct BlocksGuard {
@@ -669,8 +683,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 },
                 Some((response, blocks_guard, retries, _peer, highest_rounds)) = requests.next() => {
                     match response {
-                        Ok(blocks) => {
-                            if let Err(err) = Self::process_fetched_headers_from_authority(blocks,
+                        Ok(fetched) => {
+                            if let Err(err) = Self::process_fetched_headers_from_authority(fetched,
                                 peer_index,
                                 blocks_guard,
                                 highest_rounds,
@@ -712,8 +726,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
     /// Processes the requested raw fetched headers from peer `peer_index`. If
     /// no error is returned then the verified blocks are immediately sent
     /// to Core for processing.
+    ///
+    /// Records the fetch in the responsiveness tracker once the payload has
+    /// been verified: a verification failure counts as a failure, a success is
+    /// credited with the latency scaled by how many of the requested headers
+    /// were actually delivered.
     async fn process_fetched_headers_from_authority(
-        mut serialized_headers: Vec<Bytes>,
+        fetched: FetchedHeaders,
         peer_index: AuthorityIndex,
         requested_blocks_guard: BlocksGuard,
         highest_rounds: Vec<Round>,
@@ -728,6 +747,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         sync_method: &str,
         misbehavior_store: Arc<MisbehaviorStore>,
     ) -> ConsensusResult<()> {
+        let mut serialized_headers = fetched.serialized_headers;
         if serialized_headers.is_empty() {
             return Ok(());
         }
@@ -766,7 +786,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 }
             })
             .await
-            .expect("Spawn blocking should not fail")?;
+            .expect("Spawn blocking should not fail")
+            .inspect_err(|_| {
+                // A fast response of invalid headers must not earn rank.
+                context.peer_responsiveness.record_failure_with_timeout(
+                    DataSource::HeaderSynchronizerRequested,
+                    peer_index,
+                    FETCH_REQUEST_TIMEOUT,
+                );
+            })?;
 
         // Record commit votes from the verified blocks.
         for block in &block_headers {
@@ -850,6 +878,23 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             );
             additional_headers.clear();
         }
+
+        // Credit the fetch now that the payload verified. Only requested
+        // headers count as delivered, so unsolicited extras cannot mask a
+        // shortfall.
+        let factor = if fetched.holds_requested {
+            shortfall_factor(
+                requested_blocks_guard.block_refs.len(),
+                requested_headers.len(),
+            )
+        } else {
+            1.0
+        };
+        context.peer_responsiveness.record_success(
+            DataSource::HeaderSynchronizerRequested,
+            peer_index,
+            fetched.elapsed.mul_f64(factor),
+        );
 
         let requested_headers = drop_far_future(
             &context,
@@ -1032,15 +1077,19 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         Ok(verified_block_headers)
     }
 
-    /// Fetches the headers held by `blocks_guard` from `peer`, recording the
-    /// round trip in the responsiveness tracker. Both the live and the
-    /// periodic path go through here.
+    /// Fetches the headers held by `blocks_guard` from `peer`, recording
+    /// failures (network error, timeout, empty response from a peer that owes
+    /// the request) in the responsiveness tracker. A non-empty response is
+    /// credited only after it verifies, in
+    /// `process_fetched_headers_from_authority`, so a fast but invalid
+    /// response earns no rank. Both the live and the periodic path go through
+    /// here.
     ///
     /// A peer known to hold the headers (`holds_requested`) owes the whole
-    /// request: its latency is scaled by the shortfall and an empty response
-    /// is a failure. A peer asked speculatively owes nothing: it is credited
-    /// for what it delivers and left unrecorded otherwise, since charging its
-    /// routine empty answers would park most of the committee at the timeout.
+    /// request: an empty response is a failure. A peer asked speculatively
+    /// owes nothing: it is left unrecorded on an empty response, since
+    /// charging its routine empty answers would park most of the committee at
+    /// the timeout.
     ///
     /// Recording is unconditional; `enable_peer_responsiveness_ranking` gates
     /// only the ordering.
@@ -1054,13 +1103,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         holds_requested: bool,
         mut retries: u32,
     ) -> (
-        ConsensusResult<Vec<Bytes>>,
+        ConsensusResult<FetchedHeaders>,
         BlocksGuard,
         u32,
         AuthorityIndex,
         Vec<Round>,
     ) {
-        let requested = blocks_guard.block_refs.len();
         let start = Instant::now();
         let resp = timeout(
             request_timeout,
@@ -1079,25 +1127,22 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
 
         // Taken before the retry backoff below, which would otherwise pad every
         // failed request out to the full timeout.
+        let elapsed = start.elapsed();
         match &resp {
-            Ok(Ok(headers)) if !headers.is_empty() => {
-                let shortfall_factor = if holds_requested {
-                    (requested as f64 / headers.len() as f64).max(1.0)
-                } else {
-                    1.0
-                };
-                context.peer_responsiveness.record_success(
-                    DataSource::HeaderSynchronizer,
-                    peer,
-                    start.elapsed().mul_f64(shortfall_factor),
-                );
+            Ok(Ok(headers)) => {
+                // Nothing to report about a peer that was never expected to
+                // hold these headers and turned out not to.
+                if headers.is_empty() && holds_requested {
+                    context.peer_responsiveness.record_failure_with_timeout(
+                        DataSource::HeaderSynchronizerRequested,
+                        peer,
+                        request_timeout,
+                    );
+                }
             }
-            // Nothing to report about a peer that was never expected to hold
-            // these headers and turned out not to.
-            Ok(Ok(_)) if !holds_requested => {}
             _ => {
                 context.peer_responsiveness.record_failure_with_timeout(
-                    DataSource::HeaderSynchronizer,
+                    DataSource::HeaderSynchronizerRequested,
                     peer,
                     request_timeout,
                 );
@@ -1120,7 +1165,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 retries += 1;
                 Err(ConsensusError::NetworkRequestTimeout(err.to_string()))
             }
-            Ok(result) => result,
+            Ok(Ok(serialized_headers)) => Ok(FetchedHeaders {
+                serialized_headers,
+                elapsed,
+                holds_requested,
+            }),
         };
         (resp, blocks_guard, retries, peer, highest_rounds)
     }
@@ -1232,13 +1281,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                                 let record_probe = |ok: bool| {
                                     if ok {
                                         context.peer_responsiveness.record_success(
-                                            DataSource::HeaderSynchronizer,
+                                            DataSource::HeaderSynchronizerRequested,
                                             authority_index,
                                             latency,
                                         );
                                     } else {
                                         context.peer_responsiveness.record_failure_with_timeout(
-                                            DataSource::HeaderSynchronizer,
+                                            DataSource::HeaderSynchronizerRequested,
                                             authority_index,
                                             FETCH_REQUEST_TIMEOUT,
                                         );
@@ -1397,13 +1446,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
 
                 // Now process the returned results
                 let mut total_fetched = 0;
-                for (blocks_guard, serialized_fetched_block_headers, peer, highest_rounds) in
-                    results
-                {
-                    total_fetched += serialized_fetched_block_headers.len();
+                for (blocks_guard, fetched, peer, highest_rounds) in results {
+                    total_fetched += fetched.serialized_headers.len();
 
                     if let Err(err) = Self::process_fetched_headers_from_authority(
-                        serialized_fetched_block_headers,
+                        fetched,
                         peer,
                         blocks_guard,
                         highest_rounds,
@@ -1482,7 +1529,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         network_client: Arc<C>,
         missing_block_headers_refs: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
         dag_state: Arc<RwLock<DagState>>,
-    ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex, Vec<Round>)> {
+    ) -> Vec<(BlocksGuard, FetchedHeaders, AuthorityIndex, Vec<Round>)> {
         // Step 1: Map authorities to missing block headers refs that they are aware of
         let mut authority_to_block_headers_refs: HashMap<AuthorityIndex, Vec<BlockRef>> =
             HashMap::new();
@@ -1506,7 +1553,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         let rank_peers = |candidates: &mut Vec<AuthorityIndex>, rng: &mut StdRng| {
             if context.parameters.enable_peer_responsiveness_ranking {
                 context.peer_responsiveness.prioritize(
-                    DataSource::HeaderSynchronizer,
+                    DataSource::HeaderSynchronizerRequested,
                     candidates,
                     rng,
                 );
@@ -1695,9 +1742,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 Some((response, blocks_guard, _retries, peer_index, highest_rounds)) = request_futures.next() => {
                     let peer_hostname = &context.committee.authority(peer_index).hostname;
                     match response {
-                        Ok(fetched_block_headers) => {
-                            info!("Fetched {} block headers from peer {}", fetched_block_headers.len(), peer_hostname);
-                            results.push((blocks_guard, fetched_block_headers, peer_index, highest_rounds));
+                        Ok(fetched) => {
+                            info!("Fetched {} block headers from peer {}", fetched.serialized_headers.len(), peer_hostname);
+                            results.push((blocks_guard, fetched, peer_index, highest_rounds));
 
                             // no more pending requests are left, just break the loop
                             if request_futures.is_empty() {
@@ -1799,8 +1846,8 @@ mod tests {
         dag_state::{DagState, DataSource},
         error::{ConsensusError, ConsensusResult},
         header_synchronizer::{
-            FETCH_BLOCK_HEADERS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, HeaderSynchronizer,
-            InflightBlockHeadersMap, SyncMethod,
+            BlocksGuard, FETCH_BLOCK_HEADERS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, FetchedHeaders,
+            HeaderSynchronizer, InflightBlockHeadersMap, SyncMethod,
         },
         misbehavior_store::MisbehaviorStore,
         network::{BlockBundleStream, NetworkClient},
@@ -1808,6 +1855,14 @@ mod tests {
         transaction_ref::GenericTransactionRef,
         transactions_synchronizer::TransactionsSynchronizer,
     };
+
+    fn fetched_for_test(serialized_headers: Vec<Bytes>) -> FetchedHeaders {
+        FetchedHeaders {
+            serialized_headers,
+            elapsed: Duration::from_millis(100),
+            holds_requested: true,
+        }
+    }
 
     type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);
     type FetchRequestHeadersResponse = (Vec<VerifiedBlockHeader>, Option<Duration>);
@@ -3223,9 +3278,9 @@ mod tests {
             );
 
             // 7) Verify the returned bytes correspond to that block
-            for (_, bytes, _, _) in &results {
+            for (_, fetched, _, _) in &results {
                 let expected = missing_vbh.serialized().clone();
-                assert_eq!(bytes, &vec![expected]);
+                assert_eq!(fetched.serialized_headers, vec![expected]);
             }
         }
     }
@@ -3256,13 +3311,13 @@ mod tests {
         // Authority 5 answers header fetches quickly, 2 and 3 slowly. Without
         // ranking the committee order would always pick 2 and 3 and never 5.
         context.peer_responsiveness.record_success(
-            DataSource::HeaderSynchronizer,
+            DataSource::HeaderSynchronizerRequested,
             AuthorityIndex::new_for_test(5),
             Duration::from_millis(10),
         );
         for peer in [2, 3] {
             context.peer_responsiveness.record_success(
-                DataSource::HeaderSynchronizer,
+                DataSource::HeaderSynchronizerRequested,
                 AuthorityIndex::new_for_test(peer),
                 Duration::from_millis(2_000),
             );
@@ -3298,7 +3353,7 @@ mod tests {
 
             let known_asked: Vec<_> = results
                 .iter()
-                .map(|(_, _, peer)| *peer)
+                .map(|(_, _, peer, _)| *peer)
                 .filter(|peer| holders.contains(peer))
                 .collect();
             if known_asked.contains(&AuthorityIndex::new_for_test(5)) {
@@ -3350,13 +3405,18 @@ mod tests {
                 1,
             )
             .await;
-            assert!(response.expect("the mock answers every peer").is_empty());
+            assert!(
+                response
+                    .expect("the mock answers every peer")
+                    .serialized_headers
+                    .is_empty()
+            );
         }
 
         let latency = |peer| {
             context
                 .peer_responsiveness
-                .effective_latency_ms(DataSource::HeaderSynchronizer, peer)
+                .effective_latency_ms(DataSource::HeaderSynchronizerRequested, peer)
         };
         assert_eq!(
             latency(known_holder),
@@ -3510,27 +3570,27 @@ mod tests {
         assert_eq!(results.len(), 4, "Expected 2 known + 2 random fetches");
 
         // 7) First fetch from peer 3 (knowledge-based)
-        let (_guard3, bytes3, peer3, _) = &results[0];
+        let (_guard3, fetched3, peer3, _) = &results[0];
         assert_eq!(*peer3, AuthorityIndex::new_for_test(3));
         let expected2 = all_verified_block_headers
             [known_number_block_headers..2 * known_number_block_headers]
             .iter()
             .map(|vb| vb.serialized().clone())
             .collect::<Vec<_>>();
-        assert_eq!(bytes3, &expected2);
+        assert_eq!(fetched3.serialized_headers, expected2);
 
         // 8) Second fetch from peer 1 (additional random)
-        let (_guard1, bytes1, peer1, _) = &results[1];
+        let (_guard1, fetched1, peer1, _) = &results[1];
         assert_eq!(*peer1, AuthorityIndex::new_for_test(1));
         let expected1 = all_verified_block_headers
             [0..context.parameters.max_headers_per_header_sync_fetch]
             .iter()
             .map(|vb| vb.serialized().clone())
             .collect::<Vec<_>>();
-        assert_eq!(bytes1, &expected1);
+        assert_eq!(fetched1.serialized_headers, expected1);
 
         // 9) Third fetch from peer 4 (additional random)
-        let (_guard4, bytes4, peer4, _) = &results[2];
+        let (_guard4, fetched4, peer4, _) = &results[2];
         assert_eq!(*peer4, AuthorityIndex::new_for_test(4));
         let expected4 =
             all_verified_block_headers[context.parameters.max_headers_per_header_sync_fetch
@@ -3538,16 +3598,16 @@ mod tests {
                 .iter()
                 .map(|vb| vb.serialized().clone())
                 .collect::<Vec<_>>();
-        assert_eq!(bytes4, &expected4);
+        assert_eq!(fetched4.serialized_headers, expected4);
 
         // 10) Fourth fetch from peer 5 (fallback after peer 2 timeout)
-        let (_guard5, bytes5, peer5, _) = &results[3];
+        let (_guard5, fetched5, peer5, _) = &results[3];
         assert_eq!(*peer5, AuthorityIndex::new_for_test(5));
         let expected5 = all_verified_block_headers[0..known_number_block_headers]
             .iter()
             .map(|vb| vb.serialized().clone())
             .collect::<Vec<_>>();
-        assert_eq!(bytes5, &expected5);
+        assert_eq!(fetched5.serialized_headers, expected5);
     }
 
     #[tokio::test]
@@ -3619,7 +3679,7 @@ mod tests {
             NoopBlockVerifier,
             MockCoreThreadDispatcher,
         >::process_fetched_headers_from_authority(
-            expected_serialized_block_headers.clone(),
+            fetched_for_test(expected_serialized_block_headers.clone()),
             peer_index,
             blocks_guard, // The guard is consumed here
             vec![GENESIS_ROUND; context.committee.size()],
@@ -3664,7 +3724,7 @@ mod tests {
             NoopBlockVerifier,
             MockCoreThreadDispatcher,
         >::process_fetched_headers_from_authority(
-            expected_serialized_block_headers,
+            fetched_for_test(expected_serialized_block_headers),
             peer_index,
             blocks_guard_second,
             vec![GENESIS_ROUND; context.committee.size()],
@@ -3765,7 +3825,7 @@ mod tests {
             NoopBlockVerifier,
             MockCoreThreadDispatcher,
         >::process_fetched_headers_from_authority(
-            serialized,
+            fetched_for_test(serialized),
             peer_index,
             blocks_guard,
             vec![GENESIS_ROUND; context.committee.size()],
@@ -3852,7 +3912,7 @@ mod tests {
             NoopBlockVerifier,
             MockCoreThreadDispatcher,
         >::process_fetched_headers_from_authority(
-            serialized,
+            fetched_for_test(serialized),
             peer_index,
             blocks_guard,
             vec![5; context.committee.size()],
@@ -3944,7 +4004,7 @@ mod tests {
             NoopBlockVerifier,
             MockCoreThreadDispatcher,
         >::process_fetched_headers_from_authority(
-            serialized,
+            fetched_for_test(serialized),
             peer_index,
             blocks_guard,
             vec![5; context.committee.size()],
@@ -4033,7 +4093,10 @@ mod tests {
             NoopBlockVerifier,
             MockCoreThreadDispatcher,
         >::process_fetched_headers_from_authority(
-            vec![requested.serialized().clone(), extra.serialized().clone()],
+            fetched_for_test(vec![
+                requested.serialized().clone(),
+                extra.serialized().clone(),
+            ]),
             peer_index,
             blocks_guard,
             vec![5; context.committee.size()],
@@ -4074,7 +4137,7 @@ mod tests {
             NoopBlockVerifier,
             MockCoreThreadDispatcher,
         >::process_fetched_headers_from_authority(
-            vec![extra.serialized().clone()],
+            fetched_for_test(vec![extra.serialized().clone()]),
             peer_index,
             blocks_guard,
             vec![5; context.committee.size()],
@@ -4100,6 +4163,114 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![extra.reference()],
             "a header dropped after verification must still be delivered when requested"
+        );
+    }
+
+    /// Recording follows verification: invalid headers are charged as a
+    /// failure, and a valid response is credited with only the requested
+    /// headers counting as delivered, so unrequested extras cannot mask a
+    /// shortfall.
+    #[tokio::test]
+    async fn fetches_are_recorded_after_verification() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (commands_sender, _commands_receiver) =
+            monitored_mpsc::channel("consensus_synchronizer_commands", 1000);
+        let network_client = Arc::new(MockNetworkClient::default());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+        let inflight_blocks_map = InflightBlockHeadersMap::new();
+        let verified_cache = Arc::new(parking_lot::Mutex::new(lru::LruCache::new(
+            NonZero::new(1000).unwrap(),
+        )));
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+        let process = |fetched: FetchedHeaders, blocks_guard: BlocksGuard, peer: AuthorityIndex| {
+            HeaderSynchronizer::<MockNetworkClient, NoopBlockVerifier, MockCoreThreadDispatcher>::process_fetched_headers_from_authority(
+                fetched,
+                peer,
+                blocks_guard,
+                vec![5; context.committee.size()],
+                core_dispatcher.clone(),
+                dag_state.clone(),
+                block_verifier.clone(),
+                verified_cache.clone(),
+                commit_vote_monitor.clone(),
+                transactions_synchronizer.clone(),
+                context.clone(),
+                commands_sender.clone(),
+                "live",
+                misbehavior_store.clone(),
+            )
+        };
+        let latency = |peer| {
+            context
+                .peer_responsiveness
+                .effective_latency_ms(DataSource::HeaderSynchronizerRequested, peer)
+        };
+
+        // Peer 1 answers with garbage.
+        let requested = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(60, 0).build());
+        let garbage_peer = AuthorityIndex::new_for_test(1);
+        let blocks_guard = inflight_blocks_map
+            .lock_headers(
+                BTreeSet::from([requested.reference()]),
+                garbage_peer,
+                SyncMethod::Live,
+            )
+            .expect("the header is free to lock");
+        let result = process(
+            fetched_for_test(vec![Bytes::from_static(b"not a header")]),
+            blocks_guard,
+            garbage_peer,
+        )
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            latency(garbage_peer),
+            Some(FETCH_REQUEST_TIMEOUT.as_millis() as f64),
+            "a peer serving invalid headers should be demoted to the timeout"
+        );
+
+        // Peer 2 is asked for four headers and delivers one of them plus three
+        // valid but unrequested headers, so the response length matches the
+        // request while three quarters of it are missing.
+        let requested_headers = (30..34)
+            .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
+            .collect::<Vec<_>>();
+        let extras = (30..33)
+            .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 1).build()))
+            .collect::<Vec<_>>();
+        let mut serialized = vec![requested_headers[0].serialized().clone()];
+        serialized.extend(extras.iter().map(|header| header.serialized().clone()));
+        let padding_peer = AuthorityIndex::new_for_test(2);
+        let blocks_guard = inflight_blocks_map
+            .lock_headers(
+                requested_headers
+                    .iter()
+                    .map(|header| header.reference())
+                    .collect(),
+                padding_peer,
+                SyncMethod::Live,
+            )
+            .expect("the headers are free to lock");
+        let fetched = fetched_for_test(serialized);
+        let elapsed_ms = fetched.elapsed.as_millis() as f64;
+        let result = process(fetched, blocks_guard, padding_peer).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            latency(padding_peer),
+            Some(elapsed_ms * 4.0),
+            "one of four requested headers delivered should scale the latency by four"
         );
     }
 }

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -1695,7 +1695,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             if let Some(blocks_guard) =
                 inflight_block_headers.lock_headers(block_refs.clone(), peer, SyncMethod::Periodic)
             {
-                info!(
+                debug!(
                     "Periodic sync of {} missing block headers from peer {} {}: {}",
                     block_refs.len(),
                     peer,
@@ -1743,7 +1743,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                     let peer_hostname = &context.committee.authority(peer_index).hostname;
                     match response {
                         Ok(fetched) => {
-                            info!("Fetched {} block headers from peer {}", fetched.serialized_headers.len(), peer_hostname);
+                            debug!("Fetched {} block headers from peer {}", fetched.serialized_headers.len(), peer_hostname);
                             results.push((blocks_guard, fetched, peer_index, highest_rounds));
 
                             // no more pending requests are left, just break the loop
@@ -1757,7 +1757,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                             if let Some(next_peer) = remaining_peers.next() {
                                 // do best effort to lock guards. If we can't lock then don't bother at this run.
                                 if let Some(blocks_guard) = inflight_block_headers.swap_locks(blocks_guard, next_peer) {
-                                    info!(
+                                    debug!(
                                         "Retrying syncing {} missing block headers from peer {}: {}",
                                         blocks_guard.block_refs.len(),
                                         peer_hostname,

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -21,10 +21,8 @@ use itertools::Itertools as _;
 use lru::LruCache;
 use parking_lot::{Mutex, RwLock};
 #[cfg(not(test))]
-use rand::{
-    SeedableRng,
-    prelude::{IteratorRandom, SliceRandom, StdRng},
-};
+use rand::prelude::SliceRandom;
+use rand::{SeedableRng, prelude::StdRng};
 use starfish_config::AuthorityIndex;
 use tap::TapFallible;
 use tokio::{
@@ -101,6 +99,32 @@ impl std::fmt::Display for SyncMethod {
             SyncMethod::Live => write!(f, "live"),
             SyncMethod::Periodic => write!(f, "periodic"),
         }
+    }
+}
+
+/// Why the periodic synchronizer picked a peer: carries the metric label and
+/// whether the peer is answerable for the requested headers.
+#[derive(Debug, Clone, Copy)]
+enum PeriodicPeerChoice {
+    /// Known to hold some of the missing block headers.
+    Known,
+    /// Covers the missing block headers whose holders are unknown.
+    Random,
+    /// Takes over a request another peer failed.
+    Retry,
+}
+
+impl PeriodicPeerChoice {
+    fn as_str(self) -> &'static str {
+        match self {
+            PeriodicPeerChoice::Known => "periodic_known",
+            PeriodicPeerChoice::Random => "periodic_random",
+            PeriodicPeerChoice::Retry => "periodic_retry",
+        }
+    }
+
+    fn holds_requested(self) -> bool {
+        matches!(self, PeriodicPeerChoice::Known)
     }
 }
 
@@ -632,11 +656,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                     }
 
                     requests.push(Self::fetch_block_headers_request(
+                        context.clone(),
                         network_client.clone(),
                         peer_index,
                         headers_guard,
                         highest_rounds,
                         FETCH_REQUEST_TIMEOUT,
+                        true,
                         1,
                     ))
 
@@ -666,7 +692,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                         Err(_) => {
                             context.metrics.node_metrics.synchronizer_fetch_failures_by_peer.with_label_values(&[peer_hostname.as_str(), "live"]).inc();
                             if retries <= MAX_RETRIES {
-                                requests.push(Self::fetch_block_headers_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, retries))
+                                requests.push(Self::fetch_block_headers_request(context.clone(), network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, true, retries))
                             } else {
                                 warn!("Max retries {retries} reached while trying to fetch blocks from peer {peer_index} {peer_hostname}.");
                                 // we don't necessarily need to do, but dropping the guard here to unlock the blocks
@@ -1006,12 +1032,26 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         Ok(verified_block_headers)
     }
 
+    /// Fetches the headers held by `blocks_guard` from `peer`, recording the
+    /// round trip in the responsiveness tracker. Both the live and the
+    /// periodic path go through here.
+    ///
+    /// A peer known to hold the headers (`holds_requested`) owes the whole
+    /// request: its latency is scaled by the shortfall and an empty response
+    /// is a failure. A peer asked speculatively owes nothing: it is credited
+    /// for what it delivers and left unrecorded otherwise, since charging its
+    /// routine empty answers would park most of the committee at the timeout.
+    ///
+    /// Recording is unconditional; `enable_peer_responsiveness_ranking` gates
+    /// only the ordering.
     async fn fetch_block_headers_request(
+        context: Arc<Context>,
         network_client: Arc<C>,
         peer: AuthorityIndex,
         blocks_guard: BlocksGuard,
         highest_rounds: Vec<Round>,
         request_timeout: Duration,
+        holds_requested: bool,
         mut retries: u32,
     ) -> (
         ConsensusResult<Vec<Bytes>>,
@@ -1020,6 +1060,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         AuthorityIndex,
         Vec<Round>,
     ) {
+        let requested = blocks_guard.block_refs.len();
         let start = Instant::now();
         let resp = timeout(
             request_timeout,
@@ -1035,6 +1076,33 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             ),
         )
         .await;
+
+        // Taken before the retry backoff below, which would otherwise pad every
+        // failed request out to the full timeout.
+        match &resp {
+            Ok(Ok(headers)) if !headers.is_empty() => {
+                let shortfall_factor = if holds_requested {
+                    (requested as f64 / headers.len() as f64).max(1.0)
+                } else {
+                    1.0
+                };
+                context.peer_responsiveness.record_success(
+                    DataSource::HeaderSynchronizer,
+                    peer,
+                    start.elapsed().mul_f64(shortfall_factor),
+                );
+            }
+            // Nothing to report about a peer that was never expected to hold
+            // these headers and turned out not to.
+            Ok(Ok(_)) if !holds_requested => {}
+            _ => {
+                context.peer_responsiveness.record_failure_with_timeout(
+                    DataSource::HeaderSynchronizer,
+                    peer,
+                    request_timeout,
+                );
+            }
+        }
 
         fail_point_async!("consensus-delay");
 
@@ -1072,13 +1140,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             .spawn(monitored_future!(async move {
                 let _scope = monitored_scope("FetchOwnLastBlockHeaderTask");
 
+                // Timed: the probe seeds the responsiveness track for the whole
+                // committee before any other fetch source has a sample.
                 let fetch_own_block_header = |authority_index: AuthorityIndex, fetch_own_block_header_delay: Duration| {
                     let network_client_cloned = network_client.clone();
                     let own_index = context.own_index;
                     async move {
                         sleep(fetch_own_block_header_delay).await;
+                        let started = Instant::now();
                         let r = network_client_cloned.fetch_latest_block_headers(authority_index, vec![own_index], FETCH_REQUEST_TIMEOUT).await;
-                        (r, authority_index)
+                        (r, authority_index, started.elapsed())
                     }
                 };
 
@@ -1153,13 +1224,31 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                     'inner: loop {
                         tokio::select! {
                             result = results.next() => {
-                                let Some((result, authority_index)) = result else {
+                                let Some((result, authority_index, latency)) = result else {
                                     break 'inner;
+                                };
+                                // An empty answer that verified still counts: a peer
+                                // legitimately holds no header of ours.
+                                let record_probe = |ok: bool| {
+                                    if ok {
+                                        context.peer_responsiveness.record_success(
+                                            DataSource::HeaderSynchronizer,
+                                            authority_index,
+                                            latency,
+                                        );
+                                    } else {
+                                        context.peer_responsiveness.record_failure_with_timeout(
+                                            DataSource::HeaderSynchronizer,
+                                            authority_index,
+                                            FETCH_REQUEST_TIMEOUT,
+                                        );
+                                    }
                                 };
                                 match result {
                                     Ok(result) => {
                                         match process_block_headers(result, authority_index) {
                                             Ok(block_headers) => {
+                                                record_probe(true);
                                                 received_response[authority_index] = true;
                                                 let max_round = block_headers.into_iter().map(|b|b.round()).max().unwrap_or(0);
                                                 highest_round = highest_round.max(max_round);
@@ -1167,11 +1256,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                                                 total_stake += context.committee.stake(authority_index);
                                             },
                                             Err(err) => {
+                                                record_probe(false);
                                                 warn!("Invalid result returned from {authority_index} while fetching last own block header: {err}");
                                             }
                                         }
                                     },
                                     Err(err) => {
+                                        record_probe(false);
                                         warn!("Error {err} while fetching our own block header from peer {authority_index}. Will retry.");
                                         results.push(fetch_own_block_header(authority_index, FETCH_OWN_BLOCK_HEADER_RETRY_DELAY));
                                     }
@@ -1369,12 +1460,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
     /// Fetches the given `missing_blocks` from up to `MAX_PEERS` authorities in
     /// parallel:
     ///
-    /// Randomly select `MAX_PEERS - MAX_RANDOM_PEERS` peers from those who
-    /// are known to hold some missing block, requesting up to
-    /// `MAX_BLOCKS_PER_FETCH` block refs per peer.
+    /// Select `MAX_PEERS - MAX_RANDOM_PEERS` peers from those who are known to
+    /// hold some missing block, requesting up to `MAX_BLOCKS_PER_FETCH` block
+    /// refs per peer.
     ///
-    /// Randomly select `MAX_RANDOM_PEERS` additional peers from the
-    ///  committee (excluding self and those already selected).
+    /// Select `MAX_RANDOM_PEERS` additional peers from the committee (excluding
+    /// self and those already selected).
+    ///
+    /// Both groups, and the peers held back to retry a failed request, are
+    /// ordered by responsiveness when `enable_peer_responsiveness_ranking` is
+    /// set, and drawn uniformly otherwise.
     ///
     /// The method returns a vector with the fetched blocks from each peer that
     /// successfully responded and any corresponding additional ancestor blocks.
@@ -1407,68 +1502,56 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         // Step 2: Choose at most MAX_PEERS-MAX_RANDOM_PEERS peers from those who are
         // aware of some missing block headers
 
-        #[cfg(not(test))]
         let mut rng = StdRng::from_entropy();
+        let rank_peers = |candidates: &mut Vec<AuthorityIndex>, rng: &mut StdRng| {
+            if context.parameters.enable_peer_responsiveness_ranking {
+                context.peer_responsiveness.prioritize(
+                    DataSource::HeaderSynchronizer,
+                    candidates,
+                    rng,
+                );
+            } else {
+                // Under test the unranked order is the committee order, so the
+                // peers a scenario expects stay fixed.
+                #[cfg(not(test))]
+                candidates.shuffle(rng);
+            }
+        };
 
-        // Randomly pick up MAX_PEERS - MAX_RANDOM_PEERS authorities that are aware of
-        // missing block headers
-        #[cfg(not(test))]
+        // Pick MAX_PEERS - MAX_RANDOM_PEERS authorities aware of missing block
+        // headers, ranked before the truncation so the best-ranked holders are
+        // the ones asked.
+        let mut peers_with_block_headers: Vec<AuthorityIndex> =
+            authority_to_block_headers_refs.keys().copied().collect();
+        #[cfg(test)]
+        peers_with_block_headers.sort();
+        rank_peers(&mut peers_with_block_headers, &mut rng);
         let mut chosen_peers_with_block_headers: Vec<(
             AuthorityIndex,
             Vec<BlockRef>,
-            &str,
-        )> = authority_to_block_headers_refs
-            .iter()
-            .choose_multiple(
-                &mut rng,
-                MAX_PERIODIC_SYNC_PEERS - MAX_PERIODIC_SYNC_RANDOM_PEERS,
-            )
+            PeriodicPeerChoice,
+        )> = peers_with_block_headers
             .into_iter()
-            .map(|(&peer, block_refs)| {
-                let limited_block_refs = block_refs
+            .take(MAX_PERIODIC_SYNC_PEERS - MAX_PERIODIC_SYNC_RANDOM_PEERS)
+            .map(|peer| {
+                let limited_block_refs = authority_to_block_headers_refs[&peer]
                     .iter()
                     .copied()
                     .take(context.parameters.max_headers_per_header_sync_fetch)
                     .collect();
-                (peer, limited_block_refs, "periodic_known")
+                (peer, limited_block_refs, PeriodicPeerChoice::Known)
             })
             .collect();
-        #[cfg(test)]
-        // Deterministically pick the smallest (MAX_PEERS - MAX_RANDOM_PEERS) authority indices
-        let mut chosen_peers_with_block_headers: Vec<(
-            AuthorityIndex,
-            Vec<BlockRef>,
-            &str,
-        )> = {
-            let mut items: Vec<(AuthorityIndex, Vec<BlockRef>, &str)> =
-                authority_to_block_headers_refs
-                    .iter()
-                    .map(|(&peer, block_refs)| {
-                        let limited_block_refs = block_refs
-                            .iter()
-                            .copied()
-                            .take(context.parameters.max_headers_per_header_sync_fetch)
-                            .collect();
-                        (peer, limited_block_refs, "periodic_known")
-                    })
-                    .collect();
-            // Sort by AuthorityIndex (natural order), then take the first MAX_PEERS -
-            // MAX_RANDOM_PEERS
-            items.sort_by_key(|(peer, _, _)| *peer);
-            items
-                .into_iter()
-                .take(MAX_PERIODIC_SYNC_PEERS - MAX_PERIODIC_SYNC_RANDOM_PEERS)
-                .collect()
-        };
 
-        // Step 3: Choose at most MAX_PERIODIC_SYNC_RANDOM_PEERS random peers not known
-        // to be aware of the missing block headers
+        // Step 3: Choose at most MAX_PERIODIC_SYNC_RANDOM_PEERS peers not known to
+        // hold the missing headers. Ranked too; the exploration fraction of
+        // `prioritize` keeps the whole committee reachable through these slots.
         let already_chosen: HashSet<AuthorityIndex> = chosen_peers_with_block_headers
             .iter()
             .map(|(peer, _, _)| *peer)
             .collect();
 
-        let random_candidates: Vec<_> = context
+        let mut random_candidates: Vec<_> = context
             .committee
             .authorities()
             .filter_map(|(peer_index, _)| {
@@ -1476,15 +1559,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                     .then_some(peer_index)
             })
             .collect();
-        #[cfg(test)]
+        rank_peers(&mut random_candidates, &mut rng);
         let random_peers: Vec<AuthorityIndex> = random_candidates
             .into_iter()
             .take(MAX_PERIODIC_SYNC_RANDOM_PEERS)
             .collect();
-        #[cfg(not(test))]
-        let random_peers: Vec<AuthorityIndex> = random_candidates
-            .into_iter()
-            .choose_multiple(&mut rng, MAX_PERIODIC_SYNC_RANDOM_PEERS);
 
         #[cfg_attr(test, allow(unused_mut))]
         let mut all_missing_block_headers_refs: Vec<BlockRef> =
@@ -1497,7 +1576,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
 
         for peer in random_peers {
             if let Some(chunk) = block_headers_chunks.next() {
-                chosen_peers_with_block_headers.push((peer, chunk.to_vec(), "periodic_random"));
+                chosen_peers_with_block_headers.push((
+                    peer,
+                    chunk.to_vec(),
+                    PeriodicPeerChoice::Random,
+                ));
             } else {
                 break;
             }
@@ -1530,9 +1613,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                 .set(missing as i64);
         }
 
-        // Look at peers that were not chosen yet and try to fetch block headers from
-        // them if needed later
-        #[cfg_attr(test, expect(unused_mut))]
+        // Peers not chosen yet serve as retry targets for failed requests,
+        // ranked so retries go to the most responsive peer left.
         let mut remaining_peers: Vec<_> = context
             .committee
             .authorities()
@@ -1549,12 +1631,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             })
             .collect();
 
-        #[cfg(not(test))]
-        remaining_peers.shuffle(&mut rng);
+        rank_peers(&mut remaining_peers, &mut rng);
         let mut remaining_peers = remaining_peers.into_iter();
 
         // Send the initial requests
-        for (peer, block_headers_to_request, label) in chosen_peers_with_block_headers {
+        for (peer, block_headers_to_request, choice) in chosen_peers_with_block_headers {
+            let label = choice.as_str();
             let peer_hostname = &context.committee.authority(peer).hostname;
             let block_refs = block_headers_to_request
                 .iter()
@@ -1591,11 +1673,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                         .inc();
                 }
                 request_futures.push(Self::fetch_block_headers_request(
+                    context.clone(),
                     network_client.clone(),
                     peer,
                     blocks_guard,
                     highest_rounds.clone(),
                     FETCH_REQUEST_TIMEOUT,
+                    choice.holds_requested(),
                     1,
                 ));
             }
@@ -1641,22 +1725,24 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
                                     let metrics = &context.metrics.node_metrics;
                                     metrics
                                         .synchronizer_requested_block_headers_by_peer
-                                        .with_label_values(&[peer_hostname.as_str(), "periodic_retry"])
+                                        .with_label_values(&[peer_hostname.as_str(), PeriodicPeerChoice::Retry.as_str()])
                                         .inc_by(block_refs.len() as u64);
                                     for block_ref in &block_refs {
                                         let block_hostname =
                                             &context.committee.authority(block_ref.author).hostname;
                                         metrics
                                             .synchronizer_requested_block_headers_by_authority
-                                            .with_label_values(&[block_hostname.as_str(), "periodic_retry"])
+                                            .with_label_values(&[block_hostname.as_str(), PeriodicPeerChoice::Retry.as_str()])
                                             .inc();
                                     }
                                     request_futures.push(Self::fetch_block_headers_request(
+                                        context.clone(),
                                         network_client.clone(),
                                         next_peer,
                                         blocks_guard,
                                         highest_rounds,
                                         FETCH_REQUEST_TIMEOUT,
+                                        PeriodicPeerChoice::Retry.holds_requested(),
                                         1,
                                     ));
                                 } else {
@@ -3142,6 +3228,146 @@ mod tests {
                 assert_eq!(bytes, &vec![expected]);
             }
         }
+    }
+
+    /// With ranking on, the slots reserved for peers known to hold a missing
+    /// header go to the responsive ones among them.
+    #[tokio::test(flavor = "current_thread")]
+    async fn periodic_fetch_prefers_responsive_known_peers() {
+        const ROUNDS: usize = 30;
+
+        let (mut ctx, _) = Context::new_for_test(10);
+        ctx.parameters.enable_peer_responsiveness_ranking = true;
+        let context = Arc::new(ctx);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let inflight = InflightBlockHeadersMap::new();
+
+        // One missing header, held by authorities 2, 3 and 5. Only two of the
+        // three are asked per round.
+        let missing_vbh = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(100, 3).build());
+        let missing_ref = missing_vbh.reference();
+        let holders = [
+            AuthorityIndex::new_for_test(2),
+            AuthorityIndex::new_for_test(3),
+            AuthorityIndex::new_for_test(5),
+        ];
+
+        // Authority 5 answers header fetches quickly, 2 and 3 slowly. Without
+        // ranking the committee order would always pick 2 and 3 and never 5.
+        context.peer_responsiveness.record_success(
+            DataSource::HeaderSynchronizer,
+            AuthorityIndex::new_for_test(5),
+            Duration::from_millis(10),
+        );
+        for peer in [2, 3] {
+            context.peer_responsiveness.record_success(
+                DataSource::HeaderSynchronizer,
+                AuthorityIndex::new_for_test(peer),
+                Duration::from_millis(2_000),
+            );
+        }
+
+        let network_client = Arc::new(MockNetworkClient::default());
+        let mut asked_fast = 0;
+        for _ in 0..ROUNDS {
+            // Stubs are consumed on use, so every peer is re-stubbed per round.
+            for i in 1..=9 {
+                network_client
+                    .stub_fetch_headers_response(
+                        vec![missing_vbh.clone()],
+                        AuthorityIndex::new_for_test(i),
+                        None,
+                    )
+                    .await;
+            }
+
+            let missing_blocks = BTreeMap::from([(missing_ref, BTreeSet::from(holders))]);
+            let results = HeaderSynchronizer::<
+                MockNetworkClient,
+                NoopBlockVerifier,
+                SyncMockDispatcher,
+            >::fetch_block_headers_from_authorities_periodic(
+                context.clone(),
+                inflight.clone(),
+                network_client.clone(),
+                missing_blocks,
+                dag_state.clone(),
+            )
+            .await;
+
+            let known_asked: Vec<_> = results
+                .iter()
+                .map(|(_, _, peer)| *peer)
+                .filter(|peer| holders.contains(peer))
+                .collect();
+            if known_asked.contains(&AuthorityIndex::new_for_test(5)) {
+                asked_fast += 1;
+            }
+            // Guards are released so the next round can lock the same header.
+            drop(results);
+        }
+
+        // Only the exploration fraction can leave the fast holder out, and only
+        // when it also draws it last of the three.
+        assert!(
+            asked_fast >= ROUNDS - 3,
+            "the responsive holder should be asked nearly every round, got {asked_fast}/{ROUNDS}"
+        );
+    }
+
+    /// An empty response is a failure for a peer known to hold the requested
+    /// headers, and leaves the track of a speculatively asked peer untouched.
+    #[tokio::test(flavor = "current_thread")]
+    async fn empty_response_is_charged_only_to_a_known_holder() {
+        let (ctx, _) = Context::new_for_test(4);
+        let context = Arc::new(ctx);
+        let inflight = InflightBlockHeadersMap::new();
+        // Unstubbed, so every fetch comes back empty.
+        let network_client = Arc::new(MockNetworkClient::default());
+
+        let missing = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(100, 3).build());
+        let block_refs = BTreeSet::from([missing.reference()]);
+
+        let known_holder = AuthorityIndex::new_for_test(1);
+        let asked_speculatively = AuthorityIndex::new_for_test(2);
+        for (peer, holds_requested) in [(known_holder, true), (asked_speculatively, false)] {
+            let guard = inflight
+                .lock_headers(block_refs.clone(), peer, SyncMethod::Periodic)
+                .expect("the header is free to lock");
+            let (response, ..) = HeaderSynchronizer::<
+                MockNetworkClient,
+                NoopBlockVerifier,
+                SyncMockDispatcher,
+            >::fetch_block_headers_request(
+                context.clone(),
+                network_client.clone(),
+                peer,
+                guard,
+                vec![],
+                FETCH_REQUEST_TIMEOUT,
+                holds_requested,
+                1,
+            )
+            .await;
+            assert!(response.expect("the mock answers every peer").is_empty());
+        }
+
+        let latency = |peer| {
+            context
+                .peer_responsiveness
+                .effective_latency_ms(DataSource::HeaderSynchronizer, peer)
+        };
+        assert_eq!(
+            latency(known_holder),
+            Some(FETCH_REQUEST_TIMEOUT.as_millis() as f64),
+            "a known holder returning nothing should be demoted to the timeout"
+        );
+        assert_eq!(
+            latency(asked_speculatively),
+            None,
+            "a speculatively asked peer returning nothing should not be recorded"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -53,7 +53,7 @@ impl DataSource {
         DataSource::TransactionSynchronizer,
         DataSource::CommitSyncer,
         DataSource::FastCommitSyncer,
-        DataSource::HeaderSynchronizer,
+        DataSource::HeaderSynchronizerRequested,
     ];
 
     /// Sources whose measurements order the peers this source has no sample
@@ -68,16 +68,16 @@ impl DataSource {
         match self {
             DataSource::CommitSyncer => &[
                 DataSource::FastCommitSyncer,
-                DataSource::HeaderSynchronizer,
+                DataSource::HeaderSynchronizerRequested,
                 DataSource::TransactionSynchronizer,
             ],
             DataSource::FastCommitSyncer => &[
                 DataSource::CommitSyncer,
-                DataSource::HeaderSynchronizer,
+                DataSource::HeaderSynchronizerRequested,
                 DataSource::TransactionSynchronizer,
             ],
-            DataSource::TransactionSynchronizer => &[DataSource::HeaderSynchronizer],
-            DataSource::HeaderSynchronizer => &[DataSource::TransactionSynchronizer],
+            DataSource::TransactionSynchronizer => &[DataSource::HeaderSynchronizerRequested],
+            DataSource::HeaderSynchronizerRequested => &[DataSource::TransactionSynchronizer],
             _ => &[],
         }
     }
@@ -89,7 +89,7 @@ impl DataSource {
         match self {
             DataSource::CommitSyncer => COMMIT_SYNC_NEUTRAL_LATENCY_MS,
             DataSource::FastCommitSyncer => FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS,
-            DataSource::HeaderSynchronizer => HEADER_SYNC_NEUTRAL_LATENCY_MS,
+            DataSource::HeaderSynchronizerRequested => HEADER_SYNC_NEUTRAL_LATENCY_MS,
             _ => TRANSACTIONS_SYNC_NEUTRAL_LATENCY_MS,
         }
     }
@@ -750,7 +750,11 @@ mod tests {
     fn transactions_cold_start_follows_header_synchronizer_order() {
         let pr = responsiveness(5);
         for (peer, latency) in [(1, 400), (2, 300), (3, 200), (4, 100)] {
-            pr.record_success(DataSource::HeaderSynchronizer, idx(peer), ms(latency));
+            pr.record_success(
+                DataSource::HeaderSynchronizerRequested,
+                idx(peer),
+                ms(latency),
+            );
         }
 
         let candidates = vec![idx(1), idx(2), idx(3), idx(4)];
@@ -777,7 +781,7 @@ mod tests {
             let pr = responsiveness(4);
             // Peer 1 is slow on header fetches but quick on transaction
             // fetches; peer 2 is only known to the latter.
-            pr.record_success(DataSource::HeaderSynchronizer, idx(1), ms(5_000));
+            pr.record_success(DataSource::HeaderSynchronizerRequested, idx(1), ms(5_000));
             pr.record_success(DataSource::TransactionSynchronizer, idx(1), ms(10));
             pr.record_success(DataSource::TransactionSynchronizer, idx(2), ms(10));
 

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -4,10 +4,11 @@
 //! Per-peer responsiveness tracking and ranking for synchronizer peer
 //! selection.
 //!
-//! The transactions synchronizer and the commit syncer pick peers to fetch
-//! from. On a node with slow or asymmetric inbound links a uniform choice
-//! regularly draws slow-but-not-failing peers, adding avoidable latency to
-//! payload and commit retrieval. Each fetch source in
+//! The transactions synchronizer, the commit syncer and the header
+//! synchronizer pick peers to fetch from. On a node with slow or asymmetric
+//! inbound links a uniform choice regularly draws slow-but-not-failing peers,
+//! adding avoidable latency to payload, commit and header retrieval. Each fetch
+//! source in
 //! [`DataSource::RESPONSIVENESS_SOURCES`] is tracked separately, so a peer's
 //! record on one kind of fetch does not decide its rank on another. Until a
 //! source has a sample of its own for a peer, it places that peer by what the
@@ -48,33 +49,35 @@ use crate::{dag_state::DataSource, metrics::Metrics};
 impl DataSource {
     /// Fetch sources ranked by peer responsiveness. Sources not listed here are
     /// not ranked, and every [`PeerResponsiveness`] call for them is a no-op.
-    pub(crate) const RESPONSIVENESS_SOURCES: [DataSource; 3] = [
+    pub(crate) const RESPONSIVENESS_SOURCES: [DataSource; 4] = [
         DataSource::TransactionSynchronizer,
         DataSource::CommitSyncer,
         DataSource::FastCommitSyncer,
+        DataSource::HeaderSynchronizer,
     ];
 
     /// Sources whose measurements order the peers this source has no sample
     /// for yet, tried in this order until one of them has measured the peer.
     ///
-    /// The other commit syncer comes first: it fetches the same commits and
-    /// headers over the same links, so what it measured is already on this
-    /// source's scale, and at the handoff between the two flavors it has just
-    /// measured the very peers this one is about to choose between. The
-    /// transactions synchronizer comes last because it fetches continuously and
-    /// so has a reading even when both commit-sync tracks are empty - the state
-    /// of a node that is only starting to recover - but it measures much
-    /// lighter fetches, making it the coarser of the two.
+    /// A commit syncer reads the other flavor first (same fetches, same
+    /// scale), then the header synchronizer (same endpoint, and seeded for
+    /// every peer by the startup probe), then the transactions synchronizer
+    /// (always populated, but its fetches are the lightest). The transactions
+    /// and header synchronizers read each other, the closest scale either has.
     fn responsiveness_fallbacks(self) -> &'static [DataSource] {
         match self {
             DataSource::CommitSyncer => &[
                 DataSource::FastCommitSyncer,
+                DataSource::HeaderSynchronizer,
                 DataSource::TransactionSynchronizer,
             ],
             DataSource::FastCommitSyncer => &[
                 DataSource::CommitSyncer,
+                DataSource::HeaderSynchronizer,
                 DataSource::TransactionSynchronizer,
             ],
+            DataSource::TransactionSynchronizer => &[DataSource::HeaderSynchronizer],
+            DataSource::HeaderSynchronizer => &[DataSource::TransactionSynchronizer],
             _ => &[],
         }
     }
@@ -86,6 +89,7 @@ impl DataSource {
         match self {
             DataSource::CommitSyncer => COMMIT_SYNC_NEUTRAL_LATENCY_MS,
             DataSource::FastCommitSyncer => FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS,
+            DataSource::HeaderSynchronizer => HEADER_SYNC_NEUTRAL_LATENCY_MS,
             _ => TRANSACTIONS_SYNC_NEUTRAL_LATENCY_MS,
         }
     }
@@ -129,6 +133,11 @@ const COMMIT_SYNC_NEUTRAL_LATENCY_MS: f64 = 4_000.0;
 /// Neutral prior for fast commit sync, which serves a range in one request
 /// and so measures quicker than regular sync on the same networks.
 const FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS: f64 = 2_000.0;
+
+/// Neutral prior for the header synchronizer, rarely reached: the startup
+/// probe seeds this track for every reachable peer before the first header
+/// goes missing.
+const HEADER_SYNC_NEUTRAL_LATENCY_MS: f64 = 500.0;
 
 /// EWMA weight for a successful sample. Small, so the score is "slow to
 /// trust".
@@ -731,6 +740,55 @@ mod tests {
             assert!(
                 leads > 0.9,
                 "{source:?} should rank by what {other:?} measured, got {counts:?}"
+            );
+        }
+    }
+
+    /// A transactions-synchronizer track that is still empty orders peers by
+    /// what the header synchronizer saw.
+    #[test]
+    fn transactions_cold_start_follows_header_synchronizer_order() {
+        let pr = responsiveness(5);
+        for (peer, latency) in [(1, 400), (2, 300), (3, 200), (4, 100)] {
+            pr.record_success(DataSource::HeaderSynchronizer, idx(peer), ms(latency));
+        }
+
+        let candidates = vec![idx(1), idx(2), idx(3), idx(4)];
+        let counts = lead_counts(
+            &pr,
+            DataSource::TransactionSynchronizer,
+            &candidates,
+            10_000,
+            7,
+        );
+
+        let lead = |peer| *counts.get(&idx(peer)).unwrap_or(&0);
+        assert!(
+            lead(4) > lead(3) && lead(3) > lead(2) && lead(2) > lead(1),
+            "lead counts should follow the header-synchronizer order, got {counts:?}"
+        );
+    }
+
+    /// Both commit syncers read the header synchronizer before the
+    /// transactions synchronizer.
+    #[test]
+    fn commit_sync_reads_the_header_synchronizer_before_transactions() {
+        for source in [DataSource::CommitSyncer, DataSource::FastCommitSyncer] {
+            let pr = responsiveness(4);
+            // Peer 1 is slow on header fetches but quick on transaction
+            // fetches; peer 2 is only known to the latter.
+            pr.record_success(DataSource::HeaderSynchronizer, idx(1), ms(5_000));
+            pr.record_success(DataSource::TransactionSynchronizer, idx(1), ms(10));
+            pr.record_success(DataSource::TransactionSynchronizer, idx(2), ms(10));
+
+            let counts = lead_counts(&pr, source, &[idx(1), idx(2)], 10_000, 5);
+
+            // Reading the transactions synchronizer first would place both peers
+            // at 10ms and split the lead evenly between them.
+            let leads = *counts.get(&idx(2)).unwrap_or(&0) as f64 / 10_000.0;
+            assert!(
+                leads > 0.9,
+                "{source:?} should rank by what the header synchronizer measured, got {counts:?}"
             );
         }
     }

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -21611,6 +21611,390 @@
           ],
           "title": "Transaction synchronizer \u2014 expected fetch latency (uniform vs weighted)",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Expected per-fetch latency over peers measured for this fetch kind under uniform (random peer, the behaviour without ranking) vs responsiveness-weighted selection. The gap is the latency the ranking saves; equal lines mean peers are homogeneous and ranking is not helping. Use the Filters variable to scope to one host.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^uniform/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^weighted/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 847
+          },
+          "id": 421,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.1.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "consensus_peer_responsiveness_expected_latency_ms{kind=\"Commit syncer\"}",
+              "instant": false,
+              "legendFormat": "{{selection}} @ {{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Commit syncer \u2014 expected fetch latency (uniform vs weighted)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Expected per-fetch latency over peers measured for this fetch kind under uniform (random peer, the behaviour without ranking) vs responsiveness-weighted selection. The gap is the latency the ranking saves; equal lines mean peers are homogeneous and ranking is not helping. Use the Filters variable to scope to one host.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^uniform/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^weighted/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 855
+          },
+          "id": 422,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.1.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "consensus_peer_responsiveness_expected_latency_ms{kind=\"Fast commit syncer\"}",
+              "instant": false,
+              "legendFormat": "{{selection}} @ {{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Fast commit syncer \u2014 expected fetch latency (uniform vs weighted)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Expected per-fetch latency over peers measured for this fetch kind under uniform (random peer, the behaviour without ranking) vs responsiveness-weighted selection. The gap is the latency the ranking saves; equal lines mean peers are homogeneous and ranking is not helping. Use the Filters variable to scope to one host.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^uniform/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^weighted/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 855
+          },
+          "id": 423,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.1.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "consensus_peer_responsiveness_expected_latency_ms{kind=\"Header synchronizer\"}",
+              "instant": false,
+              "legendFormat": "{{selection}} @ {{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Header synchronizer \u2014 expected fetch latency (uniform vs weighted)",
+          "type": "timeseries"
         }
       ],
       "title": "Peer Responsiveness",

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -21986,7 +21986,7 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "consensus_peer_responsiveness_expected_latency_ms{kind=\"Header synchronizer\"}",
+              "expr": "consensus_peer_responsiveness_expected_latency_ms{kind=\"Header synchronizer requested\"}",
               "instant": false,
               "legendFormat": "{{selection}} @ {{host}}",
               "range": true,


### PR DESCRIPTION
# Description of change

> Stacked on #12485 — it extends the fallback chains that PR introduces, so the diff only makes sense on top of it. Review that one first; the base moves to `develop` once it merges.

The periodic header sync drew its peers uniformly: two out of those known to hold a missing header, two out of the rest, and a shuffle for the retries. A dead or slow peer was picked as often as a healthy one, and every round paid the full 2s fetch timeout on it before reaching a peer that answers. The last-own-header probe, meanwhile, measures every peer in the committee at startup and threw the timings away — the only reading this node ever takes of all peers under the same conditions, and the only one that exists before any other fetch source has a sample.

Track header fetches in `PeerResponsiveness` under a `HeaderSynchronizer` source, and order the periodic candidates by it.

- Fed from all three header paths: the live fetches, the periodic fetches and the startup probe. The probe seeds the track for the whole committee; later fetches refine it by EWMA.
- All three periodic groups are ranked — the known holders, the exploration slots and the retry pool — each before its truncation, so the peers actually asked are the best-ranked rather than an arbitrary subset of a larger set.
- Ranking the exploration slots is a deliberate trade: those slots exist because the "who knows" map is incomplete, so preferring peers that answer at all keeps the hedge useful, at the cost of sampling the non-knowing peers less uniformly. `prioritize`'s exploration fraction is what keeps them all reachable.

**Recording is asymmetric, and the asymmetry is load-bearing.** A peer picked because it is known to hold the requested headers is answerable for them: its latency is scaled by the delivery shortfall and an empty response is recorded as a failure. A peer asked speculatively — the random and retry slots — is not: it is credited at its plain round trip for whatever it delivers, and an empty response is left unrecorded. The periodic path asks two such peers every round and they legitimately have nothing; charging those would park most of the committee at the timeout on this track, and from there on the fallbacks of every other fetch source.

**Fallbacks.** Both commit syncers and the transactions synchronizer read this track when their own has no sample for a peer. The commit syncers read it ahead of the transactions synchronizer: it is the same `fetch_block_headers` endpoint they call to fetch the headers of a synced range, and it is the one track already filled for every peer at the moment a restarting node starts commit syncing. The transactions synchronizer and the header synchronizer fall back to each other, the closest reading either has.

| source | falls back to |
| --- | --- |
| `CommitSyncer` | `FastCommitSyncer` → `HeaderSynchronizer` → `TransactionSynchronizer` |
| `FastCommitSyncer` | `CommitSyncer` → `HeaderSynchronizer` → `TransactionSynchronizer` |
| `TransactionSynchronizer` | `HeaderSynchronizer` |
| `HeaderSynchronizer` | `TransactionSynchronizer` |

Worth noting for review:

- `enable_peer_responsiveness_ranking` gates only the ordering; recording is unconditional, following the convention of the two commits below it. With the flag off the peers asked are drawn from the same distribution as before — the two `choose_multiple` calls become `shuffle().take()`, which is the same uniform subset, and the retry pool is the same shuffle. Ordering within a group differs but does not reach behaviour: every chosen known holder is asked regardless of position, and for the random slots position only picks the chunk, from an already shuffled list. Under test the order is identical, which the untouched periodic-selection tests pin.
- Second commit adds the missing dashboard panels. The Peer Responsiveness row held a single panel hard-filtered to `kind="Transactions synchronizer"`, so the commit syncer and fast commit syncer tracks added by #12485, and the header synchronizer track added here, were emitting with nothing showing them. One panel per source now, laid out two per grid row.
- The header-sync neutral prior is 500ms, between a transaction fetch and a commit range. It is rarely reached: the startup probe gives this track a sample for anything reachable before the first header goes missing.
- The periodic metric labels move from bare strings to a `PeriodicPeerChoice` enum, which also carries whether the peer is known to hold what was requested. The label values (`periodic_known`, `periodic_random`, `periodic_retry`) are unchanged.

## Links to any relevant issues

Part of #12113
Part of #12030

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

