### PR TITLE
fix(iota-grpc-server,iota-json-rpc,iota-core): stop recording request payloads in log spans

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2561,7 +2561,12 @@ impl AuthorityState {
                     let Some(df_info) = self
                         .try_create_dynamic_field_info(new_object, written, layout_resolver.as_mut())
                         .unwrap_or_else(|e| {
-                            error!("try_create_dynamic_field_info should not fail, {}, new_object={:?}", e, new_object);
+                            error!(
+                                "try_create_dynamic_field_info should not fail, {}, new_object={}, new_object_type={}",
+                                e,
+                                new_object.id(),
+                                ObjectType::from(new_object)
+                            );
                             None
                         }
                         )

--- a/crates/iota-core/src/execution_driver.rs
+++ b/crates/iota-core/src/execution_driver.rs
@@ -131,11 +131,11 @@ pub async fn execution_process(
                 &epoch_store_clone,
             ) {
                 Err(IotaError::ValidatorHaltedAtEpochEnd) => {
-                    warn!("Could not execute transaction {digest:?} because validator is halted at epoch end. transaction={transaction:?}");
+                    warn!("Could not execute transaction {digest:?} because validator is halted at epoch end.");
                     return;
                 }
                 Err(e) => {
-                    fatal!("Failed to execute transaction {digest:?}! error={e} transaction={transaction:?}");
+                    fatal!("Failed to execute transaction {digest:?}! error={e}");
                 }
                 _ => (),
             }

--- a/crates/iota-core/src/execution_scheduler/transaction_manager.rs
+++ b/crates/iota-core/src/execution_scheduler/transaction_manager.rs
@@ -410,7 +410,13 @@ impl TransactionManager {
                         };
 
                     if input_object_kinds.len() != input_object_keys.len() {
-                        error!("Duplicated input objects: {:?}", input_object_kinds);
+                        let mut seen = HashSet::with_capacity(input_object_kinds.len());
+                        let duplicates: Vec<_> = input_object_kinds
+                            .iter()
+                            .map(|kind| kind.object_id())
+                            .filter(|id| !seen.insert(*id))
+                            .collect();
+                        error!("Duplicated input objects: {:?}", duplicates);
                     }
 
                     let receiving_object_entries = tx.data().transaction().receiving_objects();

--- a/crates/iota-grpc-server/src/ledger_service/get_objects.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_objects.rs
@@ -75,7 +75,10 @@ pub(crate) fn validate_get_object_requests(
 ///
 /// ## Data Fields
 /// - `bcs` - the full BCS-encoded object
-#[tracing::instrument(skip(reader))]
+#[tracing::instrument(
+    skip(reader, requests),
+    fields(batch_size = requests.as_ref().map_or(0, |r| r.requests.len()))
+)]
 pub(crate) fn get_objects(
     reader: Arc<GrpcReader>,
     GetObjectsRequest {

--- a/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
+++ b/crates/iota-grpc-server/src/ledger_service/get_transactions.rs
@@ -125,7 +125,13 @@ pub(crate) fn validate_get_transaction_requests(
 ///   transaction this contains only the gas charge.
 /// - `object_changes` - structured object changes (created, mutated, deleted,
 ///   wrapped, unwrapped, published)
-#[tracing::instrument(skip(reader))]
+#[tracing::instrument(
+    skip_all,
+    fields(
+        batch_size = requests.as_ref().map_or(0, |r| r.requests.len()),
+        ?max_message_size_bytes,
+    )
+)]
 pub(crate) fn get_transactions(
     reader: Arc<GrpcReader>,
     config: iota_config::node::GrpcApiConfig,
@@ -165,7 +171,7 @@ pub(crate) fn get_transactions(
     ))
 }
 
-#[tracing::instrument(skip(reader))]
+#[tracing::instrument(skip(reader, config))]
 fn get_transaction_impl(
     reader: &Arc<GrpcReader>,
     config: &iota_config::node::GrpcApiConfig,

--- a/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/mod.rs
@@ -283,7 +283,7 @@ fn parse_transaction_proto(
 ///   transaction this contains only the gas charge.
 /// - `object_changes` - structured object changes (created, mutated, deleted,
 ///   wrapped, unwrapped, published)
-#[tracing::instrument(skip(reader, executor))]
+#[tracing::instrument(skip_all, fields(batch_size = request.transactions.len()))]
 pub async fn execute_transactions(
     reader: &Arc<GrpcReader>,
     executor: &Arc<dyn TransactionExecutor>,

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -143,7 +143,7 @@ use crate::{
 ///       description
 ///     - `execution_result.execution_error.command_index` - the index of the
 ///       command that failed
-#[tracing::instrument(skip(reader, executor))]
+#[tracing::instrument(skip_all, fields(batch_size = request.transactions.len()))]
 pub async fn simulate_transactions(
     reader: &Arc<GrpcReader>,
     executor: &Arc<dyn TransactionExecutor>,

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -664,7 +664,7 @@ impl ReadApiServer for ReadApi {
         .await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, past_objects), fields(num_past_objects = past_objects.len()))]
     async fn try_multi_get_past_objects(
         &self,
         past_objects: Vec<IotaGetPastObjectRequest>,

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -578,7 +578,7 @@ impl TransactionExecutionApi {
 
 #[async_trait]
 impl WriteApiServer for TransactionExecutionApi {
-    #[instrument(skip(self))]
+    #[instrument(skip(self, tx_bytes, signatures))]
     async fn execute_transaction_block(
         &self,
         tx_bytes: Base64,
@@ -592,7 +592,7 @@ impl WriteApiServer for TransactionExecutionApi {
     }
 
     /// Calls a move view function.
-    #[instrument(skip(self))]
+    #[instrument(skip(self, arguments))]
     async fn view_function_call(
         &self,
         function_name: String,
@@ -626,7 +626,10 @@ impl WriteApiServer for TransactionExecutionApi {
         )
     }
 
-    #[instrument(skip(self, sender_address), fields(sender_address = %sender_address))]
+    #[instrument(
+        skip(self, sender_address, tx_bytes, additional_args),
+        fields(sender_address = %sender_address)
+    )]
     async fn dev_inspect_transaction_block(
         &self,
         sender_address: Address,
@@ -649,7 +652,7 @@ impl WriteApiServer for TransactionExecutionApi {
         .await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, tx_bytes))]
     async fn dry_run_transaction_block(
         &self,
         tx_bytes: Base64,


### PR DESCRIPTION
# Description of change

- An ERROR line on a testnet indexer node was several hundred KB of escaped bytes: the `simulate_transactions` span records the whole gRPC request (raw BCS transaction bytes) and the `GrpcApiConfig` as span fields, so every event emitted inside the handler — here the panic hook — is prefixed with the full dump and the actual message drowns at the end of the line.
- gRPC server: the `simulate_transactions` and `execute_transactions` spans now record only `batch_size`; `get_transactions`/`get_objects` record the batch size instead of up to 1000 digest/object protos; the per-transaction span no longer records the server config.
- JSON-RPC: `execute_transaction_block`, `dry_run_transaction_block`, `dev_inspect_transaction_block`, and `view_function_call` spans stop recording `tx_bytes`/`signatures`/`arguments`; `try_multi_get_past_objects` records the request count instead of the request list.
- iota-core: the epoch-end halt warning and the execution `fatal!` no longer embed the whole transaction (the digest already identifies it); the dynamic-field indexing error logs the object id and type instead of the full object; the duplicated-input error logs only the duplicated object ids.

## How the change has been tested

On a localnet fullnode with the adapter at debug level, a simulate request publishing a ~64KB module: before, the in-span verification event is one line of several hundred thousand chars; after, the same event is one short line `simulate_transactions{batch_size=1}: ... Verification Error ...`.

- Before this PR
```log
2026-08-11T10:13:11.140808Z DEBUG simulate_transactions{config=GrpcApiConfig { address: 0.0.0.0:50061, tls: None, max_message_size_bytes: 134217728, broadcast_buffer_size: 100, max_concurrent_stream_subscribers: 1024, max_json_move_value_size: 1048576, max_execute_transaction_batch_size: 20, max_sim
… 263,106 chars omitted (rest of the config, then the escaped BCS request bytes) …
 message: None, exec_state: None, location: Undefined, indices: [], offsets: [] }) kind=VmVerificationOrDeserializationError tx_digest=TransactionDigest("D4Uqa4as38uY1bLhTLKTunzp5NMDWEDw981tbdoJaxB3")
```
- After this PR
```log
2026-08-11T10:15:14.509344Z DEBUG simulate_transactions{batch_size=1}: iota_adapter_latest::execution_engine::checked: Verification Error. Source: Some(VMError { major_status: BAD_MAGIC, sub_status: None, message: None, exec_state: None, location: Undefined, indices: [], offsets: [] }) kind=VmVerificationOrDeserializationError tx_digest=TransactionDigest("D4Uqa4as38uY1bLhTLKTunzp5NMDWEDw981tbdoJaxB3")
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes