### PR TITLE
fix(indexer): populate checkpointed_objects during formal snapshot restore

### DIFF
--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -95,24 +95,23 @@ impl Restore for PgIndexerStore {
             );
         }
 
-        let persist_tasks = chunks
+        let (live_chunks, checkpointed_chunks): (Vec<_>, Vec<_>) = chunks
             .into_iter()
             .map(|c| {
                 let checkpointed = c
                     .iter()
                     .map(|live| StoredCheckpointedObject::try_from(live.indexed_object.clone()))
                     .collect::<Result<Vec<_>, IndexerError>>()?;
-                Ok([
-                    self.spawn_blocking_task(move |this| {
-                        this.persist_checkpointed_objects_chunk(checkpointed)
-                    }),
-                    self.spawn_blocking_task(move |this| this.persist_live_objects(c)),
-                ])
+                Ok::<_, IndexerError>((c, checkpointed))
             })
-            .collect::<Result<Vec<_>, IndexerError>>()?
+            .collect::<Result<Vec<_>, _>>()?
             .into_iter()
-            .flatten();
-        futures::future::try_join_all(persist_tasks)
+            .unzip();
+
+        let live_tasks = live_chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_live_objects(c)));
+        futures::future::try_join_all(live_tasks)
             .await
             .map_err(|e| {
                 tracing::error!(
@@ -125,6 +124,25 @@ impl Restore for PgIndexerStore {
             .map_err(|e| {
                 IndexerError::PostgresWrite(format!(
                     "failed to persist all formal snapshot object chunks: {e:?}",
+                ))
+            })?;
+
+        let checkpointed_tasks = checkpointed_chunks.into_iter().map(|c| {
+            self.spawn_blocking_task(move |this| this.persist_checkpointed_objects_chunk(c))
+        });
+        futures::future::try_join_all(checkpointed_tasks)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "failed to join futures for persisting formal snapshot partition to checkpointed_objects: {e}"
+                );
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "failed to persist all formal snapshot checkpointed object chunks: {e:?}",
                 ))
             })?;
         self.persist_displays(derived_data.displays.into_values().collect())

--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -26,6 +26,7 @@ use crate::{
         display::StoredDisplay,
         epoch::{EndOfEpochUpdate, StartOfEpochUpdate, extract_epoch_info_event},
         obj_indices::StoredObjectVersion,
+        objects::StoredCheckpointedObject,
         packages::StoredPackage,
     },
     pruning::pruner::PrunableTable,
@@ -96,7 +97,21 @@ impl Restore for PgIndexerStore {
 
         let persist_tasks = chunks
             .into_iter()
-            .map(|c| self.spawn_blocking_task(move |this| this.persist_live_objects(c)));
+            .map(|c| {
+                let checkpointed = c
+                    .iter()
+                    .map(|live| StoredCheckpointedObject::try_from(live.indexed_object.clone()))
+                    .collect::<Result<Vec<_>, IndexerError>>()?;
+                Ok([
+                    self.spawn_blocking_task(move |this| {
+                        this.persist_checkpointed_objects_chunk(checkpointed)
+                    }),
+                    self.spawn_blocking_task(move |this| this.persist_live_objects(c)),
+                ])
+            })
+            .collect::<Result<Vec<_>, IndexerError>>()?
+            .into_iter()
+            .flatten();
         futures::future::try_join_all(persist_tasks)
             .await
             .map_err(|e| {

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -431,7 +431,7 @@ impl PgIndexerStore {
         })
     }
 
-    fn persist_checkpointed_objects_chunk(
+    pub(crate) fn persist_checkpointed_objects_chunk(
         &self,
         objects: Vec<StoredCheckpointedObject>,
     ) -> Result<(), IndexerError> {


### PR DESCRIPTION
# Description of change

The formal snapshot restore wrote the snapshot's live objects only to the `objects` table, leaving `checkpointed_objects`empty. GraphQL consistent queries (`objects`, `coins`, `balances`, dynamic fields) on a restored indexer returned empty responses because of this.

- `insert_partition` now persists each restored object chunk to `checkpointed_objects` as well
- The two table writes per chunk run as parallel blocking tasks

Note: existing restored deployments will not be fixed by this, they will need either a manual fix in the DB, or a re-restore

## Links to any relevant issues

fixes #12657

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage): tested restore from **mainnet**, all objects present in both **objects** and **checkpointed_objects**

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: ⚠️ Fixed the `restore` command not populating the `checkpointed_objects` table, which made GraphQL consistent queries return incomplete results on indexers restored from a formal snapshot. Deployments that were already restored are not fixed by this change - they need to be restored again.


