### PR TITLE
feat(iota-indexer): unify API behavior

### DIFF
--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -41,7 +41,7 @@ use crate::{
     models::transactions::{StoredTransaction, tx_events_to_iota_tx_events},
     optimistic_indexing::{IngestionPath, OptimisticTransactionExecutor},
     read::IndexerReader,
-    store::package_resolver::IndexerStorePackageResolver,
+    store::package_resolver::{IndexerStorePackageResolver, SimulationPackageStore},
     types::grpc_conversion,
 };
 
@@ -60,6 +60,8 @@ const DRY_RUN_TRANSACTION_READ_MASK: &[SimulateField] = &[
 ];
 const DEV_INSPECT_TRANSACTION_READ_MASK: &[SimulateField] = &[
     SimulateField::EXECUTED_TRANSACTION_EFFECTS_BCS,
+    // Needed to resolve types against a package the simulated transaction published.
+    SimulateField::EXECUTED_TRANSACTION_OUTPUT_OBJECTS_BCS,
     SimulateField::EXECUTED_TRANSACTION_EVENTS_EVENTS_BCS,
     SimulateField::EXECUTION_RESULT_EXECUTION_ERROR_BCS_KIND,
     SimulateField::EXECUTION_RESULT_EXECUTION_ERROR_SOURCE,
@@ -97,7 +99,7 @@ impl WriteApi {
     async fn dry_run_transaction_block_impl(
         &self,
         tx_bytes: Base64,
-        package_resolver: &Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Arc<Resolver<impl PackageStore + Clone>>,
     ) -> IndexerResult<DryRunTransactionBlockResponse> {
         let tx: Transaction = bcs::from_bytes::<Transaction>(&tx_bytes.to_vec()?)?;
 
@@ -145,6 +147,15 @@ impl WriteApi {
         let tx_events = executed_transaction.events()?.events()?;
 
         let in_mem_tx_changes = TxObjectResolver::new(&objects, self.reader.clone());
+
+        // Resolve types against the packages the simulation published before falling
+        // back to the database, so that a transaction publishing a package can decode
+        // the types it introduces — an event from its `init`, for one.
+        let package_resolver = Arc::new(Resolver::new(SimulationPackageStore::new(
+            &output_objects,
+            package_resolver.package_store().clone(),
+        )));
+        let package_resolver = &package_resolver;
 
         // A transaction that carries no gas payment is simulated against a mock gas
         // coin, which the response names in the payment it ran with. That coin is not
@@ -218,7 +229,7 @@ impl WriteApi {
         tx_bytes: Base64,
         gas_price: Option<BigInt<u64>>,
         additional_args: Option<DevInspectArgs>,
-        package_resolver: &Arc<Resolver<impl PackageStore>>,
+        package_resolver: &Arc<Resolver<impl PackageStore + Clone>>,
     ) -> IndexerResult<DevInspectResults> {
         let DevInspectArgs {
             gas_sponsor,
@@ -284,6 +295,16 @@ impl WriteApi {
             .unwrap_or_default();
 
         let tx_events = executed_transaction.events()?.events()?;
+
+        // Resolve types against the packages the simulation published before falling
+        // back to the database, so that a transaction publishing a package can decode
+        // the types it introduces — an event from its `init`, for one.
+        let output_objects = grpc_conversion::objects(executed_transaction.output_objects()?)?;
+        let package_resolver = Arc::new(Resolver::new(SimulationPackageStore::new(
+            &output_objects,
+            package_resolver.package_store().clone(),
+        )));
+        let package_resolver = &package_resolver;
 
         let tx_digest = *tx_effects.transaction_digest();
         // timestamp is None because it represent a checkpoint one, on a dev inspect

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -7,10 +7,7 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use fastcrypto::encoding::Base64;
 use futures::{FutureExt, TryFutureExt};
-use iota_grpc_client::{
-    Client as GrpcClient,
-    read_mask_fields::{EpochField, SimulateField},
-};
+use iota_grpc_client::{Client as GrpcClient, read_mask_fields::SimulateField};
 use iota_json::IotaJsonValue;
 use iota_json_rpc::{
     IotaRpcModule, ObjectProvider, get_balance_changes_from_effect, get_object_changes,
@@ -25,9 +22,8 @@ use iota_json_rpc_types::{
 use iota_open_rpc::Module;
 use iota_package_resolver::{PackageStore, Resolver};
 use iota_sdk_types::{
-    Address, GasPayment, ObjectId, SenderSignedTransaction, Transaction, TransactionDigest,
-    TransactionEffects, TransactionExpiration, TransactionKind, TransactionV1, UserSignature,
-    Version,
+    Address, GasPayment, ObjectId, SenderSignedTransaction, Transaction, TransactionEffects,
+    TransactionExpiration, TransactionKind, TransactionV1, UserSignature, Version,
 };
 use iota_transaction_builder::TransactionBuilder;
 use iota_types::{
@@ -46,11 +42,14 @@ use crate::{
     optimistic_indexing::{IngestionPath, OptimisticTransactionExecutor},
     read::IndexerReader,
     store::package_resolver::IndexerStorePackageResolver,
-    types::{IndexedObjectChange, grpc_conversion},
+    types::grpc_conversion,
 };
 
 // As an optimization, we're trying to request only the fields we actually need.
 const DRY_RUN_TRANSACTION_READ_MASK: &[SimulateField] = &[
+    // The transaction the simulation ran, rather than the one that was sent: the node fills
+    // in gas the caller left unset, and that is what the response reports back.
+    SimulateField::EXECUTED_TRANSACTION_TRANSACTION_BCS,
     SimulateField::EXECUTED_TRANSACTION_SIGNATURES_BCS,
     SimulateField::EXECUTED_TRANSACTION_EFFECTS_BCS,
     SimulateField::EXECUTED_TRANSACTION_EVENTS_EVENTS_BCS,
@@ -100,8 +99,7 @@ impl WriteApi {
         tx_bytes: Base64,
         package_resolver: &Arc<Resolver<impl PackageStore>>,
     ) -> IndexerResult<DryRunTransactionBlockResponse> {
-        let tx = bcs::from_bytes::<Transaction>(&tx_bytes.to_vec()?)?;
-        let tx_digest = tx.digest();
+        let tx: Transaction = bcs::from_bytes::<Transaction>(&tx_bytes.to_vec()?)?;
 
         let simulate_tx_response = self
             .fullnode_grpc_client
@@ -125,6 +123,12 @@ impl WriteApi {
 
         let tx_effects: TransactionEffects = executed_transaction.effects()?.effects()?;
 
+        // The digest of what actually ran, which is the one the effects and the events
+        // are keyed by. It differs from the digest of the transaction as sent whenever
+        // the simulation filled gas in — a mock gas coin changes the transaction it is
+        // taken over.
+        let tx_digest = *tx_effects.transaction_digest();
+
         let tx_signatures = executed_transaction
             .signatures()?
             .signatures
@@ -132,24 +136,50 @@ impl WriteApi {
             .map(|s| -> IndexerResult<_> { Ok(s.signature()?) })
             .collect::<IndexerResult<Vec<UserSignature>>>()?;
 
-        let sender_signed_tx = SenderSignedTransaction::new(tx.clone(), tx_signatures);
+        // Report the transaction the simulation ran, not the one that was sent: the
+        // node fills in the gas the caller left unset and reports what it charged in
+        // its place, which is how a caller reads back an estimate.
+        let simulated_transaction = executed_transaction.transaction()?.transaction()?;
+        let sender_signed_tx = SenderSignedTransaction::new(simulated_transaction, tx_signatures);
 
         let tx_events = executed_transaction.events()?.events()?;
 
         let in_mem_tx_changes = TxObjectResolver::new(&objects, self.reader.clone());
 
-        // as a minor optimization we will run concurrently the following four futures
-        let fut1 = in_mem_tx_changes
-            .get_changes(&tx, &tx_effects, &tx_digest)
-            .map_ok(|(balance_changes, object_changes)| {
-                (
-                    balance_changes,
-                    object_changes
-                        .into_iter()
-                        .map(iota_json_rpc_types::ObjectChange::from)
-                        .collect::<Vec<_>>(),
-                )
-            });
+        // A transaction that carries no gas payment is simulated against a mock gas
+        // coin, which the response names in the payment it ran with. That coin is not
+        // the caller's, so neither is the balance change of paying gas out of it —
+        // exclude it, the way the node's own JSON-RPC dry run does.
+        let mocked_coin = tx
+            .gas()
+            .is_empty()
+            .then(|| sender_signed_tx.transaction().gas().first())
+            .flatten()
+            .map(|gas_ref| gas_ref.object_id);
+
+        // Derived from the transaction as sent, whose inputs are the ones the caller
+        // is asking about; a mock gas coin is not among them. Object changes do keep
+        // the mock coin, which is what the node and gRPC both report.
+        let input_objs = tx.input_objects()?;
+        let sender = tx.sender();
+
+        // as a minor optimization we will run concurrently the following five futures
+        let fut1 = get_balance_changes_from_effect(
+            &in_mem_tx_changes,
+            &tx_effects,
+            input_objs,
+            mocked_coin,
+        )
+        .map_err(Into::into);
+
+        let fut5 = get_object_changes(
+            &in_mem_tx_changes,
+            sender,
+            tx_effects.modified_at_versions(),
+            tx_effects.all_changed_objects(),
+            tx_effects.all_removed_objects(),
+        )
+        .map_err(Into::<IndexerError>::into);
 
         let fut2 = IotaTransactionBlock::try_from_with_package_resolver(
             sender_signed_tx,
@@ -168,8 +198,8 @@ impl WriteApi {
         )
         .map(Ok);
 
-        let ((balance_changes, object_changes), transaction_block, events, effects) =
-            futures::future::try_join4(fut1, fut2, fut3, fut4).await?;
+        let (balance_changes, transaction_block, events, effects, object_changes) =
+            futures::future::try_join5(fut1, fut2, fut3, fut4, fut5).await?;
 
         Ok(DryRunTransactionBlockResponse {
             effects,
@@ -201,48 +231,52 @@ impl WriteApi {
         let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
         let skip_checks = skip_checks.unwrap_or(true);
 
-        let (price, budget) = match (gas_price, gas_budget) {
-            (Some(price), Some(budget)) => (price.into_inner(), budget),
-            (price, budget) => {
-                let (ref_price, max_gas) = self.reference_gas_price_and_max_tx_gas().await?;
-                (
-                    price.map(BigInt::into_inner).unwrap_or(ref_price),
-                    budget.unwrap_or(max_gas),
-                )
-            }
-        };
-
-        let owner = gas_sponsor.unwrap_or(sender_address);
-        let payment = gas_objects.unwrap_or_default();
-
         let kind = bcs::from_bytes::<TransactionKind>(&tx_bytes.to_vec()?)?;
 
         let tx = Transaction::V1(TransactionV1 {
             kind,
             sender: sender_address,
             gas_payment: GasPayment {
-                objects: payment,
-                owner,
-                price,
-                budget,
+                // Any of these the caller leaves out is filled in by the simulation on
+                // the node: an empty payment gets a mock gas coin, a zero price gets the
+                // epoch's reference gas price, and a zero budget gets the protocol
+                // maximum.
+                objects: gas_objects.unwrap_or_default(),
+                owner: gas_sponsor.unwrap_or(sender_address),
+                price: gas_price.map(BigInt::into_inner).unwrap_or_default(),
+                budget: gas_budget.unwrap_or_default(),
             },
             expiration: TransactionExpiration::None,
         });
 
-        let raw_txn_data = show_raw_txn_data_and_effects
-            .then(|| bcs::to_bytes(&tx))
-            .transpose()?
-            .unwrap_or_default();
+        // The transaction is only read back when it is going to be reported, since it
+        // costs bytes on the wire.
+        let mut read_mask = DEV_INSPECT_TRANSACTION_READ_MASK.to_vec();
+        if show_raw_txn_data_and_effects {
+            read_mask.push(SimulateField::EXECUTED_TRANSACTION_TRANSACTION_BCS);
+        }
 
         let simulate_tx_response = self
             .fullnode_grpc_client
-            .simulate_transaction(tx, skip_checks, DEV_INSPECT_TRANSACTION_READ_MASK)
+            .simulate_transaction(tx, skip_checks, read_mask)
             .await?
             .into_inner();
 
         let executed_transaction = simulate_tx_response.executed_transaction()?;
 
         let tx_effects: TransactionEffects = executed_transaction.effects()?.effects()?;
+
+        // Report the transaction the simulation ran, not the one that was sent: the
+        // node fills in the gas the caller left unset and reports what it charged in
+        // its place, which is how a caller reads back an estimate.
+        let raw_txn_data = show_raw_txn_data_and_effects
+            .then(|| -> IndexerResult<_> {
+                Ok(bcs::to_bytes(
+                    &executed_transaction.transaction()?.transaction()?,
+                )?)
+            })
+            .transpose()?
+            .unwrap_or_default();
 
         let raw_effects = show_raw_txn_data_and_effects
             .then(|| bcs::to_bytes(&tx_effects))
@@ -287,35 +321,6 @@ impl WriteApi {
             raw_txn_data,
             raw_effects,
         })
-    }
-
-    /// Gets the reference gas price and max transaction gas from the gRPC API.
-    async fn reference_gas_price_and_max_tx_gas(&self) -> IndexerResult<(u64, u64)> {
-        let epoch = self
-            .fullnode_grpc_client
-            .get_epoch(
-                None, // we're requesting the information for the current epoch.
-                {
-                    [
-                        EpochField::REFERENCE_GAS_PRICE,
-                        EpochField::attribute("max_tx_gas"),
-                    ]
-                },
-            )
-            .await?
-            .into_inner();
-
-        let max_tx_gas = epoch
-            .protocol_config()?
-            .attributes()?
-            .get("max_tx_gas")
-            .ok_or_else(|| {
-                IndexerError::Grpc("protocol_config's `max_tx_gas` should be available".into())
-            })?
-            .parse::<u64>()
-            .map_err(|e| IndexerError::Grpc(e.to_string()))?;
-
-        Ok((epoch.reference_gas_price(), max_tx_gas))
     }
 }
 
@@ -542,38 +547,6 @@ impl TxObjectResolver {
                 .map_err(backoff::Error::transient)
         })
         .await
-    }
-
-    pub(crate) async fn get_changes(
-        &self,
-        tx: &Transaction,
-        effects: &TransactionEffects,
-        tx_digest: &TransactionDigest,
-    ) -> IndexerResult<(
-        Vec<iota_json_rpc_types::BalanceChange>,
-        Vec<IndexedObjectChange>,
-    )> {
-        let object_changes: Vec<_> = get_object_changes(
-            self,
-            tx.sender(),
-            effects.modified_at_versions(),
-            effects.all_changed_objects(),
-            effects.all_removed_objects(),
-        )
-        .await?
-        .into_iter()
-        .map(IndexedObjectChange::from)
-        .collect();
-        let balance_changes = get_balance_changes_from_effect(
-            self,
-            effects,
-            tx.input_objects().unwrap_or_else(|e| {
-                panic!("checkpointed tx {tx_digest} has invalid input objects: {e}")
-            }),
-            None,
-        )
-        .await?;
-        Ok((balance_changes, object_changes))
     }
 }
 

--- a/crates/iota-indexer/src/apis/write_api.rs
+++ b/crates/iota-indexer/src/apis/write_api.rs
@@ -99,7 +99,7 @@ impl WriteApi {
     async fn dry_run_transaction_block_impl(
         &self,
         tx_bytes: Base64,
-        package_resolver: &Arc<Resolver<impl PackageStore + Clone>>,
+        package_resolver: &Arc<Resolver<impl PackageStore>>,
     ) -> IndexerResult<DryRunTransactionBlockResponse> {
         let tx: Transaction = bcs::from_bytes::<Transaction>(&tx_bytes.to_vec()?)?;
 
@@ -153,9 +153,8 @@ impl WriteApi {
         // the types it introduces — an event from its `init`, for one.
         let package_resolver = Arc::new(Resolver::new(SimulationPackageStore::new(
             &output_objects,
-            package_resolver.package_store().clone(),
+            package_resolver.clone(),
         )));
-        let package_resolver = &package_resolver;
 
         // A transaction that carries no gas payment is simulated against a mock gas
         // coin, which the response names in the payment it ran with. That coin is not
@@ -183,6 +182,23 @@ impl WriteApi {
         )
         .map_err(Into::into);
 
+        let fut2 = IotaTransactionBlock::try_from_with_package_resolver(
+            sender_signed_tx,
+            &package_resolver,
+            tx_digest,
+        )
+        .map_err(Into::into);
+
+        // timestamp is None because it represent a checkpoint one, on a dry run
+        // operation we don't have this information.
+        let fut3 = tx_events_to_iota_tx_events(tx_events, &package_resolver, tx_digest, None);
+
+        let fut4 = IotaTransactionBlockEffects::from_native_with_clever_error(
+            tx_effects.clone(),
+            &package_resolver,
+        )
+        .map(Ok);
+
         let fut5 = get_object_changes(
             &in_mem_tx_changes,
             sender,
@@ -191,23 +207,6 @@ impl WriteApi {
             tx_effects.all_removed_objects(),
         )
         .map_err(Into::<IndexerError>::into);
-
-        let fut2 = IotaTransactionBlock::try_from_with_package_resolver(
-            sender_signed_tx,
-            package_resolver,
-            tx_digest,
-        )
-        .map_err(Into::into);
-
-        // timestamp is None because it represent a checkpoint one, on a dry run
-        // operation we don't have this information.
-        let fut3 = tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, None);
-
-        let fut4 = IotaTransactionBlockEffects::from_native_with_clever_error(
-            tx_effects.clone(),
-            package_resolver,
-        )
-        .map(Ok);
 
         let (balance_changes, transaction_block, events, effects, object_changes) =
             futures::future::try_join5(fut1, fut2, fut3, fut4, fut5).await?;
@@ -229,7 +228,7 @@ impl WriteApi {
         tx_bytes: Base64,
         gas_price: Option<BigInt<u64>>,
         additional_args: Option<DevInspectArgs>,
-        package_resolver: &Arc<Resolver<impl PackageStore + Clone>>,
+        package_resolver: &Arc<Resolver<impl PackageStore>>,
     ) -> IndexerResult<DevInspectResults> {
         let DevInspectArgs {
             gas_sponsor,
@@ -302,15 +301,14 @@ impl WriteApi {
         let output_objects = grpc_conversion::objects(executed_transaction.output_objects()?)?;
         let package_resolver = Arc::new(Resolver::new(SimulationPackageStore::new(
             &output_objects,
-            package_resolver.package_store().clone(),
+            package_resolver.clone(),
         )));
-        let package_resolver = &package_resolver;
 
         let tx_digest = *tx_effects.transaction_digest();
         // timestamp is None because it represent a checkpoint one, on a dev inspect
         // operation we don't have this information.
         let events =
-            tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, None).await?;
+            tx_events_to_iota_tx_events(tx_events, &package_resolver, tx_digest, None).await?;
 
         let execution_error = simulate_tx_response
             .execution_error()

--- a/crates/iota-indexer/src/store/package_resolver.rs
+++ b/crates/iota-indexer/src/store/package_resolver.rs
@@ -6,7 +6,9 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
-use iota_package_resolver::{Package, PackageStore, error::Error as PackageResolverError};
+use iota_package_resolver::{
+    Package, PackageStore, Resolver, error::Error as PackageResolverError,
+};
 use iota_sdk_types::Address;
 use iota_types::object::Object;
 
@@ -20,16 +22,16 @@ use crate::{db::ConnectionPool, errors::IndexerError, schema::objects, store::di
 /// never committed, so it is not in the database and only the simulation's own
 /// output holds it. The node's JSON-RPC resolves the same way, over the objects
 /// the simulation wrote with its store behind them.
-pub struct SimulationPackageStore<F> {
+pub struct SimulationPackageStore<F: PackageStore> {
     /// The packages among the objects the simulation wrote, kept as objects and
     /// deserialized on demand: a simulation usually publishes nothing, and when
     /// it does the package is only read if a type actually refers to it.
     published: BTreeMap<Address, Object>,
-    fallback: F,
+    fallback: Arc<Resolver<F>>,
 }
 
-impl<F> SimulationPackageStore<F> {
-    pub fn new(written_objects: &[Object], fallback: F) -> Self {
+impl<F: PackageStore> SimulationPackageStore<F> {
+    pub fn new(written_objects: &[Object], fallback: Arc<Resolver<F>>) -> Self {
         let published = written_objects
             .iter()
             .filter(|object| object.data.as_opt_package().is_some())
@@ -48,7 +50,7 @@ impl<F: PackageStore> PackageStore for SimulationPackageStore<F> {
     async fn fetch(&self, id: Address) -> Result<Arc<Package>, PackageResolverError> {
         match self.published.get(&id) {
             Some(object) => Package::read_from_object(object).map(Arc::new),
-            None => self.fallback.fetch(id).await,
+            None => self.fallback.package_store().fetch(id).await,
         }
     }
 }

--- a/crates/iota-indexer/src/store/package_resolver.rs
+++ b/crates/iota-indexer/src/store/package_resolver.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
@@ -11,6 +11,47 @@ use iota_sdk_types::Address;
 use iota_types::object::Object;
 
 use crate::{db::ConnectionPool, errors::IndexerError, schema::objects, store::diesel_macro::*};
+
+/// A package store that reads packages a simulation wrote before falling back
+/// to `fallback`.
+///
+/// A simulated transaction can publish a package, and then refer to its types —
+/// an event emitted from the new package's `init`, for one. That package was
+/// never committed, so it is not in the database and only the simulation's own
+/// output holds it. The node's JSON-RPC resolves the same way, over the objects
+/// the simulation wrote with its store behind them.
+pub struct SimulationPackageStore<F> {
+    /// The packages among the objects the simulation wrote, kept as objects and
+    /// deserialized on demand: a simulation usually publishes nothing, and when
+    /// it does the package is only read if a type actually refers to it.
+    published: BTreeMap<Address, Object>,
+    fallback: F,
+}
+
+impl<F> SimulationPackageStore<F> {
+    pub fn new(written_objects: &[Object], fallback: F) -> Self {
+        let published = written_objects
+            .iter()
+            .filter(|object| object.data.as_opt_package().is_some())
+            .map(|object| (object.id().into(), object.clone()))
+            .collect();
+
+        Self {
+            published,
+            fallback,
+        }
+    }
+}
+
+#[async_trait]
+impl<F: PackageStore> PackageStore for SimulationPackageStore<F> {
+    async fn fetch(&self, id: Address) -> Result<Arc<Package>, PackageResolverError> {
+        match self.published.get(&id) {
+            Some(object) => Package::read_from_object(object).map(Arc::new),
+            None => self.fallback.fetch(id).await,
+        }
+    }
+}
 
 /// A package resolver that reads packages from the database.
 pub struct IndexerStorePackageResolver {

--- a/crates/iota-indexer/tests/data/publish_with_event/Move.toml
+++ b/crates/iota-indexer/tests/data/publish_with_event/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "publish_with_event"
+version = "0.0.1"
+edition = "2024"
+
+# Pinned to the framework in this repo rather than relying on the implicit
+# dependency, which resolves over the network to a different revision.
+[dependencies]
+Iota = { local = "../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+publish_with_event = "0x0"

--- a/crates/iota-indexer/tests/data/publish_with_event/sources/publish_with_event.move
+++ b/crates/iota-indexer/tests/data/publish_with_event/sources/publish_with_event.move
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Emits an event from `init`, so that simulating the publish produces an event
+/// whose type only the just-published package defines. Decoding it requires
+/// resolving that type against the simulation's own output rather than the
+/// database, which cannot hold a package that was never committed.
+module publish_with_event::publish_with_event {
+    use std::ascii::{Self, String};
+
+    use iota::event;
+
+    public struct PublishEvent has copy, drop {
+        foo: String,
+    }
+
+    fun init(_ctx: &mut TxContext) {
+        event::emit(PublishEvent { foo: ascii::string(b"bar") })
+    }
+}

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::Path, str::FromStr};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl};
 use fastcrypto::encoding::Base64;
@@ -291,6 +294,72 @@ fn dry_run_transaction_block_without_gas_payment() {
             "object changes should still report the mock gas coin, got {:?}",
             response.object_changes
         );
+    });
+}
+
+/// Dry-running a publish decodes an event the new package's `init` emits.
+///
+/// The event's type is defined only by the package being published, which was
+/// never committed and so is not in the database. Decoding it requires
+/// resolving the type against the objects the simulation wrote. Without that
+/// the payload comes back undecoded.
+///
+/// Uses the test smart contract under `tests/data/publish_with_event`.
+#[test]
+fn dry_run_publish_resolves_events_of_the_published_package() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+        let (address, _): (_, AccountKeyPair) = get_key_pair();
+
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10 * NANOS_PER_IOTA),
+                address,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.object_id, gas_ref.version).await;
+
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.extend(["tests", "data", "publish_with_event"]);
+        let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+        let compiled_modules_bytes = compiled_package.get_package_base64(false);
+        let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+        let transaction_bytes: TransactionBlockBytes = client
+            .publish(
+                address,
+                compiled_modules_bytes,
+                dependencies,
+                Some(gas_ref.object_id),
+                100_000_000.into(),
+            )
+            .await
+            .unwrap();
+
+        let response = client
+            .dry_run_transaction_block(transaction_bytes.tx_bytes)
+            .await
+            .unwrap();
+        assert_eq!(*response.effects.status(), IotaExecutionStatus::Success);
+
+        assert_eq!(
+            response.events.data.len(),
+            1,
+            "`init` emits exactly one event, got {:?}",
+            response.events.data
+        );
+        let event = &response.events.data[0];
+        assert_eq!(event.type_.name().to_string(), "PublishEvent");
+        // An unresolved type would leave the payload undecoded.
+        assert_eq!(event.parsed_json, serde_json::json!({ "foo": "bar" }));
     });
 }
 

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -17,13 +17,15 @@ use iota_json_rpc_api::{
 };
 use iota_json_rpc_types::{
     IotaData, IotaExecutionStatus, IotaMoveStruct, IotaMoveValue, IotaObjectDataOptions,
-    IotaSystemStateSummary, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    IotaTransactionBlockResponseOptions, ObjectChange, TransactionBlockBytes,
+    IotaSystemStateSummary, IotaTransactionBlockDataAPI, IotaTransactionBlockEffectsAPI,
+    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
+    TransactionBlockBytes,
 };
 use iota_move_build::BuildConfig;
 use iota_sdk_crypto::simple::SimpleKeypair;
 use iota_sdk_types::{
-    Address, Identifier, ObjectId, ObjectReference, Owner, StructTag, TransactionKind, TypeTag,
+    Address, GasPayment, Identifier, ObjectId, ObjectReference, Owner, StructTag, Transaction,
+    TransactionExpiration, TransactionKind, TransactionV1, TypeTag,
 };
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
@@ -205,6 +207,89 @@ fn dry_run_transaction_block() {
         assert_eq!(
             indexer_tx_response.transaction.unwrap().data,
             dry_run_tx_block_resp.input
+        );
+    });
+}
+
+/// A transaction carrying no gas payment is simulated against a mock gas coin
+/// the node mints, and the response reports the transaction that ran rather
+/// than the one that was sent: the mock coin in the payment, the epoch's
+/// reference gas price, and the gas charged in place of the zero budget.
+///
+/// The mock coin is not the caller's, so no balance change is attributed to it
+/// — the same way the node's own JSON-RPC reports it.
+#[test]
+fn dry_run_transaction_block_without_gas_payment() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+        let sender = Address::random();
+        let receiver = Address::random();
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.transfer_iota(receiver, Some(1_000));
+        let pt = builder.finish();
+
+        // No gas payment, no price and no budget: the node resolves all of it.
+        let tx_data = Transaction::V1(TransactionV1 {
+            kind: TransactionKind::new_programmable(pt),
+            sender,
+            gas_payment: GasPayment {
+                objects: vec![],
+                owner: sender,
+                price: 0,
+                budget: 0,
+            },
+            expiration: TransactionExpiration::None,
+        });
+        let tx_bytes = Base64::from_bytes(&bcs::to_bytes(&tx_data).unwrap());
+
+        let response = client.dry_run_transaction_block(tx_bytes).await.unwrap();
+        assert_eq!(*response.effects.status(), IotaExecutionStatus::Success);
+
+        // The gas the simulation resolved comes back in place of the zeros.
+        let reported_gas = response.input.gas_data();
+        assert_eq!(
+            reported_gas.payment.len(),
+            1,
+            "the mock gas coin should be reported in the gas payment"
+        );
+        assert_eq!(
+            reported_gas.price,
+            cluster.get_reference_gas_price().await,
+            "the reported price should be the one the simulation charged at"
+        );
+        let gas_used = response.effects.gas_cost_summary().gas_used();
+        assert_ne!(gas_used, 0, "a successful transfer has to cost something");
+        assert_eq!(
+            reported_gas.budget, gas_used,
+            "a zero budget should come back as the gas the simulation charged"
+        );
+
+        // The mock coin pays the gas, but it is not the caller's coin, so its
+        // balance change is not reported.
+        let mock_coin = reported_gas.payment[0].object_id;
+        assert!(
+            !response
+                .balance_changes
+                .iter()
+                .any(|change| change.owner == Owner::Address(sender)),
+            "no balance change should be attributed to the mock gas coin's owner, got {:?}",
+            response.balance_changes
+        );
+        assert!(
+            response
+                .object_changes
+                .iter()
+                .any(|change| change.object_id() == mock_coin),
+            "object changes should still report the mock gas coin, got {:?}",
+            response.object_changes
         );
     });
 }


### PR DESCRIPTION
# Description of change

#12508 made the node's `iota_dryRunTransactionBlock` and
`iota_devInspectTransactionBlock` agree with gRPC `simulate_transactions` on the
gas a simulation runs with and reports. The indexer serves the same two JSON-RPC
methods by calling that gRPC endpoint, but shaped its own response — so the
contract held on the node's own server and not on the path clients reach in a
deployment.

This brings the indexer onto the same behavior. Both commits are
`crates/iota-indexer` only.

## 1. Report the gas and the changes the simulation produced

- Drop the indexer's own `reference_gas_price_and_max_tx_gas` lookup. It resolved
  a missing gas price and budget client-side, from an extra `get_epoch` call,
  before sending the transaction on. The node resolves both now, so the caller's
  values — including a zero — are passed through untouched and the simulation
  fills them in.
- Report the transaction the simulation ran, read back over gRPC
  (`SimulateExecutedTransactionField::TRANSACTION_BCS`), rather than the one the
  indexer assembled. That transaction carries the price the run charged at, the
  gas charged in place of a zero budget, and the mock gas coin minted for an
  empty payment. For dev inspect the field is only requested when
  `show_raw_txn_data_and_effects` asks for the transaction back, since it costs
  bytes on the wire.
- Key the response off the effects' transaction digest — the digest of what
  actually ran. It differs from the digest of the transaction as sent whenever a
  mock gas coin was added, and the effects and events are keyed by the former.
- Exclude the mock gas coin from balance changes. A transaction sent without a
  gas payment is simulated against a coin the caller does not own, so the balance
  change of paying gas out of it is not theirs either. The node excludes it; the
  indexer passed `None` and reported it. The coin is identified by diffing the
  payment that was sent against the payment the response reports, which is
  possible because #12508 made the response name it. Object changes keep the mock
  coin, which is what the node and gRPC both do.
- `TxObjectResolver::get_changes` goes away with that: it was used only by the dry
  run, and the two derivations it wrapped are now called directly with the
  arguments the node uses. The ingestion path has its own copy in
  `ingestion::primary::prepare` and is untouched.

## 2. Resolve types against the packages the simulation published

A dry run that publishes a package and emits an event from its `init` could not
decode that event through the indexer: types were resolved only against
`IndexerStorePackageResolver`, the database, which cannot contain a package that
was never committed. The node resolves over the objects the simulation wrote
first and falls back to its store, so the same request decodes there.

`SimulationPackageStore<F>` does the same for the indexer — the packages among the
objects the simulation wrote, then `F`. It keeps them as objects and calls
`Package::read_from_object` on demand, since a simulation usually publishes
nothing and, when it does, the package is only read if a type refers to it. Both
methods build one per request, taking the fallback from
`Resolver::package_store().clone()`; that is a `ConnectionPool` clone, and the
write path holds no package cache to lose.

Applied to dev inspect as well as the dry run, which costs `OUTPUT_OBJECTS_BCS` on
the dev-inspect read mask: the written objects now go over the wire for every dev
inspect, whether or not it publishes.

## Links to any relevant issues

Part of #12671. Follow-up to #12508.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] Indexer: `iota_dryRunTransactionBlock` and `iota_devInspectTransactionBlock` now behave the way the node's own JSON-RPC does.
  - Gas the caller leaves unset is resolved by the node rather than by the indexer: no payment gets a mock gas coin, a zero `gas_price` the epoch's reference gas price, and a zero `gas_budget` what the gas coins can back.
  - The reported transaction carries what the simulation charged — the price, the resolved budget, and the mock gas coin — instead of the transaction as sent.
  - A gasless `iota_dryRunTransactionBlock` reports the digest of what ran, so created object IDs change accordingly, and no longer attributes a balance change to the mock gas coin.
  - Event and type resolution now covers packages the simulated transaction itself published, so a dry run that publishes a package can decode the events its `init` emits.
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---
