### PR TITLE
refactor(graphql-rpc): make return type non-optional in {layout,abilities}_impl

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -2561,12 +2561,10 @@ type MoveType {
 	signature: MoveTypeSignature!
 	"""
 	Structured representation of the "shape" of values that match this type.
-	May return MoveTypeLayout::InvalidType for malformed types.
 	"""
 	layout: MoveTypeLayout!
 	"""
-	The abilities this concrete type has. Returns no abilities if the type
-	is invalid.
+	The abilities this concrete type has.
 	"""
 	abilities: [MoveAbility!]!
 }

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -438,7 +438,7 @@ impl MoveObjectImpl<'_> {
     pub(crate) async fn has_public_transfer(&self, ctx: &Context<'_>) -> Result<bool> {
         let type_: MoveType = self.0.native.struct_tag().clone().into();
         let set = type_.abilities_impl(ctx.data_unchecked()).await.extend()?;
-        Ok(set.is_some_and(|s| s.has_key() && s.has_store()))
+        Ok(set.has_key() && set.has_store())
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/move_type.rs
+++ b/crates/iota-graphql-rpc/src/types/move_type.rs
@@ -151,9 +151,7 @@ impl MoveType {
             .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
             .extend()?;
 
-        let Some(layout) = self.layout_impl(resolver).await.extend()? else {
-            return Ok(MoveTypeLayout::InvalidType);
-        };
+        let layout = self.layout_impl(resolver).await.extend()?;
 
         MoveTypeLayout::try_from(layout).extend()
     }
@@ -166,9 +164,7 @@ impl MoveType {
             .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
             .extend()?;
 
-        let Some(abilities) = self.abilities_impl(resolver).await.extend()? else {
-            return Ok(vec![]);
-        };
+        let abilities = self.abilities_impl(resolver).await.extend()?;
 
         Ok(abilities.into_iter().map(MoveAbility::from).collect())
     }
@@ -182,32 +178,28 @@ impl MoveType {
     pub(crate) async fn layout_impl(
         &self,
         resolver: &PackageResolver,
-    ) -> Result<Option<A::MoveTypeLayout>, Error> {
-        Ok(Some(
-            resolver
-                .type_layout(self.native.clone())
-                .await
-                .map_err(|e| {
-                    Error::Internal(format!(
-                        "Error calculating layout for {}: {e}",
-                        self.native.to_canonical_string(/* with_prefix */ true),
-                    ))
-                })?,
-        ))
+    ) -> Result<A::MoveTypeLayout, Error> {
+        Ok(resolver
+            .type_layout(self.native.clone())
+            .await
+            .map_err(|e| {
+                Error::Internal(format!(
+                    "Error calculating layout for {}: {e}",
+                    self.native.to_canonical_string(/* with_prefix */ true),
+                ))
+            })?)
     }
 
     pub(crate) async fn abilities_impl(
         &self,
         resolver: &PackageResolver,
-    ) -> Result<Option<AbilitySet>, Error> {
-        Ok(Some(
-            resolver.abilities(self.native.clone()).await.map_err(|e| {
-                Error::Internal(format!(
-                    "Error calculating abilities for {}: {e}",
-                    self.native.to_canonical_string(/* with_prefix */ true),
-                ))
-            })?,
-        ))
+    ) -> Result<AbilitySet, Error> {
+        Ok(resolver.abilities(self.native.clone()).await.map_err(|e| {
+            Error::Internal(format!(
+                "Error calculating abilities for {}: {e}",
+                self.native.to_canonical_string(/* with_prefix */ true),
+            ))
+        })?)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/move_type.rs
+++ b/crates/iota-graphql-rpc/src/types/move_type.rs
@@ -179,7 +179,7 @@ impl MoveType {
         &self,
         resolver: &PackageResolver,
     ) -> Result<A::MoveTypeLayout, Error> {
-        Ok(resolver
+        resolver
             .type_layout(self.native.clone())
             .await
             .map_err(|e| {
@@ -187,19 +187,19 @@ impl MoveType {
                     "Error calculating layout for {}: {e}",
                     self.native.to_canonical_string(/* with_prefix */ true),
                 ))
-            })?)
+            })
     }
 
     pub(crate) async fn abilities_impl(
         &self,
         resolver: &PackageResolver,
     ) -> Result<AbilitySet, Error> {
-        Ok(resolver.abilities(self.native.clone()).await.map_err(|e| {
+        resolver.abilities(self.native.clone()).await.map_err(|e| {
             Error::Internal(format!(
                 "Error calculating abilities for {}: {e}",
                 self.native.to_canonical_string(/* with_prefix */ true),
             ))
-        })?)
+        })
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/move_type.rs
+++ b/crates/iota-graphql-rpc/src/types/move_type.rs
@@ -144,7 +144,6 @@ impl MoveType {
     }
 
     /// Structured representation of the "shape" of values that match this type.
-    /// May return MoveTypeLayout::InvalidType for malformed types.
     async fn layout(&self, ctx: &Context<'_>) -> Result<MoveTypeLayout> {
         let resolver: &PackageResolver = ctx
             .data()
@@ -156,8 +155,7 @@ impl MoveType {
         MoveTypeLayout::try_from(layout).extend()
     }
 
-    /// The abilities this concrete type has. Returns no abilities if the type
-    /// is invalid.
+    /// The abilities this concrete type has.
     async fn abilities(&self, ctx: &Context<'_>) -> Result<Vec<MoveAbility>> {
         let resolver: &PackageResolver = ctx
             .data()

--- a/crates/iota-graphql-rpc/src/types/move_value.rs
+++ b/crates/iota-graphql-rpc/src/types/move_value.rs
@@ -111,12 +111,7 @@ impl MoveValue {
             .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
             .extend()?;
 
-        let Some(layout) = self.type_.layout_impl(resolver).await.extend()? else {
-            return Err(Error::Internal(
-                "Move value must have valid layout".to_string(),
-            ))
-            .extend();
-        };
+        let layout = self.type_.layout_impl(resolver).await.extend()?;
 
         // Factor out into its own non-GraphQL, non-async function for better
         // testability
@@ -143,12 +138,7 @@ impl MoveValue {
             .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
             .extend()?;
 
-        let Some(layout) = self.type_.layout_impl(resolver).await.extend()? else {
-            return Err(Error::Internal(
-                "Move value must have valid layout".to_string(),
-            ))
-            .extend();
-        };
+        let layout = self.type_.layout_impl(resolver).await.extend()?;
 
         // Factor out into its own non-GraphQL, non-async function for better
         // testability

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2565,12 +2565,10 @@ type MoveType {
 	signature: MoveTypeSignature!
 	"""
 	Structured representation of the "shape" of values that match this type.
-	May return MoveTypeLayout::InvalidType for malformed types.
 	"""
 	layout: MoveTypeLayout!
 	"""
-	The abilities this concrete type has. Returns no abilities if the type
-	is invalid.
+	The abilities this concrete type has.
 	"""
 	abilities: [MoveAbility!]!
 }


### PR DESCRIPTION
# Description of change

This patch makes the return type in `MoveTypeLayout::{abilities,layout}_impl` method non-optional following #10687 

## Related issues

Fixes #10911 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
