### PR TITLE
fix(consensus): record commit-sync fetch faults on the serving peer

### DIFF
--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -641,7 +641,18 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             target_authority,
             serialized_transactions,
             &mut committed_tx_refs,
-        )?;
+        )
+        .inspect_err(|_| {
+            // A malformed or uncommitted entry is content the serving peer
+            // produced (truncation only drops whole entries), but it can't be
+            // proven against an author, so the peer is charged an unprovable
+            // fault.
+            inner.misbehavior_store.record_faulty_transactions(
+                target_authority,
+                false,
+                [target_authority],
+            );
+        })?;
 
         // The response may be missing transactions for a suffix of the commits,
         // e.g. when the stream was cut off by the response byte limit or a
@@ -687,7 +698,17 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                     }
                 })
                 .await
-                .expect("Spawn blocking should not fail")?
+                .expect("Spawn blocking should not fail")
+                .inspect_err(|_| {
+                    // The peer served a payload that fails verification against
+                    // its own claimed ref; the mismatch can't be proven against
+                    // the author, whose commitment the peer may have forged.
+                    inner.misbehavior_store.record_faulty_transactions(
+                        target_authority,
+                        false,
+                        [target_authority],
+                    );
+                })?
         } else {
             BTreeMap::new()
         };
@@ -987,8 +1008,11 @@ fn process_serialized_transactions(
 /// `verify_commits` are chained by digest up to a vote-certified last commit,
 /// so any prefix of them remains trusted on its own.
 ///
-/// Returns an error attributed to `peer` when even the first commit is missing
-/// transactions, since the response then allows no forward progress.
+/// Returns an error naming `peer` when even the first commit is missing
+/// transactions, since the response then allows no forward progress. The error
+/// is not recorded as peer misbehavior: the fetch client caps response bytes
+/// and keeps partial data on mid-stream errors, so an honest response can be
+/// cut down to any prefix, including an empty one.
 fn truncate_to_fully_fetched_prefix(
     peer: AuthorityIndex,
     commits: &mut Vec<TrustedCommit>,

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -643,8 +643,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             &mut committed_tx_refs,
         )
         .inspect_err(|_| {
-            // Truncation only drops whole entries, so a malformed or
-            // uncommitted entry is the peer's own content.
+            // Truncation drops whole entries and never corrupts one, so a
+            // malformed or uncommitted entry is the peer's fault.
             inner.misbehavior_store.record_faulty_transactions(
                 target_authority,
                 false,
@@ -1276,7 +1276,7 @@ mod tests {
             );
         }
 
-        /// Runs `fetch_once` against a canned response served by authority 1
+        /// Runs `fetch_once` against a preset response served by authority 1
         /// and returns the error and the `Inner` whose misbehavior store the
         /// fetch recorded into.
         async fn fetch_once_error(
@@ -1455,7 +1455,7 @@ mod tests {
                 .enable_commit_sync_peer_selection_by_commit_votes = enabled;
             let context = Arc::new(context);
 
-            // No canned response, so every fetch fails and the loop keeps
+            // No preset response, so every fetch fails and the loop keeps
             // trying peers, exposing the full selection order.
             let network_client = Arc::new(FakeNetworkClient::default());
             let inner = make_inner(context, network_client.clone());
@@ -1572,7 +1572,7 @@ mod tests {
         async fn records_fixed_penalty_for_the_failing_peer() {
             let context = fast_sync_context(2);
             let peer = AuthorityIndex::new_for_test(1);
-            // No canned response, so the only peer always fails and the loop
+            // No preset response, so the only peer always fails and the loop
             // retries forever.
             let network_client = Arc::new(FakeNetworkClient::default());
             let inner = make_inner(context.clone(), network_client);

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -643,10 +643,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             &mut committed_tx_refs,
         )
         .inspect_err(|_| {
-            // A malformed or uncommitted entry is content the serving peer
-            // produced (truncation only drops whole entries), but it can't be
-            // proven against an author, so the peer is charged an unprovable
-            // fault.
+            // Truncation only drops whole entries, so a malformed or
+            // uncommitted entry is the peer's own content.
             inner.misbehavior_store.record_faulty_transactions(
                 target_authority,
                 false,
@@ -700,9 +698,8 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .await
                 .expect("Spawn blocking should not fail")
                 .inspect_err(|_| {
-                    // The peer served a payload that fails verification against
-                    // its own claimed ref; the mismatch can't be proven against
-                    // the author, whose commitment the peer may have forged.
+                    // Not provable against the author, whose commitment the
+                    // peer may have forged.
                     inner.misbehavior_store.record_faulty_transactions(
                         target_authority,
                         false,
@@ -890,10 +887,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                                 break;
                             }
                             Err(e) => {
-                                // Classification charges the peer for malformed
-                                // or unrequested headers and leaves a short
-                                // response untracked, since an honest one can
-                                // arrive incomplete.
                                 inner
                                     .misbehavior_store
                                     .record_faulty_block(authority, authority, &e);
@@ -1011,10 +1004,8 @@ fn process_serialized_transactions(
 /// so any prefix of them remains trusted on its own.
 ///
 /// Returns an error naming `peer` when even the first commit is missing
-/// transactions, since the response then allows no forward progress. The error
-/// is not recorded as peer misbehavior: the fetch client caps response bytes
-/// and keeps partial data on mid-stream errors, so an honest response can be
-/// cut down to any prefix, including an empty one.
+/// transactions, since the response then allows no forward progress. Not
+/// recorded as misbehavior: an honest response can be cut to any prefix.
 fn truncate_to_fully_fetched_prefix(
     peer: AuthorityIndex,
     commits: &mut Vec<TrustedCommit>,
@@ -1309,8 +1300,7 @@ mod tests {
         }
 
         /// An entry referencing a transaction no commit in the range commits
-        /// to is content the serving peer produced, so the peer is charged an
-        /// unprovable fault.
+        /// to is charged to the serving peer.
         #[tokio::test]
         async fn records_misbehavior_for_unrequested_transaction() {
             let context = fast_sync_context();
@@ -1353,9 +1343,7 @@ mod tests {
             );
         }
 
-        /// An entry that does not deserialize is content the serving peer
-        /// produced — truncation only drops whole entries — so the peer is
-        /// charged an unprovable fault.
+        /// An entry that does not deserialize is charged to the serving peer.
         #[tokio::test]
         async fn records_misbehavior_for_malformed_transaction_entry() {
             let context = fast_sync_context();
@@ -1415,9 +1403,8 @@ mod tests {
             );
         }
 
-        /// A response with no transactions at all is indistinguishable from
-        /// one cut down by the client's byte cap or a mid-stream error, so it
-        /// fails the fetch without recording misbehavior.
+        /// A response with no transactions fails the fetch but records no
+        /// misbehavior, since an honest response can arrive incomplete.
         #[tokio::test]
         async fn does_not_record_misbehavior_for_missing_transactions() {
             let context = fast_sync_context();

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1095,6 +1095,7 @@ mod tests {
             core_thread::tests::MockCoreThreadDispatcher,
             dag_state::DagState,
             encoder::create_encoder,
+            error::ConsensusError,
             header_synchronizer::HeaderSynchronizer,
             misbehavior_store::MisbehaviorStore,
             network::SerializedTransactionsV2,
@@ -1229,17 +1230,21 @@ mod tests {
             )
         }
 
+        fn fast_sync_context() -> Arc<Context> {
+            let (mut context, _) = Context::new_for_test(4);
+            context
+                .protocol_config
+                .set_consensus_fast_commit_sync_for_testing(true);
+            Arc::new(context)
+        }
+
         /// A response whose transaction payload covers only some of the
         /// returned commits (e.g. the stream was cut off by the response byte
         /// limit) must still produce output for the covered prefix of commits
         /// instead of failing the whole fetch.
         #[tokio::test]
         async fn returns_covered_prefix_of_truncated_response() {
-            let (mut context, _) = Context::new_for_test(4);
-            context
-                .protocol_config
-                .set_consensus_fast_commit_sync_for_testing(true);
-            let context = Arc::new(context);
+            let context = fast_sync_context();
 
             // Drop the second commit's transaction, as if the transaction
             // stream was cut off by the response byte limit.
@@ -1277,6 +1282,160 @@ mod tests {
                     .with_label_values(&[CommitSyncType::Fast.as_str()])
                     .get(),
                 1
+            );
+        }
+
+        /// Runs `fetch_once` against a canned response served by authority 1
+        /// and returns the error and the `Inner` whose misbehavior store the
+        /// fetch recorded into.
+        async fn fetch_once_error(
+            context: Arc<Context>,
+            response: (Vec<Bytes>, Vec<Bytes>, Vec<Bytes>),
+        ) -> (ConsensusError, Arc<Inner<FakeNetworkClient>>) {
+            let network_client = Arc::new(FakeNetworkClient {
+                commits_and_transactions: Some(response),
+                ..Default::default()
+            });
+            let inner = make_inner(context, network_client);
+            let err = FastCommitSyncer::fetch_once(
+                inner.clone(),
+                AuthorityIndex::new_for_test(1),
+                (1..=2).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap_err();
+            (err, inner)
+        }
+
+        /// An entry referencing a transaction no commit in the range commits
+        /// to is content the serving peer produced, so the peer is charged an
+        /// unprovable fault.
+        #[tokio::test]
+        async fn records_misbehavior_for_unrequested_transaction() {
+            let context = fast_sync_context();
+            let (commits, vote_headers, mut response_transactions) = two_commit_response(&context);
+            let serialized = Transaction::serialize(&[Transaction::new(vec![9u8; 16])]).unwrap();
+            let mut encoder = create_encoder(&context);
+            let commitment = TransactionsCommitment::compute_transactions_commitment(
+                &serialized,
+                &context,
+                &mut encoder,
+            )
+            .unwrap();
+            response_transactions.push(
+                bcs::to_bytes(&SerializedTransactionsV2 {
+                    transaction_ref: TransactionRef {
+                        round: 3,
+                        author: AuthorityIndex::new_for_test(0),
+                        transactions_commitment: commitment,
+                    },
+                    serialized_transactions: serialized,
+                })
+                .unwrap()
+                .into(),
+            );
+
+            let (err, inner) =
+                fetch_once_error(context, (commits, vote_headers, response_transactions)).await;
+
+            assert!(
+                matches!(err, ConsensusError::UnexpectedTransactionForCommit { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0, 1, 0, 0]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// An entry that does not deserialize is content the serving peer
+        /// produced — truncation only drops whole entries — so the peer is
+        /// charged an unprovable fault.
+        #[tokio::test]
+        async fn records_misbehavior_for_malformed_transaction_entry() {
+            let context = fast_sync_context();
+            let (commits, vote_headers, mut response_transactions) = two_commit_response(&context);
+            response_transactions[1] = Bytes::from_static(b"garbage");
+
+            let (err, inner) =
+                fetch_once_error(context, (commits, vote_headers, response_transactions)).await;
+
+            assert!(
+                matches!(err, ConsensusError::MalformedTransactions(_)),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0, 1, 0, 0]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// A payload that fails the commitment of the ref it is paired with
+        /// is charged to the serving peer, which may have forged the pairing.
+        #[tokio::test]
+        async fn records_misbehavior_for_payload_commitment_mismatch() {
+            let context = fast_sync_context();
+            let (commits, vote_headers, response_transactions) = two_commit_response(&context);
+            // Swap the two payloads so each entry fails its ref's commitment.
+            let mut entries: Vec<SerializedTransactionsV2> = response_transactions
+                .iter()
+                .map(|bytes| bcs::from_bytes(bytes).unwrap())
+                .collect();
+            let payload = entries[0].serialized_transactions.clone();
+            entries[0].serialized_transactions = entries[1].serialized_transactions.clone();
+            entries[1].serialized_transactions = payload;
+            let response_transactions = entries
+                .iter()
+                .map(|entry| bcs::to_bytes(entry).unwrap().into())
+                .collect();
+
+            let (err, inner) =
+                fetch_once_error(context, (commits, vote_headers, response_transactions)).await;
+
+            assert!(
+                matches!(err, ConsensusError::TransactionCommitmentFailure { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0, 1, 0, 0]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// A response with no transactions at all is indistinguishable from
+        /// one cut down by the client's byte cap or a mid-stream error, so it
+        /// fails the fetch without recording misbehavior.
+        #[tokio::test]
+        async fn does_not_record_misbehavior_for_missing_transactions() {
+            let context = fast_sync_context();
+            let (commits, vote_headers, _) = two_commit_response(&context);
+
+            let (err, inner) = fetch_once_error(context, (commits, vote_headers, vec![])).await;
+
+            assert!(
+                matches!(err, ConsensusError::FetchedTransactionsMismatch { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0; 4]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
             );
         }
     }

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -891,9 +891,9 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                             }
                             Err(e) => {
                                 // Classification charges the peer for malformed
-                                // or mismatched headers and leaves a short
-                                // response untracked, since the fetch client's
-                                // byte cap can truncate an honest one.
+                                // or unrequested headers and leaves a short
+                                // response untracked, since an honest one can
+                                // arrive incomplete.
                                 inner
                                     .misbehavior_store
                                     .record_faulty_block(authority, authority, &e);

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -890,11 +890,13 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                                 break;
                             }
                             Err(e) => {
-                                // TODO: verify_fetched_headers currently only returns
-                                // fetch-shape errors (wrong count/ref) which classify
-                                // as Untracked. When per-header faults become observable
-                                // here, record them as peer misbehavior via
-                                // `inner.misbehavior_store.record_faulty_block`.
+                                // Classification charges the peer for malformed
+                                // or mismatched headers and leaves a short
+                                // response untracked, since the fetch client's
+                                // byte cap can truncate an honest one.
+                                inner
+                                    .misbehavior_store
+                                    .record_faulty_block(authority, authority, &e);
                                 record_headers_for_reinitialization_failure(&inner, authority);
                                 warn!(
                                     "[{}] Failed to verify headers from {}: {}",

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1299,6 +1299,19 @@ mod tests {
             (err, inner)
         }
 
+        /// Asserts the peers' unprovable fault counts and that no provable
+        /// fault was recorded.
+        fn assert_unprovable_faults(inner: &Inner<FakeNetworkClient>, expected: Vec<u64>) {
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                expected
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
         /// An entry referencing a transaction no commit in the range commits
         /// to is charged to the serving peer.
         #[tokio::test]
@@ -1333,14 +1346,7 @@ mod tests {
                 matches!(err, ConsensusError::UnexpectedTransactionForCommit { .. }),
                 "unexpected error: {err:?}"
             );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0, 1, 0, 0]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
+            assert_unprovable_faults(&inner, vec![0, 1, 0, 0]);
         }
 
         /// An entry that does not deserialize is charged to the serving peer.
@@ -1357,14 +1363,7 @@ mod tests {
                 matches!(err, ConsensusError::MalformedTransactions(_)),
                 "unexpected error: {err:?}"
             );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0, 1, 0, 0]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
+            assert_unprovable_faults(&inner, vec![0, 1, 0, 0]);
         }
 
         /// A payload that fails the commitment of the ref it is paired with
@@ -1393,14 +1392,7 @@ mod tests {
                 matches!(err, ConsensusError::TransactionCommitmentFailure { .. }),
                 "unexpected error: {err:?}"
             );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0, 1, 0, 0]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
+            assert_unprovable_faults(&inner, vec![0, 1, 0, 0]);
         }
 
         /// A response with no transactions fails the fetch but records no
@@ -1416,14 +1408,7 @@ mod tests {
                 matches!(err, ConsensusError::FetchedTransactionsMismatch { .. }),
                 "unexpected error: {err:?}"
             );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0; 4]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
+            assert_unprovable_faults(&inner, vec![0; 4]);
         }
     }
 

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -931,8 +931,8 @@ pub(crate) mod tests {
     };
 
     /// Fake `NetworkClient` for commit syncer tests. Serves the canned
-    /// `fetch_commits_and_transactions` response when one is set and fails the
-    /// fetch when none is; all other endpoints are unimplemented.
+    /// responses when set: `fetch_commits_and_transactions` fails the fetch
+    /// when none is set, the other fetch endpoints stay unimplemented.
     #[derive(Default)]
     pub(crate) struct FakeNetworkClient {
         pub(crate) commits_and_transactions: Option<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)>,
@@ -941,6 +941,12 @@ pub(crate) mod tests {
         pub(crate) response_delay: Duration,
         /// Every peer asked for commits, in the order it was asked.
         pub(crate) requested_peers: parking_lot::Mutex<Vec<AuthorityIndex>>,
+        /// Canned `fetch_commits` response: commits and certifier headers.
+        pub(crate) commits: Option<(Vec<Bytes>, Vec<Bytes>)>,
+        /// Canned `fetch_block_headers` response.
+        pub(crate) block_headers: Option<Vec<Bytes>>,
+        /// Canned `fetch_transactions` response.
+        pub(crate) transactions: Option<Vec<Bytes>>,
     }
 
     #[async_trait::async_trait]
@@ -960,7 +966,10 @@ pub(crate) mod tests {
             _transaction_refs: Vec<TransactionRef>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
-            unimplemented!("Unimplemented")
+            match &self.transactions {
+                Some(response) => Ok(response.clone()),
+                None => unimplemented!("Unimplemented"),
+            }
         }
 
         async fn fetch_block_headers(
@@ -970,16 +979,23 @@ pub(crate) mod tests {
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
-            unimplemented!("Unimplemented")
+            match &self.block_headers {
+                Some(response) => Ok(response.clone()),
+                None => unimplemented!("Unimplemented"),
+            }
         }
 
         async fn fetch_commits(
             &self,
-            _peer: AuthorityIndex,
+            peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
         ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
-            unimplemented!("Unimplemented")
+            self.requested_peers.lock().push(peer);
+            match &self.commits {
+                Some(response) => Ok(response.clone()),
+                None => unimplemented!("Unimplemented"),
+            }
         }
 
         async fn fetch_commits_and_transactions(

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -144,14 +144,10 @@ impl CommitSyncType {
     }
 }
 
-/// Verifies that the fetched block headers are exactly the requested ones, in
-/// any order. The requested refs are distinct by construction (each header is
-/// committed once), so each received header must consume one of them: a header
-/// outside the requested set — or served twice — is an error attributed to the
-/// peer. Missing headers are a shortfall error instead, since an honest
-/// response can arrive incomplete (the server omits headers it lacks, the
-/// client cuts the stream at its byte cap). A response with more entries than
-/// requested is rejected before spending any parsing work on it.
+/// Verifies that the fetched headers are exactly the requested ones, in any
+/// order. Unrequested or duplicate headers are peer faults; missing headers
+/// are benign, since an honest response can arrive incomplete. Requested refs
+/// must be distinct, which holds by construction (a header is committed once).
 pub(crate) fn verify_fetched_headers(
     peer: AuthorityIndex,
     request_block_refs: &[BlockRef],

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -145,19 +145,17 @@ impl CommitSyncType {
 }
 
 /// Verifies that the fetched headers are exactly the requested ones, in any
-/// order. Unrequested or duplicate headers are peer faults; missing headers
-/// are benign, since an honest response can arrive incomplete. Requested refs
-/// must be distinct, which holds by construction (a header is committed once).
+/// order. Requested refs must be distinct.
 pub(crate) fn verify_fetched_headers(
     peer: AuthorityIndex,
     request_block_refs: &[BlockRef],
     serialized_block_headers: Vec<Bytes>,
 ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
     if serialized_block_headers.len() > request_block_refs.len() {
-        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
-            authority: peer,
+        return Err(ConsensusError::TooManyFetchedHeadersReturned {
+            peer,
             requested: request_block_refs.len(),
-            received_headers: serialized_block_headers.len(),
+            received: serialized_block_headers.len(),
         });
     }
     let mut pending_refs: BTreeSet<BlockRef> = request_block_refs.iter().cloned().collect();
@@ -175,10 +173,10 @@ pub(crate) fn verify_fetched_headers(
         })
         .collect::<ConsensusResult<Vec<_>>>()?;
     if !pending_refs.is_empty() {
-        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
-            authority: peer,
+        return Err(ConsensusError::NotEnoughHeadersFetched {
+            peer,
             requested: request_block_refs.len(),
-            received_headers: headers.len(),
+            received: headers.len(),
         });
     }
     Ok(headers)

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -158,8 +158,17 @@ pub(crate) fn verify_fetched_headers(
             received: serialized_block_headers.len(),
         });
     }
+    if serialized_block_headers.len() < request_block_refs.len() {
+        return Err(ConsensusError::NotEnoughHeadersFetched {
+            peer,
+            requested: request_block_refs.len(),
+            received: serialized_block_headers.len(),
+        });
+    }
+    // Counts match, so consuming a distinct requested ref per header drains
+    // the set exactly when no header errors below.
     let mut pending_refs: BTreeSet<BlockRef> = request_block_refs.iter().cloned().collect();
-    let headers = serialized_block_headers
+    serialized_block_headers
         .into_iter()
         .map(|serialized| {
             let header = VerifiedBlockHeader::new_from_bytes(serialized)?;
@@ -171,15 +180,7 @@ pub(crate) fn verify_fetched_headers(
             }
             Ok(header)
         })
-        .collect::<ConsensusResult<Vec<_>>>()?;
-    if !pending_refs.is_empty() {
-        return Err(ConsensusError::NotEnoughHeadersFetched {
-            peer,
-            requested: request_block_refs.len(),
-            received: headers.len(),
-        });
-    }
-    Ok(headers)
+        .collect()
 }
 
 // Handle to stop the CommitSyncer loop.

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -928,7 +928,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{
         Round,
-        block_header::BlockHeaderDigest,
+        block_header::{BlockHeaderDigest, TestBlockHeader},
         block_verifier::NoopBlockVerifier,
         commit::{CommitV1, CommitV2, CommitV3},
         network::BlockBundleStream,
@@ -1247,5 +1247,84 @@ pub(crate) mod tests {
         // Never divides by zero, even though the fetch paths reject empty
         // responses before reaching this point.
         assert_eq!(shortfall_factor(10, 0), 10.0);
+    }
+
+    /// `n` distinct serialized test headers and their refs.
+    fn test_headers(n: u8) -> (Vec<BlockRef>, Vec<Bytes>) {
+        (0..n)
+            .map(|i| {
+                let header = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, i).build());
+                (header.reference(), header.serialized().clone())
+            })
+            .unzip()
+    }
+
+    #[test]
+    fn verify_fetched_headers_accepts_exact_set_in_any_order() {
+        let (refs, mut headers) = test_headers(3);
+        headers.swap(0, 2);
+        let verified =
+            verify_fetched_headers(AuthorityIndex::new_for_test(1), &refs, headers).unwrap();
+        assert_eq!(verified.len(), 3);
+    }
+
+    #[test]
+    fn verify_fetched_headers_rejects_unrequested_header() {
+        let (refs, headers) = test_headers(3);
+        let response = vec![headers[0].clone(), headers[2].clone()];
+        let result = verify_fetched_headers(AuthorityIndex::new_for_test(1), &refs[..2], response);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::UnexpectedBlockHeaderForCommit { .. })
+        ));
+    }
+
+    #[test]
+    fn verify_fetched_headers_rejects_duplicate_header() {
+        let (refs, headers) = test_headers(2);
+        let response = vec![headers[0].clone(), headers[0].clone()];
+        let result = verify_fetched_headers(AuthorityIndex::new_for_test(1), &refs, response);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::UnexpectedBlockHeaderForCommit { .. })
+        ));
+    }
+
+    #[test]
+    fn verify_fetched_headers_rejects_malformed_header() {
+        let (refs, headers) = test_headers(2);
+        let response = vec![headers[0].clone(), Bytes::from_static(b"garbage")];
+        let result = verify_fetched_headers(AuthorityIndex::new_for_test(1), &refs, response);
+        assert!(matches!(result, Err(ConsensusError::MalformedHeader(_))));
+    }
+
+    #[test]
+    fn verify_fetched_headers_rejects_extra_headers_before_parsing() {
+        let (refs, mut headers) = test_headers(2);
+        headers.push(Bytes::from_static(b"garbage"));
+        let result = verify_fetched_headers(AuthorityIndex::new_for_test(1), &refs, headers);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::TooManyFetchedHeadersReturned {
+                requested: 2,
+                received: 3,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn verify_fetched_headers_rejects_missing_headers() {
+        let (refs, mut headers) = test_headers(2);
+        headers.truncate(1);
+        let result = verify_fetched_headers(AuthorityIndex::new_for_test(1), &refs, headers);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::NotEnoughHeadersFetched {
+                requested: 2,
+                received: 1,
+                ..
+            })
+        ));
     }
 }

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -144,38 +144,48 @@ impl CommitSyncType {
     }
 }
 
-/// Verifies that fetched block headers match the requested block refs.
-/// Returns verified headers or an error if count/reference mismatch.
+/// Verifies that the fetched block headers are exactly the requested ones, in
+/// any order. The requested refs are distinct by construction (each header is
+/// committed once), so each received header must consume one of them: a header
+/// outside the requested set — or served twice — is an error attributed to the
+/// peer. Missing headers are a shortfall error instead, since an honest
+/// response can arrive incomplete (the server omits headers it lacks, the
+/// client cuts the stream at its byte cap). A response with more entries than
+/// requested is rejected before spending any parsing work on it.
 pub(crate) fn verify_fetched_headers(
     peer: AuthorityIndex,
     request_block_refs: &[BlockRef],
     serialized_block_headers: Vec<Bytes>,
 ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
-    // 1. Verify count matches
-    if request_block_refs.len() != serialized_block_headers.len() {
+    if serialized_block_headers.len() > request_block_refs.len() {
         return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
             authority: peer,
             requested: request_block_refs.len(),
             received_headers: serialized_block_headers.len(),
         });
     }
-
-    // 2. Verify each header's reference matches requested
-    serialized_block_headers
+    let mut pending_refs: BTreeSet<BlockRef> = request_block_refs.iter().cloned().collect();
+    let headers = serialized_block_headers
         .into_iter()
-        .zip(request_block_refs)
-        .map(|(serialized, requested_ref)| {
+        .map(|serialized| {
             let header = VerifiedBlockHeader::new_from_bytes(serialized)?;
-            if *requested_ref != header.reference() {
+            if !pending_refs.remove(&header.reference()) {
                 return Err(ConsensusError::UnexpectedBlockHeaderForCommit {
                     peer,
-                    requested: *requested_ref,
                     received: header.reference(),
                 });
             }
             Ok(header)
         })
-        .collect()
+        .collect::<ConsensusResult<Vec<_>>>()?;
+    if !pending_refs.is_empty() {
+        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
+            authority: peer,
+            requested: request_block_refs.len(),
+            received_headers: headers.len(),
+        });
+    }
+    Ok(headers)
 }
 
 // Handle to stop the CommitSyncer loop.

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -935,9 +935,9 @@ pub(crate) mod tests {
         transaction_ref::TransactionRef,
     };
 
-    /// Fake `NetworkClient` for commit syncer tests. Serves the canned
-    /// responses when set: `fetch_commits_and_transactions` fails the fetch
-    /// when none is set, the other fetch endpoints stay unimplemented.
+    /// Fake `NetworkClient` for commit syncer tests, serving preset responses.
+    /// With no preset response, `fetch_commits_and_transactions` fails the
+    /// fetch, while the other fetch endpoints panic as unimplemented.
     #[derive(Default)]
     pub(crate) struct FakeNetworkClient {
         pub(crate) commits_and_transactions: Option<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)>,
@@ -946,11 +946,11 @@ pub(crate) mod tests {
         pub(crate) response_delay: Duration,
         /// Every peer asked for commits, in the order it was asked.
         pub(crate) requested_peers: parking_lot::Mutex<Vec<AuthorityIndex>>,
-        /// Canned `fetch_commits` response: commits and certifier headers.
+        /// Preset `fetch_commits` response: commits and certifier headers.
         pub(crate) commits: Option<(Vec<Bytes>, Vec<Bytes>)>,
-        /// Canned `fetch_block_headers` response.
+        /// Preset `fetch_block_headers` response.
         pub(crate) block_headers: Option<Vec<Bytes>>,
-        /// Canned `fetch_transactions` response.
+        /// Preset `fetch_transactions` response.
         pub(crate) transactions: Option<Vec<Bytes>>,
     }
 

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -590,16 +590,22 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         )
                         .await?;
                     // 5. Verify headers: count matches and each reference matches requested.
-                    // TODO: verify_fetched_headers currently only returns fetch-shape
-                    // errors (wrong count/ref) which classify as Untracked. When
-                    // per-header faults become observable here, record them as peer
-                    // misbehavior via
-                    // `inner.misbehavior_store.record_faulty_block`.
+                    // Classification charges the peer for malformed or
+                    // mismatched headers and leaves a short response untracked,
+                    // since the fetch client's byte cap can truncate an honest
+                    // one.
                     verify_fetched_headers(
                         target_authority,
                         request_block_refs,
                         serialized_block_headers,
                     )
+                    .inspect_err(|e| {
+                        inner.misbehavior_store.record_faulty_block(
+                            target_authority,
+                            target_authority,
+                            e,
+                        );
+                    })
                 }
             })
             .collect();

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -1390,9 +1390,10 @@ mod tests {
         }
 
         /// A response with more headers than requested is rejected before any
-        /// parsing, so nothing is recorded for it.
+        /// parsing and charged to the serving peer, since an honest response
+        /// can only be incomplete, never oversized.
         #[tokio::test]
-        async fn does_not_record_misbehavior_for_extra_headers() {
+        async fn records_misbehavior_for_extra_headers() {
             let context = Arc::new(Context::new_for_test(4).0);
             let (commits, mut block_headers, transactions) = two_commit_response(&context);
             block_headers.push(
@@ -1406,12 +1407,12 @@ mod tests {
 
             let err = result.unwrap_err();
             assert!(
-                matches!(err, ConsensusError::UnexpectedNumberOfHeadersFetched { .. }),
+                matches!(err, ConsensusError::TooManyFetchedHeadersReturned { .. }),
                 "unexpected error: {err:?}"
             );
             assert_eq!(
                 inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0; 4]
+                vec![0, 1, 0, 0]
             );
             assert_eq!(
                 inner.misbehavior_store.in_memory_faulty_blocks_provable(),
@@ -1432,7 +1433,7 @@ mod tests {
 
             let err = result.unwrap_err();
             assert!(
-                matches!(err, ConsensusError::UnexpectedNumberOfHeadersFetched { .. }),
+                matches!(err, ConsensusError::NotEnoughHeadersFetched { .. }),
                 "unexpected error: {err:?}"
             );
             assert_eq!(

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -590,9 +590,6 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         )
                         .await?;
                     // 5. Verify the returned headers are the requested ones.
-                    // Classification charges the peer for malformed or
-                    // unrequested headers and leaves a short response
-                    // untracked, since an honest one can arrive incomplete.
                     verify_fetched_headers(
                         target_authority,
                         request_block_refs,
@@ -661,11 +658,9 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         // directly
                         let mut result = BTreeMap::new();
                         for serialized_bytes in serialized_transactions {
-                            // A malformed or unrequested entry is content the
-                            // serving peer produced (truncation only drops
-                            // whole entries), but it can't be proven against an
-                            // author, so the peer is charged an unprovable
-                            // fault.
+                            // Truncation only drops whole entries, so a
+                            // malformed or unrequested entry is the peer's own
+                            // content.
                             let serialized_tx: SerializedTransactionsV2 =
                                 bcs::from_bytes(&serialized_bytes)
                                     .inspect_err(|_| {
@@ -741,9 +736,8 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                 .await
                 .expect("Spawn blocking should not fail")
                 .inspect_err(|_| {
-                    // The peer served a payload that fails verification against
-                    // its own claimed ref; the mismatch can't be proven against
-                    // the author, whose commitment the peer may have forged.
+                    // Not provable against the author, whose commitment the
+                    // peer may have forged.
                     inner.misbehavior_store.record_faulty_transactions(
                         target_authority,
                         false,
@@ -1250,9 +1244,8 @@ mod tests {
             (result, inner)
         }
 
-        /// A response missing some transactions is tolerated — the
-        /// transaction synchronizer fetches them later — and records no
-        /// misbehavior.
+        /// Missing transactions are tolerated (the transaction synchronizer
+        /// fetches them later) and record no misbehavior.
         #[tokio::test]
         async fn tolerates_missing_transactions_without_misbehavior() {
             let context = Arc::new(Context::new_for_test(4).0);
@@ -1275,8 +1268,7 @@ mod tests {
         }
 
         /// An entry referencing a transaction that was not requested is
-        /// content the serving peer produced, so the peer is charged an
-        /// unprovable fault.
+        /// charged to the serving peer.
         #[tokio::test]
         async fn records_misbehavior_for_unrequested_transaction() {
             let context = Arc::new(Context::new_for_test(4).0);
@@ -1427,9 +1419,8 @@ mod tests {
             );
         }
 
-        /// A response missing a header fails the fetch (the commits cannot be
-        /// certified without it) but records no misbehavior, since an honest
-        /// response can arrive incomplete.
+        /// A response missing a header fails the fetch but records no
+        /// misbehavior, since an honest response can arrive incomplete.
         #[tokio::test]
         async fn does_not_record_misbehavior_for_missing_headers() {
             let context = Arc::new(Context::new_for_test(4).0);

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -641,6 +641,11 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         //     TransactionSynchronizer will take care of fetching missing
                         //     transactions later.
                         if request_tx_refs.len() < serialized_transactions.len() {
+                            inner.misbehavior_store.record_faulty_transactions(
+                                target_authority,
+                                false,
+                                [target_authority],
+                            );
                             return Err(ConsensusError::TooManyFetchedTransactionsReturned(
                                 target_authority,
                             ));
@@ -651,14 +656,31 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         // directly
                         let mut result = BTreeMap::new();
                         for serialized_bytes in serialized_transactions {
+                            // A malformed or unrequested entry is content the
+                            // serving peer produced (truncation only drops
+                            // whole entries), but it can't be proven against an
+                            // author, so the peer is charged an unprovable
+                            // fault.
                             let serialized_tx: SerializedTransactionsV2 =
                                 bcs::from_bytes(&serialized_bytes)
+                                    .inspect_err(|_| {
+                                        inner.misbehavior_store.record_faulty_transactions(
+                                            target_authority,
+                                            false,
+                                            [target_authority],
+                                        )
+                                    })
                                     .map_err(ConsensusError::MalformedTransactions)?;
 
                             // 11. Verify the returned transactions match the requested transaction
                             //     refs.
                             let committed_transaction_ref = serialized_tx.transaction_ref;
                             if !requested_tx_refs_set.contains(&committed_transaction_ref) {
+                                inner.misbehavior_store.record_faulty_transactions(
+                                    target_authority,
+                                    false,
+                                    [target_authority],
+                                );
                                 return Err(ConsensusError::UnexpectedTransactionForCommit {
                                     peer: target_authority,
                                     received: committed_transaction_ref,
@@ -712,7 +734,17 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                     }
                 })
                 .await
-                .expect("Spawn blocking should not fail")?
+                .expect("Spawn blocking should not fail")
+                .inspect_err(|_| {
+                    // The peer served a payload that fails verification against
+                    // its own claimed ref; the mismatch can't be proven against
+                    // the author, whose commitment the peer may have forged.
+                    inner.misbehavior_store.record_faulty_transactions(
+                        target_authority,
+                        false,
+                        [target_authority],
+                    );
+                })?
         } else {
             BTreeMap::new()
         };

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -1062,4 +1062,290 @@ mod tests {
         );
         assert_eq!(paused, 1);
     }
+
+    mod fetch_once {
+        use std::{sync::Arc, time::Duration};
+
+        use bytes::Bytes;
+        use parking_lot::RwLock;
+        use starfish_config::AuthorityIndex;
+
+        use crate::{
+            CommitConsumerMonitor, Transaction,
+            block_header::{TestBlockHeader, TransactionsCommitment, VerifiedBlockHeader},
+            block_verifier::NoopBlockVerifier,
+            commit::{CertifiedCommits, CommitDigest, TrustedCommit},
+            commit_syncer::{Inner, regular::RegularCommitSyncer, tests::FakeNetworkClient},
+            commit_vote_monitor::CommitVoteMonitor,
+            context::Context,
+            core_thread::tests::MockCoreThreadDispatcher,
+            dag_state::DagState,
+            encoder::create_encoder,
+            error::{ConsensusError, ConsensusResult},
+            header_synchronizer::HeaderSynchronizer,
+            misbehavior_store::MisbehaviorStore,
+            network::SerializedTransactionsV2,
+            storage::{Store, mem_store::MemStore},
+            transaction_ref::{GenericTransactionRef, TransactionRef},
+            transactions_synchronizer::TransactionsSynchronizer,
+        };
+
+        fn make_inner(
+            context: Arc<Context>,
+            network_client: Arc<FakeNetworkClient>,
+        ) -> Arc<Inner<FakeNetworkClient>> {
+            let block_verifier = Arc::new(NoopBlockVerifier {});
+            let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+            let store: Arc<dyn Store> = Arc::new(MemStore::new());
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+            let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+            let transactions_synchronizer = TransactionsSynchronizer::start(
+                network_client.clone(),
+                context.clone(),
+                core_thread_dispatcher.clone(),
+                dag_state.clone(),
+                block_verifier.clone(),
+            );
+            let header_synchronizer = HeaderSynchronizer::start(
+                network_client.clone(),
+                context.clone(),
+                core_thread_dispatcher.clone(),
+                commit_vote_monitor.clone(),
+                transactions_synchronizer,
+                block_verifier.clone(),
+                dag_state.clone(),
+                false,
+                None,
+                misbehavior_store.clone(),
+            );
+            RegularCommitSyncer::new(
+                context,
+                core_thread_dispatcher,
+                commit_vote_monitor,
+                Arc::new(CommitConsumerMonitor::new(0)),
+                network_client,
+                block_verifier,
+                dag_state,
+                header_synchronizer,
+                misbehavior_store,
+                None,
+            )
+            .inner
+        }
+
+        /// A complete regular-sync response set for commit range 1..=2: two
+        /// chained commits whose leader refs point at the returned headers,
+        /// vote headers from a quorum certifying the last commit, and both
+        /// committed transactions.
+        fn two_commit_response(
+            context: &Arc<Context>,
+        ) -> ((Vec<Bytes>, Vec<Bytes>), Vec<Bytes>, Vec<Bytes>) {
+            let mut encoder = create_encoder(context);
+
+            let mut transaction_refs = Vec::new();
+            let mut serialized_transactions = Vec::new();
+            for round in 1..=2u32 {
+                let serialized =
+                    Transaction::serialize(&[Transaction::new(vec![round as u8; 16])]).unwrap();
+                let commitment = TransactionsCommitment::compute_transactions_commitment(
+                    &serialized,
+                    context,
+                    &mut encoder,
+                )
+                .unwrap();
+                transaction_refs.push(TransactionRef {
+                    round,
+                    author: AuthorityIndex::new_for_test(0),
+                    transactions_commitment: commitment,
+                });
+                serialized_transactions.push(serialized);
+            }
+
+            let leader_header_1 =
+                VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 0).build());
+            let leader_header_2 =
+                VerifiedBlockHeader::new_for_test(TestBlockHeader::new(2, 1).build());
+            let commit_1 = TrustedCommit::new_for_test(
+                context,
+                1,
+                CommitDigest::MIN,
+                0,
+                leader_header_1.reference(),
+                vec![leader_header_1.reference()],
+                vec![GenericTransactionRef::TransactionRef(transaction_refs[0])],
+            );
+            let commit_2 = TrustedCommit::new_for_test(
+                context,
+                2,
+                commit_1.digest(),
+                0,
+                leader_header_2.reference(),
+                vec![leader_header_2.reference()],
+                vec![GenericTransactionRef::TransactionRef(transaction_refs[1])],
+            );
+
+            let vote_headers: Vec<Bytes> = (0..3)
+                .map(|author| {
+                    let header = TestBlockHeader::new(3, author)
+                        .set_commit_votes(vec![commit_2.reference()])
+                        .build();
+                    VerifiedBlockHeader::new_for_test(header)
+                        .serialized()
+                        .clone()
+                })
+                .collect();
+
+            let response_transactions: Vec<Bytes> = transaction_refs
+                .iter()
+                .zip(&serialized_transactions)
+                .map(|(transaction_ref, serialized)| {
+                    bcs::to_bytes(&SerializedTransactionsV2 {
+                        transaction_ref: *transaction_ref,
+                        serialized_transactions: serialized.clone(),
+                    })
+                    .unwrap()
+                    .into()
+                })
+                .collect();
+
+            (
+                (
+                    vec![commit_1.serialized().clone(), commit_2.serialized().clone()],
+                    vote_headers,
+                ),
+                vec![
+                    leader_header_1.serialized().clone(),
+                    leader_header_2.serialized().clone(),
+                ],
+                response_transactions,
+            )
+        }
+
+        /// Runs `fetch_once` against the canned responses served by
+        /// authority 1 and returns the result and the `Inner` whose
+        /// misbehavior store the fetch recorded into.
+        async fn run_fetch_once(
+            commits: (Vec<Bytes>, Vec<Bytes>),
+            block_headers: Vec<Bytes>,
+            transactions: Vec<Bytes>,
+            context: Arc<Context>,
+        ) -> (
+            ConsensusResult<CertifiedCommits>,
+            Arc<Inner<FakeNetworkClient>>,
+        ) {
+            let network_client = Arc::new(FakeNetworkClient {
+                commits: Some(commits),
+                block_headers: Some(block_headers),
+                transactions: Some(transactions),
+                ..Default::default()
+            });
+            let inner = make_inner(context, network_client);
+            let result = RegularCommitSyncer::fetch_once(
+                inner.clone(),
+                AuthorityIndex::new_for_test(1),
+                (1..=2).into(),
+                Duration::from_millis(100),
+            )
+            .await;
+            (result, inner)
+        }
+
+        /// A response missing some transactions is tolerated — the
+        /// transaction synchronizer fetches them later — and records no
+        /// misbehavior.
+        #[tokio::test]
+        async fn tolerates_missing_transactions_without_misbehavior() {
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (commits, block_headers, mut transactions) = two_commit_response(&context);
+            transactions.truncate(1);
+
+            let (result, inner) =
+                run_fetch_once(commits, block_headers, transactions, context).await;
+
+            let certified = result.unwrap();
+            assert_eq!(certified.commits().len(), 2);
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0; 4]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// An entry referencing a transaction that was not requested is
+        /// content the serving peer produced, so the peer is charged an
+        /// unprovable fault.
+        #[tokio::test]
+        async fn records_misbehavior_for_unrequested_transaction() {
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (commits, block_headers, _) = two_commit_response(&context);
+            // Serve a transaction for a round no commit in the range commits to.
+            let serialized = Transaction::serialize(&[Transaction::new(vec![9u8; 16])]).unwrap();
+            let mut encoder = create_encoder(&context);
+            let commitment = TransactionsCommitment::compute_transactions_commitment(
+                &serialized,
+                &context,
+                &mut encoder,
+            )
+            .unwrap();
+            let transactions = vec![
+                bcs::to_bytes(&SerializedTransactionsV2 {
+                    transaction_ref: TransactionRef {
+                        round: 3,
+                        author: AuthorityIndex::new_for_test(0),
+                        transactions_commitment: commitment,
+                    },
+                    serialized_transactions: serialized,
+                })
+                .unwrap()
+                .into(),
+            ];
+
+            let (result, inner) =
+                run_fetch_once(commits, block_headers, transactions, context).await;
+
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, ConsensusError::UnexpectedTransactionForCommit { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0, 1, 0, 0]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// A header other than the requested one — the count matches, so
+        /// truncation cannot be the cause — is charged to the serving peer.
+        #[tokio::test]
+        async fn records_misbehavior_for_mismatched_header() {
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (commits, mut block_headers, transactions) = two_commit_response(&context);
+            block_headers.swap(0, 1);
+
+            let (result, inner) =
+                run_fetch_once(commits, block_headers, transactions, context).await;
+
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, ConsensusError::UnexpectedBlockHeaderForCommit { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0, 1, 0, 0]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+    }
 }

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -1244,6 +1244,19 @@ mod tests {
             (result, inner)
         }
 
+        /// Asserts the peers' unprovable fault counts and that no provable
+        /// fault was recorded.
+        fn assert_unprovable_faults(inner: &Inner<FakeNetworkClient>, expected: Vec<u64>) {
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                expected
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
         /// Missing transactions are tolerated (the transaction synchronizer
         /// fetches them later) and record no misbehavior.
         #[tokio::test]
@@ -1257,14 +1270,7 @@ mod tests {
 
             let certified = result.unwrap();
             assert_eq!(certified.commits().len(), 2);
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0; 4]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
+            assert_unprovable_faults(&inner, vec![0; 4]);
         }
 
         /// An entry referencing a transaction that was not requested is
@@ -1303,14 +1309,7 @@ mod tests {
                 matches!(err, ConsensusError::UnexpectedTransactionForCommit { .. }),
                 "unexpected error: {err:?}"
             );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0, 1, 0, 0]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
+            assert_unprovable_faults(&inner, vec![0, 1, 0, 0]);
         }
 
         /// A header outside the requested set is charged to the serving peer.
@@ -1331,93 +1330,7 @@ mod tests {
                 matches!(err, ConsensusError::UnexpectedBlockHeaderForCommit { .. }),
                 "unexpected error: {err:?}"
             );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0, 1, 0, 0]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
-        }
-
-        /// A requested header served twice is charged to the serving peer.
-        #[tokio::test]
-        async fn records_misbehavior_for_duplicate_header() {
-            let context = Arc::new(Context::new_for_test(4).0);
-            let (commits, mut block_headers, transactions) = two_commit_response(&context);
-            block_headers[1] = block_headers[0].clone();
-
-            let (result, inner) =
-                run_fetch_once(commits, block_headers, transactions, context).await;
-
-            let err = result.unwrap_err();
-            assert!(
-                matches!(err, ConsensusError::UnexpectedBlockHeaderForCommit { .. }),
-                "unexpected error: {err:?}"
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0, 1, 0, 0]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
-        }
-
-        /// Headers are matched by requested ref, not position, so a reordered
-        /// response is accepted.
-        #[tokio::test]
-        async fn accepts_headers_in_any_order() {
-            let context = Arc::new(Context::new_for_test(4).0);
-            let (commits, mut block_headers, transactions) = two_commit_response(&context);
-            block_headers.swap(0, 1);
-
-            let (result, inner) =
-                run_fetch_once(commits, block_headers, transactions, context).await;
-
-            let certified = result.unwrap();
-            assert_eq!(certified.commits().len(), 2);
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0; 4]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
-        }
-
-        /// A response with more headers than requested is rejected before any
-        /// parsing and charged to the serving peer, since an honest response
-        /// can only be incomplete, never oversized.
-        #[tokio::test]
-        async fn records_misbehavior_for_extra_headers() {
-            let context = Arc::new(Context::new_for_test(4).0);
-            let (commits, mut block_headers, transactions) = two_commit_response(&context);
-            block_headers.push(
-                VerifiedBlockHeader::new_for_test(TestBlockHeader::new(3, 2).build())
-                    .serialized()
-                    .clone(),
-            );
-
-            let (result, inner) =
-                run_fetch_once(commits, block_headers, transactions, context).await;
-
-            let err = result.unwrap_err();
-            assert!(
-                matches!(err, ConsensusError::TooManyFetchedHeadersReturned { .. }),
-                "unexpected error: {err:?}"
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0, 1, 0, 0]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
+            assert_unprovable_faults(&inner, vec![0, 1, 0, 0]);
         }
 
         /// A response missing a header fails the fetch but records no
@@ -1436,14 +1349,7 @@ mod tests {
                 matches!(err, ConsensusError::NotEnoughHeadersFetched { .. }),
                 "unexpected error: {err:?}"
             );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
-                vec![0; 4]
-            );
-            assert_eq!(
-                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
-                vec![0; 4]
-            );
+            assert_unprovable_faults(&inner, vec![0; 4]);
         }
     }
 }

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -658,9 +658,9 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                         // directly
                         let mut result = BTreeMap::new();
                         for serialized_bytes in serialized_transactions {
-                            // Truncation only drops whole entries, so a
-                            // malformed or unrequested entry is the peer's own
-                            // content.
+                            // Truncation drops whole entries and never
+                            // corrupts one, so a malformed or unrequested
+                            // entry is the peer's fault.
                             let serialized_tx: SerializedTransactionsV2 =
                                 bcs::from_bytes(&serialized_bytes)
                                     .inspect_err(|_| {
@@ -1215,7 +1215,7 @@ mod tests {
             )
         }
 
-        /// Runs `fetch_once` against the canned responses served by
+        /// Runs `fetch_once` against the preset responses served by
         /// authority 1 and returns the result and the `Inner` whose
         /// misbehavior store the fetch recorded into.
         async fn run_fetch_once(

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -589,11 +589,10 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                             timeout,
                         )
                         .await?;
-                    // 5. Verify headers: count matches and each reference matches requested.
+                    // 5. Verify the returned headers are the requested ones.
                     // Classification charges the peer for malformed or
-                    // mismatched headers and leaves a short response untracked,
-                    // since the fetch client's byte cap can truncate an honest
-                    // one.
+                    // unrequested headers and leaves a short response
+                    // untracked, since an honest one can arrive incomplete.
                     verify_fetched_headers(
                         target_authority,
                         request_block_refs,
@@ -1322,13 +1321,15 @@ mod tests {
             );
         }
 
-        /// A header other than the requested one — the count matches, so
-        /// truncation cannot be the cause — is charged to the serving peer.
+        /// A header outside the requested set is charged to the serving peer.
         #[tokio::test]
-        async fn records_misbehavior_for_mismatched_header() {
+        async fn records_misbehavior_for_unrequested_header() {
             let context = Arc::new(Context::new_for_test(4).0);
             let (commits, mut block_headers, transactions) = two_commit_response(&context);
-            block_headers.swap(0, 1);
+            block_headers[1] =
+                VerifiedBlockHeader::new_for_test(TestBlockHeader::new(3, 2).build())
+                    .serialized()
+                    .clone();
 
             let (result, inner) =
                 run_fetch_once(commits, block_headers, transactions, context).await;
@@ -1341,6 +1342,111 @@ mod tests {
             assert_eq!(
                 inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
                 vec![0, 1, 0, 0]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// A requested header served twice is charged to the serving peer.
+        #[tokio::test]
+        async fn records_misbehavior_for_duplicate_header() {
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (commits, mut block_headers, transactions) = two_commit_response(&context);
+            block_headers[1] = block_headers[0].clone();
+
+            let (result, inner) =
+                run_fetch_once(commits, block_headers, transactions, context).await;
+
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, ConsensusError::UnexpectedBlockHeaderForCommit { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0, 1, 0, 0]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// Headers are matched by requested ref, not position, so a reordered
+        /// response is accepted.
+        #[tokio::test]
+        async fn accepts_headers_in_any_order() {
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (commits, mut block_headers, transactions) = two_commit_response(&context);
+            block_headers.swap(0, 1);
+
+            let (result, inner) =
+                run_fetch_once(commits, block_headers, transactions, context).await;
+
+            let certified = result.unwrap();
+            assert_eq!(certified.commits().len(), 2);
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0; 4]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// A response with more headers than requested is rejected before any
+        /// parsing, so nothing is recorded for it.
+        #[tokio::test]
+        async fn does_not_record_misbehavior_for_extra_headers() {
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (commits, mut block_headers, transactions) = two_commit_response(&context);
+            block_headers.push(
+                VerifiedBlockHeader::new_for_test(TestBlockHeader::new(3, 2).build())
+                    .serialized()
+                    .clone(),
+            );
+
+            let (result, inner) =
+                run_fetch_once(commits, block_headers, transactions, context).await;
+
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, ConsensusError::UnexpectedNumberOfHeadersFetched { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0; 4]
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_provable(),
+                vec![0; 4]
+            );
+        }
+
+        /// A response missing a header fails the fetch (the commits cannot be
+        /// certified without it) but records no misbehavior, since an honest
+        /// response can arrive incomplete.
+        #[tokio::test]
+        async fn does_not_record_misbehavior_for_missing_headers() {
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (commits, mut block_headers, transactions) = two_commit_response(&context);
+            block_headers.truncate(1);
+
+            let (result, inner) =
+                run_fetch_once(commits, block_headers, transactions, context).await;
+
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, ConsensusError::UnexpectedNumberOfHeadersFetched { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_eq!(
+                inner.misbehavior_store.in_memory_faulty_blocks_unprovable(),
+                vec![0; 4]
             );
             assert_eq!(
                 inner.misbehavior_store.in_memory_faulty_blocks_provable(),

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -276,10 +276,9 @@ pub(crate) enum ConsensusError {
         end: CommitIndex,
     },
 
-    #[error("Received unexpected block header from peer {peer}: {requested:?} vs {received:?}")]
+    #[error("Received unrequested block header from peer {peer}: {received:?}")]
     UnexpectedBlockHeaderForCommit {
         peer: AuthorityIndex,
-        requested: BlockRef,
         received: BlockRef,
     },
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -61,12 +61,21 @@ pub(crate) enum ConsensusError {
     UnexpectedGenesisRequested { peer: AuthorityIndex },
 
     #[error(
-        "Expected {requested} but received {received_headers} block headers from authority {authority}"
+        "Received fewer block headers than requested from peer {peer}: requested {requested}, received {received}"
     )]
-    UnexpectedNumberOfHeadersFetched {
-        authority: AuthorityIndex,
+    NotEnoughHeadersFetched {
+        peer: AuthorityIndex,
         requested: usize,
-        received_headers: usize,
+        received: usize,
+    },
+
+    #[error(
+        "Received more block headers than requested from peer {peer}: requested {requested}, received {received}"
+    )]
+    TooManyFetchedHeadersReturned {
+        peer: AuthorityIndex,
+        requested: usize,
+        received: usize,
     },
 
     #[error(

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -305,9 +305,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::IncorrectShardProof { .. }
         | ConsensusError::UnrequestedHeaderOutOfWindow { .. }
         | ConsensusError::SerializedShardTooLarge { .. }
-        // A fetched header other than the one requested. Unlike a fetch
-        // shortfall, this is not explainable by response truncation, since
-        // the entry-count check runs before references are compared.
+        // A fetched header outside the requested set, or served twice.
         | ConsensusError::UnexpectedBlockHeaderForCommit { .. } => FaultType::Unprovable,
 
         // Checks that run only after the author's signature is verified, so the
@@ -1002,11 +1000,10 @@ mod tests {
                 peer: AuthorityIndex::new_for_test(0),
                 round: 3,
             },
-            // A fetched header other than the one requested: charged to the
+            // A fetched header outside the requested set: charged to the
             // serving peer.
             ConsensusError::UnexpectedBlockHeaderForCommit {
                 peer: AuthorityIndex::new_for_test(0),
-                requested: BlockRef::MIN,
                 received: BlockRef::MIN,
             },
         ];

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -296,6 +296,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::DeserializationFailure(_)
         | ConsensusError::SerializedTransactionsTooLarge { .. }
         | ConsensusError::TransactionCommitmentFailure { .. }
+        | ConsensusError::UnexpectedBlockHeaderForCommit { .. }
         // Corrupt or invalid relayed bundle parts (framing, additional-header
         // round, and shard structure/proof). We know which peer relayed them
         // but can't tie them to a verified author.
@@ -304,9 +305,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::TooBigShardRoundInABundle { .. }
         | ConsensusError::IncorrectShardProof { .. }
         | ConsensusError::UnrequestedHeaderOutOfWindow { .. }
-        | ConsensusError::SerializedShardTooLarge { .. }
-        // A fetched header outside the requested set, or served twice.
-        | ConsensusError::UnexpectedBlockHeaderForCommit { .. } => FaultType::Unprovable,
+        | ConsensusError::SerializedShardTooLarge { .. } => FaultType::Unprovable,
 
         // Checks that run only after the author's signature is verified, so the
         // signed header itself proves the author produced a block that violates
@@ -341,8 +340,9 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::UnexpectedGenesisRequested { .. }
         | ConsensusError::UnexpectedNumberOfHeadersFetched { .. }
         | ConsensusError::UnexpectedLastOwnHeader { .. }
-        // Recorded against the serving peer at the fetch sites via
-        // `record_faulty_transactions`, so deliberately not tracked again here.
+        // Transaction fetch faults, recorded against the serving peer at the
+        // fetch sites via `record_faulty_transactions` — deliberately not
+        // tracked again here.
         | ConsensusError::TooManyFetchedTransactionsReturned(_)
         | ConsensusError::UnrequestedTransactionFetched { .. }
         | ConsensusError::UnexpectedTransactionForCommit { .. }

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -596,6 +596,14 @@ impl MisbehaviorStore {
     pub(crate) fn in_memory_equivocations(&self) -> Vec<u64> {
         self.in_memory.collect(|c| c.equivocations)
     }
+
+    pub(crate) fn in_memory_faulty_blocks_provable(&self) -> Vec<u64> {
+        self.in_memory.collect(|c| c.faulty_blocks_provable)
+    }
+
+    pub(crate) fn in_memory_faulty_blocks_unprovable(&self) -> Vec<u64> {
+        self.in_memory.collect(|c| c.faulty_blocks_unprovable)
+    }
 }
 
 #[cfg(test)]

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -308,10 +308,9 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::IncorrectShardProof { .. }
         | ConsensusError::UnrequestedHeaderOutOfWindow { .. }
         | ConsensusError::SerializedShardTooLarge { .. }
-        // A fetched block header other than the one requested. The fetch
-        // client only drops whole response entries and the entry count is
-        // checked before the per-entry references, so a mismatched header is
-        // content the serving peer produced.
+        // A fetched header other than the one requested. Unlike a fetch
+        // shortfall, this is not explainable by response truncation, since
+        // the entry-count check runs before references are compared.
         | ConsensusError::UnexpectedBlockHeaderForCommit { .. } => FaultType::Unprovable,
 
         // Checks that run only after the author's signature is verified, so the

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -299,9 +299,6 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         // Corrupt or invalid relayed bundle parts (framing, additional-header
         // round, and shard structure/proof). We know which peer relayed them
         // but can't tie them to a verified author.
-        // TODO(iotaledger/iota-private#470): count these under a dedicated
-        // bundle-part counter instead of folding them into the unprovable
-        // block-fault bucket.
         | ConsensusError::MalformedShard(_)
         | ConsensusError::TooBigHeaderRoundInABundle { .. }
         | ConsensusError::TooBigShardRoundInABundle { .. }
@@ -342,19 +339,15 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         // transport, request-shape checks, local lifecycle signals, and version
         // mismatches that may stem from a benign upgrade misconfiguration rather
         // than a faulty peer.
-        //
-        // Fetch shortfalls (fewer entries than requested, or transactions
-        // covering no commit) stay untracked because the fetch client caps
-        // response bytes and keeps partial data on mid-stream errors, so an
-        // honest response can arrive incomplete. Transaction fetch faults that
-        // are peer-attributable are untracked here and recorded at the fetch
-        // sites via `record_faulty_transactions` instead.
         ConsensusError::MalformedCommit(_)
         | ConsensusError::UnexpectedGenesisRequested { .. }
         | ConsensusError::UnexpectedNumberOfHeadersFetched { .. }
         | ConsensusError::UnexpectedLastOwnHeader { .. }
+        // Recorded against the serving peer at the fetch sites via
+        // `record_faulty_transactions`, so deliberately not tracked again here.
         | ConsensusError::TooManyFetchedTransactionsReturned(_)
         | ConsensusError::UnrequestedTransactionFetched { .. }
+        | ConsensusError::UnexpectedTransactionForCommit { .. }
         | ConsensusError::TooManyAuthoritiesProvided(_)
         | ConsensusError::InvalidSizeOfHighestAcceptedRounds(..)
         | ConsensusError::InvalidAuthorityIndexRequested { .. }
@@ -374,7 +367,6 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::SerializedCommitTooLarge { .. }
         | ConsensusError::SerializedBlockHeaderTooLarge { .. }
         | ConsensusError::InvalidCommitRange { .. }
-        | ConsensusError::UnexpectedTransactionForCommit { .. }
         | ConsensusError::FetchedTransactionsMismatch { .. }
         | ConsensusError::RocksDBFailure(_)
         | ConsensusError::NetworkConfig(_)

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -307,7 +307,12 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::TooBigShardRoundInABundle { .. }
         | ConsensusError::IncorrectShardProof { .. }
         | ConsensusError::UnrequestedHeaderOutOfWindow { .. }
-        | ConsensusError::SerializedShardTooLarge { .. } => FaultType::Unprovable,
+        | ConsensusError::SerializedShardTooLarge { .. }
+        // A fetched block header other than the one requested. The fetch
+        // client only drops whole response entries and the entry count is
+        // checked before the per-entry references, so a mismatched header is
+        // content the serving peer produced.
+        | ConsensusError::UnexpectedBlockHeaderForCommit { .. } => FaultType::Unprovable,
 
         // Checks that run only after the author's signature is verified, so the
         // signed header itself proves the author produced a block that violates
@@ -370,7 +375,6 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::SerializedCommitTooLarge { .. }
         | ConsensusError::SerializedBlockHeaderTooLarge { .. }
         | ConsensusError::InvalidCommitRange { .. }
-        | ConsensusError::UnexpectedBlockHeaderForCommit { .. }
         | ConsensusError::UnexpectedTransactionForCommit { .. }
         | ConsensusError::FetchedTransactionsMismatch { .. }
         | ConsensusError::RocksDBFailure(_)
@@ -999,6 +1003,13 @@ mod tests {
                 peer: AuthorityIndex::new_for_test(0),
                 round: 3,
             },
+            // A fetched header other than the one requested: charged to the
+            // serving peer.
+            ConsensusError::UnexpectedBlockHeaderForCommit {
+                peer: AuthorityIndex::new_for_test(0),
+                requested: BlockRef::MIN,
+                received: BlockRef::MIN,
+            },
         ];
         for e in cases {
             let (prov, unprov) = classify_via_record(e);
@@ -1021,16 +1032,11 @@ mod tests {
             // Commit-chain inconsistencies.
             ConsensusError::NoCommitReceived { peer: authority },
             ConsensusError::MalformedCommit(bcs::Error::Custom("bad".to_string())),
-            // Fetch-shape errors (peer returned wrong count/ref/transactions).
+            // Fetch shortfalls (client-side truncation can produce them).
             ConsensusError::UnexpectedNumberOfHeadersFetched {
                 authority,
                 requested: 5,
                 received_headers: 3,
-            },
-            ConsensusError::UnexpectedBlockHeaderForCommit {
-                peer: authority,
-                requested: BlockRef::MIN,
-                received: BlockRef::MIN,
             },
             ConsensusError::FetchedTransactionsMismatch {
                 peer: authority,

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -338,6 +338,13 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         // transport, request-shape checks, local lifecycle signals, and version
         // mismatches that may stem from a benign upgrade misconfiguration rather
         // than a faulty peer.
+        //
+        // Fetch shortfalls (fewer entries than requested, or transactions
+        // covering no commit) stay untracked because the fetch client caps
+        // response bytes and keeps partial data on mid-stream errors, so an
+        // honest response can arrive incomplete. Transaction fetch faults that
+        // are peer-attributable are untracked here and recorded at the fetch
+        // sites via `record_faulty_transactions` instead.
         ConsensusError::MalformedCommit(_)
         | ConsensusError::UnexpectedGenesisRequested { .. }
         | ConsensusError::UnexpectedNumberOfHeadersFetched { .. }

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -297,6 +297,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::SerializedTransactionsTooLarge { .. }
         | ConsensusError::TransactionCommitmentFailure { .. }
         | ConsensusError::UnexpectedBlockHeaderForCommit { .. }
+        | ConsensusError::TooManyFetchedHeadersReturned { .. }
         // Corrupt or invalid relayed bundle parts (framing, additional-header
         // round, and shard structure/proof). We know which peer relayed them
         // but can't tie them to a verified author.
@@ -338,7 +339,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         // than a faulty peer.
         ConsensusError::MalformedCommit(_)
         | ConsensusError::UnexpectedGenesisRequested { .. }
-        | ConsensusError::UnexpectedNumberOfHeadersFetched { .. }
+        | ConsensusError::NotEnoughHeadersFetched { .. }
         | ConsensusError::UnexpectedLastOwnHeader { .. }
         // Transaction fetch faults, recorded against the serving peer at the
         // fetch sites via `record_faulty_transactions` — deliberately not
@@ -1006,6 +1007,11 @@ mod tests {
                 peer: AuthorityIndex::new_for_test(0),
                 received: BlockRef::MIN,
             },
+            ConsensusError::TooManyFetchedHeadersReturned {
+                peer: AuthorityIndex::new_for_test(0),
+                requested: 2,
+                received: 3,
+            },
         ];
         for e in cases {
             let (prov, unprov) = classify_via_record(e);
@@ -1029,10 +1035,10 @@ mod tests {
             ConsensusError::NoCommitReceived { peer: authority },
             ConsensusError::MalformedCommit(bcs::Error::Custom("bad".to_string())),
             // Fetch shortfalls (client-side truncation can produce them).
-            ConsensusError::UnexpectedNumberOfHeadersFetched {
-                authority,
+            ConsensusError::NotEnoughHeadersFetched {
+                peer: authority,
                 requested: 5,
-                received_headers: 3,
+                received: 3,
             },
             ConsensusError::FetchedTransactionsMismatch {
                 peer: authority,

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -300,10 +300,10 @@ impl NetworkClient for TonicClient {
                         .len()
                         .saturating_add(vec_serialized_block_headers.len());
                     if received_headers > max_headers {
-                        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
-                            authority: peer,
+                        return Err(ConsensusError::TooManyFetchedHeadersReturned {
+                            peer,
                             requested: max_headers,
-                            received_headers,
+                            received: received_headers,
                         });
                     }
                     for b in &vec_serialized_block_headers {


### PR DESCRIPTION
# Description of change

The fast and regular commit syncers dropped peer-attributable fetch faults that the transaction-sync path already records, so honest validators could end up with different per-peer misbehavior counts depending on which path served the data.

- Malformed or unrequested transaction entries and payloads failing verification against their refs are now charged to the serving peer as unprovable faults on both commit-sync paths, matching the transaction-sync path.
- Fetched headers are now verified against the requested set instead of by position: an unrequested, duplicate, or malformed header is charged to the serving peer, as is a response with more entries than requested (new `TooManyFetchedHeadersReturned`, rejected before parsing).
- Incomplete responses stay untracked (`FetchedTransactionsMismatch`, `NotEnoughHeadersFetched`, renamed from `UnexpectedNumberOfHeadersFetched`): the server may lack the data or clip the request to its own local limits, and the client keeps partial data on mid-stream errors, so an honest response can arrive incomplete. Truncation only drops whole entries, which is why faults inside a delivered entry remain attributable.

## Links to any relevant issues

fixes #12362

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
