### PR TITLE
feat(iota-localnet): add --disable-fullnode-pruning flag

### DIFF
--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -232,6 +232,10 @@ pub enum LocalnetCommand {
         /// Start the network without a fullnode
         #[arg(long)]
         no_full_node: bool,
+        /// Keep the fullnode's full history instead of pruning old object
+        /// versions and checkpoints.
+        #[arg(long, conflicts_with = "no_full_node")]
+        disable_fullnode_pruning: bool,
         /// Set the number of validators in the network.
         /// If a genesis was already generated with a specific number of
         /// validators, this will not override it; the user should recreate the
@@ -308,6 +312,7 @@ impl LocalnetCommand {
                 #[cfg(feature = "indexer")]
                 data_ingestion_dir,
                 no_full_node,
+                disable_fullnode_pruning,
                 committee_size,
                 epoch_duration_ms,
             } => {
@@ -325,6 +330,7 @@ impl LocalnetCommand {
                     #[cfg(feature = "indexer")]
                     data_ingestion_dir,
                     no_full_node,
+                    disable_fullnode_pruning,
                     committee_size,
                 )
                 .await
@@ -374,6 +380,7 @@ async fn start(
     fullnode_rpc_port: u16,
     #[cfg(feature = "indexer")] mut data_ingestion_dir: Option<PathBuf>,
     no_full_node: bool,
+    disable_fullnode_pruning: bool,
     committee_size: Option<usize>,
 ) -> Result<(), anyhow::Error> {
     if force_regenesis {
@@ -424,6 +431,10 @@ async fn start(
     let config_path = config_dir.clone().map_or_else(iota_config_dir, Ok)?;
 
     let mut swarm_builder = Swarm::builder();
+
+    if disable_fullnode_pruning {
+        swarm_builder = swarm_builder.with_disable_fullnode_pruning();
+    }
 
     // If this is set, then no data will be persisted between runs, and a new
     // genesis will be generated each run.

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -4,6 +4,7 @@
 
 use std::{fs::read_dir, net::SocketAddr, time::Duration};
 
+use clap::Parser;
 use iota_config::{
     IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
     IOTA_NETWORK_CONFIG, PersistedConfig,
@@ -99,6 +100,7 @@ async fn test_start() -> Result<(), anyhow::Error> {
             data_ingestion_dir: None,
             config_dir: Some(working_dir.to_path_buf()),
             no_full_node: false,
+            disable_fullnode_pruning: false,
             force_regenesis: false,
             with_faucet: None,
             faucet_amount: None,
@@ -142,6 +144,39 @@ async fn test_start() -> Result<(), anyhow::Error> {
 
     tmp_dir.close()?;
     Ok(())
+}
+
+#[test]
+fn test_parse_disable_fullnode_pruning() {
+    let command =
+        LocalnetCommand::try_parse_from(["iota-localnet", "start", "--disable-fullnode-pruning"])
+            .unwrap();
+    assert!(matches!(
+        command,
+        LocalnetCommand::Start {
+            disable_fullnode_pruning: true,
+            ..
+        }
+    ));
+
+    let command = LocalnetCommand::try_parse_from(["iota-localnet", "start"]).unwrap();
+    assert!(matches!(
+        command,
+        LocalnetCommand::Start {
+            disable_fullnode_pruning: false,
+            ..
+        }
+    ));
+
+    assert!(
+        LocalnetCommand::try_parse_from([
+            "iota-localnet",
+            "start",
+            "--disable-fullnode-pruning",
+            "--no-full-node",
+        ])
+        .is_err()
+    );
 }
 
 #[tokio::test]

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -4,7 +4,6 @@
 
 use std::{fs::read_dir, net::SocketAddr, time::Duration};
 
-use clap::Parser;
 use iota_config::{
     IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
     IOTA_NETWORK_CONFIG, PersistedConfig,
@@ -144,39 +143,6 @@ async fn test_start() -> Result<(), anyhow::Error> {
 
     tmp_dir.close()?;
     Ok(())
-}
-
-#[test]
-fn test_parse_disable_fullnode_pruning() {
-    let command =
-        LocalnetCommand::try_parse_from(["iota-localnet", "start", "--disable-fullnode-pruning"])
-            .unwrap();
-    assert!(matches!(
-        command,
-        LocalnetCommand::Start {
-            disable_fullnode_pruning: true,
-            ..
-        }
-    ));
-
-    let command = LocalnetCommand::try_parse_from(["iota-localnet", "start"]).unwrap();
-    assert!(matches!(
-        command,
-        LocalnetCommand::Start {
-            disable_fullnode_pruning: false,
-            ..
-        }
-    ));
-
-    assert!(
-        LocalnetCommand::try_parse_from([
-            "iota-localnet",
-            "start",
-            "--disable-fullnode-pruning",
-            "--no-full-node",
-        ])
-        .is_err()
-    );
 }
 
 #[tokio::test]

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -53,6 +53,7 @@ iota-localnet start [OPTIONS]
 | `--epoch-duration-ms <MS>` | Epoch duration in milliseconds (default: `60000`). Only with `--force-regenesis` or auto-generated genesis. |
 | `--committee-size <N>` | Number of validators in the network (default: `1`). |
 | `--no-full-node` | Start the network without a fullnode. |
+| `--disable-fullnode-pruning` | Keep the fullnode's full history instead of pruning old object versions and checkpoints. Cannot be combined with `--no-full-node`. |
 | `--local-migration-snapshots <PATH>...` | Paths to local migration snapshot files. |
 | `--remote-migration-snapshots <URL>...` | Remotely stored migration snapshot URLs. |
 | `--delegator <ADDRESS>` | Specify the delegator address. |


### PR DESCRIPTION
# Description of change

- Add a `--disable-fullnode-pruning` flag to `iota-localnet start`, wired to the existing `SwarmBuilder::with_disable_fullnode_pruning`, so the localnet fullnode keeps its full history instead of pruning old object versions and checkpoints. Tests and tools that read historical state over JSON-RPC need this.
- The flag conflicts with `--no-full-node`, and takes effect in both persisted and `--force-regenesis` mode, since the localnet fullnode config is always assembled by `FullnodeConfigBuilder`.
- Add the flag to the `iota-localnet start` options table in `docs/content/developer/references/cli/localnet.mdx`.

## Links to any relevant issues

Part of #12429. Supersedes the flag half of #12466 — the node config override half of that PR follows in a later one. Landing the flag on its own unblocks the ts-packages pruning work that needs a localnet fullnode with full history (context: #12403).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] CLI: `iota-localnet start --disable-fullnode-pruning` keeps the fullnode's full history.