### PR TITLE
chore: bump iota-rust-sdk rev to b05cf69

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7559,7 +7559,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7617,7 +7617,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7625,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7559,7 +7559,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7617,7 +7617,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7625,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,9 +398,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "8b122bb1baec67f86f82457c43787062acbbafd6" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "8b122bb1baec67f86f82457c43787062acbbafd6" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -440,10 +440,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "8b122bb1baec67f86f82457c43787062acbbafd6", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "8b122bb1baec67f86f82457c43787062acbbafd6", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "8b122bb1baec67f86f82457c43787062acbbafd6", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "8b122bb1baec67f86f82457c43787062acbbafd6", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,9 +398,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "b05cf69504951baeb8fbe3f434c22e596fbec330" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "b05cf69504951baeb8fbe3f434c22e596fbec330" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -440,10 +440,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b05cf69504951baeb8fbe3f434c22e596fbec330", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b05cf69504951baeb8fbe3f434c22e596fbec330", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b05cf69504951baeb8fbe3f434c22e596fbec330", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b05cf69504951baeb8fbe3f434c22e596fbec330", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -1557,7 +1557,7 @@ mod adapter_tests {
         );
 
         // transaction to submit
-        let tx_digest = TransactionDigest::generate(&mut rng);
+        let tx_digest = TransactionDigest::random_with(&mut rng);
 
         // Ensure that the original position is higher
         let (position, positions_moved, _) =
@@ -1607,7 +1607,7 @@ mod adapter_tests {
         const NUM_TEST_TRANSACTIONS: usize = 1000;
 
         for _tx_idx in 0..NUM_TEST_TRANSACTIONS {
-            let tx_digest = TransactionDigest::generate(&mut rng);
+            let tx_digest = TransactionDigest::random_with(&mut rng);
 
             let mut zero_found = false;
             for (name, _) in committee.members() {

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -175,9 +175,9 @@ fn get_registry() -> Result<Registry> {
     let sig: AuthoritySignature = Signer::sign(&kp, b"hello world");
     tracer.trace_value(&mut samples, &sig).unwrap();
 
-    let kp1 = Ed25519PrivateKey::generate(StdRng::from_seed([0; 32]));
-    let kp2 = Secp256k1PrivateKey::generate(StdRng::from_seed([0; 32]));
-    let kp3 = Secp256r1PrivateKey::generate(StdRng::from_seed([0; 32]));
+    let kp1 = Ed25519PrivateKey::random_with(StdRng::from_seed([0; 32]));
+    let kp2 = Secp256k1PrivateKey::random_with(StdRng::from_seed([0; 32]));
+    let kp3 = Secp256r1PrivateKey::random_with(StdRng::from_seed([0; 32]));
 
     // ... and the user signature which does
     let sig: SimpleSignature = kp1.sign(b"hello world");

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -405,7 +405,7 @@ mod tests {
             ServiceConfig::test_defaults(),
         )
         .await;
-        let digest = TransactionDigest::generate(StdRng::from_seed([12; 32])).to_string();
+        let digest = TransactionDigest::random_with(StdRng::from_seed([12; 32])).to_string();
 
         assert!(
             !query_is_transaction_indexed_on_node(&cluster.graphql_client, digest.as_str()).await

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -2529,7 +2529,7 @@ fn is_transaction_not_present() {
 
     runtime.block_on(async {
         let rng = StdRng::from_seed([1; 32]);
-        let digest = TransactionDigest::generate(rng);
+        let digest = TransactionDigest::random_with(rng);
 
         indexer_wait_for_checkpoint(store, 1).await;
 

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -563,7 +563,7 @@ async fn get_transaction_block() {
 async fn is_transaction_not_present() {
     let cluster = TestClusterBuilder::new().build().await;
     let rng = StdRng::from_seed([1; 32]);
-    let digest = TransactionDigest::generate(rng);
+    let digest = TransactionDigest::random_with(rng);
 
     assert!(
         !cluster

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -520,7 +520,7 @@ impl RpcExampleProvider {
     }
 
     fn iota_is_transaction_indexed_on_node(&mut self) -> Examples {
-        let digest = TransactionDigest::generate(self.rng.clone());
+        let digest = TransactionDigest::random_with(self.rng.clone());
         Examples::new(
             "iota_isTransactionIndexedOnNode",
             vec![ExamplePairing::new(

--- a/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
+++ b/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
@@ -39,11 +39,12 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // deterministically generate a keypair, testing only, do not use for mainnet,
     // use the next section to randomly generate a keypair instead.
-    let ikp_determ_0 = SimpleKeypair::from(Ed25519PrivateKey::generate(StdRng::from_seed([0; 32])));
+    let ikp_determ_0 =
+        SimpleKeypair::from(Ed25519PrivateKey::random_with(StdRng::from_seed([0; 32])));
     let _ikp_determ_1 =
-        SimpleKeypair::from(Secp256k1PrivateKey::generate(StdRng::from_seed([0; 32])));
+        SimpleKeypair::from(Secp256k1PrivateKey::random_with(StdRng::from_seed([0; 32])));
     let _ikp_determ_2 =
-        SimpleKeypair::from(Secp256r1PrivateKey::generate(StdRng::from_seed([0; 32])));
+        SimpleKeypair::from(Secp256r1PrivateKey::random_with(StdRng::from_seed([0; 32])));
 
     // randomly generate a keypair.
     let _ikp_rand_0 = SimpleKeypair::from(Ed25519PrivateKey::random());

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -492,7 +492,7 @@ impl GenesisConfig {
     pub fn benchmark_gas_keys(n: usize) -> Vec<SimpleKeypair> {
         let mut rng = StdRng::seed_from_u64(Self::BENCHMARKS_RNG_SEED);
         (0..n)
-            .map(|_| SimpleKeypair::from(AccountKeyPair::generate(&mut rng)))
+            .map(|_| SimpleKeypair::from(AccountKeyPair::random_with(&mut rng)))
             .collect()
     }
 

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -507,7 +507,7 @@ macro_rules! random_key_pair_from_sdk {
     ($private_key:ty, $variant:ident) => {
         impl RandomKeyPair for $private_key {
             fn generate_with_address(rng: &mut StdRng) -> (Address, Self) {
-                let kp = <$private_key>::generate(rng);
+                let kp = <$private_key>::random_with(rng);
                 let public = PublicKey::$variant(BytesRepresentation(kp.public_key().into_inner()));
                 (Address::from(&public), kp)
             }

--- a/crates/iota-types/src/unit_tests/crypto_tests.rs
+++ b/crates/iota-types/src/unit_tests/crypto_tests.rs
@@ -10,7 +10,7 @@ use super::*;
 
 #[test]
 fn serde_keypair() {
-    let ikp = SimpleKeypair::from(Ed25519PrivateKey::generate(StdRng::from_seed([0; 32])));
+    let ikp = SimpleKeypair::from(Ed25519PrivateKey::random_with(StdRng::from_seed([0; 32])));
     let encoded = ikp.to_bech32().unwrap();
     assert_eq!(
         encoded,

--- a/crates/iota-types/src/unit_tests/utils.rs
+++ b/crates/iota-types/src/unit_tests/utils.rs
@@ -81,7 +81,7 @@ pub fn create_fake_transaction() -> TransactionEnvelope {
 
 pub fn make_transaction_data(sender: Address) -> Transaction {
     let object =
-        Object::immutable_with_id_for_testing(ObjectId::generate(StdRng::from_seed([0; 32])));
+        Object::immutable_with_id_for_testing(ObjectId::random_with(StdRng::from_seed([0; 32])));
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder.transfer_iota(dbg_addr(2), None);

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -461,7 +461,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ///
     /// # fn main() {
     /// let mut simulacrum = Simulacrum::new();
-    /// let address = simulacrum.with_rng(|rng| Address::generate(rng));
+    /// let address = simulacrum.with_rng(|rng| Address::random_with(rng));
     /// simulacrum.request_gas(address, NANOS_PER_IOTA).unwrap();
     ///
     /// // `account` now has a Coin<IOTA> object with single IOTA in it.

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3341,7 +3341,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=b05cf69504951baeb8fbe3f434c22e596fbec330#b05cf69504951baeb8fbe3f434c22e596fbec330"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -2926,14 +2926,14 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
 
 [[package]]
 name = "iota-framework"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "bytes",
  "http",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "iota-multiaddr"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anemo",
  "eyre",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3341,7 +3341,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8b122bb1baec67f86f82457c43787062acbbafd6#8b122bb1baec67f86f82457c43787062acbbafd6"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=2eb0e2641b49248c5aba1c3247f0642225e83803#2eb0e2641b49248c5aba1c3247f0642225e83803"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus-filtered",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-filtered"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "prometheus",
  "serde",
@@ -7415,7 +7415,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.30.0-alpha"
+version = "1.31.0-alpha"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "8b122bb1baec67f86f82457c43787062acbbafd6" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b05cf69504951baeb8fbe3f434c22e596fbec330" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "b05cf69504951baeb8fbe3f434c22e596fbec330" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "8b122bb1baec67f86f82457c43787062acbbafd6" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "2eb0e2641b49248c5aba1c3247f0642225e83803" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
# Description of change

- Bump `iota-rust-sdk` rev from `8b122bb` to `b05cf69` in the workspace and example manifests.
- Adapt to the `generate` → `random_with` rename (iotaledger/iota-rust-sdk#1344) at all call sites.

## Links to any relevant issues

n/a

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

Dependency bump with mechanical call-site updates; `cargo check -p iota-types -p iota-swarm-config -p iota-open-rpc -p iota-core -p iota-sdk --tests --examples` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
