### PR TITLE
backport: feat(consensus): enable new leader schedule on testnet (#12685)

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -202,6 +202,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             Enable the P-COOL flow on devnet.
 // Version 33: Amortize the minimum checkpoint interval over a sliding window
 //             on mainnet.
+//             Enable the sliding-window reputation scoring and absolute-score
+//             bad-node selection on testnet
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3210,6 +3212,15 @@ impl ProtocolConfig {
                     // Amortize the minimum checkpoint interval over a sliding
                     // window so the checkpoint rate holds at the ceiling.
                     cfg.checkpoint_rate_window_size = Some(20);
+                    // Enable the redesigned leader schedule: sliding-window
+                    // reputation scoring and absolute-score bad-node
+                    // selection.
+                    if chain != Chain::Mainnet {
+                        cfg.feature_flags
+                            .consensus_enable_sliding_window_leader_schedule = true;
+                        cfg.feature_flags
+                            .consensus_enable_absolute_score_leader_schedule = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_33.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_33.snap
@@ -50,6 +50,8 @@ feature_flags:
   validator_metadata_verify_v2: true
   package_metadata_with_dynamic_module_metadata: true
   report_move_authentication_error: true
+  consensus_enable_sliding_window_leader_schedule: true
+  consensus_enable_absolute_score_leader_schedule: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
# Description of change

Backport of #12685 to the `1.30.0` release branch.

Enables the `consensus_enable_sliding_window_leader_schedule` and `consensus_enable_absolute_score_leader_schedule` feature flags in protocol version 33 on non-mainnet chains, turning the redesigned leader schedule on for testnet.

Original commit: 84e42656b1bf9af8bfb36505368d832c54af61e9
Original PR: https://github.com/iotaledger/iota/pull/12685

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable leader schedule redesign on testnet: sliding window and absolute-score bad node selection
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
