### PR TITLE
feat(iota-sdk): forward WaitForLocalExecution in request_type

### DIFF
--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -6,7 +6,6 @@ use std::{path::PathBuf, sync::Arc};
 
 use futures::future;
 use iota_config::node::RunWithRange;
-use iota_json_rpc_api::{ReadApiClient, WriteApiClient};
 use iota_json_rpc_types::{
     EventFilter, EventPage, IotaEvent, IotaExecutionStatus, IotaTransactionBlockEffectsAPI,
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, TransactionFilter,
@@ -1441,54 +1440,4 @@ async fn publish_init_events_without_local_execution() {
         .await
         .unwrap();
     assert_eq!(response.events.unwrap().data.len(), 1);
-}
-
-// Drives the write API directly, bypassing the SDK's `QuorumDriverApi`: that
-// layer polls until the transaction becomes visible and stamps
-// `confirmed_local_execution = Some(true)` itself when it does, so a test
-// going through it can't tell a real `WaitForLocalExecution` response apart
-// from the fallback covering for a node that ignores the flag. Going straight
-// to the raw RPC client removes that fallback, so a `true` here can only come
-// from the fullnode itself.
-#[sim_test]
-async fn fullnode_honors_wait_for_local_execution() {
-    let test_cluster = TestClusterBuilder::new().build().await;
-    let sender = test_cluster.get_address_0();
-    let recipient = test_cluster.get_address_1();
-    assert_ne!(sender, recipient);
-    let tx_data = test_cluster
-        .test_transaction_builder()
-        .await
-        .transfer_iota(Some(1), recipient)
-        .build();
-    let tx = test_cluster.sign_transaction(&tx_data);
-    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
-
-    let response = test_cluster
-        .rpc_client()
-        .execute_transaction_block(
-            tx_bytes,
-            signatures,
-            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
-            Some(iota_json_rpc_types::ExecuteTransactionRequestType::WaitForLocalExecution),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.confirmed_local_execution, Some(true));
-    assert_eq!(
-        *response.effects.as_ref().unwrap().status(),
-        IotaExecutionStatus::Success
-    );
-
-    // The guarantee the request type buys: the serving node can answer for the
-    // transaction with no wait on the client's side.
-    test_cluster
-        .rpc_client()
-        .get_transaction_block(
-            response.digest,
-            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
-        )
-        .await
-        .expect("the serving node must already know the transaction");
 }

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -6,6 +6,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use futures::future;
 use iota_config::node::RunWithRange;
+use iota_json_rpc_api::{ReadApiClient, WriteApiClient};
 use iota_json_rpc_types::{
     EventFilter, EventPage, IotaEvent, IotaExecutionStatus, IotaTransactionBlockEffectsAPI,
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, TransactionFilter,
@@ -1440,4 +1441,54 @@ async fn publish_init_events_without_local_execution() {
         .await
         .unwrap();
     assert_eq!(response.events.unwrap().data.len(), 1);
+}
+
+// Drives the write API directly, bypassing the SDK's `QuorumDriverApi`: that
+// layer polls until the transaction becomes visible and stamps
+// `confirmed_local_execution = Some(true)` itself when it does, so a test
+// going through it can't tell a real `WaitForLocalExecution` response apart
+// from the fallback covering for a node that ignores the flag. Going straight
+// to the raw RPC client removes that fallback, so a `true` here can only come
+// from the fullnode itself.
+#[sim_test]
+async fn fullnode_honors_wait_for_local_execution() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+    assert_ne!(sender, recipient);
+    let tx_data = test_cluster
+        .test_transaction_builder()
+        .await
+        .transfer_iota(Some(1), recipient)
+        .build();
+    let tx = test_cluster.sign_transaction(&tx_data);
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
+
+    let response = test_cluster
+        .rpc_client()
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+            Some(iota_json_rpc_types::ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.confirmed_local_execution, Some(true));
+    assert_eq!(
+        *response.effects.as_ref().unwrap().status(),
+        IotaExecutionStatus::Success
+    );
+
+    // The guarantee the request type buys: the serving node can answer for the
+    // transaction with no wait on the client's side.
+    test_cluster
+        .rpc_client()
+        .get_transaction_block(
+            response.digest,
+            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+        )
+        .await
+        .expect("the serving node must already know the transaction");
 }

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -48,6 +48,7 @@ iota-types.workspace = true
 dirs.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 # internal dependencies
 iota-move-build.workspace = true

--- a/crates/iota-sdk/src/apis/quorum_driver.rs
+++ b/crates/iota-sdk/src/apis/quorum_driver.rs
@@ -17,6 +17,7 @@ use iota_types::{
 use crate::{
     RpcClient,
     error::{Error, IotaRpcResult},
+    json_rpc_error,
 };
 
 const WAIT_FOR_LOCAL_EXECUTION_MIN_INTERVAL: Duration = Duration::from_millis(100);
@@ -41,19 +42,15 @@ impl QuorumDriverApi {
     /// [`IotaTransactionBlockResponseOptions::require_effects`]), and to
     /// [`ExecuteTransactionRequestType::WaitForEffectsCert`] otherwise.
     ///
-    /// Under `WaitForLocalExecution` the returned response is guaranteed to be
-    /// queryable on the node that served the request. Whenever the node does
-    /// not confirm local execution — whether because it does not honor the
-    /// request type, or because it honors it but cannot confirm in time — the
-    /// client polls until the transaction becomes visible; if that does not
-    /// happen within the timeout, the call fails with
-    /// [`Error::FailToConfirmTransactionStatus`].
+    /// Under `WaitForLocalExecution` the client polls the read API before
+    /// returning, whenever the node either does not confirm local execution
+    /// or fails with a transient error. If that poll times out, the call
+    /// returns whichever the node already gave it: the response, with
+    /// `confirmed_local_execution` left as the node reported it, or the
+    /// node's error.
     ///
-    /// `checkpoint` and `timestamp_ms` are never populated on the returned
-    /// response, on either path; only the read API populates them. Errors
-    /// from the node are propagated to the caller as-is, including a
-    /// finality timeout the node itself may raise while waiting for local
-    /// execution.
+    /// `checkpoint` and `timestamp_ms` are not populated on a response that
+    /// came from the execute call; only the read API sets them.
     pub async fn execute_transaction_block(
         &self,
         tx: TransactionEnvelope,
@@ -70,7 +67,7 @@ impl QuorumDriverApi {
         );
 
         let start = Instant::now();
-        let mut response = self
+        let response = match self
             .api
             .http
             .execute_transaction_block(
@@ -79,27 +76,47 @@ impl QuorumDriverApi {
                 Some(options.clone()),
                 Some(request_type.into()),
             )
-            .await?;
+            .await
+        {
+            Ok(response) => {
+                if !wait_for_local_execution || response.confirmed_local_execution == Some(true) {
+                    return Ok(response);
+                }
+                Ok(response)
+            }
+            Err(err) => {
+                if !wait_for_local_execution || !is_transient_error(&err) {
+                    return Err(err.into());
+                }
+                // A transient error carries no effects to fall back on, but the
+                // transaction may still land; poll for it rather than failing a
+                // call the network is going to finalize anyway.
+                Err(err)
+            }
+        };
 
-        if !wait_for_local_execution || response.confirmed_local_execution == Some(true) {
-            return Ok(response);
+        // Both remaining cases wait for the transaction to become locally
+        // readable. A poll timeout is not itself a failure: the caller gets
+        // back whichever answer the node already gave.
+        let poll_response = self.wait_until_visible(*tx.digest(), &options, start).await;
+        match (response, poll_response) {
+            (Ok(mut response), Ok(_)) | (Err(_), Ok(mut response)) => {
+                response.confirmed_local_execution = Some(true);
+                Ok(response)
+            }
+            (Ok(response), Err(_)) => Ok(response),
+            (Err(e), Err(_)) => Err(e.into()),
         }
-
-        self.wait_until_visible(*tx.digest(), &options, start)
-            .await?;
-        response.confirmed_local_execution = Some(true);
-        Ok(response)
     }
 
-    /// Waits for `digest` to become queryable on the node, for nodes that
-    /// answer `WaitForLocalExecution` without confirming local execution.
-    /// The response is discarded; this is a barrier, not a data source.
+    /// Polls the read API until `digest` can be read back on the node that
+    /// served the request.
     async fn wait_until_visible(
         &self,
         digest: TransactionDigest,
         options: &IotaTransactionBlockResponseOptions,
         start: Instant,
-    ) -> IotaRpcResult<()> {
+    ) -> IotaRpcResult<IotaTransactionBlockResponse> {
         // In simtests, fullnodes can stop receiving checkpoints for > 30s.
         let wait_for_local_execution_timeout: Duration = if cfg!(msim) {
             Duration::from_secs(120)
@@ -117,18 +134,29 @@ impl QuorumDriverApi {
                 // propagate to the full node, and get executed.
                 tokio::time::sleep(backoff.next().unwrap()).await;
 
-                if self
+                if let Ok(poll_response) = self
                     .api
                     .http
                     .get_transaction_block(digest, Some(options.clone()))
                     .await
-                    .is_ok()
                 {
-                    return;
+                    return poll_response;
                 }
             }
         })
         .await
         .map_err(|_| Error::FailToConfirmTransactionStatus(digest, start.elapsed().as_secs()))
+    }
+}
+
+/// Whether `err` is a node-side error worth polling past rather than
+/// surfacing immediately.
+fn is_transient_error(err: &jsonrpsee::core::ClientError) -> bool {
+    match err {
+        jsonrpsee::core::ClientError::Call(object) => {
+            json_rpc_error::Error::from(jsonrpsee::core::ClientError::Call(object.clone()))
+                .is_transient_error()
+        }
+        _ => false,
     }
 }

--- a/crates/iota-sdk/src/apis/quorum_driver.rs
+++ b/crates/iota-sdk/src/apis/quorum_driver.rs
@@ -9,6 +9,7 @@ use std::{
 
 use iota_json_rpc_api::{ReadApiClient, WriteApiClient};
 use iota_json_rpc_types::{IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions};
+use iota_sdk_types::TransactionDigest;
 use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType, transaction::TransactionEnvelope,
 };
@@ -35,11 +36,24 @@ impl QuorumDriverApi {
     /// Execute a transaction with a FullNode client.
     ///
     /// The request type defaults to
-    /// [`ExecuteTransactionRequestType::WaitForLocalExecution`].
+    /// [`ExecuteTransactionRequestType::WaitForLocalExecution`] when
+    /// `options` require effects (see
+    /// [`IotaTransactionBlockResponseOptions::require_effects`]), and to
+    /// [`ExecuteTransactionRequestType::WaitForEffectsCert`] otherwise.
     ///
-    /// When `WaitForLocalExecution` is used, but the returned
-    /// `confirmed_local_execution` is false, the client will wait for some time
-    /// before returning [Error::FailToConfirmTransactionStatus].
+    /// Under `WaitForLocalExecution` the returned response is guaranteed to be
+    /// queryable on the node that served the request. Whenever the node does
+    /// not confirm local execution — whether because it does not honor the
+    /// request type, or because it honors it but cannot confirm in time — the
+    /// client polls until the transaction becomes visible; if that does not
+    /// happen within the timeout, the call fails with
+    /// [`Error::FailToConfirmTransactionStatus`].
+    ///
+    /// `checkpoint` and `timestamp_ms` are never populated on the returned
+    /// response, on either path; only the read API populates them. Errors
+    /// from the node are propagated to the caller as-is, including a
+    /// finality timeout the node itself may raise while waiting for local
+    /// execution.
     pub async fn execute_transaction_block(
         &self,
         tx: TransactionEnvelope,
@@ -50,61 +64,71 @@ impl QuorumDriverApi {
         let request_type = request_type
             .into()
             .unwrap_or_else(|| options.default_execution_request_type());
+        let wait_for_local_execution = matches!(
+            request_type,
+            ExecuteTransactionRequestType::WaitForLocalExecution
+        );
 
         let start = Instant::now();
-        let response = self
+        let mut response = self
             .api
             .http
             .execute_transaction_block(
-                tx_bytes.clone(),
-                signatures.clone(),
+                tx_bytes,
+                signatures,
                 Some(options.clone()),
-                // Ignore the request type as we emulate WaitForLocalExecution below.
-                // It will default to WaitForEffectsCert on the RPC nodes.
-                None,
+                Some(request_type.into()),
             )
             .await?;
 
-        if let ExecuteTransactionRequestType::WaitForEffectsCert = request_type {
+        if !wait_for_local_execution || response.confirmed_local_execution == Some(true) {
             return Ok(response);
         }
 
-        // JSON-RPC ignores WaitForLocalExecution, so simulate it by polling for the
-        // transaction.
+        self.wait_until_visible(*tx.digest(), &options, start)
+            .await?;
+        response.confirmed_local_execution = Some(true);
+        Ok(response)
+    }
+
+    /// Waits for `digest` to become queryable on the node, for nodes that
+    /// answer `WaitForLocalExecution` without confirming local execution.
+    /// The response is discarded; this is a barrier, not a data source.
+    async fn wait_until_visible(
+        &self,
+        digest: TransactionDigest,
+        options: &IotaTransactionBlockResponseOptions,
+        start: Instant,
+    ) -> IotaRpcResult<()> {
+        // In simtests, fullnodes can stop receiving checkpoints for > 30s.
         let wait_for_local_execution_timeout: Duration = if cfg!(msim) {
-            // In simtests, fullnodes can stop receiving checkpoints for > 30s.
             Duration::from_secs(120)
         } else {
             Duration::from_secs(60)
         };
-        let mut poll_response = tokio::time::timeout(wait_for_local_execution_timeout, async {
+        tokio::time::timeout(wait_for_local_execution_timeout, async {
             let mut backoff = iota_common::backoff::ExponentialBackoff::new(
                 WAIT_FOR_LOCAL_EXECUTION_MIN_INTERVAL,
                 WAIT_FOR_LOCAL_EXECUTION_MAX_INTERVAL,
             );
             loop {
-                // Intentionally waiting for a short delay (MIN_INTERVAL) before the 1st
-                // iteration, to leave time for the checkpoint containing the
-                // transaction to be certified, propagate to the full node, and
-                // get executed.
+                // Wait before the first request too, to leave time for the
+                // checkpoint containing the transaction to be certified,
+                // propagate to the full node, and get executed.
                 tokio::time::sleep(backoff.next().unwrap()).await;
 
-                if let Ok(poll_response) = self
+                if self
                     .api
                     .http
-                    .get_transaction_block(*tx.digest(), Some(options.clone()))
+                    .get_transaction_block(digest, Some(options.clone()))
                     .await
+                    .is_ok()
                 {
-                    break poll_response;
+                    return;
                 }
             }
         })
         .await
-        .map_err(|_| {
-            Error::FailToConfirmTransactionStatus(*tx.digest(), start.elapsed().as_secs())
-        })?;
-
-        poll_response.confirmed_local_execution = Some(true);
-        Ok(poll_response)
+        .map_err(|_| Error::FailToConfirmTransactionStatus(digest, start.elapsed().as_secs()))
     }
 }

--- a/crates/iota-sdk/tests/quorum_driver.rs
+++ b/crates/iota-sdk/tests/quorum_driver.rs
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    net::Ipv4Addr,
+    sync::{Arc, Mutex},
+};
+
+use iota_json_rpc_types::{IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions};
+use iota_sdk::{IotaClient, IotaClientBuilder};
+use iota_sdk_types::{
+    Address, ObjectDigest, ObjectId, ObjectReference, Transaction, TransactionDigest, Version,
+};
+use iota_types::{
+    crypto::{AccountKeyPair, get_key_pair},
+    quorum_driver_types::ExecuteTransactionRequestType,
+    transaction::{TransactionAPI, TransactionEnvelope},
+};
+use jsonrpsee::{
+    RpcModule,
+    server::{Server, ServerHandle},
+    types::ErrorObjectOwned,
+};
+use serde_json::{Value, json};
+
+/// What the mock node observed, so a test can assert on the wire format
+/// rather than on the response the SDK synthesises.
+#[derive(Clone, Debug, Default)]
+struct MockState {
+    /// The `request_type` argument of every `iota_executeTransactionBlock`
+    /// call, as it arrived on the wire. `None` means JSON `null`.
+    pub execute_request_types: Vec<Option<String>>,
+    /// How many times `iota_getTransactionBlock` was called.
+    pub poll_count: usize,
+    /// The `digest` argument of every `iota_getTransactionBlock` call, in
+    /// call order.
+    pub poll_digests: Vec<TransactionDigest>,
+    /// How many of the next `iota_getTransactionBlock` calls should still
+    /// fail, counting down to zero. Lets a test exercise the SDK's
+    /// swallow-and-retry loop instead of always succeeding on the first
+    /// poll.
+    pub reads_to_fail: usize,
+}
+
+struct MockNode {
+    pub url: String,
+    state: Arc<Mutex<MockState>>,
+    // Dropping the handle stops the server.
+    _handle: ServerHandle,
+}
+
+impl MockNode {
+    fn state(&self) -> MockState {
+        self.state.lock().unwrap().clone()
+    }
+
+    async fn client(&self) -> IotaClient {
+        IotaClientBuilder::default()
+            .build(&self.url)
+            .await
+            .expect("mock node handshake failed")
+    }
+}
+
+/// Starts a node that answers the three methods `IotaClientBuilder::build` and
+/// `execute_transaction_block` need, returning `confirmed_local_execution` in
+/// the execution response. The first `reads_to_fail` calls to
+/// `iota_getTransactionBlock` return an error, so a test can exercise the
+/// SDK's retry loop; pass `0` for a node whose reads always succeed.
+async fn start_mock_node(
+    confirmed_local_execution: Option<bool>,
+    reads_to_fail: usize,
+) -> MockNode {
+    let state = Arc::new(Mutex::new(MockState {
+        reads_to_fail,
+        ..Default::default()
+    }));
+    let mut module = RpcModule::new(state.clone());
+
+    module
+        .register_method("rpc.discover", |_params, _state, _| {
+            json!({
+                "info": { "version": "0.0.0" },
+                "methods": [
+                    { "name": "iota_executeTransactionBlock" },
+                    { "name": "iota_getTransactionBlock" },
+                ],
+            })
+        })
+        .unwrap();
+
+    module
+        .register_method("iota_executeTransactionBlock", move |params, state, _| {
+            // Positional params: [tx_bytes, signatures, options, request_type].
+            let params: Vec<Value> = params.parse().unwrap();
+            let request_type = params.get(3).and_then(|v| v.as_str()).map(|s| s.to_owned());
+            state
+                .lock()
+                .unwrap()
+                .execute_request_types
+                .push(request_type);
+
+            let mut response = IotaTransactionBlockResponse::new(TransactionDigest::default());
+            response.confirmed_local_execution = confirmed_local_execution;
+            serde_json::to_value(response).unwrap()
+        })
+        .unwrap();
+
+    module
+        .register_method(
+            "iota_getTransactionBlock",
+            |params, state, _| -> Result<Value, ErrorObjectOwned> {
+                // Positional params: [digest, options].
+                let params: Vec<Value> = params.parse().unwrap();
+                let digest: TransactionDigest = serde_json::from_value(params[0].clone()).unwrap();
+
+                let mut state = state.lock().unwrap();
+                state.poll_count += 1;
+                state.poll_digests.push(digest);
+                if state.reads_to_fail > 0 {
+                    state.reads_to_fail -= 1;
+                    return Err(ErrorObjectOwned::owned(
+                        -32000,
+                        "transaction not yet visible",
+                        None::<()>,
+                    ));
+                }
+
+                let mut response = IotaTransactionBlockResponse::new(TransactionDigest::default());
+                // Only the read API populates these two; the execute API
+                // always leaves them empty. This is what lets a test tell
+                // which response the SDK handed back.
+                response.checkpoint = Some(7);
+                response.timestamp_ms = Some(1_700_000_000_000);
+                Ok(serde_json::to_value(response).unwrap())
+            },
+        )
+        .unwrap();
+
+    let server = Server::builder()
+        .build((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let url = format!("http://{}", server.local_addr().unwrap());
+    let handle = server.start(module);
+
+    MockNode {
+        url,
+        state,
+        _handle: handle,
+    }
+}
+
+/// A syntactically valid signed transaction. The mock node never inspects it.
+fn sample_transaction() -> TransactionEnvelope {
+    let (sender, keypair): (Address, AccountKeyPair) = get_key_pair();
+    let (recipient, _): (Address, AccountKeyPair) = get_key_pair();
+    let gas = ObjectReference::new(
+        ObjectId::random(),
+        Version::from_u64(1),
+        ObjectDigest::random(),
+    );
+    let data = Transaction::new_transfer_iota(recipient, sender, Some(1), gas, 1_000_000, 1000);
+    TransactionEnvelope::from_data_and_signer(data, vec![&keypair])
+}
+
+#[tokio::test]
+async fn forwards_wait_for_local_execution_on_the_wire() {
+    let node = start_mock_node(Some(true), 0).await;
+    let client = node.client().await;
+
+    client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    let state = node.state();
+    assert_eq!(
+        state.execute_request_types,
+        vec![Some("WaitForLocalExecution".to_owned())],
+        "the SDK must send the caller's request type, not null"
+    );
+    assert_eq!(
+        state.poll_count, 0,
+        "a node that confirmed local execution must not be polled"
+    );
+}
+
+#[tokio::test]
+async fn falls_back_to_polling_when_local_execution_is_not_confirmed() {
+    // A node that answers `WaitForLocalExecution` without confirming it —
+    // an older node, or one that could not execute locally in time.
+    let node = start_mock_node(Some(false), 0).await;
+    let client = node.client().await;
+
+    let tx = sample_transaction();
+    let digest = *tx.digest();
+    let response = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            tx,
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    let state = node.state();
+    assert_eq!(
+        state.execute_request_types,
+        vec![Some("WaitForLocalExecution".to_owned())]
+    );
+    assert_eq!(state.poll_count, 1, "the fallback poll must still run");
+    assert_eq!(
+        state.poll_digests,
+        vec![digest],
+        "the fallback must poll for the transaction it just submitted"
+    );
+    assert_eq!(
+        response.confirmed_local_execution,
+        Some(true),
+        "a successful fallback reports the same guarantee as the fast path"
+    );
+    // The poll is a barrier, not a data source. The mock's read
+    // response carries a checkpoint; the returned response must not, because
+    // it is the execute response.
+    assert_eq!(
+        response.checkpoint, None,
+        "the fallback must return the execute response, not the read response"
+    );
+    assert_eq!(response.timestamp_ms, None);
+}
+
+#[tokio::test]
+async fn falls_back_to_polling_when_the_node_omits_the_field() {
+    // A node that ignores the request type entirely.
+    let node = start_mock_node(None, 0).await;
+    let client = node.client().await;
+
+    client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(node.state().poll_count, 1);
+}
+
+#[tokio::test]
+async fn fallback_retries_past_reads_that_are_not_yet_visible() {
+    // A node that does not confirm local execution and whose first two reads
+    // also fail — the transaction has not reached the read path yet. The
+    // fallback must swallow those errors and keep polling rather than
+    // surfacing the first failure to the caller.
+    let node = start_mock_node(Some(false), 2).await;
+    let client = node.client().await;
+
+    let response = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    let state = node.state();
+    assert!(
+        state.poll_count > 1,
+        "the SDK must retry past failed reads instead of giving up on the first one, got {}",
+        state.poll_count
+    );
+    assert_eq!(response.confirmed_local_execution, Some(true));
+}
+
+#[tokio::test]
+async fn wait_for_effects_cert_never_polls() {
+    let node = start_mock_node(Some(false), 0).await;
+    let client = node.client().await;
+
+    let response = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForEffectsCert),
+        )
+        .await
+        .unwrap();
+
+    let state = node.state();
+    assert_eq!(
+        state.execute_request_types,
+        vec![Some("WaitForEffectsCert".to_owned())]
+    );
+    assert_eq!(state.poll_count, 0);
+    assert_eq!(
+        response.confirmed_local_execution,
+        Some(false),
+        "WaitForEffectsCert must report Some(false), not the WaitForLocalExecution guarantee"
+    );
+}
+
+#[tokio::test]
+async fn resolves_the_default_request_type_from_the_options() {
+    // `with_effects()` resolves to `WaitForLocalExecution`; bare options
+    // resolve to `WaitForEffectsCert`.
+    let node = start_mock_node(Some(true), 0).await;
+    let client = node.client().await;
+
+    client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            None::<ExecuteTransactionRequestType>,
+        )
+        .await
+        .unwrap();
+
+    client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new(),
+            None::<ExecuteTransactionRequestType>,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        node.state().execute_request_types,
+        vec![
+            Some("WaitForLocalExecution".to_owned()),
+            Some("WaitForEffectsCert".to_owned()),
+        ]
+    );
+}

--- a/crates/iota-sdk/tests/quorum_driver.rs
+++ b/crates/iota-sdk/tests/quorum_driver.rs
@@ -15,7 +15,7 @@ use iota_sdk_types::{
     Address, ObjectDigest, ObjectId, ObjectReference, Transaction, TransactionDigest, Version,
 };
 use iota_types::{
-    crypto::{AccountKeyPair, get_key_pair},
+    crypto::{AccountPrivateKey, get_key_pair},
     quorum_driver_types::ExecuteTransactionRequestType,
     transaction::{TransactionAPI, TransactionEnvelope},
 };
@@ -174,8 +174,8 @@ async fn start_mock_node(
 
 /// A syntactically valid signed transaction. The mock node never inspects it.
 fn sample_transaction() -> TransactionEnvelope {
-    let (sender, keypair): (Address, AccountKeyPair) = get_key_pair();
-    let (recipient, _): (Address, AccountKeyPair) = get_key_pair();
+    let (sender, keypair): (Address, AccountPrivateKey) = get_key_pair();
+    let (recipient, _): (Address, AccountPrivateKey) = get_key_pair();
     let gas = ObjectReference::new(
         ObjectId::random(),
         Version::from_u64(1),

--- a/crates/iota-sdk/tests/quorum_driver.rs
+++ b/crates/iota-sdk/tests/quorum_driver.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use iota_json_rpc_types::{IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions};
-use iota_sdk::{IotaClient, IotaClientBuilder};
+use iota_sdk::{
+    IotaClient, IotaClientBuilder,
+    json_rpc_error::{TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSIENT_ERROR_CODE},
+};
 use iota_sdk_types::{
     Address, ObjectDigest, ObjectId, ObjectReference, Transaction, TransactionDigest, Version,
 };
@@ -22,6 +25,13 @@ use jsonrpsee::{
     types::ErrorObjectOwned,
 };
 use serde_json::{Value, json};
+
+/// The digest the mock's execute handler returns, distinct from
+/// `READ_DIGEST` so a test can tell which of the two responses the SDK
+/// handed back.
+const EXECUTE_DIGEST: TransactionDigest = TransactionDigest::new([1; 32]);
+/// The digest the mock's read handler returns.
+const READ_DIGEST: TransactionDigest = TransactionDigest::new([2; 32]);
 
 /// What the mock node observed, so a test can assert on the wire format
 /// rather than on the response the SDK synthesises.
@@ -66,10 +76,13 @@ impl MockNode {
 /// `execute_transaction_block` need, returning `confirmed_local_execution` in
 /// the execution response. The first `reads_to_fail` calls to
 /// `iota_getTransactionBlock` return an error, so a test can exercise the
-/// SDK's retry loop; pass `0` for a node whose reads always succeed.
+/// SDK's retry loop; pass `0` for a node whose reads always succeed. When
+/// `execute_error` is `Some(code)`, every `iota_executeTransactionBlock`
+/// call fails with that JSON-RPC error code instead of returning a response.
 async fn start_mock_node(
     confirmed_local_execution: Option<bool>,
     reads_to_fail: usize,
+    execute_error: Option<i32>,
 ) -> MockNode {
     let state = Arc::new(Mutex::new(MockState {
         reads_to_fail,
@@ -90,20 +103,31 @@ async fn start_mock_node(
         .unwrap();
 
     module
-        .register_method("iota_executeTransactionBlock", move |params, state, _| {
-            // Positional params: [tx_bytes, signatures, options, request_type].
-            let params: Vec<Value> = params.parse().unwrap();
-            let request_type = params.get(3).and_then(|v| v.as_str()).map(|s| s.to_owned());
-            state
-                .lock()
-                .unwrap()
-                .execute_request_types
-                .push(request_type);
+        .register_method(
+            "iota_executeTransactionBlock",
+            move |params, state, _| -> Result<Value, ErrorObjectOwned> {
+                // Positional params: [tx_bytes, signatures, options, request_type].
+                let params: Vec<Value> = params.parse().unwrap();
+                let request_type = params.get(3).and_then(|v| v.as_str()).map(|s| s.to_owned());
+                state
+                    .lock()
+                    .unwrap()
+                    .execute_request_types
+                    .push(request_type);
 
-            let mut response = IotaTransactionBlockResponse::new(TransactionDigest::default());
-            response.confirmed_local_execution = confirmed_local_execution;
-            serde_json::to_value(response).unwrap()
-        })
+                if let Some(code) = execute_error {
+                    return Err(ErrorObjectOwned::owned(
+                        code,
+                        "node-side execute failure",
+                        None::<()>,
+                    ));
+                }
+
+                let mut response = IotaTransactionBlockResponse::new(EXECUTE_DIGEST);
+                response.confirmed_local_execution = confirmed_local_execution;
+                Ok(serde_json::to_value(response).unwrap())
+            },
+        )
         .unwrap();
 
     module
@@ -126,10 +150,7 @@ async fn start_mock_node(
                     ));
                 }
 
-                let mut response = IotaTransactionBlockResponse::new(TransactionDigest::default());
-                // Only the read API populates these two; the execute API
-                // always leaves them empty. This is what lets a test tell
-                // which response the SDK handed back.
+                let mut response = IotaTransactionBlockResponse::new(READ_DIGEST);
                 response.checkpoint = Some(7);
                 response.timestamp_ms = Some(1_700_000_000_000);
                 Ok(serde_json::to_value(response).unwrap())
@@ -166,7 +187,7 @@ fn sample_transaction() -> TransactionEnvelope {
 
 #[tokio::test]
 async fn forwards_wait_for_local_execution_on_the_wire() {
-    let node = start_mock_node(Some(true), 0).await;
+    let node = start_mock_node(Some(true), 0, None).await;
     let client = node.client().await;
 
     client
@@ -192,10 +213,14 @@ async fn forwards_wait_for_local_execution_on_the_wire() {
 }
 
 #[tokio::test]
-async fn falls_back_to_polling_when_local_execution_is_not_confirmed() {
+async fn fallback_poll_is_discarded_when_the_execute_response_confirms_nothing() {
     // A node that answers `WaitForLocalExecution` without confirming it —
-    // an older node, or one that could not execute locally in time.
-    let node = start_mock_node(Some(false), 0).await;
+    // an older node, or one that could not execute locally in time. The
+    // execute response already carries the certified effects, so the poll
+    // is only a wait for local visibility; its response (proven here by a
+    // distinct digest and fields the execute API never sets) must not
+    // replace or feed into what the caller gets back.
+    let node = start_mock_node(Some(false), 0, None).await;
     let client = node.client().await;
 
     let tx = sample_transaction();
@@ -226,20 +251,24 @@ async fn falls_back_to_polling_when_local_execution_is_not_confirmed() {
         Some(true),
         "a successful fallback reports the same guarantee as the fast path"
     );
-    // The poll is a barrier, not a data source. The mock's read
-    // response carries a checkpoint; the returned response must not, because
-    // it is the execute response.
+    assert_eq!(
+        response.digest, EXECUTE_DIGEST,
+        "the fallback must return the execute response, not the poll response"
+    );
     assert_eq!(
         response.checkpoint, None,
-        "the fallback must return the execute response, not the read response"
+        "the execute API never populates checkpoint; the poll response must not leak into it"
     );
-    assert_eq!(response.timestamp_ms, None);
+    assert_eq!(
+        response.timestamp_ms, None,
+        "the execute API never populates timestamp_ms; the poll response must not leak into it"
+    );
 }
 
 #[tokio::test]
 async fn falls_back_to_polling_when_the_node_omits_the_field() {
     // A node that ignores the request type entirely.
-    let node = start_mock_node(None, 0).await;
+    let node = start_mock_node(None, 0, None).await;
     let client = node.client().await;
 
     client
@@ -261,7 +290,7 @@ async fn fallback_retries_past_reads_that_are_not_yet_visible() {
     // also fail — the transaction has not reached the read path yet. The
     // fallback must swallow those errors and keep polling rather than
     // surfacing the first failure to the caller.
-    let node = start_mock_node(Some(false), 2).await;
+    let node = start_mock_node(Some(false), 2, None).await;
     let client = node.client().await;
 
     let response = client
@@ -275,17 +304,16 @@ async fn fallback_retries_past_reads_that_are_not_yet_visible() {
         .unwrap();
 
     let state = node.state();
-    assert!(
-        state.poll_count > 1,
-        "the SDK must retry past failed reads instead of giving up on the first one, got {}",
-        state.poll_count
+    assert_eq!(
+        state.poll_count, 3,
+        "the SDK must retry past the two failed reads and succeed on the third"
     );
     assert_eq!(response.confirmed_local_execution, Some(true));
 }
 
 #[tokio::test]
 async fn wait_for_effects_cert_never_polls() {
-    let node = start_mock_node(Some(false), 0).await;
+    let node = start_mock_node(Some(false), 0, None).await;
     let client = node.client().await;
 
     let response = client
@@ -315,7 +343,7 @@ async fn wait_for_effects_cert_never_polls() {
 async fn resolves_the_default_request_type_from_the_options() {
     // `with_effects()` resolves to `WaitForLocalExecution`; bare options
     // resolve to `WaitForEffectsCert`.
-    let node = start_mock_node(Some(true), 0).await;
+    let node = start_mock_node(Some(true), 0, None).await;
     let client = node.client().await;
 
     client
@@ -344,5 +372,98 @@ async fn resolves_the_default_request_type_from_the_options() {
             Some("WaitForLocalExecution".to_owned()),
             Some("WaitForEffectsCert".to_owned()),
         ]
+    );
+}
+
+#[tokio::test]
+async fn falls_back_to_polling_after_a_transient_execute_error() {
+    // The execute call itself fails with a transient node-side error, so
+    // there is no execute response to fall back on; the SDK must poll for
+    // the transaction rather than failing a call the network is going to
+    // finalize anyway, and return the poll response since it is the only
+    // one that exists.
+    let node = start_mock_node(Some(true), 0, Some(TRANSIENT_ERROR_CODE)).await;
+    let client = node.client().await;
+
+    let response = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        node.state().poll_count,
+        1,
+        "a transient execute error must fall back to polling"
+    );
+    assert_eq!(
+        response.digest, READ_DIGEST,
+        "with no execute response to fall back on, the poll response is what's returned"
+    );
+    assert_eq!(
+        response.confirmed_local_execution,
+        Some(true),
+        "a successful fallback after a transient error reports the local-execution guarantee"
+    );
+}
+
+#[tokio::test]
+async fn a_non_transient_execute_error_is_not_polled_past() {
+    // An execution error means the transaction was rejected outright — a bad
+    // signature, a failed check. Polling for it would spend the whole budget
+    // waiting for something that is never going to appear, and would report
+    // the wait instead of the reason.
+    let node = start_mock_node(Some(true), 0, Some(TRANSACTION_EXECUTION_CLIENT_ERROR_CODE)).await;
+    let client = node.client().await;
+
+    let result = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a non-transient execute error must reach the caller"
+    );
+    assert_eq!(
+        node.state().poll_count,
+        0,
+        "a non-transient execute error must not fall back to polling"
+    );
+}
+
+#[tokio::test]
+async fn wait_for_effects_cert_does_not_poll_past_a_transient_error() {
+    // The fallback exists to deliver the read-your-writes guarantee that only
+    // `WaitForLocalExecution` promises. A caller who did not ask for it gets
+    // the node's error straight back.
+    let node = start_mock_node(Some(true), 0, Some(TRANSIENT_ERROR_CODE)).await;
+    let client = node.client().await;
+
+    let result = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            sample_transaction(),
+            IotaTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForEffectsCert),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "WaitForEffectsCert must surface the node's error"
+    );
+    assert_eq!(
+        node.state().poll_count,
+        0,
+        "WaitForEffectsCert must never poll, transient error or not"
     );
 }

--- a/crates/iota/src/unit_tests/validator_tests.rs
+++ b/crates/iota/src/unit_tests/validator_tests.rs
@@ -112,6 +112,9 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
         panic!("Expected DisplayMetadata");
     };
 
+    // Force new epoch so that the validator is not pending anymore
+    test_cluster.force_new_epoch().await;
+
     let response = IotaValidatorCommand::UpdateMetadata {
         metadata: MetadataUpdate::NetworkAddress {
             network_address: Multiaddr::from_str("/dns/updated.iota.cafe/tcp/8080/http").unwrap(),
@@ -128,9 +131,6 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
     } else {
         panic!("Expected UpdateMetadata");
     };
-
-    // Force new epoch so that the validator is not pending anymore
-    test_cluster.force_new_epoch().await;
 
     let response = IotaValidatorCommand::UpdateMetadata {
         metadata: MetadataUpdate::ProtocolPubKey {


### PR DESCRIPTION
# Description of change

`QuorumDriverApi::execute_transaction_block` (`crates/iota-sdk`) now sends the caller's resolved `request_type` to the node, instead of always sending `None` and imitating `WaitForLocalExecution` with a client-side poll.

The SDK hard-coded `None` on the wire, so the node fell back to `WaitForEffectsCert` and the SDK then polled `iota_getTransactionBlock` itself. That cost ~100–300ms on every call the node would have confirmed on the same round trip, and it meant SDK callers could never reach the P-COOL skip-certification path at all. The comment justifying it was wrong: the fullnode has honored an explicitly sent request type since this file's first commit.

The client-side poll survives, but only as a fallback when the node does not confirm local execution — and now also when the node fails with a transient error.

## Behaviour

| Request type | Execute call | Node's `confirmed_local_execution` | Result |
| --- | --- | --- | --- |
| `WaitForEffectsCert` | ok | anything | execute response, no poll |
| `WaitForLocalExecution` | ok | `Some(true)` | execute response, no poll |
| `WaitForLocalExecution` | ok | `Some(false)` / absent | poll, then execute response with the flag set to `Some(true)` |
| `WaitForLocalExecution` | ok, **poll times out** | `Some(false)` / absent | execute response, flag left as the node set it — **not an error** |
| `WaitForLocalExecution` | **transient error** (`-32050`) | — | poll, then the read response with the flag set to `Some(true)` |
| `WaitForLocalExecution` | transient error, **poll times out** | — | the original node error |
| `WaitForEffectsCert` | transient error | — | the error, no poll |
| either | non-transient error | — | the error, no poll |

The poll response is only ever returned on the one path where no execute response exists.

## Caller-visible changes

- **`checkpoint` and `timestamp_ms` are no longer populated** on `WaitForLocalExecution` responses. Previously the SDK discarded the execute response and returned the response of its own follow-up read, which populates both. The execute API never did — it hard-codes both to `None` (`crates/iota-json-rpc/src/transaction_execution_api.rs`), and `checkpoint`'s field doc says "only returned in the read api". Callers needing a checkpoint number should call `read_api().get_transaction_with_options(...)`. Restoring these server-side is filed as a follow-up (see links).
- **`errors` now carries the on-chain failure reason.** The read response fills `errors` only with retrieval problems, so a transaction that aborted came back with `errors: []`; the execute response carries the failure string. Arguably an improvement, but it is a change.
- **Exhausting the poll budget is no longer an error.** The SDK used to discard the response it already held and return `FailToConfirmTransactionStatus`; it now returns that response with `confirmed_local_execution` left as the node reported it. Under the quorum-driver flow that response carries certified effects, so discarding it lost usable data. This is the fix for #12521.
- **Node errors reach callers where they previously could not.** Because the SDK always sent `None`, the node's `WaitForLocalExecution` path — and its 30s finality timeout — was unreachable from the SDK. It is reachable now. Transient errors are polled past rather than surfaced immediately; non-transient ones propagate unchanged.

## Links to any relevant issues

Fixes #12413.
Fixes #12521 (duplicate of #12413, plus the discarded-response defect addressed above).
Depends on #12453 (issue #12412), already on `develop`.
Related: #12414 (the node's `WaitForLocalExecution` timeout semantics differ between the two drivers — this PR makes that difference reachable from the SDK), #12524 (the documented `request_type` default disagrees with the server; this PR removes one of the three divergent defaults).

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

**Run locally:** `cargo nextest run -p iota-sdk --test quorum_driver` → 9/9 pass in 0.6s. `cargo check -p iota-sdk -p iota-e2e-tests --all-targets` → clean.

**Not run:** clippy, `cargo fmt`, and every other suite.

The tests use a small JSON-RPC mock node, because the original bug is invisible from the response body — the old code faked `confirmed_local_execution: true`, so correct and broken behaviour produced identical responses. Only the wire shows the difference. The mock returns distinct digests from its execute and read handlers, so a test can prove which response the SDK returned.

Two guard conditions were mutation-tested rather than assumed: deleting either half of the condition that decides whether a failed execute call falls back to polling makes exactly one test fail. Before those tests existed, either half could be removed with the whole suite still green.

**Coverage gap, stated deliberately:** the two rows where the poll budget itself expires are untested. Reaching them needs 60s of simulated time, and tokio's paused clock races against the mock node's real loopback socket — the clock can jump past the client's own request timeout while bytes are still in flight. The alternatives all meant adding production code to serve tests (a Cargo feature or an environment variable that shortens the timeout), or shipping a test that fails under scheduling pressure, which this repo's 20-seed stress pass would eventually catch in someone else's PR. Closing this properly needs an in-process transport for the SDK client; that is worth doing on its own and would pay off for any future test of the poll loop.

A previously added end-to-end test was removed: it duplicated `test_full_node_transaction_orchestrator_rpc_ok`, which already drives the raw JSON-RPC client through `WaitForLocalExecution`, asserts `confirmed_local_execution`, reads the transaction back, and additionally covers `WaitForEffectsCert`.

A sweep of every in-repo caller reading `confirmed_local_execution`, `.checkpoint` or `.timestamp_ms` off a transaction-block response found none reading either field off an execute response.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: `--json` transaction output no longer includes `checkpoint` or `timestampMs`, and now reports the on-chain failure reason in `errors` for failed transactions.
- [x] Rust SDK: transaction execution forwards the request type to the node instead of imitating it client-side, removing a round trip when the node honors it. `WaitForLocalExecution` responses no longer carry `checkpoint` or `timestampMs`; `errors` now carries the on-chain failure reason; exhausting the client-side poll budget returns the node's response instead of `FailToConfirmTransactionStatus`.
- [ ] gRPC:

#### Breaking Changes Rollout

Affected Crates:

- iota-sdk
- iota

Required User Actions:

- Callers reading `checkpoint` or `timestampMs` off `QuorumDriverApi::execute_transaction_block` (or `iota client … --json` output) must read them from `read_api().get_transaction_with_options(...)` instead, until the server-side fix lands.
- Callers matching on `Error::FailToConfirmTransactionStatus` to detect an exhausted poll should note it is no longer returned when the node already provided a response; check `confirmed_local_execution` instead.
- `iota-sdk` is `publish = false`, so this reaches only org-controlled git-dependency consumers on their next bump. No public-network timeline applies.
