### PR TITLE
refactor(iota-json-rpc-types): drop the iota-metrics dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6626,7 +6626,6 @@ dependencies = [
  "iota-enum-compat-util",
  "iota-json",
  "iota-macros",
- "iota-metrics",
  "iota-names",
  "iota-package-resolver",
  "iota-protocol-config",

--- a/crates/iota-json-rpc-types/Cargo.toml
+++ b/crates/iota-json-rpc-types/Cargo.toml
@@ -29,7 +29,6 @@ tracing.workspace = true
 iota-enum-compat-util.workspace = true
 iota-json.workspace = true
 iota-macros.workspace = true
-iota-metrics.workspace = true
 iota-names.workspace = true
 iota-package-resolver.workspace = true
 iota-protocol-config.workspace = true

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -5,7 +5,6 @@
 use std::{fmt, fmt::Display, str::FromStr};
 
 use fastcrypto::encoding::{Base58, Base64};
-use iota_metrics::monitored_scope;
 use iota_sdk_types::{Address, Event, Identifier, ObjectId, StructTag, TransactionDigest};
 use iota_types::{
     error::IotaResult,
@@ -459,7 +458,6 @@ impl EventFilter {
 
 impl Filter<IotaEvent> for EventFilter {
     fn matches(&self, item: &IotaEvent) -> bool {
-        let _scope = monitored_scope("EventFilter::matches");
         self.try_matches(item).unwrap_or_default()
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -8,7 +8,6 @@ use enum_dispatch::enum_dispatch;
 use fastcrypto::encoding::{Base64, Encoding};
 use futures::{Stream, StreamExt, stream::FuturesOrdered};
 use iota_json::{IotaJsonValue, primitive_type};
-use iota_metrics::monitored_scope;
 use iota_package_resolver::{CleverError, ErrorConstants, PackageStore, Resolver};
 use iota_sdk_types::{
     Address, Argument, CanceledTransaction, ChangeEpoch, ChangeEpochV2, ChangeEpochV3,
@@ -2757,7 +2756,6 @@ impl TransactionFilter {
 
 impl Filter<EffectsWithInput> for TransactionFilter {
     fn matches(&self, item: &EffectsWithInput) -> bool {
-        let _scope = monitored_scope("TransactionFilter::matches");
         match self {
             TransactionFilter::InputObject(o) => {
                 let Ok(input_objects) = item.input.input_objects() else {
@@ -2918,7 +2916,6 @@ impl TransactionFilterV2 {
 
 impl Filter<EffectsWithInput> for TransactionFilterV2 {
     fn matches(&self, item: &EffectsWithInput) -> bool {
-        let _scope = monitored_scope("TransactionFilterV2::matches");
         if let Some(v1) = self.as_v1() {
             return v1.matches(item);
         }


### PR DESCRIPTION
# Description of change

`iota-json-rpc-types` depended on `iota-metrics` only for three `monitored_scope` calls in `Filter::matches` implementations. That put `iota-metrics` plus `prometheus-closure-metric` and `prometheus-filtered` underneath a types crate that 32 workspace crates wait for.

- Remove the three `monitored_scope` calls from `EventFilter::matches`, `TransactionFilter::matches` and `TransactionFilterV2::matches`.
- Drop the `iota-metrics` dependency.

No other change; the filter logic is untouched.

## Why remove the scopes rather than move them

The three scopes time a pure, allocation-free predicate on the JSON-RPC subscription path. `monitored_scope` does two labelled counter increments and an `Instant::now()` on entry plus the timing on drop — more work than the predicate it measures, once per subscriber per streamed item.

Keeping them at the call site was the alternative. `iota-core`'s `streamer.rs` is the only caller that reaches these impls, and it is generic over `Filter<T>`, so preserving the three distinct scope names would mean adding a required associated const to the public `Filter` trait and implementing it in all five impls — more public API surface than the metric is worth. Happy to take that route instead if the owning team wants the timings kept.

Worth a look from whoever owns the JSON-RPC dashboards: no in-repo dashboard, alert or config refers to `EventFilter::matches`, `TransactionFilter::matches` or `TransactionFilterV2::matches`, and `iota-grpc-server` instruments its own filters separately (`EventFilter::matches_event`, `TransactionFilter::matches_transaction`), so the gRPC path keeps equivalent coverage.

## Build graph effect

Measured with `cargo metadata`, workspace crates only, excluding `cfg(msim)` and `wasm32`-only edges:

| | before | after |
| --- | --- | --- |
| `iota-json-rpc-types` transitive deps | 16 | **14** |
| `iota-transaction-builder` transitive deps | 15 | **13** |

No change to the longest compilation chain (16) — `iota-json-rpc-types` stays at level 5, floored by `iota-names` / `iota-json` / `iota-package-resolver`. This is a compile-volume change, not a depth one.

## Links to any relevant issues

Related to #12234.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

- `cargo check -p iota-json-rpc-types --all-targets` clean
- `cargo check -p iota-core -p iota-graphql-rpc -p iota-transaction-builder -p iota-json-rpc --all-targets` clean — these are the crates that use the `Filter` trait
- `cargo clippy -p iota-json-rpc-types --all-targets`, `cargo machete`, `cargo +nightly fmt` all clean

### Release Notes

- [x] Nodes (Validators and Full nodes): removed the `EventFilter::matches`, `TransactionFilter::matches` and `TransactionFilterV2::matches` entries from the `monitored_scope` metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)