### PR TITLE
fix(core): Include modified runtime-loaded objects in simulation input objects

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2328,8 +2328,16 @@ impl AuthorityState {
             checks.disabled(),
         );
 
+        let mut input_objects = inner_temp_store.input_objects;
+        iota_types::storage::extend_input_objects_with_loaded_runtime_objects(
+            &mut input_objects,
+            &effects,
+            &inner_temp_store.loaded_runtime_objects,
+            self.get_backing_store().as_object_store(),
+        );
+
         Ok(SimulateTransactionResult {
-            input_objects: inner_temp_store.input_objects,
+            input_objects,
             output_objects: inner_temp_store.written,
             events: effects.events_digest().map(|_| inner_temp_store.events),
             effects,

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -1202,6 +1202,37 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
         .unwrap();
     assert_eq!(result.effects.deleted().len(), 0);
     assert_eq!(execution_error_source(&result), Some("VMError with status ABORTED with sub status 1 at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier(\"dynamic_field\") } at code offset 0 in function definition 13".to_string()));
+
+    // dry run against the current parent: the field object is loaded at
+    // runtime and removed, so it must appear in the returned input objects at
+    // its pre-state version even though it is not a declared input
+    let field = effects.created()[0].0;
+    let pt = ProgrammableTransaction {
+        inputs: vec![CallArg::ImmutableOrOwned(new_parent.object_ref())],
+        commands: vec![Command::new_move_call(
+            object_basics.object_id,
+            Identifier::from_static("object_basics"),
+            Identifier::from_static("remove_field"),
+            vec![],
+            vec![Argument::Input(0)],
+        )],
+    };
+    let tx = Transaction::new_programmable(
+        sender,
+        vec![gas_object_ref],
+        pt,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
+        rgp,
+    );
+    let result = fullnode
+        .simulate_transaction(tx, VmChecks::Enabled)
+        .unwrap();
+    assert_eq!(result.effects.status(), &ExecutionStatus::Success);
+    let field_input = result
+        .input_objects
+        .get(&field.object_id)
+        .expect("runtime-loaded field object should be in the input objects");
+    assert_eq!(field_input.version(), field.version);
 }
 
 /// A gas payment that names an object which is not a gas coin is rejected, in

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -628,3 +628,23 @@ pub fn get_transaction_output_objects(
         .collect::<Result<Vec<_>, _>>()?;
     Ok(output_objects)
 }
+
+/// Extend a simulation's input objects with the runtime-loaded objects the
+/// effects record as modified, read from `object_store` at their pre-state
+/// versions.
+pub fn extend_input_objects_with_loaded_runtime_objects(
+    input_objects: &mut BTreeMap<ObjectId, Object>,
+    effects: &TransactionEffects,
+    loaded_runtime_objects: &BTreeMap<ObjectId, DynamicallyLoadedObjectMetadata>,
+    object_store: &dyn ObjectStore,
+) {
+    let modified_at: BTreeMap<_, _> = effects.modified_at_versions().into_iter().collect();
+    for (id, metadata) in loaded_runtime_objects {
+        if input_objects.contains_key(id) || modified_at.get(id) != Some(&metadata.version) {
+            continue;
+        }
+        if let Some(object) = object_store.get_object_by_key(id, metadata.version) {
+            input_objects.insert(*id, object);
+        }
+    }
+}

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -83,6 +83,10 @@ pub struct CachedTransactionData {
 pub struct SimulateTransactionResult {
     pub effects: TransactionEffects,
     pub events: Option<TransactionEvents>,
+    /// Every object the transaction ran with as input — including immutable
+    /// and read-only shared inputs, the packages it calls, and the gas coins
+    /// (the mock one included) — plus the runtime-loaded objects (e.g. dynamic
+    /// fields) it modified, at their pre-state versions, keyed by id.
     pub input_objects: BTreeMap<ObjectId, Object>,
     pub output_objects: BTreeMap<ObjectId, Object>,
     /// The return values and mutable-reference outputs of every command, under

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -282,6 +282,7 @@ pub(super) fn execute_prepared(
     );
 
     Ok(simulation_result(
+        store,
         inner_temp_store,
         effects,
         execution_result,
@@ -292,14 +293,23 @@ pub(super) fn execute_prepared(
 
 /// Assemble the engine's raw outputs into a [`SimulateTransactionResult`].
 fn simulation_result(
+    store: &dyn BackingStore,
     inner_temp_store: InnerTemporaryStore,
     effects: TransactionEffects,
     execution_result: Result<Vec<CommandResult>, iota_types::error::ExecutionError>,
     mock_gas_id: Option<ObjectId>,
     gas_data: GasPayment,
 ) -> SimulateTransactionResult {
+    let mut input_objects = inner_temp_store.input_objects;
+    iota_types::storage::extend_input_objects_with_loaded_runtime_objects(
+        &mut input_objects,
+        &effects,
+        &inner_temp_store.loaded_runtime_objects,
+        store.as_object_store(),
+    );
+
     SimulateTransactionResult {
-        input_objects: inner_temp_store.input_objects,
+        input_objects,
         output_objects: inner_temp_store.written,
         events: effects.events_digest().map(|_| inner_temp_store.events),
         effects,
@@ -456,6 +466,7 @@ pub(super) fn execute_with_move_authenticators(
     // results, so a signed `MoveAuthenticator` run carries none.
     Ok((
         simulation_result(
+            store,
             inner_temp_store,
             effects,
             execution_result.map(|_| Vec::new()),

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -289,8 +289,16 @@ impl EpochState {
                 checks.disabled(),
             );
 
+        let mut input_objects = inner_temp_store.input_objects;
+        iota_types::storage::extend_input_objects_with_loaded_runtime_objects(
+            &mut input_objects,
+            &effects,
+            &inner_temp_store.loaded_runtime_objects,
+            store.backing_store().as_object_store(),
+        );
+
         Ok(SimulateTransactionResult {
-            input_objects: inner_temp_store.input_objects,
+            input_objects,
             output_objects: inner_temp_store.written,
             events: effects.events_digest().map(|_| inner_temp_store.events),
             effects,


### PR DESCRIPTION
# Description of change

gRPC `simulate_transactions` failed with `cannot derive the requested change fields: object ... is unavailable (possibly pruned)` whenever the simulated transaction modified a runtime-loaded object (dynamic fields — staking, tables, bags, kiosk, …) and `balance_changes`/`object_changes` were in the read mask.

The change derivation requires every object in `effects.modified_at_versions()` to be present in the returned input set, but simulation returned only `inner_temp_store.input_objects` (declared inputs, gas, packages); runtime-loaded objects were tracked only as metadata in `loaded_runtime_objects`.

- Add `extend_input_objects_with_loaded_runtime_objects` in `iota-types::storage`: extends a simulation's input objects with the runtime-loaded objects the effects record as modified, read from the backing store at their pre-state versions.
- Apply it in all three `SimulateTransactionResult` producers: `AuthorityState::simulate_transaction` (iota-core), `simulation_result` (iota-vm-sdk executor), and `EpochState::simulate_transaction` (simulacrum).

This makes simulation consistent with the other `ExecutedTransaction` producers (ledger `get_transactions`, `execute_transactions`, checkpoint ingestion), which already return the full modified-object set.

## Links to any relevant issues

fixes #12459

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes


