### PR TITLE
fix(graphql): make type-filtered objects queries use sane plans

### DIFF
--- a/crates/iota-graphql-rpc/src/backward_view/consistent.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/consistent.rs
@@ -33,8 +33,16 @@ pub(crate) fn query(
 /// Returns active objects from `checkpointed_objects` that were consistent
 /// also at the given checkpoint.
 ///
-/// Uses a LEFT JOIN against `objects_backward_history` to exclude objects
-/// that have any entry with `superseded_at_checkpoint > checkpoint_viewed_at`.
+/// Uses a NOT EXISTS subquery against `objects_backward_history` to exclude
+/// objects that have any entry with
+/// `superseded_at_checkpoint > checkpoint_viewed_at`.
+///
+/// # Implementation notes
+///
+/// NOT EXISTS is used instead of a JOIN because it allows Postgres to pick a
+/// better plan in some cases: it can check each row with a single index
+/// lookup, instead of scanning the whole list of changed objects for every
+/// row.
 fn consistent_checkpointed_objects(
     checkpoint_viewed_at: i64,
     page: &Page<Cursor>,
@@ -47,17 +55,19 @@ fn consistent_checkpointed_objects(
         format!("object_status = {ACTIVE}")
     );
 
-    let changed_subquery = query!(format!(
-        "SELECT DISTINCT object_id FROM objects_backward_history \
-         WHERE superseded_at_checkpoint > {checkpoint_viewed_at}"
-    ));
     let mut source = query!(
-        r#"SELECT candidates.* FROM ({}) candidates
-           LEFT JOIN ({}) changed ON candidates.object_id = changed.object_id"#,
-        checkpointed_filtered,
-        changed_subquery
+        "SELECT candidates.* FROM ({}) candidates",
+        checkpointed_filtered
     );
-    source = filter!(source, "changed.object_id IS NULL");
+    source = filter!(
+        source,
+        format!(
+            "NOT EXISTS (\
+                 SELECT 1 FROM objects_backward_history changed \
+                 WHERE changed.object_id = candidates.object_id \
+                   AND changed.superseded_at_checkpoint > {checkpoint_viewed_at})"
+        )
+    );
     page.apply::<StoredBackwardObject>(source)
 }
 

--- a/crates/iota-graphql-rpc/src/backward_view/consistent.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/consistent.rs
@@ -39,9 +39,10 @@ pub(crate) fn query(
 ///
 /// # Implementation notes
 ///
-/// NOT EXISTS is used instead of a JOIN because it allows Postgres to pick a
-/// better plan in some cases: it can check each row with a single index
-/// lookup, instead of scanning the whole list of changed objects for every
+/// NOT EXISTS lets Postgres answer "did this object change?" row by row,
+/// with one index lookup each. A LEFT JOIN on a `SELECT DISTINCT` subquery
+/// takes that option away: the full list of changed objects must always be
+/// built first, and in the worst plans it is then also scanned for every
 /// row.
 fn consistent_checkpointed_objects(
     checkpoint_viewed_at: i64,

--- a/crates/iota-graphql-rpc/src/types/balance.rs
+++ b/crates/iota-graphql-rpc/src/types/balance.rs
@@ -250,19 +250,20 @@ fn balance_query(
         address,
         coin_type.clone(),
     );
-    let changed = query!(format!(
-        "SELECT DISTINCT object_id FROM objects_backward_history \
-         WHERE superseded_at_checkpoint > {checkpoint_viewed_at}"
-    ));
+    // NOT EXISTS instead of a JOIN; see `consistent_checkpointed_objects`
+    // for explanation.
     let source_a = filter!(
         query!(
-            r#"SELECT candidates.object_id, candidates.coin_balance, candidates.coin_type
-               FROM ({}) candidates
-               LEFT JOIN ({}) changed ON candidates.object_id = changed.object_id"#,
-            checkpointed,
-            changed
+            "SELECT candidates.object_id, candidates.coin_balance, candidates.coin_type \
+             FROM ({}) candidates",
+            checkpointed
         ),
-        "changed.object_id IS NULL"
+        format!(
+            "NOT EXISTS (\
+                 SELECT 1 FROM objects_backward_history changed \
+                 WHERE changed.object_id = candidates.object_id \
+                   AND changed.superseded_at_checkpoint > {checkpoint_viewed_at})"
+        )
     );
 
     let mut history = filter(

--- a/crates/iota-indexer/migrations/pg/2026-08-12-120000_backward_view_type_statistics/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-08-12-120000_backward_view_type_statistics/down.sql
@@ -1,0 +1,6 @@
+-- Restore the default extended-statistics target.
+ALTER STATISTICS checkpointed_objects_type_stats SET STATISTICS -1;
+ALTER STATISTICS objects_backward_history_type_stats SET STATISTICS -1;
+
+ANALYZE checkpointed_objects (object_type, object_type_package, object_type_module, object_type_name);
+ANALYZE objects_backward_history (object_type, object_type_package, object_type_module, object_type_name);

--- a/crates/iota-indexer/migrations/pg/2026-08-12-120000_backward_view_type_statistics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-08-12-120000_backward_view_type_statistics/up.sql
@@ -1,0 +1,11 @@
+-- Raise the extended-statistics target on the backward-diff tables so all
+-- distinct object types fit in the multi-column MCV list; types outside the
+-- list get a rows=1 estimate, leading to plans that time out.
+ALTER STATISTICS checkpointed_objects_type_stats SET STATISTICS 2500;
+ALTER STATISTICS objects_backward_history_type_stats SET STATISTICS 2500;
+
+-- Rebuild the statistics objects modified above with their new target.
+-- ANALYZE rebuilds them only if all their columns are listed; listing just
+-- those columns keeps the ANALYZE cheap.
+ANALYZE checkpointed_objects (object_type, object_type_package, object_type_module, object_type_name);
+ANALYZE objects_backward_history (object_type, object_type_package, object_type_module, object_type_name);


### PR DESCRIPTION
# Description of change

`objects(filter: { type })` timed out on testnet for types with many objects (e.g. `0x3::staking_pool::StakedIota`, 53k objects). Two fixes for this:

- Rewrite the changed-objects exclusion from `LEFT JOIN (SELECT DISTINCT ...)` to `NOT EXISTS`, so Postgres can check each row with one index lookup instead of re-scanning all changed objects per row (same change in the balance query). - **This helps in case postgres picks a bad plan, where it thinks that there are not much candidate rows, where in reality there is way more of them.**
- Add a migration raising the extended-statistics target on the object-type columns to 2500: testnet has more object types than fit in the current statistics, so rarer types got a rows=1 estimate and Postgres picked the bad plan. - **This prevents postgres from picking the bad plan altogether**

## Links to any relevant issues

fixes #12536

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Measured on a staging server with a full testnet copy (921M rows in `checkpointed_objects`), across cursors of increasing age (= more objects changed after the viewed checkpoint), query `objects(first: 3, filter: { type: "0x3::staking_pool::StakedIota" })`:

| cursor age(in terms of backward_history rows accumulated after it) | no fix | NOT EXISTS only | statistics only | both |
|---:|---:|---:|---:|---:|
| ~1k | 3.7s | 0.36s | 43ms | 43ms |
| ~10k | 24s | 0.36s | 53ms | 44ms |
| 30k–300k | timeout (>30s) | 0.36–0.39s | 73–329ms | 40–78ms |
| ~1M | 1.2s | 0.41s | 1.1s | 101ms |
| ~8M (cursor ~3h old) | 24s | 8.3s | 8.6s | 7.9s |

The planner estimate for the StakedIota filter went from 1 row to 40,627 (actual 52,458).
The migration took 1m41s on a testnet-size table.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: `objects(filter: { type })` no longer times out for types with many objects.

