### PR TITLE
chore(release-notes): remind validators to upgrade before the epoch change

### DIFF
--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -881,7 +881,9 @@ def do_generate(from_, to, is_dry_run, network=None):
                     next_epoch, when = upgrade
                     print(
                         f"\nOn `{network}`, this protocol version can be enabled no "
-                        f"earlier than `{when}` (start of epoch {next_epoch})."
+                        f"earlier than `{when}` (start of epoch {next_epoch}). "
+                        f"Please ensure that you update your validators before this epoch change. "
+                        f"Otherwise, the protocol will remove you from the committee, and both you and your stakers will lose rewards."
                     )
         print()
 

--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -883,7 +883,7 @@ def do_generate(from_, to, is_dry_run, network=None):
                         f"\nOn `{network}`, this protocol version can be enabled no "
                         f"earlier than `{when}` (start of epoch {next_epoch}). "
                         f"Please ensure that you update your validators before this epoch change. "
-                        f"Otherwise, the protocol will remove you from the committee, and both you and your stakers will lose rewards."
+                        f"Otherwise, if the upgrade threshold is reached, the protocol will remove you from the committee, and both you and your delegators will lose rewards."
                     )
         print()
 


### PR DESCRIPTION
# Description of change

The generated release notes mention the earliest date a new protocol version can be enabled, but not what happens to validators that miss it. This extends the notice to remind validators to update before the epoch change, and warns that failing to do so removes them from the committee and costs both them and their stakers rewards.

## Links to any relevant issues

None.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes