### PR TITLE
upstream(iota-adapter-transactional-tests): Port upstream miscellaneous chores (lock_file, simtest, tests)

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/entry_checks.move
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/entry_checks.move
@@ -2,20 +2,73 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-// entry checks disabled during dev inspect
+// entry checks maintained during dev inspect
 
 //# init --addresses test=0x0 --accounts A
 
 //# publish
 
 module test::m {
-    public fun return_u64(): u64 {
+
+    public fun public_take_and_return_pure(input: u64): u64 {
+        input
+    }
+
+    public fun public_take_pure(_input: u64) {
+        // Do nothing with input
+    }
+
+    entry fun entry_take_pure(_input: u64) {}
+
+
+    public fun public_take_and_return_object(obj: A): A {
+        obj
+    }
+
+    entry fun entry_take_object(obj: A) {
+        let A { id } = obj;
+        id.delete();
+    }
+
+    public fun public_pure_return_value(): u64 {
         0
     }
-    entry fun entry_take_u64(_n: u64) {
+
+    entry fun entry_return_u64(): u64 {
+        0
+    }
+
+    public struct A has key, store {
+        id: UID,
+    }
+
+    public fun create_object(ctx: &mut TxContext): A {
+        A { id: object::new(ctx) }
     }
 }
 
+
+// Basic pure tainted input
+//# programmable --sender A --inputs 0 --dev-inspect
+//> 0: test::m::public_take_and_return_pure(Input(0));
+//> 1: test::m::entry_take_pure(Result(0));
+
+// Object tainted
+//# programmable --sender A --inputs 0 --dev-inspect
+//> 0: test::m::create_object();
+//> 1: test::m::entry_take_object(Result(0));
+
+// Pass a value created by a public function
 //# programmable --sender A --dev-inspect
-//> 0: test::m::return_u64();
-//> 1: test::m::entry_take_u64(Result(0));
+//> 0: test::m::public_pure_return_value();
+//> 1: test::m::entry_take_pure(Result(0));
+
+// Use input on each call instead of result is allowed for pure inputs
+//# programmable --sender A --inputs 0 --dev-inspect
+//> 0: test::m::public_take_pure(Input(0));
+//> 1: test::m::entry_take_pure(Input(0));
+
+// Entry to entry
+//# programmable --sender A --dev-inspect
+//> 0: test::m::entry_return_u64();
+//> 1: test::m::entry_take_pure(Result(0));

--- a/crates/iota-adapter-transactional-tests/tests/dev_inspect/entry_checks.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dev_inspect/entry_checks.snap
@@ -1,20 +1,52 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 3 tasks
+processed 7 tasks
 
 init:
 A: object(0,0)
 
-task 1, lines 9-17:
+task 1, lines 9-51:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3708800, storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6764000, storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 19-21:
+task 2, lines 52-56:
+//# programmable --sender A --inputs 0 --dev-inspect
+//> 0: test::m::public_take_and_return_pure(Input(0));
+//> 1: test::m::entry_take_pure(Result(0));
+// Object tainted
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+Execution Error: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+
+task 3, lines 57-61:
+//# programmable --sender A --inputs 0 --dev-inspect
+//> 0: test::m::create_object();
+//> 1: test::m::entry_take_object(Result(0));
+// Pass a value created by a public function
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+Execution Error: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+
+task 4, lines 62-66:
 //# programmable --sender A --dev-inspect
-//> 0: test::m::return_u64();
-//> 1: test::m::entry_take_u64(Result(0));
+//> 0: test::m::public_pure_return_value();
+//> 1: test::m::entry_take_pure(Result(0));
+// Use input on each call instead of result is allowed for pure inputs
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+Execution Error: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+
+task 5, lines 67-71:
+//# programmable --sender A --inputs 0 --dev-inspect
+//> 0: test::m::public_take_pure(Input(0));
+//> 1: test::m::entry_take_pure(Input(0));
+// Entry to entry
+mutated: object(_)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6, lines 72-74:
+//# programmable --sender A --dev-inspect
+//> 0: test::m::entry_return_u64();
+//> 1: test::m::entry_take_pure(Result(0));
 Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
 Execution Error: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/entry_checks.move
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/entry_checks.move
@@ -9,13 +9,66 @@
 //# publish
 
 module test::m {
-    public fun return_u64(): u64 {
+
+    public fun public_take_and_return_pure(input: u64): u64 {
+        input
+    }
+
+    public fun public_take_pure(_input: u64) {
+        // Do nothing with input
+    }
+
+    entry fun entry_take_pure(_input: u64) {}
+
+
+    public fun public_take_and_return_object(obj: A): A {
+        obj
+    }
+
+    entry fun entry_take_object(obj: A) {
+        let A { id } = obj;
+        id.delete();
+    }
+
+    public fun public_pure_return_value(): u64 {
         0
     }
-    entry fun entry_take_u64(_n: u64) {
+
+    entry fun entry_return_u64(): u64 {
+        0
+    }
+
+    public struct A has key, store {
+        id: UID,
+    }
+
+    public fun create_object(ctx: &mut TxContext): A {
+        A { id: object::new(ctx) }
     }
 }
 
+
+// Basic pure tainted input
+//# programmable --sender A --inputs 0 --dry-run
+//> 0: test::m::public_take_and_return_pure(Input(0));
+//> 1: test::m::entry_take_pure(Result(0));
+
+// Object tainted
+//# programmable --sender A --inputs 0 --dry-run
+//> 0: test::m::create_object();
+//> 1: test::m::entry_take_object(Result(0));
+
+// Pass a value created by a public function
 //# programmable --sender A --dry-run
-//> 0: test::m::return_u64();
-//> 1: test::m::entry_take_u64(Result(0));
+//> 0: test::m::public_pure_return_value();
+//> 1: test::m::entry_take_pure(Result(0));
+
+// Use input on each call instead of result is allowed for pure inputs
+//# programmable --sender A --inputs 0 --dry-run
+//> 0: test::m::public_take_pure(Input(0));
+//> 1: test::m::entry_take_pure(Input(0));
+
+// Entry to entry
+//# programmable --sender A --dry-run
+//> 0: test::m::entry_return_u64();
+//> 1: test::m::entry_take_pure(Result(0));

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/entry_checks.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/entry_checks.snap
@@ -1,20 +1,52 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 3 tasks
+processed 7 tasks
 
 init:
 A: object(0,0)
 
-task 1, lines 9-17:
+task 1, lines 9-51:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3708800, storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6764000, storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 19-21:
+task 2, lines 52-56:
+//# programmable --sender A --inputs 0 --dry-run
+//> 0: test::m::public_take_and_return_pure(Input(0));
+//> 1: test::m::entry_take_pure(Result(0));
+// Object tainted
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+Execution Error: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+
+task 3, lines 57-61:
+//# programmable --sender A --inputs 0 --dry-run
+//> 0: test::m::create_object();
+//> 1: test::m::entry_take_object(Result(0));
+// Pass a value created by a public function
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+Execution Error: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+
+task 4, lines 62-66:
 //# programmable --sender A --dry-run
-//> 0: test::m::return_u64();
-//> 1: test::m::entry_take_u64(Result(0));
+//> 0: test::m::public_pure_return_value();
+//> 1: test::m::entry_take_pure(Result(0));
+// Use input on each call instead of result is allowed for pure inputs
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+Execution Error: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
+
+task 5, lines 67-71:
+//# programmable --sender A --inputs 0 --dry-run
+//> 0: test::m::public_take_pure(Input(0));
+//> 1: test::m::entry_take_pure(Input(0));
+// Entry to entry
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6, lines 72-74:
+//# programmable --sender A --dry-run
+//> 0: test::m::entry_return_u64();
+//> 1: test::m::entry_take_pure(Result(0));
 Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1
 Execution Error: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions in command 1

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.move
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.move
@@ -15,10 +15,23 @@ module test::m {
     public struct Obj has key {
         id: object::UID,
         contents: vector<u8>
-
     }
 
-    public entry fun large_vector(n: u64, ctx: &mut TxContext) {
+    entry fun get_objects(ctx: &mut TxContext) {
+        let mut i = 0;
+        while (i < 5) {
+            let obj = Obj { id: object::new(ctx), contents: vector::empty() };
+            transfer::transfer(obj, tx_context::sender(ctx));
+            i = i + 1;
+        };
+    }
+
+    entry fun destroy_object(obj: Obj) {
+        let Obj { id, contents: _ } = obj;
+        id.delete();
+    }
+
+    public entry fun large_storage_func(n: u64, ctx: &mut TxContext) {
         let mut v: vector<u64> = vector::empty();
         let mut i = 0;
         while (i < n) {
@@ -28,7 +41,21 @@ module test::m {
 
         transfer::transfer(Obj { id: object::new(ctx), contents: vector::empty() }, tx_context::sender(ctx))
     }
+
+    // no objects just computation
+    public entry fun large_compute_func(n: u64) {
+        let mut v: vector<u64> = vector::empty();
+        let mut i = 0;
+        while (i < n) {
+            vector::push_back(&mut v, i);
+            i = i + 1;
+        };
+    }
 }
+
+// Give A a 5 objects 2,0 to 2,4
+//# programmable --sender A
+//> 0: test::m::get_objects();
 
 // Move all A coins to B
 //# programmable --sender A --inputs @B
@@ -39,22 +66,53 @@ module test::m {
 //> SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 
-// Account A now has 3,0
-//# view-object 3,0
+// Account A now has gas object 4,0 and a balance of 2
+//# view-object 4,0
 
-// Not enough gas for large_vector()
-//# programmable --sender A --inputs 100 --dry-run --gas-payment 3,0
-//> 0: test::m::large_vector(Input(0));
+// Not enough gas for large_storage_func()
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 4,0
+//> 0: test::m::large_storage_func(Input(0));
 
 // Give A enough gas to send transaction after rebates, it should still fail
 //# programmable --sender B --inputs 2499999999 @A
 //> SplitCoins(Gas, [Input(0), Input(0)]);
 //> TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(1))
 
-// Account A now has 6,0 6,1 that are 2 gas short of the needed amount
-//# programmable --sender A --inputs 100 --dry-run --gas-payment 6,0 --gas-payment 6,1
-//> 0: test::m::large_vector(Input(0));
+// Account A now has 7,0 7,1 that are 2 gas short of the needed amount, note gas smashing rebate also occurs
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 7,0 --gas-payment 7,1
+//> 0: test::m::large_storage_func(Input(0));
+
+// Destroying an object before the transaction ends does not allow the transaction to succeed
+//# programmable --sender A --inputs object(2,0) 100 --dry-run --gas-payment 7,0 --gas-payment 7,1
+//> 0: test::m::destroy_object(Input(0));
+//> 1: test::m::large_storage_func(Input(1));
 
 // Include 3,0 in the gas payment, it should succeed
-//# programmable --sender A --inputs 100 --dry-run --gas-payment 6,0 --gas-payment 6,1 --gas-payment 3,0
-//> 0: test::m::large_vector(Input(0));
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 7,0 --gas-payment 7,1 --gas-payment 4,0
+//> 0: test::m::large_storage_func(Input(0));
+
+// Return the balance of A to zero
+//# programmable --sender A --inputs object(7,0) --dry-run --gas-payment 4,0
+
+// Return a small amount of coin to A
+//# programmable --sender B --inputs 2 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+// Give A enough gas to send transaction
+//# programmable --sender B --inputs 2499999999 @A
+//> SplitCoins(Gas, [Input(0), Input(0)]);
+//> TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(1))
+
+// Not enough gas for large_compute_func() when excluding 12,0, gas smashing rebates
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 13,0 --gas-payment 13,1
+//> 0: test::m::large_compute_func(Input(0));
+
+// Destroying an object before the transaction ends does not allow the transaction to succeed
+//# programmable --sender A --inputs object(2,0) 100 --dry-run --gas-payment 13,0 --gas-payment 13,1
+//> 0: test::m::destroy_object(Input(0));
+//> 1: test::m::large_compute_func(Input(1));
+
+// Include 3,0 in the gas payment, it should succeed
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 13,0 --gas-payment 13,1 --gas-payment 12,0
+//> 0: test::m::large_compute_func(Input(0));

--- a/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dry_run/gas_missing.snap
@@ -1,41 +1,49 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 9 tasks
+processed 17 tasks
 
 init:
 A: object(0,0), B: object(0,1), C: object(0,2)
 
-task 1, lines 9-33:
+task 1, lines 9-56:
 //# publish
 created: object(1,0)
 mutated: object(0,3)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5738000, storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 7501200, storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 34-37:
+task 2, lines 57-60:
+//# programmable --sender A
+//> 0: test::m::get_objects();
+// Move all A coins to B
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 7098400, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 61-64:
 //# programmable --sender A --inputs @B
 //> TransferObjects([Gas], Input(0))
 // Return a small amount of coin to A
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400, storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400, storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 3, lines 38-42:
+task 4, lines 65-69:
 //# programmable --sender B --inputs 2 @A
 //> SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
-// Account A now has 3,0
-created: object(3,0)
+// Account A now has gas object 4,0 and a balance of 2
+created: object(4,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800, storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 4, lines 43-45:
-//# view-object 3,0
+task 5, lines 70-72:
+//# view-object 4,0
 Owner: Address(A)
 Version: 2
 Contents: iota::coin::Coin<iota::iota::IOTA> {
     id: iota::object::UID {
         id: iota::object::ID {
-            bytes: fake(3,0),
+            bytes: fake(4,0),
         },
     },
     balance: iota::balance::Balance<iota::iota::IOTA> {
@@ -43,31 +51,82 @@ Contents: iota::coin::Coin<iota::iota::IOTA> {
     },
 }
 
-task 5, lines 46-49:
-//# programmable --sender A --inputs 100 --dry-run --gas-payment 3,0
-//> 0: test::m::large_vector(Input(0));
+task 6, lines 73-76:
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 4,0
+//> 0: test::m::large_storage_func(Input(0));
 // Give A enough gas to send transaction after rebates, it should still fail
 Error: Error checking transaction input objects: Balance of gas object 2 is lower than the needed amount: 5000000000
 
-task 6, lines 50-54:
+task 7, lines 77-81:
 //# programmable --sender B --inputs 2499999999 @A
 //> SplitCoins(Gas, [Input(0), Input(0)]);
 //> TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(1))
-// Account A now has 6,0 6,1 that are 2 gas short of the needed amount
-created: object(6,0), object(6,1)
+// Account A now has 7,0 7,1 that are 2 gas short of the needed amount, note gas smashing rebate also occurs
+created: object(7,0), object(7,1)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2941200, storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 7, lines 55-58:
-//# programmable --sender A --inputs 100 --dry-run --gas-payment 6,0 --gas-payment 6,1
-//> 0: test::m::large_vector(Input(0));
+task 8, lines 82-85:
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 7,0 --gas-payment 7,1
+//> 0: test::m::large_storage_func(Input(0));
+// Destroying an object before the transaction ends does not allow the transaction to succeed
+Error: Error checking transaction input objects: Balance of gas object 4999999998 is lower than the needed amount: 5000000000
+
+task 9, lines 86-90:
+//# programmable --sender A --inputs object(2,0) 100 --dry-run --gas-payment 7,0 --gas-payment 7,1
+//> 0: test::m::destroy_object(Input(0));
+//> 1: test::m::large_storage_func(Input(1));
 // Include 3,0 in the gas payment, it should succeed
 Error: Error checking transaction input objects: Balance of gas object 4999999998 is lower than the needed amount: 5000000000
 
-task 8, lines 59-60:
-//# programmable --sender A --inputs 100 --dry-run --gas-payment 6,0 --gas-payment 6,1 --gas-payment 3,0
-//> 0: test::m::large_vector(Input(0));
-created: object(8,0)
-mutated: object(6,0)
-deleted: object(3,0), object(6,1)
+task 10, lines 91-94:
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 7,0 --gas-payment 7,1 --gas-payment 4,0
+//> 0: test::m::large_storage_func(Input(0));
+// Return the balance of A to zero
+created: object(10,0)
+mutated: object(7,0)
+deleted: object(4,0), object(7,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2204000, storage_rebate: 2941200, non_refundable_storage_fee: 0
+
+task 11, lines 95-97:
+//# programmable --sender A --inputs object(7,0) --dry-run --gas-payment 4,0
+// Return a small amount of coin to A
+Error: Error checking transaction input objects: Balance of gas object 2 is lower than the needed amount: 5000000000
+
+task 12, lines 98-102:
+//# programmable --sender B --inputs 2 @A
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+// Give A enough gas to send transaction
+created: object(12,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 13, lines 103-107:
+//# programmable --sender B --inputs 2499999999 @A
+//> SplitCoins(Gas, [Input(0), Input(0)]);
+//> TransferObjects([NestedResult(0,0), NestedResult(0,1)], Input(1))
+// Not enough gas for large_compute_func() when excluding 12,0, gas smashing rebates
+created: object(13,0), object(13,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2941200, storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 14, lines 108-111:
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 13,0 --gas-payment 13,1
+//> 0: test::m::large_compute_func(Input(0));
+// Destroying an object before the transaction ends does not allow the transaction to succeed
+Error: Error checking transaction input objects: Balance of gas object 4999999998 is lower than the needed amount: 5000000000
+
+task 15, lines 112-116:
+//# programmable --sender A --inputs object(2,0) 100 --dry-run --gas-payment 13,0 --gas-payment 13,1
+//> 0: test::m::destroy_object(Input(0));
+//> 1: test::m::large_compute_func(Input(1));
+// Include 3,0 in the gas payment, it should succeed
+Error: Error checking transaction input objects: Balance of gas object 4999999998 is lower than the needed amount: 5000000000
+
+task 16, lines 117-118:
+//# programmable --sender A --inputs 100 --dry-run --gas-payment 13,0 --gas-payment 13,1 --gas-payment 12,0
+//> 0: test::m::large_compute_func(Input(0));
+mutated: object(13,0)
+deleted: object(12,0), object(13,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400, storage_rebate: 2941200, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/publish/basic.move
+++ b/crates/iota-adapter-transactional-tests/tests/publish/basic.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test1=0x0 test2=0x1 --accounts A
+
+// Simple publish test
+
+// Passing
+
+//# publish --dry-run
+
+module test1::m1 {
+    fun init(_: &iota::tx_context::TxContext) {
+    }
+}
+
+//# publish
+
+module test1::m2 {
+    fun init(_: &iota::tx_context::TxContext) {
+    }
+}
+
+// Failing
+
+//# publish --dry-run
+
+module test2::m3 {
+    fun init(_: &iota::tx_context::TxContext) {
+    }
+}
+
+//# publish
+
+module test2::m4 {
+    fun init(_: &iota::tx_context::TxContext) {
+    }
+}

--- a/crates/iota-adapter-transactional-tests/tests/publish/basic.snap
+++ b/crates/iota-adapter-transactional-tests/tests/publish/basic.snap
@@ -1,0 +1,29 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-16:
+//# publish --dry-run
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3891200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-25:
+//# publish
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3891200, storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 27-32:
+//# publish --dry-run
+Error: Transaction Effects Status: Publish Error, Non-zero Address. The modules in the package must have their self-addresses set to zero. in command 0
+Execution Error: Publish Error, Non-zero Address. The modules in the package must have their self-addresses set to zero. in command 0
+
+task 4, lines 34-39:
+//# publish
+Error: Transaction Effects Status: Publish Error, Non-zero Address. The modules in the package must have their self-addresses set to zero.
+Execution Error: PublishErrorNonZeroAddress: Publish Error, Non-zero Address. The modules in the package must have their self-addresses set to zero.; caused by: Publishing module m4 with non-zero address is not allowed; at command index: 0

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/basic.move
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/basic.move
@@ -10,6 +10,7 @@ module Test::M1 {
     public fun f1() { }
 }
 
+// Failing
 //# upgrade --package Test --upgrade-capability 1,1 --sender A --dry-run
 module Test::M1 {
     fun init(_ctx: &mut TxContext) { }
@@ -18,4 +19,20 @@ module Test::M1 {
 //# upgrade --package Test --upgrade-capability 1,1 --sender A
 module Test::M1 {
     fun init(_ctx: &mut TxContext) { }
+}
+
+
+// Passing
+//# upgrade --package Test --upgrade-capability 1,1 --sender A --dry-run
+module Test::M1 {
+    fun init(_ctx: &mut TxContext) { }
+    public fun f1() { }
+    public fun f2() { }
+}
+
+//# upgrade --package Test --upgrade-capability 1,1 --sender A
+module Test::M1 {
+    fun init(_ctx: &mut TxContext) { }
+    public fun f1() { }
+    public fun f2() { }
 }

--- a/crates/iota-adapter-transactional-tests/tests/upgrade/basic.snap
+++ b/crates/iota-adapter-transactional-tests/tests/upgrade/basic.snap
@@ -1,23 +1,35 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 4 tasks
+processed 6 tasks
 
 init:
 A: object(0,0)
 
-task 1, lines 7-11:
+task 1, lines 7-13:
 //# publish --upgradeable --sender A
 created: object(1,0), object(1,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5631600, storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 13-16:
+task 2, lines 14-17:
 //# upgrade --package Test --upgrade-capability 1,1 --sender A --dry-run
 Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version in command 1
 Execution Error: Invalid package upgrade. New package is incompatible with previous version in command 1
 
-task 3, lines 18-21:
+task 3, lines 19-25:
 //# upgrade --package Test --upgrade-capability 1,1 --sender A
 Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
 Execution Error: PackageUpgradeError: Invalid package upgrade. New package is incompatible with previous version; caused by: PartialVMError with status BACKWARD_INCOMPATIBLE_MODULE_UPDATE; at command index: 1
+
+task 4, lines 26-31:
+//# upgrade --package Test --upgrade-capability 1,1 --sender A --dry-run
+created: object(4,0)
+mutated: object(_), object(1,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5745600, storage_rebate: 1626400, non_refundable_storage_fee: 0
+
+task 5, lines 33-38:
+//# upgrade --package Test --upgrade-capability 1,1 --sender A
+created: object(5,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5745600, storage_rebate: 2606800, non_refundable_storage_fee: 0

--- a/crates/iota-package-management/src/lib.rs
+++ b/crates/iota-package-management/src/lib.rs
@@ -47,10 +47,10 @@ pub enum PublishedAtError {
     },
 }
 
-/// Update the `Move.lock` file with automated address management info.
-/// Expects a wallet context, the publish or upgrade command, its response.
-/// The `Move.lock` principally file records the published address (i.e.,
-/// package ID) of a package under an environment determined by the wallet
+/// Update the `Move.lock` file with automated address management info. Expects
+/// a wallet context, the publish or upgrade command, and its response. The
+/// `Move.lock` file principally records the published address (i.e., package
+/// ID) of a package under an environment determined by the wallet
 /// context config. See the `ManagedPackage` type in the lock file for a
 /// complete spec.
 pub async fn update_lock_file(
@@ -79,7 +79,7 @@ pub async fn update_lock_file(
 /// This variant accepts the package ID and version directly, allowing for
 /// updates when a single transaction publishes multiple packages.
 /// Expects a wallet context, the publish or upgrade command, and the package
-/// details. The `Move.lock` principally file records the published address
+/// details. The `Move.lock` file principally records the published address
 /// (i.e., package ID) of a package under an environment determined by the
 /// wallet context config. See the `ManagedPackage` type in the lock file for a
 /// complete spec.
@@ -99,7 +99,37 @@ pub async fn update_lock_file_with_package_id(
         .get_chain_identifier()
         .await
         .context("Network issue: couldn't determine chain identifier for updating Move.lock")?;
+    let env = context.active_env().context(
+        "Could not resolve environment from active wallet context. \
+         Try ensure `iota client active-env` is valid.",
+    )?;
 
+    update_lock_file_for_chain_env(
+        &chain_identifier,
+        env.alias(),
+        command,
+        install_dir,
+        lock_file,
+        original_id,
+        version,
+    )
+    .await
+}
+
+/// Update the `Move.lock` file with automated address management info. Expects
+/// a chain identifier, env alias, the publish or upgrade command, and the
+/// package details. The `Move.lock` file principally records the published
+/// address (i.e., package ID) of a package under an environment in the given
+/// chain. See the `ManagedPackage` type in the lock file for a complete spec.
+pub async fn update_lock_file_for_chain_env(
+    chain_identifier: &str,
+    env_alias: &str,
+    command: LockCommand,
+    install_dir: Option<PathBuf>,
+    lock_file: Option<PathBuf>,
+    original_id: ObjectId,
+    version: u64,
+) -> Result<(), anyhow::Error> {
     let Some(lock_file) = lock_file else {
         bail!(
             "Expected a `Move.lock` file to exist after publishing \
@@ -108,24 +138,20 @@ pub async fn update_lock_file_with_package_id(
         )
     };
     let install_dir = install_dir.unwrap_or(PathBuf::from("."));
-    let env = context.active_env().context(
-        "Could not resolve environment from active wallet context. \
-         Try ensure `iota client active-env` is valid.",
-    )?;
 
     let mut lock = LockFile::from(install_dir, &lock_file)?;
     match command {
         LockCommand::Publish => lock_file::schema::update_managed_address(
             &mut lock,
-            env.alias(),
+            env_alias,
             lock_file::schema::ManagedAddressUpdate::Published {
-                chain_id: chain_identifier,
+                chain_id: chain_identifier.to_string(),
                 original_id: original_id.to_string(),
             },
         ),
         LockCommand::Upgrade => lock_file::schema::update_managed_address(
             &mut lock,
-            env.alias(),
+            env_alias,
             lock_file::schema::ManagedAddressUpdate::Upgraded {
                 latest_id: original_id.to_string(),
                 version,

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -49,7 +49,7 @@ pub struct IotaPublishArgs {
     pub view_functions: Vec<String>,
     #[arg(long)]
     pub gas_price: Option<u64>,
-    #[clap(long = "dry-run")]
+    #[arg(long = "dry-run")]
     pub dry_run: bool,
 }
 

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -49,6 +49,8 @@ pub struct IotaPublishArgs {
     pub view_functions: Vec<String>,
     #[arg(long)]
     pub gas_price: Option<u64>,
+    #[clap(long = "dry-run")]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -473,6 +473,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
             dependencies,
             view_functions,
             gas_price,
+            dry_run,
         } = extra;
 
         fill_metadata(&mut modules, &view_functions, self.dynamic_module_metadata)?;
@@ -511,6 +512,34 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
         // we are assuming that all packages depend on Move Stdlib and IOTA Framework,
         // so these don't have to be provided explicitly as parameters
         dependencies.extend([ObjectId::STD, ObjectId::FRAMEWORK]);
+
+        if dry_run {
+            let sender_acc = self.get_sender(sender.clone());
+            let sender_address = sender_acc.address;
+
+            let mut builder = ProgrammableTransactionBuilder::new();
+            if upgradeable {
+                let cap = builder.publish_upgradeable(modules_bytes, dependencies);
+                builder.transfer_arg(sender_address, cap);
+            } else {
+                builder.publish_immutable(modules_bytes, dependencies);
+            };
+            let pt = builder.finish();
+            let payments = self.get_payments(sender_acc, vec![]);
+
+            let transaction = TransactionData::new_programmable(
+                sender_acc.address,
+                payments.clone(),
+                pt,
+                gas_budget,
+                gas_price,
+            );
+            let summary = self.dry_run(transaction).await?;
+            let output = self.object_summary_output(&summary, /* summarize */ false);
+
+            // do not pass back any modules for storage
+            return Ok((output, vec![]));
+        }
 
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
@@ -999,7 +1028,10 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                         .insert(package, before_upgrade);
                 }
                 let (warnings_opt, output, data, modules) = result?;
-                store_modules(self, syntax, data, modules);
+                // skip storing modules if this is a dry run
+                if !dry_run {
+                    store_modules(self, syntax, data, modules);
+                }
                 Ok(merge_output(warnings_opt, output))
             }
             IotaSubcommand::StagePackage(StagePackageCommand {
@@ -1633,7 +1665,7 @@ impl IotaTestAdapter {
 
         let pt = builder.finish();
 
-        let summary = if dry_run {
+        if dry_run {
             let transaction = TransactionData::new_programmable(
                 self.get_sender(Some(sender)).address,
                 vec![],
@@ -1641,14 +1673,15 @@ impl IotaTestAdapter {
                 gas_budget,
                 gas_price,
             );
-            self.dry_run(transaction).await?
-        } else {
-            let data = |sender, gas| {
-                TransactionData::new_programmable(sender, gas, pt, gas_budget, gas_price)
-            };
-            let transaction = self.sign_txn(Some(sender), data);
-            self.execute_txn(transaction).await?
-        };
+            let summary = self.dry_run(transaction).await?;
+            return Ok(self.object_summary_output(&summary, false));
+        }
+
+        let data =
+            |sender, gas| TransactionData::new_programmable(sender, gas, pt, gas_budget, gas_price);
+        let transaction = self.sign_txn(Some(sender), data);
+        let summary = self.execute_txn(transaction).await?;
+
         let created_package = summary
             .created
             .iter()


### PR DESCRIPTION
[run-ci]

# Description of change

Ports a batch of independent upstream maintenance commits:

- Exposes a lock-file update entry point that does not require a `WalletContext`.
- Adds transactional tests for entry-function argument checks under dry run and dev inspect, for gas smashing and deletion rebates during dry run, and for pass/fail publish and upgrade paths - plus the `--dry-run` support in the test framework those tests need.

## Upstream commits

| Commit | Description |
|--------|-------------|
| [`e980dcbf0bbb9a92f77b5e08fabef75b5619bad7`](https://github.com/MystenLabs/sui/commit/e980dcbf0bbb9a92f77b5e08fabef75b5619bad7) | chore: expose update_lock_file fn that does not depend on wallet context |
| [`60e2ea1e68378f177e8168a23399a8a9812d4148`](https://github.com/MystenLabs/sui/commit/60e2ea1e68378f177e8168a23399a8a9812d4148) | Extra entry, gas, upgrade and publish transactional tests |

### Skipped

| Commit | Description | Reason |
|--------|-------------|--------|
| [`2c50e39af115d3affddf4e297695a4a91d8e4faf`](https://github.com/MystenLabs/sui/commit/2c50e39af115d3affddf4e297695a4a91d8e4faf) | Fix simtest determinism — `tempfile` after version 3.15.0 can pollute the simulator PRNG | Already downstream - nothing left to apply. |

The skipped commit replaces `tempfile::tempdir()` with a wrapper that keeps the simulator PRNG clean. IOTA already does exactly that via `iota_common::tempdir()`, which wraps `nondeterministic!(tempfile::tempdir())`, applied repo-wide in #11189 (`d49476f37c`). All three of its changes are in place: `iota-common` is already a dependency of `iota-move-build`, `BuildConfig::new_for_testing` already calls `iota_common::tempdir()`, and the direct `tempfile` dependency the patch expects in that crate is already gone.

## Downstream adaptations

| File | Upstream | Downstream | Adaptation |
|------|----------|------------|------------|
| `iota-package-management/src/lib.rs` | new `update_lock_file_for_chain_env` takes `response: &SuiTransactionBlockResponse` | `update_lock_file_with_package_id` (IOTA-only, added in #9151 for multi-package publish) already extracts the object ref one layer up | the new function takes `original_id: ObjectId, version: u64` instead; response extraction stays where downstream already had it |
| `iota-package-management/src/lib.rs` | `context.config.get_active_env()`, `&env.alias` | `context.active_env()`, `env.alias()` (`getset` accessor) | use the downstream API |
| `iota-package-management/src/lib.rs` | `version.into()` | `get_new_package_obj_from_response` returns `ObjectReference`, not Sui's `ObjectRef` tuple, so version is already `u64` | pass `version` through |
| `iota-transactional-test-runner/src/args.rs` | `dry_run` added after `gas_price` | `IotaPublishArgs` has an extra downstream field, `view_functions` | same field placed after `gas_price`; attribute taken verbatim |
| `iota-transactional-test-runner/src/test_adapter.rs` | dry-run block anchored on `dependencies.extend([MOVE_STDLIB_PACKAGE_ID, IOTA_FRAMEWORK_PACKAGE_ID])` | `dependencies.extend([ObjectId::STD, ObjectId::FRAMEWORK])` | block inserted after the downstream line; block contents unchanged |
| `tests/publish/basic.move` | header year 2025 | new file added by this port | header year is the current year, 2026 |
| the five `.snap` files | filtered out of the Slipstreamer patch | — | regenerated locally with `cargo insta`, then compared against the upstream snapshots at `60e2ea1e` |

Snapshot differences against upstream fall into three expected categories: line numbers shifted by exactly +1 (extra IOTA licence line), error text rendered as prose downstream where Sui prints the `Debug` of the error enum, and different `gas summary` figures. Task structure, ordering, per-task pass/fail and the `created`/`mutated`/`deleted` object sets all match upstream. The gas amounts the new tests rely on needed no retuning — the balances in the assertions match upstream exactly.

For whoever ports the `[pkg-alt]` series: upstream has since deleted `update_lock_file` and `update_lock_file_for_chain_env` outright, in [`1a19182f375cc27195e17004d46c711fdeec1ae5`](https://github.com/MystenLabs/sui/commit/1a19182f375cc27195e17004d46c711fdeec1ae5) `[pkg-alt] remove move-package usages`. Chasing exact signature parity in this crate buys little, which is why the adaptation above keeps the downstream shape.

## Links to any relevant issues

Fixes #10837 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

- `cargo nextest run -p iota-adapter-transactional-tests` — 324/324 pass, including all five tests touched here.
- `cargo nextest run -p iota-verifier-transactional-tests` — 211/211 pass (second consumer of the test runner).
- `cargo check -p iota-graphql-e2e-tests --all-targets` — clean (third consumer; running it needs Postgres, so compilation only).
- `cargo check -p iota-package-management`, `cargo check -p iota --lib` — clean; the four existing `update_lock_file` call sites are unaffected.
- `cargo clippy` on both touched crates, `cargo +nightly fmt --all`, `cargo ci-license` — clean.
- Every regenerated snapshot diff was reviewed individually, and additionally compared against the upstream snapshots at `60e2ea1e`.
