### PR TITLE
feat(starfish): track streaming responsiveness per peer-author pair

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -33,7 +33,7 @@ use crate::{
     commit_syncer::CommitSyncType,
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
-    cordial_knowledge::CordialKnowledgeHandle,
+    cordial_knowledge::{CordialKnowledgeHandle, MAX_ROUND_GAP_FOR_USEFUL_PARTS},
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, DataSource},
     encoder::ShardEncoder,
@@ -893,6 +893,30 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         //    inserted
         self.add_digests_to_filter(peer_hostname, &mut additional_block_headers, block_ref)
             .await;
+
+        // The headers that survived the filter are first deliveries; sample
+        // the streaming responsiveness table with them in one batch. Catch-up
+        // headers carry old timestamps, so only headers close to the bundle's
+        // round are measured.
+        self.context
+            .peer_responsiveness
+            .record_streaming_header_deliveries(
+                peer,
+                additional_block_headers
+                    .iter()
+                    .filter(|header| {
+                        header
+                            .round()
+                            .saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
+                            >= block_ref.round
+                    })
+                    .map(|header| {
+                        (
+                            header.author(),
+                            Duration::from_millis(now.saturating_sub(header.timestamp_ms())),
+                        )
+                    }),
+            );
 
         // 9. Prepare transaction messages for shard reconstructor and send them.
         // Skipped for a dropped primary block (no shards were collected).
@@ -1799,7 +1823,9 @@ mod tests {
         commit_syncer::CommitSyncType,
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
-        cordial_knowledge::{ConnectionKnowledgeMessage, CordialKnowledge},
+        cordial_knowledge::{
+            ConnectionKnowledgeMessage, CordialKnowledge, MAX_ROUND_GAP_FOR_USEFUL_PARTS,
+        },
         core::{Core, CoreSignals, ReasonToCreateBlock},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::{DagState, DataSource},
@@ -2882,6 +2908,195 @@ mod tests {
                 min(validators * round as usize - 1, MAX_FILTER_SIZE as usize)
             )
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_streaming_responsiveness_samples_first_fresh_deliveries() {
+        // GIVEN a DAG deep enough that a round-1 header is stale relative to a
+        // bundle's block round (more than MAX_ROUND_GAP_FOR_USEFUL_PARTS
+        // behind).
+        let rounds: u32 = MAX_ROUND_GAP_FOR_USEFUL_PARTS + 4;
+        let validators = 4;
+        // Test headers are V1, which flag-on verification rejects; run with
+        // StarfishSpeed off.
+        let (mut context, key_pairs) = Context::new_for_test(validators);
+        context
+            .protocol_config
+            .set_consensus_starfish_speed_for_testing(false);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(SignedBlockVerifier::new(
+            context.clone(),
+            Arc::new(crate::block_verifier::test::TxnSizeVerifier {}),
+        ));
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+
+        let block_manager = BlockManager::new(context.clone(), dag_state.clone());
+        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (signals, _signal_receivers) = CoreSignals::new(context.clone());
+        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
+            context.clone(),
+            dag_state.clone(),
+        ));
+        let commit_observer = CommitObserver::new(
+            context.clone(),
+            CommitConsumer::new(sender.clone(), 0),
+            dag_state.clone(),
+            store.clone(),
+            leader_schedule.clone(),
+        )
+        .await;
+        let mut core = Core::new(
+            context.clone(),
+            leader_schedule,
+            transaction_consumer,
+            block_manager,
+            true,
+            commit_observer,
+            signals,
+            key_pairs[context.own_index.value()].1.clone(),
+            dag_state.clone(),
+            true,
+            Arc::new(CommitVoteMonitor::new(context.clone())),
+        );
+        core.set_last_known_proposed_round(rounds + 5);
+
+        let core_dispatcher = Arc::new(FakeCoreThreadDispatcher {
+            core: Mutex::new(core),
+        });
+        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
+        let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+
+        let network_client = Arc::new(FakeNetworkClient::default());
+
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+
+        let header_synchronizer = HeaderSynchronizer::start(
+            network_client,
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            false,
+            None,
+            Arc::new(MisbehaviorStore::new(&context)),
+        );
+        let authority_service = Arc::new(AuthorityService::new(
+            context.clone(),
+            block_verifier,
+            commit_vote_monitor,
+            header_synchronizer,
+            transactions_synchronizer,
+            core_dispatcher.clone(),
+            rx_block_broadcast,
+            dag_state.clone(),
+            store,
+            Arc::new(MisbehaviorStore::new(&context)),
+            tx_message_sender,
+            cordial_knowledge,
+        ));
+        let mut encoder = create_encoder(&context);
+
+        let protocol_keypairs = key_pairs.iter().map(|kp| kp.1.clone()).collect();
+        let mut dag_builder =
+            DagBuilder::new(context.clone()).set_protocol_keypair(protocol_keypairs);
+        dag_builder.layers(1..=rounds).build();
+        let mut all_headers: Vec<Vec<VerifiedBlockHeader>> = vec![];
+        let mut all_transactions: Vec<Vec<VerifiedTransactions>> = vec![];
+        for round in 0..=rounds {
+            all_headers.push(dag_builder.block_headers(round..=round));
+            all_transactions.push(dag_builder.transactions(round..=round));
+        }
+        // Accept every header below the top round outside the bundle path, so
+        // the bundle digest filter has never seen any of them.
+        for round in 1..rounds {
+            core_dispatcher
+                .add_block_headers(all_headers[round as usize].clone(), DataSource::Test)
+                .await
+                .expect("headers are expected to be added successfully");
+        }
+
+        let peer_1 = context.committee.to_authority_index(1).unwrap();
+        let peer_2 = context.committee.to_authority_index(2).unwrap();
+        let author_3 = context.committee.to_authority_index(3).unwrap();
+        let all_authorities: Vec<AuthorityIndex> = (0u8..(context.committee.size() as u8))
+            .map(Into::into)
+            .collect();
+        let send_bundle = |block_peer: usize, headers: Vec<VerifiedBlockHeader>| {
+            let block_bundle = BlockBundle {
+                verified_block: VerifiedBlock {
+                    verified_block_header: all_headers[rounds as usize][block_peer].clone(),
+                    verified_transactions: all_transactions[rounds as usize][block_peer].clone(),
+                },
+                verified_headers: headers,
+                serialized_shards: vec![],
+                useful_headers_authors: all_authorities.iter().copied().collect(),
+                useful_shards_authors: all_authorities.iter().copied().collect(),
+            };
+            SerializedBlockBundle::try_from(
+                SerializedBlockBundleParts::try_from(block_bundle).unwrap(),
+            )
+            .unwrap()
+        };
+
+        // WHEN peer 1's bundle delivers a stale first copy (author 2, round 1)
+        // and a fresh first copy (author 3, top round - 1).
+        authority_service
+            .handle_subscribed_block_bundle(
+                peer_1,
+                send_bundle(
+                    1,
+                    vec![
+                        all_headers[1][2].clone(),
+                        all_headers[rounds as usize - 1][3].clone(),
+                    ],
+                ),
+                &mut encoder,
+            )
+            .await
+            .expect("bundle is expected to be processed successfully");
+
+        // THEN only the fresh first delivery is sampled.
+        let responsiveness = &context.peer_responsiveness;
+        assert!(
+            responsiveness
+                .streaming_header_latency_ms(peer_1, author_3)
+                .is_some()
+        );
+        assert!(
+            responsiveness
+                .streaming_header_latency_ms(peer_1, peer_2)
+                .is_none()
+        );
+
+        // AND WHEN peer 2 re-delivers the header peer 1 already delivered.
+        authority_service
+            .handle_subscribed_block_bundle(
+                peer_2,
+                send_bundle(2, vec![all_headers[rounds as usize - 1][3].clone()]),
+                &mut encoder,
+            )
+            .await
+            .expect("bundle is expected to be processed successfully");
+
+        // THEN the duplicate is not sampled.
+        assert!(
+            responsiveness
+                .streaming_header_latency_ms(peer_2, author_3)
+                .is_none()
+        );
     }
 
     #[rstest]

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -280,13 +280,20 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             .record_faulty_block(peer, peer, error);
     }
 
+    /// Deserializes and verifies the additional headers of a bundle. Returns
+    /// the fresh headers, to be accepted into the DAG, and separately the
+    /// headers received before (their digest is in `received_block_headers`):
+    /// those still count as deliveries for the responsiveness sampling, but
+    /// must not be re-accepted. A filter hit proves byte-identity with a
+    /// header that passed verification before its digest entered the filter,
+    /// so a duplicate's fields are trusted without re-verifying its signature.
     fn extract_additional_block_headers_from_bundle(
         &self,
         peer: AuthorityIndex,
         peer_hostname: &str,
         mut serialized_headers: Vec<Bytes>,
         block_ref: BlockRef,
-    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+    ) -> ConsensusResult<(Vec<VerifiedBlockHeader>, Vec<VerifiedBlockHeader>)> {
         let block_round = block_ref.round;
         if serialized_headers.len() > self.context.parameters.max_headers_per_bundle {
             warn!("BlockBundle: {block_ref} exceeds max_headers_per_bundle.");
@@ -294,6 +301,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         };
 
         let mut additional_block_headers = vec![];
+        let mut duplicate_block_headers = vec![];
         for serialized_header in serialized_headers {
             let digest = VerifiedBlockHeader::compute_digest(&serialized_header);
             if self.received_block_headers.contains(&digest) {
@@ -303,6 +311,26 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .filtered_headers_in_bundles
                     .with_label_values(&[peer_hostname, "handle_subscribed_block_bundle"])
                     .inc();
+                // The parse cannot fail — the filter hit proves these bytes
+                // were deserialized before; skip the sample if it somehow
+                // does. The in-bundle round bound applies to duplicates too:
+                // together with the connect ceiling on the primary block it
+                // keeps a far-future header, whose digest enters the filter
+                // when its block is dropped, from being replayed as a
+                // near-zero-latency sample.
+                if let Ok(signed_block_header) =
+                    bcs::from_bytes::<SignedBlockHeader>(&serialized_header)
+                {
+                    if signed_block_header.round() < block_round {
+                        duplicate_block_headers.push(
+                            VerifiedBlockHeader::new_verified_with_digest(
+                                signed_block_header,
+                                serialized_header,
+                                digest,
+                            ),
+                        );
+                    }
+                }
                 continue;
             }
 
@@ -361,7 +389,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             .valid_headers_in_bundles
             .with_label_values(&[peer_hostname, "handle_subscribed_block_bundle"])
             .inc_by(additional_block_headers.len() as u64);
-        Ok(additional_block_headers)
+        Ok((additional_block_headers, duplicate_block_headers))
     }
     fn extract_shards_from_bundle(
         &self,
@@ -787,12 +815,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         let serialized_headers =
             std::mem::take(&mut serialized_block_bundle_parts.serialized_headers);
-        let mut additional_block_headers = self.extract_additional_block_headers_from_bundle(
-            peer,
-            peer_hostname,
-            serialized_headers,
-            block_ref,
-        )?;
+        let (mut additional_block_headers, duplicate_block_headers) = self
+            .extract_additional_block_headers_from_bundle(
+                peer,
+                peer_hostname,
+                serialized_headers,
+                block_ref,
+            )?;
 
         // 4. Observe headers and the block for the commit votes. When local commit is
         // lagging too much, commit sync loop will trigger fetching. Done before the
@@ -889,19 +918,20 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname])
             .inc();
 
-        // 8. Add digests to filter. Exclude from the vector those that are already
-        //    inserted
-        self.add_digests_to_filter(peer_hostname, &mut additional_block_headers, block_ref)
-            .await;
-
-        // The headers that survived the filter are first deliveries. Sample the
-        // streaming responsiveness table once per author, from the newest
-        // header of that author in this bundle: a bundle is one delivery event,
-        // and how old that newest header is says how current the peer is on
-        // that author.
+        // Sample the streaming responsiveness table once per author, from the
+        // newest header of that author in this bundle: a bundle is one
+        // delivery event, and how old that newest header is says how current
+        // the peer is on that author. Headers the digest filter already saw
+        // count too: sampling only first deliveries would record nothing for
+        // a peer that is consistently second and only race-winning latencies
+        // for the rest, while a re-delivery cannot make a peer look fast
+        // because the latency reference is the author's own timestamp.
         let mut newest_per_author: Vec<Option<&VerifiedBlockHeader>> =
             vec![None; self.context.committee.size()];
-        for header in &additional_block_headers {
+        for header in additional_block_headers
+            .iter()
+            .chain(duplicate_block_headers.iter())
+        {
             let newest = &mut newest_per_author[header.author()];
             if newest.is_none_or(|current| current.round() < header.round()) {
                 *newest = Some(header);
@@ -920,6 +950,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         self.context
             .peer_responsiveness
             .record_streaming_header_deliveries(peer, &deliveries);
+
+        // 8. Add digests to filter. Exclude from the vector those that are already
+        //    inserted
+        self.add_digests_to_filter(peer_hostname, &mut additional_block_headers, block_ref)
+            .await;
 
         // 9. Prepare transaction messages for shard reconstructor and send them.
         // Skipped for a dropped primary block (no shards were collected).
@@ -2914,7 +2949,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_streaming_responsiveness_samples_newest_first_delivery_per_author() {
+    async fn test_streaming_responsiveness_samples_newest_header_per_author() {
         // GIVEN a DAG deep enough that a round-1 header is far behind the
         // bundle's block round.
         let rounds: u32 = MAX_ROUND_GAP_FOR_USEFUL_PARTS + 4;
@@ -3103,18 +3138,19 @@ mod tests {
         authority_service
             .handle_subscribed_block_bundle(
                 peer_2,
-                send_bundle(2, vec![newest_of_author_3]),
+                send_bundle(2, vec![newest_of_author_3.clone()]),
                 &mut encoder,
             )
             .await
             .expect("bundle is expected to be processed successfully");
 
-        // THEN the duplicate is not sampled.
-        assert!(
-            responsiveness
-                .streaming_header_latency_ms(peer_2, author_3)
-                .is_none()
-        );
+        // THEN the re-delivery is sampled like any delivery, against the same
+        // header timestamp, so a peer that is consistently second is still
+        // measured — and cannot read faster than the first delivery did.
+        let resampled = responsiveness
+            .streaming_header_latency_ms(peer_2, author_3)
+            .expect("a re-delivery is sampled");
+        assert!((resampled - expected(&newest_of_author_3)).abs() < MARGIN_MS);
     }
 
     #[rstest]

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -33,7 +33,7 @@ use crate::{
     commit_syncer::CommitSyncType,
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
-    cordial_knowledge::{CordialKnowledgeHandle, MAX_ROUND_GAP_FOR_USEFUL_PARTS},
+    cordial_knowledge::CordialKnowledgeHandle,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, DataSource},
     encoder::ShardEncoder,
@@ -894,29 +894,32 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         self.add_digests_to_filter(peer_hostname, &mut additional_block_headers, block_ref)
             .await;
 
-        // The headers that survived the filter are first deliveries; sample
-        // the streaming responsiveness table with them in one batch. Catch-up
-        // headers carry old timestamps, so only headers close to the bundle's
-        // round are measured.
+        // The headers that survived the filter are first deliveries. Sample the
+        // streaming responsiveness table once per author, from the newest
+        // header of that author in this bundle: a bundle is one delivery event,
+        // and how old that newest header is says how current the peer is on
+        // that author.
+        let mut newest_per_author: Vec<Option<&VerifiedBlockHeader>> =
+            vec![None; self.context.committee.size()];
+        for header in &additional_block_headers {
+            let newest = &mut newest_per_author[header.author()];
+            if newest.is_none_or(|current| current.round() < header.round()) {
+                *newest = Some(header);
+            }
+        }
+        let deliveries = newest_per_author
+            .into_iter()
+            .flatten()
+            .map(|header| {
+                (
+                    header.author(),
+                    Duration::from_millis(now.saturating_sub(header.timestamp_ms())),
+                )
+            })
+            .collect::<Vec<_>>();
         self.context
             .peer_responsiveness
-            .record_streaming_header_deliveries(
-                peer,
-                additional_block_headers
-                    .iter()
-                    .filter(|header| {
-                        header
-                            .round()
-                            .saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS)
-                            >= block_ref.round
-                    })
-                    .map(|header| {
-                        (
-                            header.author(),
-                            Duration::from_millis(now.saturating_sub(header.timestamp_ms())),
-                        )
-                    }),
-            );
+            .record_streaming_header_deliveries(peer, &deliveries);
 
         // 9. Prepare transaction messages for shard reconstructor and send them.
         // Skipped for a dropped primary block (no shards were collected).
@@ -2911,10 +2914,9 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_streaming_responsiveness_samples_first_fresh_deliveries() {
-        // GIVEN a DAG deep enough that a round-1 header is stale relative to a
-        // bundle's block round (more than MAX_ROUND_GAP_FOR_USEFUL_PARTS
-        // behind).
+    async fn test_streaming_responsiveness_samples_newest_first_delivery_per_author() {
+        // GIVEN a DAG deep enough that a round-1 header is far behind the
+        // bundle's block round.
         let rounds: u32 = MAX_ROUND_GAP_FOR_USEFUL_PARTS + 4;
         let validators = 4;
         // Test headers are V1, which flag-on verification rejects; run with
@@ -3051,16 +3053,20 @@ mod tests {
             .unwrap()
         };
 
-        // WHEN peer 1's bundle delivers a stale first copy (author 2, round 1)
-        // and a fresh first copy (author 3, top round - 1).
+        // WHEN peer 1's bundle delivers two first copies of author 3, an old one
+        // (round 1) and the newest one (top round - 1), plus one of author 2.
+        let newest_of_author_3 = all_headers[rounds as usize - 1][3].clone();
+        let oldest_of_author_3 = all_headers[1][3].clone();
+        let header_of_author_2 = all_headers[1][2].clone();
         authority_service
             .handle_subscribed_block_bundle(
                 peer_1,
                 send_bundle(
                     1,
                     vec![
-                        all_headers[1][2].clone(),
-                        all_headers[rounds as usize - 1][3].clone(),
+                        oldest_of_author_3.clone(),
+                        newest_of_author_3.clone(),
+                        header_of_author_2.clone(),
                     ],
                 ),
                 &mut encoder,
@@ -3068,24 +3074,36 @@ mod tests {
             .await
             .expect("bundle is expected to be processed successfully");
 
-        // THEN only the fresh first delivery is sampled.
+        // THEN author 3 is sampled once, from its newest header, and author 2
+        // is sampled from the only header of it in the bundle - old headers are
+        // measured too, since how old the newest one is says how current the
+        // peer is on that author.
         let responsiveness = &context.peer_responsiveness;
-        assert!(
+        let expected = |header: &VerifiedBlockHeader| {
+            (context.clock.timestamp_utc_ms() - header.timestamp_ms()) as f64
+        };
+        let sampled = |author| {
             responsiveness
-                .streaming_header_latency_ms(peer_1, author_3)
-                .is_some()
-        );
+                .streaming_header_latency_ms(peer_1, author)
+                .expect("the delivery is sampled")
+        };
+        // The clock advances between the recording and this read, so allow a
+        // small margin; the two candidate headers are seconds apart.
+        const MARGIN_MS: f64 = 1_000.0;
         assert!(
-            responsiveness
-                .streaming_header_latency_ms(peer_1, peer_2)
-                .is_none()
+            (sampled(author_3) - expected(&newest_of_author_3)).abs() < MARGIN_MS,
+            "author 3 should be measured from its newest header: got {}, newest {}, oldest {}",
+            sampled(author_3),
+            expected(&newest_of_author_3),
+            expected(&oldest_of_author_3)
         );
+        assert!((sampled(peer_2) - expected(&header_of_author_2)).abs() < MARGIN_MS);
 
         // AND WHEN peer 2 re-delivers the header peer 1 already delivered.
         authority_service
             .handle_subscribed_block_bundle(
                 peer_2,
-                send_bundle(2, vec![all_headers[rounds as usize - 1][3].clone()]),
+                send_bundle(2, vec![newest_of_author_3]),
                 &mut encoder,
             )
             .await

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -87,15 +87,16 @@ impl FilterForHeaders {
         digests: Vec<(BlockHeaderDigest, FilteredHeaderInfo)>,
     ) -> Vec<BlockHeaderDigest> {
         let mut already_inserted = vec![];
-        for (digest, info) in digests.iter() {
-            if self.header_digests.insert(*digest, *info).is_some() {
-                already_inserted.push(*digest);
+        let mut newly_inserted = vec![];
+        for (digest, info) in digests {
+            if self.header_digests.insert(digest, info).is_some() {
+                already_inserted.push(digest);
+            } else {
+                newly_inserted.push(digest);
             }
         }
         let mut queue = self.queue.lock().await;
-        for (digest, _) in digests {
-            queue.push_back(digest);
-        }
+        queue.extend(newly_inserted);
         while queue.len() > MAX_FILTER_SIZE as usize {
             if let Some(removed) = queue.pop_front() {
                 self.header_digests.remove(&removed);
@@ -293,6 +294,32 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             .record_faulty_block(peer, peer, error);
     }
 
+    fn validate_additional_header_round(
+        &self,
+        peer: AuthorityIndex,
+        peer_hostname: &str,
+        header_round: Round,
+        block_round: Round,
+    ) -> ConsensusResult<()> {
+        if header_round < block_round {
+            return Ok(());
+        }
+        let error = ConsensusError::TooBigHeaderRoundInABundle {
+            header_round,
+            block_round,
+        };
+        self.context
+            .metrics
+            .node_metrics
+            .bundles_with_invalid_parts
+            .with_label_values(&[peer_hostname, "header", "invalid round in header"])
+            .inc();
+        self.misbehavior_store
+            .record_faulty_block(peer, peer, &error);
+        info!("Invalid additional block header from {}: {}", peer, error);
+        Err(error)
+    }
+
     /// Deserializes and verifies the additional headers of a bundle. Returns
     /// the fresh headers to accept into the DAG, plus the info of the already
     /// received ones — still deliveries for the responsiveness sampling, but
@@ -321,12 +348,8 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .filtered_headers_in_bundles
                     .with_label_values(&[peer_hostname, "handle_subscribed_block_bundle"])
                     .inc();
-                // The round bound keeps a far-future header, filtered even
-                // when its block is dropped, from replaying as a near-zero
-                // sample.
-                if round < block_round {
-                    duplicate_header_deliveries.push((author, round, timestamp_ms));
-                }
+                self.validate_additional_header_round(peer, peer_hostname, round, block_round)?;
+                duplicate_header_deliveries.push((author, round, timestamp_ms));
                 continue;
             }
 
@@ -337,22 +360,12 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     self.misbehavior_store.record_faulty_block(peer, peer, e);
                 })?;
 
-            let header_round = signed_block_header.round();
-            if header_round >= block_round {
-                let e = ConsensusError::TooBigHeaderRoundInABundle {
-                    header_round,
-                    block_round,
-                };
-                self.context
-                    .metrics
-                    .node_metrics
-                    .bundles_with_invalid_parts
-                    .with_label_values(&[peer_hostname, "header", "invalid round in header"])
-                    .inc();
-                self.misbehavior_store.record_faulty_block(peer, peer, &e);
-                info!("Invalid additional block header from {}: {}", peer, e);
-                return Err(e);
-            }
+            self.validate_additional_header_round(
+                peer,
+                peer_hostname,
+                signed_block_header.round(),
+                block_round,
+            )?;
 
             if let Err(e) = self.block_verifier.verify(&signed_block_header) {
                 self.context
@@ -1835,7 +1848,8 @@ mod tests {
     use crate::{
         CommitConsumer, Round, Transaction, TransactionClient,
         authority_service::{
-            AuthorityService, BroadcastedBlockStream, MAX_FILTER_SIZE, SubscriptionCounter,
+            AuthorityService, BroadcastedBlockStream, FilterForHeaders, MAX_FILTER_SIZE,
+            SubscriptionCounter, filtered_header_info,
         },
         block_header::{
             BlockHeaderAPI, BlockHeaderDigest, BlockRef, CommitmentVerifiedTransactions,
@@ -1871,6 +1885,18 @@ mod tests {
         transaction_ref::{GenericTransactionRef, TransactionRef},
         transactions_synchronizer::TransactionsSynchronizer,
     };
+
+    #[tokio::test]
+    async fn test_filter_for_headers_queues_only_new_digests() {
+        let filter = FilterForHeaders::new();
+        let digest = BlockHeaderDigest::MIN;
+        let info = (AuthorityIndex::new_for_test(0), 1, 0);
+
+        assert!(filter.add_batch(vec![(digest, info)]).await.is_empty());
+        assert_eq!(filter.add_batch(vec![(digest, info)]).await, vec![digest]);
+        assert_eq!(filter.size(), 1);
+        assert_eq!(filter.queue.lock().await.len(), 1);
+    }
 
     #[derive(Default)]
     struct FakeNetworkClient {}
@@ -2440,6 +2466,48 @@ mod tests {
         // The relaying peer (authority 0) is charged for the invalid header.
         let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[0];
         assert_eq!(counts.faulty_blocks_unprovable, 1);
+
+        let cached_header = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 1, &context, &mut encoder)
+                .set_timestamp_ms(1)
+                .build(),
+        );
+        authority_service
+            .received_block_headers
+            .add_batch(vec![(
+                cached_header.digest(),
+                filtered_header_info(&cached_header),
+            )])
+            .await;
+        let block_bundle_with_invalid_cached_header = BlockBundle {
+            verified_block: input_block.clone(),
+            verified_headers: vec![cached_header],
+            serialized_shards: vec![],
+            useful_headers_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
+            useful_shards_authors: (0u8..(committee_size as u8)).map(Into::into).collect(),
+        };
+        let serialized_block_bundle = SerializedBlockBundle::try_from(
+            SerializedBlockBundleParts::try_from(block_bundle_with_invalid_cached_header).unwrap(),
+        )
+        .unwrap();
+
+        let result = authority_service
+            .handle_subscribed_block_bundle(
+                context.committee.to_authority_index(0).unwrap(),
+                serialized_block_bundle,
+                &mut encoder,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ConsensusError::TooBigHeaderRoundInABundle {
+                header_round: 1,
+                block_round: 1,
+            })
+        ));
+        let MisbehaviorCounts::V1(counts) = &misbehavior_store.snapshot_totals()[0];
+        assert_eq!(counts.faulty_blocks_unprovable, 2);
 
         // Create a block with a big round
         let input_block = VerifiedBlock::new_for_test(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -12,7 +12,7 @@ use std::{
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use dashmap::DashSet;
+use dashmap::DashMap;
 use futures::{Stream, StreamExt, ready, stream, task};
 use iota_macros::fail_point_async;
 use parking_lot::RwLock;
@@ -24,9 +24,9 @@ use tracing::{debug, error, info, warn};
 use crate::{
     CommitIndex, Round, VerifiedBlockHeader,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, CommitmentVerifiedTransactions, GENESIS_ROUND,
-        ShardWithProof, ShardWithProofAPI, SignedBlockHeader, TransactionsCommitment,
-        VerifiedBlock, VerifiedOwnShard,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs,
+        CommitmentVerifiedTransactions, GENESIS_ROUND, ShardWithProof, ShardWithProofAPI,
+        SignedBlockHeader, TransactionsCommitment, VerifiedBlock, VerifiedOwnShard,
     },
     block_verifier::{BlockVerifier, max_shard_bytes},
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
@@ -56,15 +56,25 @@ pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
 const MAX_FILTER_SIZE: u32 = 100000;
 
+/// The author, round and timestamp of a header whose digest is in
+/// [`FilterForHeaders`], recorded when the verified header was inserted so a
+/// re-delivered copy can be sampled for responsiveness without being
+/// deserialized again.
+type FilteredHeaderInfo = (AuthorityIndex, Round, BlockTimestampMs);
+
+fn filtered_header_info(header: &VerifiedBlockHeader) -> FilteredHeaderInfo {
+    (header.author(), header.round(), header.timestamp_ms())
+}
+
 struct FilterForHeaders {
-    header_digests: DashSet<BlockHeaderDigest>,
+    header_digests: DashMap<BlockHeaderDigest, FilteredHeaderInfo>,
     queue: Mutex<VecDeque<BlockHeaderDigest>>,
 }
 
 impl FilterForHeaders {
     fn new() -> Self {
         Self {
-            header_digests: DashSet::new(),
+            header_digests: DashMap::new(),
             queue: Mutex::new(VecDeque::new()),
         }
     }
@@ -74,15 +84,18 @@ impl FilterForHeaders {
         self.header_digests.len()
     }
 
-    async fn add_batch(&self, digests: Vec<BlockHeaderDigest>) -> Vec<BlockHeaderDigest> {
+    async fn add_batch(
+        &self,
+        digests: Vec<(BlockHeaderDigest, FilteredHeaderInfo)>,
+    ) -> Vec<BlockHeaderDigest> {
         let mut already_inserted = vec![];
-        for digest in digests.iter() {
-            if !self.header_digests.insert(*digest) {
+        for (digest, info) in digests.iter() {
+            if self.header_digests.insert(*digest, *info).is_some() {
                 already_inserted.push(*digest);
             }
         }
         let mut queue = self.queue.lock().await;
-        for digest in digests {
+        for (digest, _) in digests {
             queue.push_back(digest);
         }
         while queue.len() > MAX_FILTER_SIZE as usize {
@@ -92,8 +105,10 @@ impl FilterForHeaders {
         }
         already_inserted
     }
-    fn contains(&self, header_digest: &BlockHeaderDigest) -> bool {
-        self.header_digests.contains(header_digest)
+    fn get(&self, header_digest: &BlockHeaderDigest) -> Option<FilteredHeaderInfo> {
+        self.header_digests
+            .get(header_digest)
+            .map(|info| *info.value())
     }
 }
 
@@ -282,18 +297,18 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 
     /// Deserializes and verifies the additional headers of a bundle. Returns
     /// the fresh headers, to be accepted into the DAG, and separately the
-    /// headers received before (their digest is in `received_block_headers`):
-    /// those still count as deliveries for the responsiveness sampling, but
-    /// must not be re-accepted. A filter hit proves byte-identity with a
-    /// header that passed verification before its digest entered the filter,
-    /// so a duplicate's fields are trusted without re-verifying its signature.
+    /// author, round and timestamp of each header received before (its digest
+    /// is in `received_block_headers`): those still count as deliveries for
+    /// the responsiveness sampling, but must not be re-accepted. The fields of
+    /// a duplicate come from the filter, recorded when the verified header was
+    /// inserted, so a duplicate costs a lookup, not a deserialization.
     fn extract_additional_block_headers_from_bundle(
         &self,
         peer: AuthorityIndex,
         peer_hostname: &str,
         mut serialized_headers: Vec<Bytes>,
         block_ref: BlockRef,
-    ) -> ConsensusResult<(Vec<VerifiedBlockHeader>, Vec<VerifiedBlockHeader>)> {
+    ) -> ConsensusResult<(Vec<VerifiedBlockHeader>, Vec<FilteredHeaderInfo>)> {
         let block_round = block_ref.round;
         if serialized_headers.len() > self.context.parameters.max_headers_per_bundle {
             warn!("BlockBundle: {block_ref} exceeds max_headers_per_bundle.");
@@ -301,35 +316,23 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         };
 
         let mut additional_block_headers = vec![];
-        let mut duplicate_block_headers = vec![];
+        let mut duplicate_header_deliveries = vec![];
         for serialized_header in serialized_headers {
             let digest = VerifiedBlockHeader::compute_digest(&serialized_header);
-            if self.received_block_headers.contains(&digest) {
+            if let Some((author, round, timestamp_ms)) = self.received_block_headers.get(&digest) {
                 self.context
                     .metrics
                     .node_metrics
                     .filtered_headers_in_bundles
                     .with_label_values(&[peer_hostname, "handle_subscribed_block_bundle"])
                     .inc();
-                // The parse cannot fail — the filter hit proves these bytes
-                // were deserialized before; skip the sample if it somehow
-                // does. The in-bundle round bound applies to duplicates too:
+                // The in-bundle round bound applies to duplicates too:
                 // together with the connect ceiling on the primary block it
                 // keeps a far-future header, whose digest enters the filter
                 // when its block is dropped, from being replayed as a
                 // near-zero-latency sample.
-                if let Ok(signed_block_header) =
-                    bcs::from_bytes::<SignedBlockHeader>(&serialized_header)
-                {
-                    if signed_block_header.round() < block_round {
-                        duplicate_block_headers.push(
-                            VerifiedBlockHeader::new_verified_with_digest(
-                                signed_block_header,
-                                serialized_header,
-                                digest,
-                            ),
-                        );
-                    }
+                if round < block_round {
+                    duplicate_header_deliveries.push((author, round, timestamp_ms));
                 }
                 continue;
             }
@@ -389,7 +392,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             .valid_headers_in_bundles
             .with_label_values(&[peer_hostname, "handle_subscribed_block_bundle"])
             .inc_by(additional_block_headers.len() as u64);
-        Ok((additional_block_headers, duplicate_block_headers))
+        Ok((additional_block_headers, duplicate_header_deliveries))
     }
     fn extract_shards_from_bundle(
         &self,
@@ -534,12 +537,17 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         peer_hostname: &str,
         additional_block_headers: &mut Vec<VerifiedBlockHeader>,
         block_ref: BlockRef,
+        block_timestamp_ms: BlockTimestampMs,
     ) {
-        let mut digests_to_add_to_filter = vec![];
+        let mut digests_to_add_to_filter = Vec::with_capacity(additional_block_headers.len() + 1);
         for block_header in additional_block_headers.iter() {
-            digests_to_add_to_filter.push(block_header.digest())
+            digests_to_add_to_filter
+                .push((block_header.digest(), filtered_header_info(block_header)))
         }
-        digests_to_add_to_filter.push(block_ref.digest);
+        digests_to_add_to_filter.push((
+            block_ref.digest,
+            (block_ref.author, block_ref.round, block_timestamp_ms),
+        ));
         let digests_to_exclude = self
             .received_block_headers
             .add_batch(digests_to_add_to_filter)
@@ -789,8 +797,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let gen_transaction_ref = GenericTransactionRef::from(transaction_ref);
         // 2. Record timestamp drift metric (NEW mode - no waiting or rejection)
         let now = self.context.clock.timestamp_utc_ms();
-        let forward_time_drift =
-            Duration::from_millis(verified_block.timestamp_ms().saturating_sub(now));
+        let block_timestamp_ms = verified_block.timestamp_ms();
+        let forward_time_drift = Duration::from_millis(block_timestamp_ms.saturating_sub(now));
         self.context
             .metrics
             .node_metrics
@@ -798,7 +806,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
             .inc_by(forward_time_drift.as_millis() as u64);
         let latency_to_process_stream =
-            Duration::from_millis(now.saturating_sub(verified_block.timestamp_ms()));
+            Duration::from_millis(now.saturating_sub(block_timestamp_ms));
         self.context
             .metrics
             .node_metrics
@@ -815,7 +823,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         let serialized_headers =
             std::mem::take(&mut serialized_block_bundle_parts.serialized_headers);
-        let (mut additional_block_headers, duplicate_block_headers) = self
+        let (mut additional_block_headers, duplicate_header_deliveries) = self
             .extract_additional_block_headers_from_bundle(
                 peer,
                 peer_hostname,
@@ -918,43 +926,31 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname])
             .inc();
 
-        // Sample the streaming responsiveness table once per author, from the
-        // newest header of that author in this bundle: a bundle is one
-        // delivery event, and how old that newest header is says how current
-        // the peer is on that author. Headers the digest filter already saw
-        // count too: sampling only first deliveries would record nothing for
-        // a peer that is consistently second and only race-winning latencies
-        // for the rest, while a re-delivery cannot make a peer look fast
-        // because the latency reference is the author's own timestamp.
-        let mut newest_per_author: Vec<Option<&VerifiedBlockHeader>> =
-            vec![None; self.context.committee.size()];
-        for header in additional_block_headers
-            .iter()
-            .chain(duplicate_block_headers.iter())
-        {
-            let newest = &mut newest_per_author[header.author()];
-            if newest.is_none_or(|current| current.round() < header.round()) {
-                *newest = Some(header);
-            }
+        // Sample the streaming responsiveness table from this bundle's
+        // headers, the duplicates the digest filter already saw included; the
+        // sampling rules live on `record_streaming_header_deliveries`.
+        if !additional_block_headers.is_empty() || !duplicate_header_deliveries.is_empty() {
+            self.context
+                .peer_responsiveness
+                .record_streaming_header_deliveries(
+                    peer,
+                    now,
+                    additional_block_headers
+                        .iter()
+                        .map(filtered_header_info)
+                        .chain(duplicate_header_deliveries),
+                );
         }
-        let deliveries = newest_per_author
-            .into_iter()
-            .flatten()
-            .map(|header| {
-                (
-                    header.author(),
-                    Duration::from_millis(now.saturating_sub(header.timestamp_ms())),
-                )
-            })
-            .collect::<Vec<_>>();
-        self.context
-            .peer_responsiveness
-            .record_streaming_header_deliveries(peer, &deliveries);
 
         // 8. Add digests to filter. Exclude from the vector those that are already
         //    inserted
-        self.add_digests_to_filter(peer_hostname, &mut additional_block_headers, block_ref)
-            .await;
+        self.add_digests_to_filter(
+            peer_hostname,
+            &mut additional_block_headers,
+            block_ref,
+            block_timestamp_ms,
+        )
+        .await;
 
         // 9. Prepare transaction messages for shard reconstructor and send them.
         // Skipped for a dropped primary block (no shards were collected).
@@ -3051,7 +3047,7 @@ mod tests {
             DagBuilder::new(context.clone()).set_protocol_keypair(protocol_keypairs);
         dag_builder.layers(1..=rounds).build();
         let mut all_headers: Vec<Vec<VerifiedBlockHeader>> = vec![];
-        let mut all_transactions: Vec<Vec<VerifiedTransactions>> = vec![];
+        let mut all_transactions: Vec<Vec<CommitmentVerifiedTransactions>> = vec![];
         for round in 0..=rounds {
             all_headers.push(dag_builder.block_headers(round..=round));
             all_transactions.push(dag_builder.transactions(round..=round));

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -56,10 +56,8 @@ pub(crate) const COMMIT_LAG_MULTIPLIER: u32 = 5;
 
 const MAX_FILTER_SIZE: u32 = 100000;
 
-/// The author, round and timestamp of a header whose digest is in
-/// [`FilterForHeaders`], recorded when the verified header was inserted so a
-/// re-delivered copy can be sampled for responsiveness without being
-/// deserialized again.
+/// Author, round and timestamp of a filtered header, recorded when it was
+/// inserted so a re-delivered copy is sampled without deserializing it again.
 type FilteredHeaderInfo = (AuthorityIndex, Round, BlockTimestampMs);
 
 fn filtered_header_info(header: &VerifiedBlockHeader) -> FilteredHeaderInfo {
@@ -296,12 +294,9 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
     }
 
     /// Deserializes and verifies the additional headers of a bundle. Returns
-    /// the fresh headers, to be accepted into the DAG, and separately the
-    /// author, round and timestamp of each header received before (its digest
-    /// is in `received_block_headers`): those still count as deliveries for
-    /// the responsiveness sampling, but must not be re-accepted. The fields of
-    /// a duplicate come from the filter, recorded when the verified header was
-    /// inserted, so a duplicate costs a lookup, not a deserialization.
+    /// the fresh headers to accept into the DAG, plus the info of the already
+    /// received ones — still deliveries for the responsiveness sampling, but
+    /// not to be re-accepted.
     fn extract_additional_block_headers_from_bundle(
         &self,
         peer: AuthorityIndex,
@@ -326,11 +321,9 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                     .filtered_headers_in_bundles
                     .with_label_values(&[peer_hostname, "handle_subscribed_block_bundle"])
                     .inc();
-                // The in-bundle round bound applies to duplicates too:
-                // together with the connect ceiling on the primary block it
-                // keeps a far-future header, whose digest enters the filter
-                // when its block is dropped, from being replayed as a
-                // near-zero-latency sample.
+                // The round bound keeps a far-future header, filtered even
+                // when its block is dropped, from replaying as a near-zero
+                // sample.
                 if round < block_round {
                     duplicate_header_deliveries.push((author, round, timestamp_ms));
                 }
@@ -926,9 +919,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname])
             .inc();
 
-        // Sample the streaming responsiveness table from this bundle's
-        // headers, the duplicates the digest filter already saw included; the
-        // sampling rules live on `record_streaming_header_deliveries`.
+        // Sample streaming responsiveness from the delivered headers,
+        // duplicates included; see `record_streaming_header_deliveries`.
         if !additional_block_headers.is_empty() || !duplicate_header_deliveries.is_empty() {
             self.context
                 .peer_responsiveness
@@ -3105,10 +3097,8 @@ mod tests {
             .await
             .expect("bundle is expected to be processed successfully");
 
-        // THEN author 3 is sampled once, from its newest header, and author 2
-        // is sampled from the only header of it in the bundle - old headers are
-        // measured too, since how old the newest one is says how current the
-        // peer is on that author.
+        // THEN author 3 is sampled from its newest header, author 2 from its
+        // only one; old headers are measured too.
         let responsiveness = &context.peer_responsiveness;
         let expected = |header: &VerifiedBlockHeader| {
             (context.clock.timestamp_utc_ms() - header.timestamp_ms()) as f64
@@ -3140,9 +3130,8 @@ mod tests {
             .await
             .expect("bundle is expected to be processed successfully");
 
-        // THEN the re-delivery is sampled like any delivery, against the same
-        // header timestamp, so a peer that is consistently second is still
-        // measured — and cannot read faster than the first delivery did.
+        // THEN the re-delivery is sampled too, against the same header
+        // timestamp.
         let resampled = responsiveness
             .streaming_header_latency_ms(peer_2, author_3)
             .expect("a re-delivery is sampled");

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -32,7 +32,7 @@ use crate::{
 /// Maximum round gap to consider a peer's useful shards/headers as still
 /// relevant. 40 rounds correspond to at least 2 second due to the minimum block
 /// delay
-const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 40;
+pub(crate) const MAX_ROUND_GAP_FOR_USEFUL_PARTS: Round = 40;
 /// Capacity of the cordial knowledge channel. For normal operation with
 /// 100 authorities, this allows buffering up to 5 seconds of headers at 20
 /// blocks/sec. When the channel is full, the sender will skip sending new

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -37,6 +37,11 @@
 //! ranking (including the failure state) and shuffles uniformly, so every peer
 //! keeps being sampled and a failed peer re-enters the ranked draw as soon as
 //! a fetch succeeds again.
+//!
+//! The block-bundle streaming path is tracked per (peer, author) rather than
+//! per peer: how fast a peer delivers a given author's headers depends on the
+//! pair, not on the peer alone. The table feeds the selection of which peers
+//! to request a missing author's headers from.
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -64,6 +69,8 @@ impl DataSource {
     /// every peer by the startup probe), then the transactions synchronizer
     /// (always populated, but its fetches are the lightest). The transactions
     /// and header synchronizers read each other, the closest scale either has.
+    /// The streaming-headers table reads the header synchronizer first (same
+    /// payload kind, seeded for every peer by the startup probe).
     fn responsiveness_fallbacks(self) -> &'static [DataSource] {
         match self {
             DataSource::CommitSyncer => &[
@@ -78,6 +85,10 @@ impl DataSource {
             ],
             DataSource::TransactionSynchronizer => &[DataSource::HeaderSynchronizerRequested],
             DataSource::HeaderSynchronizerRequested => &[DataSource::TransactionSynchronizer],
+            DataSource::BlockBundleStream => &[
+                DataSource::HeaderSynchronizerRequested,
+                DataSource::TransactionSynchronizer,
+            ],
             _ => &[],
         }
     }
@@ -90,6 +101,7 @@ impl DataSource {
             DataSource::CommitSyncer => COMMIT_SYNC_NEUTRAL_LATENCY_MS,
             DataSource::FastCommitSyncer => FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS,
             DataSource::HeaderSynchronizerRequested => HEADER_SYNC_NEUTRAL_LATENCY_MS,
+            DataSource::BlockBundleStream => STREAMING_HEADERS_NEUTRAL_LATENCY_MS,
             _ => TRANSACTIONS_SYNC_NEUTRAL_LATENCY_MS,
         }
     }
@@ -139,6 +151,12 @@ const FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS: f64 = 2_000.0;
 /// goes missing.
 const HEADER_SYNC_NEUTRAL_LATENCY_MS: f64 = 500.0;
 
+/// Neutral prior for streaming headers: what a peer's subscription bundles
+/// take to deliver another author's fresh headers, measured from the header's
+/// own timestamp — the author-to-peer hop, the wait for the peer's next
+/// bundle, and the bundle's delivery to us.
+const STREAMING_HEADERS_NEUTRAL_LATENCY_MS: f64 = 500.0;
+
 /// EWMA weight for a successful sample. Small, so the score is "slow to
 /// trust".
 const ALPHA_SUCCESS: f64 = 0.3;
@@ -159,6 +177,11 @@ struct PeerStat {
 /// [`DataSource::RESPONSIVENESS_SOURCES`] are present.
 struct Tracks {
     per_kind: HashMap<DataSource, Vec<PeerStat>>,
+    /// Latency of headers delivered through subscription bundles, indexed
+    /// `[peer][author]`: how fast a peer delivers an author's headers depends
+    /// on the pair, not on the peer alone. A cell is sampled when the peer's
+    /// bundle is the first to deliver a fresh header of that author.
+    streaming_headers: Vec<Vec<PeerStat>>,
 }
 
 /// Tracks per-peer responsiveness and ranks candidates for synchronizer peer
@@ -178,6 +201,7 @@ impl PeerResponsiveness {
                     .into_iter()
                     .map(|source| (source, vec![PeerStat::default(); size]))
                     .collect(),
+                streaming_headers: vec![vec![PeerStat::default(); size]; size],
             }),
         })
     }
@@ -215,6 +239,35 @@ impl PeerResponsiveness {
     ) {
         let sample = (timeout.as_secs_f64() * 1_000.0).max(source.neutral_latency_ms());
         self.update_failure(source, peer, sample);
+    }
+
+    /// Records the end-to-end deliveries of one bundle's headers through
+    /// `peer`'s subscription stream, as `(author, latency)` samples, under a
+    /// single lock acquisition.
+    ///
+    /// Callers must only report deliveries that were genuinely first — a
+    /// duplicate of a header another peer already delivered must not be
+    /// sampled, so a peer cannot look fast by re-sending what is already known.
+    pub(crate) fn record_streaming_header_deliveries(
+        &self,
+        peer: AuthorityIndex,
+        deliveries: impl IntoIterator<Item = (AuthorityIndex, Duration)>,
+    ) {
+        let mut tracks = self.inner.lock();
+        let Some(row) = tracks.streaming_headers.get_mut(peer.value()) else {
+            return;
+        };
+        for (author, latency) in deliveries {
+            let Some(stat) = row.get_mut(author.value()) else {
+                continue;
+            };
+            let sample = (latency.as_secs_f64() * 1_000.0).max(MIN_LATENCY_MS);
+            let new = match stat.effective_latency_ms {
+                None => sample,
+                Some(prev) => (1.0 - ALPHA_SUCCESS) * prev + ALPHA_SUCCESS * sample,
+            };
+            stat.effective_latency_ms = Some(new);
+        }
     }
 
     fn update(&self, source: DataSource, peer: AuthorityIndex, sample: f64, alpha: f64) {
@@ -347,15 +400,23 @@ impl PeerResponsiveness {
             })
             .collect();
 
-        // Healthy peers are sorted by latency (ties broken by a random key so
-        // an all-equal set, e.g. cold start, is ordered uniformly). The window
-        // of the best peers is permuted by draws with probability proportional
-        // to `1 / latency`; the rest keep their latency order. Peers whose
-        // most recent fetch failed always go last, fastest first, and re-enter
-        // the randomized draw with their next success.
+        Self::reorder_by_latency(candidates, &stats, rng);
+    }
+
+    /// Writes the ranked order back into `candidates` from per-candidate
+    /// `(effective latency, last fetch failed)` stats: healthy peers sorted by
+    /// latency (ties broken by a random key so an all-equal set, e.g. cold
+    /// start, is ordered uniformly), the [`SELECTION_WINDOW`] best permuted by
+    /// draws with probability proportional to `1 / latency`, the rest in
+    /// latency order, and failed peers last, fastest first.
+    fn reorder_by_latency<R: Rng>(
+        candidates: &mut [AuthorityIndex],
+        stats: &[(f64, bool)],
+        rng: &mut R,
+    ) {
         let mut healthy: Vec<(f64, f64, AuthorityIndex)> = Vec::new();
         let mut failed: Vec<(f64, f64, AuthorityIndex)> = Vec::new();
-        for (peer, (latency, last_fetch_failed)) in candidates.iter().zip(&stats) {
+        for (peer, (latency, last_fetch_failed)) in candidates.iter().zip(stats) {
             let entry = (*latency, rng.gen::<f64>(), *peer);
             if *last_fetch_failed {
                 failed.push(entry);
@@ -468,6 +529,20 @@ impl PeerResponsiveness {
             .get(peer.value())
             .and_then(|stat| stat.effective_latency_ms)
     }
+
+    #[cfg(test)]
+    pub(crate) fn streaming_header_latency_ms(
+        &self,
+        peer: AuthorityIndex,
+        author: AuthorityIndex,
+    ) -> Option<f64> {
+        self.inner
+            .lock()
+            .streaming_headers
+            .get(peer.value())?
+            .get(author.value())
+            .and_then(|stat| stat.effective_latency_ms)
+    }
 }
 
 #[cfg(test)]
@@ -578,6 +653,44 @@ mod tests {
             .effective_latency_ms(DataSource::TransactionSynchronizer, idx(1))
             .unwrap();
         assert!((v - 130.0).abs() < 1e-6, "got {v}");
+    }
+
+    #[test]
+    fn streaming_delivery_seeds_then_smooths_ewma() {
+        let pr = responsiveness(4);
+        pr.record_streaming_header_deliveries(idx(1), [(idx(2), ms(100))]);
+        assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(2)), Some(100.0));
+        // Second sample blends with ALPHA_SUCCESS: 0.7*100 + 0.3*200 = 130.
+        pr.record_streaming_header_deliveries(idx(1), [(idx(2), ms(200))]);
+        let v = pr.streaming_header_latency_ms(idx(1), idx(2)).unwrap();
+        assert!((v - 130.0).abs() < 1e-6, "got {v}");
+    }
+
+    #[test]
+    fn streaming_cells_are_independent() {
+        let pr = responsiveness(4);
+        // One batch spreads over the peer's row; another peer's cell for the
+        // same author is a separate measurement.
+        pr.record_streaming_header_deliveries(idx(1), [(idx(2), ms(300)), (idx(3), ms(50))]);
+        pr.record_streaming_header_deliveries(idx(3), [(idx(2), ms(700))]);
+
+        assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(2)), Some(300.0));
+        assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(3)), Some(50.0));
+        assert_eq!(pr.streaming_header_latency_ms(idx(3), idx(2)), Some(700.0));
+        assert_eq!(pr.streaming_header_latency_ms(idx(2), idx(1)), None);
+        // The table does not leak into the per-source fetch tracks.
+        assert_eq!(
+            pr.effective_latency_ms(DataSource::TransactionSynchronizer, idx(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn streaming_delivery_out_of_range_is_noop() {
+        let pr = responsiveness(4);
+        pr.record_streaming_header_deliveries(idx(200), [(idx(1), ms(50))]);
+        pr.record_streaming_header_deliveries(idx(1), [(idx(200), ms(50))]);
+        assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(1)), None);
     }
 
     #[test]

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -179,8 +179,9 @@ struct Tracks {
     per_kind: HashMap<DataSource, Vec<PeerStat>>,
     /// Latency of headers delivered through subscription bundles, indexed
     /// `[peer][author]`: how fast a peer delivers an author's headers depends
-    /// on the pair, not on the peer alone. A cell is sampled when the peer's
-    /// bundle is the first to deliver a fresh header of that author.
+    /// on the pair, not on the peer alone. A cell is sampled once per bundle
+    /// that first delivers a header of that author, from the newest such
+    /// header, so the reading is how current the peer is on that author.
     streaming_headers: Vec<Vec<PeerStat>>,
 }
 
@@ -242,22 +243,26 @@ impl PeerResponsiveness {
     }
 
     /// Records the end-to-end deliveries of one bundle's headers through
-    /// `peer`'s subscription stream, as `(author, latency)` samples, under a
-    /// single lock acquisition.
+    /// `peer`'s subscription stream. The caller computes the `(author,
+    /// latency)` samples up front so that only the writes happen under the
+    /// lock, taken once for the whole bundle.
     ///
-    /// Callers must only report deliveries that were genuinely first — a
-    /// duplicate of a header another peer already delivered must not be
-    /// sampled, so a peer cannot look fast by re-sending what is already known.
+    /// Callers must pass at most one sample per author, taken from the newest
+    /// header of that author in the bundle, so that a peer pushing a whole
+    /// chain of one author's headers is not weighted by how much it sent. Only
+    /// genuinely first deliveries may be reported — a duplicate of a header
+    /// another peer already delivered must not be sampled, so a peer cannot
+    /// look fast by re-sending what is already known.
     pub(crate) fn record_streaming_header_deliveries(
         &self,
         peer: AuthorityIndex,
-        deliveries: impl IntoIterator<Item = (AuthorityIndex, Duration)>,
+        deliveries: &[(AuthorityIndex, Duration)],
     ) {
         let mut tracks = self.inner.lock();
         let Some(row) = tracks.streaming_headers.get_mut(peer.value()) else {
             return;
         };
-        for (author, latency) in deliveries {
+        for &(author, latency) in deliveries {
             let Some(stat) = row.get_mut(author.value()) else {
                 continue;
             };
@@ -658,10 +663,10 @@ mod tests {
     #[test]
     fn streaming_delivery_seeds_then_smooths_ewma() {
         let pr = responsiveness(4);
-        pr.record_streaming_header_deliveries(idx(1), [(idx(2), ms(100))]);
+        pr.record_streaming_header_deliveries(idx(1), &[(idx(2), ms(100))]);
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(2)), Some(100.0));
         // Second sample blends with ALPHA_SUCCESS: 0.7*100 + 0.3*200 = 130.
-        pr.record_streaming_header_deliveries(idx(1), [(idx(2), ms(200))]);
+        pr.record_streaming_header_deliveries(idx(1), &[(idx(2), ms(200))]);
         let v = pr.streaming_header_latency_ms(idx(1), idx(2)).unwrap();
         assert!((v - 130.0).abs() < 1e-6, "got {v}");
     }
@@ -671,8 +676,8 @@ mod tests {
         let pr = responsiveness(4);
         // One batch spreads over the peer's row; another peer's cell for the
         // same author is a separate measurement.
-        pr.record_streaming_header_deliveries(idx(1), [(idx(2), ms(300)), (idx(3), ms(50))]);
-        pr.record_streaming_header_deliveries(idx(3), [(idx(2), ms(700))]);
+        pr.record_streaming_header_deliveries(idx(1), &[(idx(2), ms(300)), (idx(3), ms(50))]);
+        pr.record_streaming_header_deliveries(idx(3), &[(idx(2), ms(700))]);
 
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(2)), Some(300.0));
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(3)), Some(50.0));
@@ -688,8 +693,8 @@ mod tests {
     #[test]
     fn streaming_delivery_out_of_range_is_noop() {
         let pr = responsiveness(4);
-        pr.record_streaming_header_deliveries(idx(200), [(idx(1), ms(50))]);
-        pr.record_streaming_header_deliveries(idx(1), [(idx(200), ms(50))]);
+        pr.record_streaming_header_deliveries(idx(200), &[(idx(1), ms(50))]);
+        pr.record_streaming_header_deliveries(idx(1), &[(idx(200), ms(50))]);
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(1)), None);
     }
 

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -180,8 +180,9 @@ struct Tracks {
     /// Latency of headers delivered through subscription bundles, indexed
     /// `[peer][author]`: how fast a peer delivers an author's headers depends
     /// on the pair, not on the peer alone. A cell is sampled once per bundle
-    /// that first delivers a header of that author, from the newest such
-    /// header, so the reading is how current the peer is on that author.
+    /// carrying a header of that author, from the newest such header, whether
+    /// or not another peer delivered it first, so the reading is how current
+    /// the peer is on that author.
     streaming_headers: Vec<Vec<PeerStat>>,
 }
 
@@ -249,10 +250,13 @@ impl PeerResponsiveness {
     ///
     /// Callers must pass at most one sample per author, taken from the newest
     /// header of that author in the bundle, so that a peer pushing a whole
-    /// chain of one author's headers is not weighted by how much it sent. Only
-    /// genuinely first deliveries may be reported — a duplicate of a header
-    /// another peer already delivered must not be sampled, so a peer cannot
-    /// look fast by re-sending what is already known.
+    /// chain of one author's headers is not weighted by how much it sent.
+    /// Duplicates of headers another peer already delivered are reported like
+    /// any delivery: sampling only first deliveries would record nothing for
+    /// a peer that is consistently second and only race-winning latencies for
+    /// the rest. Callers must measure each sample against the header's own
+    /// timestamp, so a re-delivery cannot read faster than the genuine first
+    /// delivery did.
     pub(crate) fn record_streaming_header_deliveries(
         &self,
         peer: AuthorityIndex,

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -38,10 +38,10 @@
 //! keeps being sampled and a failed peer re-enters the ranked draw as soon as
 //! a fetch succeeds again.
 //!
-//! The block-bundle streaming path is tracked per (peer, author) rather than
-//! per peer: how fast a peer delivers a given author's headers depends on the
-//! pair, not on the peer alone. The table feeds the selection of which peers
-//! to request a missing author's headers from.
+//! The block-bundle streaming path is tracked separately, per (peer, author)
+//! pair, recorded for the upcoming selection of which peers to request a
+//! missing author's headers from; see
+//! [`PeerResponsiveness::record_streaming_header_deliveries`].
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -49,7 +49,7 @@ use parking_lot::Mutex;
 use rand::{Rng, seq::SliceRandom as _};
 use starfish_config::{AuthorityIndex, Committee};
 
-use crate::{dag_state::DataSource, metrics::Metrics};
+use crate::{Round, block_header::BlockTimestampMs, dag_state::DataSource, metrics::Metrics};
 
 impl DataSource {
     /// Fetch sources ranked by peer responsiveness. Sources not listed here are
@@ -69,8 +69,6 @@ impl DataSource {
     /// every peer by the startup probe), then the transactions synchronizer
     /// (always populated, but its fetches are the lightest). The transactions
     /// and header synchronizers read each other, the closest scale either has.
-    /// The streaming-headers table reads the header synchronizer first (same
-    /// payload kind, seeded for every peer by the startup probe).
     fn responsiveness_fallbacks(self) -> &'static [DataSource] {
         match self {
             DataSource::CommitSyncer => &[
@@ -85,10 +83,6 @@ impl DataSource {
             ],
             DataSource::TransactionSynchronizer => &[DataSource::HeaderSynchronizerRequested],
             DataSource::HeaderSynchronizerRequested => &[DataSource::TransactionSynchronizer],
-            DataSource::BlockBundleStream => &[
-                DataSource::HeaderSynchronizerRequested,
-                DataSource::TransactionSynchronizer,
-            ],
             _ => &[],
         }
     }
@@ -101,7 +95,6 @@ impl DataSource {
             DataSource::CommitSyncer => COMMIT_SYNC_NEUTRAL_LATENCY_MS,
             DataSource::FastCommitSyncer => FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS,
             DataSource::HeaderSynchronizerRequested => HEADER_SYNC_NEUTRAL_LATENCY_MS,
-            DataSource::BlockBundleStream => STREAMING_HEADERS_NEUTRAL_LATENCY_MS,
             _ => TRANSACTIONS_SYNC_NEUTRAL_LATENCY_MS,
         }
     }
@@ -151,15 +144,18 @@ const FAST_COMMIT_SYNC_NEUTRAL_LATENCY_MS: f64 = 2_000.0;
 /// goes missing.
 const HEADER_SYNC_NEUTRAL_LATENCY_MS: f64 = 500.0;
 
-/// Neutral prior for streaming headers: what a peer's subscription bundles
-/// take to deliver another author's fresh headers, measured from the header's
-/// own timestamp — the author-to-peer hop, the wait for the peer's next
-/// bundle, and the bundle's delivery to us.
-const STREAMING_HEADERS_NEUTRAL_LATENCY_MS: f64 = 500.0;
-
 /// EWMA weight for a successful sample. Small, so the score is "slow to
 /// trust".
 const ALPHA_SUCCESS: f64 = 0.3;
+
+/// Seeds or blends a smoothed latency with a new sample: the first sample
+/// becomes the value, later ones are blended with weight `alpha`.
+fn blend_latency_ms(prev: Option<f64>, sample_ms: f64, alpha: f64) -> f64 {
+    match prev {
+        None => sample_ms,
+        Some(prev) => (1.0 - alpha) * prev + alpha * sample_ms,
+    }
+}
 
 #[derive(Clone, Default)]
 struct PeerStat {
@@ -177,20 +173,20 @@ struct PeerStat {
 /// [`DataSource::RESPONSIVENESS_SOURCES`] are present.
 struct Tracks {
     per_kind: HashMap<DataSource, Vec<PeerStat>>,
-    /// Latency of headers delivered through subscription bundles, indexed
-    /// `[peer][author]`: how fast a peer delivers an author's headers depends
-    /// on the pair, not on the peer alone. A cell is sampled once per bundle
-    /// carrying a header of that author, from the newest such header, whether
-    /// or not another peer delivered it first, so the reading is how current
-    /// the peer is on that author.
-    streaming_headers: Vec<Vec<PeerStat>>,
 }
 
 /// Tracks per-peer responsiveness and ranks candidates for synchronizer peer
 /// selection. Shared per epoch.
 pub(crate) struct PeerResponsiveness {
     metrics: Arc<Metrics>,
+    committee_size: usize,
     inner: Mutex<Tracks>,
+    /// Smoothed latency of headers delivered through subscription bundles,
+    /// indexed `[peer][author]`, `None` until the first sample; see
+    /// [`Self::record_streaming_header_deliveries`]. Under its own lock: the
+    /// bundle path writes here on every received bundle and shares no data
+    /// with the per-source tracks.
+    streaming_headers: Mutex<Vec<Vec<Option<f64>>>>,
 }
 
 impl PeerResponsiveness {
@@ -198,13 +194,14 @@ impl PeerResponsiveness {
         let size = committee.size();
         Arc::new(Self {
             metrics,
+            committee_size: size,
             inner: Mutex::new(Tracks {
                 per_kind: DataSource::RESPONSIVENESS_SOURCES
                     .into_iter()
                     .map(|source| (source, vec![PeerStat::default(); size]))
                     .collect(),
-                streaming_headers: vec![vec![PeerStat::default(); size]; size],
             }),
+            streaming_headers: Mutex::new(vec![vec![None; size]; size]),
         })
     }
 
@@ -243,39 +240,48 @@ impl PeerResponsiveness {
         self.update_failure(source, peer, sample);
     }
 
-    /// Records the end-to-end deliveries of one bundle's headers through
-    /// `peer`'s subscription stream. The caller computes the `(author,
-    /// latency)` samples up front so that only the writes happen under the
-    /// lock, taken once for the whole bundle.
+    /// Records the header deliveries of one bundle received through `peer`'s
+    /// subscription stream, given as the `(author, round, timestamp)` of each
+    /// delivered header. Duplicates of headers another peer already delivered
+    /// must be reported like any delivery: sampling only first deliveries
+    /// would record nothing for a peer that is consistently second and only
+    /// race-winning latencies for the rest.
     ///
-    /// Callers must pass at most one sample per author, taken from the newest
-    /// header of that author in the bundle, so that a peer pushing a whole
-    /// chain of one author's headers is not weighted by how much it sent.
-    /// Duplicates of headers another peer already delivered are reported like
-    /// any delivery: sampling only first deliveries would record nothing for
-    /// a peer that is consistently second and only race-winning latencies for
-    /// the rest. Callers must measure each sample against the header's own
-    /// timestamp, so a re-delivery cannot read faster than the genuine first
-    /// delivery did.
+    /// One sample per author is taken, from the newest header of that author
+    /// in the bundle — a bundle is one delivery event, and how old that
+    /// newest header is says how current the peer is on that author, while a
+    /// peer pushing a whole chain is not weighted by how much it sent. The
+    /// sample is the header's own timestamp to `now_ms`, so the author's
+    /// clock bias cancels when peers are compared for one author, and a
+    /// re-delivery cannot read faster than the genuine first delivery did.
+    /// The samples are folded before the lock, which is taken once per
+    /// bundle.
     pub(crate) fn record_streaming_header_deliveries(
         &self,
         peer: AuthorityIndex,
-        deliveries: &[(AuthorityIndex, Duration)],
+        now_ms: BlockTimestampMs,
+        headers: impl IntoIterator<Item = (AuthorityIndex, Round, BlockTimestampMs)>,
     ) {
-        let mut tracks = self.inner.lock();
-        let Some(row) = tracks.streaming_headers.get_mut(peer.value()) else {
-            return;
-        };
-        for &(author, latency) in deliveries {
-            let Some(stat) = row.get_mut(author.value()) else {
+        let mut newest_per_author: Vec<Option<(Round, BlockTimestampMs)>> =
+            vec![None; self.committee_size];
+        for (author, round, timestamp_ms) in headers {
+            let Some(newest) = newest_per_author.get_mut(author.value()) else {
                 continue;
             };
-            let sample = (latency.as_secs_f64() * 1_000.0).max(MIN_LATENCY_MS);
-            let new = match stat.effective_latency_ms {
-                None => sample,
-                Some(prev) => (1.0 - ALPHA_SUCCESS) * prev + ALPHA_SUCCESS * sample,
+            if newest.is_none_or(|(current_round, _)| current_round < round) {
+                *newest = Some((round, timestamp_ms));
+            }
+        }
+        let mut table = self.streaming_headers.lock();
+        let Some(row) = table.get_mut(peer.value()) else {
+            return;
+        };
+        for (author, newest) in newest_per_author.into_iter().enumerate() {
+            let Some((_, timestamp_ms)) = newest else {
+                continue;
             };
-            stat.effective_latency_ms = Some(new);
+            let sample = (now_ms.saturating_sub(timestamp_ms) as f64).max(MIN_LATENCY_MS);
+            row[author] = Some(blend_latency_ms(row[author], sample, ALPHA_SUCCESS));
         }
     }
 
@@ -288,11 +294,8 @@ impl PeerResponsiveness {
             let Some(stat) = track.get_mut(peer.value()) else {
                 return;
             };
-            let new = match stat.effective_latency_ms {
-                None => sample,
-                Some(prev) => (1.0 - alpha) * prev + alpha * sample,
-            };
-            stat.effective_latency_ms = Some(new);
+            stat.effective_latency_ms =
+                Some(blend_latency_ms(stat.effective_latency_ms, sample, alpha));
             stat.last_fetch_failed = false;
             Self::snapshot(track)
         };
@@ -545,12 +548,11 @@ impl PeerResponsiveness {
         peer: AuthorityIndex,
         author: AuthorityIndex,
     ) -> Option<f64> {
-        self.inner
-            .lock()
+        *self
             .streaming_headers
+            .lock()
             .get(peer.value())?
-            .get(author.value())
-            .and_then(|stat| stat.effective_latency_ms)
+            .get(author.value())?
     }
 }
 
@@ -667,21 +669,30 @@ mod tests {
     #[test]
     fn streaming_delivery_seeds_then_smooths_ewma() {
         let pr = responsiveness(4);
-        pr.record_streaming_header_deliveries(idx(1), &[(idx(2), ms(100))]);
+        pr.record_streaming_header_deliveries(idx(1), 1_000, [(idx(2), 1, 900)]);
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(2)), Some(100.0));
         // Second sample blends with ALPHA_SUCCESS: 0.7*100 + 0.3*200 = 130.
-        pr.record_streaming_header_deliveries(idx(1), &[(idx(2), ms(200))]);
+        pr.record_streaming_header_deliveries(idx(1), 1_400, [(idx(2), 2, 1_200)]);
         let v = pr.streaming_header_latency_ms(idx(1), idx(2)).unwrap();
         assert!((v - 130.0).abs() < 1e-6, "got {v}");
     }
 
     #[test]
+    fn streaming_delivery_samples_newest_header_per_author() {
+        let pr = responsiveness(4);
+        // A chain of one author's headers in one bundle is one sample, from
+        // the newest header by round, regardless of order.
+        pr.record_streaming_header_deliveries(idx(1), 1_000, [(idx(2), 5, 950), (idx(2), 2, 100)]);
+        assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(2)), Some(50.0));
+    }
+
+    #[test]
     fn streaming_cells_are_independent() {
         let pr = responsiveness(4);
-        // One batch spreads over the peer's row; another peer's cell for the
+        // One bundle spreads over the peer's row; another peer's cell for the
         // same author is a separate measurement.
-        pr.record_streaming_header_deliveries(idx(1), &[(idx(2), ms(300)), (idx(3), ms(50))]);
-        pr.record_streaming_header_deliveries(idx(3), &[(idx(2), ms(700))]);
+        pr.record_streaming_header_deliveries(idx(1), 1_000, [(idx(2), 1, 700), (idx(3), 1, 950)]);
+        pr.record_streaming_header_deliveries(idx(3), 1_000, [(idx(2), 1, 300)]);
 
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(2)), Some(300.0));
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(3)), Some(50.0));
@@ -697,8 +708,8 @@ mod tests {
     #[test]
     fn streaming_delivery_out_of_range_is_noop() {
         let pr = responsiveness(4);
-        pr.record_streaming_header_deliveries(idx(200), &[(idx(1), ms(50))]);
-        pr.record_streaming_header_deliveries(idx(1), &[(idx(200), ms(50))]);
+        pr.record_streaming_header_deliveries(idx(200), 1_000, [(idx(1), 1, 900)]);
+        pr.record_streaming_header_deliveries(idx(1), 1_000, [(idx(200), 1, 900)]);
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(1)), None);
     }
 

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -39,9 +39,7 @@
 //! a fetch succeeds again.
 //!
 //! The block-bundle streaming path is tracked separately, per (peer, author)
-//! pair, recorded for the upcoming selection of which peers to request a
-//! missing author's headers from; see
-//! [`PeerResponsiveness::record_streaming_header_deliveries`].
+//! pair; see [`PeerResponsiveness::record_streaming_header_deliveries`].
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -148,8 +146,8 @@ const HEADER_SYNC_NEUTRAL_LATENCY_MS: f64 = 500.0;
 /// trust".
 const ALPHA_SUCCESS: f64 = 0.3;
 
-/// Seeds or blends a smoothed latency with a new sample: the first sample
-/// becomes the value, later ones are blended with weight `alpha`.
+/// First sample seeds the value; later ones are EWMA-blended with weight
+/// `alpha`.
 fn blend_latency_ms(prev: Option<f64>, sample_ms: f64, alpha: f64) -> f64 {
     match prev {
         None => sample_ms,
@@ -181,11 +179,7 @@ pub(crate) struct PeerResponsiveness {
     metrics: Arc<Metrics>,
     committee_size: usize,
     inner: Mutex<Tracks>,
-    /// Smoothed latency of headers delivered through subscription bundles,
-    /// indexed `[peer][author]`, `None` until the first sample; see
-    /// [`Self::record_streaming_header_deliveries`]. Under its own lock: the
-    /// bundle path writes here on every received bundle and shares no data
-    /// with the per-source tracks.
+    /// Smoothed streaming-delivery latency, indexed `[peer][author]`.
     streaming_headers: Mutex<Vec<Vec<Option<f64>>>>,
 }
 
@@ -240,22 +234,12 @@ impl PeerResponsiveness {
         self.update_failure(source, peer, sample);
     }
 
-    /// Records the header deliveries of one bundle received through `peer`'s
-    /// subscription stream, given as the `(author, round, timestamp)` of each
-    /// delivered header. Duplicates of headers another peer already delivered
-    /// must be reported like any delivery: sampling only first deliveries
-    /// would record nothing for a peer that is consistently second and only
-    /// race-winning latencies for the rest.
-    ///
-    /// One sample per author is taken, from the newest header of that author
-    /// in the bundle — a bundle is one delivery event, and how old that
-    /// newest header is says how current the peer is on that author, while a
-    /// peer pushing a whole chain is not weighted by how much it sent. The
-    /// sample is the header's own timestamp to `now_ms`, so the author's
-    /// clock bias cancels when peers are compared for one author, and a
-    /// re-delivery cannot read faster than the genuine first delivery did.
-    /// The samples are folded before the lock, which is taken once per
-    /// bundle.
+    /// Records one bundle's header deliveries from `peer`, duplicates
+    /// included — sampling only first deliveries would leave a consistently
+    /// second peer unmeasured. One sample per author, from its newest header,
+    /// measured from the header's own timestamp to `now_ms`: the author's
+    /// clock bias cancels across peers and a re-delivery cannot read fast.
+    /// The lock is taken once per bundle.
     pub(crate) fn record_streaming_header_deliveries(
         &self,
         peer: AuthorityIndex,
@@ -416,11 +400,8 @@ impl PeerResponsiveness {
     }
 
     /// Writes the ranked order back into `candidates` from per-candidate
-    /// `(effective latency, last fetch failed)` stats: healthy peers sorted by
-    /// latency (ties broken by a random key so an all-equal set, e.g. cold
-    /// start, is ordered uniformly), the [`SELECTION_WINDOW`] best permuted by
-    /// draws with probability proportional to `1 / latency`, the rest in
-    /// latency order, and failed peers last, fastest first.
+    /// `(effective latency, last fetch failed)` stats; the ordering rules are
+    /// described on [`Self::prioritize`].
     fn reorder_by_latency<R: Rng>(
         candidates: &mut [AuthorityIndex],
         stats: &[(f64, bool)],
@@ -680,8 +661,7 @@ mod tests {
     #[test]
     fn streaming_delivery_samples_newest_header_per_author() {
         let pr = responsiveness(4);
-        // A chain of one author's headers in one bundle is one sample, from
-        // the newest header by round, regardless of order.
+        // One sample per author, from its newest header, regardless of order.
         pr.record_streaming_header_deliveries(idx(1), 1_000, [(idx(2), 5, 950), (idx(2), 2, 100)]);
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(2)), Some(50.0));
     }
@@ -689,8 +669,7 @@ mod tests {
     #[test]
     fn streaming_cells_are_independent() {
         let pr = responsiveness(4);
-        // One bundle spreads over the peer's row; another peer's cell for the
-        // same author is a separate measurement.
+        // Each (peer, author) cell is a separate measurement.
         pr.record_streaming_header_deliveries(idx(1), 1_000, [(idx(2), 1, 700), (idx(3), 1, 950)]);
         pr.record_streaming_header_deliveries(idx(3), 1_000, [(idx(2), 1, 300)]);
 


### PR DESCRIPTION
# Description of change

Adds a per-(peer, author) latency table for the block-bundle streaming path to the peer responsiveness module. How fast a peer delivers a given author's headers depends on the pair — how early the peer learns that author's blocks and how fast its bundles reach us — so a single per-peer value cannot rank supplier candidates.

- A cell is sampled once per bundle carrying a header of that author, from the newest such header: a bundle is one delivery event, and how old that newest header is says how current the peer is on that author
- Duplicates of headers another peer already delivered are sampled too: sampling only first deliveries would record nothing for a peer that is consistently second and only race-winning latencies for the rest. The digest filter stores each header's author, round and timestamp when the verified header is inserted, so a duplicate costs a lookup instead of a deserialization, and the in-bundle round bound keeps a far-future header from being replayed as a near-zero sample
- The latency reference is the author's own timestamp, so its clock bias cancels when candidates are compared for one author, and a re-delivery cannot read faster than the genuine first delivery did
- One bundle's samples are recorded in a single batched call (one lock acquisition on the bundle path); the ranking machinery shared with `prioritize` is factored out for the upcoming consumer

Stacked on #12622.

### Where this is heading

This is the first step of a revision of the cordial knowledge mechanism. Today, once an author lags, every peer ends up pushing that author's headers to the same node simultaneously. The end state: a node advertises a missing author to only a few peers, chosen as the fastest deliverers of that author's headers, and a peer is credited as useful only for headers it genuinely delivered first. This PR adds the measurement those choices will be based on; the follow-up PRs change the usefulness crediting and bound the number of suppliers per author.

## Links to any relevant issues

Fixes #12639
Part of #12679

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
