### PR TITLE
fix(iota-core): select the fullnode submission driver per request from the current epoch store (#12520)

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3383,16 +3383,7 @@ impl AuthorityState {
     /// It doesn't properly reconfigure the node, hence should be only used for
     /// testing.
     pub async fn reconfigure_for_testing(&self) {
-        // The current protocol config used in the epoch store may have been overridden
-        // and diverged from the protocol config definitions. That override may
-        // have now been dropped when the initial guard was dropped. We reapply
-        // the override before creating the new epoch store, to make sure that
-        // the new epoch store has the same protocol config as the current one.
-        // Since this is for testing only, we mostly like to keep the protocol config
-        // the same across epochs.
-        let protocol_config = self.epoch_store_for_testing().protocol_config().clone();
-        self.reconfigure_for_testing_with_protocol_config(protocol_config)
-            .await;
+        self.reconfigure_for_testing_impl(None).await;
     }
 
     /// Like [`Self::reconfigure_for_testing`], but the next epoch uses the
@@ -3401,8 +3392,18 @@ impl AuthorityState {
         &self,
         protocol_config: ProtocolConfig,
     ) {
+        self.reconfigure_for_testing_impl(Some(protocol_config))
+            .await;
+    }
+
+    async fn reconfigure_for_testing_impl(&self, protocol_config: Option<ProtocolConfig>) {
         let mut execution_lock = self.execution_lock_for_reconfiguration().await;
         let epoch_store = self.epoch_store_for_testing().clone();
+        // Default to the epoch store's config, whose override guard may have
+        // been dropped. Read it under the lock so config and epoch store are
+        // one snapshot.
+        let protocol_config =
+            protocol_config.unwrap_or_else(|| epoch_store.protocol_config().clone());
         let _guard =
             ProtocolConfig::apply_overrides_for_testing(move |_, _| protocol_config.clone());
         let new_epoch_store = epoch_store.new_at_next_epoch_for_testing(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3383,9 +3383,6 @@ impl AuthorityState {
     /// It doesn't properly reconfigure the node, hence should be only used for
     /// testing.
     pub async fn reconfigure_for_testing(&self) {
-        let mut execution_lock = self.execution_lock_for_reconfiguration().await;
-        let epoch_store = self.epoch_store_for_testing().clone();
-        let protocol_config = epoch_store.protocol_config().clone();
         // The current protocol config used in the epoch store may have been overridden
         // and diverged from the protocol config definitions. That override may
         // have now been dropped when the initial guard was dropped. We reapply
@@ -3393,6 +3390,19 @@ impl AuthorityState {
         // the new epoch store has the same protocol config as the current one.
         // Since this is for testing only, we mostly like to keep the protocol config
         // the same across epochs.
+        let protocol_config = self.epoch_store_for_testing().protocol_config().clone();
+        self.reconfigure_for_testing_with_protocol_config(protocol_config)
+            .await;
+    }
+
+    /// Like [`Self::reconfigure_for_testing`], but the next epoch uses the
+    /// given protocol config.
+    pub async fn reconfigure_for_testing_with_protocol_config(
+        &self,
+        protocol_config: ProtocolConfig,
+    ) {
+        let mut execution_lock = self.execution_lock_for_reconfiguration().await;
+        let epoch_store = self.epoch_store_for_testing().clone();
         let _guard =
             ProtocolConfig::apply_overrides_for_testing(move |_, _| protocol_config.clone());
         let new_epoch_store = epoch_store.new_at_next_epoch_for_testing(

--- a/crates/iota-core/src/transaction_driver/mod.rs
+++ b/crates/iota-core/src/transaction_driver/mod.rs
@@ -54,7 +54,7 @@ pub trait AuthorityAggregatorUpdatable<A>: Send + Sync + 'static {
     fn update_authority_aggregator(&self, new_authorities: Arc<AuthorityAggregator<A>>);
 }
 
-use iota_config::node::NodeConfig;
+use iota_config::validator_client_monitor_config::ValidatorClientMonitorConfig;
 
 /// Options for submitting a transaction.
 #[derive(Clone, Default, Debug)]
@@ -93,6 +93,9 @@ pub struct TransactionDriver<A> {
     submitter: TransactionSubmitter,
     certifier: EffectsCertifier,
     client_monitor: Arc<ValidatorClientMonitor>,
+    /// Whether the P-COOL flow is enabled in the current epoch; latency-ping
+    /// and health-check rounds are skipped while false.
+    pcool_flow_enabled: Arc<dyn Fn() -> bool + Send + Sync>,
 }
 
 impl<A> TransactionDriver<A>
@@ -103,17 +106,15 @@ where
         authority_aggregator: Arc<AuthorityAggregator<A>>,
         reconfig_observer: Arc<dyn ReconfigObserver<A> + Sync + Send>,
         metrics: Arc<TransactionDriverMetrics>,
-        node_config: Option<&NodeConfig>,
+        validator_client_monitor_config: Option<ValidatorClientMonitorConfig>,
         client_metrics: Arc<ValidatorClientMetrics>,
+        pcool_flow_enabled: Arc<dyn Fn() -> bool + Send + Sync>,
     ) -> Arc<Self> {
         let shared_swap = Arc::new(ArcSwap::new(authority_aggregator));
 
-        // Extract validator client monitor config from NodeConfig or use default
-        let monitor_config = node_config
-            .and_then(|nc| nc.validator_client_monitor_config.clone())
-            .unwrap_or_default();
+        let monitor_config = validator_client_monitor_config.unwrap_or_default();
         let client_monitor = Arc::new(ValidatorClientMonitor::new(monitor_config, client_metrics));
-        client_monitor.spawn_health_checks(&shared_swap);
+        client_monitor.spawn_health_checks(&shared_swap, pcool_flow_enabled.clone());
 
         let driver = Arc::new(Self {
             authority_aggregator: shared_swap,
@@ -122,6 +123,7 @@ where
             submitter: TransactionSubmitter::new(metrics.clone()),
             certifier: EffectsCertifier::new(metrics),
             client_monitor,
+            pcool_flow_enabled,
         });
 
         let driver_clone = driver.clone();
@@ -415,6 +417,11 @@ where
 
         loop {
             interval.tick().await;
+
+            // Validators reject pings while the P-COOL flow is disabled.
+            if !(self.pcool_flow_enabled)() {
+                continue;
+            }
 
             let mut tasks = JoinSet::new();
 

--- a/crates/iota-core/src/transaction_driver/mod.rs
+++ b/crates/iota-core/src/transaction_driver/mod.rs
@@ -10,7 +10,7 @@ mod transaction_submitter;
 
 use std::{
     net::SocketAddr,
-    sync::Arc,
+    sync::{Arc, Weak},
     time::{Duration, Instant},
 };
 
@@ -126,9 +126,8 @@ where
             pcool_flow_enabled,
         });
 
-        let driver_clone = driver.clone();
-
-        spawn_logged_monitored_task!(Self::run_latency_checks(driver_clone));
+        let driver_weak = Arc::downgrade(&driver);
+        spawn_logged_monitored_task!(Self::run_latency_checks(driver_weak));
 
         driver.enable_reconfig(reconfig_observer);
         driver
@@ -407,7 +406,7 @@ where
 
     // Runs a background task to send ping transactions to all validators to perform
     // latency checks.
-    async fn run_latency_checks(self: Arc<Self>) {
+    async fn run_latency_checks(driver: Weak<Self>) {
         const INTERVAL_BETWEEN_RUNS: Duration = Duration::from_secs(15);
         const MAX_JITTER: Duration = Duration::from_secs(10);
         const PING_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -418,14 +417,19 @@ where
         loop {
             interval.tick().await;
 
+            // Weak, so this detached task cannot keep the driver alive.
+            let Some(driver) = driver.upgrade() else {
+                break;
+            };
+
             // Validators reject pings while the P-COOL flow is disabled.
-            if !(self.pcool_flow_enabled)() {
+            if !(driver.pcool_flow_enabled)() {
                 continue;
             }
 
             let mut tasks = JoinSet::new();
 
-            Self::ping(self.clone(), &mut tasks, MAX_JITTER, PING_REQUEST_TIMEOUT);
+            Self::ping(driver, &mut tasks, MAX_JITTER, PING_REQUEST_TIMEOUT);
 
             while let Some(result) = tasks.join_next().await {
                 if let Err(e) = result {

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -106,8 +106,9 @@ enum Driver<A: Clone> {
 pub struct TransactionOrchestrator<A: Clone> {
     quorum_driver: Arc<QuorumDriverHandler<A>>,
     transaction_driver: Arc<TransactionDriver<A>>,
-    /// Set once QuorumDriver WAL recovery has run.
-    qd_recovery: OnceLock<()>,
+    /// Set once QuorumDriver WAL recovery has started. The receiver reports
+    /// completion.
+    qd_recovery: OnceLock<watch::Receiver<bool>>,
     validator_state: Arc<AuthorityState>,
     /// Keeps the pending-tx-log cleanup loop alive.
     _local_executor_handle: JoinHandle<()>,
@@ -206,13 +207,16 @@ where
             Self::loop_pending_transaction_log(effects_receiver, pending_tx_log_clone).await;
         });
 
+        // `Weak` so detached driver tasks cannot pin the authority state.
         let pcool_flow_enabled: Arc<dyn Fn() -> bool + Send + Sync> = {
-            let validator_state = validator_state.clone();
+            let validator_state = Arc::downgrade(&validator_state);
             Arc::new(move || {
-                validator_state
-                    .load_epoch_store_one_call_per_task()
-                    .protocol_config()
-                    .enable_pcool_flow()
+                validator_state.upgrade().is_some_and(|state| {
+                    state
+                        .load_epoch_store_one_call_per_task()
+                        .protocol_config()
+                        .enable_pcool_flow()
+                })
             })
         };
         let transaction_driver = TransactionDriver::new(
@@ -238,7 +242,11 @@ where
         // WAL recovery is a startup duty when the quorum driver serves from
         // boot; under P-COOL it is deferred to the first flag-off selection.
         if !use_transaction_driver {
-            this.ensure_qd_recovery();
+            Self::schedule_txes_in_log(this.pending_tx_log.clone(), this.quorum_driver.clone());
+            let (_complete_tx, complete_rx) = watch::channel(true);
+            this.qd_recovery
+                .set(complete_rx)
+                .expect("recovery cell is empty at construction");
         }
         this
     }
@@ -251,22 +259,41 @@ where
     /// Returns the flow selected by `epoch_store`'s P-COOL flag. Call with
     /// the request's own epoch store snapshot so the flag and the submission
     /// see the same epoch.
-    fn select_driver(&self, epoch_store: &AuthorityPerEpochStore) -> Driver<A> {
+    async fn select_driver(&self, epoch_store: &AuthorityPerEpochStore) -> Driver<A> {
         if epoch_store.protocol_config().enable_pcool_flow() {
             Driver::Transaction(self.transaction_driver.clone())
         } else {
-            self.ensure_qd_recovery();
+            self.ensure_qd_recovery().await;
             Driver::Quorum(self.quorum_driver.clone())
         }
     }
 
-    /// Runs QuorumDriver WAL recovery exactly once. The snapshot happens
-    /// before the caller can submit (concurrent callers block on the
-    /// `OnceLock`), so a triggering request cannot be double-driven.
-    fn ensure_qd_recovery(&self) {
-        self.qd_recovery.get_or_init(|| {
-            Self::schedule_txes_in_log(self.pending_tx_log.clone(), self.quorum_driver.clone());
-        });
+    /// Runs QuorumDriver WAL recovery exactly once, snapshotting before the
+    /// caller can submit. The receiver is stored synchronously and the scan
+    /// runs in a detached task, so a cancelled waiter cannot discard the
+    /// one-time state.
+    async fn ensure_qd_recovery(&self) {
+        let mut complete_rx = self
+            .qd_recovery
+            .get_or_init(|| {
+                let pending_tx_log = self.pending_tx_log.clone();
+                let quorum_driver = self.quorum_driver.clone();
+                let (complete_tx, complete_rx) = watch::channel(false);
+                spawn_monitored_task!(async move {
+                    tokio::task::spawn_blocking(move || {
+                        Self::schedule_txes_in_log(pending_tx_log, quorum_driver)
+                    })
+                    .await
+                    .expect("WAL recovery must not panic");
+                    let _ = complete_tx.send(true);
+                });
+                complete_rx
+            })
+            .clone();
+        complete_rx
+            .wait_for(|complete| *complete)
+            .await
+            .expect("the WAL recovery task must not panic");
     }
 
     #[instrument(name = "tx_orchestrator_execute_transaction_block", level = "trace", skip_all,
@@ -329,8 +356,10 @@ where
             request_type,
             ExecuteTransactionRequestType::WaitForLocalExecution
         );
-        let (mut response, seq) = match (self.select_driver(&epoch_store), wait_for_local_execution)
-        {
+        let (mut response, seq) = match (
+            self.select_driver(&epoch_store).await,
+            wait_for_local_execution,
+        ) {
             (Driver::Transaction(td), true) => {
                 let in_flight_transactions = self.in_flight_transactions.clone();
                 let validator_state = self.validator_state.clone();
@@ -682,7 +711,7 @@ where
             .validity_check(&epoch_store.tx_validity_check_context())
             .map_err(QuorumDriverError::InvalidTransaction)?;
 
-        match self.select_driver(&epoch_store) {
+        match self.select_driver(&epoch_store).await {
             Driver::Transaction(td) => {
                 let in_flight_transactions = self.in_flight_transactions.clone();
                 let validator_state = self.validator_state.clone();
@@ -1289,11 +1318,11 @@ where
     /// Runs driver selection for `epoch_store`, with its recovery side
     /// effect.
     #[cfg(any(test, feature = "test-utils"))]
-    pub fn select_driver_for_testing(&self, epoch_store: &AuthorityPerEpochStore) {
-        self.select_driver(epoch_store);
+    pub async fn select_driver_for_testing(&self, epoch_store: &AuthorityPerEpochStore) {
+        self.select_driver(epoch_store).await;
     }
 
-    /// Reports whether QuorumDriver WAL recovery has run.
+    /// Reports whether QuorumDriver WAL recovery has been started.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn qd_recovery_started_for_testing(&self) -> bool {
         self.qd_recovery.get().is_some()
@@ -2094,7 +2123,9 @@ mod tests {
         assert!(!orchestrator.qd_recovery_started_for_testing());
 
         // Selection under the flag keeps recovery uninitialized.
-        orchestrator.select_driver_for_testing(&state.epoch_store_for_testing());
+        orchestrator
+            .select_driver_for_testing(&state.epoch_store_for_testing())
+            .await;
         assert!(!orchestrator.qd_recovery_started_for_testing());
 
         // Epoch 1 with P-COOL off: the first selection runs recovery.
@@ -2107,10 +2138,41 @@ mod tests {
         let epoch_store = state.epoch_store_for_testing();
         assert_eq!(epoch_store.epoch(), 1);
 
-        orchestrator.select_driver_for_testing(&epoch_store);
+        orchestrator.select_driver_for_testing(&epoch_store).await;
         assert!(orchestrator.qd_recovery_started_for_testing());
         // Repeated selections keep the one-shot state.
-        orchestrator.select_driver_for_testing(&epoch_store);
+        orchestrator.select_driver_for_testing(&epoch_store).await;
+        assert!(orchestrator.qd_recovery_started_for_testing());
+    }
+
+    /// A cancelled first waiter must not discard the one-time recovery
+    /// state. A later selection completes against the same state.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn qd_recovery_survives_cancelled_first_selection() {
+        use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+
+        let (state, orchestrator, _tempdir, _reconfig_tx) =
+            build_orchestrator_with_pcool(true).await;
+        assert!(!orchestrator.qd_recovery_started_for_testing());
+
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown);
+        protocol_config.set_enable_pcool_flow_for_testing(false);
+        state
+            .reconfigure_for_testing_with_protocol_config(protocol_config)
+            .await;
+        let epoch_store = state.epoch_store_for_testing();
+
+        // One poll runs the synchronous init. Dropping the future then
+        // cancels the wait mid-recovery.
+        {
+            let selection = orchestrator.select_driver_for_testing(&epoch_store);
+            tokio::pin!(selection);
+            let _ = futures::poll!(selection.as_mut());
+        }
+        assert!(orchestrator.qd_recovery_started_for_testing());
+
+        orchestrator.select_driver_for_testing(&epoch_store).await;
         assert!(orchestrator.qd_recovery_started_for_testing());
     }
 }

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -12,7 +12,7 @@ use std::{
     net::SocketAddr,
     ops::Deref,
     path::Path,
-    sync::{Arc, OnceLock},
+    sync::Arc,
     time::Duration,
 };
 
@@ -99,19 +99,18 @@ enum Driver<A: Clone> {
 /// finality. It adds inflight deduplication, waiting for local execution,
 /// recovery, and epoch change handling.
 ///
-/// Both drivers exist for the node's lifetime; the epoch's P-COOL flag
-/// selects which one serves a request. QuorumDriver WAL recovery runs
-/// exactly once: at construction when the flag is off, else on the first
-/// flag-off selection.
+/// The epoch's P-COOL flag selects the flow serving a request. The
+/// TransactionDriver always exists, so it tracks epochs before the flag
+/// enables it. The QuorumDriver exists only when the node booted with
+/// P-COOL disabled and ran WAL recovery then; after a rollback a node
+/// booted under P-COOL must be restarted.
 pub struct TransactionOrchestrator<A: Clone> {
-    quorum_driver: Arc<QuorumDriverHandler<A>>,
+    quorum_driver: Option<Arc<QuorumDriverHandler<A>>>,
     transaction_driver: Arc<TransactionDriver<A>>,
-    /// Set once QuorumDriver WAL recovery has started. The receiver reports
-    /// completion.
-    qd_recovery: OnceLock<watch::Receiver<bool>>,
     validator_state: Arc<AuthorityState>,
-    /// Keeps the pending-tx-log cleanup loop alive.
-    _local_executor_handle: JoinHandle<()>,
+    /// Handle to the pending-tx-log cleanup loop; present only with the
+    /// quorum driver.
+    _local_executor_handle: Option<JoinHandle<()>>,
     pending_tx_log: Arc<WritePathPendingTransactionLog>,
     /// Digests currently being driven to finality by the TransactionDriver;
     /// used to deduplicate concurrent submissions of the same transaction,
@@ -185,27 +184,33 @@ where
             parent_path.join("fullnode_pending_transactions"),
         ));
 
-        // Registered up front for both flows: registration panics on
-        // duplicates.
+        // Registered for both flows even when the quorum driver is not
+        // built, so metric presence does not depend on the boot mode.
         let quorum_driver_metrics = Arc::new(QuorumDriverMetrics::new(prometheus_registry));
         let transaction_driver_metrics =
             Arc::new(TransactionDriverMetrics::new(prometheus_registry));
         let client_metrics = Arc::new(ValidatorClientMetrics::new(prometheus_registry));
 
-        let quorum_driver = Arc::new(
-            QuorumDriverHandlerBuilder::new(validators.clone(), quorum_driver_metrics)
-                .with_notifier(notifier.clone())
-                .with_reconfig_observer(Arc::new(reconfig_observer))
-                .start(),
-        );
-
-        // The cleanup loop must exist before any WAL recovery runs, so a
-        // recovered transaction cannot complete before its receiver exists.
-        let effects_receiver = quorum_driver.subscribe_to_effects();
-        let pending_tx_log_clone = pending_tx_log.clone();
-        let _local_executor_handle = spawn_monitored_task!(async move {
-            Self::loop_pending_transaction_log(effects_receiver, pending_tx_log_clone).await;
-        });
+        let (quorum_driver, _local_executor_handle) = if use_transaction_driver {
+            (None, None)
+        } else {
+            let quorum_driver = Arc::new(
+                QuorumDriverHandlerBuilder::new(validators.clone(), quorum_driver_metrics)
+                    .with_notifier(notifier.clone())
+                    .with_reconfig_observer(Arc::new(reconfig_observer))
+                    .start(),
+            );
+            // The cleanup loop must exist before WAL recovery runs, so a
+            // recovered transaction cannot complete before its receiver
+            // exists.
+            let effects_receiver = quorum_driver.subscribe_to_effects();
+            let pending_tx_log_clone = pending_tx_log.clone();
+            let local_executor_handle = spawn_monitored_task!(async move {
+                Self::loop_pending_transaction_log(effects_receiver, pending_tx_log_clone).await;
+            });
+            Self::schedule_txes_in_log(pending_tx_log.clone(), quorum_driver.clone());
+            (Some(quorum_driver), Some(local_executor_handle))
+        };
 
         // `Weak` so detached driver tasks cannot pin the authority state.
         let pcool_flow_enabled: Arc<dyn Fn() -> bool + Send + Sync> = {
@@ -228,27 +233,16 @@ where
             pcool_flow_enabled,
         );
 
-        let this = Self {
+        Self {
             quorum_driver,
             transaction_driver,
-            qd_recovery: OnceLock::new(),
             validator_state,
             _local_executor_handle,
             pending_tx_log,
             in_flight_transactions: Default::default(),
             notifier,
             metrics,
-        };
-        // WAL recovery is a startup duty when the quorum driver serves from
-        // boot; under P-COOL it is deferred to the first flag-off selection.
-        if !use_transaction_driver {
-            Self::schedule_txes_in_log(this.pending_tx_log.clone(), this.quorum_driver.clone());
-            let (_complete_tx, complete_rx) = watch::channel(true);
-            this.qd_recovery
-                .set(complete_rx)
-                .expect("recovery cell is empty at construction");
         }
-        this
     }
 }
 
@@ -258,42 +252,30 @@ where
 {
     /// Returns the flow selected by `epoch_store`'s P-COOL flag. Call with
     /// the request's own epoch store snapshot so the flag and the submission
-    /// see the same epoch.
-    async fn select_driver(&self, epoch_store: &AuthorityPerEpochStore) -> Driver<A> {
+    /// see the same epoch. Errors when the quorum driver is selected on a
+    /// node that booted under P-COOL: such a node never ran WAL recovery and
+    /// must be restarted.
+    fn select_driver(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> Result<Driver<A>, QuorumDriverError> {
         if epoch_store.protocol_config().enable_pcool_flow() {
-            Driver::Transaction(self.transaction_driver.clone())
-        } else {
-            self.ensure_qd_recovery().await;
-            Driver::Quorum(self.quorum_driver.clone())
+            return Ok(Driver::Transaction(self.transaction_driver.clone()));
         }
-    }
-
-    /// Runs QuorumDriver WAL recovery exactly once, snapshotting before the
-    /// caller can submit. The receiver is stored synchronously and the scan
-    /// runs in a detached task, so a cancelled waiter cannot discard the
-    /// one-time state.
-    async fn ensure_qd_recovery(&self) {
-        let mut complete_rx = self
-            .qd_recovery
-            .get_or_init(|| {
-                let pending_tx_log = self.pending_tx_log.clone();
-                let quorum_driver = self.quorum_driver.clone();
-                let (complete_tx, complete_rx) = watch::channel(false);
-                spawn_monitored_task!(async move {
-                    tokio::task::spawn_blocking(move || {
-                        Self::schedule_txes_in_log(pending_tx_log, quorum_driver)
-                    })
-                    .await
-                    .expect("WAL recovery must not panic");
-                    let _ = complete_tx.send(true);
-                });
-                complete_rx
+        self.quorum_driver
+            .clone()
+            .map(Driver::Quorum)
+            .ok_or_else(|| {
+                error!(
+                    "This fullnode started while P-COOL was enabled and must be restarted to \
+                     serve the certificate-based flow"
+                );
+                QuorumDriverError::QuorumDriverInternal(IotaError::UnsupportedFeature {
+                    error: "this fullnode started while P-COOL was enabled and must be \
+                            restarted to serve the certificate-based flow"
+                        .to_string(),
+                })
             })
-            .clone();
-        complete_rx
-            .wait_for(|complete| *complete)
-            .await
-            .expect("the WAL recovery task must not panic");
     }
 
     #[instrument(name = "tx_orchestrator_execute_transaction_block", level = "trace", skip_all,
@@ -356,58 +338,56 @@ where
             request_type,
             ExecuteTransactionRequestType::WaitForLocalExecution
         );
-        let (mut response, seq) = match (
-            self.select_driver(&epoch_store).await,
-            wait_for_local_execution,
-        ) {
-            (Driver::Transaction(td), true) => {
-                let in_flight_transactions = self.in_flight_transactions.clone();
-                let validator_state = self.validator_state.clone();
-                let metrics = self.metrics.clone();
-                // Detached so a client disconnect (this future dropped) does
-                // not cancel a submission that may already be in consensus;
-                // the task drives the transaction to finality on its own.
-                join_submission_task(spawn_monitored_task!(Self::submit_with_checkpoint_race(
-                    td,
-                    in_flight_transactions,
-                    validator_state,
-                    metrics,
-                    request,
-                    client_addr,
-                    tx_digest,
-                )))
-                .await?
-            }
-            (Driver::Transaction(td), false) => {
-                let in_flight_transactions = self.in_flight_transactions.clone();
-                let validator_state = self.validator_state.clone();
-                // Detached for the same reason as above.
-                let result = join_submission_task(spawn_monitored_task!(
-                    Self::submit_with_transaction_driver(
+        let (mut response, seq) =
+            match (self.select_driver(&epoch_store)?, wait_for_local_execution) {
+                (Driver::Transaction(td), true) => {
+                    let in_flight_transactions = self.in_flight_transactions.clone();
+                    let validator_state = self.validator_state.clone();
+                    let metrics = self.metrics.clone();
+                    // Detached so a client disconnect (this future dropped) does
+                    // not cancel a submission that may already be in consensus;
+                    // the task drives the transaction to finality on its own.
+                    join_submission_task(spawn_monitored_task!(Self::submit_with_checkpoint_race(
                         td,
                         in_flight_transactions,
                         validator_state,
+                        metrics,
                         request,
                         client_addr,
-                        false,
-                    )
-                ))
-                .await?;
-                (Some(result), None)
-            }
-            (Driver::Quorum(qd), _) => {
-                let qd_resp = self
-                    .execute_transaction_impl(
-                        &qd,
-                        &epoch_store,
-                        request,
-                        transaction.clone(),
-                        client_addr,
-                    )
+                        tx_digest,
+                    )))
+                    .await?
+                }
+                (Driver::Transaction(td), false) => {
+                    let in_flight_transactions = self.in_flight_transactions.clone();
+                    let validator_state = self.validator_state.clone();
+                    // Detached for the same reason as above.
+                    let result = join_submission_task(spawn_monitored_task!(
+                        Self::submit_with_transaction_driver(
+                            td,
+                            in_flight_transactions,
+                            validator_state,
+                            request,
+                            client_addr,
+                            false,
+                        )
+                    ))
                     .await?;
-                (Some(quorum_driver_response_to_v1(qd_resp)), None)
-            }
-        };
+                    (Some(result), None)
+                }
+                (Driver::Quorum(qd), _) => {
+                    let qd_resp = self
+                        .execute_transaction_impl(
+                            &qd,
+                            &epoch_store,
+                            request,
+                            transaction.clone(),
+                            client_addr,
+                        )
+                        .await?;
+                    (Some(quorum_driver_response_to_v1(qd_resp)), None)
+                }
+            };
 
         // `needs_cache_rebuild` is derived from finality, not caller intent:
         // the QD fallback path returns `Certified` and a duplicate
@@ -711,7 +691,7 @@ where
             .validity_check(&epoch_store.tx_validity_check_context())
             .map_err(QuorumDriverError::InvalidTransaction)?;
 
-        match self.select_driver(&epoch_store).await {
+        match self.select_driver(&epoch_store)? {
             Driver::Transaction(td) => {
                 let in_flight_transactions = self.in_flight_transactions.clone();
                 let validator_state = self.validator_state.clone();
@@ -1287,45 +1267,46 @@ where
         }
     }
 
-    pub fn quorum_driver(&self) -> &Arc<QuorumDriverHandler<A>> {
-        &self.quorum_driver
+    /// Returns the quorum driver, or `None` when the node booted under
+    /// P-COOL. Test-only: submissions must go through the per-request
+    /// driver selection.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn quorum_driver(&self) -> Option<&Arc<QuorumDriverHandler<A>>> {
+        self.quorum_driver.as_ref()
     }
 
-    pub fn clone_quorum_driver(&self) -> Arc<QuorumDriverHandler<A>> {
+    /// Owned variant of [`Self::quorum_driver`].
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn clone_quorum_driver(&self) -> Option<Arc<QuorumDriverHandler<A>>> {
         self.quorum_driver.clone()
     }
 
-    pub fn transaction_driver(&self) -> &Arc<TransactionDriver<A>> {
-        &self.transaction_driver
-    }
-
-    /// Returns the quorum driver's aggregator; both drivers keep theirs
-    /// current, so either is authoritative.
+    /// Returns the transaction driver's aggregator; it always exists and its
+    /// reconfig observer keeps it current.
     pub fn clone_authority_aggregator(&self) -> Arc<AuthorityAggregator<A>> {
-        self.quorum_driver.authority_aggregator().load_full()
+        self.transaction_driver.authority_aggregator().load_full()
     }
 
     /// Returns an effects receiver only while the quorum driver is the
-    /// currently selected flow; the P-COOL flow has no effects broadcast.
+    /// currently selected flow and this node can serve it; the P-COOL flow
+    /// has no effects broadcast.
     pub fn subscribe_to_effects_queue(&self) -> Option<Receiver<QuorumDriverEffectsQueueResult>> {
         let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
         if epoch_store.protocol_config().enable_pcool_flow() {
             return None;
         }
-        Some(self.quorum_driver.subscribe_to_effects())
+        self.quorum_driver
+            .as_ref()
+            .map(|quorum_driver| quorum_driver.subscribe_to_effects())
     }
 
-    /// Runs driver selection for `epoch_store`, with its recovery side
-    /// effect.
+    /// Runs driver selection for `epoch_store` and reports its outcome.
     #[cfg(any(test, feature = "test-utils"))]
-    pub async fn select_driver_for_testing(&self, epoch_store: &AuthorityPerEpochStore) {
-        self.select_driver(epoch_store).await;
-    }
-
-    /// Reports whether QuorumDriver WAL recovery has been started.
-    #[cfg(any(test, feature = "test-utils"))]
-    pub fn qd_recovery_started_for_testing(&self) -> bool {
-        self.qd_recovery.get().is_some()
+    pub fn select_driver_for_testing(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> Result<(), QuorumDriverError> {
+        self.select_driver(epoch_store).map(|_| ())
     }
 
     fn update_metrics(
@@ -1362,20 +1343,14 @@ where
             info!("Skipping loading pending transactions from pending_tx_log.");
             return;
         }
-        // Snapshot before the driver is handed out, so a submission that
-        // triggered deferred recovery cannot land in the log and be
-        // double-driven. Bounded: only the quorum-driver path writes this
-        // log, so it holds at most what was pending when that flow was last
-        // active.
-        let pending_txes = pending_tx_log
-            .load_all_pending_transactions()
-            // Failing to read the WAL means the store is broken.
-            .expect("failed to load all pending transactions");
-        info!(
-            "Recovering {} pending transactions from pending_tx_log.",
-            pending_txes.len()
-        );
         spawn_logged_monitored_task!(async move {
+            let pending_txes = pending_tx_log
+                .load_all_pending_transactions()
+                .expect("failed to load all pending transactions");
+            info!(
+                "Recovering {} pending transactions from pending_tx_log.",
+                pending_txes.len()
+            );
             for (i, tx) in pending_txes.into_iter().enumerate() {
                 // TODO: ideally pending_tx_log would not contain VerifiedTransaction, but that
                 // requires a migration.
@@ -2104,31 +2079,39 @@ mod tests {
         (state, orchestrator, tempdir, reconfig_tx)
     }
 
-    /// A flag-off boot runs QuorumDriver WAL recovery at construction.
+    /// A flag-off boot builds the quorum driver and runs WAL recovery at
+    /// construction.
     #[tokio::test(flavor = "multi_thread")]
     async fn qd_recovery_eager_on_flag_off_boot() {
-        let (_state, orchestrator, _tempdir, _reconfig_tx) =
+        let (state, orchestrator, _tempdir, _reconfig_tx) =
             build_orchestrator_with_pcool(false).await;
-        assert!(orchestrator.qd_recovery_started_for_testing());
+        assert!(orchestrator.quorum_driver().is_some());
+        assert!(
+            orchestrator
+                .select_driver_for_testing(&state.epoch_store_for_testing())
+                .is_ok()
+        );
     }
 
-    /// A flag-on boot leaves QuorumDriver WAL recovery uninitialized; the
-    /// first flag-off selection runs it, before the request path can submit.
+    /// A node booted under P-COOL has no quorum driver. After a rollback it
+    /// must reject quorum-driver selection until restarted.
     #[tokio::test(flavor = "multi_thread")]
-    async fn qd_recovery_deferred_until_first_flag_off_selection() {
+    async fn flag_on_boot_rejects_selection_after_rollback() {
         use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 
         let (state, orchestrator, _tempdir, _reconfig_tx) =
             build_orchestrator_with_pcool(true).await;
-        assert!(!orchestrator.qd_recovery_started_for_testing());
+        assert!(orchestrator.quorum_driver().is_none());
 
-        // Selection under the flag keeps recovery uninitialized.
-        orchestrator
-            .select_driver_for_testing(&state.epoch_store_for_testing())
-            .await;
-        assert!(!orchestrator.qd_recovery_started_for_testing());
+        // Selection under the flag serves the P-COOL flow.
+        assert!(
+            orchestrator
+                .select_driver_for_testing(&state.epoch_store_for_testing())
+                .is_ok()
+        );
 
-        // Epoch 1 with P-COOL off: the first selection runs recovery.
+        // Epoch 1 with P-COOL off: selection and the effects queue must both
+        // report the missing quorum driver.
         let mut protocol_config =
             ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown);
         protocol_config.set_enable_pcool_flow_for_testing(false);
@@ -2138,41 +2121,10 @@ mod tests {
         let epoch_store = state.epoch_store_for_testing();
         assert_eq!(epoch_store.epoch(), 1);
 
-        orchestrator.select_driver_for_testing(&epoch_store).await;
-        assert!(orchestrator.qd_recovery_started_for_testing());
-        // Repeated selections keep the one-shot state.
-        orchestrator.select_driver_for_testing(&epoch_store).await;
-        assert!(orchestrator.qd_recovery_started_for_testing());
-    }
-
-    /// A cancelled first waiter must not discard the one-time recovery
-    /// state. A later selection completes against the same state.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn qd_recovery_survives_cancelled_first_selection() {
-        use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
-
-        let (state, orchestrator, _tempdir, _reconfig_tx) =
-            build_orchestrator_with_pcool(true).await;
-        assert!(!orchestrator.qd_recovery_started_for_testing());
-
-        let mut protocol_config =
-            ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown);
-        protocol_config.set_enable_pcool_flow_for_testing(false);
-        state
-            .reconfigure_for_testing_with_protocol_config(protocol_config)
-            .await;
-        let epoch_store = state.epoch_store_for_testing();
-
-        // One poll runs the synchronous init. Dropping the future then
-        // cancels the wait mid-recovery.
-        {
-            let selection = orchestrator.select_driver_for_testing(&epoch_store);
-            tokio::pin!(selection);
-            let _ = futures::poll!(selection.as_mut());
-        }
-        assert!(orchestrator.qd_recovery_started_for_testing());
-
-        orchestrator.select_driver_for_testing(&epoch_store).await;
-        assert!(orchestrator.qd_recovery_started_for_testing());
+        assert!(matches!(
+            orchestrator.select_driver_for_testing(&epoch_store),
+            Err(QuorumDriverError::QuorumDriverInternal(_))
+        ));
+        assert!(orchestrator.subscribe_to_effects_queue().is_none());
     }
 }

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -2,16 +2,17 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-// Transaction Orchestrator is a Node component that utilizes Quorum Driver (or
-// optionally TransactionDriver) to submit transactions to validators for
-// finality, and proactively executes finalized transactions locally.
+// Transaction Orchestrator is a Node component that utilizes Quorum Driver or
+// TransactionDriver (selected per request by the P-COOL protocol flag) to
+// submit transactions to validators for finality, and proactively executes
+// finalized transactions locally.
 
 use std::{
     collections::{BTreeMap, HashMap, hash_map::Entry},
     net::SocketAddr,
     ops::Deref,
     path::Path,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::Duration,
 };
 
@@ -84,9 +85,8 @@ const LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 const WAIT_FOR_FINALITY_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// The submission flow used to drive transactions to finality. Exactly one
-/// flow is active, selected by the P-COOL protocol flag at construction
-/// time.
+/// The submission flow for a transaction, selected per request by the
+/// epoch's P-COOL flag.
 enum Driver<A: Clone> {
     /// Certificate-based flow (P-COOL disabled).
     Quorum(Arc<QuorumDriverHandler<A>>),
@@ -98,10 +98,19 @@ enum Driver<A: Clone> {
 /// and TransactionDriver for submitting transactions to validators for
 /// finality. It adds inflight deduplication, waiting for local execution,
 /// recovery, and epoch change handling.
+///
+/// Both drivers exist for the node's lifetime; the epoch's P-COOL flag
+/// selects which one serves a request. QuorumDriver WAL recovery runs
+/// exactly once: at construction when the flag is off, else on the first
+/// flag-off selection.
 pub struct TransactionOrchestrator<A: Clone> {
-    driver: Driver<A>,
+    quorum_driver: Arc<QuorumDriverHandler<A>>,
+    transaction_driver: Arc<TransactionDriver<A>>,
+    /// Set once QuorumDriver WAL recovery has run.
+    qd_recovery: OnceLock<()>,
     validator_state: Arc<AuthorityState>,
-    _local_executor_handle: Option<JoinHandle<()>>,
+    /// Keeps the pending-tx-log cleanup loop alive.
+    _local_executor_handle: JoinHandle<()>,
     pending_tx_log: Arc<WritePathPendingTransactionLog>,
     /// Digests currently being driven to finality by the TransactionDriver;
     /// used to deduplicate concurrent submissions of the same transaction,
@@ -124,34 +133,20 @@ impl TransactionOrchestrator<NetworkAuthorityClient> {
         prometheus_registry: &Registry,
         node_config: Option<&NodeConfig>,
     ) -> Self {
-        // Check protocol config to determine if P-COOL flow is enabled
-        let epoch_store = validator_state.load_epoch_store_one_call_per_task();
-        let use_transaction_driver = epoch_store.protocol_config().enable_pcool_flow();
+        let td_reconfig_observer = TdOnsiteReconfigObserver::new(
+            reconfig_channel.resubscribe(),
+            validator_state.get_object_cache_reader().clone(),
+            validator_state.clone_committee_store(),
+            validators.safe_client_metrics_base.clone(),
+        );
 
-        // Create TransactionDriver reconfig observer only if P-COOL is enabled
-        let td_reconfig_observer = if use_transaction_driver {
-            Some(TdOnsiteReconfigObserver::new(
-                reconfig_channel.resubscribe(),
-                validator_state.get_object_cache_reader().clone(),
-                validator_state.clone_committee_store(),
-                validators.safe_client_metrics_base.clone(),
-            ))
-        } else {
-            None
-        };
-
-        // Create QuorumDriver reconfig observer only if P-COOL is NOT enabled
-        let qd_reconfig_observer = if !use_transaction_driver {
-            Some(OnsiteReconfigObserver::new(
-                reconfig_channel.resubscribe(),
-                validator_state.get_object_cache_reader().clone(),
-                validator_state.clone_committee_store(),
-                validators.safe_client_metrics_base.clone(),
-                validators.metrics.deref().clone(),
-            ))
-        } else {
-            None
-        };
+        let qd_reconfig_observer = OnsiteReconfigObserver::new(
+            reconfig_channel.resubscribe(),
+            validator_state.get_object_cache_reader().clone(),
+            validator_state.clone_committee_store(),
+            validators.safe_client_metrics_base.clone(),
+            validators.metrics.deref().clone(),
+        );
 
         TransactionOrchestrator::new(
             validators,
@@ -176,11 +171,10 @@ where
         validator_state: Arc<AuthorityState>,
         parent_path: &Path,
         prometheus_registry: &Registry,
-        reconfig_observer: Option<OnsiteReconfigObserver>,
-        td_reconfig_observer: Option<TdOnsiteReconfigObserver>,
+        reconfig_observer: OnsiteReconfigObserver,
+        td_reconfig_observer: TdOnsiteReconfigObserver,
         node_config: Option<&NodeConfig>,
     ) -> Self {
-        // Check protocol config to determine if P-COOL flow is enabled
         let epoch_store = validator_state.load_epoch_store_one_call_per_task();
         let use_transaction_driver = epoch_store.protocol_config().enable_pcool_flow();
 
@@ -190,54 +184,63 @@ where
             parent_path.join("fullnode_pending_transactions"),
         ));
 
-        let (driver, _local_executor_handle) = if !use_transaction_driver {
-            let qd_metrics = Arc::new(QuorumDriverMetrics::new(prometheus_registry));
-            let reconfig_observer = Arc::new(
-                reconfig_observer
-                    .expect("QuorumDriver reconfig observer required when P-COOL is disabled"),
-            );
-            let handler = Arc::new(
-                QuorumDriverHandlerBuilder::new(validators, qd_metrics)
-                    .with_notifier(notifier.clone())
-                    .with_reconfig_observer(reconfig_observer)
-                    .start(),
-            );
-            let effects_receiver = handler.subscribe_to_effects();
-            let pending_tx_log_clone = pending_tx_log.clone();
-            let local_executor_handle = spawn_monitored_task!(async move {
-                Self::loop_pending_transaction_log(effects_receiver, pending_tx_log_clone).await;
-            });
-            // Pending-transaction recovery is QuorumDriver-only; the
-            // TransactionDriver goes directly to consensus and tracks no
-            // pending certificates.
-            Self::schedule_txes_in_log(pending_tx_log.clone(), handler.clone());
-            (Driver::Quorum(handler), Some(local_executor_handle))
-        } else {
-            let td_metrics = Arc::new(TransactionDriverMetrics::new(prometheus_registry));
-            let client_metrics = Arc::new(ValidatorClientMetrics::new(prometheus_registry));
-            let observer = td_reconfig_observer
-                .expect("TransactionDriver reconfig observer required when P-COOL is enabled");
-            (
-                Driver::Transaction(TransactionDriver::new(
-                    validators,
-                    Arc::new(observer),
-                    td_metrics,
-                    node_config,
-                    client_metrics,
-                )),
-                None,
-            )
-        };
+        // Registered up front for both flows: registration panics on
+        // duplicates.
+        let quorum_driver_metrics = Arc::new(QuorumDriverMetrics::new(prometheus_registry));
+        let transaction_driver_metrics =
+            Arc::new(TransactionDriverMetrics::new(prometheus_registry));
+        let client_metrics = Arc::new(ValidatorClientMetrics::new(prometheus_registry));
 
-        Self {
-            driver,
+        let quorum_driver = Arc::new(
+            QuorumDriverHandlerBuilder::new(validators.clone(), quorum_driver_metrics)
+                .with_notifier(notifier.clone())
+                .with_reconfig_observer(Arc::new(reconfig_observer))
+                .start(),
+        );
+
+        // The cleanup loop must exist before any WAL recovery runs, so a
+        // recovered transaction cannot complete before its receiver exists.
+        let effects_receiver = quorum_driver.subscribe_to_effects();
+        let pending_tx_log_clone = pending_tx_log.clone();
+        let _local_executor_handle = spawn_monitored_task!(async move {
+            Self::loop_pending_transaction_log(effects_receiver, pending_tx_log_clone).await;
+        });
+
+        let pcool_flow_enabled: Arc<dyn Fn() -> bool + Send + Sync> = {
+            let validator_state = validator_state.clone();
+            Arc::new(move || {
+                validator_state
+                    .load_epoch_store_one_call_per_task()
+                    .protocol_config()
+                    .enable_pcool_flow()
+            })
+        };
+        let transaction_driver = TransactionDriver::new(
+            validators,
+            Arc::new(td_reconfig_observer),
+            transaction_driver_metrics,
+            node_config.and_then(|config| config.validator_client_monitor_config.clone()),
+            client_metrics,
+            pcool_flow_enabled,
+        );
+
+        let this = Self {
+            quorum_driver,
+            transaction_driver,
+            qd_recovery: OnceLock::new(),
             validator_state,
             _local_executor_handle,
             pending_tx_log,
             in_flight_transactions: Default::default(),
             notifier,
             metrics,
+        };
+        // WAL recovery is a startup duty when the quorum driver serves from
+        // boot; under P-COOL it is deferred to the first flag-off selection.
+        if !use_transaction_driver {
+            this.ensure_qd_recovery();
         }
+        this
     }
 }
 
@@ -245,6 +248,27 @@ impl<A> TransactionOrchestrator<A>
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
+    /// Returns the flow selected by `epoch_store`'s P-COOL flag. Call with
+    /// the request's own epoch store snapshot so the flag and the submission
+    /// see the same epoch.
+    fn select_driver(&self, epoch_store: &AuthorityPerEpochStore) -> Driver<A> {
+        if epoch_store.protocol_config().enable_pcool_flow() {
+            Driver::Transaction(self.transaction_driver.clone())
+        } else {
+            self.ensure_qd_recovery();
+            Driver::Quorum(self.quorum_driver.clone())
+        }
+    }
+
+    /// Runs QuorumDriver WAL recovery exactly once. The snapshot happens
+    /// before the caller can submit (concurrent callers block on the
+    /// `OnceLock`), so a triggering request cannot be double-driven.
+    fn ensure_qd_recovery(&self) {
+        self.qd_recovery.get_or_init(|| {
+            Self::schedule_txes_in_log(self.pending_tx_log.clone(), self.quorum_driver.clone());
+        });
+    }
+
     #[instrument(name = "tx_orchestrator_execute_transaction_block", level = "trace", skip_all,
         fields(
         tx_digest = ?request.transaction.digest(),
@@ -305,9 +329,9 @@ where
             request_type,
             ExecuteTransactionRequestType::WaitForLocalExecution
         );
-        let (mut response, seq) = match (&self.driver, wait_for_local_execution) {
+        let (mut response, seq) = match (self.select_driver(&epoch_store), wait_for_local_execution)
+        {
             (Driver::Transaction(td), true) => {
-                let td = td.clone();
                 let in_flight_transactions = self.in_flight_transactions.clone();
                 let validator_state = self.validator_state.clone();
                 let metrics = self.metrics.clone();
@@ -326,7 +350,6 @@ where
                 .await?
             }
             (Driver::Transaction(td), false) => {
-                let td = td.clone();
                 let in_flight_transactions = self.in_flight_transactions.clone();
                 let validator_state = self.validator_state.clone();
                 // Detached for the same reason as above.
@@ -346,7 +369,7 @@ where
             (Driver::Quorum(qd), _) => {
                 let qd_resp = self
                     .execute_transaction_impl(
-                        qd,
+                        &qd,
                         &epoch_store,
                         request,
                         transaction.clone(),
@@ -659,9 +682,8 @@ where
             .validity_check(&epoch_store.tx_validity_check_context())
             .map_err(QuorumDriverError::InvalidTransaction)?;
 
-        match &self.driver {
+        match self.select_driver(&epoch_store) {
             Driver::Transaction(td) => {
-                let td = td.clone();
                 let in_flight_transactions = self.in_flight_transactions.clone();
                 let validator_state = self.validator_state.clone();
                 // v1 does not do an internal wait; callers (e.g. the gRPC
@@ -683,7 +705,7 @@ where
             }
             Driver::Quorum(qd) => {
                 let qd_resp = self
-                    .execute_transaction_impl(qd, &epoch_store, request, transaction, client_addr)
+                    .execute_transaction_impl(&qd, &epoch_store, request, transaction, client_addr)
                     .await?;
                 Ok(quorum_driver_response_to_v1(qd_resp))
             }
@@ -1236,39 +1258,45 @@ where
         }
     }
 
-    /// Returns the quorum driver, or `None` under the P-COOL flow.
-    pub fn quorum_driver(&self) -> Option<&Arc<QuorumDriverHandler<A>>> {
-        match &self.driver {
-            Driver::Quorum(handler) => Some(handler),
-            Driver::Transaction(_) => None,
-        }
+    pub fn quorum_driver(&self) -> &Arc<QuorumDriverHandler<A>> {
+        &self.quorum_driver
     }
 
-    /// Returns the quorum driver, or `None` under the P-COOL flow.
-    pub fn clone_quorum_driver(&self) -> Option<Arc<QuorumDriverHandler<A>>> {
-        self.quorum_driver().cloned()
+    pub fn clone_quorum_driver(&self) -> Arc<QuorumDriverHandler<A>> {
+        self.quorum_driver.clone()
     }
 
-    /// Returns the transaction driver, or `None` when the P-COOL flow is
-    /// disabled.
-    pub fn transaction_driver(&self) -> Option<&Arc<TransactionDriver<A>>> {
-        match &self.driver {
-            Driver::Quorum(_) => None,
-            Driver::Transaction(td) => Some(td),
-        }
+    pub fn transaction_driver(&self) -> &Arc<TransactionDriver<A>> {
+        &self.transaction_driver
     }
 
-    /// Returns the authority aggregator of the active driver.
+    /// Returns the quorum driver's aggregator; both drivers keep theirs
+    /// current, so either is authoritative.
     pub fn clone_authority_aggregator(&self) -> Arc<AuthorityAggregator<A>> {
-        match &self.driver {
-            Driver::Quorum(qd) => qd.authority_aggregator().load_full(),
-            Driver::Transaction(td) => td.authority_aggregator().load_full(),
-        }
+        self.quorum_driver.authority_aggregator().load_full()
     }
 
-    /// Returns `None` under the P-COOL flow, which has no effects broadcast.
+    /// Returns an effects receiver only while the quorum driver is the
+    /// currently selected flow; the P-COOL flow has no effects broadcast.
     pub fn subscribe_to_effects_queue(&self) -> Option<Receiver<QuorumDriverEffectsQueueResult>> {
-        self.quorum_driver().map(|qd| qd.subscribe_to_effects())
+        let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
+        if epoch_store.protocol_config().enable_pcool_flow() {
+            return None;
+        }
+        Some(self.quorum_driver.subscribe_to_effects())
+    }
+
+    /// Runs driver selection for `epoch_store`, with its recovery side
+    /// effect.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn select_driver_for_testing(&self, epoch_store: &AuthorityPerEpochStore) {
+        self.select_driver(epoch_store);
+    }
+
+    /// Reports whether QuorumDriver WAL recovery has run.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn qd_recovery_started_for_testing(&self) -> bool {
+        self.qd_recovery.get().is_some()
     }
 
     fn update_metrics(
@@ -1301,18 +1329,24 @@ where
         pending_tx_log: Arc<WritePathPendingTransactionLog>,
         quorum_driver: Arc<QuorumDriverHandler<A>>,
     ) {
+        if std::env::var("SKIP_LOADING_FROM_PENDING_TX_LOG").is_ok() {
+            info!("Skipping loading pending transactions from pending_tx_log.");
+            return;
+        }
+        // Snapshot before the driver is handed out, so a submission that
+        // triggered deferred recovery cannot land in the log and be
+        // double-driven. Bounded: only the quorum-driver path writes this
+        // log, so it holds at most what was pending when that flow was last
+        // active.
+        let pending_txes = pending_tx_log
+            .load_all_pending_transactions()
+            // Failing to read the WAL means the store is broken.
+            .expect("failed to load all pending transactions");
+        info!(
+            "Recovering {} pending transactions from pending_tx_log.",
+            pending_txes.len()
+        );
         spawn_logged_monitored_task!(async move {
-            if std::env::var("SKIP_LOADING_FROM_PENDING_TX_LOG").is_ok() {
-                info!("Skipping loading pending transactions from pending_tx_log.");
-                return;
-            }
-            let pending_txes = pending_tx_log
-                .load_all_pending_transactions()
-                .expect("failed to load all pending transactions");
-            info!(
-                "Recovering {} pending transactions from pending_tx_log.",
-                pending_txes.len()
-            );
             for (i, tx) in pending_txes.into_iter().enumerate() {
                 // TODO: ideally pending_tx_log would not contain VerifiedTransaction, but that
                 // requires a migration.
@@ -1995,5 +2029,88 @@ mod tests {
 
         // The digest can be driven again once the entry is gone.
         let _guard = acquire_driving(&in_flight, tx_digest);
+    }
+
+    async fn build_orchestrator_with_pcool(
+        enable_pcool: bool,
+    ) -> (
+        Arc<AuthorityState>,
+        TransactionOrchestrator<NetworkAuthorityClient>,
+        tempfile::TempDir,
+        tokio::sync::broadcast::Sender<IotaSystemState>,
+    ) {
+        use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+
+        use crate::{
+            authority::test_authority_builder::TestAuthorityBuilder,
+            authority_aggregator::AuthorityAggregatorBuilder,
+        };
+
+        telemetry_subscribers::init_for_testing();
+        let network_config =
+            iota_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir().build();
+
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown);
+        protocol_config.set_enable_pcool_flow_for_testing(enable_pcool);
+        let state = TestAuthorityBuilder::new()
+            .with_network_config(&network_config, 0)
+            .with_protocol_config(protocol_config)
+            .build()
+            .await;
+
+        let (aggregator, _clients) =
+            AuthorityAggregatorBuilder::from_genesis(&network_config.genesis)
+                .build_network_clients();
+        let (reconfig_tx, reconfig_rx) = tokio::sync::broadcast::channel(16);
+        let tempdir = tempfile::tempdir().unwrap();
+        let orchestrator = TransactionOrchestrator::new_with_auth_aggregator(
+            Arc::new(aggregator),
+            state.clone(),
+            reconfig_rx,
+            tempdir.path(),
+            &Registry::new(),
+            None,
+        );
+        (state, orchestrator, tempdir, reconfig_tx)
+    }
+
+    /// A flag-off boot runs QuorumDriver WAL recovery at construction.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn qd_recovery_eager_on_flag_off_boot() {
+        let (_state, orchestrator, _tempdir, _reconfig_tx) =
+            build_orchestrator_with_pcool(false).await;
+        assert!(orchestrator.qd_recovery_started_for_testing());
+    }
+
+    /// A flag-on boot leaves QuorumDriver WAL recovery uninitialized; the
+    /// first flag-off selection runs it, before the request path can submit.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn qd_recovery_deferred_until_first_flag_off_selection() {
+        use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+
+        let (state, orchestrator, _tempdir, _reconfig_tx) =
+            build_orchestrator_with_pcool(true).await;
+        assert!(!orchestrator.qd_recovery_started_for_testing());
+
+        // Selection under the flag keeps recovery uninitialized.
+        orchestrator.select_driver_for_testing(&state.epoch_store_for_testing());
+        assert!(!orchestrator.qd_recovery_started_for_testing());
+
+        // Epoch 1 with P-COOL off: the first selection runs recovery.
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown);
+        protocol_config.set_enable_pcool_flow_for_testing(false);
+        state
+            .reconfigure_for_testing_with_protocol_config(protocol_config)
+            .await;
+        let epoch_store = state.epoch_store_for_testing();
+        assert_eq!(epoch_store.epoch(), 1);
+
+        orchestrator.select_driver_for_testing(&epoch_store);
+        assert!(orchestrator.qd_recovery_started_for_testing());
+        // Repeated selections keep the one-shot state.
+        orchestrator.select_driver_for_testing(&epoch_store);
+        assert!(orchestrator.qd_recovery_started_for_testing());
     }
 }

--- a/crates/iota-core/src/validator_client_monitor/monitor.rs
+++ b/crates/iota-core/src/validator_client_monitor/monitor.rs
@@ -47,9 +47,12 @@ impl ValidatorClientMonitor {
         }
     }
 
+    /// `enabled` is checked per round; rounds are skipped while it reports
+    /// false.
     pub fn spawn_health_checks<A: AuthorityAPI + Send + Sync + 'static>(
         self: &Arc<Self>,
         authority_aggregator: &Arc<ArcSwap<AuthorityAggregator<A>>>,
+        enabled: Arc<dyn Fn() -> bool + Send + Sync>,
     ) -> JoinHandle<()> {
         let period = self.config.health_check_interval;
         let monitor = Arc::downgrade(self);
@@ -57,7 +60,7 @@ impl ValidatorClientMonitor {
         // weak pointers allow health check task break early once shared arc objects are
         // dropped
         tokio::spawn(async move {
-            Self::run_health_checks(monitor, authority_aggregator, period).await;
+            Self::run_health_checks(monitor, authority_aggregator, period, enabled).await;
         })
     }
 
@@ -117,12 +120,16 @@ impl ValidatorClientMonitor {
         monitor: Weak<Self>,
         authority_aggregator: Weak<ArcSwap<AuthorityAggregator<A>>>,
         period: Duration,
+        enabled: Arc<dyn Fn() -> bool + Send + Sync>,
     ) {
         let mut interval = interval(period);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
             interval.tick().await;
+            if !enabled() {
+                continue;
+            }
             let Some(monitor) = monitor.upgrade() else {
                 break;
             };

--- a/crates/iota-core/src/validator_client_monitor/monitor.rs
+++ b/crates/iota-core/src/validator_client_monitor/monitor.rs
@@ -127,15 +127,17 @@ impl ValidatorClientMonitor {
 
         loop {
             interval.tick().await;
-            if !enabled() {
-                continue;
-            }
+            // Upgrade first: a permanently false `enabled` must not keep
+            // the task alive past these exits.
             let Some(monitor) = monitor.upgrade() else {
                 break;
             };
             let Some(authority_agg) = authority_aggregator.upgrade() else {
                 break;
             };
+            if !enabled() {
+                continue;
+            }
             let authority_agg = authority_agg.load();
             let mut tasks = monitor.spawn_health_checks_tasks(&*authority_agg);
             drop(authority_agg);

--- a/crates/iota-e2e-tests/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/iota-e2e-tests/tests/onsite_reconfig_observer_tests.rs
@@ -27,6 +27,7 @@ async fn test_onsite_reconfig_observer_basic() {
         node.transaction_orchestrator()
             .unwrap()
             .clone_quorum_driver()
+            .expect("quorum driver exists on a flag-off boot")
     });
     assert_eq!(qd.current_epoch(), 0);
     let rx = fullnode.with(|node| node.subscribe_to_epoch_change());
@@ -51,6 +52,7 @@ async fn test_onsite_reconfig_observer_basic() {
         node.transaction_orchestrator()
             .unwrap()
             .clone_quorum_driver()
+            .expect("quorum driver exists on a flag-off boot")
     });
     assert_eq!(qd.current_epoch(), 1);
     assert_eq!(

--- a/crates/iota-e2e-tests/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/iota-e2e-tests/tests/onsite_reconfig_observer_tests.rs
@@ -27,7 +27,6 @@ async fn test_onsite_reconfig_observer_basic() {
         node.transaction_orchestrator()
             .unwrap()
             .clone_quorum_driver()
-            .expect("quorum driver should be present when P-COOL is disabled")
     });
     assert_eq!(qd.current_epoch(), 0);
     let rx = fullnode.with(|node| node.subscribe_to_epoch_change());
@@ -52,7 +51,6 @@ async fn test_onsite_reconfig_observer_basic() {
         node.transaction_orchestrator()
             .unwrap()
             .clone_quorum_driver()
-            .expect("quorum driver should be present when P-COOL is disabled")
     });
     assert_eq!(qd.current_epoch(), 1);
     assert_eq!(

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -26,11 +26,13 @@ use iota_test_transaction_builder::{
 use iota_types::{
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
     error::IotaError,
+    iota_system_state::IotaSystemStateTrait,
     quorum_driver_types::{
         EffectsFinalityInfo, ExecuteTransactionRequestType, ExecuteTransactionRequestV1,
         ExecuteTransactionResponseV1, FinalizedEffects, IsTransactionExecutedLocally,
         QuorumDriverError,
     },
+    supported_protocol_versions::SupportedProtocolVersions,
     transaction::{TransactionAPI, TransactionEnvelope},
 };
 use test_cluster::{TestClusterBuilder, override_pcool_flow};
@@ -61,7 +63,6 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let digest = *txn.digest();
     orchestrator
         .quorum_driver()
-        .expect("quorum driver should be present when P-COOL is disabled")
         .submit_transaction_no_ticket(
             ExecuteTransactionRequestV1::new(txn),
             Some(make_socket_addr()),
@@ -201,7 +202,6 @@ async fn test_transaction_orchestrator_reconfig() {
         node.transaction_orchestrator()
             .unwrap()
             .quorum_driver()
-            .expect("quorum driver should be present when P-COOL is disabled")
             .current_epoch()
     });
     assert_eq!(epoch, 0);
@@ -218,7 +218,6 @@ async fn test_transaction_orchestrator_reconfig() {
                 node.transaction_orchestrator()
                     .unwrap()
                     .quorum_driver()
-                    .expect("quorum driver should be present when P-COOL is disabled")
                     .current_epoch()
             });
             if epoch == 1 {
@@ -397,6 +396,93 @@ async fn test_wait_for_local_execution_across_epoch_boundary() {
         EffectsFinalityInfo::Checkpointed(epoch, _seq) => assert_eq!(epoch, 1),
         other => panic!("expected Checkpointed finality, got {other:?}"),
     }
+}
+
+/// The driver must follow `enable_pcool_flow` across the upgrade that flips
+/// it, without a fullnode restart: boot at v31 (flag off, QuorumDriver),
+/// upgrade to v32 (flag on), and the same orchestrator instance must serve
+/// both sides — post-upgrade via the TransactionDriver.
+///
+/// No `override_pcool_flow`: the env override would pin the flag for every
+/// version.
+#[sim_test]
+async fn test_orchestrator_follows_pcool_flag_across_protocol_upgrade() {
+    telemetry_subscribers::init_for_testing();
+    const START: u64 = 31;
+    const FINISH: u64 = 32;
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_protocol_version(START.into())
+        .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(START, FINISH))
+        .with_epoch_duration_ms(20_000)
+        .build()
+        .await;
+
+    let orchestrator = test_cluster
+        .fullnode_handle
+        .iota_node
+        .with(|node| node.transaction_orchestrator().unwrap());
+    let pcool_enabled = || {
+        test_cluster.fullnode_handle.iota_node.with(|node| {
+            node.state()
+                .epoch_store_for_testing()
+                .protocol_config()
+                .enable_pcool_flow()
+        })
+    };
+
+    // Boot state: flag off, WAL recovery already ran.
+    assert!(!pcool_enabled());
+    assert!(orchestrator.qd_recovery_started_for_testing());
+
+    let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
+    let (response, _) = execute_with_orchestrator(
+        &orchestrator,
+        tx,
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await
+    .expect("pre-upgrade submission must succeed on the certificate flow");
+    assert!(matches!(
+        response.effects.finality_info,
+        EffectsFinalityInfo::Certified(_)
+    ));
+
+    // All validators support FINISH, so the upgrade lands at the first epoch
+    // boundary.
+    let system_state = test_cluster.wait_for_protocol_version(FINISH.into()).await;
+    let flip_epoch = system_state.epoch();
+    test_cluster.wait_for_epoch_all_nodes(flip_epoch).await;
+    assert!(pcool_enabled());
+
+    // Same orchestrator, no restart: the request must use the
+    // TransactionDriver — validators now reject the certificate flow.
+    let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
+    let (response, executed_locally) = execute_with_orchestrator(
+        &orchestrator,
+        tx,
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await
+    .expect("post-upgrade submission must succeed without a fullnode restart");
+    assert!(executed_locally);
+    match response.effects.finality_info {
+        EffectsFinalityInfo::Checkpointed(epoch, _) => assert!(epoch >= flip_epoch),
+        EffectsFinalityInfo::QuorumExecuted(epoch) => assert!(epoch >= flip_epoch),
+        other => panic!("expected TransactionDriver finality, got {other:?}"),
+    }
+
+    // The TransactionDriver must keep tracking reconfiguration.
+    test_cluster.wait_for_epoch(Some(flip_epoch + 1)).await;
+    test_cluster.wait_for_epoch_all_nodes(flip_epoch + 1).await;
+    let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
+    execute_with_orchestrator(
+        &orchestrator,
+        tx,
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await
+    .expect("submission must succeed one epoch after the flip");
 }
 
 async fn execute_with_orchestrator(
@@ -1315,4 +1401,107 @@ async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
     );
 
     Ok(())
+}
+
+/// The ON→OFF flip: a rollback epoch must not strand fullnodes that booted
+/// under P-COOL. msim-only: the per-version protocol override is
+/// thread-local, and `MAX_ALLOWED` exists only under msim.
+#[cfg(msim)]
+mod pcool_rollback {
+    use iota_protocol_config::ProtocolVersion;
+
+    use super::*;
+
+    const START: u64 = ProtocolVersion::MAX.as_u64();
+    const FINISH: u64 = ProtocolVersion::MAX_ALLOWED.as_u64();
+
+    /// Mirror of `test_orchestrator_follows_pcool_flag_across_protocol_upgrade`:
+    /// boot with P-COOL on, flip it off at the upgrade, and the same
+    /// fullnode must switch to the QuorumDriver (running its deferred WAL
+    /// recovery) and keep serving.
+    #[sim_test]
+    async fn test_orchestrator_follows_pcool_rollback_across_protocol_upgrade() {
+        telemetry_subscribers::init_for_testing();
+        // Set on both branches: the FINISH config derives from START, where
+        // the flag defaults to on. No `override_pcool_flow` — the env
+        // override applies to every version.
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|version, mut config| {
+            config.set_enable_pcool_flow_for_testing(version.as_u64() < FINISH);
+            config
+        });
+
+        let test_cluster = TestClusterBuilder::new()
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, FINISH,
+            ))
+            .with_epoch_duration_ms(20_000)
+            .build()
+            .await;
+
+        let orchestrator = test_cluster
+            .fullnode_handle
+            .iota_node
+            .with(|node| node.transaction_orchestrator().unwrap());
+        let pcool_enabled = || {
+            test_cluster.fullnode_handle.iota_node.with(|node| {
+                node.state()
+                    .epoch_store_for_testing()
+                    .protocol_config()
+                    .enable_pcool_flow()
+            })
+        };
+
+        // Boot state: flag on, WAL recovery deferred.
+        assert!(pcool_enabled());
+        assert!(!orchestrator.qd_recovery_started_for_testing());
+
+        let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
+        let (response, _) = execute_with_orchestrator(
+            &orchestrator,
+            tx,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
+        .await
+        .expect("pre-rollback submission must succeed on the P-COOL flow");
+        assert!(matches!(
+            response.effects.finality_info,
+            EffectsFinalityInfo::Checkpointed(..) | EffectsFinalityInfo::QuorumExecuted(_)
+        ));
+
+        let system_state = test_cluster.wait_for_protocol_version(FINISH.into()).await;
+        let flip_epoch = system_state.epoch();
+        test_cluster.wait_for_epoch_all_nodes(flip_epoch).await;
+        assert!(!pcool_enabled());
+
+        // Same orchestrator, no restart: the request must use the
+        // QuorumDriver — validators now reject `submit_tx`.
+        let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
+        let digest = *tx.digest();
+        let (response, _executed_locally) = execute_with_orchestrator(
+            &orchestrator,
+            tx,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
+        .await
+        .expect("post-rollback submission must succeed without a fullnode restart");
+        // `Certified` proves the QuorumDriver served it. `executed_locally`
+        // is not asserted: consensus needs ~10s post-boundary to regain
+        // block subscribers, which can exceed the 10s local-execution wait.
+        assert!(matches!(
+            response.effects.finality_info,
+            EffectsFinalityInfo::Certified(_)
+        ));
+        timeout(
+            Duration::from_secs(30),
+            test_cluster
+                .fullnode_handle
+                .iota_node
+                .state()
+                .get_transaction_cache_reader()
+                .notify_read_executed_effects_for_testing("", &[digest]),
+        )
+        .await
+        .expect("the fullnode must execute the post-rollback transaction locally");
+        assert!(orchestrator.qd_recovery_started_for_testing());
+    }
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -63,6 +63,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let digest = *txn.digest();
     orchestrator
         .quorum_driver()
+        .expect("quorum driver exists on a flag-off boot")
         .submit_transaction_no_ticket(
             ExecuteTransactionRequestV1::new(txn),
             Some(make_socket_addr()),
@@ -202,6 +203,7 @@ async fn test_transaction_orchestrator_reconfig() {
         node.transaction_orchestrator()
             .unwrap()
             .quorum_driver()
+            .expect("quorum driver exists on a flag-off boot")
             .current_epoch()
     });
     assert_eq!(epoch, 0);
@@ -218,6 +220,7 @@ async fn test_transaction_orchestrator_reconfig() {
                 node.transaction_orchestrator()
                     .unwrap()
                     .quorum_driver()
+                    .expect("quorum driver exists on a flag-off boot")
                     .current_epoch()
             });
             if epoch == 1 {
@@ -431,9 +434,9 @@ async fn test_orchestrator_follows_pcool_flag_across_protocol_upgrade() {
         })
     };
 
-    // Boot state: flag off, WAL recovery already ran.
+    // Boot state: flag off, quorum driver built and recovered.
     assert!(!pcool_enabled());
-    assert!(orchestrator.qd_recovery_started_for_testing());
+    assert!(orchestrator.quorum_driver().is_some());
 
     let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
     let (response, _) = execute_with_orchestrator(
@@ -1401,107 +1404,4 @@ async fn test_submission_survives_caller_abort() -> Result<(), anyhow::Error> {
     );
 
     Ok(())
-}
-
-/// The ON→OFF flip: a rollback epoch must not strand fullnodes that booted
-/// under P-COOL. msim-only: the per-version protocol override is
-/// thread-local, and `MAX_ALLOWED` exists only under msim.
-#[cfg(msim)]
-mod pcool_rollback {
-    use iota_protocol_config::ProtocolVersion;
-
-    use super::*;
-
-    const START: u64 = ProtocolVersion::MAX.as_u64();
-    const FINISH: u64 = ProtocolVersion::MAX_ALLOWED.as_u64();
-
-    /// Mirror of `test_orchestrator_follows_pcool_flag_across_protocol_upgrade`:
-    /// boot with P-COOL on, flip it off at the upgrade, and the same
-    /// fullnode must switch to the QuorumDriver (running its deferred WAL
-    /// recovery) and keep serving.
-    #[sim_test]
-    async fn test_orchestrator_follows_pcool_rollback_across_protocol_upgrade() {
-        telemetry_subscribers::init_for_testing();
-        // Set on both branches: the FINISH config derives from START, where
-        // the flag defaults to on. No `override_pcool_flow`, since the env
-        // override applies to every version.
-        let _guard = ProtocolConfig::apply_overrides_for_testing(|version, mut config| {
-            config.set_enable_pcool_flow_for_testing(version.as_u64() < FINISH);
-            config
-        });
-
-        let test_cluster = TestClusterBuilder::new()
-            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
-                START, FINISH,
-            ))
-            .with_epoch_duration_ms(20_000)
-            .build()
-            .await;
-
-        let orchestrator = test_cluster
-            .fullnode_handle
-            .iota_node
-            .with(|node| node.transaction_orchestrator().unwrap());
-        let pcool_enabled = || {
-            test_cluster.fullnode_handle.iota_node.with(|node| {
-                node.state()
-                    .epoch_store_for_testing()
-                    .protocol_config()
-                    .enable_pcool_flow()
-            })
-        };
-
-        // Boot state: flag on, WAL recovery deferred.
-        assert!(pcool_enabled());
-        assert!(!orchestrator.qd_recovery_started_for_testing());
-
-        let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
-        let (response, _) = execute_with_orchestrator(
-            &orchestrator,
-            tx,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
-        )
-        .await
-        .expect("pre-rollback submission must succeed on the P-COOL flow");
-        assert!(matches!(
-            response.effects.finality_info,
-            EffectsFinalityInfo::Checkpointed(..) | EffectsFinalityInfo::QuorumExecuted(_)
-        ));
-
-        let system_state = test_cluster.wait_for_protocol_version(FINISH.into()).await;
-        let flip_epoch = system_state.epoch();
-        test_cluster.wait_for_epoch_all_nodes(flip_epoch).await;
-        assert!(!pcool_enabled());
-
-        // Same orchestrator, no restart: the request must use the
-        // QuorumDriver, since validators now reject `submit_tx`.
-        let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
-        let digest = *tx.digest();
-        let (response, _executed_locally) = execute_with_orchestrator(
-            &orchestrator,
-            tx,
-            ExecuteTransactionRequestType::WaitForLocalExecution,
-        )
-        .await
-        .expect("post-rollback submission must succeed without a fullnode restart");
-        // `Certified` proves the QuorumDriver served it. `executed_locally`
-        // is not asserted: consensus needs ~10s post-boundary to regain
-        // block subscribers, which can exceed the 10s local-execution wait.
-        assert!(matches!(
-            response.effects.finality_info,
-            EffectsFinalityInfo::Certified(_)
-        ));
-        timeout(
-            Duration::from_secs(30),
-            test_cluster
-                .fullnode_handle
-                .iota_node
-                .state()
-                .get_transaction_cache_reader()
-                .notify_read_executed_effects_for_testing("", &[digest]),
-        )
-        .await
-        .expect("the fullnode must execute the post-rollback transaction locally");
-        assert!(orchestrator.qd_recovery_started_for_testing());
-    }
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -401,7 +401,7 @@ async fn test_wait_for_local_execution_across_epoch_boundary() {
 /// The driver must follow `enable_pcool_flow` across the upgrade that flips
 /// it, without a fullnode restart: boot at v31 (flag off, QuorumDriver),
 /// upgrade to v32 (flag on), and the same orchestrator instance must serve
-/// both sides — post-upgrade via the TransactionDriver.
+/// both sides, post-upgrade via the TransactionDriver.
 ///
 /// No `override_pcool_flow`: the env override would pin the flag for every
 /// version.
@@ -456,7 +456,7 @@ async fn test_orchestrator_follows_pcool_flag_across_protocol_upgrade() {
     assert!(pcool_enabled());
 
     // Same orchestrator, no restart: the request must use the
-    // TransactionDriver — validators now reject the certificate flow.
+    // TransactionDriver, since validators now reject the certificate flow.
     let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
     let (response, executed_locally) = execute_with_orchestrator(
         &orchestrator,
@@ -1423,7 +1423,7 @@ mod pcool_rollback {
     async fn test_orchestrator_follows_pcool_rollback_across_protocol_upgrade() {
         telemetry_subscribers::init_for_testing();
         // Set on both branches: the FINISH config derives from START, where
-        // the flag defaults to on. No `override_pcool_flow` — the env
+        // the flag defaults to on. No `override_pcool_flow`, since the env
         // override applies to every version.
         let _guard = ProtocolConfig::apply_overrides_for_testing(|version, mut config| {
             config.set_enable_pcool_flow_for_testing(version.as_u64() < FINISH);
@@ -1474,7 +1474,7 @@ mod pcool_rollback {
         assert!(!pcool_enabled());
 
         // Same orchestrator, no restart: the request must use the
-        // QuorumDriver — validators now reject `submit_tx`.
+        // QuorumDriver, since validators now reject `submit_tx`.
         let tx = make_transfer_iota_transaction(&test_cluster.wallet, None, None).await;
         let digest = *tx.digest();
         let (response, _executed_locally) = execute_with_orchestrator(

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1749,7 +1749,7 @@ impl IotaNode {
     }
 
     /// Subscribe to the quorum driver's effects stream; errors while the
-    /// P-COOL flow is selected.
+    /// quorum driver is not the currently served flow on this node.
     pub fn subscribe_to_transaction_orchestrator_effects(
         &self,
     ) -> Result<tokio::sync::broadcast::Receiver<QuorumDriverEffectsQueueResult>> {
@@ -1759,7 +1759,12 @@ impl IotaNode {
                 anyhow::anyhow!("Transaction Orchestrator is not enabled in this node.")
             })?
             .subscribe_to_effects_queue()
-            .ok_or_else(|| anyhow::anyhow!("Effects queue is not available under the P-COOL flow."))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Effects queue is not available: the quorum driver is not the currently \
+                     served flow on this node."
+                )
+            })
     }
 
     /// This function awaits the completion of checkpoint execution of the

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1731,11 +1731,9 @@ impl IotaNode {
     // self.state.db()
     // }
 
-    /// Clone the AuthorityAggregator currently used by this node's
-    /// transaction orchestrator, if the node is a fullnode. After reconfig,
-    /// the active driver builds a new AuthorityAggregator. The caller
-    /// of this function will mostly likely want to call this again
-    /// to get a fresh one.
+    /// Clone an AuthorityAggregator from the transaction orchestrator, if
+    /// this is a fullnode. The snapshot goes stale after an epoch change;
+    /// call again for a fresh one.
     pub fn clone_authority_aggregator(
         &self,
     ) -> Option<Arc<AuthorityAggregator<NetworkAuthorityClient>>> {
@@ -1750,6 +1748,8 @@ impl IotaNode {
         self.transaction_orchestrator.clone()
     }
 
+    /// Subscribe to the quorum driver's effects stream; errors while the
+    /// P-COOL flow is selected.
     pub fn subscribe_to_transaction_orchestrator_effects(
         &self,
     ) -> Result<tokio::sync::broadcast::Receiver<QuorumDriverEffectsQueueResult>> {


### PR DESCRIPTION
# Description of change

The fullnode's `TransactionOrchestrator` picked its submission driver (QuorumDriver vs TransactionDriver) once, at process start; validators check `enable_pcool_flow` per request. A fullnode not restarted after the flip epoch kept submitting on the rejected path.

Enabling P-COOL is seamless. Disabling it again is not planned for mainnet/testnet, so a node that booted under P-COOL requires a restart to serve the certificate flow (team decision).

- The epoch's P-COOL flag selects the flow serving a request, mirroring the validator-side checks.
- The TransactionDriver always exists, with its reconfig observer running from boot, so it tracks epochs before the flag enables it. Its latency-ping and health-check rounds are skipped while the flow is disabled (pings go through the real submission path, which validators reject) and resume when the flag returns; both tasks hold weak references and exit on teardown.
- The QuorumDriver is built only on a flag-off boot (`Option`), together with its effects/pending-log cleanup loop and WAL recovery. On a node that booted under P-COOL, submissions selecting it fail with an internal error whose detail says a restart is required (also logged by the fullnode), and the effects subscription is unavailable.
- Driver accessors are test-only; production code reaches a driver only through per-request selection.
- Driver metrics register up front regardless of boot mode.
- `TransactionDriver::new` takes `Option<ValidatorClientMonitorConfig>` instead of `Option<&NodeConfig>`, plus a P-COOL predicate.
- New test util `AuthorityState::reconfigure_for_testing_with_protocol_config` lets tests change the protocol config at an epoch boundary.

A stale-committee first attempt right after the flip epoch is covered by the existing retry machinery: epoch mismatches are retriable and the TransactionDriver reloads its aggregator on every attempt, the same as any epoch boundary.

## Links to any relevant issues

fixes #12520

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

New tests:

- e2e: OFF→ON flip via a real v31→v32 protocol upgrade; the same fullnode submits on both sides of the boundary.
- Unit: a flag-off boot builds the quorum driver and runs WAL recovery at construction; a node booted under P-COOL rejects quorum-driver selection after a rollback and returns no effects receiver.

Unit tests and clippy verified locally; simtests run in CI.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Full nodes now follow the P-COOL enablement at the epoch boundary without a restart, and stop sending latency pings and health checks while the P-COOL flow is disabled. Full nodes that started while P-COOL was enabled require a restart before serving the certificate flow after a rollback; until then their submissions fail and the fullnode log states that a restart is required.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC: