### PR TITLE
fix(indexer): restore partitions correctly  (#12699)

### DIFF
--- a/crates/iota-indexer/src/restore/persist.rs
+++ b/crates/iota-indexer/src/restore/persist.rs
@@ -1,9 +1,11 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 use bytes::Bytes;
+use diesel::connection::SimpleConnection;
+use downcast::Any;
 use fastcrypto::hash::{HashFunction, Sha3_256};
 use iota_core::authority::authority_store_tables::LiveObject as SnapshotObject;
 use iota_snapshot::{FileMetadata, VerifiedEpochInfo, reader::LiveObjectIter, restore::Restore};
@@ -30,7 +32,7 @@ use crate::{
         packages::StoredPackage,
     },
     pruning::pruner::PrunableTable,
-    store::{IndexerStore, PgIndexerStore},
+    store::{IndexerStore, PgIndexerStore, diesel_macro::*},
     types::{IndexedCheckpoint, IndexedPackage},
 };
 
@@ -231,11 +233,59 @@ async fn populate_epochs(
         .await
 }
 
+const EPOCH_PARTITIONED_TABLES: [&str; 2] = ["transactions", "events"];
+
+/// Moves the initial partition of `transactions`, and `events` to `epoch`.
+///
+/// The migrations create a single `<table>_partition_0` that eludes the pruner,
+/// and grows indefinitely.
+///
+/// Herein, that partition is dropped, and the partition of the restore epoch
+/// is created instead with the respective lower bound.
+///
+/// # Errors
+///
+/// Returns an error if the database rejects the partition restore.
+async fn restore_partitions(
+    store: &PgIndexerStore,
+    epoch: u64,
+    epoch_start_tx: u64,
+) -> IndexerResult<()> {
+    store
+        .execute_in_blocking_worker(move |this| {
+            let pool = this.blocking_cp();
+            transactional_blocking_with_retry!(
+                &pool,
+                |conn| {
+                    let query = EPOCH_PARTITIONED_TABLES
+                        .iter()
+                        .map(|table| {
+                            format!(
+                                "DROP TABLE {table}_partition_0;
+                                 CREATE TABLE {table}_partition_{epoch} PARTITION OF {table}
+                                     FOR VALUES FROM ({epoch_start_tx}) TO (MAXVALUE);"
+                            )
+                        })
+                        .join("\n");
+                    conn.batch_execute(&query)?;
+                    Ok::<(), IndexerError>(())
+                },
+                Duration::from_secs(10)
+            )?;
+            tracing::info!("Moved the initial epoch partitions to epoch {epoch}");
+            Ok(())
+        })
+        .await
+}
+
 /// We populate the remaining tables after the objects.
 ///
 /// This includes `epochs`, `chain_identifier` which we populate in parallel
 /// with setting the checkpoint watermark to the last checkpoint of the snapshot
 /// epoch.
+///
+/// We also move the initial partition of `transactions`, and `events` to the
+/// epoch that follows the snapshot.
 ///
 /// Finally we populate `protocol_configs`, `feature_flags` up to the
 /// protocol version that the snapshot epoch corresponds to, and the
@@ -256,6 +306,7 @@ pub(crate) async fn populate_remaining_tables(
         Default::default(), // We don't store this as part of the checkpoint so it's ok to set to 0
     );
     let next_epoch = sync_watermark.epoch + 1;
+    let next_epoch_start_tx = sync_watermark.network_total_transactions;
     let pruning_watermarks: Vec<_> = PrunableTable::iter()
         .map(|table| (table, next_epoch))
         .collect();
@@ -263,6 +314,7 @@ pub(crate) async fn populate_remaining_tables(
         populate_epochs(store, verified_epoch_info),
         populate_chain_id(store, snapshot_chain_id),
         store.persist_checkpoints(vec![sync_watermark]),
+        restore_partitions(store, next_epoch, next_epoch_start_tx),
     )?;
     tokio::try_join!(
         populate_protocol_and_feature_flags(store, snapshot_chain_id),

--- a/crates/iota-indexer/src/store/pg_partition_manager.rs
+++ b/crates/iota-indexer/src/store/pg_partition_manager.rs
@@ -12,7 +12,7 @@ use diesel::{
     sql_types::{BigInt, VarChar},
 };
 use downcast::Any;
-use tracing::{error, info};
+use tracing::info;
 
 use crate::{
     db::ConnectionPool, errors::IndexerError, ingestion::primary::persist::EpochToCommit,
@@ -167,47 +167,74 @@ impl PgPartitionManager {
         }
     }
 
+    fn advance_partition(
+        &self,
+        table: &str,
+        last_partition: u64,
+        next_partition: u64,
+        last_partition_start: u64,
+        next_partition_start: u64,
+    ) -> Result<(), IndexerError> {
+        transactional_blocking_with_retry!(
+            &self.cp,
+            |conn| {
+                RunQueryDsl::execute(
+                    diesel::sql_query("CALL advance_partition($1, $2, $3, $4, $5)")
+                        .bind::<diesel::sql_types::Text, _>(table)
+                        .bind::<diesel::sql_types::BigInt, _>(last_partition as i64)
+                        .bind::<diesel::sql_types::BigInt, _>(next_partition as i64)
+                        .bind::<diesel::sql_types::BigInt, _>(last_partition_start as i64)
+                        .bind::<diesel::sql_types::BigInt, _>(next_partition_start as i64),
+                    conn,
+                )
+            },
+            Duration::from_secs(10)
+        )?;
+        Ok(())
+    }
+
     pub fn advance_epoch(
         &self,
         table: String,
         last_partition: u64,
         data: &EpochPartitionData,
     ) -> Result<(), IndexerError> {
-        let Some(partition_range) = self.determine_epoch_partition_range(&table, data) else {
+        let Some((last_epoch_start, next_epoch_start)) =
+            self.determine_epoch_partition_range(&table, data)
+        else {
             return Ok(());
         };
         if data.next_epoch == 0 {
-            tracing::info!("Epoch 0 partition has been created in the initial setup.");
+            info!("Epoch 0 partition has been created in the initial setup.");
             return Ok(());
         }
         if last_partition == data.last_epoch {
-            transactional_blocking_with_retry!(
-                &self.cp,
-                |conn| {
-                    RunQueryDsl::execute(
-                        diesel::sql_query("CALL advance_partition($1, $2, $3, $4, $5)")
-                            .bind::<diesel::sql_types::Text, _>(table.clone())
-                            .bind::<diesel::sql_types::BigInt, _>(data.last_epoch as i64)
-                            .bind::<diesel::sql_types::BigInt, _>(data.next_epoch as i64)
-                            .bind::<diesel::sql_types::BigInt, _>(partition_range.0 as i64)
-                            .bind::<diesel::sql_types::BigInt, _>(partition_range.1 as i64),
-                        conn,
-                    )
-                },
-                Duration::from_secs(10)
+            self.advance_partition(
+                &table,
+                data.last_epoch,
+                data.next_epoch,
+                last_epoch_start,
+                next_epoch_start,
             )?;
-
             info!(
                 "Advanced epoch partition for table {} from {} to {}, prev partition upper bound {}",
-                table, last_partition, data.next_epoch, partition_range.0
+                table, last_partition, data.next_epoch, next_epoch_start
+            );
+        } else if last_partition == 0 {
+            // this applies to instances that were restored from a formal snapshot before
+            // v1.31
+            info!("Healing epoch-based partitions. This might take some time.");
+            self.advance_partition(&table, last_partition, data.next_epoch, 0, next_epoch_start)?;
+            info!(
+                "Healed epoch partition for table {} from {} to {}, prev partition upper bound {}",
+                table, last_partition, data.next_epoch, next_epoch_start
             );
         } else if last_partition != data.next_epoch {
-            // skip when the partition is already advanced once, which is possible when
-            // indexer crashes and restarts; error otherwise.
-            error!(
-                "epoch partition for table {table} is not in sync with the last epoch {}.",
+            let emsg = format!(
+                "Advancing to epoch {} failed. Corrupted partitions for table {table}",
                 data.last_epoch
             );
+            return Err(IndexerError::PostgresWrite(emsg));
         } else {
             info!(
                 "Epoch has been advanced to {} already, skipping.",


### PR DESCRIPTION
# Description of change

This patch fixes a bug that would cause the `transactions`, and `events` table to grow indefinitely without partitioning after a formal-snapshot restore.

The partitions are restored correctly with these changes, in order to set the proper partition suffix and transaction range after the restore. This allow the pruner to delete old partitions, and the partition manager to advance partitions correctly.

In addition, self-healing logic has been added for instances that have been already restore to minimize operations.

## Links to any relevant issues

Fixes #12692

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)

Tested healing of an already restored instance, and restoring a new instance. Results were as expected.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.


### Release Notes

- [x] Indexer: :screwdriver: :warning: This patch fixes a bug in the `restore` operations, where the tables for transactions and events would grow indefinitely eluding the pruner, without partitioning their data. Operators that are running an Indexer instance restored from a formal snapshot, are advised to upgrade immediately to the new version of the software, so that self-healing of the partitions will take effect with the next epoch. Some downtime on the read path should be expected while the self healing is in progress.
At any case, the affected partitions `{transactions,events}_partition_0` must be dropped manually, when the data therein fall beyond the configured retention period, if any.


