### PR TITLE
chore(graphql): document the historic fallback feature

### DIFF
--- a/crates/iota-graphql-rpc/README.md
+++ b/crates/iota-graphql-rpc/README.md
@@ -123,6 +123,52 @@ To run it with the `iota-localnet start` subcommand, switch to the root director
 `cargo run --features indexer --bin iota-localnet start --with-indexer --pg-port 5432 --pg-db-name iota_indexer --with-graphql=0.0.0.0:8000`
 ```
 
+## Historic fallback (REST KV store)
+
+The GraphQL server supports an experimental historic fallback feature via the `--fallback-kv-url` flag.
+The Indexer prunes historical data below a retention watermark, so by default the server cannot read checkpoints, transactions, events, or object versions older than that watermark.
+When a [REST KV store](../../dev-tools/iota-rest-kv/README.md) is configured, the server falls back to it for reads that miss the pruned Postgres data, so pruned history stays queryable.
+It depends on the API served by the `iota-rest-kv` crate, which is still being finalized and subject to change.
+
+> [!WARNING]
+> This is an experimental feature and is subject to change without notice.
+
+### Enabling
+
+Pass the REST KV store URL when starting the server:
+
+```sh
+iota-graphql-rpc start-server \
+  --db-url postgres://<user>:<password>@<host>:5432/<db> \
+  --node-rpc-url http://<fullnode>:<grpc-port> \
+  --fallback-kv-url http://<rest-kv-host>:<port>
+```
+
+Without `--fallback-kv-url` (the default), no fallback is performed and pruned data is unreachable.
+
+The remaining options tune batching, concurrency, and caching of the fallback requests:
+
+| Flag                                   | Env var                              | Default  | Description                                                  |
+| -------------------------------------- | ------------------------------------ | -------- | ------------------------------------------------------------ |
+| `--fallback-kv-url`                    | —                                    | _(none)_ | REST KV store URL. Enables the fallback when set.            |
+| `--fallback-kv-multi-fetch-batch-size` | `FALLBACK_KV_MULTI_FETCH_BATCH_SIZE` | `100`    | Maximum number of keys per batch request to the KV store.    |
+| `--fallback-kv-concurrent-fetches`     | `FALLBACK_KV_CONCURRENT_FETCHES`     | `10`     | Maximum number of concurrent batch requests to the KV store. |
+| `--fallback-kv-cache-size`             | `FALLBACK_KV_CACHE_SIZE`             | `100000` | Number of entries cached from the KV store.                  |
+
+### Queries with fallback
+
+These queries use the fallback when the requested data has been pruned from Postgres:
+
+- Checkpoints: `checkpoint(id)` (by sequence number or digest), `checkpoints`, `Epoch.checkpoints`
+- Transactions by digest: `transactionBlock(digest)`, `transactionBlocksByDigests`
+- Transactions by filter: `transactionBlocks(filter: { atCheckpoint })` and `Checkpoint.transactionBlocks`; `transactionBlocks(filter: { affectedAddress })` and `Address.transactionBlocks(relation: AFFECTED)`; `transactionBlocks(filter: { transactionIds })`
+- Events of a transaction: `events(filter: { transactionDigest })`
+- Objects at a past version: `object(address, version)`, including dynamic fields resolved at a parent object's version
+
+Resolving a dynamic field or dynamic object field at a parent object's version needs that version recorded in the indexer's `objects_version` table. On indexers restored from a snapshot, versions below the restore point cannot be served this way and return `DATA_PRUNED`.
+
+Other read paths are served only from Postgres and cannot see pruned data.
+
 ## Running tests
 
 The crate provides test coverage for server functionality, covering client validation, query validation, reading and writing data, query limits, and health checks.

--- a/docs/content/operator/extended-data-services/graphql.mdx
+++ b/docs/content/operator/extended-data-services/graphql.mdx
@@ -24,7 +24,7 @@ The GraphQL service holds no state of its own. Multiple instances can run in par
 
 - An indexer Postgres database. The schema version in the database must match the one compiled into the GraphQL binary; otherwise the GraphQL service refuses to start. For the `executeTransactionBlock` operation to work properly the indexer writer should be running and synced with the tip of the network. See [IOTA Indexer](./iota-indexer.mdx) for details on running the indexer writer.
 - A fullnode gRPC endpoint. Required at start-up — the server fails to start if `--node-rpc-url` is not set, even when no client issues a mutation or a dry run.
-- Note that currently fallback service cannot be configured for GraphQL, so data pruned by indexer writer is not accessible through GraphQL. See [Pruning](./iota-indexer.mdx#pruning) for the indexer-side retention model.
+- An optional REST KV store for historic fallback. When configured, it lets the GraphQL service serve data already pruned by the indexer writer. Currently experimental. See [Pruned data](#pruned-data) below and [Pruning](./iota-indexer.mdx#pruning) for the indexer-side retention model.
 
 ## Hardware requirements
 
@@ -71,6 +71,34 @@ The most important settings are covered in subsections below. All settings are l
 ### Fullnode endpoint
 
 `--node-rpc-url` is the gRPC URL of a fullnode that the GraphQL service forwards `executeTransactionBlock` and `dryRunTransactionBlock` to. It is required at start-up.
+
+### Pruned data
+
+:::warning Experimental
+
+The historic fallback depends on the API from the `iota-rest-kv` crate which is still being finalised. Treat the flags below as experimental — they may change or be replaced.
+
+:::
+
+Data already [pruned](./iota-indexer.mdx#pruning) by the indexer writer can be served by the GraphQL service using a historic fallback feature.
+To use it, the operator runs a separate self-hosted REST KV store and points the GraphQL service at it via `--fallback-kv-url`.
+When `--fallback-kv-url` is unset (the default), no fallback is performed and pruned data is unreachable via GraphQL.
+
+These queries fall back to the KV store when their data has been pruned from the database:
+
+- `checkpoint`, `checkpoints`, `Epoch.checkpoints`
+- `transactionBlock`, `transactionBlocksByDigests`
+- `transactionBlocks` with filter `atCheckpoint`, `affectedAddress`, or `transactionIds`, and the matching `Checkpoint.transactionBlocks` and `Address.transactionBlocks` (`AFFECTED` relation)
+- `events` with filter `transactionDigest`
+- `object` at a past version, including dynamic fields resolved at a parent object's version
+
+:::note
+
+Resolving a dynamic field or dynamic object field at a parent object's version needs that version recorded in the indexer's `objects_version` table. On indexers restored from a snapshot, versions below the restore point cannot be served this way and return `DATA_PRUNED`.
+
+:::
+
+The `--fallback-kv-multi-fetch-batch-size`, `--fallback-kv-concurrent-fetches`, and `--fallback-kv-cache-size` knobs tune the KV client's request batching, concurrency, and in-memory cache.
 
 ### HTTP server
 
@@ -158,6 +186,10 @@ reverse-registry-id = "0x..."
 | `--skip-migration-consistency-check`  | `false`                                                  | Skip the start-up check that local migrations match the database.                                 |
 | `--max-available-range`               | `9000`                                                   | Maximum window (in checkpoints) in which consistent view on objects can be served. Also `MAX_AVAILABLE_RANGE` env var. |
 | `--node-rpc-url`                      | _(required)_                                             | Fullnode gRPC URL used for `executeTransactionBlock` and `dryRunTransactionBlock`.                |
+| `--fallback-kv-url`                   | _(none)_                                                 | Experimental. REST KV store URL for historic fallback. Disabled when unset.                       |
+| `--fallback-kv-multi-fetch-batch-size` | `100`                                                   | Experimental. Maximum number of keys per batch request to the fallback KV store. Also `FALLBACK_KV_MULTI_FETCH_BATCH_SIZE` env var. |
+| `--fallback-kv-concurrent-fetches`    | `10`                                                     | Experimental. Maximum number of concurrent batch requests to the fallback KV store. Also `FALLBACK_KV_CONCURRENT_FETCHES` env var. |
+| `--fallback-kv-cache-size`            | `100000`                                                 | Experimental. In-memory cache size for historic fallback. Also `FALLBACK_KV_CACHE_SIZE` env var.  |
 | `--ide-title`, `-i`                   | `IOTA GraphQL IDE`                                       | Title displayed at the top of the GraphiQL IDE.                                                   |
 | `--config`, `-c`                      | _(none)_                                                 | Path to a TOML file with service configuration; see below.                                        |
 


### PR DESCRIPTION
# Description of change

Documents the archival (historic) fallback for `iota-graphql-rpc`:

- **`crates/iota-graphql-rpc/README.md`** — a standalone "Historic fallback (REST KV store)" section: which queries fall back, how to enable it (`--fallback-kv-url` and the tuning flags), and the list of covered queries.
- **`docs/content/operator/extended-data-services/graphql.mdx`** (operator doc) — a "Pruned data" section mirroring the JSON-RPC operator doc, the four `--fallback-kv-*` flags added to the settings table, and the stale dependency note ("fallback service cannot be configured for GraphQL") replaced.

Both note the one limit: resolving a dynamic field or dynamic object field at a parent object's version needs that version in `objects_version`, so on snapshot-restored indexers versions below the restore point return `DATA_PRUNED`.

Docs only, no code change.

## Links to any relevant issues

fixes #11941