### PR TITLE
chore(ci): drop removed Turborepo nightly workflow from Slack routing

### DIFF
--- a/.github/workflows/develop_ci_slack_report.yml
+++ b/.github/workflows/develop_ci_slack_report.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         if: github.event.workflow_run.conclusion != 'cancelled' || steps.failed-jobs.outputs.count != '0'
         with:
-          webhook: ${{ (github.event.workflow_run.name == 'Nightly checks' || github.event.workflow_run.name == 'Turborepo Nightly checks') && secrets.NIGHTLY_BROKEN_CI_SLACK_WEBHOOK || secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}
+          webhook: ${{ github.event.workflow_run.name == 'Nightly checks' && secrets.NIGHTLY_BROKEN_CI_SLACK_WEBHOOK || secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook
           # Fail the run if Slack rejects the request, so a broken webhook is visible instead of silently dropped.
           errors: true


### PR DESCRIPTION
# Description of change

- Remove the `'Turborepo Nightly checks'` name from the Slack webhook selection in `develop_ci_slack_report.yml`.
- That workflow left this repo with the tooling move to `ts-packages` (e39553e2138), so the branch routing it to the nightly webhook is dead code. `Nightly checks` still routes to the nightly webhook; everything else falls through to the dev webhook, unchanged.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)