### PR TITLE
fix(move-tracing): Enable zstd trace compression for wasm 

### DIFF
--- a/crates/iota-vm-sdk/src/debug.rs
+++ b/crates/iota-vm-sdk/src/debug.rs
@@ -7,11 +7,8 @@
 
 use std::path::PathBuf;
 
-use move_trace_format::format::{MoveTraceBuilder, TraceVersion};
-#[cfg(not(target_arch = "wasm32"))]
-use move_trace_format::format::{MoveTraceReader, TraceEvent};
+use move_trace_format::format::{MoveTraceBuilder, MoveTraceReader, TraceEvent, TraceVersion};
 
-#[cfg(not(target_arch = "wasm32"))]
 use crate::error::TraceError;
 
 /// Configuration for a single debug-enabled run.
@@ -125,9 +122,6 @@ impl ExecutionTrace {
     /// The trace as the VM encoded it: a version header line followed by one
     /// JSON-encoded event per line, zstd-compressed. Write it to a file with
     /// the `json.zst` extension to open the run in the Move trace debugger.
-    ///
-    /// (On wasm32 the Move trace format is not compressed, so these are plain
-    /// line-delimited JSON bytes.)
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
@@ -138,7 +132,6 @@ impl ExecutionTrace {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl ExecutionTrace {
     /// The events the VM emitted, in order, decoded from the encoded trace.
     ///
@@ -147,8 +140,6 @@ impl ExecutionTrace {
     /// encoded bytes do (a run of ~15,000 events decodes from 66 KB of
     /// compressed bytes to about 4 MB), which is why they are not decoded up
     /// front.
-    ///
-    /// Not available on wasm32; see [`bytes`](Self::bytes).
     ///
     /// # Errors
     ///
@@ -163,10 +154,8 @@ impl ExecutionTrace {
 
 /// The events of an [`ExecutionTrace`], decoded as the iterator advances. See
 /// [`ExecutionTrace::events`].
-#[cfg(not(target_arch = "wasm32"))]
 pub struct TraceEvents<'a>(MoveTraceReader<'static, std::io::Cursor<&'a [u8]>>);
 
-#[cfg(not(target_arch = "wasm32"))]
 impl Iterator for TraceEvents<'_> {
     type Item = Result<TraceEvent, TraceError>;
 

--- a/crates/iota-vm-sdk/src/error.rs
+++ b/crates/iota-vm-sdk/src/error.rs
@@ -47,7 +47,6 @@ pub enum VmSdkError {
     Vm(#[from] VmError),
     /// A captured [`ExecutionTrace`](crate::ExecutionTrace)'s encoded bytes
     /// could not be read back into events.
-    #[cfg(not(target_arch = "wasm32"))]
     #[error(transparent)]
     Trace(#[from] TraceError),
     /// The requested protocol version cannot serve the request: either this
@@ -156,7 +155,6 @@ impl VmError {
 
 /// A captured execution trace's encoded bytes could not be decoded back into
 /// events.
-#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 #[error("read execution trace: {source}")]

--- a/crates/iota-vm-sdk/src/lib.rs
+++ b/crates/iota-vm-sdk/src/lib.rs
@@ -47,12 +47,12 @@ pub mod graphql;
 #[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
 mod wasm;
 
-#[cfg(not(target_arch = "wasm32"))]
-pub use debug::TraceEvents;
-pub use debug::{DebugArtifacts, DebugConfig, ExecutionTrace, ProfileOutput, ProfileSink};
-#[cfg(not(target_arch = "wasm32"))]
-pub use error::TraceError;
-pub use error::{ExecutionError, SignatureError, StoreError, ValidationError, VmError, VmSdkError};
+pub use debug::{
+    DebugArtifacts, DebugConfig, ExecutionTrace, ProfileOutput, ProfileSink, TraceEvents,
+};
+pub use error::{
+    ExecutionError, SignatureError, StoreError, TraceError, ValidationError, VmError, VmSdkError,
+};
 pub use executor::{
     ChainContext, CommandResult, DecodedEvent, ExecuteOptions, ExecutionMode, ExecutionResult,
     LocalVm, SignatureStatus,

--- a/crates/iota-vm-sdk/src/wasm/mod.rs
+++ b/crates/iota-vm-sdk/src/wasm/mod.rs
@@ -57,6 +57,7 @@ fn err_to_js(e: VmSdkError) -> JsError {
         VmSdkError::MissingObject { .. } => "MissingObject",
         VmSdkError::Execution(_) => "Execution",
         VmSdkError::Vm(_) => "Vm",
+        VmSdkError::Trace(_) => "Trace",
         VmSdkError::UnsupportedProtocolVersion { .. } => "UnsupportedProtocolVersion",
     };
     JsError::new(&format!("{tag}: {e}"))

--- a/external-crates/move/crates/move-trace-format/Cargo.toml
+++ b/external-crates/move/crates/move-trace-format/Cargo.toml
@@ -11,15 +11,17 @@ description = "Move Trace Format"
 # external dependencies
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
+zstd.workspace = true
 
 # internal dependencies
 move-binary-format.workspace = true
 move-core-types.workspace = true
 
-# `zstd` wraps a C library that does not build for `wasm32-unknown-unknown`
-# (consumed there via `iota-vm-sdk`), so trace compression is native-only.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-zstd.workspace = true
+# `zstd` bundles a C library whose default build assembles an x86-64 huffman
+# decoder; `no_asm` selects the portable C one so it compiles for wasm32
+# (consumed there via `iota-vm-sdk`).
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+zstd = { workspace = true, features = ["no_asm"] }
 
 [features]
 default = []

--- a/external-crates/move/crates/move-trace-format/src/format.rs
+++ b/external-crates/move/crates/move-trace-format/src/format.rs
@@ -4,11 +4,11 @@
 
 // IDEA: Post trace analysis -- report when values are dropped.
 
-use std::fmt::Display;
 #[cfg(not(target_arch = "wasm32"))]
+use std::sync::mpsc::Receiver;
 use std::{
+    fmt::Display,
     io::{BufRead, BufReader},
-    sync::mpsc::Receiver,
 };
 
 use move_binary_format::{
@@ -37,12 +37,10 @@ const TRACE_VERSION: TraceVersion = 2;
 
 /// Compression level for the trace. This is the level of compression that we
 /// will use for the trace in zstd.
-#[cfg(not(target_arch = "wasm32"))]
 const COMPRESSION_LEVEL: i32 = 1;
 
 /// Size of the compression chunk. This is the size of the buffer that we will
 /// compress at a time.
-#[cfg(not(target_arch = "wasm32"))]
 const COMPRESSION_CHUNK_SIZE: usize = 1024 * 1024 * 1024;
 
 /// Size of the channel buffer. This is the size of the buffer that we will use
@@ -208,13 +206,13 @@ pub struct BufferedEventStream {
     sender: std::sync::mpsc::SyncSender<TraceEvent>,
 }
 
-// `wasm32-unknown-unknown` has neither threads nor the `zstd` C library, so the
-// trace is buffered uncompressed on that target. Tracing is not exercised on
-// wasm (the builder is only created when tracing is enabled); this exists so
-// the crate compiles there.
+// `wasm32-unknown-unknown` has no threads, so events are compressed on the
+// calling thread there. Both variants feed the encoder the same bytes in the
+// same order, so the trace they produce is identical.
 #[cfg(target_arch = "wasm32")]
 pub struct BufferedEventStream {
     pub event_count: TraceIndex,
+    events: zstd::stream::Encoder<'static, Vec<u8>>,
     buf: Vec<u8>,
 }
 
@@ -310,18 +308,20 @@ impl BufferedEventStream {
 impl BufferedEventStream {
     pub fn new() -> Self {
         use std::io::Write;
-        let mut buf = Vec::new();
+        let mut events = zstd::stream::Encoder::new(Vec::new(), COMPRESSION_LEVEL).unwrap();
         serde_json::to_writer(
-            &mut buf,
+            &mut events,
             &TraceVersionData {
                 version: TRACE_VERSION,
             },
         )
         .unwrap();
-        writeln!(&mut buf).unwrap();
+        writeln!(&mut events).unwrap();
+
         Self {
             event_count: 0,
-            buf,
+            events,
+            buf: Vec::new(),
         }
     }
 
@@ -329,11 +329,19 @@ impl BufferedEventStream {
         use std::io::Write;
         serde_json::to_writer(&mut self.buf, &event).unwrap();
         writeln!(&mut self.buf).unwrap();
+
+        if self.buf.len() > COMPRESSION_CHUNK_SIZE {
+            self.events
+                .write_all(&std::mem::take(&mut self.buf))
+                .unwrap();
+        }
         self.event_count += 1;
     }
 
-    pub fn finish(self) -> Vec<u8> {
-        self.buf
+    pub fn finish(mut self) -> Vec<u8> {
+        use std::io::Write;
+        self.events.write_all(self.buf.as_slice()).unwrap();
+        self.events.finish().unwrap()
     }
 }
 
@@ -540,13 +548,11 @@ impl Display for Effect {
 
 // Streaming reader for Move traces
 
-#[cfg(not(target_arch = "wasm32"))]
 pub struct MoveTraceReader<'a, R: std::io::Read> {
     pub version: TraceVersion,
     reader: BufReader<zstd::stream::Decoder<'a, BufReader<R>>>,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl<R: std::io::Read> MoveTraceReader<'_, R> {
     pub fn new(data: R) -> std::io::Result<Self> {
         let data = zstd::stream::Decoder::new(data)?;
@@ -570,7 +576,6 @@ impl<R: std::io::Read> MoveTraceReader<'_, R> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl<R: std::io::Read> Iterator for MoveTraceReader<'_, R> {
     type Item = std::io::Result<TraceEvent>;
 


### PR DESCRIPTION
# Description of change

PR #12400 introduced a new compressed Move Trace format v2. Currently, `wasm32` targets wrongly produce **uncompressed** Move Traces: the trace is a plain line-delimited JSON while still carrying `version: 2` and the `json.zst` extension, so a file written from a wasm run could not be opened in the Move trace debugger.

The issue exists because `zstd` is declared native-only, on the assumption that its bundled C library cannot build for `wasm32-unknown-unknown`, but it actually can: `zstd-sys` already ships a wasm shim for that triple and only needs its `no_asm` feature, because its default build assembles an x86-64 Huffman decoder.

Changes:
- `move-trace-format/Cargo.toml`: `zstd` becomes an ordinary dependency, with `no_asm` added for `wasm32` only, so native keeps the assembly decoder.
- `move-trace-format/src/format.rs`: 
    - The `wasm32` `BufferedEventStream` now compresses the trace as the native one.
    - `COMPRESSION_LEVEL`, `COMPRESSION_CHUNK_SIZE` and `MoveTraceReader` are un-gated now that both targets use them. 5 target gates in `format.rs` are dropped, keeping the file closer to upstream so the queued `move-trace-format` commits stay cheap to port.
- `iota-vm-sdk`: 9 target gates dropped, so `ExecutionTrace::events`, `TraceEvents`, `TraceError` and the `VmSdkError::Trace` variant exist on both targets, and the trace API no longer differs by target. `err_to_js` gained the matching `Trace` arm — a gap that existed only because the variant was gated out of the wasm build.

## Follow-ups

To be filed separately; none of this is addressed here. In particular, this fixes the trace **format** — it does not make tracing available in the browser.

- **Tracing is still not reachable from the wasm build.** Three things independently prevent it:
    1. `wasm::simulate` builds its `ExecuteOptions` without `with_debug(...)`, so `DebugConfig::trace` is always `false`; 
    2. the example builds with `features wasm-bindgen` only, so the VM's tracer is not compiled in;
    3.  only the `MoveAuthenticator` path threads a `MoveTraceBuilder`, dev-inspect accepting none (#12430). The corrected encoder is reachable today only from a Rust consumer targeting wasm32 built with `features tracing,wasm-bindgen`. Exposing it to JS — a `trace` flag on `SimulateRequest`, the encoded bytes on `SimulateResult` — would also give the browser-level verification this PR could only approximate.
- **(Maybe)One encoder instead of two.** Replace the target-specific `BufferedEventStream`s with a single synchronous one: verified byte-identical and ~13 lines shorter than upstream's.
- **Run `iota-vm-sdk`'s unit tests under `wasm32` in CI**, so the wasm encoder is executed and not merely type-checked.

## Links to any relevant issues

fixes #12554

## How the change has been tested

- [x]  Basic tests (linting, compilation, formatting, unit/integration tests)
- [x]  Patch-specific tests (correctness, functionality coverage)
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x]  I have checked that new and existing unit tests pass locally with my changes

Native, from the repo root:

```bash
cargo test -p iota-vm-sdk
cargo clippy -p iota-vm-sdk --all-features --all-targets
```

Native, from `external-crates/move`:

```bash
cargo test -p move-trace-format
cargo test -p move-cli --features tracing --test tracing_testsuite   # fixtures unchanged
```

wasm32, with and without the tracer compiled in:

```bash
cargo check -p iota-vm-sdk --features iota-vm-sdk/wasm-bindgen --target wasm32-unknown-unknown
cargo check -p iota-vm-sdk --features iota-vm-sdk/wasm-bindgen,iota-vm-sdk/tracing --target wasm32-unknown-unknown
```