### PR TITLE
refactor: rename `GasCoin::to_object` to `to_move_struct`

### DIFF
--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -286,9 +286,9 @@ fn get_registry() -> Result<Registry> {
     // the SDK's MovePackage uses BTreeMap<Identifier, Vec<u8>> with serde_with,
     // and Identifier's custom serde (DisplayFromStr) is incompatible with
     // serde_reflection's tracing deserializer for map keys.
-    let sample_move_obj = MoveStruct::new_gas_coin(1u64.into(), ObjectId::ZERO, 0);
+    let sample_move_struct = MoveStruct::new_gas_coin(1u64.into(), ObjectId::ZERO, 0);
     tracer
-        .trace_value(&mut samples, &ObjectData::Struct(sample_move_obj))
+        .trace_value(&mut samples, &ObjectData::Struct(sample_move_struct))
         .unwrap();
     let sample_upgrade_info = UpgradeInfo {
         upgraded_id: ObjectId::ZERO,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4878,9 +4878,9 @@ async fn prepare_authority_and_shared_object_cert()
 
     let shared_object_id = ObjectId::random();
     let shared_object = {
-        let obj = MoveStruct::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
-        let owner = Owner::Shared(obj.version());
-        Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
+        let move_struct = MoveStruct::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
+        let owner = Owner::Shared(move_struct.version());
+        Object::new_move(move_struct, owner, TransactionDigest::GENESIS_MARKER)
     };
     let initial_shared_version = shared_object.version();
 
@@ -4978,9 +4978,9 @@ async fn test_consensus_commit_prologue_generation(#[values(false, true)] pcool:
     let gas_objects = create_gas_objects(2, sender);
     let shared_object_id = ObjectId::random();
     let shared_object = {
-        let obj = MoveStruct::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
-        let owner = Owner::Shared(obj.version());
-        Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
+        let move_struct = MoveStruct::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
+        let owner = Owner::Shared(move_struct.version());
+        Object::new_move(move_struct, owner, TransactionDigest::GENESIS_MARKER)
     };
     let initial_shared_version = shared_object.version();
     let (authority_state, package_object_ref) = init_state_with_objects_and_object_basics(
@@ -5114,9 +5114,9 @@ async fn test_consensus_message_processed() {
 
     let shared_object_id = ObjectId::random();
     let shared_object = {
-        let obj = MoveStruct::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
-        let owner = Owner::Shared(obj.version());
-        Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
+        let move_struct = MoveStruct::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
+        let owner = Owner::Shared(move_struct.version());
+        Object::new_move(move_struct, owner, TransactionDigest::GENESIS_MARKER)
     };
     let initial_shared_version = shared_object.version();
 
@@ -6477,9 +6477,9 @@ fn create_shared_objects(num: u32) -> Vec<Object> {
     for _ in 0..num {
         let shared_object_id = ObjectId::random();
         let shared_object = {
-            let obj = MoveStruct::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
-            let owner = Owner::Shared(obj.version());
-            Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
+            let move_struct = MoveStruct::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
+            let owner = Owner::Shared(move_struct.version());
+            Object::new_move(move_struct, owner, TransactionDigest::GENESIS_MARKER)
         };
         objects.push(shared_object);
     }

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -61,7 +61,7 @@ pub fn create_large_object(padding_bytes_len: usize) -> (ObjectId, Object) {
     let owner = Address::random();
     let mut contents = GasCoin::new(id, 100).to_bcs_bytes();
     contents.extend(vec![0u8; padding_bytes_len]);
-    let move_obj = MoveStruct::new_from_execution_with_limit(
+    let move_struct = MoveStruct::new_from_execution_with_limit(
         StructTag::new_gas_coin(),
         OBJECT_START_VERSION,
         contents,
@@ -69,7 +69,7 @@ pub fn create_large_object(padding_bytes_len: usize) -> (ObjectId, Object) {
     )
     .unwrap();
     let obj = Object::new_move(
-        move_obj,
+        move_struct,
         Owner::Address(owner),
         TransactionDigest::GENESIS_MARKER,
     );

--- a/crates/iota-grpc-server/tests/list_owned_objects.rs
+++ b/crates/iota-grpc-server/tests/list_owned_objects.rs
@@ -40,7 +40,7 @@ use tonic::transport::Channel;
 /// Create a gas-coin `Object` owned by `owner` with the given `object_id`.
 fn make_gas_coin(owner: Address, object_id: ObjectId, balance: u64) -> Object {
     let contents = GasCoin::new(object_id, balance).to_bcs_bytes();
-    let move_obj = MoveStruct::new_from_execution_with_limit(
+    let move_struct = MoveStruct::new_from_execution_with_limit(
         StructTag::new_gas_coin(),
         OBJECT_START_VERSION,
         contents,
@@ -48,7 +48,7 @@ fn make_gas_coin(owner: Address, object_id: ObjectId, balance: u64) -> Object {
     )
     .unwrap();
     Object::new_move(
-        move_obj,
+        move_struct,
         Owner::Address(owner),
         TransactionDigest::GENESIS_MARKER,
     )
@@ -63,7 +63,7 @@ fn make_large_gas_coin(
 ) -> Object {
     let mut contents = GasCoin::new(object_id, balance).to_bcs_bytes();
     contents.extend(vec![0u8; padding]);
-    let move_obj = MoveStruct::new_from_execution_with_limit(
+    let move_struct = MoveStruct::new_from_execution_with_limit(
         StructTag::new_gas_coin(),
         OBJECT_START_VERSION,
         contents,
@@ -71,7 +71,7 @@ fn make_large_gas_coin(
     )
     .unwrap();
     Object::new_move(
-        move_obj,
+        move_struct,
         Owner::Address(owner),
         TransactionDigest::GENESIS_MARKER,
     )

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -1013,13 +1013,13 @@ mod tests {
                 get_test_coin(Some("0xAAA"), CoinType::Gas),
             ];
             let coins_clone = coins.clone();
-            let coin_move_object = MoveStruct::new_gas_coin(
+            let coin_move_struct = MoveStruct::new_gas_coin(
                 coins[0].version,
                 coins[0].coin_object_id,
                 coins[0].balance,
             );
             let coin_object = Object::new_move(
-                coin_move_object,
+                coin_move_struct,
                 Owner::Immutable,
                 coins[0].previous_transaction,
             );

--- a/crates/iota-ledger-signer/src/utils.rs
+++ b/crates/iota-ledger-signer/src/utils.rs
@@ -78,7 +78,7 @@ fn object_from_response(resp: IotaObjectResponse) -> Option<Object> {
         _ => return None,
     };
 
-    let move_object = MoveStruct::new_from_execution_with_limit(
+    let move_struct = MoveStruct::new_from_execution_with_limit(
         move_object_type.into(),
         data.version,
         bcs_bytes,
@@ -88,7 +88,7 @@ fn object_from_response(resp: IotaObjectResponse) -> Option<Object> {
     let owner = data.owner?;
     let previous_transaction = data.previous_transaction?;
 
-    let object = Object::new_move(move_object, owner, previous_transaction);
+    let object = Object::new_move(move_struct, owner, previous_transaction);
 
     // We need to get the inner object to modify the storage rebate
     let mut inner = object.into_inner();

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -325,7 +325,7 @@ impl RpcExampleProvider {
                 IotaObjectResponse::new_with_data(IotaObjectData {
                     content: Some(
                         IotaParsedData::try_from_object(
-                            coin.to_object(Version::from_u64(1)),
+                            coin.to_move_struct(Version::from_u64(1)),
                             GasCoin::layout(),
                         )
                         .unwrap(),
@@ -367,7 +367,7 @@ impl RpcExampleProvider {
         let result = IotaPastObjectResponse::VersionFound(IotaObjectData {
             content: Some(
                 IotaParsedData::try_from_object(
-                    coin.to_object(Version::from_u64(1)),
+                    coin.to_move_struct(Version::from_u64(1)),
                     GasCoin::layout(),
                 )
                 .unwrap(),
@@ -1482,7 +1482,7 @@ impl RpcExampleProvider {
             IotaPastObjectResponse::VersionFound(IotaObjectData {
                 content: Some(
                     IotaParsedData::try_from_object(
-                        coin.to_object(Version::from_u64(1)),
+                        coin.to_move_struct(Version::from_u64(1)),
                         GasCoin::layout(),
                     )
                     .unwrap(),
@@ -1500,7 +1500,7 @@ impl RpcExampleProvider {
             IotaPastObjectResponse::VersionFound(IotaObjectData {
                 content: Some(
                     IotaParsedData::try_from_object(
-                        coin2.to_object(Version::from_u64(4)),
+                        coin2.to_move_struct(Version::from_u64(4)),
                         GasCoin::layout(),
                     )
                     .unwrap(),

--- a/crates/iota-types/src/gas_coin.rs
+++ b/crates/iota-types/src/gas_coin.rs
@@ -101,7 +101,7 @@ mod checked {
             bcs::to_bytes(&self).unwrap()
         }
 
-        pub fn to_object(&self, version: Version) -> MoveStruct {
+        pub fn to_move_struct(&self, version: Version) -> MoveStruct {
             MoveStruct::new_gas_coin(version, *self.id(), self.value())
         }
 

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -85,21 +85,21 @@ impl IotaSystemStateWrapper {
         let old_field_object = get_dynamic_field_object_from_store(object_store, id, &self.version)
             .expect("Dynamic field object of wrapper should always be present in the object store");
         let mut new_field_object = old_field_object.clone();
-        let move_object = new_field_object
+        let move_struct = new_field_object
             .data
             .as_opt_mut_struct()
             .expect("Dynamic field object must be a Move object");
         match self.version {
             1 => {
                 Self::advance_epoch_safe_mode_impl::<IotaSystemStateV1>(
-                    move_object,
+                    move_struct,
                     params,
                     protocol_config,
                 );
             }
             2 => {
                 Self::advance_epoch_safe_mode_impl::<IotaSystemStateV2>(
-                    move_object,
+                    move_struct,
                     params,
                     protocol_config,
                 );
@@ -107,7 +107,7 @@ impl IotaSystemStateWrapper {
             #[cfg(msim)]
             IOTA_SYSTEM_STATE_SIM_TEST_V1 => {
                 Self::advance_epoch_safe_mode_impl::<SimTestIotaSystemStateV1>(
-                    move_object,
+                    move_struct,
                     params,
                     protocol_config,
                 );
@@ -115,7 +115,7 @@ impl IotaSystemStateWrapper {
             #[cfg(msim)]
             IOTA_SYSTEM_STATE_SIM_TEST_SHALLOW_V1 => {
                 Self::advance_epoch_safe_mode_impl::<SimTestIotaSystemStateShallowV1>(
-                    move_object,
+                    move_struct,
                     params,
                     protocol_config,
                 );
@@ -123,7 +123,7 @@ impl IotaSystemStateWrapper {
             #[cfg(msim)]
             IOTA_SYSTEM_STATE_SIM_TEST_DEEP_V1 => {
                 Self::advance_epoch_safe_mode_impl::<SimTestIotaSystemStateDeepV1>(
-                    move_object,
+                    move_struct,
                     params,
                     protocol_config,
                 );
@@ -134,14 +134,14 @@ impl IotaSystemStateWrapper {
     }
 
     fn advance_epoch_safe_mode_impl<T>(
-        move_object: &mut MoveStruct,
+        move_struct: &mut MoveStruct,
         params: &AdvanceEpochParams,
         protocol_config: &ProtocolConfig,
     ) where
         T: Serialize + DeserializeOwned + IotaSystemStateTrait,
     {
         let mut field: Field<u64, T> =
-            bcs::from_bytes(move_object.contents()).expect("bcs deserialization should never fail");
+            bcs::from_bytes(move_struct.contents()).expect("bcs deserialization should never fail");
         tracing::info!(
             "Advance epoch safe mode: current epoch: {}, protocol_version: {}, system_state_version: {}",
             field.value.epoch(),
@@ -156,7 +156,7 @@ impl IotaSystemStateWrapper {
             field.value.system_state_version()
         );
         let new_contents = bcs::to_bytes(&field).expect("bcs serialization should never fail");
-        move_object
+        move_struct
             .update_contents(new_contents, protocol_config)
             .expect("Update iota system object content cannot fail since it should be small");
     }

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -617,9 +617,9 @@ impl Object {
     /// Make a new random test shared object.
     pub fn shared_for_testing() -> Object {
         let id = ObjectId::random();
-        let obj = MoveStruct::new_gas_coin(OBJECT_START_VERSION, id, 10);
-        let owner = Owner::Shared(obj.version());
-        Object::new_move(obj, owner, TransactionDigest::GENESIS_MARKER)
+        let move_struct = MoveStruct::new_gas_coin(OBJECT_START_VERSION, id, 10);
+        let owner = Owner::Shared(move_struct.version());
+        Object::new_move(move_struct, owner, TransactionDigest::GENESIS_MARKER)
     }
 
     pub fn with_id_owner_gas_for_testing(id: ObjectId, owner: Address, gas: u64) -> Self {
@@ -724,9 +724,9 @@ impl Object {
     /// Generate a new gas coin worth `value` with a random object ID and owner
     /// For testing purposes only
     pub fn new_gas_with_balance_and_owner_for_testing(value: u64, owner: Address) -> Self {
-        let obj = MoveStruct::new_gas_coin(OBJECT_START_VERSION, ObjectId::random(), value);
+        let move_struct = MoveStruct::new_gas_coin(OBJECT_START_VERSION, ObjectId::random(), value);
         Object::new_move(
-            obj,
+            move_struct,
             Owner::Address(owner),
             TransactionDigest::GENESIS_MARKER,
         )
@@ -904,8 +904,8 @@ mod tests {
     // inadvertently changed.
     #[test]
     fn test_object_digest_and_serialized_format() {
-        let g =
-            GasCoin::new_for_testing_with_id(ObjectId::ZERO, 123).to_object(OBJECT_START_VERSION);
+        let g = GasCoin::new_for_testing_with_id(ObjectId::ZERO, 123)
+            .to_move_struct(OBJECT_START_VERSION);
         let o = Object::new_move(g, Owner::Address(Address::ZERO), TransactionDigest::ZERO);
         let bytes = bcs::to_bytes(&o).unwrap();
 
@@ -932,7 +932,7 @@ mod tests {
     #[test]
     fn test_get_coin_value_unchecked() {
         fn test_for_value(v: u64) {
-            let g = GasCoin::new_for_testing(v).to_object(OBJECT_START_VERSION);
+            let g = GasCoin::new_for_testing(v).to_move_struct(OBJECT_START_VERSION);
             assert_eq!(g.get_coin_value_unchecked(), v);
             assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
         }
@@ -953,7 +953,7 @@ mod tests {
     #[test]
     fn test_set_coin_value_unchecked() {
         fn test_for_value(v: u64) {
-            let mut g = GasCoin::new_for_testing(u64::MAX).to_object(OBJECT_START_VERSION);
+            let mut g = GasCoin::new_for_testing(u64::MAX).to_move_struct(OBJECT_START_VERSION);
             g.set_coin_value_unchecked(v);
             assert_eq!(g.get_coin_value_unchecked(), v);
             assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -217,7 +217,7 @@ impl TestCheckpointDataBuilder {
             !self.live_objects.contains_key(&object_id),
             "Object already exists: {object_id}. Please use a different object index.",
         );
-        let move_object = MoveStruct::new_coin(
+        let move_struct = MoveStruct::new_coin(
             coin_type,
             // version doesn't matter since we will set it to the lamport version when we finalize
             // the transaction
@@ -225,7 +225,7 @@ impl TestCheckpointDataBuilder {
             object_id,
             balance,
         );
-        let object = Object::new_move(move_object, owner, TransactionDigest::ZERO);
+        let object = Object::new_move(move_struct, owner, TransactionDigest::ZERO);
         tx_builder.created_objects.insert(object_id, object);
         self
     }

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
@@ -383,7 +383,7 @@ impl Inner<'_> {
     }
 }
 
-fn deserialize_move_object(
+fn deserialize_move_struct(
     obj: &MoveStruct,
     child_ty: &Type,
     child_ty_layout: &R::MoveTypeLayout,
@@ -456,7 +456,7 @@ impl<'a> ChildObjectStore<'a> {
         };
 
         Ok(Some(
-            match deserialize_move_object(&obj, child_ty, child_layout, child_struct_tag)? {
+            match deserialize_move_struct(&obj, child_ty, child_layout, child_struct_tag)? {
                 ObjectResult::MismatchedType => (ObjectResult::MismatchedType, obj_meta),
                 ObjectResult::Loaded((_, _, v)) => {
                     // Find all UIDs inside of the value and update the object parent maps with the

--- a/iota-execution/latest/iota-move-natives/src/test_scenario.rs
+++ b/iota-execution/latest/iota-move-natives/src/test_scenario.rs
@@ -676,7 +676,7 @@ pub fn allocate_receiving_ticket_for_object(
             E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
         ));
     };
-    let move_object =
+    let move_struct =
         MoveStruct::new_from_execution_with_limit(tag, object_version, bytes, 250 * 1024).unwrap();
 
     let Some((owner, _)) = inventories
@@ -705,7 +705,7 @@ pub fn allocate_receiving_ticket_for_object(
     );
 
     let object = Object::new_move(
-        move_object,
+        move_struct,
         Owner::Address(*owner),
         TransactionDigest::default(),
     );


### PR DESCRIPTION
# Description of change

`GasCoin::to_object` returns a `MoveStruct`, not a `MoveObject`, so the name no longer matched the return type. Rename it to `to_move_struct`, and do the same for the surrounding names that still called a `MoveStruct` an object:

- `advance_epoch_safe_mode_impl`'s `move_object: &mut MoveStruct` parameter and its caller.
- `deserialize_move_object` → `deserialize_move_struct`.
- Every `let … = MoveStruct::…` binding named `move_object` / `move_obj` / `coin_move_object` / `sample_move_obj` / bare `obj`.

Rename only — no behaviour change.

Left alone as out of scope: `move_object_type` in `iota-ledger-signer` (it holds an `ObjectType`), and the read-side bindings that come from `as_opt_struct()` rather than a constructor.

## Links to any relevant issues

fixes #12363

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

`cargo check --all-targets` and `cargo +nightly fmt` on the touched crates.

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)