### PR TITLE
refactor: remove the multisig_keys() test util

### DIFF
--- a/crates/iota-e2e-tests/tests/multisig_tests.rs
+++ b/crates/iota-e2e-tests/tests/multisig_tests.rs
@@ -7,7 +7,10 @@ use std::net::SocketAddr;
 use iota_core::authority_client::validator::ValidatorAPI;
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_crypto::{secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair};
+use iota_sdk_crypto::{
+    ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey, secp256r1::Secp256r1PrivateKey,
+    simple::SimpleKeypair,
+};
 use iota_sdk_types::{
     Address, UserSignature,
     crypto::{
@@ -20,7 +23,7 @@ use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     error::{IotaError, IotaResult},
     transaction::TransactionEnvelope,
-    utils::{make_upgraded_multisig_tx, multisig_keys},
+    utils::make_upgraded_multisig_tx,
 };
 use p256::pkcs8::DecodePublicKey;
 use passkey_authenticator::{Authenticator, UserCheck, UserValidationMethod};
@@ -118,7 +121,9 @@ async fn create_credential_and_sign_test_tx_with_passkey_multisig(
 
     // Construct a multisig with 4 pks (ed25519, secp256k1, secp256r1, passkey) with
     // threshold = 1.
-    let (kp1, kp2, kp3) = multisig_keys();
+    let kp1 = Ed25519PrivateKey::random();
+    let kp2 = Secp256k1PrivateKey::random();
+    let kp3 = Secp256r1PrivateKey::random();
     let pk0 = kp1.public_key(); // ed25519
     let pk1 = kp2.public_key(); // secp256k1
     let pk2 = kp3.public_key(); // secp256r1
@@ -251,7 +256,9 @@ async fn test_multisig_e2e() {
     let context = &test_cluster.wallet;
     let rgp = test_cluster.get_reference_gas_price().await;
 
-    let (kp1, kp2, kp3) = multisig_keys();
+    let kp1 = Ed25519PrivateKey::random();
+    let kp2 = Secp256k1PrivateKey::random();
+    let kp3 = Secp256r1PrivateKey::random();
     let pk0 = kp1.public_key(); // ed25519
     let pk1: PublicKey = kp2.public_key().into(); // secp256k1
     let pk2 = kp3.public_key(); // secp256r1

--- a/crates/iota-types/src/unit_tests/multisig_tests.rs
+++ b/crates/iota-types/src/unit_tests/multisig_tests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_crypto::Signer;
+use iota_sdk_crypto::{Signer, ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey};
 use iota_sdk_types::{
     Address,
     crypto::{
@@ -14,7 +14,6 @@ use iota_sdk_types::{
 use crate::{
     error::IotaError,
     signature::{AuthenticatorTrait, VerifyParams},
-    utils::multisig_keys,
 };
 
 #[test]
@@ -23,7 +22,8 @@ fn verify_rejects_signature_pubkey_scheme_mismatch() {
     // key, but whose accompanying member signature is Secp256k1. The committee
     // and bitmap are otherwise well-formed, so `validate()` passes and the
     // mismatch is only observable inside `verify_claims`.
-    let (kp1, kp2, _) = multisig_keys();
+    let kp1 = Ed25519PrivateKey::random();
+    let kp2 = Secp256k1PrivateKey::random();
 
     let multisig_pk =
         MultisigCommittee::new(vec![MultisigMember::new(kp1.public_key(), 1)], 1).unwrap();

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -155,22 +155,10 @@ pub fn to_sender_signed_transaction_with_multi_signers(
     TransactionEnvelope::from_data_and_signer(tx, signers)
 }
 
-pub fn keys() -> Vec<SimpleKeypair> {
-    let (kp1, kp2, kp3) = multisig_keys();
-    vec![kp1.into(), kp2.into(), kp3.into()]
-}
-
-pub fn multisig_keys() -> (Ed25519PrivateKey, Secp256k1PrivateKey, Secp256r1PrivateKey) {
-    let mut seed = StdRng::from_seed([0; 32]);
-    let kp1 = Ed25519PrivateKey::generate(&mut seed);
-    let kp2 = Secp256k1PrivateKey::generate(&mut seed);
-    let kp3 = Secp256r1PrivateKey::generate(&mut seed);
-
-    (kp1, kp2, kp3)
-}
-
 pub fn make_upgraded_multisig_tx() -> TransactionEnvelope {
-    let (kp1, kp2, kp3) = multisig_keys();
+    let kp1 = Ed25519PrivateKey::random();
+    let kp2 = Secp256k1PrivateKey::random();
+    let kp3 = Secp256r1PrivateKey::random();
     let pk1 = kp1.public_key();
     let pk2 = kp2.public_key();
     let pk3 = kp3.public_key();


### PR DESCRIPTION
# Description of change

Removes the `multisig_keys()` util: its callers only need three keys of distinct schemes, not deterministic values, so they generate them inline with the SDK's `::random()`. Also drops the `keys()` wrapper, which had no callers.

One more #11590 checklist item.

## Links to any relevant issues

Part of #11590.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`iota-types` and `iota-e2e-tests` compile clean with `--all-targets`; the multisig unit tests pass locally, the e2e sim tests run in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8HDhvVEyBujVabtPaZtoe)_