### PR TITLE
upstream: [graphql] Port header map ordering fix and clever error codes (#10835)

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -125,11 +125,11 @@ Response: {
 task 16, lines 66-71:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
-    "content-type": "application/graphql-response+json",
-    "x-iota-rpc-version": "1.30.0-testing-no-sha",
-    "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
     "content-length": "157",
+    "content-type": "application/graphql-response+json",
+    "vary": "origin, access-control-request-method, access-control-request-headers",
+    "x-iota-rpc-version": "1.30.0-testing-no-sha",
 }
 Service version: 1.30.0-testing-no-sha
 Response: {

--- a/crates/iota-graphql-e2e-tests/tests/errors/clever_errors.move
+++ b/crates/iota-graphql-e2e-tests/tests/errors/clever_errors.move
@@ -36,6 +36,9 @@ module P0::m {
     #[error]
     const ImNotAString: vector<u64> = vector[1,2,3,4,5];
 
+    #[error(code=1)]
+    const StringWithCode: vector<u8> = b"This is a string with code attached";
+
     public fun callU8() {
         abort ImAU8
     }
@@ -72,6 +75,14 @@ module P0::m {
         abort ImNotAString
     }
 
+    public fun callStringWithCode() {
+        abort StringWithCode
+    }
+
+    public fun callNoCodeOrConst() {
+        abort
+    }
+
     public fun normalAbort() {
         abort 0
     }
@@ -99,6 +110,10 @@ module P0::m {
 
 //# run P0::m::callU64vec
 
+//# run P0::m::callStringWithCode
+
+//# run P0::m::callNoCodeOrConst
+
 //# run P0::m::normalAbort
 
 //# run P0::m::assertLineNo
@@ -107,11 +122,12 @@ module P0::m {
 
 //# run-graphql
 {
-  transactionBlocks(last: 11) {
+  transactionBlocks(last: 13) {
     nodes {
       effects {
         status
         errors
+        abortCode
       }
     }
   }
@@ -152,6 +168,9 @@ module P0::m {
     #[error]
     const ImNotAString: vector<u64> = vector[1,2,3,4,5,6];
 
+    #[error(code=1)]
+    const StringWithCode: vector<u8> = b"This is a string with code attached v2";
+
     public fun callU8() {
         abort ImAU8
     }
@@ -186,6 +205,14 @@ module P0::m {
 
     public fun callU64vec() {
         abort ImNotAString
+    }
+
+    public fun callStringWithCode() {
+        abort StringWithCode
+    }
+
+    public fun callNoCodeOrConst() {
+        abort
     }
 
     public fun normalAbort() {
@@ -228,6 +255,7 @@ module P0::m {
       effects {
         status
         errors
+        abortCode
       }
     }
   }

--- a/crates/iota-graphql-e2e-tests/tests/errors/clever_errors.snap
+++ b/crates/iota-graphql-e2e-tests/tests/errors/clever_errors.snap
@@ -1,77 +1,87 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 29 tasks
+processed 31 tasks
 
 init:
 A: object(0,0)
 
-task 1, lines 7-82:
+task 1, lines 7-93:
 //# publish --upgradeable --sender A
 created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9728000, storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10769200, storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 84:
+task 2, line 95:
 //# run P0::m::callU8
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834303192399873
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834303192399873; caused by: VMError with status ABORTED with sub status 13906834303192399873 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU8 at offset 1 at code offset 1 in function definition 0; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834311782334465
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834311782334465; caused by: VMError with status ABORTED with sub status 13906834311782334465 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU8 at offset 1 at code offset 1 in function definition 0; at command index: 0
 
-task 3, line 86:
+task 3, line 97:
 //# run P0::m::callU16
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834316077432835
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834316077432835; caused by: VMError with status ABORTED with sub status 13906834316077432835 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU16 at offset 1 at code offset 1 in function definition 1; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834324667367427
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834324667367427; caused by: VMError with status ABORTED with sub status 13906834324667367427 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU16 at offset 1 at code offset 1 in function definition 1; at command index: 0
 
-task 4, line 88:
+task 4, line 99:
 //# run P0::m::callU32
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834328962465797
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834328962465797; caused by: VMError with status ABORTED with sub status 13906834328962465797 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU32 at offset 1 at code offset 1 in function definition 2; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834337552400389
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834337552400389; caused by: VMError with status ABORTED with sub status 13906834337552400389 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU32 at offset 1 at code offset 1 in function definition 2; at command index: 0
 
-task 5, line 90:
+task 5, line 101:
 //# run P0::m::callU64
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834341847498759
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834341847498759; caused by: VMError with status ABORTED with sub status 13906834341847498759 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU64 at offset 1 at code offset 1 in function definition 3; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834350437433351
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834350437433351; caused by: VMError with status ABORTED with sub status 13906834350437433351 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU64 at offset 1 at code offset 1 in function definition 3; at command index: 0
 
-task 6, line 92:
+task 6, line 103:
 //# run P0::m::callU128
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834354732531721
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834354732531721; caused by: VMError with status ABORTED with sub status 13906834354732531721 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU128 at offset 1 at code offset 1 in function definition 4; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834363322466313
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834363322466313; caused by: VMError with status ABORTED with sub status 13906834363322466313 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU128 at offset 1 at code offset 1 in function definition 4; at command index: 0
 
-task 7, line 94:
+task 7, line 105:
 //# run P0::m::callU256
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834367617564683
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834367617564683; caused by: VMError with status ABORTED with sub status 13906834367617564683 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU256 at offset 1 at code offset 1 in function definition 5; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834376207499275
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834376207499275; caused by: VMError with status ABORTED with sub status 13906834376207499275 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU256 at offset 1 at code offset 1 in function definition 5; at command index: 0
 
-task 8, line 96:
+task 8, line 107:
 //# run P0::m::callAddress
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834380502728719
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834380502728719; caused by: VMError with status ABORTED with sub status 13906834380502728719 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callAddress at offset 1 at code offset 1 in function definition 6; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834389092663311
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834389092663311; caused by: VMError with status ABORTED with sub status 13906834389092663311 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callAddress at offset 1 at code offset 1 in function definition 6; at command index: 0
 
-task 9, line 98:
+task 9, line 109:
 //# run P0::m::callString
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834393387761681
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834393387761681; caused by: VMError with status ABORTED with sub status 13906834393387761681 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callString at offset 1 at code offset 1 in function definition 7; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834401977696273
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834401977696273; caused by: VMError with status ABORTED with sub status 13906834401977696273 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callString at offset 1 at code offset 1 in function definition 7; at command index: 0
 
-task 10, line 100:
+task 10, line 111:
 //# run P0::m::callU64vec
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834406272794643
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834406272794643; caused by: VMError with status ABORTED with sub status 13906834406272794643 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU64vec at offset 1 at code offset 1 in function definition 8; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834414862729235
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834414862729235; caused by: VMError with status ABORTED with sub status 13906834414862729235 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callU64vec at offset 1 at code offset 1 in function definition 8; at command index: 0
 
-task 11, line 102:
+task 11, line 113:
+//# run P0::m::callStringWithCode
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callStringWithCode (function index 9) at offset 1, Abort Code: 13835339783663255573
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callStringWithCode (function index 9) at offset 1, Abort Code: 13835339783663255573; caused by: VMError with status ABORTED with sub status 13835339783663255573 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callStringWithCode at offset 1 at code offset 1 in function definition 9; at command index: 0
+
+task 12, line 115:
+//# run P0::m::callNoCodeOrConst
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callNoCodeOrConst (function index 10) at offset 1, Abort Code: 13906834444926320639
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callNoCodeOrConst (function index 10) at offset 1, Abort Code: 13906834444926320639; caused by: VMError with status ABORTED with sub status 13906834444926320639 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::callNoCodeOrConst at offset 1 at code offset 1 in function definition 10; at command index: 0
+
+task 13, line 117:
 //# run P0::m::normalAbort
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::normalAbort (function index 9) at offset 1, Abort Code: 0
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::normalAbort (function index 9) at offset 1, Abort Code: 0; caused by: VMError with status ABORTED with sub status 0 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::normalAbort at offset 1 at code offset 1 in function definition 9; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::normalAbort (function index 11) at offset 1, Abort Code: 0
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::normalAbort (function index 11) at offset 1, Abort Code: 0; caused by: VMError with status ABORTED with sub status 0 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::normalAbort at offset 1 at code offset 1 in function definition 11; at command index: 0
 
-task 12, line 104:
+task 14, line 119:
 //# run P0::m::assertLineNo
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::assertLineNo (function index 10) at offset 1, Abort Code: 13906834436336386047
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::assertLineNo (function index 10) at offset 1, Abort Code: 13906834436336386047; caused by: VMError with status ABORTED with sub status 13906834436336386047 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::assertLineNo at offset 1 at code offset 1 in function definition 10; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::assertLineNo (function index 12) at offset 1, Abort Code: 13906834470696124415
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::assertLineNo (function index 12) at offset 1, Abort Code: 13906834470696124415; caused by: VMError with status ABORTED with sub status 13906834470696124415 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::assertLineNo at offset 1 at code offset 1 in function definition 12; at command index: 0
 
-task 13, line 106:
+task 15, line 121:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 14, lines 108-118:
+task 16, lines 123-134:
 //# run-graphql
 Response: {
   "data": {
@@ -79,67 +89,92 @@ Response: {
       "nodes": [
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callU8' (line 30), abort 'ImAU8': 0",
+            "abortCode": "13906834311782334465",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callU8' (line 32), abort 'ImAU8': 0",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callU16' (line 33), abort 'ImAU16': 1",
+            "abortCode": "13906834324667367427",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callU16' (line 35), abort 'ImAU16': 1",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callU32' (line 36), abort 'ImAU32': 2",
+            "abortCode": "13906834337552400389",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callU32' (line 38), abort 'ImAU32': 2",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callU64' (line 39), abort 'ImAU64': 3",
+            "abortCode": "13906834350437433351",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callU64' (line 41), abort 'ImAU64': 3",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callU128' (line 42), abort 'ImAU128': 4",
+            "abortCode": "13906834363322466313",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callU128' (line 44), abort 'ImAU128': 4",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callU256' (line 45), abort 'ImAU256': 5",
+            "abortCode": "13906834376207499275",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callU256' (line 47), abort 'ImAU256': 5",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callAddress' (line 48), abort 'ImAnAddress': 0x0000000000000000000000000000000000000000000000000000000000000006",
+            "abortCode": "13906834389092663311",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callAddress' (line 50), abort 'ImAnAddress': 0x0000000000000000000000000000000000000000000000000000000000000006",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callString' (line 51), abort 'ImAString': This is a string",
+            "abortCode": "13906834401977696273",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callString' (line 53), abort 'ImAString': This is a string",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::callU64vec' (line 54), abort 'ImNotAString': BQEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAA=",
+            "abortCode": "13906834414862729235",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callU64vec' (line 56), abort 'ImNotAString': BQEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAA=",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::normalAbort' (instruction 1), abort code: 0",
+            "abortCode": "1",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callStringWithCode' (line 59), abort(code = 1) 'StringWithCode': This is a string with code attached",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x51dcb287d03b54a4d0c860c5f08819418d13328deff5f58a5f1ceae1b9379a17::m::assertLineNo' (line 60)",
+            "abortCode": "13906834444926320639",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::callNoCodeOrConst' (line 62)",
+            "status": "FAILURE"
+          }
+        },
+        {
+          "effects": {
+            "abortCode": "0",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::normalAbort' (instruction 1), abort code: 0",
+            "status": "FAILURE"
+          }
+        },
+        {
+          "effects": {
+            "abortCode": "13906834470696124415",
+            "errors": "Error in 1st command, from '0x2a362015ddb47ad0e905a84b4d7563eb365441feec7737540ac78dfe2c9d3ce6::m::assertLineNo' (line 68)",
             "status": "FAILURE"
           }
         }
@@ -148,72 +183,72 @@ Response: {
   }
 }
 
-task 15, lines 120-198:
+task 17, lines 136-225:
 //# upgrade --package P0 --upgrade-capability 1,0 --sender A
-created: object(15,0)
+created: object(17,0)
 mutated: object(0,0), object(1,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9834400, storage_rebate: 2606800, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10898400, storage_rebate: 2606800, non_refundable_storage_fee: 0
 
-task 16, line 200:
+task 18, line 227:
 //# run P0::m::callU8
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834801408606209
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834801408606209; caused by: VMError with status ABORTED with sub status 13906834801408606209 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU8 at offset 1 at code offset 1 in function definition 0; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834878718017537
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834878718017537; caused by: VMError with status ABORTED with sub status 13906834878718017537 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU8 at offset 1 at code offset 1 in function definition 0; at command index: 0
 
-task 17, line 202:
+task 19, line 229:
 //# run P0::m::callU16
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834814293639171
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834814293639171; caused by: VMError with status ABORTED with sub status 13906834814293639171 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU16 at offset 1 at code offset 1 in function definition 1; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834891603050499
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834891603050499; caused by: VMError with status ABORTED with sub status 13906834891603050499 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU16 at offset 1 at code offset 1 in function definition 1; at command index: 0
 
-task 18, line 204:
+task 20, line 231:
 //# run P0::m::callU32
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834827178672133
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834827178672133; caused by: VMError with status ABORTED with sub status 13906834827178672133 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU32 at offset 1 at code offset 1 in function definition 2; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834904488083461
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834904488083461; caused by: VMError with status ABORTED with sub status 13906834904488083461 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU32 at offset 1 at code offset 1 in function definition 2; at command index: 0
 
-task 19, line 206:
+task 21, line 233:
 //# run P0::m::callU64
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834840063705095
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834840063705095; caused by: VMError with status ABORTED with sub status 13906834840063705095 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU64 at offset 1 at code offset 1 in function definition 3; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834917373116423
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834917373116423; caused by: VMError with status ABORTED with sub status 13906834917373116423 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU64 at offset 1 at code offset 1 in function definition 3; at command index: 0
 
-task 20, line 208:
+task 22, line 235:
 //# run P0::m::callU128
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834852948738057
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834852948738057; caused by: VMError with status ABORTED with sub status 13906834852948738057 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU128 at offset 1 at code offset 1 in function definition 4; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834930258149385
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834930258149385; caused by: VMError with status ABORTED with sub status 13906834930258149385 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU128 at offset 1 at code offset 1 in function definition 4; at command index: 0
 
-task 21, line 210:
+task 23, line 237:
 //# run P0::m::callU256
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834865833771019
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834865833771019; caused by: VMError with status ABORTED with sub status 13906834865833771019 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU256 at offset 1 at code offset 1 in function definition 5; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834943143182347
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834943143182347; caused by: VMError with status ABORTED with sub status 13906834943143182347 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU256 at offset 1 at code offset 1 in function definition 5; at command index: 0
 
-task 22, line 212:
+task 24, line 239:
 //# run P0::m::callAddress
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834878718935055
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834878718935055; caused by: VMError with status ABORTED with sub status 13906834878718935055 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callAddress at offset 1 at code offset 1 in function definition 6; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834956028346383
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834956028346383; caused by: VMError with status ABORTED with sub status 13906834956028346383 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callAddress at offset 1 at code offset 1 in function definition 6; at command index: 0
 
-task 23, line 214:
+task 25, line 241:
 //# run P0::m::callString
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834891603968017
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834891603968017; caused by: VMError with status ABORTED with sub status 13906834891603968017 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callString at offset 1 at code offset 1 in function definition 7; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834968913379345
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834968913379345; caused by: VMError with status ABORTED with sub status 13906834968913379345 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callString at offset 1 at code offset 1 in function definition 7; at command index: 0
 
-task 24, line 216:
+task 26, line 243:
 //# run P0::m::callU64vec
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834904489000979
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834904489000979; caused by: VMError with status ABORTED with sub status 13906834904489000979 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU64vec at offset 1 at code offset 1 in function definition 8; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834981798412307
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834981798412307; caused by: VMError with status ABORTED with sub status 13906834981798412307 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::callU64vec at offset 1 at code offset 1 in function definition 8; at command index: 0
 
-task 25, line 218:
+task 27, line 245:
 //# run P0::m::normalAbort
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::normalAbort (function index 9) at offset 1, Abort Code: 0
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::normalAbort (function index 9) at offset 1, Abort Code: 0; caused by: VMError with status ABORTED with sub status 0 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::normalAbort at offset 1 at code offset 1 in function definition 9; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::normalAbort (function index 11) at offset 1, Abort Code: 0
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::normalAbort (function index 11) at offset 1, Abort Code: 0; caused by: VMError with status ABORTED with sub status 0 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::normalAbort at offset 1 at code offset 1 in function definition 11; at command index: 0
 
-task 26, line 220:
+task 28, line 247:
 //# run P0::m::assertLineNo
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::assertLineNo (function index 10) at offset 1, Abort Code: 13906834934552592383
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::assertLineNo (function index 10) at offset 1, Abort Code: 13906834934552592383; caused by: VMError with status ABORTED with sub status 13906834934552592383 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::assertLineNo at offset 1 at code offset 1 in function definition 10; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::assertLineNo (function index 12) at offset 1, Abort Code: 13906835037631807487
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::assertLineNo (function index 12) at offset 1, Abort Code: 13906835037631807487; caused by: VMError with status ABORTED with sub status 13906835037631807487 at location Module ModuleId { address: fake(1,1), name: Identifier("m") } and message fake(1,1)::m::assertLineNo at offset 1 at code offset 1 in function definition 12; at command index: 0
 
-task 27, line 222:
+task 29, line 249:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 28, lines 224-234:
+task 30, lines 251-262:
 //# run-graphql
 Response: {
   "data": {
@@ -221,55 +256,64 @@ Response: {
       "nodes": [
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU32' (line 152), abort 'ImAU32': 9",
+            "abortCode": "13906834904488083461",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::callU32' (line 170), abort 'ImAU32': 9",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU64' (line 155), abort 'ImAU64': 10",
+            "abortCode": "13906834917373116423",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::callU64' (line 173), abort 'ImAU64': 10",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU128' (line 158), abort 'ImAU128': 11",
+            "abortCode": "13906834930258149385",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::callU128' (line 176), abort 'ImAU128': 11",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU256' (line 161), abort 'ImAU256': 12",
+            "abortCode": "13906834943143182347",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::callU256' (line 179), abort 'ImAU256': 12",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callAddress' (line 164), abort 'ImAnAddress': 0x000000000000000000000000000000000000000000000000000000000000000d",
+            "abortCode": "13906834956028346383",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::callAddress' (line 182), abort 'ImAnAddress': 0x000000000000000000000000000000000000000000000000000000000000000d",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callString' (line 167), abort 'ImAString': This is a string in v2",
+            "abortCode": "13906834968913379345",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::callString' (line 185), abort 'ImAString': This is a string in v2",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::callU64vec' (line 170), abort 'ImNotAString': BgEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAAGAAAAAAAAAA==",
+            "abortCode": "13906834981798412307",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::callU64vec' (line 188), abort 'ImNotAString': BgEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAABQAAAAAAAAAGAAAAAAAAAA==",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::normalAbort' (instruction 1), abort code: 0",
+            "abortCode": "0",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::normalAbort' (instruction 1), abort code: 0",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x284c0b3b3bfadc4a177f2cc291443cf3934083e7ba7b5ad4689b646857563dd9::m::assertLineNo' (line 176)",
+            "abortCode": "13906835037631807487",
+            "errors": "Error in 1st command, from '0x09ce5ca031d4671c5a972d43621619b7c23ca23ae72594291bf42143905adab1::m::assertLineNo' (line 200)",
             "status": "FAILURE"
           }
         }

--- a/crates/iota-graphql-e2e-tests/tests/errors/clever_errors_in_macros.move
+++ b/crates/iota-graphql-e2e-tests/tests/errors/clever_errors_in_macros.move
@@ -10,8 +10,15 @@ module P0::m {
         assert!(false, EMsg) // putting this early to make the line number clear
     }
 
+    macro fun const_assert_with_code() {
+        assert!(false, ECodedError) // putting this early to make the line number clear
+    }
+
     #[error]
     const EMsg: vector<u8> = b"This is a string";
+
+    #[error(code = 1)]
+    const ECodedError: vector<u8> = b"Coded clever error";
 
     macro fun a() {
         assert!(false)
@@ -32,6 +39,10 @@ module P0::m {
     entry fun t_const_assert() {
         const_assert!() // this assert will _not_ have its line number changed
     }
+
+    entry fun t_const_assert_with_code() {
+        const_assert_with_code!() // assert should point to this line
+    }
 }
 
 //# run P0::m::t_a
@@ -40,11 +51,13 @@ module P0::m {
 
 //# run P0::m::t_const_assert
 
+//# run P0::m::t_const_assert_with_code
+
 //# create-checkpoint
 
 //# run-graphql
 {
-  transactionBlocks(last: 3) {
+  transactionBlocks(last: 4) {
     nodes {
       effects {
         status

--- a/crates/iota-graphql-e2e-tests/tests/errors/clever_errors_in_macros.snap
+++ b/crates/iota-graphql-e2e-tests/tests/errors/clever_errors_in_macros.snap
@@ -1,37 +1,42 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 7 tasks
+processed 8 tasks
 
 init:
 A: object(0,0)
 
-task 1, lines 7-35:
+task 1, lines 7-46:
 //# publish --sender A
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4180000, storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4818400, storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 37:
+task 2, line 48:
 //# run P0::m::t_a
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_a (function index 0) at offset 1, Abort Code: 13906834268832661503
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::t_a (function index 0) at offset 1, Abort Code: 13906834268832661503; caused by: VMError with status ABORTED with sub status 13906834268832661503 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::t_a at offset 1 at code offset 1 in function definition 0; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_a (function index 0) at offset 1, Abort Code: 13906834290307497983
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::t_a (function index 0) at offset 1, Abort Code: 13906834290307497983; caused by: VMError with status ABORTED with sub status 13906834290307497983 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::t_a at offset 1 at code offset 1 in function definition 0; at command index: 0
 
-task 3, line 39:
+task 3, line 50:
 //# run P0::m::t_calls_a
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_calls_a (function index 1) at offset 1, Abort Code: 13906834281717563391
-Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::t_calls_a (function index 1) at offset 1, Abort Code: 13906834281717563391; caused by: VMError with status ABORTED with sub status 13906834281717563391 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::t_calls_a at offset 1 at code offset 1 in function definition 1; at command index: 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_calls_a (function index 1) at offset 1, Abort Code: 13906834303192399871
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::t_calls_a (function index 1) at offset 1, Abort Code: 13906834303192399871; caused by: VMError with status ABORTED with sub status 13906834303192399871 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::t_calls_a at offset 1 at code offset 1 in function definition 1; at command index: 0
 
-task 4, line 41:
+task 4, line 52:
 //# run P0::m::t_const_assert
 Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_const_assert (function index 2) at offset 1, Abort Code: 13906834217293053953
 Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::t_const_assert (function index 2) at offset 1, Abort Code: 13906834217293053953; caused by: VMError with status ABORTED with sub status 13906834217293053953 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::t_const_assert at offset 1 at code offset 1 in function definition 2; at command index: 0
 
-task 5, line 43:
+task 5, line 54:
+//# run P0::m::t_const_assert_with_code
+Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_const_assert_with_code (function index 3) at offset 1, Abort Code: 13835339586093580291
+Execution Error: MoveAbort: Move Runtime Abort. Location: P0::m::t_const_assert_with_code (function index 3) at offset 1, Abort Code: 13835339586093580291; caused by: VMError with status ABORTED with sub status 13835339586093580291 at location Module ModuleId { address: P0, name: Identifier("m") } and message P0::m::t_const_assert_with_code at offset 1 at code offset 1 in function definition 3; at command index: 0
+
+task 6, line 56:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 6, lines 45-55:
+task 7, lines 58-68:
 //# run-graphql
 Response: {
   "data": {
@@ -39,19 +44,25 @@ Response: {
       "nodes": [
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x907c510b67cf9bc0cfe868250a8991c6e92eafbb1a2f10d8c6a1652c8c29ad18::m::t_a' (line 21)",
+            "errors": "Error in 1st command, from '0xf187e1912d99ad3498fe2b68b7e0173bc21bda33b9063c91860468959d449d3a::m::t_a' (line 26)",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x907c510b67cf9bc0cfe868250a8991c6e92eafbb1a2f10d8c6a1652c8c29ad18::m::t_calls_a' (line 24)",
+            "errors": "Error in 1st command, from '0xf187e1912d99ad3498fe2b68b7e0173bc21bda33b9063c91860468959d449d3a::m::t_calls_a' (line 29)",
             "status": "FAILURE"
           }
         },
         {
           "effects": {
-            "errors": "Error in 1st command, from '0x907c510b67cf9bc0cfe868250a8991c6e92eafbb1a2f10d8c6a1652c8c29ad18::m::t_const_assert' (line 10), abort 'EMsg': This is a string",
+            "errors": "Error in 1st command, from '0xf187e1912d99ad3498fe2b68b7e0173bc21bda33b9063c91860468959d449d3a::m::t_const_assert' (line 10), abort 'EMsg': This is a string",
+            "status": "FAILURE"
+          }
+        },
+        {
+          "effects": {
+            "errors": "Error in 1st command, from '0xf187e1912d99ad3498fe2b68b7e0173bc21bda33b9063c91860468959d449d3a::m::t_const_assert_with_code' (line 13), abort(code = 1) 'ECodedError': Coded clever error",
             "status": "FAILURE"
           }
         }

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -4483,6 +4483,11 @@ type TransactionBlockEffects {
 	"""
 	errors: String
 	"""
+	The error code of the Move abort, populated if this transaction failed
+	with a Move abort.
+	"""
+	abortCode: BigInt
+	"""
 	Transactions whose outputs this transaction depends upon.
 	"""
 	dependencies(first: Int, after: String, last: Int, before: String): DependencyConnection!

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -11,11 +11,17 @@ use iota_indexer::{
     optimistic_indexing::IngestionPath,
 };
 use iota_json_rpc_types::IotaExecutionStatus;
-use iota_sdk_types::{Event as NativeEvent, ExecutionStatus as NativeExecutionStatus};
+use iota_package_resolver::CleverError;
+use iota_sdk_types::{
+    Event as NativeEvent, ExecutionError as ExecutionFailureStatus,
+    ExecutionStatus as NativeExecutionStatus,
+};
 use iota_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
+    iota_sdk_types_conversions::identifier_sdk_to_core,
     transaction::TransactionData as NativeTransactionData,
 };
+use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};
 
 use crate::{
     config::DEFAULT_PAGE_SIZE,
@@ -25,6 +31,7 @@ use crate::{
     types::{
         balance_change::BalanceChange,
         base64::Base64,
+        big_int::BigInt,
         checkpoint::{Checkpoint, CheckpointId},
         cursor::{JsonCursor, Page},
         date_time::DateTime,
@@ -140,6 +147,36 @@ impl TransactionBlockEffects {
             IotaExecutionStatus::Success => Ok(None),
             IotaExecutionStatus::Failure { error } => Ok(Some(error)),
         }
+    }
+
+    /// The error code of the Move abort, populated if this transaction failed
+    /// with a Move abort.
+    #[graphql(complexity = 0)]
+    async fn abort_code(&self, ctx: &Context<'_>) -> Result<Option<BigInt>> {
+        let resolver: &PackageResolver = ctx.data_unchecked();
+
+        let NativeExecutionStatus::Failure {
+            error: ExecutionFailureStatus::MoveAbort { location, code },
+            ..
+        } = self.native().status()
+        else {
+            return Ok(None);
+        };
+
+        let module_id = ModuleId::new(
+            AccountAddress::from(location.package.into_bytes()),
+            identifier_sdk_to_core(&location.module),
+        );
+
+        let Some(CleverError {
+            error_code: Some(error_code),
+            ..
+        }) = resolver.resolve_clever_error(module_id, *code).await
+        else {
+            return Ok(Some(BigInt::from(*code)));
+        };
+
+        Ok(Some(BigInt::from(error_code as u64)))
     }
 
     /// Transactions whose outputs this transaction depends upon.

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -4487,6 +4487,11 @@ type TransactionBlockEffects {
 	"""
 	errors: String
 	"""
+	The error code of the Move abort, populated if this transaction failed
+	with a Move abort.
+	"""
+	abortCode: BigInt
+	"""
 	Transactions whose outputs this transaction depends upon.
 	"""
 	dependencies(first: Int, after: String, last: Int, before: String): DependencyConnection!

--- a/crates/iota-indexer/tests/data/clever_errors/sources/clever_errors.move
+++ b/crates/iota-indexer/tests/data/clever_errors/sources/clever_errors.move
@@ -6,7 +6,14 @@ module clever_errors::clever_errors {
     #[error]
     const ENotFound: vector<u8> = b"Element not found in vector 💥 🚀 🌠";
 
+    #[error(code = 1)]
+    const ECodedError: vector<u8> = b"Coded clever error";
+
     public fun clever_aborter() {
         assert!(false, ENotFound);
+    }
+
+    public fun clever_aborter_with_code() {
+        assert!(false, ECodedError);
     }
 }

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1731,7 +1731,7 @@ fn clever_errors() {
         let fn_name = format!("{}::clever_errors::clever_aborter", object_ref.object_id);
         let clever_error = "'ENotFound': Element not found in vector 💥 🚀 🌠";
         let expected_error =
-            format!("Error in 1st command, from '{fn_name}' (line 10), abort {clever_error}");
+            format!("Error in 1st command, from '{fn_name}' (line 13), abort {clever_error}");
         let effects = indexer_tx_response.effects.unwrap();
         let IotaExecutionStatus::Failure { error } = effects.status() else {
             panic!("transaction should have failed");
@@ -1739,6 +1739,50 @@ fn clever_errors() {
         assert_eq!(error, &expected_error);
 
         // Check error in the response as well
+        let response_error = indexer_tx_response
+            .errors
+            .first()
+            .expect("execution error should be in the response");
+        assert_eq!(response_error, &expected_error);
+
+        // Abort on a constant declaring `#[error(code = ...)]`: the code is
+        // rendered alongside the identifier and the constant.
+        let gas = effects.gas_object().reference;
+        let tx_data = TestTransactionBuilder::new(address, gas, 1000)
+            .move_call(
+                object_ref.object_id,
+                "clever_errors",
+                "clever_aborter_with_code",
+                vec![],
+            )
+            .build();
+        let signed_transaction = to_sender_signed_transaction(tx_data, &keypair);
+        let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
+
+        let indexer_tx_response = client
+            .execute_transaction_block(
+                tx_bytes,
+                signatures,
+                Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution.into()),
+            )
+            .await
+            .unwrap();
+
+        let fn_name = format!(
+            "{}::clever_errors::clever_aborter_with_code",
+            object_ref.object_id
+        );
+        let clever_error = "'ECodedError': Coded clever error";
+        let expected_error = format!(
+            "Error in 1st command, from '{fn_name}' (line 17), abort(code = 1) {clever_error}"
+        );
+        let effects = indexer_tx_response.effects.unwrap();
+        let IotaExecutionStatus::Failure { error } = effects.status() else {
+            panic!("transaction should have failed");
+        };
+        assert_eq!(error, &expected_error);
+
         let response_error = indexer_tx_response
             .errors
             .first()

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -1505,6 +1505,7 @@ impl IotaExecutionStatus {
                         module_id,
                         source_line_number,
                         error_info,
+                        error_code,
                     }) = resolver
                         .resolve_clever_error(module_id.clone(), *code)
                         .await
@@ -1516,27 +1517,36 @@ impl IotaExecutionStatus {
                         );
                     };
 
+                    let error_code_str = match error_code {
+                        Some(code) => format!("(code = {code})"),
+                        None => String::new(),
+                    };
+
                     match error_info {
                         ErrorConstants::Rendered {
                             identifier,
                             constant,
                         } => {
                             format!(
-                                "from '{}{fname_string} (line {source_line_number}), abort '{identifier}': {constant}",
+                                "from '{}{fname_string} (line {source_line_number}), abort{error_code_str} '{identifier}': {constant}",
                                 module_id.to_canonical_display(true)
                             )
                         }
                         ErrorConstants::Raw { identifier, bytes } => {
                             let const_str = Base64::encode(bytes);
                             format!(
-                                "from '{}{fname_string} (line {source_line_number}), abort '{identifier}': {const_str}",
+                                "from '{}{fname_string} (line {source_line_number}), abort{error_code_str} '{identifier}': {const_str}",
                                 module_id.to_canonical_display(true)
                             )
                         }
                         ErrorConstants::None => {
                             format!(
-                                "from '{}{fname_string} (line {source_line_number})",
-                                module_id.to_canonical_display(true)
+                                "from '{}{fname_string} (line {source_line_number}){}",
+                                module_id.to_canonical_display(true),
+                                match error_code {
+                                    Some(code) => format!(" abort(code = {code})"),
+                                    None => String::new(),
+                                }
                             )
                         }
                     }
@@ -1544,9 +1554,9 @@ impl IotaExecutionStatus {
                 // Convert the command index into an ordinal.
                 command_index += 1;
                 let suffix = match command_index % 10 {
-                    1 => "st",
-                    2 => "nd",
-                    3 => "rd",
+                    1 if command_index % 100 != 11 => "st",
+                    2 if command_index % 100 != 12 => "nd",
+                    3 if command_index % 100 != 13 => "rd",
                     _ => "th",
                 };
                 IotaExecutionStatus::Failure {

--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -122,6 +122,8 @@ pub struct CleverError {
     pub error_info: ErrorConstants,
     /// The line number in the source file where the error occurred.
     pub source_line_number: u16,
+    /// The error code of the abort
+    pub error_code: Option<u8>,
 }
 
 /// The `ErrorConstants` enum is used to represent the different kinds of error
@@ -642,6 +644,7 @@ impl<S: PackageStore> Resolver<S> {
             .ok()?;
         let module = package.module(module_id.name().as_str()).ok()?.bytecode();
         let source_line_number = bitset.line_number()?;
+        let error_code = bitset.error_code();
 
         // We only have a line number in our clever error, so return early.
         if bitset.identifier_index().is_none() && bitset.constant_index().is_none() {
@@ -649,6 +652,7 @@ impl<S: PackageStore> Resolver<S> {
                 module_id,
                 error_info: ErrorConstants::None,
                 source_line_number,
+                error_code,
             });
         } else if bitset.identifier_index().is_none() || bitset.constant_index().is_none() {
             return None;
@@ -688,6 +692,7 @@ impl<S: PackageStore> Resolver<S> {
             module_id,
             error_info,
             source_line_number,
+            error_code,
         })
     }
 }

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -682,7 +682,13 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
 
                 let mut output = vec![];
                 if show_headers {
-                    output.push(format!("Headers: {:#?}", resp.http_headers.unwrap()));
+                    let headers_map: BTreeMap<_, _> = resp
+                        .http_headers
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|(h, v)| Some((h?.to_string(), v)))
+                        .collect();
+                    output.push(format!("Headers: {headers_map:#?}"));
                 }
                 if show_service_version {
                     output.push(format!(

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -5266,12 +5266,31 @@ async fn test_clever_errors() -> Result<(), anyhow::Error> {
     .await
     .unwrap_err();
 
+    // Clever error with an error code
+    let clever_error_with_code = IotaClientCommands::Call {
+        package: package.reference.object_id,
+        module: "clever_errors".to_string(),
+        function: "clever_aborter_with_code".to_string(),
+        type_args: vec![],
+        args: vec![],
+        payment: PaymentArgs::default(),
+        gas_data: GasDataArgs {
+            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await
+    .unwrap_err();
+
     let error_string = format!(
-        "Non-clever-abort\n---\n{}\n---\nLine-only-abort\n---\n{}\n---\nClever-error-utf8\n---\n{}\n---\nClever-error-non-utf8\n---\n{}\n---\n",
+        "Non-clever-abort\n---\n{}\n---\nLine-only-abort\n---\n{}\n---\nClever-error-utf8\n---\n{}\n---\nClever-error-non-utf8\n---\n{}\n---\n\nClever-error-with-code\n---\n{}\n---\n",
         elide_transaction_digest(non_clever_abort.to_string()),
         elide_transaction_digest(line_only_abort.to_string()),
         elide_transaction_digest(clever_error_utf8.to_string()),
-        elide_transaction_digest(clever_error_non_utf8.to_string())
+        elide_transaction_digest(clever_error_non_utf8.to_string()),
+        elide_transaction_digest(clever_error_with_code.to_string())
     );
 
     insta::assert_snapshot!(error_string);

--- a/crates/iota/tests/data/clever_errors/sources/clever_errors.move
+++ b/crates/iota/tests/data/clever_errors/sources/clever_errors.move
@@ -11,6 +11,9 @@ module clever_errors::clever_errors {
     #[error]
     const ENotAString: vector<u64> = vector[1,2,3,4];
 
+    #[error(code = 1)]
+    const ECodedError: vector<u8> = b"Coded clever error";
+
     public fun aborter() {
         abort 0
     }
@@ -25,5 +28,9 @@ module clever_errors::clever_errors {
 
     public fun clever_aborter_not_a_string() {
         assert!(false, ENotAString);
+    }
+
+    public fun clever_aborter_with_code() {
+        assert!(false, ECodedError);
     }
 }

--- a/crates/iota/tests/snapshots/cli_tests__body_fn.snap
+++ b/crates/iota/tests/snapshots/cli_tests__body_fn.snap
@@ -8,13 +8,18 @@ Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, f
 ---
 Line-only-abort
 ---
-Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::aborter_line_no' (line 19)
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::aborter_line_no' (line 22)
 ---
 Clever-error-utf8
 ---
-Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter' (line 23), abort 'ENotFound': Element not found in vector 💥 🚀 🌠
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter' (line 26), abort 'ENotFound': Element not found in vector 💥 🚀 🌠
 ---
 Clever-error-non-utf8
 ---
-Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter_not_a_string' (line 27), abort 'ENotAString': BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter_not_a_string' (line 30), abort 'ENotAString': BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA
+---
+
+Clever-error-with-code
+---
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter_with_code' (line 34), abort(code = 1) 'ECodedError': Coded clever error
 ---

--- a/crates/iota/tests/snapshots/cli_tests__clever_errors.snap
+++ b/crates/iota/tests/snapshots/cli_tests__clever_errors.snap
@@ -8,13 +8,18 @@ Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, f
 ---
 Line-only-abort
 ---
-Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::aborter_line_no' (line 19)
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::aborter_line_no' (line 22)
 ---
 Clever-error-utf8
 ---
-Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter' (line 23), abort 'ENotFound': Element not found in vector 💥 🚀 🌠
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter' (line 26), abort 'ENotFound': Element not found in vector 💥 🚀 🌠
 ---
 Clever-error-non-utf8
 ---
-Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter_not_a_string' (line 27), abort 'ENotAString': BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter_not_a_string' (line 30), abort 'ENotAString': BAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAAQAAAAAAAAA
+---
+
+Clever-error-with-code
+---
+Error executing transaction 'ELIDED_TRANSACTION_DIGEST': Error in 1st command, from 'ELIDED_ADDRESS::clever_errors::clever_aborter_with_code' (line 34), abort(code = 1) 'ECodedError': Coded clever error
 ---


### PR DESCRIPTION
# Description of change

Ports two upstream GraphQL commits:

- Print the GraphQL response headers of `run-graphql` transactional tests through a `BTreeMap`, so the snapshot output is deterministically ordered.
- Resolve the error code of a clever error: it is now part of the rendered abort message and exposed as a new `abortCode` field on `TransactionBlockEffects`.

## Upstream commits

| Commit | Upstream PR | Description |
|--------|-------------|-------------|
| `e200e730a14d0bb044ac6b05c7294cd3685f6809` | #21939 | [graphql] Fix header map ordering in transactional-test-runner |
| `fa4fe8341d5d4af735daebf8fe7984f257121df7` | #21941 | [graphql] Add error code to graphql clever error |

## Downstream adaptations

| Upstream | Downstream | Reason |
|---|---|---|
| second header-printing site in `test_adapter.rs` | not ported | it belongs to upstream's JSON-RPC transactional subcommand; IOTA's test runner only has `RunGraphqlCommand` |
| `crates/iota-indexer-alt-e2e-tests/tests/jsonrpc/test_framework/framework.snap` | not ported | crate does not exist in IOTA |
| abort message rendering in `iota-graphql-rpc/src/types/transaction_block_effects.rs` | `IotaExecutionStatus::from_native_with_clever_error` in `crates/iota-json-rpc-types/src/iota_transaction.rs` | IOTA renders clever errors in one shared place (used by GraphQL, JSON-RPC and the indexer) instead of duplicating it in the GraphQL layer. The rendered strings are identical to upstream's; upstream's switch from `format!` to `write!` was not needed because the shared function does not return a `Result`. |
| `resolve_native_status_impl(resolver)` in the new `abortCode` resolver | `self.native().status()` | IOTA has no such helper; this is what the neighbouring `errors` resolver uses |
| `ExecutionFailureStatus::MoveAbort(loc, code)` | `ExecutionFailureStatus::MoveAbort { location, code }` + `ModuleId::new(...)` | IOTA uses the SDK's `ExecutionError` shape, which keeps package and module separate |
| `tests/stable/errors/clever_errors.move`, `tests/stable/call/simple.snap` | `tests/errors/…`, `tests/call/…` | IOTA has no `stable/` test directory |
| `staging.graphql`, `snapshot_tests__staging.graphql.snap` | not ported | IOTA has no staging schema |
| `snapshot_tests__schema.graphql.snap` | `snapshot_tests__schema_sdl_export.snap` | different snapshot test name downstream |

Snapshots and `schema.graphql` were regenerated locally (they are filtered out of the upstream patches).

## Notes for the reviewer

One commit per upstream patch; both were applied with `git apply` first and every deviation is listed in the table above.

**`e200e730` — header map ordering**

- `test_adapter.rs`: `run-graphql --show-headers` printed `http::HeaderMap`'s `Debug`, whose order follows the map's internal hash table and is therefore not stable across runs. It now collects into a `BTreeMap<String, HeaderValue>`, so the output is sorted by header name.
- `tests/call/simple.snap`: the only change is the five header lines being reordered alphabetically, values untouched.

**`fa4fe834` — error code in clever errors**

- `iota-package-resolver`: `CleverError` gains `error_code: Option<u8>`, taken from `ErrorBitset::error_code()` (already available downstream). It is `None` for `#[error]` constants that declare no code.
- `iota-json-rpc-types`: the downstream home of the message rendering that upstream changed inline in the GraphQL resolver. Two behaviour changes: the abort gets a `(code = N)` suffix when the constant declares a code, and the ordinal suffix no longer yields `11st`/`12nd`/`13rd`. The existing `format!` composition was kept rather than upstream's `write!` rewrite (which upstream needed only for `?` on `fmt::Error`); the resulting strings are identical to upstream's, checked literal by literal.
- `iota-graphql-rpc`: the new `abortCode` field, falling back to the raw abort code when the abort is not a clever error — so `normalAbort` reports `0`, as upstream.
- `clever_errors.move` / `.snap`: two new tasks (`callStringWithCode` for `#[error(code=1)]`, `callNoCodeOrConst` for a bare `abort`) plus `abortCode` in both queries. The large snapshot churn follows from those two tasks: task numbers, source line numbers, published package IDs and gas costs all shift, because clever-error abort codes encode the source line number and the module bytes changed.

Worth a closer look:

- The decision to change the shared renderer: `(code = N)` therefore also appears in JSON-RPC and indexer responses, not only in GraphQL as upstream. The CLI is unaffected — its `clever_errors` fixture declares no coded constants and `cli_tests__clever_errors.snap` is unchanged.
- `clever_errors.snap`: that the only semantic additions are the two new tasks, the `abortCode` values, and the `abort(code = 1)` message for `callStringWithCode`.

## Links to any relevant issues

Closes #10835

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

- `cargo check --workspace --all-targets`, `cargo ci-clippy`, `cargo ci-license`, `cargo machete`, `cargo +nightly fmt --all`
- `cargo nextest run -p iota-package-resolver -p iota-json-rpc-types -p iota-graphql-rpc`
- `cargo test -p iota-graphql-e2e-tests --features pg_integration` against a local Postgres, including the regenerated `errors/clever_errors.snap` and `call/simple.snap`
- `cargo test -p iota-graphql-rpc --test snapshot_tests` (regenerated `schema.graphql` and its snapshot)

### Release Notes

- [x] Indexer: Clever error messages now include the error code of the abort, if the abort constant declares one, and the command ordinal no longer renders as `11st`/`12nd`/`13rd`.
- [x] JSON-RPC: Clever error messages now include the error code of the abort, if the abort constant declares one, and the command ordinal no longer renders as `11st`/`12nd`/`13rd`.
- [x] GraphQL: Added `TransactionBlockEffects.abortCode`; clever error messages now include the error code of the abort, if the abort constant declares one, and the command ordinal no longer renders as `11st`/`12nd`/`13rd`.
