### PR TITLE
refactor: delete the IotaSignature trait

### DIFF
--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -24,7 +24,7 @@ use iota_macros::sim_test;
 use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
-use iota_sdk_crypto::Signer;
+use iota_sdk_crypto::IotaSigner as _;
 use iota_sdk_types::{
     Address, Argument, CanceledTransaction, CheckpointSequenceNumber, Command,
     ConsensusDeterminedVersionAssignments, Digest, EpochId, ExecutionError, ExecutionStatus,
@@ -32,7 +32,7 @@ use iota_sdk_types::{
     ProgrammableTransaction, SharedObjectReference, StructTag, Transaction, TransactionDigest,
     TransactionEffects, TransactionEffectsDigest, TransactionExpiration, TransactionKind,
     TransactionV1, TypeTag, Version, VersionAssignment,
-    crypto::{Intent, IntentScope, SimpleSignature},
+    crypto::{Intent, IntentScope},
 };
 use iota_types::{
     base_types::{AuthorityName, TxContext, dbg_addr, dbg_object_id, random_object_ref},
@@ -1369,15 +1369,9 @@ async fn test_handle_transfer_transaction_bad_signature() {
     *bad_signature_transfer_transaction
         .data_mut_for_testing()
         .tx_signatures_mut_for_testing() = vec![
-        Signer::<SimpleSignature>::sign(
-            &unknown_key,
-            transfer_transaction
-                .data()
-                .intent_message()
-                .signing_digest()
-                .inner(),
-        )
-        .into(),
+        unknown_key
+            .sign_transaction(transfer_transaction.data().transaction())
+            .unwrap(),
     ];
 
     assert!(

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -24,6 +24,7 @@ use iota_macros::sim_test;
 use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
+use iota_sdk_crypto::Signer;
 use iota_sdk_types::{
     Address, Argument, CanceledTransaction, CheckpointSequenceNumber, Command,
     ConsensusDeterminedVersionAssignments, Digest, EpochId, ExecutionError, ExecutionStatus,
@@ -37,8 +38,8 @@ use iota_types::{
     base_types::{AuthorityName, TxContext, dbg_addr, dbg_object_id, random_object_ref},
     committee::Committee,
     crypto::{
-        AccountKeyPair, AuthorityKeyPair, AuthorityPublicKey, AuthoritySignInfo, IotaSignature,
-        get_key_pair, random_committee_key_pairs_of_size,
+        AccountKeyPair, AuthorityKeyPair, AuthorityPublicKey, AuthoritySignInfo, get_key_pair,
+        random_committee_key_pairs_of_size,
     },
     dynamic_field::{DynamicFieldInfo, DynamicFieldType},
     effects::{TestEffectsBuilder, TransactionEffectsAPI, TransactionEffectsExt},
@@ -1368,8 +1369,15 @@ async fn test_handle_transfer_transaction_bad_signature() {
     *bad_signature_transfer_transaction
         .data_mut_for_testing()
         .tx_signatures_mut_for_testing() = vec![
-        SimpleSignature::new_secure(&transfer_transaction.data().intent_message(), &unknown_key)
-            .into(),
+        Signer::<SimpleSignature>::sign(
+            &unknown_key,
+            transfer_transaction
+                .data()
+                .intent_message()
+                .signing_digest()
+                .inner(),
+        )
+        .into(),
     ];
 
     assert!(

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -10,6 +10,7 @@ use std::{
 use fastcrypto::traits::KeyPair;
 use iota_macros::sim_test;
 use iota_protocol_config::{Chain, OverrideGuard, ProtocolConfig, ProtocolVersion};
+use iota_sdk_crypto::Signer as _;
 use iota_sdk_types::{
     Address, ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, GenesisTransaction,
     Identifier, SenderSignedTransaction, SharedObjectReference, TransactionKind,
@@ -17,7 +18,7 @@ use iota_sdk_types::{
 };
 use iota_types::{
     base_types::{dbg_addr, random_object_ref},
-    crypto::{AccountKeyPair, IotaSignature, get_key_pair},
+    crypto::{AccountKeyPair, get_key_pair},
     error::{IotaError, UserInputError},
     messages_grpc::HandleSoftBundleCertificatesRequestV1,
     transaction::TransactionAPI,
@@ -75,7 +76,8 @@ async fn test_handle_transfer_transaction_bad_signature() {
         |mut_tx| {
             let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
             let data = mut_tx.data_mut_for_testing();
-            let signature = SimpleSignature::new_secure(&data.intent_message(), &unknown_key);
+            let signature: SimpleSignature =
+                unknown_key.sign(data.intent_message().signing_digest().inner());
             *data.tx_signatures_mut_for_testing() = vec![signature.into()];
         },
         |err| {
@@ -805,7 +807,8 @@ async fn test_handle_certificate_errors() {
     let mut absent_sig_tx = transfer_transaction.clone();
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
     let data = absent_sig_tx.data_mut_for_testing();
-    let signature = SimpleSignature::new_secure(&data.intent_message(), &unknown_key);
+    let signature: SimpleSignature =
+        unknown_key.sign(data.intent_message().signing_digest().inner());
     *data.tx_signatures_mut_for_testing() = vec![signature.into()];
     let ct = CertifiedTransaction::new(
         data.clone(),

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -10,11 +10,11 @@ use std::{
 use fastcrypto::traits::KeyPair;
 use iota_macros::sim_test;
 use iota_protocol_config::{Chain, OverrideGuard, ProtocolConfig, ProtocolVersion};
-use iota_sdk_crypto::Signer as _;
+use iota_sdk_crypto::IotaSigner as _;
 use iota_sdk_types::{
     Address, ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments, GenesisTransaction,
     Identifier, SenderSignedTransaction, SharedObjectReference, TransactionKind,
-    crypto::{IntentScope, SimpleSignature},
+    crypto::IntentScope,
 };
 use iota_types::{
     base_types::{dbg_addr, random_object_ref},
@@ -76,9 +76,8 @@ async fn test_handle_transfer_transaction_bad_signature() {
         |mut_tx| {
             let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
             let data = mut_tx.data_mut_for_testing();
-            let signature: SimpleSignature =
-                unknown_key.sign(data.intent_message().signing_digest().inner());
-            *data.tx_signatures_mut_for_testing() = vec![signature.into()];
+            let signature = unknown_key.sign_transaction(data.transaction()).unwrap();
+            *data.tx_signatures_mut_for_testing() = vec![signature];
         },
         |err| {
             assert_matches!(err, IotaError::SignerSignatureAbsent { .. });
@@ -807,9 +806,8 @@ async fn test_handle_certificate_errors() {
     let mut absent_sig_tx = transfer_transaction.clone();
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
     let data = absent_sig_tx.data_mut_for_testing();
-    let signature: SimpleSignature =
-        unknown_key.sign(data.intent_message().signing_digest().inner());
-    *data.tx_signatures_mut_for_testing() = vec![signature.into()];
+    let signature = unknown_key.sign_transaction(data.transaction()).unwrap();
+    *data.tx_signatures_mut_for_testing() = vec![signature];
     let ct = CertifiedTransaction::new(
         data.clone(),
         vec![signed_transaction.auth_sig().clone()],

--- a/crates/iota-keys/src/keystore.rs
+++ b/crates/iota-keys/src/keystore.rs
@@ -15,16 +15,14 @@ use anyhow::{Context, anyhow, bail, ensure};
 use bip32::DerivationPath;
 use bip39::{Language, Mnemonic, Seed};
 use iota_sdk_crypto::{
-    ToFromBech32, ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey,
+    Signer, ToFromBech32, ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey,
     secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair,
 };
 use iota_sdk_types::{
     Address, SignatureScheme,
     crypto::{Intent, IntentMessage, SimpleSignature},
 };
-use iota_types::crypto::{
-    EncodeDecodeBase64, IotaSignature, PublicKey, enum_dispatch, get_key_pair_from_rng,
-};
+use iota_types::crypto::{EncodeDecodeBase64, PublicKey, enum_dispatch, get_key_pair_from_rng};
 use rand::{SeedableRng, rngs::StdRng};
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -355,7 +353,7 @@ impl AccountKeystore for FileBasedKeystore {
         })?;
 
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(SimpleSignature::new_hashed(msg, keypair)),
+            StoredKey::KeyPair(keypair) => Ok(keypair.sign(msg)),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_hashed is not supported for account type",
             )),
@@ -379,7 +377,7 @@ impl AccountKeystore for FileBasedKeystore {
 
         let intent_msg = &IntentMessage::new(intent, msg);
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(SimpleSignature::new_secure(intent_msg, keypair)),
+            StoredKey::KeyPair(keypair) => Ok(keypair.sign(intent_msg.signing_digest().inner())),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_secure is not supported for account type",
             )),
@@ -748,7 +746,7 @@ impl AccountKeystore for InMemKeystore {
         })?;
 
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(SimpleSignature::new_hashed(msg, keypair)),
+            StoredKey::KeyPair(keypair) => Ok(keypair.sign(msg)),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_hashed is not supported for account type",
             )),
@@ -772,7 +770,7 @@ impl AccountKeystore for InMemKeystore {
 
         let intent_msg = &IntentMessage::new(intent, msg);
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(SimpleSignature::new_secure(intent_msg, keypair)),
+            StoredKey::KeyPair(keypair) => Ok(keypair.sign(intent_msg.signing_digest().inner())),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_secure is not supported for account type",
             )),

--- a/crates/iota-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/iota-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -21,11 +21,9 @@ use iota_json_rpc_types::{
 };
 use iota_sdk::{IotaClient, IotaClientBuilder};
 use iota_sdk_crypto::{ToFromBech32, simple::SimpleKeypair};
-use iota_sdk_types::{
-    Address, ObjectId, ObjectReference, Transaction, TransactionDigest, crypto::SimpleSignature,
-};
+use iota_sdk_types::{Address, ObjectId, ObjectReference, Transaction, TransactionDigest};
 use iota_types::{
-    crypto::{AccountKeyPair, IotaSignature, get_key_pair},
+    crypto::{AccountKeyPair, get_key_pair},
     quorum_driver_types::ExecuteTransactionRequestType,
     transaction::TransactionEnvelope,
 };
@@ -793,12 +791,10 @@ pub(crate) async fn sign_and_execute(
     tx: Transaction,
     request_type: ExecuteTransactionRequestType,
 ) -> IotaTransactionBlockResponse {
-    let signature = SimpleSignature::new_secure(&tx.intent_message(), keypair);
-
     let transaction_response = match client
         .quorum_driver_api()
         .execute_transaction_block(
-            TransactionEnvelope::from_data(tx, vec![signature]),
+            TransactionEnvelope::from_data_and_signer(tx, vec![keypair]),
             IotaTransactionBlockResponseOptions::new().with_effects(),
             Some(request_type),
         )

--- a/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
+++ b/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
@@ -19,14 +19,16 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::IotaTransactionBlockResponseOptions,
     types::{
-        crypto::{IotaSignature, PublicKey},
-        programmable_transaction_builder::ProgrammableTransactionBuilder,
+        crypto::PublicKey, programmable_transaction_builder::ProgrammableTransactionBuilder,
         transaction::TransactionAPI,
     },
 };
 use iota_sdk_crypto::{
-    Signer as _, ToFromBase64, ToFromBech32, ed25519::Ed25519PrivateKey,
-    secp256k1::Secp256k1PrivateKey, secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair,
+    Signer as _, ToFromBase64, ToFromBech32, Verifier as _,
+    ed25519::Ed25519PrivateKey,
+    secp256k1::Secp256k1PrivateKey,
+    secp256r1::Secp256r1PrivateKey,
+    simple::{SimpleKeypair, SimpleVerifier},
 };
 use iota_sdk_types::{Address, Transaction, UserSignature, crypto::SimpleSignature};
 use rand::{SeedableRng, rngs::StdRng};
@@ -143,11 +145,12 @@ async fn main() -> Result<(), anyhow::Error> {
     // use SimpleKeypair to sign the digest.
     let iota_sig: SimpleSignature = ikp_determ_0.sign(&digest);
 
-    // if you would like to verify the signature locally before submission, use this
-    // function. if it fails to verify locally, the transaction will fail to
+    // if you would like to verify the signature locally before submission, check
+    // it against the signing digest and make sure its public key matches the
+    // sender. if it fails to verify locally, the transaction will fail to
     // execute in IOTA.
-    let res = iota_sig.verify_secure(&intent_msg, sender);
-    assert!(res.is_ok());
+    assert_eq!(Address::from(iota_sig.to_public_key()), sender);
+    assert!(SimpleVerifier.verify(&digest, &iota_sig).is_ok());
 
     // execute the transaction.
     let transaction_response = client

--- a/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
+++ b/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
@@ -24,11 +24,8 @@ use iota_sdk::{
     },
 };
 use iota_sdk_crypto::{
-    Signer as _, ToFromBase64, ToFromBech32, Verifier as _,
-    ed25519::Ed25519PrivateKey,
-    secp256k1::Secp256k1PrivateKey,
-    secp256r1::Secp256r1PrivateKey,
-    simple::{SimpleKeypair, SimpleVerifier},
+    IotaVerifier as _, Signer as _, ToFromBase64, ToFromBech32, ed25519::Ed25519PrivateKey,
+    secp256k1::Secp256k1PrivateKey, secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair,
 };
 use iota_sdk_types::{Address, Transaction, UserSignature, crypto::SimpleSignature};
 use rand::{SeedableRng, rngs::StdRng};
@@ -145,12 +142,13 @@ async fn main() -> Result<(), anyhow::Error> {
     // use SimpleKeypair to sign the digest.
     let iota_sig: SimpleSignature = ikp_determ_0.sign(&digest);
 
-    // if you would like to verify the signature locally before submission, check
-    // it against the signing digest and make sure its public key matches the
-    // sender. if it fails to verify locally, the transaction will fail to
-    // execute in IOTA.
-    assert_eq!(Address::from(iota_sig.to_public_key()), sender);
-    assert!(SimpleVerifier.verify(&digest, &iota_sig).is_ok());
+    // if you would like to verify the signature locally before submission,
+    // verify it against the transaction with the sender's public key, which
+    // also ensures the signature carries the matching public key. if it fails
+    // to verify locally, the transaction will fail to execute in IOTA.
+    let iota_sig = UserSignature::Simple(iota_sig);
+    let res = ikp_determ_0.public_key().verify_transaction(&tx, &iota_sig);
+    assert!(res.is_ok());
 
     // execute the transaction.
     let transaction_response = client
@@ -158,7 +156,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             iota_types::transaction::TransactionEnvelope::from_user_sig_data(
                 intent_msg.value.clone(),
-                vec![UserSignature::Simple(iota_sig)],
+                vec![iota_sig],
             ),
             IotaTransactionBlockResponseOptions::default(),
             None,

--- a/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
+++ b/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
@@ -142,9 +142,9 @@ async fn main() -> Result<(), anyhow::Error> {
     // use SimpleKeypair to sign the digest.
     let iota_sig: SimpleSignature = ikp_determ_0.sign(&digest);
 
-    // if you would like to verify the signature locally before submission,
+    // If you would like to verify the signature locally before submission,
     // verify it against the transaction with the sender's public key, which
-    // also ensures the signature carries the matching public key. if it fails
+    // also ensures the signature carries the matching public key. If it fails
     // to verify locally, the transaction will fail to execute in IOTA.
     let iota_sig = UserSignature::Simple(iota_sig);
     let res = ikp_determ_0.public_key().verify_transaction(&tx, &iota_sig);

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -33,11 +33,8 @@ use fastcrypto::{
     serde_helpers::BytesRepresentation,
 };
 use iota_sdk_crypto::{
-    Verifier,
-    ed25519::Ed25519PrivateKey,
-    secp256k1::Secp256k1PrivateKey,
-    secp256r1::Secp256r1PrivateKey,
-    simple::{SimpleKeypair, SimpleVerifier},
+    ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey, secp256r1::Secp256r1PrivateKey,
+    simple::SimpleKeypair,
 };
 use iota_sdk_types::{
     Address, SignatureScheme,
@@ -617,69 +614,6 @@ impl IotaPublicKey for Secp256r1PublicKey {
 
 pub trait IotaPublicKey: VerifyingKey {
     const SIGNATURE_SCHEME: SignatureScheme;
-}
-
-/// Node-only behaviour layered on top of the SDK [`SimpleSignature`]:
-/// construction from a signer and intent-message verification.
-pub trait IotaSignature: Sized {
-    /// Signs a message that is already in hashed form.
-    fn new_hashed(
-        hashed_msg: &[u8],
-        secret: &impl iota_sdk_crypto::Signer<SimpleSignature>,
-    ) -> SimpleSignature {
-        secret.sign(hashed_msg)
-    }
-
-    /// Signs the BCS hash of the value wrapped in the intent message.
-    #[instrument(level = "trace", skip_all)]
-    fn new_secure<T>(
-        value: &IntentMessage<T>,
-        secret: &impl iota_sdk_crypto::Signer<SimpleSignature>,
-    ) -> SimpleSignature
-    where
-        T: Serialize,
-    {
-        // Compute the BCS hash of the value in intent message. In the case of
-        // transaction data, this is the BCS hash of `struct Transaction`,
-        // different from the transaction digest itself that computes the BCS
-        // hash of the Rust type prefix and `struct Transaction`.
-        // (See `fn digest` in `impl Message for SenderSignedTransaction`).
-        let mut hasher = DefaultHash::default();
-        hasher.update(bcs::to_bytes(&value).expect("Message serialization should not fail"));
-
-        secret.sign(&hasher.finalize().digest)
-    }
-
-    fn verify_secure<T>(&self, value: &IntentMessage<T>, author: Address) -> IotaResult<()>
-    where
-        T: Serialize;
-}
-
-impl IotaSignature for SimpleSignature {
-    #[instrument(level = "trace", skip_all)]
-    fn verify_secure<T>(&self, value: &IntentMessage<T>, author: Address) -> Result<(), IotaError>
-    where
-        T: Serialize,
-    {
-        let mut hasher = DefaultHash::default();
-        hasher.update(bcs::to_bytes(&value).expect("Message serialization should not fail"));
-        let digest = hasher.finalize().digest;
-
-        // `SimpleVerifier` only checks the signature against its embedded public
-        // key, so the signer/author binding is enforced here.
-        let address: Address = self.to_public_key().into();
-        if author != address {
-            return Err(IotaError::IncorrectSigner {
-                error: format!("Incorrect signer, expected {author}, got {address}"),
-            });
-        }
-
-        SimpleVerifier
-            .verify(&digest, self)
-            .map_err(|e| IotaError::InvalidSignature {
-                error: format!("Fail to verify user sig {e}"),
-            })
-    }
 }
 
 /// AuthoritySignInfoTrait is a trait used specifically for a few structs in

--- a/crates/iota-types/src/signature.rs
+++ b/crates/iota-types/src/signature.rs
@@ -2,13 +2,14 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use iota_sdk_crypto::{Verifier, simple::SimpleVerifier};
 use iota_sdk_types::{
     Address, UserSignature,
     crypto::{IntentMessage, SimpleSignature},
 };
 use serde::Serialize;
 
-use crate::error::IotaResult;
+use crate::error::{IotaError, IotaResult};
 
 #[derive(Default, Debug, Clone)]
 pub struct VerifyParams {
@@ -59,8 +60,6 @@ impl AuthenticatorTrait for UserSignature {
     }
 }
 
-/// This ports the wrapper trait to the verify_secure defined on
-/// [`SimpleSignature`].
 impl AuthenticatorTrait for SimpleSignature {
     #[tracing::instrument(level = "trace", skip_all)]
     fn verify_claims<T>(
@@ -72,7 +71,19 @@ impl AuthenticatorTrait for SimpleSignature {
     where
         T: Serialize,
     {
-        use crate::crypto::IotaSignature;
-        self.verify_secure(value, author)
+        // `SimpleVerifier` only checks the signature against its embedded public
+        // key, so the signer/author binding is enforced here.
+        let address: Address = self.to_public_key().into();
+        if author != address {
+            return Err(IotaError::IncorrectSigner {
+                error: format!("Incorrect signer, expected {author}, got {address}"),
+            });
+        }
+
+        SimpleVerifier
+            .verify(value.signing_digest().inner(), self)
+            .map_err(|e| IotaError::InvalidSignature {
+                error: format!("Fail to verify user sig {e}"),
+            })
     }
 }

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -39,8 +39,7 @@ use crate::{
     committee::{Committee, EpochId},
     crypto::{
         AuthoritySignInfo, AuthoritySignInfoTrait, AuthoritySignature,
-        AuthorityStrongQuorumSignInfo, DefaultHash, EmptySignInfo, IotaSignature, Signer,
-        zero_ed25519_signature,
+        AuthorityStrongQuorumSignInfo, DefaultHash, EmptySignInfo, Signer, zero_ed25519_signature,
     },
     execution::SharedInput,
     message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope},
@@ -2339,11 +2338,8 @@ impl TransactionEnvelope {
         signers: Vec<&impl iota_sdk_crypto::Signer<SimpleSignature>>,
     ) -> Self {
         let signatures = {
-            let intent_msg = tx.intent_message();
-            signers
-                .into_iter()
-                .map(|s| SimpleSignature::new_secure(&intent_msg, s))
-                .collect()
+            let digest = tx.signing_digest();
+            signers.into_iter().map(|s| s.sign(&digest)).collect()
         };
         Self::from_data(tx, signatures)
     }
@@ -2358,8 +2354,8 @@ impl TransactionEnvelope {
         intent: Intent,
         signer: &impl iota_sdk_crypto::Signer<SimpleSignature>,
     ) -> SimpleSignature {
-        let intent_msg = IntentMessage::new(intent, tx);
-        SimpleSignature::new_secure(&intent_msg, signer)
+        let digest = IntentMessage::new(intent, tx).signing_digest();
+        signer.sign(digest.inner())
     }
 
     pub fn from_user_sig_data(tx: Transaction, signatures: Vec<UserSignature>) -> Self {

--- a/crates/iota-types/src/unit_tests/base_types_tests.rs
+++ b/crates/iota-types/src/unit_tests/base_types_tests.rs
@@ -12,7 +12,7 @@ use fastcrypto::{
     traits::EncodeDecodeBase64,
 };
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_crypto::ToFromBytes as _;
+use iota_sdk_crypto::{Signer as _, ToFromBytes as _};
 use iota_sdk_types::{
     Address, Digest, Owner, TransactionDigest,
     crypto::{Intent, IntentMessage, IntentScope, SimpleSignature},
@@ -24,13 +24,13 @@ use crate::{
     base_types::TypeTag,
     crypto::{
         AccountKeyPair, AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature,
-        IotaSignature,
         bcs_signable_test::{Bar, Foo},
         get_key_pair,
     },
     dynamic_field::DynamicFieldInfo,
     gas_coin::GasCoin,
     object::Object,
+    signature::{AuthenticatorTrait, VerifyParams},
 };
 
 #[test]
@@ -55,31 +55,36 @@ fn test_signatures() {
     let foox = IntentMessage::new(Intent::iota_transaction(), Foo("hellox".into()));
     let bar = IntentMessage::new(Intent::iota_transaction(), Bar("hello".into()));
 
-    let s = SimpleSignature::new_secure(&foo, &sec1);
-    assert!(s.verify_secure(&foo, addr1).is_ok());
-    assert!(s.verify_secure(&foo, addr2).is_err());
-    assert!(s.verify_secure(&foox, addr1).is_err());
+    let aux = VerifyParams::default();
+    let s: SimpleSignature = sec1.sign(foo.signing_digest().inner());
+    assert!(s.verify_claims(&foo, addr1, &aux).is_ok());
+    assert!(s.verify_claims(&foo, addr2, &aux).is_err());
+    assert!(s.verify_claims(&foox, addr1, &aux).is_err());
     assert!(
-        s.verify_secure(
+        s.verify_claims(
             &IntentMessage::new(
                 Intent::iota_app(IntentScope::SenderSignedTransaction),
                 Foo("hello".into())
             ),
             addr1,
+            &aux,
         )
         .is_err()
     );
 
     // The struct type is different, but the serialization is the same.
-    assert!(s.verify_secure(&bar, addr1).is_ok());
+    assert!(s.verify_claims(&bar, addr1, &aux).is_ok());
 }
 
 #[test]
 fn test_signatures_serde() {
     let sec1 = AccountKeyPair::random();
     let foo = Foo("hello".into());
-    let s =
-        SimpleSignature::new_secure(&IntentMessage::new(Intent::iota_transaction(), foo), &sec1);
+    let s: SimpleSignature = sec1.sign(
+        IntentMessage::new(Intent::iota_transaction(), foo)
+            .signing_digest()
+            .inner(),
+    );
 
     let serialized = bcs::to_bytes(&s).unwrap();
     println!("{serialized:?}");

--- a/crates/iota-types/src/unit_tests/intent_tests.rs
+++ b/crates/iota-types/src/unit_tests/intent_tests.rs
@@ -3,13 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::traits::KeyPair;
-use iota_sdk_crypto::Signer as _;
+use iota_sdk_crypto::IotaSigner as _;
 use iota_sdk_types::{
     ObjectId, Transaction,
-    crypto::{
-        Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion, PersonalMessage,
-        SimpleSignature,
-    },
+    crypto::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion, PersonalMessage},
 };
 
 use crate::{
@@ -49,11 +46,7 @@ fn test_personal_message_intent() {
     assert_eq!(&intent_bcs[3..], &p_message_bcs);
 
     // Let's ensure we can sign and verify intents.
-    let s: SimpleSignature = sec1.sign(
-        IntentMessage::new(intent, p_message)
-            .signing_digest()
-            .inner(),
-    );
+    let s = sec1.sign_personal_message(&p_message).unwrap();
     let verification = s.verify_claims(
         &IntentMessage::new(intent, p_message_2),
         addr1,
@@ -81,8 +74,8 @@ fn test_authority_signature_intent() {
         gas_price * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         gas_price,
     );
-    let signature = sender_key.sign(&tx.signing_digest());
-    let tx = TransactionEnvelope::from_data(tx, vec![signature]);
+    let signature = sender_key.sign_transaction(&tx).unwrap();
+    let tx = TransactionEnvelope::from_user_sig_data(tx, vec![signature]);
     let tx1 = tx.clone();
     assert!(
         tx.try_into_verified_for_testing(&Default::default())

--- a/crates/iota-types/src/unit_tests/intent_tests.rs
+++ b/crates/iota-types/src/unit_tests/intent_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::traits::KeyPair;
+use iota_sdk_crypto::Signer as _;
 use iota_sdk_types::{
     ObjectId, Transaction,
     crypto::{
@@ -15,10 +16,10 @@ use crate::{
     base_types::dbg_addr,
     committee::EpochId,
     crypto::{
-        AccountKeyPair, AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature,
-        IotaSignature, get_key_pair,
+        AccountKeyPair, AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature, get_key_pair,
     },
     object::Object,
+    signature::{AuthenticatorTrait, VerifyParams},
     transaction::{TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionAPI, TransactionEnvelope},
 };
 
@@ -48,8 +49,16 @@ fn test_personal_message_intent() {
     assert_eq!(&intent_bcs[3..], &p_message_bcs);
 
     // Let's ensure we can sign and verify intents.
-    let s = SimpleSignature::new_secure(&IntentMessage::new(intent, p_message), &sec1);
-    let verification = s.verify_secure(&IntentMessage::new(intent, p_message_2), addr1);
+    let s: SimpleSignature = sec1.sign(
+        IntentMessage::new(intent, p_message)
+            .signing_digest()
+            .inner(),
+    );
+    let verification = s.verify_claims(
+        &IntentMessage::new(intent, p_message_2),
+        addr1,
+        &VerifyParams::default(),
+    );
     assert!(verification.is_ok())
 }
 
@@ -72,7 +81,7 @@ fn test_authority_signature_intent() {
         gas_price * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         gas_price,
     );
-    let signature = SimpleSignature::new_secure(&tx.intent_message(), &sender_key);
+    let signature: SimpleSignature = sender_key.sign(&tx.signing_digest());
     let tx = TransactionEnvelope::from_data(tx, vec![signature]);
     let tx1 = tx.clone();
     assert!(

--- a/crates/iota-types/src/unit_tests/intent_tests.rs
+++ b/crates/iota-types/src/unit_tests/intent_tests.rs
@@ -81,7 +81,7 @@ fn test_authority_signature_intent() {
         gas_price * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         gas_price,
     );
-    let signature: SimpleSignature = sender_key.sign(&tx.signing_digest());
+    let signature = sender_key.sign(&tx.signing_digest());
     let tx = TransactionEnvelope::from_data(tx, vec![signature]);
     let tx1 = tx.clone();
     assert!(

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -25,7 +25,7 @@ use crate::{
     committee::Committee,
     crypto::{
         AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfoTrait,
-        IotaAuthoritySignature, IotaSignature, PublicKey, VerificationObligation,
+        IotaAuthoritySignature, PublicKey, VerificationObligation,
         bcs_signable_test::{Foo, get_obligation_input},
         get_key_pair,
     },
@@ -716,8 +716,8 @@ fn signature_from_signer(
     intent: Intent,
     signer: &impl Signer<SimpleSignature>,
 ) -> SimpleSignature {
-    let intent_msg = IntentMessage::new(intent, tx);
-    SimpleSignature::new_secure(&intent_msg, signer)
+    let digest = IntentMessage::new(intent, tx).signing_digest();
+    signer.sign(digest.inner())
 }
 
 #[test]


### PR DESCRIPTION
# Description of change

Deletes the `IotaSignature` trait: since the `AuthenticatorTrait`/`verify_claims` rework its methods were thin wrappers around what the SDK already provides, so call sites now sign via `Signer` over `signing_digest()` and the verification (including the signer/author binding) lives directly in the `AuthenticatorTrait` impl for `SimpleSignature`.

One more #11590 checklist item.

## Links to any relevant issues

Part of #11590.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`iota-types`, `iota-keys`, `iota-core` and `iota-rpc-loadgen` compile clean with `--all-targets`; the `iota-types`/`iota-keys` unit tests pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8HDhvVEyBujVabtPaZtoe)_