### PR TITLE
refactor(iota-config): one startup validation shared by node and tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7108,6 +7108,7 @@ dependencies = [
  "reqwest",
  "rustc_version_runtime",
  "serde",
+ "serde_yaml",
  "tap",
  "telemetry-subscribers",
  "tokio",

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -221,7 +221,8 @@ pub struct NodeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_with_range: Option<RunWithRange>,
 
-    // For killswitch use None
+    // For killswitch use None. A node that also sets `firewall_config` must
+    // drop that too; `validate` rejects a firewall without a policy.
     #[serde(
         skip_serializing_if = "Option::is_none",
         default = "default_traffic_controller_policy_config"
@@ -793,6 +794,69 @@ impl NodeConfig {
 
     pub fn jsonrpc_server_type(&self) -> ServerType {
         self.jsonrpc_server_type.unwrap_or(ServerType::Http)
+    }
+
+    /// A config selects the validator role exactly when it has a consensus
+    /// config.
+    pub fn is_validator(&self) -> bool {
+        self.consensus_config.is_some()
+    }
+
+    /// Check the startup invariants centralized here. Call this before
+    /// starting a node, and after assembling or patching a config.
+    ///
+    /// This performs no I/O and is not an exhaustive check that every
+    /// subsystem-specific value can be initialized.
+    ///
+    /// # Errors
+    ///
+    /// An error means a checked invariant is broken: no node could start with
+    /// this config as it stands, or would start ignoring part of it.
+    pub fn validate(&self) -> Result<()> {
+        // Validators do not expose the gRPC API, so these two fields are only
+        // checked on a fullnode. An absent `grpc-api-config` key deserializes
+        // to a default config, so this mostly guards configs assembled in
+        // process, such as by the builders and the override engine.
+        if !self.is_validator() && self.enable_grpc_api && self.grpc_api_config.is_none() {
+            anyhow::bail!(
+                "`enable-grpc-api` is set but `grpc-api-config` is missing; set \
+                 `grpc-api-config` or turn off `enable-grpc-api`"
+            );
+        }
+        // Snapshot publication is a fullnode-only role.
+        if self.is_validator()
+            && self
+                .state_snapshot_write_config
+                .object_store_config
+                .is_some()
+        {
+            anyhow::bail!(
+                "`state-snapshot-write-config.object-store-config` is set, but snapshot upload \
+                 is only supported on fullnodes; remove the setting or move the upload to a \
+                 fullnode"
+            );
+        }
+        // The uploader builds the store at startup, which needs a backend.
+        if self
+            .state_snapshot_write_config
+            .object_store_config
+            .as_ref()
+            .is_some_and(|store| store.object_store.is_none())
+        {
+            anyhow::bail!(
+                "`state-snapshot-write-config.object-store-config` has no `object-store`; \
+                 snapshot upload needs a storage backend"
+            );
+        }
+        // The firewall is driven by the traffic controller, which only runs
+        // when a policy is configured.
+        if self.firewall_config.is_some() && self.policy_config.is_none() {
+            anyhow::bail!(
+                "`firewall-config` is set but `policy-config` is not; the firewall is silently \
+                 ignored without a `policy-config`"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -1556,13 +1620,16 @@ mod tests {
 
     use fastcrypto::traits::KeyPair;
     use iota_keys::keypair_file::{write_authority_keypair_to_file, write_keypair_to_file};
-    use iota_types::crypto::{
-        AuthorityKeyPair, NetworkKeyPair, get_key_pair_from_rng, network_to_simple_keypair,
+    use iota_types::{
+        crypto::{
+            AuthorityKeyPair, NetworkKeyPair, get_key_pair_from_rng, network_to_simple_keypair,
+        },
+        traffic_control::RemoteFirewallConfig,
     };
     use rand::{SeedableRng, rngs::StdRng};
 
-    use super::Genesis;
-    use crate::NodeConfig;
+    use super::{Genesis, GrpcApiConfig, ObjectStoreConfig};
+    use crate::{NodeConfig, object_storage_config::ObjectStoreType};
 
     #[test]
     fn serialize_genesis_from_file() {
@@ -1579,6 +1646,99 @@ mod tests {
         const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
 
         let _template: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+    }
+
+    #[test]
+    fn validate_requires_a_grpc_config_when_the_api_is_enabled() {
+        const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
+
+        let mut config: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+        config.grpc_api_config = None;
+        config.validate().unwrap();
+
+        config.enable_grpc_api = true;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("`grpc-api-config` is missing"), "{err}");
+
+        config.grpc_api_config = Some(GrpcApiConfig::default());
+        config.validate().unwrap();
+
+        // Validators do not expose the gRPC API; the check does not apply.
+        config.grpc_api_config = None;
+        config.consensus_config = Some(consensus_config());
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn an_absent_grpc_api_config_deserializes_to_the_default_one() {
+        const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
+
+        // The shape a fullnode config file has in practice: the API is turned
+        // on and `grpc-api-config` is left out.
+        let config: NodeConfig =
+            serde_yaml::from_str(&format!("{TEMPLATE}\nenable-grpc-api: true\n")).unwrap();
+
+        assert!(config.grpc_api_config.is_some());
+        config.validate().unwrap();
+    }
+
+    fn consensus_config() -> super::ConsensusConfig {
+        serde_yaml::from_str("db-path: consensus-db").unwrap()
+    }
+
+    fn object_store_config() -> ObjectStoreConfig {
+        ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::File),
+            directory: Some(PathBuf::from("/opt/iota/snapshots")),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn validate_rejects_snapshot_upload_on_a_validator() {
+        const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
+
+        let mut config: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+        config.state_snapshot_write_config.object_store_config = Some(object_store_config());
+        config.validate().unwrap();
+
+        config.consensus_config = Some(consensus_config());
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("snapshot upload"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_a_snapshot_store_without_a_backend() {
+        const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
+
+        let mut config: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+        config.state_snapshot_write_config.object_store_config = Some(ObjectStoreConfig::default());
+
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("storage backend"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_a_firewall_without_a_policy() {
+        const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
+
+        let mut config: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+        config.firewall_config = Some(RemoteFirewallConfig {
+            remote_fw_url: "http://localhost:65000".to_owned(),
+            destination_port: 8080,
+            delegate_spam_blocking: false,
+            delegate_error_blocking: false,
+            drain_path: PathBuf::from("/tmp/drain"),
+            drain_timeout_secs: 300,
+        });
+
+        // The template omits `policy-config`, which serde fills with the
+        // default policy, so the firewall is driven.
+        config.validate().unwrap();
+
+        config.policy_config = None;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("`firewall-config` is set"), "{err}");
     }
 
     #[test]

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -802,16 +802,8 @@ impl NodeConfig {
         self.consensus_config.is_some()
     }
 
-    /// Check the startup invariants centralized here. Call this before
-    /// starting a node, and after assembling or patching a config.
-    ///
-    /// This performs no I/O and is not an exhaustive check that every
-    /// subsystem-specific value can be initialized.
-    ///
-    /// # Errors
-    ///
-    /// An error means a checked invariant is broken: no node could start with
-    /// this config as it stands, or would start ignoring part of it.
+    /// Validate the node config, returning an error if a node could not
+    /// start with this config or would start ignoring part of it.
     pub fn validate(&self) -> Result<()> {
         // Validators do not expose the gRPC API, so these two fields are only
         // checked on a fullnode. An absent `grpc-api-config` key deserializes

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -60,7 +60,7 @@ pub struct IotaRuntimes {
 
 impl IotaRuntimes {
     pub fn new(config: &NodeConfig) -> Self {
-        let is_validator = config.consensus_config().is_some();
+        let is_validator = config.is_validator();
         let (node_threads, serving_threads) =
             size_worker_threads(available_cpu_cores(), is_validator);
 

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -17,9 +17,7 @@ use fastcrypto::traits::KeyPair;
 use iota_config::{
     Config, IOTA_BENCHMARK_GENESIS_GAS_KEYSTORE_FILENAME, IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG,
     IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG, NodeConfig,
-    PersistedConfig, genesis_blob_exists, iota_config_dir,
-    node::{Genesis, GrpcApiConfig},
-    p2p::SeedPeer,
+    PersistedConfig, genesis_blob_exists, iota_config_dir, node::Genesis, p2p::SeedPeer,
 };
 use iota_faucet::{AppState, FaucetConfig, SimpleFaucet, create_wallet_context, start_faucet};
 #[cfg(feature = "indexer")]
@@ -45,7 +43,7 @@ use iota_swarm_config::{
 };
 use rand::rngs::OsRng;
 use tempfile::tempdir;
-use tracing::{info, warn};
+use tracing::info;
 
 const CONCURRENCY_LIMIT: usize = 30;
 const DEFAULT_COMMITTEE_SIZE: usize = 1;
@@ -62,7 +60,9 @@ const DEFAULT_INDEXER_PORT: u16 = 9124;
 const FULLNODE_CONFIG_NOTE: &str = "\
 # `iota-localnet start` reads only the following values from this file:
 # iota-names-config, enable-grpc-api, grpc-api-config, db-path, genesis,
-# migration-tx-data-path. Change other values at start time with
+# migration-tx-data-path, and rejects the file if it carries a
+# `consensus-config` or would not pass the node's own config validation.
+# Change other values at start time with
 # `iota-localnet start --node-config-override [scope:]<path>=<value>`.
 # The file remains a complete config for running a standalone `iota-node`.
 ";
@@ -485,8 +485,9 @@ async fn start(
         eprintln!(
             "{}",
             "[warning] The --with-grpc flag is deprecated. Use `--node-config-override \
-             fullnode:enable-grpc-api=true` and optionally `--node-config-override \
-             fullnode:grpc-api-config.address=<HOST:PORT>` instead."
+             fullnode:enable-grpc-api=true`, which keeps the default address \
+             0.0.0.0:50051, and `--node-config-override \
+             fullnode:grpc-api-config.address=<HOST:PORT>` to bind elsewhere."
                 .yellow()
                 .bold()
         );
@@ -586,6 +587,24 @@ async fn start(
                 "Loading IOTA-Names options from fullnode config file at {fullnode_config_path:?}"
             );
 
+            let fullnode_config: NodeConfig = PersistedConfig::read(&fullnode_config_path)
+                .map_err(|err| {
+                    err.context(format!(
+                        "Cannot open fullnode config file at {fullnode_config_path:?}"
+                    ))
+                })?;
+            // A consensus config makes the node a validator, both to `validate`
+            // and to the swarm's node partitions.
+            ensure!(
+                !fullnode_config.is_validator(),
+                "fullnode config file at {fullnode_config_path:?} has a `consensus-config`, \
+                 which makes it a validator config"
+            );
+            // The same verdict `iota-node` gives when it reads this file.
+            fullnode_config.validate().with_context(|| {
+                format!("fullnode config file at {fullnode_config_path:?} is invalid")
+            })?;
+
             // Keep this field list in sync with FULLNODE_CONFIG_NOTE.
             let NodeConfig {
                 iota_names_config,
@@ -595,11 +614,7 @@ async fn start(
                 genesis: fullnode_genesis,
                 migration_tx_data_path: fullnode_migration_tx_data_path,
                 ..
-            } = PersistedConfig::read(&fullnode_config_path).map_err(|err| {
-                err.context(format!(
-                    "Cannot open fullnode config file at {fullnode_config_path:?}"
-                ))
-            })?;
+            } = fullnode_config;
             ensure!(
                 genesis.eq(&fullnode_genesis),
                 "Fullnode must use the same genesis blob as validators in IOTA network config"
@@ -616,15 +631,10 @@ async fn start(
 
             swarm_builder = swarm_builder.with_fullnode_enable_grpc_api(enable_grpc_api);
             if enable_grpc_api {
-                // Apply gRPC configuration if enabled
-                if let Some(grpc_config) = grpc_api_config {
-                    info!("Enabling gRPC API for fullnode with config: {grpc_config:?}");
-                    swarm_builder = swarm_builder.with_fullnode_grpc_api_config(grpc_config);
-                } else {
-                    warn!("gRPC API enabled but no grpc-api-config provided, using default");
-                    swarm_builder =
-                        swarm_builder.with_fullnode_grpc_api_config(GrpcApiConfig::default());
-                }
+                let grpc_config = grpc_api_config
+                    .expect("the loaded config was validated: an enabled gRPC API has a config");
+                info!("Enabling gRPC API for fullnode with config: {grpc_config:?}");
+                swarm_builder = swarm_builder.with_fullnode_grpc_api_config(grpc_config);
             }
         }
 
@@ -720,8 +730,8 @@ async fn start(
             config
                 .grpc_api_config
                 .as_ref()
-                .map(|grpc| grpc.address)
-                .unwrap_or_else(|| GrpcApiConfig::default().address)
+                .expect("the swarm build validates that an enabled gRPC API has a config")
+                .address
         })
     });
     if let Some(grpc_address) = fullnode_grpc_address {
@@ -1333,6 +1343,18 @@ mod tests {
             .with_enable_grpc_api(enable_grpc_api)
             .with_data_ingestion_dir(data_ingestion_dir)
             .build_from_parts(&mut OsRng, &[], Genesis::new_empty())
+    }
+
+    #[test]
+    fn an_enabled_grpc_api_is_built_with_an_address() {
+        let dir = tempdir().unwrap();
+        let config = built_fullnode_config(dir.path(), true, None);
+        config.validate().unwrap();
+
+        // What the localnet reports as the gRPC URL, and what the `expect`s
+        // on the start path rely on.
+        assert!(config.enable_grpc_api);
+        assert!(config.grpc_api_config.is_some());
     }
 
     #[test]

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -2,7 +2,9 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fs::read_dir, net::SocketAddr, time::Duration};
+#[cfg(not(msim))]
+use std::fs::{read_to_string, write};
+use std::{fs::read_dir, net::SocketAddr, path::Path, time::Duration};
 
 use iota_config::{
     IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
@@ -16,14 +18,12 @@ use iota_macros::sim_test;
 use iota_sdk::iota_client_config::IotaClientConfig;
 use iota_swarm_config::{
     genesis_config::DEFAULT_NUMBER_OF_AUTHORITIES, network_config::NetworkConfigLight,
+    node_config_override::NodeConfigOverride,
 };
 
-#[sim_test]
-async fn test_genesis() -> Result<(), anyhow::Error> {
-    let tmp_dir = iota_common::tempdir();
-    let working_dir = tmp_dir.path();
-
-    // Genesis
+/// A `genesis` command that leaves every field but the ones passed in at the
+/// value the CLI defaults to.
+fn genesis_command(working_dir: &Path, committee_size: usize) -> LocalnetCommand {
     LocalnetCommand::Genesis {
         working_dir: Some(working_dir.to_path_buf()),
         write_config: None,
@@ -32,13 +32,49 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         epoch_duration_ms: None,
         benchmark_ips: None,
         with_faucet: false,
-        committee_size: DEFAULT_NUMBER_OF_AUTHORITIES,
+        committee_size,
         num_additional_gas_accounts: None,
         chain_start_timestamp_ms: None,
         admin_interface_address: None,
     }
-    .execute()
-    .await?;
+}
+
+/// A `start` command that leaves every field but the ones passed in at the
+/// value the CLI defaults to.
+fn start_command(
+    config_dir: &Path,
+    disable_fullnode_pruning: bool,
+    node_config_override: Vec<NodeConfigOverride>,
+) -> LocalnetCommand {
+    LocalnetCommand::Start {
+        #[cfg(feature = "indexer")]
+        data_ingestion_dir: None,
+        config_dir: Some(config_dir.to_path_buf()),
+        no_full_node: false,
+        disable_fullnode_pruning,
+        node_config_override,
+        force_regenesis: false,
+        with_faucet: None,
+        faucet_amount: None,
+        faucet_coin_count: None,
+        with_grpc: None,
+        fullnode_rpc_port: 9000,
+        committee_size: None,
+        epoch_duration_ms: None,
+        #[cfg(feature = "indexer")]
+        indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
+    }
+}
+
+#[sim_test]
+async fn test_genesis() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+
+    // Genesis
+    genesis_command(working_dir, DEFAULT_NUMBER_OF_AUTHORITIES)
+        .execute()
+        .await?;
 
     // Get all the new file names
     let files = read_dir(working_dir)?
@@ -66,21 +102,9 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     assert_eq!(5, wallet_conf.keystore().addresses().len());
 
     // Genesis 2nd time should fail
-    let result = LocalnetCommand::Genesis {
-        working_dir: Some(working_dir.to_path_buf()),
-        write_config: None,
-        force: false,
-        from_config: None,
-        epoch_duration_ms: None,
-        benchmark_ips: None,
-        with_faucet: false,
-        committee_size: DEFAULT_NUMBER_OF_AUTHORITIES,
-        num_additional_gas_accounts: None,
-        chain_start_timestamp_ms: None,
-        admin_interface_address: None,
-    }
-    .execute()
-    .await;
+    let result = genesis_command(working_dir, DEFAULT_NUMBER_OF_AUTHORITIES)
+        .execute()
+        .await;
     assert!(matches!(result, Err(..)));
 
     tmp_dir.close()?;
@@ -91,22 +115,10 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
 async fn test_genesis_rejects_a_zero_committee_size() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
 
-    let err = LocalnetCommand::Genesis {
-        working_dir: Some(tmp_dir.path().to_path_buf()),
-        write_config: None,
-        force: false,
-        from_config: None,
-        epoch_duration_ms: None,
-        benchmark_ips: None,
-        with_faucet: false,
-        committee_size: 0,
-        num_additional_gas_accounts: None,
-        chain_start_timestamp_ms: None,
-        admin_interface_address: None,
-    }
-    .execute()
-    .await
-    .unwrap_err();
+    let err = genesis_command(tmp_dir.path(), 0)
+        .execute()
+        .await
+        .unwrap_err();
 
     let err = format!("{err:#}");
     assert!(err.contains("Committee size must be at least 1."), "{err}");
@@ -119,26 +131,13 @@ async fn test_genesis_rejects_a_zero_committee_size() -> Result<(), anyhow::Erro
 async fn test_start_reports_a_failing_node_config_override() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
 
-    let err = LocalnetCommand::Start {
-        #[cfg(feature = "indexer")]
-        data_ingestion_dir: None,
-        config_dir: Some(tmp_dir.path().to_path_buf()),
-        no_full_node: false,
-        disable_fullnode_pruning: false,
+    let err = start_command(
+        tmp_dir.path(),
+        false,
         // One character off, so the override fails when it is applied to
         // the built config.
-        node_config_override: vec!["fullnode:enable-index-processng=false".parse()?],
-        force_regenesis: false,
-        with_faucet: None,
-        faucet_amount: None,
-        faucet_coin_count: None,
-        with_grpc: None,
-        fullnode_rpc_port: 9000,
-        committee_size: None,
-        epoch_duration_ms: None,
-        #[cfg(feature = "indexer")]
-        indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
-    }
+        vec!["fullnode:enable-index-processng=false".parse()?],
+    )
     .execute()
     .await
     .unwrap_err();
@@ -157,13 +156,10 @@ async fn test_start() -> Result<(), anyhow::Error> {
 
     if let Ok(res) = tokio::time::timeout(
         Duration::from_secs(10),
-        LocalnetCommand::Start {
-            #[cfg(feature = "indexer")]
-            data_ingestion_dir: None,
-            config_dir: Some(working_dir.to_path_buf()),
-            no_full_node: false,
-            disable_fullnode_pruning: true,
-            node_config_override: vec![
+        start_command(
+            working_dir,
+            true,
+            vec![
                 // Exercises the override path through the CLI; the values
                 // match what --disable-fullnode-pruning and the defaults
                 // already set, so the started network is unaffected.
@@ -171,17 +167,7 @@ async fn test_start() -> Result<(), anyhow::Error> {
                     .parse()?,
                 "validator:enable-soft-locking=true".parse()?,
             ],
-            force_regenesis: false,
-            with_faucet: None,
-            faucet_amount: None,
-            faucet_coin_count: None,
-            with_grpc: None,
-            fullnode_rpc_port: 9000,
-            committee_size: None,
-            epoch_duration_ms: None,
-            #[cfg(feature = "indexer")]
-            indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
-        }
+        )
         .execute(),
     )
     .await
@@ -211,6 +197,93 @@ async fn test_start() -> Result<(), anyhow::Error> {
     assert!(!wallet_conf.envs().is_empty());
 
     assert_eq!(5, wallet_conf.keystore().addresses().len());
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+// A plain tokio test: `start` rejects the config before it launches a node, so
+// it needs no simulator and must also run where `#[sim_test]`s are skipped. It
+// is excluded under msim because the start path calls
+// `tokio::task::spawn_blocking`, which the simulator runs on the current
+// simulator node — a plain tokio test has none.
+#[cfg(not(msim))]
+#[tokio::test]
+async fn test_start_rejects_a_persisted_config_no_node_could_start_with()
+-> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+
+    genesis_command(working_dir, 1).execute().await?;
+
+    // An enabled gRPC API without a config: `iota-node` refuses to start with
+    // it, so the localnet must refuse it too instead of filling in a default.
+    let fullnode_config_path = working_dir.join(IOTA_FULLNODE_CONFIG);
+    let mut fullnode_config: serde_yaml::Value =
+        serde_yaml::from_str(&read_to_string(&fullnode_config_path)?)?;
+    let fields = fullnode_config.as_mapping_mut().unwrap();
+    fields.insert("enable-grpc-api".into(), true.into());
+    fields.insert("grpc-api-config".into(), serde_yaml::Value::Null);
+    write(
+        &fullnode_config_path,
+        serde_yaml::to_string(&fullnode_config)?,
+    )?;
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(30),
+        start_command(working_dir, false, vec![]).execute(),
+    )
+    .await
+    .expect("start must reject the config instead of launching a network")
+    .unwrap_err();
+
+    let err = format!("{err:#}");
+    assert!(err.contains(IOTA_FULLNODE_CONFIG), "{err}");
+    assert!(err.contains("`grpc-api-config` is missing"), "{err}");
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+// A plain tokio test for the same reason as the test above.
+#[cfg(not(msim))]
+#[tokio::test]
+async fn test_start_rejects_a_persisted_fullnode_config_with_a_consensus_config()
+-> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+
+    genesis_command(working_dir, 1).execute().await?;
+
+    // A `consensus-config` turns the file into a validator config, which the
+    // fullnode checks are not written for: `validate` skips the gRPC API rule
+    // for validators, so the localnet must reject the file up front.
+    let fullnode_config_path = working_dir.join(IOTA_FULLNODE_CONFIG);
+    let mut fullnode_config: serde_yaml::Value =
+        serde_yaml::from_str(&read_to_string(&fullnode_config_path)?)?;
+    let fields = fullnode_config.as_mapping_mut().unwrap();
+    fields.insert(
+        "consensus-config".into(),
+        serde_yaml::from_str("db-path: consensus-db")?,
+    );
+    fields.insert("enable-grpc-api".into(), true.into());
+    fields.insert("grpc-api-config".into(), serde_yaml::Value::Null);
+    write(
+        &fullnode_config_path,
+        serde_yaml::to_string(&fullnode_config)?,
+    )?;
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(30),
+        start_command(working_dir, false, vec![]).execute(),
+    )
+    .await
+    .expect("start must reject the config instead of launching a network")
+    .unwrap_err();
+
+    let err = format!("{err:#}");
+    assert!(err.contains(IOTA_FULLNODE_CONFIG), "{err}");
+    assert!(err.contains("which makes it a validator config"), "{err}");
 
     tmp_dir.close()?;
     Ok(())

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -62,6 +62,9 @@ prometheus-filtered.workspace = true
 telemetry-subscribers.workspace = true
 typed-store.workspace = true
 
+[dev-dependencies]
+serde_yaml.workspace = true
+
 [build-dependencies]
 rustc_version_runtime = "0.3"
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2554,7 +2554,7 @@ pub async fn build_http_server(
     prometheus_registry: &Registry,
 ) -> Result<Option<iota_http::ServerHandle>> {
     // Validators do not expose these APIs
-    if config.consensus_config().is_some() {
+    if config.is_validator() {
         return Ok(None);
     }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -347,13 +347,13 @@ impl IotaNode {
     }
 
     pub async fn start_async(
-        config: NodeConfig,
+        mut config: NodeConfig,
         registry_service: RegistryService,
         server_version: ServerVersion,
         serving_rt_handle: tokio::runtime::Handle,
     ) -> Result<Arc<IotaNode>> {
+        config.validate()?;
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
-        let mut config = config.clone();
         if config.supported_protocol_versions.is_none() {
             info!(
                 "populating config.supported_protocol_versions with default {:?}",
@@ -363,7 +363,7 @@ impl IotaNode {
         }
 
         let run_with_range = config.run_with_range;
-        let is_validator = config.consensus_config().is_some();
+        let is_validator = config.is_validator();
         let is_full_node = !is_validator;
         let prometheus_registry = registry_service.default_registry();
 
@@ -658,12 +658,8 @@ impl IotaNode {
 
         info!("start snapshot upload");
         // Start uploading state snapshot to remote store
-        let state_snapshot_handle = Self::start_state_snapshot(
-            &config,
-            &prometheus_registry,
-            checkpoint_store.clone(),
-            is_full_node,
-        )?;
+        let state_snapshot_handle =
+            Self::start_state_snapshot(&config, &prometheus_registry, checkpoint_store.clone())?;
 
         let checkpoint_progress_tracker = Arc::new(CheckpointProgressTracker::new());
 
@@ -985,22 +981,18 @@ impl IotaNode {
         self.close_epoch(&epoch_store).await
     }
 
-    /// Creates a StateSnapshotUploader and starts it if the StateSnapshotConfig
-    /// is set.
+    /// Creates a StateSnapshotUploader and starts it if
+    /// `state-snapshot-write-config.object-store-config` is set. Snapshot
+    /// publication is a fullnode-only role.
     fn start_state_snapshot(
         config: &NodeConfig,
         prometheus_registry: &Registry,
         checkpoint_store: Arc<CheckpointStore>,
-        is_full_node: bool,
     ) -> Result<Option<tokio::sync::broadcast::Sender<()>>> {
         if let Some(remote_store_config) = &config.state_snapshot_write_config.object_store_config {
-            // Snapshot publication is a fullnode-only role.
-            anyhow::ensure!(
-                is_full_node,
-                "Snapshot upload is configured, but this node is a validator. \
-                 Snapshot publication is only supported on fullnodes. Remove the \
-                 `state_snapshot_write_config.object_store_config` setting, or move \
-                 the upload to a fullnode."
+            debug_assert!(
+                !config.is_validator(),
+                "`NodeConfig::validate` rejects snapshot upload on a validator"
             );
             let snapshot_uploader = StateSnapshotUploader::new(
                 &config.db_checkpoint_path(),
@@ -2476,19 +2468,15 @@ fn build_kv_store(
 }
 
 /// Builds and starts the gRPC server for the IOTA node based on the node's
-/// configuration.
+/// configuration; validators return early as they do not expose the gRPC
+/// API.
 ///
-/// This function performs the following tasks:
-/// 1. Checks if the node is a validator by inspecting the consensus
-///    configuration; if so, it returns early as validators do not expose gRPC
-///    APIs.
-/// 2. Checks if gRPC is enabled in the configuration.
-/// 3. Creates broadcast channels for checkpoint streaming.
-/// 4. Initializes the gRPC checkpoint service.
-/// 5. Spawns the gRPC server to listen for incoming connections.
+/// Returns `None` on a validator and when the gRPC API is disabled.
 ///
-/// Returns a tuple of optional broadcast channels for checkpoint summary and
-/// data.
+/// # Panics
+///
+/// Panics if the gRPC API is enabled without a `grpc-api-config`;
+/// [`NodeConfig::validate`] rejects such a config at startup.
 async fn build_grpc_server(
     config: &NodeConfig,
     state: Arc<AuthorityState>,
@@ -2497,14 +2485,17 @@ async fn build_grpc_server(
     prometheus_registry: &Registry,
     server_version: ServerVersion,
 ) -> Result<Option<GrpcServerHandle>> {
-    // Validators do not expose gRPC APIs
-    if config.consensus_config().is_some() || !config.enable_grpc_api {
+    // Validators do not expose gRPC APIs. This return must agree with the
+    // gRPC rule in `NodeConfig::validate`, which is what makes the `expect`
+    // below unreachable.
+    if config.is_validator() || !config.enable_grpc_api {
         return Ok(None);
     }
 
-    let Some(grpc_config) = &config.grpc_api_config else {
-        return Err(anyhow!("gRPC API is enabled but no configuration provided"));
-    };
+    let grpc_config = config
+        .grpc_api_config
+        .as_ref()
+        .expect("`NodeConfig::validate` rejects an enabled gRPC API without a config");
 
     // Get chain identifier from state directly
     let chain_id = state.get_chain_identifier();
@@ -2805,5 +2796,71 @@ mod runtime_split_tests {
             caller_pool, bind_pool,
             "the fix must move the bind off the caller (node-core) runtime onto serving"
         );
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use iota_config::NodeConfig;
+    use iota_metrics::RegistryService;
+    use prometheus_filtered::Registry;
+
+    use super::IotaNode;
+
+    /// The node validates its config before it does anything else, which is
+    /// what keeps the `expect` in `build_grpc_server` unreachable.
+    #[tokio::test]
+    async fn start_rejects_a_config_no_node_could_start_with() {
+        let mut config: NodeConfig = serde_yaml::from_str(
+            r#"
+db-path: /nonexistent/db
+network-address: /dns/localhost/tcp/8080/http
+metrics-address: "0.0.0.0:9184"
+json-rpc-address: "0.0.0.0:9000"
+genesis:
+  genesis-file-location: /nonexistent/genesis.blob
+"#,
+        )
+        .unwrap();
+        config.enable_grpc_api = true;
+        config.grpc_api_config = None;
+
+        let err = IotaNode::start(config, RegistryService::new(Registry::new()))
+            .await
+            .unwrap_err();
+
+        let err = format!("{err:#}");
+        assert!(err.contains("`grpc-api-config` is missing"), "{err}");
+    }
+
+    /// The same, for a validator configured to upload state snapshots, which
+    /// is what keeps the `debug_assert` in `start_state_snapshot` unreachable.
+    #[tokio::test]
+    async fn start_rejects_snapshot_upload_on_a_validator() {
+        let config: NodeConfig = serde_yaml::from_str(
+            r#"
+db-path: /nonexistent/db
+network-address: /dns/localhost/tcp/8080/http
+metrics-address: "0.0.0.0:9184"
+json-rpc-address: "0.0.0.0:9000"
+genesis:
+  genesis-file-location: /nonexistent/genesis.blob
+consensus-config:
+  db-path: /nonexistent/consensus-db
+state-snapshot-write-config:
+  object-store-config:
+    object-store: File
+    directory: /nonexistent/snapshots
+  concurrency: 1
+"#,
+        )
+        .unwrap();
+
+        let err = IotaNode::start(config, RegistryService::new(Registry::new()))
+            .await
+            .unwrap_err();
+
+        let err = format!("{err:#}");
+        assert!(err.contains("snapshot upload"), "{err}");
     }
 }

--- a/crates/iota-swarm-config/src/node_config_override.rs
+++ b/crates/iota-swarm-config/src/node_config_override.rs
@@ -191,15 +191,18 @@ impl NodeConfigOverride {
         // default, so the round trip would set them behind the user's back.
         // Keep the old value unless the override needs the deserialized
         // default in place: a newly created firewall config only takes effect
-        // alongside a policy config, and an enabled gRPC API needs a config.
-        // `apply_leaves_untouched_fields_unchanged` guards the list.
+        // alongside a policy config, and on a fullnode an enabled gRPC API
+        // needs a config. `apply_leaves_untouched_fields_unchanged` guards
+        // the list.
         let firewall_config_created =
             config.firewall_config.is_none() && new_config.firewall_config.is_some();
         if !(self.targets(&["policy-config"]) || firewall_config_created) {
             new_config.policy_config = config.policy_config.clone();
         }
         if !(self.targets(&["grpc-api-config"])
-            || (self.targets(&["enable-grpc-api"]) && new_config.enable_grpc_api))
+            || (self.targets(&["enable-grpc-api"])
+                && new_config.enable_grpc_api
+                && new_config.consensus_config.is_none()))
         {
             new_config.grpc_api_config = config.grpc_api_config.clone();
         }
@@ -214,12 +217,11 @@ impl NodeConfigOverride {
                 .periodic_compaction_threshold_days;
         }
 
-        if new_config.enable_grpc_api && new_config.grpc_api_config.is_none() {
-            bail!(
-                "`{self}` leaves the gRPC API enabled without a `grpc-api-config`, a state a \
-                 fullnode refuses to start in"
-            );
-        }
+        // The base config may already have been invalid, so the wording
+        // does not claim the override caused it.
+        new_config.validate().with_context(|| {
+            format!("with `{self}` applied, no node could start with this config")
+        })?;
 
         *config = new_config;
         Ok(())
@@ -600,9 +602,26 @@ mod tests {
         assert!(config.enable_grpc_api);
         assert!(config.grpc_api_config.is_some());
 
-        // Clearing the config while the API is enabled is rejected.
-        assert!(clear.apply_to(&mut config).is_err());
+        // Clearing the config while the API is enabled is rejected, with
+        // the startup invariant as the cause.
+        let err = format!("{:#}", clear.apply_to(&mut config).unwrap_err());
+        assert!(
+            err.contains("`enable-grpc-api` is set but `grpc-api-config` is missing"),
+            "{err}"
+        );
+        assert!(err.contains("no node could start with"), "{err}");
         assert!(config.grpc_api_config.is_some());
+    }
+
+    #[test]
+    fn enabling_the_grpc_api_on_a_validator_does_not_create_a_config() {
+        // Validators do not expose the gRPC API, so enabling it neither
+        // requires nor materializes a config there.
+        let mut config = validator_test_config();
+        let enable: NodeConfigOverride = "enable-grpc-api=true".parse().unwrap();
+        enable.apply_to(&mut config).unwrap();
+        assert!(config.enable_grpc_api);
+        assert!(config.grpc_api_config.is_none());
     }
 
     #[test]
@@ -626,17 +645,25 @@ mod tests {
         assert!(config.firewall_config.is_none());
         assert!(config.policy_config.is_none());
 
-        // An edit to an existing firewall config must not resurrect a policy
-        // config that was explicitly cleared.
+        // An edit to an existing firewall config must not reset the policy
+        // config to the serde default.
         let mut config = test_config();
         set.apply_to(&mut config).unwrap();
-        let clear_policy: NodeConfigOverride = "policy-config=null".parse().unwrap();
-        clear_policy.apply_to(&mut config).unwrap();
-        assert!(config.policy_config.is_none());
+        let edit_policy: NodeConfigOverride = "policy-config.channel-capacity=42".parse().unwrap();
+        edit_policy.apply_to(&mut config).unwrap();
         let edit: NodeConfigOverride = "firewall-config.destination-port=65001".parse().unwrap();
         edit.apply_to(&mut config).unwrap();
         assert_eq!(config.firewall_config.unwrap().destination_port, 65001);
-        assert!(config.policy_config.is_none());
+        assert_eq!(config.policy_config.unwrap().channel_capacity, 42);
+
+        // Clearing the policy config leaves the firewall inert, so it is
+        // rejected while one is set.
+        let mut config = test_config();
+        set.apply_to(&mut config).unwrap();
+        let clear_policy: NodeConfigOverride = "policy-config=null".parse().unwrap();
+        let err = clear_policy.apply_to(&mut config).unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("`firewall-config` is set"), "{err}");
     }
 
     #[test]

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use futures::future::try_join_all;
 use iota_config::{
     ExecutionCacheConfig, IOTA_GENESIS_FILENAME, NodeConfig,
@@ -418,6 +418,9 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
     /// - An override fails to apply to a built config.
     /// - The network has a fullnode and a validator config has no
     ///   `p2p-config.external-address`.
+    /// - A supplied validator config has no `consensus-config`.
+    /// - A supplied validator config fails [`NodeConfig::validate`].
+    /// - A built fullnode config fails [`NodeConfig::validate`].
     ///
     /// # Panics
     ///
@@ -537,6 +540,14 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             network_config.validator_configs.len(),
         )?;
         for (index, validator) in network_config.validator_configs.iter_mut().enumerate() {
+            // A missing consensus config makes the node a fullnode, both to
+            // `validate` and to the swarm's node partitions. Checked before
+            // the overrides so the error names the missing section rather
+            // than the override that is judged under fullnode rules.
+            ensure!(
+                validator.is_validator(),
+                "validator {index} has no consensus-config"
+            );
             apply_node_config_overrides(
                 self.node_config_overrides
                     .iter()
@@ -546,6 +557,9 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             .with_context(|| {
                 format!("failed to apply node config overrides to validator {index}")
             })?;
+            validator
+                .validate()
+                .with_context(|| format!("validator {index} config is invalid"))?;
         }
 
         let mut nodes: HashMap<_, _> = network_config
@@ -626,6 +640,9 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 &mut config,
             )
             .with_context(|| format!("failed to apply node config overrides to fullnode {idx}"))?;
+            config
+                .validate()
+                .with_context(|| format!("fullnode {idx} config is invalid"))?;
             info!(
                 "SwarmBuilder configuring full node with name {}",
                 config.authority_public_key()
@@ -756,10 +773,11 @@ impl Swarm {
     ///
     /// # Panics
     ///
-    /// Panics on an override that fails to apply and on a node that fails to
-    /// start.
+    /// Panics on an override that fails to apply, on a config that fails
+    /// [`NodeConfig::validate`], and on a node that fails to start.
     pub async fn spawn_new_node(&mut self, mut config: NodeConfig) -> IotaNodeHandle {
         self.apply_node_config_overrides_for_spawn(&mut config);
+        config.validate().unwrap_or_else(|err| panic!("{err:#}"));
         let name = config.authority_public_key();
         let node = Node::new(config);
         node.start().await.unwrap();
@@ -840,7 +858,7 @@ impl AsRef<Path> for SwarmDirectory {
 mod test {
     use std::num::NonZeroUsize;
 
-    use iota_config::IOTA_GENESIS_FILENAME;
+    use iota_config::{IOTA_GENESIS_FILENAME, object_storage_config::ObjectStoreConfig};
     use iota_swarm_config::{
         network_config_builder::ConfigBuilder, node_config_override::NodeConfigOverride,
     };
@@ -1132,6 +1150,80 @@ mod test {
         );
         let fullnode = swarm.fullnodes().next().unwrap();
         assert!(!fullnode.config().enable_index_processing);
+    }
+
+    #[test]
+    fn try_build_rejects_a_supplied_validator_config_no_node_could_start_with() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut network_config = ConfigBuilder::new(dir.path())
+            .committee_size(NonZeroUsize::new(1).unwrap())
+            .build();
+        // A supplied validator config can carry settings the node refuses
+        // to start with.
+        network_config.validator_configs[0]
+            .state_snapshot_write_config
+            .object_store_config = Some(ObjectStoreConfig::default());
+
+        let err = Swarm::builder()
+            .with_network_config(network_config)
+            .try_build()
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("validator 0 config is invalid"), "{err}");
+        assert!(err.contains("snapshot upload"), "{err}");
+    }
+
+    #[test]
+    fn try_build_rejects_a_supplied_validator_config_without_a_consensus_config() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut network_config = ConfigBuilder::new(dir.path())
+            .committee_size(NonZeroUsize::new(1).unwrap())
+            .build();
+        // A supplied validator config can omit the consensus config, which
+        // makes it a fullnode to `validate` and to `fullnodes()`. The rest
+        // of the entry is then judged under fullnode rules, so the missing
+        // section must be reported before any override is applied.
+        network_config.validator_configs[0].consensus_config = None;
+        network_config.validator_configs[0].enable_grpc_api = true;
+        network_config.validator_configs[0].grpc_api_config = None;
+
+        let err = Swarm::builder()
+            .with_network_config(network_config)
+            .with_node_config_overrides(vec!["all:enable-soft-locking=true".parse().unwrap()])
+            .try_build()
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("validator 0 has no consensus-config"), "{err}");
+    }
+
+    #[test]
+    fn try_build_rejects_a_fullnode_override_no_node_could_start_with() {
+        let err = Swarm::builder()
+            .committee_size(NonZeroUsize::new(1).unwrap())
+            .with_fullnode_count(1)
+            .with_node_config_overrides(vec![
+                // A snapshot store without a backend: the node refuses to
+                // start with it.
+                "fullnode:state-snapshot-write-config.object-store-config.directory=/tmp/snapshots"
+                    .parse()
+                    .unwrap(),
+            ])
+            .try_build()
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("storage backend"), "{err}");
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "snapshot upload")]
+    async fn spawn_new_node_panics_on_a_config_no_node_could_start_with() {
+        let mut swarm = Swarm::builder()
+            .committee_size(NonZeroUsize::new(1).unwrap())
+            .build();
+        let mut config = swarm.config().validator_configs()[0].clone();
+        config.state_snapshot_write_config.object_store_config = Some(ObjectStoreConfig::default());
+
+        swarm.spawn_new_node(config).await;
     }
 
     #[tokio::test]

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -731,7 +731,7 @@ impl Swarm {
     pub fn validator_nodes(&self) -> impl Iterator<Item = &Node> {
         self.nodes
             .values()
-            .filter(|node| node.config().consensus_config.is_some())
+            .filter(|node| node.config().is_validator())
     }
 
     pub fn validator_node_handles(&self) -> Vec<IotaNodeHandle> {
@@ -764,7 +764,7 @@ impl Swarm {
     pub fn fullnodes(&self) -> impl Iterator<Item = &Node> {
         self.nodes
             .values()
-            .filter(|node| node.config().consensus_config.is_none())
+            .filter(|node| !node.config().is_validator())
     }
 
     /// Start a node from `config` and add it to the swarm.
@@ -790,7 +790,7 @@ impl Swarm {
     /// initial build. `validator-<N>` scoped overrides refer to positions in
     /// the initial network config, so they are skipped here.
     fn apply_node_config_overrides_for_spawn(&self, config: &mut NodeConfig) {
-        let is_fullnode = config.consensus_config.is_none();
+        let is_fullnode = !config.is_validator();
         apply_node_config_overrides(
             self.node_config_overrides.iter().filter(|config_override| {
                 if is_fullnode {


### PR DESCRIPTION
# Description of change

The node's can-this-config-start rules and the override engine's cross-field checks are the same policy in two places; this merges them.

- Add `NodeConfig::validate()` holding the startup invariants, taken from the node's real refusal sites only: a fullnode with `enable-grpc-api` needs a `grpc-api-config` (validators do not expose the gRPC API, so those two fields are not checked there), snapshot upload (`state-snapshot-write-config.object-store-config`) is fullnode-only, and a snapshot store needs a storage backend (the uploader could never build one without). One rule covers a config the node would start but silently ignore: `firewall-config` without a `policy-config` is rejected, since the traffic controller only exists when a policy is set. Startup checks that need I/O (genesis loading, URL fetches) stay out. Adds `NodeConfig::is_validator()`, used by `validate` and the node's startup checks.
- Call it at the top of `IotaNode::start_async`, before any store is opened. The gRPC refusal site becomes an `expect` and the snapshot site a `debug_assert`, both documented as unreachable and each pinned by a test that `IotaNode::start` rejects a config failing its rule; the same holds for `iota-localnet`'s gRPC-address fallback, which is now an `expect` instead of repairing with a default address (a branch only an explicit `grpc-api-config: null` could reach, since an absent key deserializes to the default). A persisted `fullnode.yaml` is validated on load, so localnet applies the node's own checks to the file, plus a localnet-only rule rejecting one that carries a `consensus-config`. (`test-cluster` keeps its own fallbacks; it exposes no override API, so it is out of scope here.)
- The override engine validates the patched config through the same function, with wording that does not claim the override caused a pre-existing problem; built fullnode configs and supplied validator configs are validated in `SwarmBuilder::try_build` and `Swarm::spawn_new_node`, which catches invalid entries in a hand-edited `network.yaml` — including a validator entry with no `consensus-config`, which would otherwise be judged under fullnode rules and join the swarm's fullnode partition.
- Keep the "an override must not add or remove `consensus-config`" rule in the override engine: it guards a node's kind, not whether a config can start.
- Behavior changes: the engine now matches the node on validators — it accepts a validator left with `enable-grpc-api` and no config, and `validator:enable-grpc-api=true` no longer materializes a default `grpc-api-config`. Setting snapshot upload on a validator fails when the override is applied instead of at node launch, a snapshot store without a backend is rejected up front instead of at uploader startup, and a config carrying `firewall-config` without `policy-config` is rejected instead of silently ignoring the firewall. A persisted `fullnode.yaml` with `enable-grpc-api: true` and an explicit null `grpc-api-config` is rejected instead of silently repaired, a `fullnode.yaml` carrying a `consensus-config` is rejected as a validator config, and a `network.yaml` validator entry without `consensus-config` is rejected naming the validator, before any override is applied to it. Error text names the config keys. Since each override is validated as it is applied, a state only a later override completes can be rejected order-dependently — the next PR moves validation to the batch's final state.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Nodes (Validators and Full nodes): a config with `firewall-config` set and `policy-config` explicitly `null` is now rejected at startup, instead of starting with the firewall silently ignored.
- [x] CLI: `iota-localnet start --node-config-override` rejections changed — a validator left with `enable-grpc-api` and no `grpc-api-config` is now accepted (the node ignores it), and setting snapshot upload on a validator fails when the override is applied. `iota-localnet start` now also rejects a persisted `fullnode.yaml` whose enabled gRPC API has an explicit null config or which carries a `consensus-config`, and a `network.yaml` validator entry without `consensus-config`.