### PR TITLE
feat(iota-localnet,iota-swarm-config): deterministic localnet ports

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,6 +20,13 @@ or (package(iota-indexer) and (binary(ingestion_tests)))
 '''
 
 [[profile.default.overrides]]
+# Tests that start a local network on its fixed ports, so they cannot run next to each other
+threads-required = "num-test-threads"
+filter = '''
+package(iota-localnet) and (test(test_start) or test(start_works_with_a_committee_of_two))
+'''
+
+[[profile.default.overrides]]
 # Slow tests that should run single threaded and only get 1 retry (like the default) but a longer timeout
 threads-required = "num-test-threads"
 slow-timeout = { period = "120s", terminate-after = 5 }

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -57,6 +57,13 @@ const DEFAULT_GRPC_PORT: u16 = 50051;
 const DEFAULT_GRAPHQL_PORT: u16 = 9125;
 #[cfg(feature = "indexer")]
 const DEFAULT_INDEXER_PORT: u16 = 9124;
+/// The fullnode's metrics port on 127.0.0.1. Its admin interface takes the
+/// next port and its p2p address the one after that.
+const FULLNODE_PORT_BASE: u16 = 9184;
+/// First port of the validator layout on 127.0.0.1: validator `i` takes the
+/// ten ports starting at `VALIDATOR_PORT_BASE + 10 * i`, of which the first
+/// five are its network, p2p, metrics, primary and admin interface addresses.
+const VALIDATOR_PORT_BASE: u16 = 9200;
 
 #[cfg(feature = "indexer")]
 #[derive(Args)]
@@ -442,7 +449,9 @@ async fn start(
         let committee_size = NonZeroUsize::new(committee_size.unwrap_or(DEFAULT_COMMITTEE_SIZE))
             .ok_or_else(|| anyhow!("Committee size must be at least 1."))?;
 
-        swarm_builder = swarm_builder.committee_size(committee_size);
+        swarm_builder = swarm_builder
+            .committee_size(committee_size)
+            .with_deterministic_validator_ports(VALIDATOR_PORT_BASE);
         let genesis_config = GenesisConfig::custom_genesis(1, 100);
         swarm_builder = swarm_builder.with_genesis_config(genesis_config);
         let epoch_duration_ms = epoch_duration_ms.unwrap_or(DEFAULT_EPOCH_DURATION_MS);
@@ -615,7 +624,8 @@ async fn start(
     } else {
         swarm_builder = swarm_builder
             .with_fullnode_count(1)
-            .with_fullnode_rpc_addr(fullnode_url);
+            .with_fullnode_rpc_addr(fullnode_url)
+            .with_deterministic_fullnode_ports(FULLNODE_PORT_BASE);
     }
 
     let mut swarm = tokio::task::spawn_blocking(move || swarm_builder.build()).await?;
@@ -969,7 +979,9 @@ async fn genesis(
     builder = if let Some(validators) = validator_info {
         builder.with_validators(validators)
     } else {
-        builder.committee_size(NonZeroUsize::new(committee_size).unwrap())
+        builder
+            .committee_size(NonZeroUsize::new(committee_size).unwrap())
+            .with_deterministic_ports(VALIDATOR_PORT_BASE)
     };
 
     if let Some(address) = admin_interface_address_with_port {
@@ -1006,6 +1018,7 @@ async fn genesis(
         .with_rpc_addr(iota_config::node::default_json_rpc_address())
         .with_genesis(genesis.clone())
         .with_admin_interface_address(admin_interface_address_with_port)
+        .with_deterministic_ports(FULLNODE_PORT_BASE)
         .try_build_from_parts(&mut OsRng, network_config.validator_configs(), genesis)?;
 
     fullnode_config.save(iota_config_dir.join(IOTA_FULLNODE_CONFIG))?;

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -57,12 +57,11 @@ const DEFAULT_GRPC_PORT: u16 = 50051;
 const DEFAULT_GRAPHQL_PORT: u16 = 9125;
 #[cfg(feature = "indexer")]
 const DEFAULT_INDEXER_PORT: u16 = 9124;
-/// The fullnode's metrics port on 127.0.0.1. Its admin interface takes the
-/// next port and its p2p address the one after that.
+/// Port base of the fullnode layout, see
+/// [`FullnodeConfigBuilder::with_deterministic_ports`].
 const FULLNODE_PORT_BASE: u16 = 9184;
-/// First port of the validator layout on 127.0.0.1: validator `i` takes the
-/// ten ports starting at `VALIDATOR_PORT_BASE + 10 * i`, of which the first
-/// five are its network, p2p, metrics, primary and admin interface addresses.
+/// Port base of the validator layout, see
+/// [`ConfigBuilder::with_deterministic_ports`].
 const VALIDATOR_PORT_BASE: u16 = 9200;
 
 #[cfg(feature = "indexer")]

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -195,14 +195,54 @@ async fn genesis_gives_every_node_fixed_ports() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Waits for the fullnode to execute a checkpoint, which it can only get by
+/// syncing from the validators.
+#[cfg(not(msim))]
+async fn wait_until_the_fullnode_syncs(rpc_port: u16) {
+    use iota_sdk::IotaClientBuilder;
+
+    let url = format!("http://127.0.0.1:{rpc_port}");
+    let synced = tokio::time::timeout(Duration::from_secs(120), async {
+        loop {
+            if let Ok(client) = IotaClientBuilder::default().build(&url).await {
+                if let Ok(checkpoint) = client
+                    .read_api()
+                    .get_latest_checkpoint_sequence_number()
+                    .await
+                {
+                    // Checkpoint 0 comes from the genesis blob the fullnode
+                    // already has, so only a later one is synced.
+                    if checkpoint > 0 {
+                        return;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await;
+
+    assert!(synced.is_ok(), "the fullnode executed no checkpoint");
+}
+
+/// The simulator gives every node an address of its own and routes loopback
+/// addresses back to the caller, so the fullnode's JSON-RPC endpoint, which
+/// `start` binds on all interfaces without reporting the address, cannot be
+/// reached from the test. Give the network time to come up instead.
+#[cfg(msim)]
+async fn wait_until_the_fullnode_syncs(_rpc_port: u16) {
+    tokio::time::sleep(Duration::from_secs(10)).await;
+}
+
 #[sim_test]
 async fn test_start() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
     let working_dir = tmp_dir.path();
+    let fullnode_rpc_port = 9000;
 
-    if let Ok(res) = tokio::time::timeout(
-        Duration::from_secs(10),
-        LocalnetCommand::Start {
+    // `start` runs until the network fails, so race it against the fullnode.
+    tokio::select! {
+        result = LocalnetCommand::Start {
             #[cfg(feature = "indexer")]
             data_ingestion_dir: None,
             config_dir: Some(working_dir.to_path_buf()),
@@ -213,18 +253,18 @@ async fn test_start() -> Result<(), anyhow::Error> {
             faucet_amount: None,
             faucet_coin_count: None,
             with_grpc: None,
-            fullnode_rpc_port: 9000,
+            fullnode_rpc_port,
             committee_size: None,
             epoch_duration_ms: None,
             #[cfg(feature = "indexer")]
             indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
         }
-        .execute(),
-    )
-    .await
-    {
-        res.unwrap();
-    };
+        .execute() => {
+            result?;
+            unreachable!("the local network stops on failure only");
+        }
+        () = wait_until_the_fullnode_syncs(fullnode_rpc_port) => {}
+    }
 
     // Get all the new file names
     let files = read_dir(working_dir)?
@@ -248,6 +288,47 @@ async fn test_start() -> Result<(), anyhow::Error> {
     assert!(!wallet_conf.envs().is_empty());
 
     assert_eq!(5, wallet_conf.keystore().addresses().len());
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+/// The deterministic port layout must leave every node its own IP, which the
+/// simulator hands out one per node and panics on if two nodes share one.
+#[sim_test]
+async fn start_works_with_a_committee_of_two() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+
+    if let Ok(res) = tokio::time::timeout(
+        Duration::from_secs(10),
+        LocalnetCommand::Start {
+            #[cfg(feature = "indexer")]
+            data_ingestion_dir: None,
+            config_dir: Some(working_dir.to_path_buf()),
+            no_full_node: false,
+            disable_fullnode_pruning: false,
+            force_regenesis: false,
+            with_faucet: None,
+            faucet_amount: None,
+            faucet_coin_count: None,
+            with_grpc: None,
+            fullnode_rpc_port: 9000,
+            committee_size: Some(2),
+            epoch_duration_ms: None,
+            #[cfg(feature = "indexer")]
+            indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
+        }
+        .execute(),
+    )
+    .await
+    {
+        res.unwrap();
+    };
+
+    let network_conf =
+        PersistedConfig::<NetworkConfigLight>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
+    assert_eq!(2, network_conf.validator_configs().len());
 
     tmp_dir.close()?;
     Ok(())

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -2,11 +2,11 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fs::read_dir, net::SocketAddr, time::Duration};
+use std::{collections::BTreeSet, fs::read_dir, net::SocketAddr, time::Duration};
 
 use iota_config::{
     IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
-    IOTA_NETWORK_CONFIG, PersistedConfig,
+    IOTA_NETWORK_CONFIG, NodeConfig, PersistedConfig,
 };
 use iota_keys::keystore::AccountKeystore;
 #[cfg(feature = "indexer")]
@@ -82,6 +82,114 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     .execute()
     .await;
     assert!(matches!(result, Err(..)));
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+/// The port layout documented in
+/// `docs/content/developer/references/cli/localnet.mdx`.
+#[tokio::test]
+async fn genesis_gives_every_node_fixed_ports() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+
+    LocalnetCommand::Genesis {
+        working_dir: Some(working_dir.to_path_buf()),
+        write_config: None,
+        force: false,
+        from_config: None,
+        epoch_duration_ms: None,
+        benchmark_ips: None,
+        with_faucet: false,
+        committee_size: 4,
+        num_additional_gas_accounts: None,
+        chain_start_timestamp_ms: None,
+        admin_interface_address: None,
+    }
+    .execute()
+    .await?;
+
+    let network_config =
+        PersistedConfig::<NetworkConfigLight>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
+    let mut ports = Vec::new();
+
+    for (i, validator) in network_config.validator_configs().iter().enumerate() {
+        let base = 9200 + 10 * i as u16;
+        assert_eq!(
+            validator.network_address.to_string(),
+            format!("/ip4/127.0.0.1/tcp/{base}/http")
+        );
+        assert_eq!(
+            validator
+                .p2p_config
+                .external_address
+                .as_ref()
+                .unwrap()
+                .to_string(),
+            format!("/ip4/127.0.0.1/udp/{}/http", base + 1)
+        );
+        assert_eq!(
+            validator.p2p_config.listen_address,
+            SocketAddr::from(([127, 0, 0, 1], base + 1))
+        );
+        assert_eq!(
+            validator.metrics_address,
+            SocketAddr::from(([127, 0, 0, 1], base + 2))
+        );
+        assert_eq!(
+            validator.admin_interface_address,
+            SocketAddr::from(([127, 0, 0, 1], base + 4))
+        );
+        ports.extend([base, base + 1, base + 2, base + 4]);
+    }
+
+    // The primary address is only kept in the committee metadata of the genesis
+    // blob, in an order of its own.
+    let genesis = network_config.validator_configs()[0].genesis.genesis()?;
+    let primary_addresses = genesis
+        .validator_set_for_tooling()
+        .iter()
+        .map(|validator| validator.verified_metadata().primary_address.to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        primary_addresses,
+        (0..4)
+            .map(|i| format!("/ip4/127.0.0.1/udp/{}/http", 9203 + 10 * i))
+            .collect::<BTreeSet<_>>()
+    );
+    ports.extend((0..4).map(|i| 9203 + 10 * i));
+
+    let fullnode = PersistedConfig::<NodeConfig>::read(&working_dir.join(IOTA_FULLNODE_CONFIG))?;
+    assert_eq!(
+        fullnode.metrics_address,
+        SocketAddr::from(([127, 0, 0, 1], 9184))
+    );
+    assert_eq!(
+        fullnode.admin_interface_address,
+        SocketAddr::from(([127, 0, 0, 1], 9185))
+    );
+    assert_eq!(
+        fullnode
+            .p2p_config
+            .external_address
+            .as_ref()
+            .unwrap()
+            .to_string(),
+        "/ip4/127.0.0.1/udp/9186/http"
+    );
+    assert_eq!(
+        fullnode.p2p_config.listen_address,
+        SocketAddr::from(([127, 0, 0, 1], 9186))
+    );
+    assert_eq!(fullnode.json_rpc_address.port(), 9000);
+    ports.extend([9184, 9185, 9186, 9000]);
+
+    assert_eq!(
+        ports.iter().collect::<BTreeSet<_>>().len(),
+        ports.len(),
+        "two nodes share a port: {ports:?}"
+    );
 
     tmp_dir.close()?;
     Ok(())

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -293,8 +293,8 @@ async fn test_start() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// The deterministic port layout must leave every node its own IP, which the
-/// simulator hands out one per node and panics on if two nodes share one.
+/// The simulator panics when two nodes share an IP, so a second validator
+/// catches a layout that pins addresses instead of ports.
 #[sim_test]
 async fn start_works_with_a_committee_of_two() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -112,8 +112,6 @@ pub struct ValidatorGenesisConfigBuilder {
     /// Whether to use a specific p2p listen ip address. This is useful for
     /// testing on AWS.
     p2p_listen_ip_address: Option<IpAddr>,
-    /// Which ip the metrics endpoint binds. Defaults to all interfaces with
-    /// deterministic ports and to localhost otherwise.
     metrics_ip_address: Option<IpAddr>,
 }
 

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -112,6 +112,9 @@ pub struct ValidatorGenesisConfigBuilder {
     /// Whether to use a specific p2p listen ip address. This is useful for
     /// testing on AWS.
     p2p_listen_ip_address: Option<IpAddr>,
+    /// Which ip the metrics endpoint binds. Defaults to all interfaces with
+    /// deterministic ports and to localhost otherwise.
+    metrics_ip_address: Option<IpAddr>,
 }
 
 impl ValidatorGenesisConfigBuilder {
@@ -149,6 +152,14 @@ impl ValidatorGenesisConfigBuilder {
         self
     }
 
+    /// Bind the metrics endpoint to `metrics_ip_address`. Without this, it
+    /// binds all interfaces when the ports are deterministic, so that a
+    /// testbed can scrape it, and localhost otherwise.
+    pub fn with_metrics_ip_address(mut self, metrics_ip_address: IpAddr) -> Self {
+        self.metrics_ip_address = Some(metrics_ip_address);
+        self
+    }
+
     pub fn build<R: rand::RngCore + rand::CryptoRng>(self, rng: &mut R) -> ValidatorGenesisConfig {
         let ip = self.ip.unwrap_or_else(local_ip_utils::get_new_ip);
         let localhost = local_ip_utils::localhost_for_testing();
@@ -164,6 +175,8 @@ impl ValidatorGenesisConfigBuilder {
         let (protocol_key_pair, network_key_pair): (NetworkKeyPair, NetworkKeyPair) =
             (get_key_pair_from_rng(rng).1, get_key_pair_from_rng(rng).1);
 
+        let metrics_ip = self.metrics_ip_address.map(|ip| ip.to_string());
+
         let (
             network_address,
             p2p_address,
@@ -174,8 +187,16 @@ impl ValidatorGenesisConfigBuilder {
             (
                 local_ip_utils::new_deterministic_tcp_address_for_testing(&ip, offset),
                 local_ip_utils::new_deterministic_udp_address_for_testing(&ip, offset + 1),
-                local_ip_utils::new_deterministic_tcp_address_for_testing(&ip, offset + 2)
-                    .with_zero_ip(),
+                match &metrics_ip {
+                    Some(metrics_ip) => local_ip_utils::new_deterministic_tcp_address_for_testing(
+                        metrics_ip,
+                        offset + 2,
+                    ),
+                    None => {
+                        local_ip_utils::new_deterministic_tcp_address_for_testing(&ip, offset + 2)
+                            .with_zero_ip()
+                    }
+                },
                 local_ip_utils::new_deterministic_udp_address_for_testing(&ip, offset + 3),
                 local_ip_utils::new_deterministic_tcp_address_for_testing(&ip, offset + 4),
             )
@@ -183,7 +204,9 @@ impl ValidatorGenesisConfigBuilder {
             (
                 local_ip_utils::new_tcp_address_for_testing(&ip),
                 local_ip_utils::new_udp_address_for_testing(&ip),
-                local_ip_utils::new_tcp_address_for_testing(&localhost),
+                local_ip_utils::new_tcp_address_for_testing(
+                    metrics_ip.as_deref().unwrap_or(&localhost),
+                ),
                 local_ip_utils::new_udp_address_for_testing(&ip),
                 local_ip_utils::new_tcp_address_for_testing(&localhost),
             )
@@ -481,5 +504,48 @@ impl GenesisConfig {
             gas_amounts: vec![DEFAULT_GAS_AMOUNT; DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT],
         });
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use rand::rngs::OsRng;
+
+    use super::ValidatorGenesisConfigBuilder;
+
+    #[test]
+    fn deterministic_ports_fill_the_five_slots_of_a_validator() {
+        let config = ValidatorGenesisConfigBuilder::new()
+            .with_ip("127.0.0.1".to_owned())
+            .with_deterministic_ports(9200)
+            .with_metrics_ip_address(Ipv4Addr::LOCALHOST.into())
+            .build(&mut OsRng);
+
+        assert_eq!(
+            config.network_address.to_string(),
+            "/ip4/127.0.0.1/tcp/9200/http"
+        );
+        assert_eq!(
+            config.p2p_address.to_string(),
+            "/ip4/127.0.0.1/udp/9201/http"
+        );
+        assert_eq!(config.metrics_address.to_string(), "127.0.0.1:9202");
+        assert_eq!(
+            config.primary_address.to_string(),
+            "/ip4/127.0.0.1/udp/9203/http"
+        );
+        assert_eq!(config.admin_interface_address.to_string(), "127.0.0.1:9204");
+    }
+
+    #[test]
+    fn the_metrics_endpoint_binds_all_interfaces_unless_an_ip_is_given() {
+        let config = ValidatorGenesisConfigBuilder::new()
+            .with_ip("127.0.0.1".to_owned())
+            .with_deterministic_ports(9200)
+            .build(&mut OsRng);
+
+        assert_eq!(config.metrics_address.to_string(), "0.0.0.0:9202");
     }
 }

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -13,7 +13,6 @@ use fastcrypto::traits::KeyPair;
 use iota_config::{
     ExecutionCacheConfig,
     genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
-    local_ip_utils,
     node::AuthorityOverloadConfig,
     transaction_deny_config::TransactionDenyConfig,
 };
@@ -51,9 +50,9 @@ pub enum CommitteeConfig {
     Deterministic((NonZeroUsize, Option<Vec<AccountKeyPair>>)),
 }
 
-/// Give the validator at `index` its fixed addresses on 127.0.0.1, including
-/// the metrics endpoint, which the deterministic layout otherwise binds on all
-/// interfaces.
+/// Give the validator at `index` its fixed ports on the address it would get
+/// anyway, and bind its metrics endpoint on localhost, which the deterministic
+/// layout otherwise binds on all interfaces.
 fn place_on_deterministic_ports(
     builder: ValidatorGenesisConfigBuilder,
     port_base: u16,
@@ -71,7 +70,6 @@ fn place_on_deterministic_ports(
         });
 
     builder
-        .with_ip(local_ip_utils::localhost_for_testing())
         .with_deterministic_ports(port_offset)
         .with_metrics_ip_address(Ipv4Addr::LOCALHOST.into())
 }
@@ -197,10 +195,10 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
-    /// Give every generated validator fixed addresses on 127.0.0.1 instead of
-    /// currently-free ports: validator `i` takes the ten ports starting at
-    /// `port_base + 10 * i`, of which the first five are its network, p2p,
-    /// metrics, primary and admin interface addresses.
+    /// Give every generated validator fixed ports instead of currently-free
+    /// ones: validator `i` takes the ten ports starting at `port_base + 10 *
+    /// i`, of which the first five are its network, p2p, metrics, primary and
+    /// admin interface addresses.
     ///
     /// Has no effect on `CommitteeConfig::Validators`, whose addresses come
     /// from the caller, or on `CommitteeConfig::Deterministic`, which lays out

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -50,9 +50,6 @@ pub enum CommitteeConfig {
     Deterministic((NonZeroUsize, Option<Vec<AccountKeyPair>>)),
 }
 
-/// Give the validator at `index` its fixed ports on the address it would get
-/// anyway, and bind its metrics endpoint on localhost, which the deterministic
-/// layout otherwise binds on all interfaces.
 fn place_on_deterministic_ports(
     builder: ValidatorGenesisConfigBuilder,
     port_base: u16,
@@ -199,6 +196,10 @@ impl<R> ConfigBuilder<R> {
     /// ones: validator `i` takes the ten ports starting at `port_base + 10 *
     /// i`, of which the first five are its network, p2p, metrics, primary and
     /// admin interface addresses.
+    ///
+    /// Only the ports are fixed: every address keeps the IP its validator
+    /// would have used anyway, except the metrics endpoint, which binds
+    /// localhost.
     ///
     /// Has no effect on `CommitteeConfig::Validators`, whose addresses come
     /// from the caller, or on `CommitteeConfig::Deterministic`, which lays out

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    net::SocketAddr,
+    net::{Ipv4Addr, SocketAddr},
     num::NonZeroUsize,
     path::{Path, PathBuf},
     sync::Arc,
@@ -13,6 +13,7 @@ use fastcrypto::traits::KeyPair;
 use iota_config::{
     ExecutionCacheConfig,
     genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
+    local_ip_utils,
     node::AuthorityOverloadConfig,
     transaction_deny_config::TransactionDenyConfig,
 };
@@ -37,6 +38,9 @@ use crate::{
     node_config_builder::ValidatorConfigBuilder,
 };
 
+/// Number of ports the deterministic layout reserves per validator.
+const DETERMINISTIC_PORTS_PER_VALIDATOR: u16 = 10;
+
 pub enum CommitteeConfig {
     Size(NonZeroUsize),
     Validators(Vec<ValidatorGenesisConfig>),
@@ -45,6 +49,31 @@ pub enum CommitteeConfig {
     /// the provided rng as a source of randomness as well as generating
     /// deterministic network port information.
     Deterministic((NonZeroUsize, Option<Vec<AccountKeyPair>>)),
+}
+
+/// Give the validator at `index` its fixed addresses on 127.0.0.1, including
+/// the metrics endpoint, which the deterministic layout otherwise binds on all
+/// interfaces.
+fn place_on_deterministic_ports(
+    builder: ValidatorGenesisConfigBuilder,
+    port_base: u16,
+    index: usize,
+) -> ValidatorGenesisConfigBuilder {
+    let port_offset = u16::try_from(index)
+        .ok()
+        .and_then(|index| index.checked_mul(DETERMINISTIC_PORTS_PER_VALIDATOR))
+        .and_then(|offset| port_base.checked_add(offset))
+        .unwrap_or_else(|| {
+            panic!(
+                "committee of {} does not fit above port {port_base}",
+                index + 1
+            )
+        });
+
+    builder
+        .with_ip(local_ip_utils::localhost_for_testing())
+        .with_deterministic_ports(port_offset)
+        .with_metrics_ip_address(Ipv4Addr::LOCALHOST.into())
 }
 
 pub type SupportedProtocolVersionsCallback = Arc<
@@ -97,6 +126,7 @@ pub struct ConfigBuilder<R = OsRng> {
     global_state_hash_v1_enabled_config: Option<GlobalStateHashV1EnabledConfig>,
     empty_validator_genesis: bool,
     admin_interface_address: Option<SocketAddr>,
+    deterministic_port_base: Option<u16>,
 }
 
 impl ConfigBuilder {
@@ -124,6 +154,7 @@ impl ConfigBuilder {
             global_state_hash_v1_enabled_config: Some(GlobalStateHashV1EnabledConfig::Global(true)),
             empty_validator_genesis: false,
             admin_interface_address: None,
+            deterministic_port_base: None,
         }
     }
 
@@ -163,6 +194,19 @@ impl<R> ConfigBuilder<R> {
 
     pub fn with_validators(mut self, validators: Vec<ValidatorGenesisConfig>) -> Self {
         self.committee = CommitteeConfig::Validators(validators);
+        self
+    }
+
+    /// Give every generated validator fixed addresses on 127.0.0.1 instead of
+    /// currently-free ports: validator `i` takes the ten ports starting at
+    /// `port_base + 10 * i`, of which the first five are its network, p2p,
+    /// metrics, primary and admin interface addresses.
+    ///
+    /// Has no effect on `CommitteeConfig::Validators`, whose addresses come
+    /// from the caller, or on `CommitteeConfig::Deterministic`, which lays out
+    /// its own ports.
+    pub fn with_deterministic_ports(mut self, port_base: u16) -> Self {
+        self.deterministic_port_base = Some(port_base);
         self
     }
 
@@ -324,6 +368,7 @@ impl<R> ConfigBuilder<R> {
             global_state_hash_v1_enabled_config: self.global_state_hash_v1_enabled_config,
             empty_validator_genesis: self.empty_validator_genesis,
             admin_interface_address: self.admin_interface_address,
+            deterministic_port_base: self.deterministic_port_base,
         }
     }
 
@@ -360,11 +405,15 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 let (_, keys) = Committee::new_simple_test_committee_of_size(size.into());
 
                 keys.into_iter()
-                    .map(|authority_key| {
+                    .enumerate()
+                    .map(|(i, authority_key)| {
                         let mut builder = ValidatorGenesisConfigBuilder::new()
                             .with_authority_key_pair(authority_key);
                         if let Some(rgp) = self.reference_gas_price {
                             builder = builder.with_gas_price(rgp);
+                        }
+                        if let Some(port_base) = self.deterministic_port_base {
+                            builder = place_on_deterministic_ports(builder, port_base, i);
                         }
                         builder.build(&mut rng)
                     })
@@ -378,12 +427,16 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 let (_, authority_keys) = Committee::new_simple_test_committee_of_size(keys.len());
                 keys.into_iter()
                     .zip(authority_keys)
-                    .map(|(account_key, authority_key)| {
+                    .enumerate()
+                    .map(|(i, (account_key, authority_key))| {
                         let mut builder = ValidatorGenesisConfigBuilder::new()
                             .with_authority_key_pair(authority_key)
                             .with_account_key_pair(account_key);
                         if let Some(rgp) = self.reference_gas_price {
                             builder = builder.with_gas_price(rgp);
+                        }
+                        if let Some(port_base) = self.deterministic_port_base {
+                            builder = place_on_deterministic_ports(builder, port_base, i);
                         }
                         builder.build(&mut rng)
                     })

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -2,7 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf};
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
+    path::PathBuf,
+};
 
 use anyhow::anyhow;
 use fastcrypto::{
@@ -302,6 +306,7 @@ pub struct FullnodeConfigBuilder {
     grpc_api_config: Option<GrpcApiConfig>,
     discovery_config: Option<DiscoveryConfig>,
     chain_override: Option<Chain>,
+    deterministic_port_base: Option<u16>,
 }
 
 impl FullnodeConfigBuilder {
@@ -444,6 +449,16 @@ impl FullnodeConfigBuilder {
         self
     }
 
+    /// Give the fullnode fixed addresses on 127.0.0.1 instead of
+    /// currently-free ports: `port_base` for the metrics endpoint,
+    /// `port_base + 1` for the admin interface and `port_base + 2` for p2p.
+    ///
+    /// Addresses set explicitly on this builder still win.
+    pub fn with_deterministic_ports(mut self, port_base: u16) -> Self {
+        self.deterministic_port_base = Some(port_base);
+        self
+    }
+
     /// Build the fullnode config against the given validator configs.
     ///
     /// # Panics
@@ -493,6 +508,17 @@ impl FullnodeConfigBuilder {
         let migration_tx_data_path =
             Some(config_directory.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME));
 
+        let localhost = local_ip_utils::localhost_for_testing();
+        let deterministic_metrics_address = self
+            .deterministic_port_base
+            .map(|port_base| SocketAddr::from((Ipv4Addr::LOCALHOST, port_base)));
+        let deterministic_admin_interface_address = self
+            .deterministic_port_base
+            .map(|port_base| SocketAddr::from((Ipv4Addr::LOCALHOST, port_base + 1)));
+        let deterministic_p2p_address = self.deterministic_port_base.map(|port_base| {
+            local_ip_utils::new_deterministic_udp_address_for_testing(&localhost, port_base + 2)
+        });
+
         let p2p_config = {
             let seed_peers = validator_configs
                 .iter()
@@ -515,16 +541,24 @@ impl FullnodeConfigBuilder {
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
             P2pConfig {
-                listen_address: self.p2p_listen_address.unwrap_or_else(|| {
-                    validator_config.p2p_listen_address.unwrap_or_else(|| {
-                        validator_config
-                            .p2p_address
-                            .udp_multiaddr_to_listen_address()
-                            .unwrap()
+                listen_address: self
+                    .p2p_listen_address
+                    .or_else(|| {
+                        deterministic_p2p_address
+                            .as_ref()
+                            .and_then(|address| address.udp_multiaddr_to_listen_address())
                     })
-                }),
+                    .unwrap_or_else(|| {
+                        validator_config.p2p_listen_address.unwrap_or_else(|| {
+                            validator_config
+                                .p2p_address
+                                .udp_multiaddr_to_listen_address()
+                                .unwrap()
+                        })
+                    }),
                 external_address: self
                     .p2p_external_address
+                    .or(deterministic_p2p_address)
                     .or(Some(validator_config.p2p_address.clone())),
                 seed_peers,
                 // Set a shorter timeout for checkpoint content download in tests, since
@@ -589,9 +623,11 @@ impl FullnodeConfigBuilder {
                 .unwrap_or(validator_config.network_address),
             metrics_address: self
                 .metrics_address
+                .or(deterministic_metrics_address)
                 .unwrap_or_else(local_ip_utils::new_local_tcp_socket_for_testing),
             admin_interface_address: self
                 .admin_interface_address
+                .or(deterministic_admin_interface_address)
                 .unwrap_or_else(local_ip_utils::new_local_tcp_socket_for_testing),
             json_rpc_address,
             consensus_config: None,
@@ -691,4 +727,40 @@ fn get_key_path(key_pair: &AuthorityKeyPair) -> String {
     // being unique.
     key_path.truncate(12);
     key_path
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::OsRng;
+
+    use super::{FullnodeConfigBuilder, Genesis};
+
+    #[test]
+    fn deterministic_ports_fill_the_three_slots_of_a_fullnode() {
+        let config = FullnodeConfigBuilder::new()
+            .with_deterministic_ports(9184)
+            .build_from_parts(&mut OsRng, &[], Genesis::new_empty());
+
+        assert_eq!(config.metrics_address.to_string(), "127.0.0.1:9184");
+        assert_eq!(config.admin_interface_address.to_string(), "127.0.0.1:9185");
+        assert_eq!(
+            config.p2p_config.external_address.unwrap().to_string(),
+            "/ip4/127.0.0.1/udp/9186/http"
+        );
+        assert_eq!(
+            config.p2p_config.listen_address.to_string(),
+            "127.0.0.1:9186"
+        );
+    }
+
+    #[test]
+    fn an_address_set_on_the_builder_wins_over_the_deterministic_ports() {
+        let config = FullnodeConfigBuilder::new()
+            .with_deterministic_ports(9184)
+            .with_admin_interface_address(Some(([127, 0, 0, 1], 1337)))
+            .build_from_parts(&mut OsRng, &[], Genesis::new_empty());
+
+        assert_eq!(config.admin_interface_address.to_string(), "127.0.0.1:1337");
+        assert_eq!(config.metrics_address.to_string(), "127.0.0.1:9184");
+    }
 }

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -2,11 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    num::NonZeroUsize,
-    path::PathBuf,
-};
+use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf};
 
 use anyhow::anyhow;
 use fastcrypto::{
@@ -449,9 +445,10 @@ impl FullnodeConfigBuilder {
         self
     }
 
-    /// Give the fullnode fixed addresses on 127.0.0.1 instead of
-    /// currently-free ports: `port_base` for the metrics endpoint,
-    /// `port_base + 1` for the admin interface and `port_base + 2` for p2p.
+    /// Give the fullnode fixed ports instead of currently-free ones:
+    /// `port_base` for the metrics endpoint, `port_base + 1` for the admin
+    /// interface and `port_base + 2` for p2p, all on the fullnode's own
+    /// address.
     ///
     /// Addresses set explicitly on this builder still win.
     pub fn with_deterministic_ports(mut self, port_base: u16) -> Self {
@@ -493,12 +490,12 @@ impl FullnodeConfigBuilder {
         // Take advantage of ValidatorGenesisConfigBuilder to build the keypairs and
         // addresses, even though this is a fullnode.
         let validator_config = ValidatorGenesisConfigBuilder::new().build(rng);
-        let ip = validator_config
+        let node_ip = validator_config
             .network_address
             .to_socket_addr()
             .unwrap()
-            .ip()
-            .to_string();
+            .ip();
+        let ip = node_ip.to_string();
 
         let key_path = get_key_path(&validator_config.authority_key_pair);
         let config_directory = self
@@ -508,7 +505,6 @@ impl FullnodeConfigBuilder {
         let migration_tx_data_path =
             Some(config_directory.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME));
 
-        let localhost = local_ip_utils::localhost_for_testing();
         let deterministic_port = |offset: u16| {
             self.deterministic_port_base.map(|port_base| {
                 port_base.checked_add(offset).unwrap_or_else(|| {
@@ -517,12 +513,11 @@ impl FullnodeConfigBuilder {
             })
         };
         let deterministic_metrics_address =
-            deterministic_port(0).map(|port| SocketAddr::from((Ipv4Addr::LOCALHOST, port)));
+            deterministic_port(0).map(|port| SocketAddr::new(node_ip, port));
         let deterministic_admin_interface_address =
-            deterministic_port(1).map(|port| SocketAddr::from((Ipv4Addr::LOCALHOST, port)));
-        let deterministic_p2p_address = deterministic_port(2).map(|port| {
-            local_ip_utils::new_deterministic_udp_address_for_testing(&localhost, port)
-        });
+            deterministic_port(1).map(|port| SocketAddr::new(node_ip, port));
+        let deterministic_p2p_address = deterministic_port(2)
+            .map(|port| local_ip_utils::new_deterministic_udp_address_for_testing(&ip, port));
 
         let p2p_config = {
             let seed_peers = validator_configs
@@ -736,26 +731,29 @@ fn get_key_path(key_pair: &AuthorityKeyPair) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
     use rand::rngs::OsRng;
 
     use super::{FullnodeConfigBuilder, Genesis};
 
+    /// The layout owns the ports only: the addresses stay on the IP the
+    /// fullnode would have used anyway, which is localhost outside the
+    /// simulator and one address of its own inside it.
     #[test]
     fn deterministic_ports_fill_the_three_slots_of_a_fullnode() {
         let config = FullnodeConfigBuilder::new()
             .with_deterministic_ports(9184)
             .build_from_parts(&mut OsRng, &[], Genesis::new_empty());
+        let ip = config.network_address.to_socket_addr().unwrap().ip();
 
-        assert_eq!(config.metrics_address.to_string(), "127.0.0.1:9184");
-        assert_eq!(config.admin_interface_address.to_string(), "127.0.0.1:9185");
+        assert_eq!(config.metrics_address, SocketAddr::new(ip, 9184));
+        assert_eq!(config.admin_interface_address, SocketAddr::new(ip, 9185));
         assert_eq!(
             config.p2p_config.external_address.unwrap().to_string(),
-            "/ip4/127.0.0.1/udp/9186/http"
+            format!("/ip4/{ip}/udp/9186/http")
         );
-        assert_eq!(
-            config.p2p_config.listen_address.to_string(),
-            "127.0.0.1:9186"
-        );
+        assert_eq!(config.p2p_config.listen_address, SocketAddr::new(ip, 9186));
     }
 
     #[test]
@@ -764,8 +762,9 @@ mod tests {
             .with_deterministic_ports(9184)
             .with_admin_interface_address(Some(([127, 0, 0, 1], 1337)))
             .build_from_parts(&mut OsRng, &[], Genesis::new_empty());
+        let ip = config.network_address.to_socket_addr().unwrap().ip();
 
         assert_eq!(config.admin_interface_address.to_string(), "127.0.0.1:1337");
-        assert_eq!(config.metrics_address.to_string(), "127.0.0.1:9184");
+        assert_eq!(config.metrics_address, SocketAddr::new(ip, 9184));
     }
 }

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -737,9 +737,6 @@ mod tests {
 
     use super::{FullnodeConfigBuilder, Genesis};
 
-    /// The layout owns the ports only: the addresses stay on the IP the
-    /// fullnode would have used anyway, which is localhost outside the
-    /// simulator and one address of its own inside it.
     #[test]
     fn deterministic_ports_fill_the_three_slots_of_a_fullnode() {
         let config = FullnodeConfigBuilder::new()

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -509,14 +509,19 @@ impl FullnodeConfigBuilder {
             Some(config_directory.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME));
 
         let localhost = local_ip_utils::localhost_for_testing();
-        let deterministic_metrics_address = self
-            .deterministic_port_base
-            .map(|port_base| SocketAddr::from((Ipv4Addr::LOCALHOST, port_base)));
-        let deterministic_admin_interface_address = self
-            .deterministic_port_base
-            .map(|port_base| SocketAddr::from((Ipv4Addr::LOCALHOST, port_base + 1)));
-        let deterministic_p2p_address = self.deterministic_port_base.map(|port_base| {
-            local_ip_utils::new_deterministic_udp_address_for_testing(&localhost, port_base + 2)
+        let deterministic_port = |offset: u16| {
+            self.deterministic_port_base.map(|port_base| {
+                port_base.checked_add(offset).unwrap_or_else(|| {
+                    panic!("the fullnode port layout does not fit above port {port_base}")
+                })
+            })
+        };
+        let deterministic_metrics_address =
+            deterministic_port(0).map(|port| SocketAddr::from((Ipv4Addr::LOCALHOST, port)));
+        let deterministic_admin_interface_address =
+            deterministic_port(1).map(|port| SocketAddr::from((Ipv4Addr::LOCALHOST, port)));
+        let deterministic_p2p_address = deterministic_port(2).map(|port| {
+            local_ip_utils::new_deterministic_udp_address_for_testing(&localhost, port)
         });
 
         let p2p_config = {

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -75,6 +75,8 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_enable_grpc_api: bool,
     fullnode_grpc_api_config: Option<GrpcApiConfig>,
     disable_address_verification_cooldown: bool,
+    deterministic_validator_port_base: Option<u16>,
+    deterministic_fullnode_port_base: Option<u16>,
 }
 
 impl SwarmBuilder {
@@ -110,6 +112,8 @@ impl SwarmBuilder {
             fullnode_enable_grpc_api: false,
             fullnode_grpc_api_config: None,
             disable_address_verification_cooldown: false,
+            deterministic_validator_port_base: None,
+            deterministic_fullnode_port_base: None,
         }
     }
 }
@@ -147,6 +151,8 @@ impl<R> SwarmBuilder<R> {
             fullnode_enable_grpc_api: self.fullnode_enable_grpc_api,
             fullnode_grpc_api_config: self.fullnode_grpc_api_config,
             disable_address_verification_cooldown: self.disable_address_verification_cooldown,
+            deterministic_validator_port_base: self.deterministic_validator_port_base,
+            deterministic_fullnode_port_base: self.deterministic_fullnode_port_base,
         }
     }
 
@@ -172,6 +178,29 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_validators(mut self, validators: Vec<ValidatorGenesisConfig>) -> Self {
         self.committee = CommitteeConfig::Validators(validators);
+        self
+    }
+
+    /// Give every generated validator fixed addresses on 127.0.0.1 instead of
+    /// currently-free ports: validator `i` takes the ten ports starting at
+    /// `port_base + 10 * i`, of which the first five are its network, p2p,
+    /// metrics, primary and admin interface addresses.
+    ///
+    /// Has no effect when the validators come from a network config or from
+    /// `with_validators`.
+    pub fn with_deterministic_validator_ports(mut self, port_base: u16) -> Self {
+        self.deterministic_validator_port_base = Some(port_base);
+        self
+    }
+
+    /// Give the first fullnode fixed addresses on 127.0.0.1 instead of
+    /// currently-free ports: `port_base` for the metrics endpoint,
+    /// `port_base + 1` for the admin interface and `port_base + 2` for p2p.
+    ///
+    /// Further fullnodes keep currently-free ports, since the three addresses
+    /// can only be used once.
+    pub fn with_deterministic_fullnode_ports(mut self, port_base: u16) -> Self {
+        self.deterministic_fullnode_port_base = Some(port_base);
         self
     }
 
@@ -443,6 +472,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 config_builder = config_builder.with_data_ingestion_dir(path);
             }
 
+            if let Some(port_base) = self.deterministic_validator_port_base {
+                config_builder = config_builder.with_deterministic_ports(port_base);
+            }
+
             if let Some(max_submit_position) = self.max_submit_position {
                 config_builder = config_builder.with_max_submit_position(max_submit_position);
             }
@@ -556,6 +589,9 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 }
                 if let Some(rpc_port) = self.fullnode_rpc_port {
                     builder = builder.with_rpc_port(rpc_port);
+                }
+                if let Some(port_base) = self.deterministic_fullnode_port_base {
+                    builder = builder.with_deterministic_ports(port_base);
                 }
             }
             let config = builder
@@ -730,7 +766,7 @@ impl AsRef<Path> for SwarmDirectory {
 
 #[cfg(test)]
 mod test {
-    use std::num::NonZeroUsize;
+    use std::{collections::BTreeSet, num::NonZeroUsize};
 
     use iota_swarm_config::network_config_builder::ConfigBuilder;
 
@@ -777,5 +813,38 @@ mod test {
         }
 
         println!("hello");
+    }
+
+    #[test]
+    fn deterministic_ports_reach_the_node_configs() {
+        let swarm = Swarm::builder()
+            .committee_size(NonZeroUsize::new(2).unwrap())
+            .with_deterministic_validator_ports(9200)
+            .with_fullnode_count(1)
+            .with_deterministic_fullnode_ports(9184)
+            .build();
+
+        let validator_ports = swarm
+            .validator_nodes()
+            .map(|validator| validator.config().network_address.to_string())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            validator_ports,
+            BTreeSet::from([
+                "/ip4/127.0.0.1/tcp/9200/http".to_owned(),
+                "/ip4/127.0.0.1/tcp/9210/http".to_owned(),
+            ])
+        );
+
+        let fullnode = swarm.fullnodes().next().unwrap().config();
+        assert_eq!(fullnode.metrics_address.to_string(), "127.0.0.1:9184");
+        assert_eq!(
+            fullnode.admin_interface_address.to_string(),
+            "127.0.0.1:9185"
+        );
+        assert_eq!(
+            fullnode.p2p_config.listen_address.to_string(),
+            "127.0.0.1:9186"
+        );
     }
 }

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -181,10 +181,10 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    /// Give every generated validator fixed addresses on 127.0.0.1 instead of
-    /// currently-free ports: validator `i` takes the ten ports starting at
-    /// `port_base + 10 * i`, of which the first five are its network, p2p,
-    /// metrics, primary and admin interface addresses.
+    /// Give every generated validator fixed ports instead of currently-free
+    /// ones: validator `i` takes the ten ports starting at `port_base + 10 *
+    /// i`, of which the first five are its network, p2p, metrics, primary and
+    /// admin interface addresses.
     ///
     /// Has no effect when the validators come from a network config or from
     /// `with_validators`.
@@ -193,9 +193,10 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    /// Give the first fullnode fixed addresses on 127.0.0.1 instead of
-    /// currently-free ports: `port_base` for the metrics endpoint,
-    /// `port_base + 1` for the admin interface and `port_base + 2` for p2p.
+    /// Give the first fullnode fixed ports instead of currently-free ones:
+    /// `port_base` for the metrics endpoint, `port_base + 1` for the admin
+    /// interface and `port_base + 2` for p2p, all on the fullnode's own
+    /// address.
     ///
     /// Further fullnodes keep currently-free ports, since the three addresses
     /// can only be used once.
@@ -766,7 +767,7 @@ impl AsRef<Path> for SwarmDirectory {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeSet, num::NonZeroUsize};
+    use std::{collections::BTreeSet, net::SocketAddr, num::NonZeroUsize};
 
     use iota_swarm_config::network_config_builder::ConfigBuilder;
 
@@ -815,6 +816,9 @@ mod test {
         println!("hello");
     }
 
+    /// The layout owns the ports only: every address stays on the IP its node
+    /// would have used anyway, which is localhost outside the simulator and one
+    /// address per node inside it.
     #[test]
     fn deterministic_ports_reach_the_node_configs() {
         let swarm = Swarm::builder()
@@ -826,25 +830,24 @@ mod test {
 
         let validator_ports = swarm
             .validator_nodes()
-            .map(|validator| validator.config().network_address.to_string())
+            .map(|validator| {
+                validator
+                    .config()
+                    .network_address
+                    .to_socket_addr()
+                    .unwrap()
+                    .port()
+            })
             .collect::<BTreeSet<_>>();
-        assert_eq!(
-            validator_ports,
-            BTreeSet::from([
-                "/ip4/127.0.0.1/tcp/9200/http".to_owned(),
-                "/ip4/127.0.0.1/tcp/9210/http".to_owned(),
-            ])
-        );
+        assert_eq!(validator_ports, BTreeSet::from([9200, 9210]));
 
         let fullnode = swarm.fullnodes().next().unwrap().config();
-        assert_eq!(fullnode.metrics_address.to_string(), "127.0.0.1:9184");
+        let ip = fullnode.network_address.to_socket_addr().unwrap().ip();
+        assert_eq!(fullnode.metrics_address, SocketAddr::new(ip, 9184));
+        assert_eq!(fullnode.admin_interface_address, SocketAddr::new(ip, 9185));
         assert_eq!(
-            fullnode.admin_interface_address.to_string(),
-            "127.0.0.1:9185"
-        );
-        assert_eq!(
-            fullnode.p2p_config.listen_address.to_string(),
-            "127.0.0.1:9186"
+            fullnode.p2p_config.listen_address,
+            SocketAddr::new(ip, 9186)
         );
     }
 }

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -181,10 +181,8 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    /// Give every generated validator fixed ports instead of currently-free
-    /// ones: validator `i` takes the ten ports starting at `port_base + 10 *
-    /// i`, of which the first five are its network, p2p, metrics, primary and
-    /// admin interface addresses.
+    /// Lay the generated validators out as
+    /// [`ConfigBuilder::with_deterministic_ports`] describes.
     ///
     /// Has no effect when the validators come from a network config or from
     /// `with_validators`.
@@ -193,10 +191,8 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    /// Give the first fullnode fixed ports instead of currently-free ones:
-    /// `port_base` for the metrics endpoint, `port_base + 1` for the admin
-    /// interface and `port_base + 2` for p2p, all on the fullnode's own
-    /// address.
+    /// Lay the first fullnode out as
+    /// [`FullnodeConfigBuilder::with_deterministic_ports`] describes.
     ///
     /// Further fullnodes keep currently-free ports, since the three addresses
     /// can only be used once.
@@ -816,9 +812,6 @@ mod test {
         println!("hello");
     }
 
-    /// The layout owns the ports only: every address stays on the IP its node
-    /// would have used anyway, which is localhost outside the simulator and one
-    /// address per node inside it.
     #[test]
     fn deterministic_ports_reach_the_node_configs() {
         let swarm = Swarm::builder()

--- a/docs/content/developer/getting-started/local-network.mdx
+++ b/docs/content/developer/getting-started/local-network.mdx
@@ -75,6 +75,10 @@ Use `iota-localnet start --help` to see these options in your console.
 
 :::
 
+The network binds the same ports on every run: the fullnode uses `9000` for JSON-RPC, `9184` for metrics, `9185` for its
+admin interface and `9186` for p2p, and validator `i` uses the ten ports starting at `9200 + 10 * i`. See
+[Ports](../references/cli/localnet.mdx#ports) for the full layout.
+
 ## Interact With Your Local Node
 
 ### Using cURL

--- a/docs/content/developer/getting-started/local-network.mdx
+++ b/docs/content/developer/getting-started/local-network.mdx
@@ -75,9 +75,7 @@ Use `iota-localnet start --help` to see these options in your console.
 
 :::
 
-The network binds the same ports on every run: the fullnode uses `9000` for JSON-RPC, `9184` for metrics, `9185` for its
-admin interface and `9186` for p2p, and validator `i` uses the ten ports starting at `9200 + 10 * i`. See
-[Ports](../references/cli/localnet.mdx#ports) for the full layout.
+The network binds the same ports on every run, listed under [Ports](../references/cli/localnet.mdx#ports).
 
 ## Interact With Your Local Node
 

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -58,6 +58,37 @@ iota-localnet start [OPTIONS]
 | `--remote-migration-snapshots <URL>...` | Remotely stored migration snapshot URLs. |
 | `--delegator <ADDRESS>` | Specify the delegator address. |
 
+### Ports
+
+Every node port is fixed, so a local network binds the same ports on every run and on every machine.
+The metrics, admin interface, p2p, network and primary addresses are on `127.0.0.1`; the JSON-RPC, faucet, indexer, GraphQL and gRPC services listen on `0.0.0.0`.
+
+| Port | Used by |
+|--------|-------------|
+| `9000` | Fullnode JSON-RPC (change it with `--fullnode-rpc-port`). |
+| `9123` | Faucet (`--with-faucet`). |
+| `9124` | Indexer (`--with-indexer`). |
+| `9125` | GraphQL (`--with-graphql`). |
+| `9184` | Fullnode metrics. |
+| `9185` | Fullnode admin interface. |
+| `9186` | Fullnode p2p (UDP). |
+| `50051` | Fullnode gRPC API (`--with-grpc`). |
+
+Validator `i` takes the ten ports starting at `9200 + 10 * i`, so validator 0 uses `9200`-`9209`, validator 1 uses `9210`-`9219`, and so on.
+
+| Port | Used by |
+|--------|-------------|
+| `9200 + 10 * i` | Validator network address (TCP). |
+| `9201 + 10 * i` | Validator p2p address (UDP). |
+| `9202 + 10 * i` | Validator metrics. |
+| `9203 + 10 * i` | Validator primary address (UDP). |
+| `9204 + 10 * i` | Validator admin interface. |
+| `9205 + 10 * i` to `9209 + 10 * i` | Reserved. |
+
+With the default committee size of 1 a local network uses `9200`-`9204`, and with `--committee-size 4` it uses `9200`-`9234`.
+A node fails to start if one of its ports is already taken, for instance by a second local network.
+The admin interface addresses can be changed with `iota-localnet genesis --admin-interface-address`.
+
 :::info Indexer options
 
 When built with the `indexer` feature, additional options are available:

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -74,7 +74,7 @@ The metrics, admin interface, p2p, network and primary addresses are on `127.0.0
 | `9186` | Fullnode p2p (UDP). |
 | `50051` | Fullnode gRPC API (`--with-grpc`). |
 
-Validator `i` takes the ten ports starting at `9200 + 10 * i`, so validator 0 uses `9200`-`9209`, validator 1 uses `9210`-`9219`, and so on.
+Each validator owns a block of ten ports starting at `9200 + 10 * i`: validator 0 owns `9200`-`9209`, validator 1 owns `9210`-`9219`, and so on. Only the first five of a block are used; the other five are reserved so future endpoints don't shift the layout.
 
 | Port | Used by |
 |--------|-------------|
@@ -85,7 +85,7 @@ Validator `i` takes the ten ports starting at `9200 + 10 * i`, so validator 0 us
 | `9204 + 10 * i` | Validator admin interface. |
 | `9205 + 10 * i` to `9209 + 10 * i` | Reserved. |
 
-With the default committee size of 1 a local network uses `9200`-`9204`, and with `--committee-size 4` it uses `9200`-`9234`.
+The default committee of 1 therefore owns `9200`-`9209`, and `--committee-size 4` owns `9200`-`9239`.
 A node fails to start if one of its ports is already taken, for instance by a second local network.
 The admin interface addresses can be changed with `iota-localnet genesis --admin-interface-address`.
 


### PR DESCRIPTION
# Description of change

`iota-localnet` picked most of its node ports at random, so every genesis produced different validator and fullnode addresses and a persisted config directory was only reproducible by accident. This gives the local network a fixed port layout on `127.0.0.1`, so a run binds the same ports on every machine and the written configs can be diffed between runs.

Nothing is lost by no longer asking the OS for a free port: `get_available_port` only forces a `TIME_WAIT` on the port it returns, which the OS honours for a grace period of roughly a minute, and says nothing about a process explicitly binding it. In persisted mode those addresses are chosen once at genesis, written to `network.yaml` and reused by every later `start`, days later, with nothing rechecking — so today's localnet ports already carry no availability property.

- Fullnode: `9184` metrics, `9185` admin interface, `9186` p2p. Validator `i`: the ten ports starting at `9200 + 10 * i`, with `+0` network address (tcp), `+1` p2p address (udp), `+2` metrics, `+3` primary address (udp), `+4` admin interface, `+5` to `+9` reserved.
- Unchanged: `9000` fullnode JSON-RPC, `9123` faucet, `9124` indexer, `9125` GraphQL, `50051` fullnode gRPC.
- `iota-swarm-config`: `ConfigBuilder::with_deterministic_ports` lays out the generated validators, `FullnodeConfigBuilder::with_deterministic_ports` the fullnode, and `ValidatorGenesisConfigBuilder::with_metrics_ip_address` keeps the metrics endpoint on `127.0.0.1` rather than on all interfaces, which is what the existing benchmark layout does.
- `iota-swarm`: `SwarmBuilder::with_deterministic_validator_ports` and `with_deterministic_fullnode_ports` pass the layout through; the fullnode knob applies to the first fullnode only, since its three addresses can only be used once.
- `iota-localnet`: `genesis` and `start` (both persisted and `--force-regenesis`) use the layout. Addresses set explicitly still win, so `--fullnode-rpc-port` and `genesis --admin-interface-address` are unaffected.
- All the new knobs are opt-in and only `iota-localnet` sets them: test-cluster, the swarm tests and the e2e tests keep picking free ports, so parallel CI runs cannot collide.
- Docs: a port table in the `iota-localnet` CLI reference, and a pointer to it from the local network guide.

Two things this deliberately leaves alone: the state-sync fullnode configs written by `genesis --from-config` keep their deployment addresses (`0.0.0.0`, `/opt/iota` paths), since their p2p address comes from the genesis config file rather than being generated; and the fullnode db path still derives from a freshly generated key, so it still changes between genesis runs. Both belong to the follow-up that persists a `GenesisConfig` and derives the node configs from it.

## Links to any relevant issues

part of #12403, #12429 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] CLI: `iota-localnet` node ports are now fixed instead of random — fullnode `9184` metrics, `9185` admin interface, `9186` p2p, and validator `i` on the ten ports starting at `9200 + 10 * i` (`+0` network, `+1` p2p, `+2` metrics, `+3` primary, `+4` admin). JSON-RPC (`9000`), faucet (`9123`), indexer (`9124`), GraphQL (`9125`) and gRPC (`50051`) are unchanged. A local network now fails to start if another one already holds those ports.