### PR TITLE
fix(json-rpc): exclude transaction-not-found errors from error policy

### DIFF
--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -13,13 +13,14 @@ use fastcrypto::encoding::Base64;
 use iota_core::authority_client::{
     make_network_authority_clients_with_network_config, validator::ValidatorAPI,
 };
+use iota_json_rpc_api::TRANSACTION_NOT_FOUND_ERROR_CODE;
 use iota_json_rpc_types::{
     IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
     IotaTransactionBlockResponseOptions,
 };
 use iota_macros::sim_test;
 use iota_network::default_iota_network_config;
-use iota_sdk_types::UserSignature;
+use iota_sdk_types::{TransactionDigest, UserSignature};
 use iota_swarm_config::network_config_builder::ConfigBuilder;
 use iota_test_transaction_builder::batch_make_transfer_transactions;
 use iota_traffic_controller::{
@@ -511,6 +512,39 @@ async fn test_fullnode_traffic_control_error_blocked() -> Result<(), anyhow::Err
         tokio::task::yield_now().await;
     }
     panic!("Expected spam policy to trigger within {txn_count} requests");
+}
+
+#[tokio::test]
+async fn unknown_transaction_does_not_trigger_fullnode_error_policy() {
+    telemetry_subscribers::init_for_testing();
+    let policy_config = PolicyConfig {
+        connection_blocklist_ttl_sec: 3,
+        error_policy_type: PolicyType::TestNConnIP(1),
+        dry_run: false,
+        ..Default::default()
+    };
+    let test_cluster = TestClusterBuilder::new()
+        .with_fullnode_policy_config(Some(policy_config))
+        .build()
+        .await;
+
+    let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
+    let digest = TransactionDigest::from([42; 32]);
+
+    for request_number in 1..=2 {
+        let response: Result<IotaTransactionBlockResponse, _> = jsonrpc_client
+            .request("iota_getTransactionBlock", rpc_params![digest])
+            .await;
+        let error = response.expect_err("an unknown transaction should return an error");
+        let jsonrpsee::core::ClientError::Call(error) = error else {
+            panic!("request {request_number} returned a non-JSON-RPC error: {error}");
+        };
+        assert_eq!(error.code(), TRANSACTION_NOT_FOUND_ERROR_CODE);
+
+        if request_number == 1 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/iota-json-rpc-api/src/lib.rs
+++ b/crates/iota-json-rpc-api/src/lib.rs
@@ -336,6 +336,7 @@ pub const CLIENT_TARGET_API_VERSION_HEADER: &str = "client-target-api-version";
 
 pub const TRANSIENT_ERROR_CODE: i32 = -32050;
 pub const TRANSACTION_EXECUTION_CLIENT_ERROR_CODE: i32 = -32002;
+pub const TRANSACTION_NOT_FOUND_ERROR_CODE: i32 = -32003;
 
 /// Convert a jsonrpsee client error into a generic error object.
 pub fn error_object_from_rpc(rpc_err: ClientError) -> ErrorObjectOwned {

--- a/crates/iota-json-rpc/src/axum_router.rs
+++ b/crates/iota-json-rpc/src/axum_router.rs
@@ -15,6 +15,7 @@ use axum::{
 use hyper::{HeaderMap, header::HeaderValue};
 use iota_json_rpc_api::{
     CLIENT_TARGET_API_VERSION_HEADER, TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
+    TRANSACTION_NOT_FOUND_ERROR_CODE,
 };
 use iota_traffic_controller::{TrafficController, parse_ip, policies::TrafficTally};
 use iota_types::traffic_control::{ClientIdSource, PolicyConfig, Weight};
@@ -272,9 +273,40 @@ fn handle_traffic_resp(
 fn normalize(err: ErrorCode) -> Weight {
     match err {
         ErrorCode::InvalidRequest | ErrorCode::InvalidParams => Weight::one(),
+        ErrorCode::ServerError(i) if i == TRANSACTION_NOT_FOUND_ERROR_CODE => Weight::zero(),
         // e.g. invalid client signature
         ErrorCode::ServerError(i) if i == TRANSACTION_EXECUTION_CLIENT_ERROR_CODE => Weight::one(),
         _ => Weight::zero(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_json_rpc_api::{
+        TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSACTION_NOT_FOUND_ERROR_CODE,
+    };
+    use iota_types::traffic_control::Weight;
+    use jsonrpsee::types::ErrorCode;
+
+    use super::normalize;
+
+    #[test]
+    fn transaction_not_found_has_zero_error_weight() {
+        assert_eq!(
+            normalize(ErrorCode::ServerError(TRANSACTION_NOT_FOUND_ERROR_CODE)),
+            Weight::zero()
+        );
+    }
+
+    #[test]
+    fn client_errors_have_full_error_weight() {
+        assert_eq!(normalize(ErrorCode::InvalidParams), Weight::one());
+        assert_eq!(
+            normalize(ErrorCode::ServerError(
+                TRANSACTION_EXECUTION_CLIENT_ERROR_CODE
+            )),
+            Weight::one()
+        );
     }
 }
 

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -7,7 +7,8 @@ use std::collections::BTreeMap;
 use fastcrypto::error::FastCryptoError;
 use hyper::header::InvalidHeaderValue;
 use iota_json_rpc_api::{
-    TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSIENT_ERROR_CODE, error_object_from_rpc,
+    TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSACTION_NOT_FOUND_ERROR_CODE,
+    TRANSIENT_ERROR_CODE, error_object_from_rpc,
 };
 use iota_json_rpc_types::IotaObjectResponseError;
 use iota_names::error::IotaNamesError;
@@ -126,8 +127,12 @@ impl From<Error> for RpcError {
                 None,
             )),
             Error::Iota(iota_error) => match iota_error {
-                IotaError::TransactionNotFound { .. }
-                | IotaError::TransactionsNotFound { .. }
+                IotaError::TransactionNotFound { .. } => RpcError::Call(ErrorObject::owned::<()>(
+                    TRANSACTION_NOT_FOUND_ERROR_CODE,
+                    iota_error.to_string(),
+                    None,
+                )),
+                IotaError::TransactionsNotFound { .. }
                 | IotaError::TransactionEventsNotFound { .. } => {
                     RpcError::Call(ErrorObject::owned::<()>(
                         ErrorCode::InvalidParams.code(),
@@ -294,6 +299,18 @@ mod tests {
             Version::from_u64(0),
             ObjectDigest::new([0; 32]),
         )
+    }
+
+    #[test]
+    fn transaction_not_found_uses_dedicated_error_code() {
+        let error = Error::Iota(IotaError::TransactionNotFound {
+            digest: TransactionDigest::from([1; 32]),
+        });
+
+        let rpc_error: RpcError = error.into();
+        let error_object = error_object_from_rpc(rpc_error);
+
+        assert_eq!(error_object.code(), TRANSACTION_NOT_FOUND_ERROR_CODE);
     }
 
     mod match_quorum_driver_error_tests {

--- a/crates/iota-sdk/src/json_rpc_error.rs
+++ b/crates/iota-sdk/src/json_rpc_error.rs
@@ -43,7 +43,6 @@ impl Error {
                 | METHOD_NOT_FOUND_CODE
                 | BATCHES_NOT_SUPPORTED_CODE
                 | TRANSACTION_EXECUTION_CLIENT_ERROR_CODE
-                | TRANSACTION_NOT_FOUND_ERROR_CODE
         )
     }
 
@@ -80,14 +79,15 @@ mod tests {
     use super::{Error, TRANSACTION_NOT_FOUND_ERROR_CODE};
 
     #[test]
-    fn transaction_not_found_is_classified_as_a_client_error() {
+    fn transaction_not_found_has_dedicated_classification() {
         let error = Error {
             code: TRANSACTION_NOT_FOUND_ERROR_CODE,
             message: "Transaction not found".to_string(),
             data: None,
         };
 
-        assert!(error.is_client_error());
+        assert!(error.is_call_error());
+        assert!(!error.is_client_error());
         assert!(error.is_transaction_not_found());
         assert!(!error.is_execution_error());
         assert!(!error.is_transient_error());

--- a/crates/iota-sdk/src/json_rpc_error.rs
+++ b/crates/iota-sdk/src/json_rpc_error.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_json_rpc_api::error_object_from_rpc;
-pub use iota_json_rpc_api::{TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSIENT_ERROR_CODE};
+pub use iota_json_rpc_api::{
+    TRANSACTION_EXECUTION_CLIENT_ERROR_CODE, TRANSACTION_NOT_FOUND_ERROR_CODE, TRANSIENT_ERROR_CODE,
+};
 use jsonrpsee::types::error::UNKNOWN_ERROR_CODE;
 use thiserror::Error;
 
@@ -41,6 +43,7 @@ impl Error {
                 | METHOD_NOT_FOUND_CODE
                 | BATCHES_NOT_SUPPORTED_CODE
                 | TRANSACTION_EXECUTION_CLIENT_ERROR_CODE
+                | TRANSACTION_NOT_FOUND_ERROR_CODE
         )
     }
 
@@ -50,6 +53,10 @@ impl Error {
 
     pub fn is_transient_error(&self) -> bool {
         self.code == TRANSIENT_ERROR_CODE
+    }
+
+    pub fn is_transaction_not_found(&self) -> bool {
+        self.code == TRANSACTION_NOT_FOUND_ERROR_CODE
     }
 }
 
@@ -65,5 +72,24 @@ impl From<jsonrpsee::core::ClientError> for Error {
                 .data()
                 .map(|v| serde_json::from_str(v.get()).expect("raw json is always valid")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, TRANSACTION_NOT_FOUND_ERROR_CODE};
+
+    #[test]
+    fn transaction_not_found_is_classified_as_a_client_error() {
+        let error = Error {
+            code: TRANSACTION_NOT_FOUND_ERROR_CODE,
+            message: "Transaction not found".to_string(),
+            data: None,
+        };
+
+        assert!(error.is_client_error());
+        assert!(error.is_transaction_not_found());
+        assert!(!error.is_execution_error());
+        assert!(!error.is_transient_error());
     }
 }

--- a/crates/iota-types/src/traffic_control.rs
+++ b/crates/iota-types/src/traffic_control.rs
@@ -108,8 +108,29 @@ impl Weight {
 
     pub fn is_sampled(&self) -> bool {
         let mut rng = rand::thread_rng();
+        // `Uniform::new` excludes the upper bound, so a weight of 1.0 accepts every
+        // sample.
         let sample = rand::distributions::Uniform::new(0.0, 1.0).sample(&mut rng);
-        sample <= self.value()
+        self.accepts(sample)
+    }
+
+    fn accepts(&self, sample: f32) -> bool {
+        sample < self.value()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Weight;
+
+    #[test]
+    fn zero_weight_rejects_the_lowest_sample() {
+        assert!(!Weight::zero().accepts(0.0));
+    }
+
+    #[test]
+    fn full_weight_accepts_the_highest_sample() {
+        assert!(Weight::one().accepts(1.0 - f32::EPSILON));
     }
 }
 


### PR DESCRIPTION
# Description of change

- Return a dedicated JSON-RPC error code when a transaction is not found.
- Exclude this response from the full node error policy.
- Ensure zero-weight tallies are never sampled.
- Preserve the JSON-RPC client-error classification in the local Rust SDK.
- Continue counting the request toward the spam policy.
- Keep invalid requests and terminal transaction errors fully weighted.

## Links to any relevant issues

Fixes #12522.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Full nodes no longer count transaction-not-found responses toward the error policy. Zero-weight tallies are never sampled.
- [ ] Indexer:
- [x] JSON-RPC: iota_getTransactionBlock now returns error code -32003 when a transaction is not found.
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: JSON-RPC errors expose and identify the transaction-not-found error code.
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---
