### PR TITLE
refactor(iota-swarm,iota-swarm-config): make swarm config assembly fallible

### DIFF
--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -995,7 +995,7 @@ async fn genesis(
         .with_rpc_addr(iota_config::node::default_json_rpc_address())
         .with_genesis(genesis.clone())
         .with_admin_interface_address(admin_interface_address_with_port)
-        .build_from_parts(&mut OsRng, network_config.validator_configs(), genesis);
+        .try_build_from_parts(&mut OsRng, network_config.validator_configs(), genesis)?;
 
     fullnode_config.save(iota_config_dir.join(IOTA_FULLNODE_CONFIG))?;
     let mut ssfn_nodes = vec![];
@@ -1016,20 +1016,29 @@ async fn genesis(
                 .with_admin_interface_address(admin_interface_address_with_port)
                 .with_json_rpc_address(([0, 0, 0, 0], 9000))
                 .with_genesis(genesis.clone())
-                .build_from_parts(&mut OsRng, network_config.validator_configs(), genesis);
+                .try_build_from_parts(&mut OsRng, network_config.validator_configs(), genesis)?;
             ssfn_nodes.push(ssfn_config.clone());
             ssfn_config.save(path)?;
         }
 
-        let ssfn_seed_peers: Vec<SeedPeer> = ssfn_nodes
+        let ssfn_seed_peers = ssfn_nodes
             .iter()
-            .map(|config| SeedPeer {
-                peer_id: Some(anemo::PeerId(
-                    config.network_key_pair().public().0.to_bytes(),
-                )),
-                address: config.p2p_config.external_address.clone().unwrap(),
+            .enumerate()
+            .map(|(index, config)| {
+                let address = config.p2p_config.external_address.clone().ok_or_else(|| {
+                    anyhow!(
+                        "state sync fullnode {index} has no `p2p-config.external-address`, which \
+                         the validators need to derive their seed peers"
+                    )
+                })?;
+                Ok(SeedPeer {
+                    peer_id: Some(anemo::PeerId(
+                        config.network_key_pair().public().0.to_bytes(),
+                    )),
+                    address,
+                })
             })
-            .collect();
+            .collect::<Result<Vec<SeedPeer>, anyhow::Error>>()?;
 
         for (i, mut validator) in network_config
             .into_validator_configs()

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -4,6 +4,7 @@
 
 use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf};
 
+use anyhow::anyhow;
 use fastcrypto::{
     encoding::{Encoding, Hex},
     traits::KeyPair,
@@ -443,12 +444,37 @@ impl FullnodeConfigBuilder {
         self
     }
 
+    /// Build the fullnode config against the given validator configs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Self::try_build_from_parts`] returns an error.
     pub fn build_from_parts<R: rand::RngCore + rand::CryptoRng>(
         self,
         rng: &mut R,
         validator_configs: &[NodeConfig],
         genesis: iota_config::node::Genesis,
     ) -> NodeConfig {
+        self.try_build_from_parts(rng, validator_configs, genesis)
+            .unwrap_or_else(|err| panic!("{err:#}"))
+    }
+
+    /// Build the fullnode config against the given validator configs.
+    ///
+    /// Fails if a validator config has no `p2p-config.external-address`,
+    /// which the fullnode's seed peers are derived from.
+    ///
+    /// # Panics
+    ///
+    /// Panics on failures the config cannot be built without: creating the
+    /// temporary config directory, allocating a local port, or parsing a
+    /// generated network address.
+    pub fn try_build_from_parts<R: rand::RngCore + rand::CryptoRng>(
+        self,
+        rng: &mut R,
+        validator_configs: &[NodeConfig],
+        genesis: iota_config::node::Genesis,
+    ) -> anyhow::Result<NodeConfig> {
         // Take advantage of ValidatorGenesisConfigBuilder to build the keypairs and
         // addresses, even though this is a fullnode.
         let validator_config = ValidatorGenesisConfigBuilder::new().build(rng);
@@ -470,13 +496,23 @@ impl FullnodeConfigBuilder {
         let p2p_config = {
             let seed_peers = validator_configs
                 .iter()
-                .map(|config| SeedPeer {
-                    peer_id: Some(anemo::PeerId(
-                        config.network_key_pair().public().0.to_bytes(),
-                    )),
-                    address: config.p2p_config.external_address.clone().unwrap(),
+                .enumerate()
+                .map(|(index, config)| {
+                    let address = config.p2p_config.external_address.clone().ok_or_else(|| {
+                        anyhow!(
+                            "validator {index} has no `p2p-config.external-address`, which the \
+                             fullnode needs to derive its seed peers: either its config never set \
+                             one or it was cleared"
+                        )
+                    })?;
+                    Ok(SeedPeer {
+                        peer_id: Some(anemo::PeerId(
+                            config.network_key_pair().public().0.to_bytes(),
+                        )),
+                        address,
+                    })
                 })
-                .collect();
+                .collect::<anyhow::Result<Vec<_>>>()?;
 
             P2pConfig {
                 listen_address: self.p2p_listen_address.unwrap_or_else(|| {
@@ -503,11 +539,13 @@ impl FullnodeConfigBuilder {
             }
         };
 
-        let json_rpc_address = self.rpc_addr.unwrap_or_else(|| {
-            let rpc_port = self
-                .rpc_port
-                .unwrap_or_else(|| local_ip_utils::get_available_port(&ip));
-            format!("{ip}:{rpc_port}").parse().unwrap()
+        let json_rpc_address = self.json_rpc_address.unwrap_or_else(|| {
+            self.rpc_addr.unwrap_or_else(|| {
+                let rpc_port = self
+                    .rpc_port
+                    .unwrap_or_else(|| local_ip_utils::get_available_port(&ip));
+                format!("{ip}:{rpc_port}").parse().unwrap()
+            })
         });
 
         let grpc_api_config = self.grpc_api_config.or_else(|| {
@@ -534,7 +572,7 @@ impl FullnodeConfigBuilder {
             pruning_config.set_num_epochs_to_retain(u64::MAX);
         };
 
-        NodeConfig {
+        Ok(NodeConfig {
             authority_key_pair: AuthorityKeyPairWithPath::new(validator_config.authority_key_pair),
             account_key_pair: KeyPairWithPath::new(validator_config.account_key_pair),
             protocol_key_pair: KeyPairWithPath::new(network_to_simple_keypair(
@@ -551,11 +589,11 @@ impl FullnodeConfigBuilder {
                 .unwrap_or(validator_config.network_address),
             metrics_address: self
                 .metrics_address
-                .unwrap_or(local_ip_utils::new_local_tcp_socket_for_testing()),
+                .unwrap_or_else(local_ip_utils::new_local_tcp_socket_for_testing),
             admin_interface_address: self
                 .admin_interface_address
-                .unwrap_or(local_ip_utils::new_local_tcp_socket_for_testing()),
-            json_rpc_address: self.json_rpc_address.unwrap_or(json_rpc_address),
+                .unwrap_or_else(local_ip_utils::new_local_tcp_socket_for_testing),
+            json_rpc_address,
             consensus_config: None,
             enable_index_processing: default_enable_index_processing(),
             genesis,
@@ -602,21 +640,45 @@ impl FullnodeConfigBuilder {
             grpc_api_config,
             chain_override_for_testing: self.chain_override,
             validator_client_monitor_config: None,
-        }
+        })
     }
 
+    /// Build the fullnode config against the given network config.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Self::try_build`] returns an error.
     pub fn build<R: rand::RngCore + rand::CryptoRng>(
         self,
         rng: &mut R,
         network_config: &NetworkConfig,
     ) -> NodeConfig {
+        self.try_build(rng, network_config)
+            .unwrap_or_else(|err| panic!("{err:#}"))
+    }
+
+    /// Build the fullnode config against the given network config.
+    ///
+    /// Fails if a validator config has no `p2p-config.external-address`,
+    /// which the fullnode's seed peers are derived from.
+    ///
+    /// # Panics
+    ///
+    /// Panics on failures the config cannot be built without: creating the
+    /// temporary config directory, allocating a local port, or parsing a
+    /// generated network address.
+    pub fn try_build<R: rand::RngCore + rand::CryptoRng>(
+        self,
+        rng: &mut R,
+        network_config: &NetworkConfig,
+    ) -> anyhow::Result<NodeConfig> {
         let genesis = self
             .genesis
             .as_ref()
             .or_else(|| network_config.get_validator_genesis())
             .cloned()
             .unwrap_or_else(|| iota_config::node::Genesis::new(network_config.genesis.clone()));
-        self.build_from_parts(rng, network_config.validator_configs(), genesis)
+        self.try_build_from_parts(rng, network_config.validator_configs(), genesis)
     }
 }
 
@@ -629,4 +691,25 @@ fn get_key_path(key_pair: &AuthorityKeyPair) -> String {
     // being unique.
     key_path.truncate(12);
     key_path
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::OsRng;
+
+    use super::*;
+
+    #[test]
+    fn fullnode_build_needs_validator_p2p_external_addresses() {
+        let mut validator = ValidatorConfigBuilder::new()
+            .build_without_genesis(ValidatorGenesisConfigBuilder::new().build(&mut OsRng));
+        validator.p2p_config.external_address = None;
+
+        let err = FullnodeConfigBuilder::new()
+            .try_build_from_parts(&mut OsRng, &[validator], Genesis::new_empty())
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("validator 0"), "{err}");
+        assert!(err.contains("seed peers"), "{err}");
+    }
 }

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -692,24 +692,3 @@ fn get_key_path(key_pair: &AuthorityKeyPair) -> String {
     key_path.truncate(12);
     key_path
 }
-
-#[cfg(test)]
-mod tests {
-    use rand::rngs::OsRng;
-
-    use super::*;
-
-    #[test]
-    fn fullnode_build_needs_validator_p2p_external_addresses() {
-        let mut validator = ValidatorConfigBuilder::new()
-            .build_without_genesis(ValidatorGenesisConfigBuilder::new().build(&mut OsRng));
-        validator.p2p_config.external_address = None;
-
-        let err = FullnodeConfigBuilder::new()
-            .try_build_from_parts(&mut OsRng, &[validator], Genesis::new_empty())
-            .unwrap_err();
-        let err = format!("{err:#}");
-        assert!(err.contains("validator 0"), "{err}");
-        assert!(err.contains("seed peers"), "{err}");
-    }
-}

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -379,7 +379,22 @@ impl<R> SwarmBuilder<R> {
 
 impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
     /// Create the configured Swarm.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`SwarmBuilder::try_build`] returns an error.
     pub fn build(self) -> Swarm {
+        self.try_build().unwrap_or_else(|err| panic!("{err:#}"))
+    }
+
+    /// Create the configured Swarm.
+    ///
+    /// # Panics
+    ///
+    /// Panics on failures the swarm cannot run without, including creating its
+    /// temporary directory, saving the genesis blob, and building the genesis
+    /// (see [`ConfigBuilder::build`]).
+    pub fn try_build(self) -> Result<Swarm> {
         let dir = if let Some(dir) = self.dir {
             SwarmDirectory::Persistent(dir)
         } else {
@@ -546,12 +561,12 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 nodes.insert(config.authority_public_key(), Node::new(config));
             });
         }
-        Swarm {
+        Ok(Swarm {
             dir,
             network_config,
             nodes,
             fullnode_config_builder,
-        }
+        })
     }
 }
 

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures::future::try_join_all;
 use iota_config::{
     ExecutionCacheConfig, IOTA_GENESIS_FILENAME, NodeConfig,
@@ -389,11 +389,17 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
 
     /// Create the configured Swarm.
     ///
+    /// # Errors
+    ///
+    /// - The network has a fullnode and a validator config has no
+    ///   `p2p-config.external-address`.
+    ///
     /// # Panics
     ///
-    /// Panics on failures the swarm cannot run without, including creating its
-    /// temporary directory, saving the genesis blob, and building the genesis
-    /// (see [`ConfigBuilder::build`]).
+    /// Panics on failures the swarm cannot run without: creating its temporary
+    /// directory, saving the genesis blob, parsing a generated network address,
+    /// and building the genesis (e.g. on invalid genesis parameters or a
+    /// validator below the minimum stake).
     pub fn try_build(self) -> Result<Swarm> {
         let dir = if let Some(dir) = self.dir {
             SwarmDirectory::Persistent(dir)
@@ -540,26 +546,26 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 fullnode_config_builder.with_grpc_api_config(grpc_config.clone());
         }
 
-        if self.fullnode_count > 0 {
-            (0..self.fullnode_count).for_each(|idx| {
-                let mut builder = fullnode_config_builder.clone();
-                if idx == 0 {
-                    // Only the first fullnode is used as the rpc fullnode, we can only use the
-                    // same address once.
-                    if let Some(rpc_addr) = self.fullnode_rpc_addr {
-                        builder = builder.with_rpc_addr(rpc_addr);
-                    }
-                    if let Some(rpc_port) = self.fullnode_rpc_port {
-                        builder = builder.with_rpc_port(rpc_port);
-                    }
+        for idx in 0..self.fullnode_count {
+            let mut builder = fullnode_config_builder.clone();
+            if idx == 0 {
+                // Only the first fullnode is used as the rpc fullnode, we can only use the
+                // same address once.
+                if let Some(rpc_addr) = self.fullnode_rpc_addr {
+                    builder = builder.with_rpc_addr(rpc_addr);
                 }
-                let config = builder.build(&mut OsRng, &network_config);
-                info!(
-                    "SwarmBuilder configuring full node with name {}",
-                    config.authority_public_key()
-                );
-                nodes.insert(config.authority_public_key(), Node::new(config));
-            });
+                if let Some(rpc_port) = self.fullnode_rpc_port {
+                    builder = builder.with_rpc_port(rpc_port);
+                }
+            }
+            let config = builder
+                .try_build(&mut OsRng, &network_config)
+                .context("failed to build the fullnode config")?;
+            info!(
+                "SwarmBuilder configuring full node with name {}",
+                config.authority_public_key()
+            );
+            nodes.insert(config.authority_public_key(), Node::new(config));
         }
         Ok(Swarm {
             dir,
@@ -726,7 +732,31 @@ impl AsRef<Path> for SwarmDirectory {
 mod test {
     use std::num::NonZeroUsize;
 
+    use iota_swarm_config::network_config_builder::ConfigBuilder;
+
     use super::Swarm;
+
+    #[test]
+    fn try_build_fails_when_a_validator_has_no_p2p_external_address() {
+        // The fullnode derives its seed peers from the validators' external
+        // addresses.
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut network_config = ConfigBuilder::new(dir.path())
+            .committee_size(NonZeroUsize::new(1).unwrap())
+            .build();
+        network_config.validator_configs[0]
+            .p2p_config
+            .external_address = None;
+
+        let err = Swarm::builder()
+            .with_network_config(network_config)
+            .with_fullnode_count(1)
+            .try_build()
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(err.contains("validator 0"), "{err}");
+        assert!(err.contains("seed peers"), "{err}");
+    }
 
     #[tokio::test]
     async fn launch() {


### PR DESCRIPTION
# Description of change

Gives the swarm and fullnode config builders fallible forms, so a caller that assembles configs from user input can report an error instead of taking a panic. No call site changes behavior: the panicking forms stay and delegate.

- `iota-swarm`: add `SwarmBuilder::try_build() -> anyhow::Result<Swarm>`; `build()` becomes `try_build().unwrap_or_else(|err| panic!("{err:#}"))`, keeping the existing panic message. The fullnode loop becomes a `for` loop so the build can propagate an error.
- `iota-swarm-config`: add `FullnodeConfigBuilder::try_build` / `try_build_from_parts`. A validator config without `p2p-config.external-address` — which the fullnode's seed peers are derived from — is now a clean error naming the validator and both possible causes (its config never set one, or it was cleared) instead of an `unwrap`. `build` / `build_from_parts` delegate to them.
- `iota-swarm-config`: while touching `try_build_from_parts`, `json_rpc_address` is resolved once from `json_rpc_address` → `rpc_addr` → a freshly allocated port, so a supplied address no longer allocates a throwaway port; the two `unwrap_or(new_local_tcp_socket_for_testing())` calls become `unwrap_or_else` for the same reason.
- `iota-localnet`: `genesis` builds the fullnode and state-sync-fullnode configs through the fallible form, and derives the validators' seed peers from the state-sync fullnodes without an `unwrap`.

## Links to any relevant issues

Part of #12429. Replaces #12608, which is closed in favor of this PR: the same two commits, rebased onto `develop` with the override-engine parts dropped (they return with the override PR that follows).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes