### PR TITLE
feat(iota-core,iota-types): report failed deny-rule update execution at effects commit

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -42,8 +42,8 @@ use iota_sdk_types::{
     Address, CheckpointContentsDigest, CheckpointDigest, Digest, EndOfEpochTransactionKind,
     ExecutionStatus, MoveAuthenticator, ObjectDigest, ObjectId, ObjectReference, Owner,
     RandomnessRound, SenderSignedTransaction, StructTag, SystemPackage, Transaction,
-    TransactionDigest, TransactionEffects, TransactionEffectsDigest, TransactionEvents, TypeTag,
-    Version,
+    TransactionDigest, TransactionEffects, TransactionEffectsDigest, TransactionEvents,
+    TransactionKind, TypeTag, Version,
     checkpoint::{CheckpointCommitment, CheckpointContents, CheckpointSummary},
     crypto::{Intent, IntentScope},
     gas::GasCostSummary,
@@ -1712,6 +1712,7 @@ impl AuthorityState {
             &effects,
             tx_guard,
             execution_guard,
+            expected_effects_digest,
             epoch_store,
         )?;
 
@@ -1745,6 +1746,7 @@ impl AuthorityState {
         effects: &TransactionEffects,
         tx_guard: TxGuard,
         _execution_guard: ExecutionLockReadGuard<'_>,
+        expected_effects_digest: Option<TransactionEffectsDigest>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult {
         let _scope: Option<iota_metrics::MonitoredScopeGuard> =
@@ -1781,6 +1783,13 @@ impl AuthorityState {
         );
         self.get_cache_writer()
             .try_write_transaction_outputs(epoch_store.epoch(), transaction_outputs.into())?;
+
+        self.report_failed_deny_rule_update_execution(
+            transaction,
+            effects,
+            expected_effects_digest,
+            epoch_store,
+        );
 
         if transaction.transaction().is_end_of_epoch_tx() {
             // At the end of epoch, since system packages may have been upgraded, force
@@ -3326,6 +3335,52 @@ impl AuthorityState {
             );
             cur_epoch_store.metrics.deny_rule_mirror_divergence.set(1);
         }
+    }
+
+    /// Reports a `TransactionDenyRulesUpdate` whose execution failed — an
+    /// invariant violation, the update is built to exclude every expected
+    /// failure. The object misses the delta until the epoch boundary re-seeds
+    /// the mirror. Identification is by kind, so the report needs no tracking
+    /// state and holds across restarts and replays.
+    ///
+    /// `expected_effects_digest` is `Some` when these effects were handed to
+    /// this node with the transaction, which is the case while executing a
+    /// certified checkpoint: the failure is then part of agreed history, so it
+    /// is reported without asserting. Effects the node derived itself assert,
+    /// because only then is the broken invariant its own.
+    pub(crate) fn report_failed_deny_rule_update_execution(
+        &self,
+        transaction: &VerifiedExecutableTransaction,
+        effects: &TransactionEffects,
+        expected_effects_digest: Option<TransactionEffectsDigest>,
+        epoch_store: &AuthorityPerEpochStore,
+    ) {
+        if !matches!(
+            transaction.transaction().kind(),
+            TransactionKind::TransactionDenyRulesUpdate(_)
+        ) || effects.status().is_success()
+        {
+            return;
+        }
+        epoch_store
+            .metrics
+            .deny_rule_update_execution_failures
+            .inc();
+        if expected_effects_digest.is_some() {
+            error!(
+                digest = ?transaction.digest(),
+                status = ?effects.status(),
+                "TransactionDenyRulesUpdate failed execution; the object misses its delta until \
+                 the epoch boundary re-seeds the mirror"
+            );
+            return;
+        }
+        debug_fatal!(
+            "TransactionDenyRulesUpdate failed execution; the object misses its delta until the \
+             epoch boundary re-seeds the mirror (digest: {:?}, status: {:?})",
+            transaction.digest(),
+            effects.status(),
+        );
     }
 
     #[instrument(level = "error", skip_all)]

--- a/crates/iota-core/src/epoch/epoch_metrics.rs
+++ b/crates/iota-core/src/epoch/epoch_metrics.rs
@@ -140,6 +140,10 @@ pub struct EpochMetrics {
     /// Set to 1, and never cleared, when the `TransactionDenyRules` object
     /// diverged from the mirrored state at an epoch boundary.
     pub deny_rule_mirror_divergence: IntGauge,
+
+    /// The number of injected deny-rule update transactions whose execution
+    /// failed — always an invariant violation.
+    pub deny_rule_update_execution_failures: IntCounter,
 }
 
 impl EpochMetrics {
@@ -298,6 +302,12 @@ impl EpochMetrics {
                 "deny_rule_mirror_divergence",
                 "Set to 1 when the TransactionDenyRules object diverged from the mirrored state \
                  at an epoch boundary",
+                registry
+            )
+            .unwrap(),
+            deny_rule_update_execution_failures: register_int_counter_with_registry!(
+                "deny_rule_update_execution_failures",
+                "The number of injected deny-rule update transactions whose execution failed",
                 registry
             )
             .unwrap(),

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1408,3 +1408,197 @@ async fn deny_rule_mirror_guard_fails_on_a_missing_object() {
     .unwrap();
     authority_state.check_transaction_deny_rules_consistency(&closing_store, &next_without_object);
 }
+
+/// Failure effects for a `TransactionDenyRulesUpdate` fire the report;
+/// success effects and other transaction kinds do not. Identification is by
+/// kind, so a fresh authority — a restart — reports a failure it never
+/// scheduled; a tracking-set refactor would break this test. The effects
+/// arrive with an expected digest here, as they do while executing a certified
+/// checkpoint, so the report counts and logs without asserting.
+#[tokio::test]
+async fn failed_deny_rule_update_execution_is_reported() {
+    use std::collections::BTreeSet;
+
+    use iota_sdk_types::{ExecutionError, ExecutionStatus, TransactionDenyRulesUpdate};
+    use iota_types::{
+        effects::TestEffectsBuilder, executable_transaction::VerifiedExecutableTransaction,
+        transaction::VerifiedTransaction,
+    };
+
+    let update_transaction = || {
+        VerifiedExecutableTransaction::new_system(
+            VerifiedTransaction::new_transaction_deny_rules_update(TransactionDenyRulesUpdate {
+                epoch: 0,
+                round: 1,
+                added_addresses: [Address::new([7u8; 32])].into(),
+                removed_addresses: BTreeSet::new(),
+                added_objects: BTreeSet::new(),
+                removed_objects: BTreeSet::new(),
+                added_packages: BTreeSet::new(),
+                removed_packages: BTreeSet::new(),
+                package_publish_disabled: false,
+                package_upgrade_disabled: false,
+                shared_object_disabled: false,
+                user_transaction_disabled: false,
+                receiving_objects_disabled: false,
+                move_authenticator_disabled: false,
+                deny_rules_obj_initial_shared_version: Version::from_u64(1),
+            }),
+            0,
+        )
+    };
+    let failure = || ExecutionStatus::Failure {
+        error: ExecutionError::InsufficientGas,
+        command: None,
+    };
+    let update_effects = |transaction: &VerifiedExecutableTransaction, status: ExecutionStatus| {
+        TestEffectsBuilder::new(transaction.data())
+            .with_shared_input_versions(
+                [(
+                    iota_types::IOTA_TRANSACTION_DENY_RULES_OBJECT_ID,
+                    Version::from_u64(1),
+                )]
+                .into(),
+            )
+            .with_status(status)
+            .build()
+    };
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+    let failures = || store.metrics.deny_rule_update_execution_failures.get();
+
+    let update = update_transaction();
+    let effects = update_effects(&update, ExecutionStatus::Success);
+    authority_state.report_failed_deny_rule_update_execution(
+        &update,
+        &effects,
+        Some(effects.digest()),
+        &store,
+    );
+    assert_eq!(failures(), 0);
+
+    let effects = update_effects(&update, failure());
+    authority_state.report_failed_deny_rule_update_execution(
+        &update,
+        &effects,
+        Some(effects.digest()),
+        &store,
+    );
+    assert_eq!(failures(), 1);
+
+    let genesis = VerifiedExecutableTransaction::new_system(
+        VerifiedTransaction::new_genesis_transaction(Vec::new(), Vec::new()),
+        0,
+    );
+    let genesis_effects = TestEffectsBuilder::new(genesis.data())
+        .with_status(failure())
+        .build();
+    authority_state.report_failed_deny_rule_update_execution(
+        &genesis,
+        &genesis_effects,
+        Some(genesis_effects.digest()),
+        &store,
+    );
+    assert_eq!(failures(), 1);
+
+    let restarted_state = TestAuthorityBuilder::new().build().await;
+    let restarted_store = restarted_state.epoch_store_for_testing();
+    let update = update_transaction();
+    let effects = update_effects(&update, failure());
+    restarted_state.report_failed_deny_rule_update_execution(
+        &update,
+        &effects,
+        Some(effects.digest()),
+        &restarted_store,
+    );
+    assert_eq!(
+        restarted_store
+            .metrics
+            .deny_rule_update_execution_failures
+            .get(),
+        1
+    );
+}
+
+/// Effects the node derived itself carry no expected digest, and a failure in
+/// them is this node's own broken invariant: the report asserts. Only the
+/// simulator can observe a `debug_fatal!` instead of aborting on it, so the
+/// live path is covered here rather than in the plain unit test above.
+#[cfg(msim)]
+#[iota_macros::sim_test]
+async fn failed_deny_rule_update_execution_asserts_on_derived_effects() {
+    use std::{
+        collections::BTreeSet,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use iota_common::register_debug_fatal_handler;
+    use iota_sdk_types::{ExecutionError, ExecutionStatus, TransactionDenyRulesUpdate};
+    use iota_types::{
+        effects::TestEffectsBuilder, executable_transaction::VerifiedExecutableTransaction,
+        transaction::VerifiedTransaction,
+    };
+
+    static ASSERTED: AtomicUsize = AtomicUsize::new(0);
+    register_debug_fatal_handler!("TransactionDenyRulesUpdate failed execution", || {
+        ASSERTED.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let update = VerifiedExecutableTransaction::new_system(
+        VerifiedTransaction::new_transaction_deny_rules_update(TransactionDenyRulesUpdate {
+            epoch: 0,
+            round: 1,
+            added_addresses: [Address::new([7u8; 32])].into(),
+            removed_addresses: BTreeSet::new(),
+            added_objects: BTreeSet::new(),
+            removed_objects: BTreeSet::new(),
+            added_packages: BTreeSet::new(),
+            removed_packages: BTreeSet::new(),
+            package_publish_disabled: false,
+            package_upgrade_disabled: false,
+            shared_object_disabled: false,
+            user_transaction_disabled: false,
+            receiving_objects_disabled: false,
+            move_authenticator_disabled: false,
+            deny_rules_obj_initial_shared_version: Version::from_u64(1),
+        }),
+        0,
+    );
+    let effects = |status| {
+        TestEffectsBuilder::new(update.data())
+            .with_shared_input_versions(
+                [(
+                    iota_types::IOTA_TRANSACTION_DENY_RULES_OBJECT_ID,
+                    Version::from_u64(1),
+                )]
+                .into(),
+            )
+            .with_status(status)
+            .build()
+    };
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let store = authority_state.epoch_store_for_testing();
+
+    authority_state.report_failed_deny_rule_update_execution(
+        &update,
+        &effects(ExecutionStatus::Success),
+        None,
+        &store,
+    );
+    assert_eq!(ASSERTED.load(Ordering::SeqCst), 0);
+    assert_eq!(store.metrics.deny_rule_update_execution_failures.get(), 0);
+
+    authority_state.report_failed_deny_rule_update_execution(
+        &update,
+        &effects(ExecutionStatus::Failure {
+            error: ExecutionError::InsufficientGas,
+            command: None,
+        }),
+        None,
+        &store,
+    );
+    assert_eq!(ASSERTED.load(Ordering::SeqCst), 1);
+    assert_eq!(store.metrics.deny_rule_update_execution_failures.get(), 1);
+}

--- a/crates/iota-types/src/effects/test_effects_builder.rs
+++ b/crates/iota-types/src/effects/test_effects_builder.rs
@@ -268,7 +268,10 @@ impl TestEffectsBuilder {
                 )
             }))
             .collect();
-        let gas_object_id = self.transaction.transaction().gas()[0].object_id;
+        // A system transaction carries only a placeholder gas payment that
+        // never appears in the changed objects.
+        let gas_object_id = (!self.transaction.transaction().is_system_tx())
+            .then(|| self.transaction.transaction().gas()[0].object_id);
         let event_digest = self.events_digest;
         let dependencies = vec![];
 
@@ -281,7 +284,7 @@ impl TestEffectsBuilder {
             self.transaction.digest(),
             lamport_version,
             changed_objects,
-            Some(gas_object_id),
+            gas_object_id,
             event_digest,
             dependencies,
         )


### PR DESCRIPTION
## Description of change

Report a failed `TransactionDenyRulesUpdate` execution the moment its effects commit, instead of staying silent until the epoch-boundary guard.

- `AuthorityState::commit_transaction`: a `TransactionDenyRulesUpdate` with failure effects logs an ERROR and bumps the new `deny_rule_update_execution_failures` counter. The hook is the single path all executions funnel through (consensus, checkpoint execution, genesis), and it fires once per transaction.
- Identification is by transaction kind — stateless, so the report needs no tracking set and holds across restarts and replays.
- Observability only: no feedback into the mirror or the diff; repair stays at the epoch-boundary re-seed.
- `TestEffectsBuilder` no longer records a gas object for system transactions (they carry only a placeholder gas payment).

Closes #12599

## How the change has been tested

- `failed_deny_rule_update_execution_is_reported`: failure effects fire the report, success effects and other kinds do not, and a freshly opened authority reports a failure it never scheduled.
- Full deny-rule battery (20 tests) and clippy on the touched crates.