### PR TITLE
feat(consensus): dedicated misbehavior counter for invalid bundle parts

### DIFF
--- a/crates/iota-core/src/authority/misbehavior.rs
+++ b/crates/iota-core/src/authority/misbehavior.rs
@@ -151,8 +151,7 @@ pub(crate) fn observations_from_consensus_output(
     match version {
         MisbehaviorReportVersion::V1 => {
             // The V1 report format has no bundle-part category; fold those
-            // counts into the unprovable bucket, where they were counted
-            // before the split.
+            // counts into the unprovable bucket.
             let unprovable = project(counts.faulty_blocks_unprovable, "faulty_blocks_unprovable");
             let bundle_parts = project(counts.invalid_bundle_parts, "invalid_bundle_parts");
             let folded = unprovable

--- a/crates/iota-core/src/authority/misbehavior.rs
+++ b/crates/iota-core/src/authority/misbehavior.rs
@@ -104,7 +104,8 @@ pub(crate) fn merge_max(
                 invalid_bundle_parts: elem_max(&x.invalid_bundle_parts, &y.invalid_bundle_parts),
             })
         }
-        (a, b) => panic!(
+        (a @ MisbehaviorObservations::V1(_), b @ MisbehaviorObservations::V2(_))
+        | (a @ MisbehaviorObservations::V2(_), b @ MisbehaviorObservations::V1(_)) => panic!(
             "cross-version misbehavior observation merge: {a:?} vs {b:?} — \
              all observations within an epoch share one report version"
         ),

--- a/crates/iota-core/src/authority/misbehavior.rs
+++ b/crates/iota-core/src/authority/misbehavior.rs
@@ -3,7 +3,8 @@
 
 use iota_protocol_config::ProtocolConfig;
 use iota_types::messages_consensus::{
-    MisbehaviorObservations, MisbehaviorObservationsV1, VersionedMisbehaviorReport,
+    MisbehaviorObservations, MisbehaviorObservationsV1, MisbehaviorObservationsV2,
+    VersionedMisbehaviorReport,
 };
 use tracing::error;
 
@@ -13,18 +14,20 @@ use crate::consensus_types::consensus_output_api::ConsensusOutputMisbehaviorCoun
 /// the current epoch. Loaded once from `ProtocolConfig` and threaded through
 /// `MisbehaviorMonitor` / `ReportAggregator` / `Scoreboard` as a `Copy` token.
 ///
-/// The schema itself (which categories exist and their layout) lives in
-/// `MisbehaviorObservationsV1`; this enum only versions the wire format and
-/// gates acceptance.
+/// The schema itself (which categories exist and their layout) lives in the
+/// `MisbehaviorObservations` variants; this enum only versions the wire
+/// format and gates acceptance.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MisbehaviorReportVersion {
     V1,
+    V2,
 }
 
 impl MisbehaviorReportVersion {
     pub fn from_protocol(protocol_config: &ProtocolConfig) -> Self {
         match protocol_config.scorer_version_as_option() {
             None | Some(1) => Self::V1,
+            Some(2) => Self::V2,
             Some(version) => panic!("Unsupported scorer version {version}"),
         }
     }
@@ -33,6 +36,7 @@ impl MisbehaviorReportVersion {
     pub fn accepts_report(&self, report: &VersionedMisbehaviorReport) -> bool {
         match self {
             Self::V1 => matches!(report.payload, MisbehaviorObservations::V1(_)),
+            Self::V2 => matches!(report.payload, MisbehaviorObservations::V2(_)),
         }
     }
 }
@@ -49,13 +53,20 @@ pub(crate) fn zero_observations(
             missing_proposals: vec![0u64; committee_size],
             equivocations: vec![0u64; committee_size],
         }),
+        MisbehaviorReportVersion::V2 => MisbehaviorObservations::V2(MisbehaviorObservationsV2 {
+            faulty_blocks_provable: vec![0u64; committee_size],
+            faulty_blocks_unprovable: vec![0u64; committee_size],
+            missing_proposals: vec![0u64; committee_size],
+            equivocations: vec![0u64; committee_size],
+            invalid_bundle_parts: vec![0u64; committee_size],
+        }),
     }
 }
 
-/// Element-wise maximum merge across all metrics. Cross-version merges become
-/// a deliberate design decision when V2 lands (currently impossible — single
-/// variant). Adding a metric to `MisbehaviorObservationsV1` will surface as a
-/// missing-field error here, forcing the new metric to be considered.
+/// Element-wise maximum merge across all metrics. Both inputs are always the
+/// epoch's single report version: the monitor's local observations and the
+/// aggregator's accepted reports are constructed from the same
+/// `MisbehaviorReportVersion`, so cross-version pairs cannot occur.
 pub(crate) fn merge_max(
     a: &MisbehaviorObservations,
     b: &MisbehaviorObservations,
@@ -78,6 +89,25 @@ pub(crate) fn merge_max(
                 equivocations: elem_max(&x.equivocations, &y.equivocations),
             })
         }
+        (MisbehaviorObservations::V2(x), MisbehaviorObservations::V2(y)) => {
+            MisbehaviorObservations::V2(MisbehaviorObservationsV2 {
+                faulty_blocks_provable: elem_max(
+                    &x.faulty_blocks_provable,
+                    &y.faulty_blocks_provable,
+                ),
+                faulty_blocks_unprovable: elem_max(
+                    &x.faulty_blocks_unprovable,
+                    &y.faulty_blocks_unprovable,
+                ),
+                missing_proposals: elem_max(&x.missing_proposals, &y.missing_proposals),
+                equivocations: elem_max(&x.equivocations, &y.equivocations),
+                invalid_bundle_parts: elem_max(&x.invalid_bundle_parts, &y.invalid_bundle_parts),
+            })
+        }
+        (a, b) => panic!(
+            "cross-version misbehavior observation merge: {a:?} vs {b:?} — \
+             all observations within an epoch share one report version"
+        ),
     }
 }
 
@@ -119,7 +149,28 @@ pub(crate) fn observations_from_consensus_output(
         }
     };
     match version {
-        MisbehaviorReportVersion::V1 => MisbehaviorObservations::V1(MisbehaviorObservationsV1 {
+        MisbehaviorReportVersion::V1 => {
+            // The V1 report format has no bundle-part category; fold those
+            // counts into the unprovable bucket, where they were counted
+            // before the split.
+            let unprovable = project(counts.faulty_blocks_unprovable, "faulty_blocks_unprovable");
+            let bundle_parts = project(counts.invalid_bundle_parts, "invalid_bundle_parts");
+            let folded = unprovable
+                .iter()
+                .zip(&bundle_parts)
+                .map(|(unprov, bundle)| unprov.saturating_add(*bundle))
+                .collect();
+            MisbehaviorObservations::V1(MisbehaviorObservationsV1 {
+                faulty_blocks_provable: project(
+                    counts.faulty_blocks_provable,
+                    "faulty_blocks_provable",
+                ),
+                faulty_blocks_unprovable: folded,
+                missing_proposals: project(counts.missing_proposals, "missing_proposals"),
+                equivocations: project(counts.equivocations, "equivocations"),
+            })
+        }
+        MisbehaviorReportVersion::V2 => MisbehaviorObservations::V2(MisbehaviorObservationsV2 {
             faulty_blocks_provable: project(
                 counts.faulty_blocks_provable,
                 "faulty_blocks_provable",
@@ -130,6 +181,7 @@ pub(crate) fn observations_from_consensus_output(
             ),
             missing_proposals: project(counts.missing_proposals, "missing_proposals"),
             equivocations: project(counts.equivocations, "equivocations"),
+            invalid_bundle_parts: project(counts.invalid_bundle_parts, "invalid_bundle_parts"),
         }),
     }
 }

--- a/crates/iota-core/src/authority/misbehavior.rs
+++ b/crates/iota-core/src/authority/misbehavior.rs
@@ -104,11 +104,14 @@ pub(crate) fn merge_max(
                 invalid_bundle_parts: elem_max(&x.invalid_bundle_parts, &y.invalid_bundle_parts),
             })
         }
-        (a @ MisbehaviorObservations::V1(_), b @ MisbehaviorObservations::V2(_))
-        | (a @ MisbehaviorObservations::V2(_), b @ MisbehaviorObservations::V1(_)) => panic!(
-            "cross-version misbehavior observation merge: {a:?} vs {b:?} — \
-             all observations within an epoch share one report version"
-        ),
+        // Exhaustive on the first component: a new version must add its
+        // diagonal merge arm above rather than fall through to the panic.
+        (a @ MisbehaviorObservations::V1(_), b) | (a @ MisbehaviorObservations::V2(_), b) => {
+            panic!(
+                "cross-version misbehavior observation merge: {a:?} vs {b:?} — \
+                 all observations within an epoch share one report version"
+            )
+        }
     }
 }
 

--- a/crates/iota-core/src/authority/misbehavior_monitor.rs
+++ b/crates/iota-core/src/authority/misbehavior_monitor.rs
@@ -78,6 +78,9 @@ impl MisbehaviorMonitor {
             MisbehaviorObservations::V1(o) => {
                 VersionedMisbehaviorReport::new_v1(self.authority, generation, o.clone())
             }
+            MisbehaviorObservations::V2(o) => {
+                VersionedMisbehaviorReport::new_v2(self.authority, generation, o.clone())
+            }
         }
     }
 

--- a/crates/iota-core/src/authority/report_aggregator.rs
+++ b/crates/iota-core/src/authority/report_aggregator.rs
@@ -248,7 +248,9 @@ mod tests {
     };
 
     fn mock_protocol_config() -> ProtocolConfig {
-        ProtocolConfig::get_for_max_version_UNSAFE()
+        let mut config = ProtocolConfig::get_for_max_version_UNSAFE();
+        config.set_scorer_version_for_testing(2);
+        config
     }
 
     fn mock_report_version() -> MisbehaviorReportVersion {

--- a/crates/iota-core/src/authority/report_aggregator.rs
+++ b/crates/iota-core/src/authority/report_aggregator.rs
@@ -72,14 +72,14 @@ impl ReportAggregator {
             return Err(ReportValidationError::WrongReportVersion);
         }
         let committee_size = self.received_reports_state.len();
-        match &report.payload {
-            MisbehaviorObservations::V1(payload) => {
-                if payload.verify(committee_size) {
-                    Ok(())
-                } else {
-                    Err(ReportValidationError::PayloadShape)
-                }
-            }
+        let payload_ok = match &report.payload {
+            MisbehaviorObservations::V1(payload) => payload.verify(committee_size),
+            MisbehaviorObservations::V2(payload) => payload.verify(committee_size),
+        };
+        if payload_ok {
+            Ok(())
+        } else {
+            Err(ReportValidationError::PayloadShape)
         }
     }
 
@@ -237,7 +237,8 @@ pub(crate) struct DBReceivedReportsStatePerAuthority {
 mod tests {
     use iota_protocol_config::ProtocolConfig;
     use iota_types::messages_consensus::{
-        MisbehaviorObservations, MisbehaviorObservationsV1, VersionedMisbehaviorReport,
+        MisbehaviorObservations, MisbehaviorObservationsV1, MisbehaviorObservationsV2,
+        VersionedMisbehaviorReport,
     };
 
     use crate::{
@@ -271,6 +272,20 @@ mod tests {
                 faulty_blocks_unprovable: raw_counts[1].clone(),
                 missing_proposals: raw_counts[2].clone(),
                 equivocations: raw_counts[3].clone(),
+            },
+        )
+    }
+
+    fn report_v2(raw_counts: &[Vec<u64>; 5]) -> VersionedMisbehaviorReport {
+        VersionedMisbehaviorReport::new_v2(
+            iota_types::base_types::AuthorityName::default(),
+            0,
+            MisbehaviorObservationsV2 {
+                faulty_blocks_provable: raw_counts[0].clone(),
+                faulty_blocks_unprovable: raw_counts[1].clone(),
+                missing_proposals: raw_counts[2].clone(),
+                equivocations: raw_counts[3].clone(),
+                invalid_bundle_parts: raw_counts[4].clone(),
             },
         )
     }
@@ -362,8 +377,26 @@ mod tests {
     #[test]
     fn test_validate_report_valid() {
         let aggregator = mock_aggregator(3);
-        let report = report_v1(&[vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9], vec![0, 0, 0]]);
+        let report = report_v2(&[
+            vec![1, 2, 3],
+            vec![4, 5, 6],
+            vec![7, 8, 9],
+            vec![0, 0, 0],
+            vec![1, 0, 2],
+        ]);
         assert!(aggregator.validate_report(&report).is_ok());
+    }
+
+    #[test]
+    fn test_validate_report_wrong_version() {
+        // The max-version aggregator accepts only the current report format;
+        // a V1 report is rejected before its payload shape is even checked.
+        let aggregator = mock_aggregator(3);
+        let report = report_v1(&[vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9], vec![0, 0, 0]]);
+        assert_eq!(
+            aggregator.validate_report(&report),
+            Err(ReportValidationError::WrongReportVersion)
+        );
     }
 
     #[test]
@@ -426,11 +459,12 @@ mod tests {
         // Aggregator built for a 3-validator committee; incoming report has
         // 4-element vectors — should be rejected as malformed.
         let aggregator = mock_aggregator(3);
-        let report = report_v1(&[
+        let report = report_v2(&[
             vec![1, 2, 3, 4],
             vec![5, 6, 7, 8],
             vec![9, 10, 11, 12],
             vec![0, 0, 0, 0],
+            vec![1, 1, 1, 1],
         ]);
         assert_eq!(
             aggregator.validate_report(&report),

--- a/crates/iota-core/src/authority/report_aggregator.rs
+++ b/crates/iota-core/src/authority/report_aggregator.rs
@@ -72,11 +72,7 @@ impl ReportAggregator {
             return Err(ReportValidationError::WrongReportVersion);
         }
         let committee_size = self.received_reports_state.len();
-        let payload_ok = match &report.payload {
-            MisbehaviorObservations::V1(payload) => payload.verify(committee_size),
-            MisbehaviorObservations::V2(payload) => payload.verify(committee_size),
-        };
-        if payload_ok {
+        if report.payload.verify(committee_size) {
             Ok(())
         } else {
             Err(ReportValidationError::PayloadShape)

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -584,7 +584,7 @@ impl MetricParams {
 
 #[cfg(test)]
 mod tests {
-    use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+    use iota_protocol_config::ProtocolConfig;
     use iota_types::messages_consensus::{
         MisbehaviorObservations, MisbehaviorObservationsV1, MisbehaviorObservationsV2,
         VersionedMisbehaviorReport,
@@ -596,14 +596,18 @@ mod tests {
         scorer::{MAX_SCORE, Scoreboard, ScorerV1, ScorerV2, VotingPower},
     };
 
-    fn mock_protocol_config() -> ProtocolConfig {
-        ProtocolConfig::get_for_max_version_UNSAFE()
+    fn mock_protocol_config_with_scorer(version: u16) -> ProtocolConfig {
+        let mut config = ProtocolConfig::get_for_max_version_UNSAFE();
+        config.set_scorer_version_for_testing(version);
+        config
     }
 
-    /// Protocol config pinned to the last protocol version with scorer
-    /// version 1, to keep the V1 scoring path covered.
+    fn mock_protocol_config() -> ProtocolConfig {
+        mock_protocol_config_with_scorer(2)
+    }
+
     fn mock_protocol_config_scorer_v1() -> ProtocolConfig {
-        ProtocolConfig::get_for_version(ProtocolVersion::new(32), Chain::Testnet)
+        mock_protocol_config_with_scorer(1)
     }
 
     fn mock_report_version() -> MisbehaviorReportVersion {
@@ -678,8 +682,7 @@ mod tests {
 
     #[test]
     fn test_update_scores() {
-        // Committee of 3, voting powers [2, 5, 20]. Runs the max-version
-        // (V2) scorer.
+        // Committee of 3, voting powers [2, 5, 20]. Runs the V2 scorer.
         //
         // Weighted medians (total_vp = 27, threshold = 14):
         //   provable[0]:      reporters [(5,2),(0,5),(0,20)] → sorted

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -228,7 +228,7 @@ impl ScorerV1 {
             "median_report requires at least one reporter"
         );
         let committee_size = voting_power.len();
-        let median_for = |select: &dyn Fn(&MisbehaviorObservationsV1) -> &[u64]| {
+        let weighted_median_for = |select: &dyn Fn(&MisbehaviorObservationsV1) -> &[u64]| {
             let rows: Vec<(&[u64], VotingPower)> = reporters
                 .iter()
                 .map(|(counts, vp)| (select(counts), *vp))
@@ -237,10 +237,10 @@ impl ScorerV1 {
         };
 
         MisbehaviorObservationsV1 {
-            faulty_blocks_provable: median_for(&|c| &c.faulty_blocks_provable),
-            faulty_blocks_unprovable: median_for(&|c| &c.faulty_blocks_unprovable),
-            missing_proposals: median_for(&|c| &c.missing_proposals),
-            equivocations: median_for(&|c| &c.equivocations),
+            faulty_blocks_provable: weighted_median_for(&|c| &c.faulty_blocks_provable),
+            faulty_blocks_unprovable: weighted_median_for(&|c| &c.faulty_blocks_unprovable),
+            missing_proposals: weighted_median_for(&|c| &c.missing_proposals),
+            equivocations: weighted_median_for(&|c| &c.equivocations),
         }
     }
 
@@ -370,7 +370,7 @@ impl ScorerV2 {
             "median_report requires at least one reporter"
         );
         let committee_size = voting_power.len();
-        let median_for = |select: &dyn Fn(&MisbehaviorObservationsV2) -> &[u64]| {
+        let weighted_median_for = |select: &dyn Fn(&MisbehaviorObservationsV2) -> &[u64]| {
             let rows: Vec<(&[u64], VotingPower)> = reporters
                 .iter()
                 .map(|(counts, vp)| (select(counts), *vp))
@@ -379,11 +379,11 @@ impl ScorerV2 {
         };
 
         MisbehaviorObservationsV2 {
-            faulty_blocks_provable: median_for(&|c| &c.faulty_blocks_provable),
-            faulty_blocks_unprovable: median_for(&|c| &c.faulty_blocks_unprovable),
-            missing_proposals: median_for(&|c| &c.missing_proposals),
-            equivocations: median_for(&|c| &c.equivocations),
-            invalid_bundle_parts: median_for(&|c| &c.invalid_bundle_parts),
+            faulty_blocks_provable: weighted_median_for(&|c| &c.faulty_blocks_provable),
+            faulty_blocks_unprovable: weighted_median_for(&|c| &c.faulty_blocks_unprovable),
+            missing_proposals: weighted_median_for(&|c| &c.missing_proposals),
+            equivocations: weighted_median_for(&|c| &c.equivocations),
+            invalid_bundle_parts: weighted_median_for(&|c| &c.invalid_bundle_parts),
         }
     }
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -104,7 +104,7 @@ impl VersionedScorer {
                     .iter()
                     .map(|(observations, vp)| match observations.as_ref() {
                         MisbehaviorObservations::V1(o) => (o, *vp),
-                        other => panic!(
+                        other @ MisbehaviorObservations::V2(_) => panic!(
                             "V1 scorer received {other:?} — the aggregator only \
                              accepts the epoch's report version"
                         ),
@@ -118,7 +118,7 @@ impl VersionedScorer {
                     .iter()
                     .map(|(observations, vp)| match observations.as_ref() {
                         MisbehaviorObservations::V2(o) => (o, *vp),
-                        other => panic!(
+                        other @ MisbehaviorObservations::V1(_) => panic!(
                             "V2 scorer received {other:?} — the aggregator only \
                              accepts the epoch's report version"
                         ),
@@ -590,7 +590,9 @@ mod tests {
         arcs.iter()
             .map(|(arc, vp)| match arc.as_ref() {
                 MisbehaviorObservations::V1(o) => (o, *vp),
-                other => panic!("expected V1 observations, got {other:?}"),
+                other @ MisbehaviorObservations::V2(_) => {
+                    panic!("expected V1 observations, got {other:?}")
+                }
             })
             .collect()
     }

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -139,9 +139,10 @@ struct ScorerV1 {
     faulty_blocks_unprovable: MetricParams,
     missing_proposals: MetricParams,
     equivocations: MetricParams,
-    /// `SCALE_FACTOR - sum(minor weights)`. Pre-multiplied by `MAX_SCORE` to
-    /// produce the per-authority initial value before the weighted-minor
-    /// accumulation loop.
+    /// The unallocated remainder of the weight budget
+    /// (`SCALE_FACTOR - sum(minor weights)`), i.e. the fraction of `MAX_SCORE`
+    /// an authority keeps even with every minor metric maxed out. Only a
+    /// major metric can take the score below it.
     baseline_score: u64,
 }
 
@@ -270,9 +271,10 @@ struct ScorerV2 {
     missing_proposals: MetricParams,
     equivocations: MetricParams,
     invalid_bundle_parts: MetricParams,
-    /// `SCALE_FACTOR - sum(minor weights)`. Pre-multiplied by `MAX_SCORE` to
-    /// produce the per-authority initial value before the weighted-minor
-    /// accumulation loop.
+    /// The unallocated remainder of the weight budget
+    /// (`SCALE_FACTOR - sum(minor weights)`), i.e. the fraction of `MAX_SCORE`
+    /// an authority keeps even with every minor metric maxed out. Only a
+    /// major metric can take the score below it.
     baseline_score: u64,
 }
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -264,7 +264,7 @@ impl ScorerV1 {
         voting_power: &[u64],
         median: &MisbehaviorObservationsV1,
     ) -> Vec<u64> {
-        score_from_metric_pairs(
+        score_from_medians(
             &self.metric_pairs(median),
             voting_power.len(),
             self.baseline_score,
@@ -423,7 +423,7 @@ impl ScorerV2 {
         voting_power: &[u64],
         median: &MisbehaviorObservationsV2,
     ) -> Vec<u64> {
-        score_from_metric_pairs(
+        score_from_medians(
             &self.metric_pairs(median),
             voting_power.len(),
             self.baseline_score,
@@ -501,7 +501,7 @@ fn weighted_median_rows(committee_size: usize, rows: &[(&[u64], VotingPower)]) -
     median_for_metric
 }
 
-/// Maps a median report, given as `(median row, params)` pairs, to the
+/// Maps per-category `(median row, params)` entries of a median report to the
 /// per-authority final score vector.
 ///
 /// A score is an integer in `[0, MAX_SCORE]`. Each minor metric's score is
@@ -509,8 +509,8 @@ fn weighted_median_rows(committee_size: usize, rows: &[(&[u64], VotingPower)]) -
 /// `sum(minor_weights) + baseline_score = SCALE_FACTOR`, so we need
 /// `MAX_SCORE * SCALE_FACTOR < 2^64` to avoid overflow (asserted at init).
 /// Major metrics are multiplicative (factor 0 or 1).
-fn score_from_metric_pairs(
-    pairs: &[(&[u64], &MetricParams)],
+fn score_from_medians(
+    medians_with_params: &[(&[u64], &MetricParams)],
     committee_size: usize,
     baseline_score: u64,
 ) -> Vec<u64> {
@@ -518,7 +518,7 @@ fn score_from_metric_pairs(
 
     // Phase 1: weighted-minor accumulation. Values are in
     // [0, MAX_SCORE * SCALE_FACTOR].
-    for (row, params) in pairs {
+    for (row, params) in medians_with_params {
         if let MetricKind::Minor { weight } = params.kind {
             for (authority, &count) in row.iter().enumerate() {
                 final_scores[authority] += params.metric_to_score(count, MAX_SCORE) * weight;
@@ -532,7 +532,7 @@ fn score_from_metric_pairs(
     }
 
     // Phase 2: multiplicative major-metric gates (factor 0 or 1).
-    for (row, params) in pairs {
+    for (row, params) in medians_with_params {
         if matches!(params.kind, MetricKind::Major) {
             for (authority, score) in final_scores.iter_mut().enumerate() {
                 *score *= params.metric_to_score(row[authority], 1);

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use iota_protocol_config::ProtocolConfig;
-use iota_types::messages_consensus::{MisbehaviorObservations, MisbehaviorObservationsV1};
+use iota_types::messages_consensus::{
+    MisbehaviorObservations, MisbehaviorObservationsV1, MisbehaviorObservationsV2,
+};
 
 use crate::authority::authority_per_epoch_store::report_aggregator::ReportAggregator;
 
@@ -69,18 +71,24 @@ impl Scoreboard {
 /// so per-version scorer impls take typed inputs and never re-match.
 enum VersionedScorer {
     V1(ScorerV1),
+    V2(ScorerV2),
 }
 
 impl VersionedScorer {
     fn from_protocol(protocol_config: &ProtocolConfig) -> Self {
         match protocol_config.scorer_version_as_option() {
             None | Some(1) => Self::V1(ScorerV1::v1_parameters()),
+            Some(2) => Self::V2(ScorerV2::v2_parameters()),
             Some(version) => panic!("Unsupported scorer version {version}"),
         }
     }
 
     /// Computes the new score vector. Returns `None` when no reports have been
     /// received yet (the published vector is left untouched in that case).
+    ///
+    /// All aggregated reports match the scorer's version: the aggregator is
+    /// built from the same `scorer_version` and rejects other wire variants,
+    /// so the destructure below panics rather than skipping mismatches.
     fn update_scores(
         &self,
         voting_power: &[u64],
@@ -92,17 +100,31 @@ impl VersionedScorer {
         }
         match self {
             Self::V1(scorer) => {
-                // Destructure each reporter into its V1 inner once. When V2
-                // lands this `match` becomes non-exhaustive, forcing a
-                // deliberate decision about cross-version reports rather than
-                // silently dropping them.
                 let reporters_v1: Vec<(&MisbehaviorObservationsV1, VotingPower)> = reporters
                     .iter()
                     .map(|(observations, vp)| match observations.as_ref() {
                         MisbehaviorObservations::V1(o) => (o, *vp),
+                        other => panic!(
+                            "V1 scorer received {other:?} — the aggregator only \
+                             accepts the epoch's report version"
+                        ),
                     })
                     .collect();
                 let median = scorer.median_report(voting_power, &reporters_v1);
+                Some(scorer.score_from_median(voting_power, &median))
+            }
+            Self::V2(scorer) => {
+                let reporters_v2: Vec<(&MisbehaviorObservationsV2, VotingPower)> = reporters
+                    .iter()
+                    .map(|(observations, vp)| match observations.as_ref() {
+                        MisbehaviorObservations::V2(o) => (o, *vp),
+                        other => panic!(
+                            "V2 scorer received {other:?} — the aggregator only \
+                             accepts the epoch's report version"
+                        ),
+                    })
+                    .collect();
+                let median = scorer.median_report(voting_power, &reporters_v2);
                 Some(scorer.score_from_median(voting_power, &median))
             }
         }
@@ -159,41 +181,12 @@ impl ScorerV1 {
             kind: MetricKind::Major,
         };
 
-        let metrics = [
+        let baseline_score = validate_params_and_baseline(&[
             &faulty_blocks_provable,
             &faulty_blocks_unprovable,
             &missing_proposals,
             &equivocations,
-        ];
-
-        // Init-time invariants. Cheaper than guarding every score evaluation.
-        for p in &metrics {
-            assert!(p.allowance < p.maximum, "allowance must be < maximum");
-            assert!(
-                p.maximum <= u64::MAX / MAX_SCORE,
-                "maximum must be <= u64::MAX / MAX_SCORE to keep arithmetic safe"
-            );
-            if let MetricKind::Major = p.kind {
-                assert!(
-                    p.allowance == 0 && p.maximum == 1,
-                    "major metric must have allowance=0 and maximum=1 so any occurrence \
-                     collapses the score to zero"
-                );
-            }
-        }
-
-        let minor_weights_sum: u64 = metrics
-            .iter()
-            .map(|p| match p.kind {
-                MetricKind::Minor { weight } => weight,
-                MetricKind::Major => 0,
-            })
-            .sum();
-        assert!(
-            minor_weights_sum <= SCALE_FACTOR,
-            "minor weights sum ({minor_weights_sum}) exceeds SCALE_FACTOR ({SCALE_FACTOR})"
-        );
-        let baseline_score = SCALE_FACTOR - minor_weights_sum;
+        ]);
 
         Self {
             faulty_blocks_provable,
@@ -235,91 +228,289 @@ impl ScorerV1 {
             "median_report requires at least one reporter"
         );
         let committee_size = voting_power.len();
-        // Sum only over reporters, not the full committee — the median is
-        // weighted by the voting power of authorities that actually submitted.
-        let total_voting_power: VotingPower = reporters.iter().map(|(_, vp)| *vp).sum();
-
-        // Reused across all (metric, authority) pairs — one allocation total.
-        let mut chunk: Vec<(u64, VotingPower)> = Vec::with_capacity(reporters.len());
-
-        let mut weighted_median_for = |select: &dyn Fn(&MisbehaviorObservationsV1) -> &[u64]| {
-            let mut median_for_metric = Vec::with_capacity(committee_size);
-            for authority in 0..committee_size {
-                chunk.clear();
-                chunk.extend(
-                    reporters
-                        .iter()
-                        .map(|(counts, vp)| (select(counts)[authority], *vp)),
-                );
-                chunk.sort_unstable_by_key(|&(val, _)| val);
-
-                let mut accumulated = 0;
-                for &(val, vp) in &chunk {
-                    accumulated += vp;
-                    if accumulated * 2 >= total_voting_power {
-                        median_for_metric.push(val);
-                        break;
-                    }
-                }
-            }
-            debug_assert_eq!(
-                median_for_metric.len(),
-                committee_size,
-                "weighted median did not produce a value for every authority; \
-                 this is a bug — accumulated voting power must always reach total"
-            );
-            median_for_metric
+        let median_for = |select: &dyn Fn(&MisbehaviorObservationsV1) -> &[u64]| {
+            let rows: Vec<(&[u64], VotingPower)> = reporters
+                .iter()
+                .map(|(counts, vp)| (select(counts), *vp))
+                .collect();
+            weighted_median_rows(committee_size, &rows)
         };
 
         MisbehaviorObservationsV1 {
-            faulty_blocks_provable: weighted_median_for(&|c| &c.faulty_blocks_provable),
-            faulty_blocks_unprovable: weighted_median_for(&|c| &c.faulty_blocks_unprovable),
-            missing_proposals: weighted_median_for(&|c| &c.missing_proposals),
-            equivocations: weighted_median_for(&|c| &c.equivocations),
+            faulty_blocks_provable: median_for(&|c| &c.faulty_blocks_provable),
+            faulty_blocks_unprovable: median_for(&|c| &c.faulty_blocks_unprovable),
+            missing_proposals: median_for(&|c| &c.missing_proposals),
+            equivocations: median_for(&|c| &c.equivocations),
         }
     }
 
     /// Given the median report, produces the per-authority final score vector.
-    ///
-    /// A score is an integer in `[0, MAX_SCORE]`. Each minor metric's score is
-    /// also in `[0, MAX_SCORE]`; their weights satisfy
-    /// `sum(minor_weights) + baseline_score = SCALE_FACTOR`, so we need
-    /// `MAX_SCORE * SCALE_FACTOR < 2^64` to avoid overflow (asserted at init).
-    /// Major metrics are multiplicative (factor 0 or 1).
     fn score_from_median(
         &self,
         voting_power: &[u64],
         median: &MisbehaviorObservationsV1,
     ) -> Vec<u64> {
-        let committee_size = voting_power.len();
-        let mut final_scores = vec![self.baseline_score * MAX_SCORE; committee_size];
-
-        // Phase 1: weighted-minor accumulation. Values are in
-        // [0, MAX_SCORE * SCALE_FACTOR].
-        for (row, params) in &self.metric_pairs(median) {
-            if let MetricKind::Minor { weight } = params.kind {
-                for (authority, &count) in row.iter().enumerate() {
-                    final_scores[authority] += params.metric_to_score(count, MAX_SCORE) * weight;
-                }
-            }
-        }
-
-        // Scale down to [0, MAX_SCORE].
-        for score in final_scores.iter_mut() {
-            *score /= SCALE_FACTOR;
-        }
-
-        // Phase 2: multiplicative major-metric gates (factor 0 or 1).
-        for (row, params) in &self.metric_pairs(median) {
-            if matches!(params.kind, MetricKind::Major) {
-                for (authority, score) in final_scores.iter_mut().enumerate() {
-                    *score *= params.metric_to_score(row[authority], 1);
-                }
-            }
-        }
-
-        final_scores
+        score_from_metric_pairs(
+            &self.metric_pairs(median),
+            voting_power.len(),
+            self.baseline_score,
+        )
     }
+}
+
+/// V2 scoring parameters and implementation for
+/// `MisbehaviorObservationsV2`. Same math as `ScorerV1` with a fifth
+/// category: invalid bundle parts, carved out of the V1 unprovable weight so
+/// the total penalty budget stays the same. Field order mirrors
+/// `MisbehaviorObservationsV2` so the score loop can iterate `(row, params)`
+/// pairs without an indirection through `Misbehavior`.
+struct ScorerV2 {
+    faulty_blocks_provable: MetricParams,
+    faulty_blocks_unprovable: MetricParams,
+    missing_proposals: MetricParams,
+    equivocations: MetricParams,
+    invalid_bundle_parts: MetricParams,
+    /// `SCALE_FACTOR - sum(minor weights)`. Pre-multiplied by `MAX_SCORE` to
+    /// produce the per-authority initial value before the weighted-minor
+    /// accumulation loop.
+    baseline_score: u64,
+}
+
+impl ScorerV2 {
+    fn v2_parameters() -> Self {
+        // 1 provable faulty block is allowed without punishment, to account
+        // for honest mistakes / protocol edge cases.
+        let faulty_blocks_provable = MetricParams {
+            allowance: 1,
+            maximum: 5,
+            kind: MetricKind::Minor {
+                weight: SCALE_FACTOR * 30 / 100,
+            },
+        };
+        // The V1 unprovable weight (10%) is split evenly between unprovable
+        // block faults and invalid bundle parts; allowances and maximums stay
+        // at the V1 values for both.
+        let faulty_blocks_unprovable = MetricParams {
+            allowance: 2,
+            maximum: 10,
+            kind: MetricKind::Minor {
+                weight: SCALE_FACTOR * 5 / 100,
+            },
+        };
+        let invalid_bundle_parts = MetricParams {
+            allowance: 2,
+            maximum: 10,
+            kind: MetricKind::Minor {
+                weight: SCALE_FACTOR * 5 / 100,
+            },
+        };
+        // ~3% of consensus rounds in an epoch allowed; ~10% leads to zero
+        // score.
+        let missing_proposals = MetricParams {
+            allowance: 48_000,
+            maximum: 160_000,
+            kind: MetricKind::Minor {
+                weight: SCALE_FACTOR * 35 / 100,
+            },
+        };
+        // Equivocations: any occurrence collapses the score to zero.
+        let equivocations = MetricParams {
+            allowance: 0,
+            maximum: 1,
+            kind: MetricKind::Major,
+        };
+
+        let baseline_score = validate_params_and_baseline(&[
+            &faulty_blocks_provable,
+            &faulty_blocks_unprovable,
+            &missing_proposals,
+            &equivocations,
+            &invalid_bundle_parts,
+        ]);
+
+        Self {
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+            invalid_bundle_parts,
+            baseline_score,
+        }
+    }
+
+    /// `(row in median, params)` pairs for the explicit named-field iteration
+    /// used by both phases of the score formula. Adding a metric to
+    /// `MisbehaviorObservationsV2` / `ScorerV2` makes this array a
+    /// missing-field error, forcing the new metric to be wired in.
+    fn metric_pairs<'a>(
+        &'a self,
+        median: &'a MisbehaviorObservationsV2,
+    ) -> [(&'a [u64], &'a MetricParams); 5] {
+        [
+            (&median.faulty_blocks_provable, &self.faulty_blocks_provable),
+            (
+                &median.faulty_blocks_unprovable,
+                &self.faulty_blocks_unprovable,
+            ),
+            (&median.missing_proposals, &self.missing_proposals),
+            (&median.equivocations, &self.equivocations),
+            (&median.invalid_bundle_parts, &self.invalid_bundle_parts),
+        ]
+    }
+
+    /// Calculates the weighted median across all reporters for each metric and
+    /// authority. Caller is responsible for ensuring `reporters` is non-empty.
+    fn median_report(
+        &self,
+        voting_power: &[u64],
+        reporters: &[(&MisbehaviorObservationsV2, VotingPower)],
+    ) -> MisbehaviorObservationsV2 {
+        debug_assert!(
+            !reporters.is_empty(),
+            "median_report requires at least one reporter"
+        );
+        let committee_size = voting_power.len();
+        let median_for = |select: &dyn Fn(&MisbehaviorObservationsV2) -> &[u64]| {
+            let rows: Vec<(&[u64], VotingPower)> = reporters
+                .iter()
+                .map(|(counts, vp)| (select(counts), *vp))
+                .collect();
+            weighted_median_rows(committee_size, &rows)
+        };
+
+        MisbehaviorObservationsV2 {
+            faulty_blocks_provable: median_for(&|c| &c.faulty_blocks_provable),
+            faulty_blocks_unprovable: median_for(&|c| &c.faulty_blocks_unprovable),
+            missing_proposals: median_for(&|c| &c.missing_proposals),
+            equivocations: median_for(&|c| &c.equivocations),
+            invalid_bundle_parts: median_for(&|c| &c.invalid_bundle_parts),
+        }
+    }
+
+    /// Given the median report, produces the per-authority final score vector.
+    fn score_from_median(
+        &self,
+        voting_power: &[u64],
+        median: &MisbehaviorObservationsV2,
+    ) -> Vec<u64> {
+        score_from_metric_pairs(
+            &self.metric_pairs(median),
+            voting_power.len(),
+            self.baseline_score,
+        )
+    }
+}
+
+/// Init-time invariant checks for a scorer's full parameter set. Cheaper than
+/// guarding every score evaluation. Returns the baseline score
+/// (`SCALE_FACTOR - sum(minor weights)`).
+fn validate_params_and_baseline(metrics: &[&MetricParams]) -> u64 {
+    for p in metrics {
+        assert!(p.allowance < p.maximum, "allowance must be < maximum");
+        assert!(
+            p.maximum <= u64::MAX / MAX_SCORE,
+            "maximum must be <= u64::MAX / MAX_SCORE to keep arithmetic safe"
+        );
+        if let MetricKind::Major = p.kind {
+            assert!(
+                p.allowance == 0 && p.maximum == 1,
+                "major metric must have allowance=0 and maximum=1 so any occurrence \
+                 collapses the score to zero"
+            );
+        }
+    }
+
+    let minor_weights_sum: u64 = metrics
+        .iter()
+        .map(|p| match p.kind {
+            MetricKind::Minor { weight } => weight,
+            MetricKind::Major => 0,
+        })
+        .sum();
+    assert!(
+        minor_weights_sum <= SCALE_FACTOR,
+        "minor weights sum ({minor_weights_sum}) exceeds SCALE_FACTOR ({SCALE_FACTOR})"
+    );
+    SCALE_FACTOR - minor_weights_sum
+}
+
+/// Weighted median across all reporters for one metric. `rows` pairs each
+/// reporter's per-authority counts with that reporter's voting power; the
+/// median for an authority is the smallest reported value whose cumulative
+/// reporter voting power reaches half of the total. Caller guarantees `rows`
+/// is non-empty.
+fn weighted_median_rows(committee_size: usize, rows: &[(&[u64], VotingPower)]) -> Vec<u64> {
+    // Sum only over reporters, not the full committee — the median is
+    // weighted by the voting power of authorities that actually submitted.
+    let total_voting_power: VotingPower = rows.iter().map(|(_, vp)| *vp).sum();
+
+    // Reused across all authorities — one allocation total.
+    let mut chunk: Vec<(u64, VotingPower)> = Vec::with_capacity(rows.len());
+
+    let mut median_for_metric = Vec::with_capacity(committee_size);
+    for authority in 0..committee_size {
+        chunk.clear();
+        chunk.extend(rows.iter().map(|(counts, vp)| (counts[authority], *vp)));
+        chunk.sort_unstable_by_key(|&(val, _)| val);
+
+        let mut accumulated = 0;
+        for &(val, vp) in &chunk {
+            accumulated += vp;
+            if accumulated * 2 >= total_voting_power {
+                median_for_metric.push(val);
+                break;
+            }
+        }
+    }
+    debug_assert_eq!(
+        median_for_metric.len(),
+        committee_size,
+        "weighted median did not produce a value for every authority; \
+         this is a bug — accumulated voting power must always reach total"
+    );
+    median_for_metric
+}
+
+/// Maps a median report, given as `(median row, params)` pairs, to the
+/// per-authority final score vector.
+///
+/// A score is an integer in `[0, MAX_SCORE]`. Each minor metric's score is
+/// also in `[0, MAX_SCORE]`; the weights satisfy
+/// `sum(minor_weights) + baseline_score = SCALE_FACTOR`, so we need
+/// `MAX_SCORE * SCALE_FACTOR < 2^64` to avoid overflow (asserted at init).
+/// Major metrics are multiplicative (factor 0 or 1).
+fn score_from_metric_pairs(
+    pairs: &[(&[u64], &MetricParams)],
+    committee_size: usize,
+    baseline_score: u64,
+) -> Vec<u64> {
+    let mut final_scores = vec![baseline_score * MAX_SCORE; committee_size];
+
+    // Phase 1: weighted-minor accumulation. Values are in
+    // [0, MAX_SCORE * SCALE_FACTOR].
+    for (row, params) in pairs {
+        if let MetricKind::Minor { weight } = params.kind {
+            for (authority, &count) in row.iter().enumerate() {
+                final_scores[authority] += params.metric_to_score(count, MAX_SCORE) * weight;
+            }
+        }
+    }
+
+    // Scale down to [0, MAX_SCORE].
+    for score in final_scores.iter_mut() {
+        *score /= SCALE_FACTOR;
+    }
+
+    // Phase 2: multiplicative major-metric gates (factor 0 or 1).
+    for (row, params) in pairs {
+        if matches!(params.kind, MetricKind::Major) {
+            for (authority, score) in final_scores.iter_mut().enumerate() {
+                *score *= params.metric_to_score(row[authority], 1);
+            }
+        }
+    }
+
+    final_scores
 }
 
 #[derive(Copy, Clone)]
@@ -359,19 +550,26 @@ impl MetricParams {
 
 #[cfg(test)]
 mod tests {
-    use iota_protocol_config::ProtocolConfig;
+    use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use iota_types::messages_consensus::{
-        MisbehaviorObservations, MisbehaviorObservationsV1, VersionedMisbehaviorReport,
+        MisbehaviorObservations, MisbehaviorObservationsV1, MisbehaviorObservationsV2,
+        VersionedMisbehaviorReport,
     };
 
     use crate::authority::authority_per_epoch_store::{
         misbehavior::MisbehaviorReportVersion,
         report_aggregator::ReportAggregator,
-        scorer::{MAX_SCORE, Scoreboard, ScorerV1, VotingPower},
+        scorer::{MAX_SCORE, Scoreboard, ScorerV1, ScorerV2, VotingPower},
     };
 
     fn mock_protocol_config() -> ProtocolConfig {
         ProtocolConfig::get_for_max_version_UNSAFE()
+    }
+
+    /// Protocol config pinned to the last protocol version with scorer
+    /// version 1, to keep the V1 scoring path covered.
+    fn mock_protocol_config_scorer_v1() -> ProtocolConfig {
+        ProtocolConfig::get_for_version(ProtocolVersion::new(32), Chain::Testnet)
     }
 
     fn mock_report_version() -> MisbehaviorReportVersion {
@@ -392,6 +590,7 @@ mod tests {
         arcs.iter()
             .map(|(arc, vp)| match arc.as_ref() {
                 MisbehaviorObservations::V1(o) => (o, *vp),
+                other => panic!("expected V1 observations, got {other:?}"),
             })
             .collect()
     }
@@ -410,6 +609,14 @@ mod tests {
                 missing_proposals: raw_counts[2].clone(),
                 equivocations: raw_counts[3].clone(),
             },
+        )
+    }
+
+    fn report_v2(raw_counts: &[Vec<u64>; 5]) -> VersionedMisbehaviorReport {
+        VersionedMisbehaviorReport::new_v2(
+            iota_types::base_types::AuthorityName::default(),
+            0,
+            observations_v2(raw_counts),
         )
     }
 
@@ -435,7 +642,8 @@ mod tests {
 
     #[test]
     fn test_update_scores() {
-        // Committee of 3, voting powers [2, 5, 20].
+        // Committee of 3, voting powers [2, 5, 20]. Runs the max-version
+        // (V2) scorer.
         //
         // Weighted medians (total_vp = 27, threshold = 14):
         //   provable[0]:      reporters [(5,2),(0,5),(0,20)] → sorted
@@ -449,11 +657,72 @@ mod tests {
         // 0   authority 1: all medians = 0 → MAX_SCORE
         //   authority 2: provable median = 15 ≥ max(5) → provable contribution = 0,
         //                all other metrics 0 → score = baseline + unprovable + missing
-        // = 45876
+        // + bundle = 16387 + 3276 + 22937 + 3276 = 45876
         let voting_power = vec![2, 5, 20];
         let committee_size = voting_power.len();
         let aggregator = mock_aggregator(committee_size);
         let scorer = mock_scoreboard(voting_power);
+
+        assert!(scorer.current_scores().iter().all(|&s| s == MAX_SCORE));
+
+        set_reports(
+            &aggregator,
+            &[
+                (
+                    report_v2(&[
+                        vec![5, 0, 0],
+                        vec![0, 0, 0],
+                        vec![0, 0, 0],
+                        vec![0, 0, 0],
+                        vec![0, 0, 0],
+                    ]),
+                    0,
+                ),
+                (
+                    report_v2(&[
+                        vec![0, 10, 0],
+                        vec![0, 0, 0],
+                        vec![0, 0, 0],
+                        vec![0, 0, 0],
+                        vec![0, 0, 0],
+                    ]),
+                    1,
+                ),
+                (
+                    report_v2(&[
+                        vec![0, 0, 15],
+                        vec![0, 0, 0],
+                        vec![0, 0, 0],
+                        vec![5, 0, 0],
+                        vec![0, 0, 0],
+                    ]),
+                    2,
+                ),
+            ],
+        );
+
+        scorer.update_scores(&aggregator);
+
+        let expected_score = vec![0, 65536, 45876];
+        let actual_score = scorer.current_scores();
+        assert_eq!(actual_score, expected_score);
+    }
+
+    #[test]
+    fn test_update_scores_scorer_v1() {
+        // Same scenario as `test_update_scores`, on the pinned scorer-V1
+        // protocol version with V1 reports.
+        //
+        // Authority 2's score differs only in the V1 weight split:
+        // baseline + unprovable + missing = 16386 + 6553 + 22937 = 45876.
+        let config = mock_protocol_config_scorer_v1();
+        let voting_power = vec![2, 5, 20];
+        let committee_size = voting_power.len();
+        let aggregator = ReportAggregator::new(
+            MisbehaviorReportVersion::from_protocol(&config),
+            committee_size,
+        );
+        let scorer = Scoreboard::new(voting_power, &config);
 
         assert!(scorer.current_scores().iter().all(|&s| s == MAX_SCORE));
 
@@ -652,6 +921,129 @@ mod tests {
                 }
             ),
             vec![45876, MAX_SCORE, MAX_SCORE]
+        );
+    }
+
+    fn observations_v2(raw_counts: &[Vec<u64>; 5]) -> MisbehaviorObservationsV2 {
+        MisbehaviorObservationsV2 {
+            faulty_blocks_provable: raw_counts[0].clone(),
+            faulty_blocks_unprovable: raw_counts[1].clone(),
+            missing_proposals: raw_counts[2].clone(),
+            equivocations: raw_counts[3].clone(),
+            invalid_bundle_parts: raw_counts[4].clone(),
+        }
+    }
+
+    #[test]
+    fn test_calculate_median_report_v2() {
+        // Three equal reporters — the middle value wins for each (metric,
+        // authority) pair, including the bundle-part row.
+        let scorer = ScorerV2::v2_parameters();
+        let voting_power = vec![10, 10, 10];
+
+        let reports = [
+            observations_v2(&[
+                vec![1, 8, 9],
+                vec![10, 15, 12],
+                vec![4, 5, 6],
+                vec![1, 20, 3],
+                vec![2, 7, 30],
+            ]),
+            observations_v2(&[
+                vec![7, 8, 9],
+                vec![10, 11, 12],
+                vec![4, 5, 6],
+                vec![1, 2, 0],
+                vec![2, 3, 40],
+            ]),
+            observations_v2(&[
+                vec![6, 8, 9],
+                vec![10, 11, 12],
+                vec![4, 22, 6],
+                vec![1, 2, 30],
+                vec![9, 3, 50],
+            ]),
+        ];
+        let reporters: Vec<(&MisbehaviorObservationsV2, VotingPower)> =
+            reports.iter().map(|o| (o, 10)).collect();
+
+        let median = scorer.median_report(&voting_power, &reporters);
+        assert_eq!(
+            median,
+            observations_v2(&[
+                vec![6, 8, 9],
+                vec![10, 11, 12],
+                vec![4, 5, 6],
+                vec![1, 2, 3],
+                vec![2, 3, 40],
+            ])
+        );
+    }
+
+    #[test]
+    fn test_score_from_median_v2() {
+        // V2 parameters:
+        //   allowances:      [1, 2, 48_000, 0, 2]
+        //   maximums:        [5, 10, 160_000, 1, 10]
+        //   minor weights:   [19660, 3276, 22937, 3276]  (30%, 5%, 35%, 5%)
+        //   baseline_score:  16387  (SCALE_FACTOR - sum_of_minor_weights)
+        let committee_size = 3;
+        let voting_power = vec![10; committee_size];
+        let scorer = ScorerV2::v2_parameters();
+
+        // All-zero misbehaviors → every authority gets MAX_SCORE.
+        assert_eq!(
+            scorer.score_from_median(
+                &voting_power,
+                &observations_v2(&[vec![0; 3], vec![0; 3], vec![0; 3], vec![0; 3], vec![0; 3]])
+            ),
+            vec![MAX_SCORE, MAX_SCORE, MAX_SCORE]
+        );
+
+        // Authority 0 reaches the bundle-part maximum (≥ 10) → its weight
+        // drops out: MAX_SCORE - 3276 = 62260.
+        assert_eq!(
+            scorer.score_from_median(
+                &voting_power,
+                &observations_v2(&[
+                    vec![0; 3],
+                    vec![0; 3],
+                    vec![0; 3],
+                    vec![0; 3],
+                    vec![10, 0, 0]
+                ])
+            ),
+            vec![62260, MAX_SCORE, MAX_SCORE]
+        );
+
+        // Bundle-part counts within the allowance (≤ 2) are not punished.
+        assert_eq!(
+            scorer.score_from_median(
+                &voting_power,
+                &observations_v2(&[
+                    vec![0; 3],
+                    vec![0; 3],
+                    vec![0; 3],
+                    vec![0; 3],
+                    vec![2, 0, 0]
+                ])
+            ),
+            vec![MAX_SCORE, MAX_SCORE, MAX_SCORE]
+        );
+
+        // Equivocation still collapses the score to zero.
+        assert_eq!(
+            scorer.score_from_median(
+                &voting_power,
+                &observations_v2(&[
+                    vec![0; 3],
+                    vec![0; 3],
+                    vec![0; 3],
+                    vec![1, 0, 0],
+                    vec![0; 3]
+                ])
+            ),
+            vec![0, MAX_SCORE, MAX_SCORE]
         );
     }
 }

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -201,21 +201,32 @@ impl ScorerV1 {
     }
 
     /// `(row in median, params)` pairs for the explicit named-field iteration
-    /// used by both phases of the score formula. Adding a metric to
-    /// `MisbehaviorObservationsV1` / `ScorerV1` makes this array a
-    /// missing-field error, forcing the new metric to be wired in.
+    /// used by both phases of the score formula. Both structs are
+    /// destructured, so adding a metric to `MisbehaviorObservationsV1` /
+    /// `ScorerV1` is a missing-field error here, forcing the new metric to
+    /// be wired in.
     fn metric_pairs<'a>(
         &'a self,
         median: &'a MisbehaviorObservationsV1,
     ) -> [(&'a [u64], &'a MetricParams); 4] {
+        let MisbehaviorObservationsV1 {
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+        } = median;
+        let Self {
+            faulty_blocks_provable: provable_params,
+            faulty_blocks_unprovable: unprovable_params,
+            missing_proposals: missing_params,
+            equivocations: equivocation_params,
+            baseline_score: _,
+        } = self;
         [
-            (&median.faulty_blocks_provable, &self.faulty_blocks_provable),
-            (
-                &median.faulty_blocks_unprovable,
-                &self.faulty_blocks_unprovable,
-            ),
-            (&median.missing_proposals, &self.missing_proposals),
-            (&median.equivocations, &self.equivocations),
+            (faulty_blocks_provable.as_slice(), provable_params),
+            (faulty_blocks_unprovable.as_slice(), unprovable_params),
+            (missing_proposals.as_slice(), missing_params),
+            (equivocations.as_slice(), equivocation_params),
         ]
     }
 
@@ -345,22 +356,35 @@ impl ScorerV2 {
     }
 
     /// `(row in median, params)` pairs for the explicit named-field iteration
-    /// used by both phases of the score formula. Adding a metric to
-    /// `MisbehaviorObservationsV2` / `ScorerV2` makes this array a
-    /// missing-field error, forcing the new metric to be wired in.
+    /// used by both phases of the score formula. Both structs are
+    /// destructured, so adding a metric to `MisbehaviorObservationsV2` /
+    /// `ScorerV2` is a missing-field error here, forcing the new metric to
+    /// be wired in.
     fn metric_pairs<'a>(
         &'a self,
         median: &'a MisbehaviorObservationsV2,
     ) -> [(&'a [u64], &'a MetricParams); 5] {
+        let MisbehaviorObservationsV2 {
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+            invalid_bundle_parts,
+        } = median;
+        let Self {
+            faulty_blocks_provable: provable_params,
+            faulty_blocks_unprovable: unprovable_params,
+            missing_proposals: missing_params,
+            equivocations: equivocation_params,
+            invalid_bundle_parts: bundle_params,
+            baseline_score: _,
+        } = self;
         [
-            (&median.faulty_blocks_provable, &self.faulty_blocks_provable),
-            (
-                &median.faulty_blocks_unprovable,
-                &self.faulty_blocks_unprovable,
-            ),
-            (&median.missing_proposals, &self.missing_proposals),
-            (&median.equivocations, &self.equivocations),
-            (&median.invalid_bundle_parts, &self.invalid_bundle_parts),
+            (faulty_blocks_provable.as_slice(), provable_params),
+            (faulty_blocks_unprovable.as_slice(), unprovable_params),
+            (missing_proposals.as_slice(), missing_params),
+            (equivocations.as_slice(), equivocation_params),
+            (invalid_bundle_parts.as_slice(), bundle_params),
         ]
     }
 

--- a/crates/iota-core/src/authority/scorer.rs
+++ b/crates/iota-core/src/authority/scorer.rs
@@ -131,9 +131,11 @@ impl VersionedScorer {
     }
 }
 
-/// V1 scoring parameters and implementation. Field order mirrors
-/// `MisbehaviorObservationsV1` so the score loop can iterate
-/// `(row, params)` pairs without an indirection through `Misbehavior`.
+/// V1 scoring parameters and implementation. Every category is a
+/// `MetricKind::Minor` except `equivocations`, the sole
+/// `MetricKind::Major`. Field order mirrors `MisbehaviorObservationsV1` so
+/// the score loop can iterate `(row, params)` pairs without an indirection
+/// through `Misbehavior`.
 struct ScorerV1 {
     faulty_blocks_provable: MetricParams,
     faulty_blocks_unprovable: MetricParams,
@@ -262,9 +264,11 @@ impl ScorerV1 {
 /// V2 scoring parameters and implementation for
 /// `MisbehaviorObservationsV2`. Same math as `ScorerV1` with a fifth
 /// category: invalid bundle parts, carved out of the V1 unprovable weight so
-/// the total penalty budget stays the same. Field order mirrors
-/// `MisbehaviorObservationsV2` so the score loop can iterate `(row, params)`
-/// pairs without an indirection through `Misbehavior`.
+/// the total penalty budget stays the same. Every category is a
+/// `MetricKind::Minor` except `equivocations`, the sole `MetricKind::Major`.
+/// Field order mirrors `MisbehaviorObservationsV2` so the score loop can
+/// iterate `(row, params)` pairs without an indirection through
+/// `Misbehavior`.
 struct ScorerV2 {
     faulty_blocks_provable: MetricParams,
     faulty_blocks_unprovable: MetricParams,
@@ -515,6 +519,10 @@ fn score_from_metric_pairs(
     final_scores
 }
 
+/// How a misbehavior category affects the score: graded categories (minor)
+/// each erode their own share of a bounded weight budget, so they can never
+/// take the score to zero on their own; disqualifying offenses (major) zero
+/// the score outright on any occurrence.
 #[derive(Copy, Clone)]
 enum MetricKind {
     /// Linear penalty between `allowance` and `maximum`, weighted into the

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -25,14 +25,15 @@ pub(crate) type ConsensusOutputTransactions =
 ///
 /// Per-field empty `Vec`s mean "not wired yet" and are zero-filled by the
 /// mapper. Today this struct is structurally identical to
-/// `MisbehaviorObservationsV1`; the separation exists so consensus's
-/// observation set and the wire schema can evolve on independent cadences.
+/// `MisbehaviorObservationsV2`; the separation exists so consensus's
+/// observation set and the wire schema can evolve independently.
 #[derive(Debug, Default)]
 pub struct ConsensusOutputMisbehaviorCounts {
     pub faulty_blocks_provable: Vec<u64>,
     pub faulty_blocks_unprovable: Vec<u64>,
     pub missing_proposals: Vec<u64>,
     pub equivocations: Vec<u64>,
+    pub invalid_bundle_parts: Vec<u64>,
 }
 
 pub(crate) trait ConsensusOutputAPI: Display {
@@ -140,23 +141,39 @@ impl ConsensusOutputAPI for starfish_core::CommittedSubDag {
     }
 
     fn misbehavior_counts(&self) -> ConsensusOutputMisbehaviorCounts {
-        let (faulty_blocks_provable, faulty_blocks_unprovable, missing_proposals, equivocations) =
-            self.misbehavior_counts
-                .iter()
-                .map(|counts| match counts {
-                    starfish_core::MisbehaviorCounts::V1(v1) => (
-                        v1.faulty_blocks_provable,
-                        v1.faulty_blocks_unprovable,
-                        v1.missing_proposals,
-                        v1.equivocations,
-                    ),
-                })
-                .multiunzip();
+        let (
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+            invalid_bundle_parts,
+        ) = self
+            .misbehavior_counts
+            .iter()
+            .map(|counts| match counts {
+                // V1 counts predate the bundle-part counter.
+                starfish_core::MisbehaviorCounts::V1(v1) => (
+                    v1.faulty_blocks_provable,
+                    v1.faulty_blocks_unprovable,
+                    v1.missing_proposals,
+                    v1.equivocations,
+                    0,
+                ),
+                starfish_core::MisbehaviorCounts::V2(v2) => (
+                    v2.faulty_blocks_provable,
+                    v2.faulty_blocks_unprovable,
+                    v2.missing_proposals,
+                    v2.equivocations,
+                    v2.invalid_bundle_parts,
+                ),
+            })
+            .multiunzip();
         ConsensusOutputMisbehaviorCounts {
             faulty_blocks_provable,
             faulty_blocks_unprovable,
             missing_proposals,
             equivocations,
+            invalid_bundle_parts,
         }
     }
 }
@@ -165,7 +182,7 @@ impl ConsensusOutputAPI for starfish_core::CommittedSubDag {
 mod tests {
     use starfish_core::{
         BlockRef, CommitDigest, CommitRef, CommittedSubDag, MisbehaviorCounts, MisbehaviorCountsV1,
-        VerifiedBlockHeader,
+        MisbehaviorCountsV2, VerifiedBlockHeader,
     };
 
     use super::*;
@@ -173,17 +190,19 @@ mod tests {
     #[test]
     fn test_misbehavior_counts_transposes_per_authority_to_per_field_vecs() {
         let counts = vec![
+            // A V1 entry maps with the bundle-part counter zero-filled.
             MisbehaviorCounts::V1(MisbehaviorCountsV1 {
                 faulty_blocks_provable: 1,
                 faulty_blocks_unprovable: 2,
                 missing_proposals: 3,
                 equivocations: 4,
             }),
-            MisbehaviorCounts::V1(MisbehaviorCountsV1 {
+            MisbehaviorCounts::V2(MisbehaviorCountsV2 {
                 faulty_blocks_provable: 10,
                 faulty_blocks_unprovable: 20,
                 missing_proposals: 30,
                 equivocations: 40,
+                invalid_bundle_parts: 50,
             }),
             MisbehaviorCounts::default(),
         ];
@@ -204,6 +223,7 @@ mod tests {
         assert_eq!(out.faulty_blocks_unprovable, vec![2, 20, 0]);
         assert_eq!(out.missing_proposals, vec![3, 30, 0]);
         assert_eq!(out.equivocations, vec![4, 40, 0]);
+        assert_eq!(out.invalid_bundle_parts, vec![0, 50, 0]);
     }
 
     #[test]
@@ -223,5 +243,6 @@ mod tests {
         assert!(out.faulty_blocks_unprovable.is_empty());
         assert!(out.missing_proposals.is_empty());
         assert!(out.equivocations.is_empty());
+        assert!(out.invalid_bundle_parts.is_empty());
     }
 }

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -151,7 +151,6 @@ impl ConsensusOutputAPI for starfish_core::CommittedSubDag {
             .misbehavior_counts
             .iter()
             .map(|counts| match counts {
-                // V1 counts predate the bundle-part counter.
                 starfish_core::MisbehaviorCounts::V1(v1) => (
                     v1.faulty_blocks_provable,
                     v1.faulty_blocks_unprovable,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1287,15 +1287,15 @@
           "params": [
             {
               "name": "version",
-              "value": 33
+              "value": 34
             }
           ],
           "result": {
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "33",
-              "protocolVersion": "33",
+              "maxSupportedProtocolVersion": "34",
+              "protocolVersion": "34",
               "featureFlags": {
                 "accept_passkey_in_multisig": true,
                 "additional_borrow_checks": true,
@@ -2129,7 +2129,7 @@
                   "u64": "10000"
                 },
                 "scorer_version": {
-                  "u16": "1"
+                  "u16": "2"
                 },
                 "storage_gas_price": {
                   "u64": "76"

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-pub const MAX_PROTOCOL_VERSION: u64 = 33;
+pub const MAX_PROTOCOL_VERSION: u64 = 34;
 
 /// Protocol version that IIP8 took effect.
 pub const PROTOCOL_VERSION_IIP8: u64 = 20;
@@ -204,6 +204,9 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             on mainnet.
 //             Enable the sliding-window reputation scoring and absolute-score
 //             bad-node selection on testnet
+// Version 34: Bump the scorer version to 2 on devnet: misbehavior reports
+//             carry a dedicated counter for invalid bundle parts, previously
+//             folded into the unprovable block-fault counter.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3266,6 +3269,14 @@ impl ProtocolConfig {
                             .consensus_enable_sliding_window_leader_schedule = true;
                         cfg.feature_flags
                             .consensus_enable_absolute_score_leader_schedule = true;
+                    }
+                }
+                34 => {
+                    if chain != Chain::Testnet && chain != Chain::Mainnet {
+                        // Misbehavior reports carry a dedicated counter for
+                        // invalid bundle parts, previously folded into the
+                        // unprovable block-fault counter.
+                        cfg.scorer_version = Some(2);
                     }
                 }
                 // Use this template when making changes:

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_34.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_34.snap
@@ -1,0 +1,345 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 34
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
+  enable_move_authentication_for_sponsor: true
+  pass_validator_scores_to_advance_epoch: true
+  consensus_fast_commit_sync: true
+  consensus_block_restrictions: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+  pre_consensus_sponsor_only_move_authentication: true
+  always_advance_dkg_to_resolution: true
+  validator_metadata_verify_v2: true
+  report_move_authentication_error: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_auth_gas: 20000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 100
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_rate_window_size: 20
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2
+auth_context_authenticator_function_info_v1_cost_base: 270
+min_validator_count: 4
+max_validator_count: 150
+min_validator_joining_stake: 2000000000000000
+validator_low_stake_threshold: 1500000000000000
+validator_very_low_stake_threshold: 1000000000000000
+validator_low_stake_grace_period: 7

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_34.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_34.snap
@@ -1,0 +1,351 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 34
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
+  enable_move_authentication_for_sponsor: true
+  pass_validator_scores_to_advance_epoch: true
+  calculate_validator_scores: true
+  consensus_fast_commit_sync: true
+  consensus_block_restrictions: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+  pre_consensus_sponsor_only_move_authentication: true
+  consensus_starfish_speed: true
+  always_advance_dkg_to_resolution: true
+  validator_metadata_verify_v2: true
+  package_metadata_with_dynamic_module_metadata: true
+  report_move_authentication_error: true
+  consensus_enable_sliding_window_leader_schedule: true
+  consensus_enable_absolute_score_leader_schedule: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_auth_gas: 20000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 100
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_rate_window_size: 20
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+scorer_version: 1
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2
+auth_context_authenticator_function_info_v1_cost_base: 270
+min_validator_count: 4
+max_validator_count: 150
+min_validator_joining_stake: 2000000000000000
+validator_low_stake_threshold: 1500000000000000
+validator_very_low_stake_threshold: 1000000000000000
+validator_low_stake_grace_period: 7

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_34.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_34.snap
@@ -1,0 +1,362 @@
+---
+source: crates/iota-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 34
+feature_flags:
+  consensus_transaction_ordering: ByGasPrice
+  enable_poseidon: true
+  enable_group_ops_native_function_msm: true
+  per_object_congestion_control_mode: TotalTxCount
+  consensus_choice: Starfish
+  enable_vdf: true
+  passkey_auth: true
+  relocate_event_module: true
+  protocol_defined_base_fee: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  native_charging_v2: true
+  convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
+  variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
+  consensus_zstd_compression: true
+  congestion_control_min_free_execution_slot: true
+  accept_passkey_in_multisig: true
+  consensus_batched_block_sync: true
+  congestion_control_gas_price_feedback_mechanism: true
+  validate_identifier_inputs: true
+  minimize_child_object_mutations: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  normalize_ptb_arguments: true
+  select_committee_from_eligible_validators: true
+  track_non_committee_eligible_validators: true
+  select_committee_supporting_next_epoch_version: true
+  consensus_median_timestamp_with_checkpoint_enforcement: true
+  consensus_commit_transactions_only_for_traversed_headers: true
+  congestion_limit_overshoot_in_gas_price_feedback_mechanism: true
+  separate_gas_price_feedback_mechanism_for_randomness: true
+  metadata_in_module_bytes: true
+  publish_package_metadata: true
+  enable_move_authentication: true
+  enable_move_authentication_for_sponsor: true
+  pass_validator_scores_to_advance_epoch: true
+  calculate_validator_scores: true
+  adjust_rewards_by_score: true
+  pass_calculated_validator_scores_to_advance_epoch: true
+  consensus_fast_commit_sync: true
+  consensus_block_restrictions: true
+  move_native_tx_context: true
+  additional_borrow_checks: true
+  pre_consensus_sponsor_only_move_authentication: true
+  consensus_starfish_speed: true
+  always_advance_dkg_to_resolution: true
+  enable_pcool_flow: true
+  validator_metadata_verify_v2: true
+  package_metadata_with_dynamic_module_metadata: true
+  report_move_authentication_error: true
+  consensus_enable_sliding_window_leader_schedule: true
+  consensus_enable_absolute_score_leader_schedule: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000
+max_auth_gas: 250000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 2
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 10000
+reward_slashing_rate: 10000
+storage_gas_price: 76
+base_gas_price: 1000
+validator_target_reward: 767000000000000
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 100
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_digest_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 1
+consensus_bad_nodes_stake_threshold: 20
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1000
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+max_deferral_rounds_for_congestion_control: 10
+min_checkpoint_interval_ms: 200
+checkpoint_rate_window_size: 20
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+max_committee_members_count: 100
+consensus_gc_depth: 60
+max_congestion_limit_overshoot_per_commit: 100
+scorer_version: 2
+auth_context_digest_cost_base: 30
+auth_context_tx_data_bytes_cost_base: 30
+auth_context_tx_data_bytes_cost_per_byte: 2
+auth_context_tx_commands_cost_base: 30
+auth_context_tx_commands_cost_per_byte: 2
+auth_context_tx_inputs_cost_base: 30
+auth_context_tx_inputs_cost_per_byte: 2
+auth_context_replace_cost_base: 30
+auth_context_replace_cost_per_byte: 2
+auth_context_authenticator_function_info_v1_cost_base: 270
+min_validator_count: 4
+max_validator_count: 150
+min_validator_joining_stake: 2000000000000000
+validator_low_stake_threshold: 1500000000000000
+validator_very_low_stake_threshold: 1000000000000000
+validator_low_stake_grace_period: 7

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 33
+  protocol_version: 34
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
 accounts:

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,12 +3,12 @@ source: crates/iota-swarm-config/tests/snapshot_tests.rs
 expression: genesis.iota_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 33
+protocol_version: 34
 system_state_version: 1
 iota_treasury_cap:
   inner:
     id:
-      id: "0x31d8b5e81cf798068b3adcdd5b566c46c38bfbcc9567e81ffde1d85d3df0a901"
+      id: "0xc73e347f54820618ba07456686fec2e3b1e21370dfcb2dd09ddd5e974e8362e4"
     total_supply:
       value: "751500000000000000"
 validators:
@@ -244,13 +244,13 @@ validators:
         next_epoch_primary_address: ~
         extra_fields:
           id:
-            id: "0xeb4fc81d263f7ddf6bca3ef94c39d39ebe7cafb01c0c500f07d52f0c33a482b0"
+            id: "0x8a36f6f59c33b10365f044dd05066812e42146fe5db95f4c0a811ae57d857bed"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x883d75656bdb228c486a17466cf4fa4c3cd854c174ed5738b29d6a9c4e9f73b3"
+      operation_cap_id: "0x428130278be99d76f6993d36214e82297434efd3d2b8fda192196073d8be76f6"
       gas_price: 1000
       staking_pool:
-        id: "0x3a99e2a22824f07e0473d672f4c3589b78d88872c87519b7cff4f6c1801fa250"
+        id: "0x67edfd7fbc2c556ac8752408a3c914749fe3da258ac9d074a78c48071ac287dd"
         activation_epoch: 0
         deactivation_epoch: ~
         iota_balance: 1500000000000000
@@ -258,14 +258,14 @@ validators:
           value: 0
         pool_token_balance: 1500000000000000
         exchange_rates:
-          id: "0x8d6409254784dcf64d6ed3b3a1ebcf741af3aa2808da390b86c8fdfac7b9471a"
+          id: "0xbd8cd8f9eb2a58d0ad6c6596c948cae0f1ac4cb1e0269ea2aa3269fb685d4487"
           size: 1
         pending_stake: 0
         pending_total_iota_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x9bbcea50bfba787815d93b6e30e13b88532c4a2c49136634e07ff517e31f1005"
+            id: "0x591a81674f512100f0c12874d97c38ead0f2e5c8773edb90ba0813a85c42f1c1"
           size: 0
       commission_rate: 200
       next_epoch_stake: 1500000000000000
@@ -273,27 +273,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x67b9d7aca076854999f8429f0e930ddbc0ef3057c3e5b83f736818133a643988"
+          id: "0x3dfb4d014044eeadb608480a31e40994853e592967dbbf313e949effe406cebc"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x6bfb2d807c9c34347c3f99fb9a177e1c9a269643a225c3c2329e29c4388e365c"
+      id: "0x8a393c976cf9c9d9947d2179bab665db9c517de4e38a3cfcd80c5405e2b1596c"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x5094aef0bf18be9a1f976282b1c7f903063addbbeee400a3cf44851758b851e3"
+    id: "0x8daec430063ba3a4ecf1be343e59424e4006136d1365f2097be025502e87b95a"
     size: 1
   inactive_validators:
-    id: "0x6714471d29f15327f3648ec363a7b8c2bac92d71c7798fbac538c7db39ed3006"
+    id: "0x669f1f7690a483a7f1470deff90f76359922b84594e2c2157936b20c8b499117"
     size: 0
   validator_candidates:
-    id: "0xf79386e939785174aa61c733d81cce881330adecd5aca1d56d15a7e3b4b09224"
+    id: "0xec9f572329aaa280d0ce223c781e6a08c5157f6047c53a3319e6bfe2b45f9cac"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x7c491681f7e1704a108fcf30a850f2d1e037ed841526b9f9e6736dbcc97023e3"
+      id: "0xe1f08025b53f8468f97f1e2ebd9f9430e24f60e022a5cc19c7ee7ece0bea938d"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -310,7 +310,7 @@ parameters:
   validator_low_stake_grace_period: 0
   extra_fields:
     id:
-      id: "0x691e60e6051f3b722ef6214c12468f620a43c27f3006f679417a471a9c6ef613"
+      id: "0x89d134f142f99fb5d4a85ae6137016356468e790d55217ab564c5f427633d857"
     size: 0
 iota_system_admin_cap:
   dummy_field: false
@@ -327,5 +327,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x96ad99b9d381a7afaf8dcf55344d57de14802c0557e68b72faaa8d214748c18d"
+    id: "0x9c06497da343042cc65ffe36011718ae9c4b2f53314eb96fd1190fa4daf22245"
   size: 0

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -436,6 +436,16 @@ pub enum MisbehaviorObservations {
     V2(MisbehaviorObservationsV2),
 }
 
+impl MisbehaviorObservations {
+    /// Verifies the payload shape against the committee size.
+    pub fn verify(&self, committee_size: usize) -> bool {
+        match self {
+            Self::V1(payload) => payload.verify(committee_size),
+            Self::V2(payload) => payload.verify(committee_size),
+        }
+    }
+}
+
 impl VersionedMisbehaviorReport {
     pub fn new_v1(
         authority: AuthorityName,

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -535,9 +535,9 @@ impl MisbehaviorObservationsV1 {
 }
 
 /// V2 misbehavior observations: the V1 categories plus a dedicated
-/// per-authority count of invalid bundle parts (previously folded into
-/// `faulty_blocks_unprovable`). Field order is part of the wire format — BCS
-/// serializes named struct fields in declaration order.
+/// per-authority count of invalid bundle parts (counted under
+/// `faulty_blocks_unprovable` in the V1 format). Field order is part of the
+/// wire format — BCS serializes named struct fields in declaration order.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MisbehaviorObservationsV2 {
     pub faulty_blocks_provable: Vec<u64>,

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -433,6 +433,7 @@ pub struct VersionedMisbehaviorReport {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum MisbehaviorObservations {
     V1(MisbehaviorObservationsV1),
+    V2(MisbehaviorObservationsV2),
 }
 
 impl VersionedMisbehaviorReport {
@@ -444,6 +445,19 @@ impl VersionedMisbehaviorReport {
         Self {
             authority,
             payload: MisbehaviorObservations::V1(observations),
+            generation,
+            digest: OnceCell::new(),
+        }
+    }
+
+    pub fn new_v2(
+        authority: AuthorityName,
+        generation: u64,
+        observations: MisbehaviorObservationsV2,
+    ) -> Self {
+        Self {
+            authority,
+            payload: MisbehaviorObservations::V2(observations),
             generation,
             digest: OnceCell::new(),
         }
@@ -465,6 +479,16 @@ impl VersionedMisbehaviorReport {
                 &report.faulty_blocks_unprovable,
                 &report.missing_proposals,
                 &report.equivocations,
+            ]
+            .into_iter()
+            .flatten()
+            .fold(0u64, |acc, metric| acc.saturating_add(*metric)),
+            MisbehaviorObservations::V2(report) => [
+                &report.faulty_blocks_provable,
+                &report.faulty_blocks_unprovable,
+                &report.missing_proposals,
+                &report.equivocations,
+                &report.invalid_bundle_parts,
             ]
             .into_iter()
             .flatten()
@@ -507,6 +531,29 @@ impl MisbehaviorObservationsV1 {
             return false;
         }
         true
+    }
+}
+
+/// V2 misbehavior observations: the V1 categories plus a dedicated
+/// per-authority count of invalid bundle parts (previously folded into
+/// `faulty_blocks_unprovable`). Field order is part of the wire format — BCS
+/// serializes named struct fields in declaration order.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MisbehaviorObservationsV2 {
+    pub faulty_blocks_provable: Vec<u64>,
+    pub faulty_blocks_unprovable: Vec<u64>,
+    pub missing_proposals: Vec<u64>,
+    pub equivocations: Vec<u64>,
+    pub invalid_bundle_parts: Vec<u64>,
+}
+
+impl MisbehaviorObservationsV2 {
+    pub fn verify(&self, committee_size: usize) -> bool {
+        self.faulty_blocks_provable.len() == committee_size
+            && self.faulty_blocks_unprovable.len() == committee_size
+            && self.missing_proposals.len() == committee_size
+            && self.equivocations.len() == committee_size
+            && self.invalid_bundle_parts.len() == committee_size
     }
 }
 
@@ -860,6 +907,38 @@ mod tests {
         assert_eq!(
             legacy_bytes, new_bytes,
             "VersionedMisbehaviorReport wire format must not change — testnet is live"
+        );
+    }
+
+    /// Pins the BCS encoding of the `MisbehaviorObservations::V2` payload:
+    /// variant tag 1 (ULEB128 of the declaration index) followed by the five
+    /// per-authority vectors in declaration order.
+    #[test]
+    fn misbehavior_observations_v2_wire_format() {
+        let payload = MisbehaviorObservations::V2(MisbehaviorObservationsV2 {
+            faulty_blocks_provable: vec![1, 2, 3],
+            faulty_blocks_unprovable: vec![4, 5, 6],
+            missing_proposals: vec![7, 8, 9],
+            equivocations: vec![10, 11, 12],
+            invalid_bundle_parts: vec![13, 14, 15],
+        });
+
+        let mut expected = vec![1u8];
+        expected.extend(
+            bcs::to_bytes(&(
+                vec![1u64, 2, 3],
+                vec![4u64, 5, 6],
+                vec![7u64, 8, 9],
+                vec![10u64, 11, 12],
+                vec![13u64, 14, 15],
+            ))
+            .unwrap(),
+        );
+
+        assert_eq!(
+            bcs::to_bytes(&payload).unwrap(),
+            expected,
+            "MisbehaviorObservations::V2 wire format must not change"
         );
     }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1873,7 +1873,7 @@ mod tests {
         error::{ConsensusError, ConsensusResult},
         header_synchronizer::HeaderSynchronizer,
         leader_schedule::LeaderSchedule,
-        misbehavior_store::{MisbehaviorCounts, MisbehaviorStore},
+        misbehavior_store::MisbehaviorStore,
         network::{
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
@@ -2239,7 +2239,8 @@ mod tests {
                 .get(),
             1,
         );
-        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[peer.value()];
+        let totals = misbehavior_store.snapshot_totals();
+        let counts = totals[peer.value()].as_v2();
         assert_eq!(
             counts.faulty_blocks_provable, 1,
             "two signed headers for one slot are provable equivocation"
@@ -2330,7 +2331,7 @@ mod tests {
         }
 
         let counts = misbehavior_store.snapshot_totals();
-        let MisbehaviorCounts::V1(counts) = &counts[0];
+        let counts = counts[0].as_v2();
         assert_eq!(counts.faulty_blocks_unprovable, 1);
 
         let input_block = VerifiedBlock::new_for_test(
@@ -2360,7 +2361,7 @@ mod tests {
         ));
 
         let counts = misbehavior_store.snapshot_totals();
-        let MisbehaviorCounts::V1(counts) = &counts[0];
+        let counts = counts[0].as_v2();
         assert_eq!(counts.faulty_blocks_unprovable, 2);
     }
 
@@ -2464,8 +2465,9 @@ mod tests {
         }
 
         // The relaying peer (authority 0) is charged for the invalid header.
-        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[0];
-        assert_eq!(counts.faulty_blocks_unprovable, 1);
+        let totals = misbehavior_store.snapshot_totals();
+        let counts = totals[0].as_v2();
+        assert_eq!(counts.invalid_bundle_parts, 1);
 
         let cached_header = VerifiedBlockHeader::new_for_test(
             TestBlockHeader::new_with_commitment(1, 1, &context, &mut encoder)
@@ -2639,7 +2641,8 @@ mod tests {
         assert_eq!(authority_service.received_block_headers.size(), 0);
 
         // The relaying peer (authority 0) is charged for the invalid metadata.
-        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[0];
+        let totals = misbehavior_store.snapshot_totals();
+        let counts = totals[0].as_v2();
         assert_eq!(counts.faulty_blocks_unprovable, 1);
     }
 
@@ -4831,8 +4834,9 @@ mod tests {
             ),
             "an oversized shard must be refused, got {result:?}"
         );
-        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[peer.value()];
-        assert_eq!(counts.faulty_blocks_unprovable, 1);
+        let totals = misbehavior_store.snapshot_totals();
+        let counts = totals[peer.value()].as_v2();
+        assert_eq!(counts.invalid_bundle_parts, 1);
 
         // At exactly the maximum length the size gate passes, so the shard is
         // only rejected by the following proof check.

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2508,8 +2508,9 @@ mod tests {
                 block_round: 1,
             })
         ));
-        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[0];
-        assert_eq!(counts.faulty_blocks_unprovable, 2);
+        let totals = misbehavior_store.snapshot_totals();
+        let counts = totals[0].as_v2();
+        assert_eq!(counts.invalid_bundle_parts, 2);
 
         // Create a block with a big round
         let input_block = VerifiedBlock::new_for_test(

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -1744,8 +1744,8 @@ mod tests {
         let misbehavior_store = dag_state.read().misbehavior_store().clone();
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
         let faults = |authority: u8| {
-            let crate::misbehavior_store::MisbehaviorCounts::V1(counts) =
-                &misbehavior_store.snapshot_totals()[authority as usize];
+            let totals = misbehavior_store.snapshot_totals();
+            let counts = totals[authority as usize].as_v2();
             (
                 counts.faulty_blocks_provable,
                 counts.faulty_blocks_unprovable,

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -4058,9 +4058,9 @@ mod tests {
                 .get(),
             1
         );
-        let crate::misbehavior_store::MisbehaviorCounts::V1(counts) =
-            &misbehavior_store.snapshot_totals()[peer_index.value()];
-        assert_eq!(counts.faulty_blocks_unprovable, 1);
+        let totals = misbehavior_store.snapshot_totals();
+        let counts = totals[peer_index.value()].as_v2();
+        assert_eq!(counts.invalid_bundle_parts, 1);
     }
 
     /// A header dropped as an unrequested extra stays fetchable: a later

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -78,7 +78,7 @@ pub use block_header::{
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use context::Clock;
-pub use misbehavior_store::{MisbehaviorCounts, MisbehaviorCountsV1};
+pub use misbehavior_store::{MisbehaviorCounts, MisbehaviorCountsV1, MisbehaviorCountsV2};
 pub use network::tonic_network::to_socket_addr;
 #[cfg(msim)]
 pub use storage::delete_all_transactions_from_store;

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -354,6 +354,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) faulty_blocks_unprovable_by_peer: IntGaugeVec,
     pub(crate) equivocations_by_authority: IntGaugeVec,
     pub(crate) missing_proposals_by_authority: IntGaugeVec,
+    pub(crate) invalid_bundle_parts_by_peer: IntGaugeVec,
     pub(crate) strong_vote_extra_wait_seconds: Histogram,
     pub(crate) strong_vote_missing_authorities: Histogram,
     pub(crate) strong_blames_emitted_for_leader: IntCounterVec,
@@ -1413,6 +1414,13 @@ impl NodeMetrics {
                 "missing_proposals_by_authority",
                 "Missing proposals per authority (source: persisted or in_memory)",
                 &["authority", "source"],
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            invalid_bundle_parts_by_peer: register_int_gauge_vec_with_registry!(
+                "invalid_bundle_parts_by_peer",
+                "Invalid relayed bundle parts per peer (source: persisted or in_memory)",
+                &["peer", "source"],
                 registry;
                 MetricLevel::Warn,
             ).unwrap(),

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -61,8 +61,7 @@ impl MisbehaviorStore {
             // future MisbehaviorCounts variant trips the compiler here.
             let storage_metrics = recovered.get(&authority_index).cloned().unwrap_or_default();
             match storage_metrics {
-                // Rows persisted before the bundle-part counter existed
-                // restore with it at zero.
+                // V1 rows carry no bundle-part count; restore it as zero.
                 MisbehaviorCounts::V1(inner) => {
                     self.persisted.set_block_faults(
                         idx,

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -697,6 +697,7 @@ impl MisbehaviorCounts {
 mod tests {
     use std::sync::Arc;
 
+    use fastcrypto::error::FastCryptoError;
     use starfish_config::Parameters;
 
     use super::*;
@@ -1071,6 +1072,14 @@ mod tests {
                 AuthorityIndex::new_for_test(0),
                 AuthorityIndex::new_for_test(1),
             ),
+            ConsensusError::MalformedHeader(bcs::Error::Custom("bad".to_string())),
+            ConsensusError::MalformedSignature(FastCryptoError::InvalidSignature),
+            ConsensusError::SignatureVerificationFailure(FastCryptoError::InvalidSignature),
+            ConsensusError::TransactionCommitmentFailure {
+                round: 3,
+                author: AuthorityIndex::new_for_test(0),
+                peer: AuthorityIndex::new_for_test(0),
+            },
         ];
         for e in cases {
             let (prov, unprov, bundle) = classify_via_record(e);

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -1137,6 +1137,15 @@ mod tests {
                 author: AuthorityIndex::new_for_test(0),
                 peer: AuthorityIndex::new_for_test(0),
             },
+            ConsensusError::UnexpectedBlockHeaderForCommit {
+                peer: AuthorityIndex::new_for_test(0),
+                received: BlockRef::MIN,
+            },
+            ConsensusError::TooManyFetchedHeadersReturned {
+                peer: AuthorityIndex::new_for_test(0),
+                requested: 2,
+                received: 3,
+            },
         ];
         for e in cases {
             let (prov, unprov, bundle) = classify_via_record(e);

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -61,11 +61,27 @@ impl MisbehaviorStore {
             // future MisbehaviorCounts variant trips the compiler here.
             let storage_metrics = recovered.get(&authority_index).cloned().unwrap_or_default();
             match storage_metrics {
+                // Rows persisted before the bundle-part counter existed
+                // restore with it at zero.
                 MisbehaviorCounts::V1(inner) => {
                     self.persisted.set_block_faults(
                         idx,
                         inner.faulty_blocks_provable,
                         inner.faulty_blocks_unprovable,
+                        0,
+                    );
+                    self.persisted.set_dag_faults(
+                        idx,
+                        inner.missing_proposals,
+                        inner.equivocations,
+                    );
+                }
+                MisbehaviorCounts::V2(inner) => {
+                    self.persisted.set_block_faults(
+                        idx,
+                        inner.faulty_blocks_provable,
+                        inner.faulty_blocks_unprovable,
+                        inner.invalid_bundle_parts,
                     );
                     self.persisted.set_dag_faults(
                         idx,
@@ -146,7 +162,7 @@ impl MisbehaviorStore {
         }
 
         if eviction_advanced || had_faulty {
-            Some(MisbehaviorCounts::V1(self.persisted.snapshot(idx)))
+            Some(MisbehaviorCounts::V2(self.persisted.snapshot(idx)))
         } else {
             None
         }
@@ -155,11 +171,11 @@ impl MisbehaviorStore {
     /// Flush buffered faulty block counts from in_memory to persisted
     /// for one authority. Returns true if any counts were moved.
     fn flush_faulty_block_buffer(&self, idx: usize) -> bool {
-        let (prov, unprov) = self.in_memory.drain_block_faults(idx);
-        if prov == 0 && unprov == 0 {
+        let (prov, unprov, bundle) = self.in_memory.drain_block_faults(idx);
+        if prov == 0 && unprov == 0 && bundle == 0 {
             return false;
         }
-        self.persisted.add_block_faults(idx, prov, unprov);
+        self.persisted.add_block_faults(idx, prov, unprov, bundle);
         true
     }
 
@@ -173,13 +189,15 @@ impl MisbehaviorStore {
             .map(|i| {
                 let persisted = self.persisted.snapshot(i);
                 let in_memory = self.in_memory.snapshot(i);
-                MisbehaviorCounts::V1(MisbehaviorCountsV1 {
+                MisbehaviorCounts::V2(MisbehaviorCountsV2 {
                     faulty_blocks_provable: persisted.faulty_blocks_provable
                         + in_memory.faulty_blocks_provable,
                     faulty_blocks_unprovable: persisted.faulty_blocks_unprovable
                         + in_memory.faulty_blocks_unprovable,
                     missing_proposals: persisted.missing_proposals + in_memory.missing_proposals,
                     equivocations: persisted.equivocations + in_memory.equivocations,
+                    invalid_bundle_parts: persisted.invalid_bundle_parts
+                        + in_memory.invalid_bundle_parts,
                 })
             })
             .collect()
@@ -201,6 +219,8 @@ impl MisbehaviorStore {
     ///   distributing a block they could have verified themselves.
     /// - Unprovable faults (bad/missing signature): charged to `peer` only — we
     ///   can't verify the author field, but we know who sent it to us.
+    /// - Bundle-part faults (corrupt framing, metadata, or shard): charged to
+    ///   `peer` only, under the dedicated bundle-part counter.
     pub(crate) fn record_faulty_block(
         &self,
         peer: AuthorityIndex,
@@ -229,6 +249,9 @@ impl MisbehaviorStore {
             }
             FaultType::Unprovable => {
                 self.in_memory.record_block_fault_unprovable(peer_idx);
+            }
+            FaultType::BundlePart => {
+                self.in_memory.record_bundle_part_fault(peer_idx);
             }
             FaultType::Untracked => {}
         }
@@ -269,12 +292,13 @@ enum FaultType {
     /// The signed block header itself is proof of misbehavior.
     Provable,
     /// Can't prove authorship — either because the signature is bad or
-    /// missing, because the header is rejected by a pre-signature check
+    /// missing, or because the header is rejected by a pre-signature check
     /// (epoch / genesis / author-vs-peer mismatch) so its `author` field
-    /// can't be trusted, or because the fault is in a relayed bundle part
-    /// (framing, metadata, or shard) that isn't tied to a verified author.
-    /// Charged to the sending peer, not the claimed author.
+    /// can't be trusted. Charged to the sending peer, not the claimed author.
     Unprovable,
+    /// Corrupt or invalid relayed bundle part (framing, metadata, or shard)
+    /// that isn't tied to a verified author. Charged to the sending peer.
+    BundlePart,
     /// Not counted as misbehavior.
     Untracked,
 }
@@ -298,16 +322,17 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::SerializedTransactionsTooLarge { .. }
         | ConsensusError::TransactionCommitmentFailure { .. }
         | ConsensusError::UnexpectedBlockHeaderForCommit { .. }
-        | ConsensusError::TooManyFetchedHeadersReturned { .. }
+        | ConsensusError::TooManyFetchedHeadersReturned { .. } => FaultType::Unprovable,
+
         // Corrupt or invalid relayed bundle parts (framing, additional-header
         // round, and shard structure/proof). We know which peer relayed them
         // but can't tie them to a verified author.
-        | ConsensusError::MalformedShard(_)
+        ConsensusError::MalformedShard(_)
         | ConsensusError::TooBigHeaderRoundInABundle { .. }
         | ConsensusError::TooBigShardRoundInABundle { .. }
         | ConsensusError::IncorrectShardProof { .. }
         | ConsensusError::UnrequestedHeaderOutOfWindow { .. }
-        | ConsensusError::SerializedShardTooLarge { .. } => FaultType::Unprovable,
+        | ConsensusError::SerializedShardTooLarge { .. } => FaultType::BundlePart,
 
         // Checks that run only after the author's signature is verified, so the
         // signed header itself proves the author produced a block that violates
@@ -391,7 +416,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
     }
 }
 
-/// The four Prometheus gauges that mirror `MisbehaviorCountsV1` for one
+/// The five Prometheus gauges that mirror `MisbehaviorCountsV2` for one
 /// `(authority, source)` pair, pre-resolved at construction so per-call
 /// methods don't repeat `with_label_values` lookups and don't have to
 /// thread `&NodeMetrics` and `hostname` through every call site.
@@ -400,6 +425,7 @@ struct AuthorityGauges {
     block_fault_unprovable: IntGauge,
     missing_proposals: IntGauge,
     equivocations: IntGauge,
+    invalid_bundle_parts: IntGauge,
 }
 
 /// Per-authority misbehavior counters and matching Prometheus gauges.
@@ -407,7 +433,7 @@ struct AuthorityGauges {
 /// per-authority `Mutex` lock, so concurrent observers see counter and gauge
 /// agree.
 struct CommitteeMisbehaviorCounts {
-    authorities: Vec<Mutex<MisbehaviorCountsV1>>,
+    authorities: Vec<Mutex<MisbehaviorCountsV2>>,
     gauges: Vec<AuthorityGauges>,
 }
 
@@ -430,12 +456,15 @@ impl CommitteeMisbehaviorCounts {
                         .missing_proposals_by_authority
                         .with_label_values(labels),
                     equivocations: metrics.equivocations_by_authority.with_label_values(labels),
+                    invalid_bundle_parts: metrics
+                        .invalid_bundle_parts_by_peer
+                        .with_label_values(labels),
                 }
             })
             .collect();
         Self {
             authorities: (0..committee.size())
-                .map(|_| Mutex::new(MisbehaviorCountsV1::default()))
+                .map(|_| Mutex::new(MisbehaviorCountsV2::default()))
                 .collect(),
             gauges,
         }
@@ -453,36 +482,48 @@ impl CommitteeMisbehaviorCounts {
         self.gauges[idx].block_fault_unprovable.inc();
     }
 
-    /// Atomically take both block-fault counters AND zero the matching gauges.
-    /// The caller transfers the returned `(provable, unprovable)` into the
-    /// persisted bucket via `add_block_faults`.
-    fn drain_block_faults(&self, idx: usize) -> (u64, u64) {
+    fn record_bundle_part_fault(&self, idx: usize) {
+        let mut c = self.authorities[idx].lock().unwrap();
+        c.invalid_bundle_parts += 1;
+        self.gauges[idx].invalid_bundle_parts.inc();
+    }
+
+    /// Atomically take all block-fault counters AND zero the matching gauges.
+    /// The caller transfers the returned `(provable, unprovable,
+    /// bundle_parts)` into the persisted bucket via `add_block_faults`.
+    fn drain_block_faults(&self, idx: usize) -> (u64, u64, u64) {
         let mut c = self.authorities[idx].lock().unwrap();
         let prov = std::mem::take(&mut c.faulty_blocks_provable);
         let unprov = std::mem::take(&mut c.faulty_blocks_unprovable);
+        let bundle = std::mem::take(&mut c.invalid_bundle_parts);
         self.gauges[idx].block_fault_provable.set(0);
         self.gauges[idx].block_fault_unprovable.set(0);
-        (prov, unprov)
+        self.gauges[idx].invalid_bundle_parts.set(0);
+        (prov, unprov, bundle)
     }
 
     /// Receive a `drain_block_faults` payload — additive on counters and
     /// gauges.
-    fn add_block_faults(&self, idx: usize, prov: u64, unprov: u64) {
+    fn add_block_faults(&self, idx: usize, prov: u64, unprov: u64, bundle: u64) {
         let mut c = self.authorities[idx].lock().unwrap();
         c.faulty_blocks_provable += prov;
         c.faulty_blocks_unprovable += unprov;
+        c.invalid_bundle_parts += bundle;
         self.gauges[idx].block_fault_provable.add(prov as i64);
         self.gauges[idx].block_fault_unprovable.add(unprov as i64);
+        self.gauges[idx].invalid_bundle_parts.add(bundle as i64);
     }
 
-    /// Overwrite both block-fault counters and gauges. Used to restore from
+    /// Overwrite all block-fault counters and gauges. Used to restore from
     /// storage on startup.
-    fn set_block_faults(&self, idx: usize, prov: u64, unprov: u64) {
+    fn set_block_faults(&self, idx: usize, prov: u64, unprov: u64, bundle: u64) {
         let mut c = self.authorities[idx].lock().unwrap();
         c.faulty_blocks_provable = prov;
         c.faulty_blocks_unprovable = unprov;
+        c.invalid_bundle_parts = bundle;
         self.gauges[idx].block_fault_provable.set(prov as i64);
         self.gauges[idx].block_fault_unprovable.set(unprov as i64);
+        self.gauges[idx].invalid_bundle_parts.set(bundle as i64);
     }
 
     /// Overwrite the DAG-observed faults (`missing_proposals` +
@@ -507,23 +548,24 @@ impl CommitteeMisbehaviorCounts {
     }
 
     /// Stable read clone of one authority's counters.
-    fn snapshot(&self, idx: usize) -> MisbehaviorCountsV1 {
+    fn snapshot(&self, idx: usize) -> MisbehaviorCountsV2 {
         self.authorities[idx].lock().unwrap().clone()
     }
 
     fn reset(&self) {
         for (m, g) in self.authorities.iter().zip(self.gauges.iter()) {
             let mut c = m.lock().unwrap();
-            *c = MisbehaviorCountsV1::default();
+            *c = MisbehaviorCountsV2::default();
             g.block_fault_provable.set(0);
             g.block_fault_unprovable.set(0);
             g.missing_proposals.set(0);
             g.equivocations.set(0);
+            g.invalid_bundle_parts.set(0);
         }
     }
 
     #[cfg(test)]
-    fn collect<F: Fn(&MisbehaviorCountsV1) -> u64>(&self, field: F) -> Vec<u64> {
+    fn collect<F: Fn(&MisbehaviorCountsV2) -> u64>(&self, field: F) -> Vec<u64> {
         self.authorities
             .iter()
             .map(|m| field(&m.lock().unwrap()))
@@ -554,11 +596,12 @@ fn calculate_misbehavior_counts_for_range(
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum MisbehaviorCounts {
     V1(MisbehaviorCountsV1),
+    V2(MisbehaviorCountsV2),
 }
 
 impl Default for MisbehaviorCounts {
     fn default() -> Self {
-        Self::V1(MisbehaviorCountsV1::default())
+        Self::V2(MisbehaviorCountsV2::default())
     }
 }
 
@@ -568,6 +611,17 @@ pub struct MisbehaviorCountsV1 {
     pub faulty_blocks_unprovable: u64,
     pub missing_proposals: u64,
     pub equivocations: u64,
+}
+
+/// Extends `MisbehaviorCountsV1` with a dedicated counter for invalid relayed
+/// bundle parts (framing, metadata, or shard faults).
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct MisbehaviorCountsV2 {
+    pub faulty_blocks_provable: u64,
+    pub faulty_blocks_unprovable: u64,
+    pub missing_proposals: u64,
+    pub equivocations: u64,
+    pub invalid_bundle_parts: u64,
 }
 
 #[cfg(test)]
@@ -611,6 +665,32 @@ impl MisbehaviorCounts {
             missing_proposals,
             equivocations,
         })
+    }
+
+    pub(crate) fn new_v2_for_test(
+        faulty_blocks_provable: u64,
+        faulty_blocks_unprovable: u64,
+        missing_proposals: u64,
+        equivocations: u64,
+        invalid_bundle_parts: u64,
+    ) -> Self {
+        Self::V2(MisbehaviorCountsV2 {
+            faulty_blocks_provable,
+            faulty_blocks_unprovable,
+            missing_proposals,
+            equivocations,
+            invalid_bundle_parts,
+        })
+    }
+
+    /// Test accessor for the V2 payload; panics on any other variant. All
+    /// counts produced by a running store are V2 (V1 exists only for reading
+    /// old persisted rows).
+    pub(crate) fn as_v2(&self) -> &MisbehaviorCountsV2 {
+        match self {
+            Self::V2(inner) => inner,
+            other => panic!("expected MisbehaviorCounts::V2, got {other:?}"),
+        }
     }
 }
 
@@ -745,7 +825,10 @@ mod tests {
             2,
             &context,
         );
-        assert_eq!(result, Some(MisbehaviorCounts::new_v1_for_test(0, 0, 3, 0)));
+        assert_eq!(
+            result,
+            Some(MisbehaviorCounts::new_v2_for_test(0, 0, 3, 0, 0))
+        );
 
         // Out-of-bounds authority → None
         let oob = AuthorityIndex::new_for_test(4);
@@ -910,10 +993,10 @@ mod tests {
 
     // ── Error classification tests ────────────────────────────────────────────
 
-    /// Classifies `error` and returns `(provable_delta, unprovable_delta)` for
-    /// authority 0 (used as both peer and author so there is no peer-vs-author
-    /// split to consider).
-    fn classify_via_record(error: &ConsensusError) -> (u64, u64) {
+    /// Classifies `error` and returns `(provable_delta, unprovable_delta,
+    /// bundle_part_delta)` for authority 0 (used as both peer and author so
+    /// there is no peer-vs-author split to consider).
+    fn classify_via_record(error: &ConsensusError) -> (u64, u64, u64) {
         let context = Arc::new(Context::new_for_test(4).0);
         let store = MisbehaviorStore::new(&context);
         let authority = AuthorityIndex::new_for_test(0);
@@ -922,6 +1005,7 @@ mod tests {
         (
             counts.faulty_blocks_provable,
             counts.faulty_blocks_unprovable,
+            counts.invalid_bundle_parts,
         )
     }
 
@@ -969,9 +1053,10 @@ mod tests {
             },
         ];
         for e in cases {
-            let (prov, unprov) = classify_via_record(e);
+            let (prov, unprov, bundle) = classify_via_record(e);
             assert_eq!(prov, 1, "expected provable for {e:?}");
             assert_eq!(unprov, 0, "expected no unprovable for {e:?}");
+            assert_eq!(bundle, 0, "expected no bundle-part for {e:?}");
         }
     }
 
@@ -987,8 +1072,20 @@ mod tests {
                 AuthorityIndex::new_for_test(0),
                 AuthorityIndex::new_for_test(1),
             ),
-            // Corrupt or invalid relayed bundle parts: charged to the relaying
-            // peer, not to a verified author.
+        ];
+        for e in cases {
+            let (prov, unprov, bundle) = classify_via_record(e);
+            assert_eq!(prov, 0, "expected no provable for {e:?}");
+            assert_eq!(unprov, 1, "expected unprovable for {e:?}");
+            assert_eq!(bundle, 0, "expected no bundle-part for {e:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bundle_part_errors() {
+        // Corrupt or invalid relayed bundle parts: charged to the relaying
+        // peer under the dedicated bundle-part counter.
+        let cases: &[ConsensusError] = &[
             ConsensusError::MalformedShard(bcs::Error::Custom("bad".to_string())),
             ConsensusError::TooBigHeaderRoundInABundle {
                 header_round: 5,
@@ -1002,22 +1099,22 @@ mod tests {
                 peer: AuthorityIndex::new_for_test(0),
                 round: 3,
             },
-            // A fetched header outside the requested set: charged to the
-            // serving peer.
-            ConsensusError::UnexpectedBlockHeaderForCommit {
+            ConsensusError::UnrequestedHeaderOutOfWindow {
                 peer: AuthorityIndex::new_for_test(0),
-                received: BlockRef::MIN,
+                author: AuthorityIndex::new_for_test(1),
+                round: 10,
             },
-            ConsensusError::TooManyFetchedHeadersReturned {
+            ConsensusError::SerializedShardTooLarge {
                 peer: AuthorityIndex::new_for_test(0),
-                requested: 2,
-                received: 3,
+                size: 100,
+                limit: 50,
             },
         ];
         for e in cases {
-            let (prov, unprov) = classify_via_record(e);
+            let (prov, unprov, bundle) = classify_via_record(e);
             assert_eq!(prov, 0, "expected no provable for {e:?}");
-            assert_eq!(unprov, 1, "expected unprovable for {e:?}");
+            assert_eq!(unprov, 0, "expected no unprovable for {e:?}");
+            assert_eq!(bundle, 1, "expected bundle-part for {e:?}");
         }
     }
 
@@ -1051,9 +1148,10 @@ mod tests {
             ConsensusError::WrongShardVersion { actual: "V1" },
         ];
         for e in cases {
-            let (prov, unprov) = classify_via_record(e);
+            let (prov, unprov, bundle) = classify_via_record(e);
             assert_eq!(prov, 0, "expected no provable for {e:?}");
             assert_eq!(unprov, 0, "expected no unprovable (untracked) for {e:?}");
+            assert_eq!(bundle, 0, "expected no bundle-part (untracked) for {e:?}");
         }
     }
 
@@ -1088,11 +1186,60 @@ mod tests {
         // Untouched authorities are zero across both buckets.
         let provable_totals: Vec<u64> = snapshot
             .iter()
-            .map(|c| match c {
-                MisbehaviorCounts::V1(v1) => v1.faulty_blocks_provable,
-            })
+            .map(|c| c.as_v2().faulty_blocks_provable)
             .collect();
         assert_eq!(provable_totals, vec![5, 1, 0, 0]);
+    }
+
+    #[tokio::test]
+    async fn test_recovery_upgrades_v1_rows() {
+        // Persisted V1 rows (written before the bundle-part counter existed)
+        // restore with `invalid_bundle_parts` at zero; V2 rows restore fully.
+        let committee_size = 4;
+        let context = Arc::new(Context::new_for_test(committee_size).0);
+        let store = MisbehaviorStore::new(&context);
+
+        let recovered = BTreeMap::from([
+            (
+                AuthorityIndex::new_for_test(0),
+                MisbehaviorCounts::new_v1_for_test(1, 2, 3, 4),
+            ),
+            (
+                AuthorityIndex::new_for_test(1),
+                MisbehaviorCounts::new_v2_for_test(5, 6, 7, 8, 9),
+            ),
+        ]);
+        let recent_refs_by_authority = vec![BTreeSet::new(); committee_size];
+        let evicted_rounds = vec![0; committee_size];
+        store.initialize_misbehavior_counts(
+            recovered,
+            &recent_refs_by_authority,
+            &evicted_rounds,
+            0,
+            &context,
+        );
+
+        let totals = store.snapshot_totals();
+        assert_eq!(
+            *totals[0].as_v2(),
+            MisbehaviorCountsV2 {
+                faulty_blocks_provable: 1,
+                faulty_blocks_unprovable: 2,
+                missing_proposals: 3,
+                equivocations: 4,
+                invalid_bundle_parts: 0,
+            }
+        );
+        assert_eq!(
+            *totals[1].as_v2(),
+            MisbehaviorCountsV2 {
+                faulty_blocks_provable: 5,
+                faulty_blocks_unprovable: 6,
+                missing_proposals: 7,
+                equivocations: 8,
+                invalid_bundle_parts: 9,
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -161,7 +161,12 @@ impl MisbehaviorStore {
         }
 
         if eviction_advanced || had_faulty {
-            Some(MisbehaviorCounts::V2(self.persisted.snapshot(idx)))
+            let counts = self.persisted.snapshot(idx);
+            let persisted = match context.protocol_config.scorer_version_as_option() {
+                Some(2) => MisbehaviorCounts::V2(counts),
+                _ => MisbehaviorCounts::V1(counts.fold_into_v1()),
+            };
+            Some(persisted)
         } else {
             None
         }
@@ -623,6 +628,20 @@ pub struct MisbehaviorCountsV2 {
     pub invalid_bundle_parts: u64,
 }
 
+impl MisbehaviorCountsV2 {
+    /// Folds the bundle-part count into `faulty_blocks_unprovable`.
+    fn fold_into_v1(&self) -> MisbehaviorCountsV1 {
+        MisbehaviorCountsV1 {
+            faulty_blocks_provable: self.faulty_blocks_provable,
+            faulty_blocks_unprovable: self
+                .faulty_blocks_unprovable
+                .saturating_add(self.invalid_bundle_parts),
+            missing_proposals: self.missing_proposals,
+            equivocations: self.equivocations,
+        }
+    }
+}
+
 #[cfg(test)]
 impl MisbehaviorStore {
     pub(crate) fn persisted_missing_proposals(&self) -> Vec<u64> {
@@ -835,6 +854,44 @@ mod tests {
         let result =
             store.update_misbehavior_counts_on_eviction(oob, &recent_refs, 2, 1, 3, &context);
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_persisted_variant_follows_scorer_version() {
+        // With scorer version 2 inactive, persisted rows use the V1 format so a
+        // rollback to a binary without the V2 variant can still read them, and
+        // the bundle-part count folds into `faulty_blocks_unprovable`.
+        let mut context = Context::new_for_test(4).0;
+        context.protocol_config.set_scorer_version_for_testing(1);
+        let context = Arc::new(context);
+        let store = MisbehaviorStore::new(&context);
+        let authority = AuthorityIndex::new_for_test(0);
+
+        store.record_faulty_block(
+            authority,
+            authority,
+            &ConsensusError::WrongEpoch {
+                expected: 1,
+                actual: 2,
+            },
+        );
+        store.record_faulty_block(
+            authority,
+            authority,
+            &ConsensusError::MalformedShard(bcs::Error::Custom("bad".to_string())),
+        );
+
+        let result = store.update_misbehavior_counts_on_eviction(
+            authority,
+            &BTreeSet::new(),
+            0,
+            0,
+            1,
+            &context,
+        );
+
+        // V1 row: the one bundle part folds into unprovable (1 + 1).
+        assert_eq!(result, Some(MisbehaviorCounts::new_v1_for_test(0, 2, 0, 0)));
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -1616,13 +1616,13 @@ mod tests {
     async fn test_reconstruction_rejects_transactions_failing_validity_check() {
         let (counts, author, info_length) = reconstruct_failing_payload(false).await;
 
-        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        let author_counts = counts[author.value()].as_v2();
         assert_eq!(
             author_counts.faulty_blocks_provable, 0,
             "The author must not be charged without a verified header tying the commitment to them"
         );
         for counts in counts.iter().take(info_length) {
-            let MisbehaviorCounts::V1(peer_counts) = counts;
+            let peer_counts = counts.as_v2();
             assert_eq!(
                 peer_counts.faulty_blocks_unprovable, 1,
                 "Each peer that relayed a shard of the invalid payload must be charged unprovably"
@@ -1637,7 +1637,7 @@ mod tests {
     async fn test_reconstruction_charges_author_when_header_present() {
         let (counts, author, info_length) = reconstruct_failing_payload(true).await;
 
-        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        let author_counts = counts[author.value()].as_v2();
         assert_eq!(
             author_counts.faulty_blocks_provable, 1,
             "The author must be charged provably when a verified header commits to the payload"
@@ -1646,7 +1646,7 @@ mod tests {
             if i == author.value() {
                 continue;
             }
-            let MisbehaviorCounts::V1(peer_counts) = counts;
+            let peer_counts = counts.as_v2();
             assert_eq!(
                 peer_counts.faulty_blocks_unprovable, 1,
                 "Each relaying peer other than the author must still be charged unprovably"
@@ -1728,7 +1728,7 @@ mod tests {
 
         // The author is not charged provably, even though a verified header ties
         // it to the (wrong) commitment.
-        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        let author_counts = counts[author.value()].as_v2();
         assert_eq!(
             author_counts.faulty_blocks_provable, 0,
             "The author must not be charged for a peer-produced commitment mismatch"
@@ -1736,7 +1736,7 @@ mod tests {
         // Every peer that relayed a shard — including the author, as a relayer —
         // is charged an unprovable fault.
         for counts in counts.iter().take(info_length) {
-            let MisbehaviorCounts::V1(peer_counts) = counts;
+            let peer_counts = counts.as_v2();
             assert_eq!(
                 peer_counts.faulty_blocks_unprovable, 1,
                 "Each peer that relayed a shard must be charged unprovably"

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -682,9 +682,10 @@ async fn scan_misbehavior_counts(
         .expect("scan should not fail");
     assert!(scanned.is_empty());
 
+    // One entry per envelope version so both round-trip through storage.
     let metrics_updates = [
         MisbehaviorCounts::new_v1_for_test(1, 2, 4, 3),
-        MisbehaviorCounts::new_v1_for_test(0, 0, 0, 0),
+        MisbehaviorCounts::new_v2_for_test(5, 6, 7, 8, 9),
     ];
     let authorities = [
         AuthorityIndex::new_for_test(0),

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1268,7 +1268,6 @@ mod tests {
         core_thread::CoreError,
         dag_state::{DagState, DataSource},
         encoder::create_encoder,
-        misbehavior_store::MisbehaviorCounts,
         network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
         transaction_ref::TransactionRef,
@@ -1472,7 +1471,7 @@ mod tests {
         );
 
         let counts = dag_state.read().misbehavior_store().snapshot_totals();
-        let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];
+        let author_counts = counts[author.value()].as_v2();
         assert_eq!(
             author_counts.faulty_blocks_provable, 1,
             "The author should be charged for the provably invalid payload"
@@ -1545,7 +1544,7 @@ mod tests {
                 .is_empty()
         );
         let counts = dag_state.read().misbehavior_store().snapshot_totals();
-        let MisbehaviorCounts::V1(peer_counts) = &counts[peer.value()];
+        let peer_counts = counts[peer.value()].as_v2();
         assert!(
             peer_counts.faulty_blocks_unprovable >= 1,
             "The serving peer must be charged for returning too many transactions"
@@ -2165,7 +2164,7 @@ mod tests {
         // undeserializable bytes. Peers are tried in a stable order in tests, so
         // peer 1 is always reached before the fetch succeeds from peer 2.
         let counts = dag_state.read().misbehavior_store().snapshot_totals();
-        let MisbehaviorCounts::V1(peer_counts) = &counts[AuthorityIndex::new_for_test(1).value()];
+        let peer_counts = counts[AuthorityIndex::new_for_test(1).value()].as_v2();
         assert!(
             peer_counts.faulty_blocks_unprovable >= 1,
             "The corrupted peer must be charged for serving undeserializable bytes"
@@ -2273,12 +2272,12 @@ mod tests {
         // AND the serving peer is charged an unprovable fault for relaying the
         // unrequested payload, while the author it named is not blamed.
         let counts = dag_state.read().misbehavior_store().snapshot_totals();
-        let MisbehaviorCounts::V1(peer_counts) = &counts[AuthorityIndex::new_for_test(1).value()];
+        let peer_counts = counts[AuthorityIndex::new_for_test(1).value()].as_v2();
         assert!(
             peer_counts.faulty_blocks_unprovable >= 1,
             "The serving peer must be charged for the unrequested payload"
         );
-        let MisbehaviorCounts::V1(framed_author) = &counts[AuthorityIndex::new_for_test(3).value()];
+        let framed_author = counts[AuthorityIndex::new_for_test(3).value()].as_v2();
         assert_eq!(
             framed_author.faulty_blocks_provable, 0,
             "The author named by the peer must not be blamed"

--- a/dev-tools/grafana-local/dashboards/validator-dashboard-v2.json
+++ b/dev-tools/grafana-local/dashboards/validator-dashboard-v2.json
@@ -125,7 +125,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 11 },
+      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 11 },
       "id": 4,
       "options": {
         "legend": {
@@ -177,7 +177,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 11 },
+      "gridPos": { "h": 9, "w": 8, "x": 8, "y": 11 },
       "id": 5,
       "options": {
         "legend": {
@@ -199,6 +199,58 @@
         }
       ],
       "title": "Unprovably faulty blocks (by sending peer)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${Environment}" },
+      "description": "Invalid relayed bundle parts per peer (bundle framing, metadata, or shard faults). Not tied to a verified author, so attributed to the sending peer. `in_memory` stacked on `persisted`; sum is the running total.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 11 },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${Environment}" },
+          "editorMode": "code",
+          "expr": "invalid_bundle_parts_by_peer{network=\"$network\", host=~\"$validator\", peer=~\"$authority\"}",
+          "legendFormat": "{{host}} / {{peer}} ({{source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Invalid bundle parts (by sending peer)",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
# Description of change

Give invalid bundle parts (framing, metadata, and shard faults in relayed bundles) their own misbehavior category instead of counting them as unprovable block faults, end to end: `MisbehaviorCountsV2` in the starfish misbehavior store (plus an `invalid_bundle_parts_by_peer` gauge and a dashboard panel), `MisbehaviorObservationsV2` on the report wire, and a `ScorerV2`, gated by `scorer_version = 2` — enabled on devnet at protocol version 33, with testnet and mainnet to follow later.

- Consensus always counts the new category locally; while scorer version 1 is active the report builder folds it back into `faulty_blocks_unprovable`, so the report wire format and scoring are unchanged where scorer version 2 is not yet active.
- `ScorerV2` splits the 10% unprovable weight evenly between the two categories (5% + 5%, same allowance/maximum) — placeholder parameters, tuning can follow separately.

## Links to any relevant issues

fixes iotaledger/iota-private#470

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
