### PR TITLE
chore: ignore lru unsoundness advisory, drop stale sized-chunks ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,11 @@ ignore = [
   # seed derives from the stack pointer and cannot be controlled by msim,
   # breaking simtest determinism (e.g. test_passive_reconfig_determinism).
   "RUSTSEC-2026-0002",
+  # `LruCache::pop()` is not panic-safe: a panic in a key's `Drop` skips
+  # `detach()` and leaves dangling pointers in the list. None of the key types
+  # we store have a `Drop` that can panic. Fixed in 0.18.2, which is blocked by
+  # the msim determinism problem described above.
+  "RUSTSEC-2026-0253",
   # proc-macro-error2 is unmaintained
   # Can be removed once `getset` updates: https://github.com/jbaublitz/getset/issues/132
   "RUSTSEC-2026-0173",
@@ -76,9 +81,8 @@ ignore = [
   # Same as above
   "RUSTSEC-2026-0195",
   # `im` is unmaintained and its `OrdSet` insertion is unsound, together with
-  # its `sized-chunks` and `bitmaps` dependencies. Only reachable through
-  # `fastcrypto-zkp`; remove once that switches to `imbl`.
-  "RUSTSEC-2023-0126",
+  # its `bitmaps` dependency. Only reachable through `fastcrypto-zkp`; remove
+  # once that switches to `imbl`.
   "RUSTSEC-2026-0248",
   "RUSTSEC-2026-0251",
   # `bitmaps` is also pulled in by `imbl-sized-chunks`


### PR DESCRIPTION
# Description of change

`cargo deny check advisories` fails on `develop` (it only runs nightly, not on PRs), and also warns about an ignore that no longer matches anything. This gets it back to `advisories ok`:

- Ignores `RUSTSEC-2026-0253` (`LruCache::pop()` is not panic-safe). The fix is `lru` 0.18.2, blocked by the same msim determinism problem already documented for `RUSTSEC-2026-0002` in `deny.toml` — bumping it aborts `test_passive_reconfig_determinism` with `non-determinism detected`, as that comment predicts (details in the comment below). None of the key types stored in our caches have a `Drop` that can panic, so the unsound path isn't reachable here.
- Drops the `RUSTSEC-2023-0126` ignore, which stopped matching once the lockfile picked up a patched `sized-chunks`.

Dropping the ignore instead of getting off `lru` 0.12 would mean changing the determinism machinery — the `LruCache` warm-up in `iota_macros::sim_test`, or a fixed hasher for the caches reachable from sim tests. Worth its own PR if an ignore isn't good enough for a use-after-free.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

`cargo deny check advisories` reports `advisories ok` with no `advisory-not-detected` warnings. The yanked `spin` 0.9.8 warning is pre-existing on `develop` and untouched.