### PR TITLE
refactor(graphql): exclude tx-kind from filter combinations

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.snap
@@ -107,19 +107,6 @@ Response: {
         ]
       }
     },
-    "combinedWithKind": {
-      "nodes": [
-        {
-          "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
-        },
-        {
-          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
-        },
-        {
-          "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
-        }
-      ]
-    },
     "combinedWithOtherSent": {
       "nodes": [
         {
@@ -137,5 +124,22 @@ Response: {
         }
       ]
     }
-  }
+  },
+  "errors": [
+    {
+      "message": "The provided filter combination is not supported",
+      "locations": [
+        {
+          "line": 11,
+          "column": 3
+        }
+      ],
+      "path": [
+        "combinedWithKind"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
 }

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/kind.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/kind.move
@@ -172,3 +172,24 @@ module Test::M1 {
     }
   }
 }
+
+//# run-graphql
+# unsupported filter combination (includes kind)
+{
+  transactionBlocks(filter: {sentAddress: "@{A}" recvAddress: "@{B}" atCheckpoint: 2 kind: PROGRAMMABLE_TX}) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      endCursor
+      startCursor
+    }
+    nodes {
+      digest
+      effects {
+        checkpoint {
+          sequenceNumber
+        }
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/kind.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/kind.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 16 tasks
+processed 17 tasks
 
 init:
 A: object(0,0), B: object(0,1), C: object(0,2), D: object(0,3), E: object(0,4)
@@ -276,4 +276,27 @@ Response: {
       }
     }
   }
+}
+
+task 16, lines 176-195:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "The provided filter combination is not supported",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
 }

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/transaction_ids.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/transaction_ids.move
@@ -84,23 +84,3 @@ module Test::M1 {
     }
   }
 }
-
-//# run-graphql
-{
-  transactionBlocks(scanLimit: 10 filter: {recvAddress: "@{A}" transactionIds: []}) {
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      endCursor
-      startCursor
-    }
-    nodes {
-      digest
-      effects {
-        checkpoint {
-          sequenceNumber
-        }
-      }
-    }
-  }
-}

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/transaction_ids.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/transaction_ids.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 9 tasks
+processed 8 tasks
 
 init:
 A: object(0,0)
@@ -71,37 +71,14 @@ Response: {
 task 7, lines 68-86:
 //# run-graphql
 Response: {
-  "data": null,
-  "errors": [
-    {
-      "message": "A scan limit must be specified for the given filter combination",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "transactionBlocks"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
-}
-
-task 8, lines 88-106:
-//# run-graphql
-Response: {
   "data": {
     "transactionBlocks": {
       "nodes": [],
       "pageInfo": {
-        "endCursor": "eyJjIjoyLCJ0IjoyLCJpIjp0cnVlfQ",
+        "endCursor": null,
         "hasNextPage": false,
         "hasPreviousPage": false,
-        "startCursor": "eyJjIjoyLCJ0IjowLCJpIjp0cnVlfQ"
+        "startCursor": null
       }
     }
   }

--- a/crates/iota-graphql-e2e-tests/tests/transactions/scan_limit/require.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/scan_limit/require.move
@@ -140,48 +140,6 @@ module Test::M1 {
 //# run-graphql
 # scanLimit required
 {
-  transactionBlocks(filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 kind: PROGRAMMABLE_TX}) {
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      endCursor
-      startCursor
-    }
-    nodes {
-      digest
-      effects {
-        checkpoint {
-          sequenceNumber
-        }
-      }
-    }
-  }
-}
-
-//# run-graphql
-# valid
-{
-  transactionBlocks(scanLimit: 50 filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 kind: PROGRAMMABLE_TX}) {
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      endCursor
-      startCursor
-    }
-    nodes {
-      digest
-      effects {
-        checkpoint {
-          sequenceNumber
-        }
-      }
-    }
-  }
-}
-
-//# run-graphql
-# scanLimit required
-{
   transactionBlocks(filter: {sentAddress: "@{A}" recvAddress: "@{B}" afterCheckpoint: 1 beforeCheckpoint: 4 inputObject: "@{obj_3_0}"}) {
     pageInfo {
       hasNextPage

--- a/crates/iota-graphql-e2e-tests/tests/transactions/scan_limit/require.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/scan_limit/require.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 25 tasks
+processed 23 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -481,126 +481,6 @@ task 20, lines 161-180:
 Response: {
   "data": {
     "transactionBlocks": {
-      "nodes": [
-        {
-          "digest": "HwRcMnKbBuAC1co626aK74p6SbC78rmXT2qN7jxiKzJ3",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 2
-            }
-          }
-        },
-        {
-          "digest": "5PjriUj23FMCUEANkp4iCqHnTqLfzRMozMVepcswSxP6",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 2
-            }
-          }
-        },
-        {
-          "digest": "EJdcQCAxwG93tqorEwuB8aSxs1JN4714PUYXczSnKsvE",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 2
-            }
-          }
-        },
-        {
-          "digest": "HW6pcLT6wCiEvVmUEhCH1g4L9rJZXSH9FP5aMmk9Eoqh",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 2
-            }
-          }
-        },
-        {
-          "digest": "BqRHXGyWZyqpPUTgAFFQjsJ3gNaHNEKkEjJBCLp31486",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 2
-            }
-          }
-        },
-        {
-          "digest": "67H4RdM1W8syC8vXnbhr6b6gJaV2zB9rFpfPMN3GMqU4",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 3
-            }
-          }
-        },
-        {
-          "digest": "3urahk5sycRMHoT6N6xFAoH3N8n7NsFDgttb6AEY4oy6",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 3
-            }
-          }
-        },
-        {
-          "digest": "HZ9hakoXhrwtuBFPtpaw2qfxZ4qZzXJDPa7hfzQpzuCE",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 3
-            }
-          }
-        },
-        {
-          "digest": "FY7ZEP9PCRcPSgXhkGKe9CDEBLw8nHDeRrrjA4kEjRxk",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 3
-            }
-          }
-        },
-        {
-          "digest": "7ibLbGJPEvCHu5KHnBQcpQz6uRANZhUM1VborB8dszJJ",
-          "effects": {
-            "checkpoint": {
-              "sequenceNumber": 3
-            }
-          }
-        }
-      ],
-      "pageInfo": {
-        "endCursor": "eyJjIjozLCJ0IjoxMSwiaSI6dHJ1ZX0",
-        "hasNextPage": false,
-        "hasPreviousPage": false,
-        "startCursor": "eyJjIjozLCJ0IjoyLCJpIjp0cnVlfQ"
-      }
-    }
-  }
-}
-
-task 21, lines 182-201:
-//# run-graphql
-Response: {
-  "data": null,
-  "errors": [
-    {
-      "message": "A scan limit must be specified for the given filter combination",
-      "locations": [
-        {
-          "line": 3,
-          "column": 3
-        }
-      ],
-      "path": [
-        "transactionBlocks"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
-}
-
-task 22, lines 203-222:
-//# run-graphql
-Response: {
-  "data": {
-    "transactionBlocks": {
       "nodes": [],
       "pageInfo": {
         "endCursor": "eyJjIjozLCJ0IjoxMSwiaSI6dHJ1ZX0",
@@ -612,7 +492,7 @@ Response: {
   }
 }
 
-task 23, lines 225-244:
+task 21, lines 183-202:
 //# run-graphql
 Response: {
   "data": null,
@@ -635,7 +515,7 @@ Response: {
   ]
 }
 
-task 24, lines 246-270:
+task 22, lines 204-228:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -44,10 +44,11 @@ type Address implements IOwner {
 	defaults to `SENT`.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -413,10 +414,11 @@ type Checkpoint {
 	Transactions in this checkpoint.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -547,10 +549,11 @@ type Coin implements IMoveObject & IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -721,10 +724,11 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -1165,10 +1169,11 @@ type Epoch {
 	The epoch's corresponding transaction blocks.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2142,10 +2147,11 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2352,10 +2358,11 @@ type MovePackage implements IObject & IOwner {
 	Note that objects that have been sent to a package become inaccessible.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2796,10 +2803,11 @@ type NameRegistration implements IMoveObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2981,10 +2989,11 @@ type Object implements IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -3650,10 +3659,11 @@ type Query {
 	The transaction blocks that exist in the network.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -4110,10 +4120,11 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -67,8 +67,13 @@ type Address implements IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	transactionBlocks(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	transactionBlocks(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
 
 type AddressConnection {
@@ -435,8 +440,13 @@ type Checkpoint {
 	
 	By default, the scanning range consists of all transactions in this
 	checkpoint.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
 
 type CheckpointConnection {
@@ -572,8 +582,13 @@ type Coin implements IMoveObject & IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -747,8 +762,13 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -1190,8 +1210,13 @@ type Epoch {
 	
 	By default, the scanning range consists of all transactions in this
 	epoch.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
 
 type Event {
@@ -1572,7 +1597,7 @@ interface IObject {
 	"""
 	The transaction blocks that sent objects to this object.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -2170,8 +2195,13 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -2381,8 +2411,13 @@ type MovePackage implements IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the package's content.
 	"""
@@ -2826,8 +2861,13 @@ type NameRegistration implements IMoveObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -3012,8 +3052,13 @@ type Object implements IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -3683,8 +3728,13 @@ type Query {
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters. Transactions that don't have a checkpoint yet
 	are always omitted.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	Query events that are emitted in the network.
 	We currently do not support filtering by emitting module and event type
@@ -4143,8 +4193,13 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -45,10 +45,10 @@ type Address implements IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -69,9 +69,8 @@ type Address implements IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
@@ -420,10 +419,10 @@ type Checkpoint {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -442,9 +441,8 @@ type Checkpoint {
 	checkpoint.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
@@ -560,10 +558,10 @@ type Coin implements IMoveObject & IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -584,9 +582,8 @@ type Coin implements IMoveObject & IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -740,10 +737,10 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -764,9 +761,8 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -1190,10 +1186,10 @@ type Epoch {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -1212,9 +1208,8 @@ type Epoch {
 	epoch.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
@@ -2173,10 +2168,10 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2197,9 +2192,8 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -2389,10 +2383,10 @@ type MovePackage implements IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2413,9 +2407,8 @@ type MovePackage implements IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -2839,10 +2832,10 @@ type NameRegistration implements IMoveObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2863,9 +2856,8 @@ type NameRegistration implements IMoveObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -3030,10 +3022,10 @@ type Object implements IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -3054,9 +3046,8 @@ type Object implements IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -3705,10 +3696,10 @@ type Query {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -3730,9 +3721,8 @@ type Query {
 	are always omitted.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -4171,10 +4161,10 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -4195,9 +4185,8 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -576,7 +576,7 @@ impl Default for Limits {
             // Filter-specific limits, such as the number of transaction ids that can be specified
             // for the `TransactionBlockFilter`.
             max_transaction_ids: 1000,
-            max_scan_limit: 100_000_000,
+            max_scan_limit: 1_000_000,
             // Protocol limit for max transaction bytes allowed + base64
             // overhead (roughly 1/3 of the original string). This is rounded up.
             //

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -153,10 +153,11 @@ impl Address {
     /// defaults to `SENT`.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -176,6 +176,11 @@ impl Address {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -188,6 +193,9 @@ impl Address {
         before: Option<transaction_block::Cursor>,
         relation: Option<AddressTransactionBlockRelationship>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         use AddressTransactionBlockRelationship as R;

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -154,10 +154,10 @@ impl Address {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -178,9 +178,8 @@ impl Address {
     /// `atCheckpoint` filters.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -210,6 +210,11 @@ impl Checkpoint {
     ///
     /// By default, the scanning range consists of all transactions in this
     /// checkpoint.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -221,6 +226,9 @@ impl Checkpoint {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -189,10 +189,11 @@ impl Checkpoint {
     /// Transactions in this checkpoint.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -190,10 +190,10 @@ impl Checkpoint {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -212,9 +212,8 @@ impl Checkpoint {
     /// checkpoint.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -232,6 +232,11 @@ impl Coin {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -243,6 +248,9 @@ impl Coin {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         ObjectImpl(&self.super_.super_)

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -209,10 +209,11 @@ impl Coin {
     /// The transaction blocks that sent objects to this object.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -210,10 +210,10 @@ impl Coin {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -234,9 +234,8 @@ impl Coin {
     /// `atCheckpoint` filters.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/iota-graphql-rpc/src/types/coin_metadata.rs
@@ -195,10 +195,10 @@ impl CoinMetadata {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -219,9 +219,8 @@ impl CoinMetadata {
     /// `atCheckpoint` filters.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/iota-graphql-rpc/src/types/coin_metadata.rs
@@ -194,10 +194,11 @@ impl CoinMetadata {
     /// The transaction blocks that sent objects to this object.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/iota-graphql-rpc/src/types/coin_metadata.rs
@@ -217,6 +217,11 @@ impl CoinMetadata {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -228,6 +233,9 @@ impl CoinMetadata {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         ObjectImpl(&self.super_.super_)

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -225,10 +225,10 @@ impl Epoch {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -247,9 +247,8 @@ impl Epoch {
     /// epoch.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -224,10 +224,11 @@ impl Epoch {
     /// The epoch's corresponding transaction blocks.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -245,6 +245,11 @@ impl Epoch {
     ///
     /// By default, the scanning range consists of all transactions in this
     /// epoch.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -256,6 +261,9 @@ impl Epoch {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -249,10 +249,10 @@ impl NameRegistration {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -273,9 +273,8 @@ impl NameRegistration {
     /// `atCheckpoint` filters.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -248,10 +248,11 @@ impl NameRegistration {
     /// The transaction blocks that sent objects to this object.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -271,6 +271,11 @@ impl NameRegistration {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -282,6 +287,9 @@ impl NameRegistration {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         ObjectImpl(&self.super_.super_)

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -264,10 +264,11 @@ impl MoveObject {
     /// The transaction blocks that sent objects to this object.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -265,10 +265,10 @@ impl MoveObject {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -289,9 +289,8 @@ impl MoveObject {
     /// `atCheckpoint` filters.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -287,6 +287,11 @@ impl MoveObject {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -298,6 +303,9 @@ impl MoveObject {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         ObjectImpl(&self.super_)

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -361,10 +361,11 @@ impl MovePackage {
     /// Note that objects that have been sent to a package become inaccessible.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -384,6 +384,11 @@ impl MovePackage {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -395,6 +400,9 @@ impl MovePackage {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         ObjectImpl(&self.super_)

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -362,10 +362,10 @@ impl MovePackage {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -386,9 +386,8 @@ impl MovePackage {
     /// `atCheckpoint` filters.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -495,10 +495,11 @@ impl Object {
     /// The transaction blocks that sent objects to this object.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -500,10 +500,10 @@ impl Object {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -524,9 +524,8 @@ impl Object {
     /// `atCheckpoint` filters.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -285,7 +285,11 @@ pub(crate) struct HistoricalObjectCursor {
         arg(name = "last", ty = "Option<u64>"),
         arg(name = "before", ty = "Option<transaction_block::Cursor>"),
         arg(name = "filter", ty = "Option<TransactionBlockFilter>"),
-        arg(name = "scan_limit", ty = "Option<u64>"),
+        arg(
+            name = "scan_limit",
+            ty = "Option<u64>",
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        ),
         ty = "ScanConnection<String, TransactionBlock>",
         desc = "The transaction blocks that sent objects to this object."
     ),
@@ -518,6 +522,11 @@ impl Object {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -529,6 +538,9 @@ impl Object {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         ObjectImpl(self)

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -483,10 +483,10 @@ impl Query {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -508,9 +508,8 @@ impl Query {
     /// are always omitted.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -506,6 +506,11 @@ impl Query {
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters. Transactions that don't have a checkpoint yet
     /// are always omitted.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -517,6 +522,9 @@ impl Query {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -482,10 +482,11 @@ impl Query {
     /// The transaction blocks that exist in the network.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/stake.rs
+++ b/crates/iota-graphql-rpc/src/types/stake.rs
@@ -237,6 +237,11 @@ impl StakedIota {
     /// GraphQL, but it can be restricted by the `after` and `before`
     /// cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
     /// `atCheckpoint` filters.
+    ///
+    /// DEPRECATION NOTICE: Support for the combination of two or more complex
+    /// filters as discussed above will stop with the v1.38 release, after more
+    /// than three months. `scanLimit` will thus become obsolete and will be
+    /// removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]
@@ -248,6 +253,9 @@ impl StakedIota {
         last: Option<u64>,
         before: Option<transaction_block::Cursor>,
         filter: Option<TransactionBlockFilter>,
+        #[graphql(
+            deprecation = "`scanLimit` will be removed with v1.38, along with the support for combining complex filters."
+        )]
         scan_limit: Option<u64>,
     ) -> Result<ScanConnection<String, TransactionBlock>> {
         ObjectImpl(&self.super_.super_)

--- a/crates/iota-graphql-rpc/src/types/stake.rs
+++ b/crates/iota-graphql-rpc/src/types/stake.rs
@@ -214,10 +214,11 @@ impl StakedIota {
     /// The transaction blocks that sent objects to this object.
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
-    /// gathering a page of results. It is required for queries that apply
-    /// more than two complex filters (on function, kind, sender, recipient,
-    /// input object, changed object, or ids), and can be at most
-    /// `serviceConfig.maxScanLimit`.
+    /// gathering a page of results. It is required for queries that apply two
+    /// or more complex filters (on function, recipient, input object,
+    /// changed object, or wrapped or deleted object), and can be at most
+    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+    /// any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when

--- a/crates/iota-graphql-rpc/src/types/stake.rs
+++ b/crates/iota-graphql-rpc/src/types/stake.rs
@@ -215,10 +215,10 @@ impl StakedIota {
     ///
     /// `scanLimit` restricts the number of candidate transactions scanned when
     /// gathering a page of results. It is required for queries that apply two
-    /// or more complex filters (on function, recipient, input object,
-    /// changed object, or wrapped or deleted object), and can be at most
-    /// `serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-    /// any of them.
+    /// or more complex filters (on function, affected address, recipient, input
+    /// object, changed object, or wrapped or deleted object), and can be at
+    /// most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+    /// combined with any of them.
     ///
     /// When the scan limit is reached the page will be returned even if it has
     /// fewer than `first` results when paginating forward (`last` when
@@ -239,9 +239,8 @@ impl StakedIota {
     /// `atCheckpoint` filters.
     ///
     /// DEPRECATION NOTICE: Support for the combination of two or more complex
-    /// filters as discussed above will stop with the v1.38 release, after more
-    /// than three months. `scanLimit` will thus become obsolete and will be
-    /// removed as well.
+    /// filters as discussed above will stop with the v1.38 release. `scanLimit`
+    /// will thus become obsolete and will be removed as well.
     #[graphql(
         complexity = "first.or(last).unwrap_or(DEFAULT_PAGE_SIZE as u64) as usize * child_complexity"
     )]

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -48,6 +48,19 @@ pub(crate) struct TransactionBlockFilter {
 }
 
 impl TransactionBlockFilter {
+    /// Infer whether the provided filter is unsupported.
+    ///
+    /// We reserve this flag for filter combinations that are either too complex
+    /// to serve, or might not make sense (e.g. rich queries on system
+    /// transactions).
+    pub(crate) fn is_unsupported(&self) -> bool {
+        self.is_unsupported_kind_combo()
+    }
+
+    fn is_unsupported_kind_combo(&self) -> bool {
+        self.kind.is_some() && self.scan_count() > 1
+    }
+
     /// Try to create a filter whose results are the intersection of transaction
     /// blocks in `self`'s results and transaction blocks in `other`'s
     /// results. This may not be possible if the resulting filter is
@@ -83,11 +96,23 @@ impl TransactionBlockFilter {
         })
     }
 
-    /// Most filter conditions require a scan limit if used in tandem with other
-    /// filters. The exception to this is sender and checkpoint, since
-    /// sender is denormalized on all tables, and the corresponding tx range
-    /// can be determined for a checkpoint.
-    pub(crate) fn requires_scan_limit(&self) -> bool {
+    /// The number of set filters that force a separate lookup table read.
+    ///
+    /// For example, `tx_recipients` for `recv_address` or `tx_kinds` for
+    /// `kind`.
+    ///
+    /// Combining two or more of them takes a scan over an unknown range of
+    /// transactions on each lookup table.
+    ///
+    /// Combining the remaining filters does not have this effect:
+    ///
+    /// * `sent_address` is available as a denormalized column on the other
+    ///   filters' tables, and is served by `tx_senders` only when set on its
+    ///   own.
+    /// * `{after,at,before}_checkpoint` bound the range of transactions each
+    ///   read is confined to.
+    /// * `transaction_ids` matches at most one transaction per digest given.
+    fn scan_count(&self) -> usize {
         [
             self.function.is_some(),
             self.kind.is_some(),
@@ -96,12 +121,16 @@ impl TransactionBlockFilter {
             self.input_object.is_some(),
             self.changed_object.is_some(),
             self.wrapped_or_deleted_object.is_some(),
-            self.transaction_ids.is_some(),
         ]
         .into_iter()
         .filter(|is_set| *is_set)
         .count()
-            > 1
+    }
+
+    /// A scan limit is required once more than one filter has to be scanned
+    /// (see [`Self::scan_count`]).
+    pub(crate) fn requires_scan_limit(&self) -> bool {
+        self.scan_count() > 1
     }
 
     /// Returns the transaction sender to query `tx_sender`.
@@ -109,14 +138,7 @@ impl TransactionBlockFilter {
     /// If there are other filters set that would query tables with a `sender`
     /// column, then this returns `None`.
     pub(crate) fn explicit_sender(&self) -> Option<IotaAddress> {
-        if self.function.is_none()
-            && self.kind.is_none()
-            && self.recv_address.is_none()
-            && self.affected_address.is_none()
-            && self.input_object.is_none()
-            && self.changed_object.is_none()
-            && self.wrapped_or_deleted_object.is_none()
-        {
+        if self.scan_count() == 0 {
             self.sent_address
         } else {
             None
@@ -208,5 +230,135 @@ impl TransactionBlockFilter {
                     if (kind == TransactionBlockKindInput::SystemTx)
                         != (sender == IotaAddress::from(NativeAddress::ZERO))
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::type_filter::ModuleFilter;
+
+    impl TransactionBlockFilter {
+        const OBJECT: IotaAddress = IotaAddress([2; 32]);
+        const SENDER: IotaAddress = IotaAddress([1; 32]);
+
+        /// One filter per scanned table.
+        fn scanned() -> Vec<Self> {
+            vec![
+                Self {
+                    function: Some(FqNameFilter::ByModule(ModuleFilter::ByPackage(
+                        Self::OBJECT,
+                    ))),
+                    ..Default::default()
+                },
+                Self {
+                    kind: Some(TransactionBlockKindInput::SystemTx),
+                    ..Default::default()
+                },
+                Self {
+                    recv_address: Some(Self::SENDER),
+                    ..Default::default()
+                },
+                Self {
+                    input_object: Some(Self::OBJECT),
+                    ..Default::default()
+                },
+                Self {
+                    changed_object: Some(Self::OBJECT),
+                    ..Default::default()
+                },
+                Self {
+                    wrapped_or_deleted_object: Some(Self::OBJECT),
+                    ..Default::default()
+                },
+            ]
+        }
+
+        /// Every combination of two distinct scanned filters.
+        fn scanned_pairs() -> Vec<Self> {
+            let scanned = Self::scanned();
+            scanned
+                .iter()
+                .enumerate()
+                .flat_map(|(i, a)| {
+                    scanned[i + 1..]
+                        .iter()
+                        .map(|b| a.clone().intersect(b.clone()).unwrap())
+                })
+                .collect()
+        }
+
+        /// Every filter that is not scanned, in one value.
+        fn unscanned() -> Self {
+            Self {
+                sent_address: Some(Self::SENDER),
+                after_checkpoint: Some(UInt53::from(1)),
+                at_checkpoint: Some(UInt53::from(5)),
+                before_checkpoint: Some(UInt53::from(10)),
+                transaction_ids: Some(vec![]),
+                ..Default::default()
+            }
+        }
+    }
+
+    #[test]
+    fn scan_count_counts_scanned_filters_only() {
+        assert_eq!(TransactionBlockFilter::default().scan_count(), 0);
+        assert_eq!(TransactionBlockFilter::unscanned().scan_count(), 0);
+
+        for filter in TransactionBlockFilter::scanned() {
+            let filter = filter
+                .intersect(TransactionBlockFilter::unscanned())
+                .unwrap();
+            assert_eq!(filter.scan_count(), 1);
+        }
+
+        for filter in TransactionBlockFilter::scanned_pairs() {
+            assert_eq!(filter.scan_count(), 2);
+        }
+    }
+
+    #[test]
+    fn scan_limit_required_beyond_one_scan() {
+        assert!(!TransactionBlockFilter::unscanned().requires_scan_limit());
+
+        for filter in TransactionBlockFilter::scanned() {
+            let filter = filter
+                .intersect(TransactionBlockFilter::unscanned())
+                .unwrap();
+            assert!(!filter.requires_scan_limit());
+        }
+
+        for filter in TransactionBlockFilter::scanned_pairs() {
+            assert!(filter.requires_scan_limit());
+        }
+    }
+
+    #[test]
+    fn kind_unsupported_only_alongside_another_scan() {
+        for filter in TransactionBlockFilter::scanned() {
+            let filter = filter
+                .intersect(TransactionBlockFilter::unscanned())
+                .unwrap();
+            assert!(!filter.is_unsupported());
+        }
+
+        for filter in TransactionBlockFilter::scanned_pairs() {
+            assert_eq!(filter.is_unsupported(), filter.kind.is_some());
+        }
+    }
+
+    #[test]
+    fn explicit_sender_dropped_by_any_scan() {
+        let unscanned = TransactionBlockFilter::unscanned();
+        assert_eq!(
+            unscanned.explicit_sender(),
+            Some(TransactionBlockFilter::SENDER)
+        );
+
+        for filter in TransactionBlockFilter::scanned() {
+            let filter = filter.intersect(unscanned.clone()).unwrap();
+            assert_eq!(filter.explicit_sender(), None);
+        }
     }
 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -271,6 +271,10 @@ mod tests {
                     wrapped_or_deleted_object: Some(Self::OBJECT),
                     ..Default::default()
                 },
+                Self {
+                    affected_address: Some(Self::OBJECT),
+                    ..Default::default()
+                },
             ]
         }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -403,6 +403,12 @@ impl TransactionBlock {
     ) -> Result<ScanConnection<String, TransactionBlock>, Error> {
         let limits = &ctx.data_unchecked::<ServiceConfig>().limits;
 
+        if filter.is_unsupported() {
+            return Err(Error::Client(
+                "The provided filter combination is not supported".into(),
+            ));
+        }
+
         // If the caller has provided some arbitrary combination of `function`, `kind`,
         // `recvAddress`, `inputObject`, or `changedObject`, we require setting a
         // `scanLimit`.

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -409,7 +409,7 @@ impl TransactionBlock {
             ));
         }
 
-        // If the caller has provided some arbitrary combination of `function`, `kind`,
+        // If the caller has provided some arbitrary combination of `function`,
         // `recvAddress`, `inputObject`, or `changedObject`, we require setting a
         // `scanLimit`.
         if let Some(scan_limit) = scan_limit {

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -49,10 +49,10 @@ type Address implements IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -73,9 +73,8 @@ type Address implements IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
@@ -424,10 +423,10 @@ type Checkpoint {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -446,9 +445,8 @@ type Checkpoint {
 	checkpoint.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
@@ -564,10 +562,10 @@ type Coin implements IMoveObject & IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -588,9 +586,8 @@ type Coin implements IMoveObject & IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -744,10 +741,10 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -768,9 +765,8 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -1194,10 +1190,10 @@ type Epoch {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -1216,9 +1212,8 @@ type Epoch {
 	epoch.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
@@ -2177,10 +2172,10 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2201,9 +2196,8 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -2393,10 +2387,10 @@ type MovePackage implements IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2417,9 +2411,8 @@ type MovePackage implements IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -2843,10 +2836,10 @@ type NameRegistration implements IMoveObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2867,9 +2860,8 @@ type NameRegistration implements IMoveObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -3034,10 +3026,10 @@ type Object implements IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -3058,9 +3050,8 @@ type Object implements IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -3709,10 +3700,10 @@ type Query {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -3734,9 +3725,8 @@ type Query {
 	are always omitted.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
@@ -4175,10 +4165,10 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
 	gathering a page of results. It is required for queries that apply two
-	or more complex filters (on function, recipient, input object,
-	changed object, or wrapped or deleted object), and can be at most
-	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
-	any of them.
+	or more complex filters (on function, affected address, recipient, input
+	object, changed object, or wrapped or deleted object), and can be at
+	most `serviceConfig.maxScanLimit`. A `kind` filter cannot be
+	combined with any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -4199,9 +4189,8 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	`atCheckpoint` filters.
 	
 	DEPRECATION NOTICE: Support for the combination of two or more complex
-	filters as discussed above will stop with the v1.38 release, after more
-	than three months. `scanLimit` will thus become obsolete and will be
-	removed as well.
+	filters as discussed above will stop with the v1.38 release. `scanLimit`
+	will thus become obsolete and will be removed as well.
 	"""
 	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -71,8 +71,13 @@ type Address implements IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	transactionBlocks(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	transactionBlocks(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
 
 type AddressConnection {
@@ -439,8 +444,13 @@ type Checkpoint {
 	
 	By default, the scanning range consists of all transactions in this
 	checkpoint.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
 
 type CheckpointConnection {
@@ -576,8 +586,13 @@ type Coin implements IMoveObject & IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -751,8 +766,13 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -1194,8 +1214,13 @@ type Epoch {
 	
 	By default, the scanning range consists of all transactions in this
 	epoch.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 }
 
 type Event {
@@ -1576,7 +1601,7 @@ interface IObject {
 	"""
 	The transaction blocks that sent objects to this object.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -2174,8 +2199,13 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -2385,8 +2415,13 @@ type MovePackage implements IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the package's content.
 	"""
@@ -2830,8 +2865,13 @@ type NameRegistration implements IMoveObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -3016,8 +3056,13 @@ type Object implements IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""
@@ -3687,8 +3732,13 @@ type Query {
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters. Transactions that don't have a checkpoint yet
 	are always omitted.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	Query events that are emitted in the network.
 	We currently do not support filtering by emitting module and event type
@@ -4147,8 +4197,13 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	GraphQL, but it can be restricted by the `after` and `before`
 	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
 	`atCheckpoint` filters.
+	
+	DEPRECATION NOTICE: Support for the combination of two or more complex
+	filters as discussed above will stop with the v1.38 release, after more
+	than three months. `scanLimit` will thus become obsolete and will be
+	removed as well.
 	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int @deprecated(reason: "`scanLimit` will be removed with v1.38, along with the support for combining complex filters.")): TransactionBlockConnection!
 	"""
 	The Base64-encoded BCS serialization of the object's content.
 	"""

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -48,10 +48,11 @@ type Address implements IOwner {
 	defaults to `SENT`.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -417,10 +418,11 @@ type Checkpoint {
 	Transactions in this checkpoint.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -551,10 +553,11 @@ type Coin implements IMoveObject & IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -725,10 +728,11 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -1169,10 +1173,11 @@ type Epoch {
 	The epoch's corresponding transaction blocks.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2146,10 +2151,11 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2356,10 +2362,11 @@ type MovePackage implements IObject & IOwner {
 	Note that objects that have been sent to a package become inaccessible.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2800,10 +2807,11 @@ type NameRegistration implements IMoveObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -2985,10 +2993,11 @@ type Object implements IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -3654,10 +3663,11 @@ type Query {
 	The transaction blocks that exist in the network.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when
@@ -4114,10 +4124,11 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	The transaction blocks that sent objects to this object.
 	
 	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
+	gathering a page of results. It is required for queries that apply two
+	or more complex filters (on function, recipient, input object,
+	changed object, or wrapped or deleted object), and can be at most
+	`serviceConfig.maxScanLimit`. A `kind` filter cannot be combined with
+	any of them.
 	
 	When the scan limit is reached the page will be returned even if it has
 	fewer than `first` results when paginating forward (`last` when


### PR DESCRIPTION
# Description of change

This patch lowers the default `max_scan_limit` to 1M rows, and excludes `kind` from combinations with other transaction filters.

Additionally it adds a deprecation notice on the support for combining complex filters, which implies the removal of `scanLimit`

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Release Notes

- [x] GraphQL: :warning: excluded transaction kind from the filter combinations. The impact is expected to be negligible as most other filters make sense only for programmable transactions, but nevertheless users are advised to refactor dependent logic accordingly.
        :warning: This patch also deprecates `scanLimit` as the support for the combination of two or more complex filters (on function, recipient, input object, changed object, affected address, or wrapped or deleted object) will stop after more than three months with the v1.38 release. Users are kindly requested to adapt their dependent logic accordingly within this transition period.
