### PR TITLE
feat(graphql): historical fallback to the archival KV store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6357,6 +6357,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
@@ -185,3 +185,18 @@ fragment DynamicFieldsSelect on DynamicFieldConnection {
     }
   }
 }
+
+//# run-graphql
+# The dynamic field wrapper object was deleted when the child was reclaimed:
+# fetching it at the exact deletion version resolves as non-existent, while
+# the version before still resolves.
+{
+  wrapper_at_deletion_version: object(address: "@{obj_3_0}", version: 4) {
+    version
+    status
+  }
+  wrapper_before_deletion: object(address: "@{obj_3_0}", version: 3) {
+    version
+    status
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 9 tasks
+processed 10 tasks
 
 init:
 A: object(0,0)
@@ -213,6 +213,18 @@ Response: {
         "edges": []
       },
       "dynamicObjectField": null
+    }
+  }
+}
+
+task 9, lines 189-202:
+//# run-graphql
+Response: {
+  "data": {
+    "wrapper_at_deletion_version": null,
+    "wrapper_before_deletion": {
+      "status": "INDEXED",
+      "version": 3
     }
   }
 }

--- a/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.move
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL checkpoint queries under pruning, with no historical
+// fallback configured. Covers:
+// - top-level `Query.checkpoints` after pruning
+// - paginating with a cursor that points below the pruning watermark
+// - `Query.checkpoint(sequenceNumber)` for both pruned and unpruned seqs
+// - nested `Epoch.checkpoints` on a fully-pruned epoch and on the current one
+
+//# init --protocol-version 12 --addresses Test=0x0 --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public entry fun noop() {}
+}
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: top-level checkpoints, defaults.
+# After waiting for pruning, only unpruned checkpoints come back.
+# `hasPreviousPage` must be `false` because we clamp `absolute_lo_incl` to the
+# pruning watermark.
+{
+  checkpoints {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql
+# B: top-level checkpoints with `first: 2`.
+# `hasNextPage` should be `true` (more unpruned data above), `hasPreviousPage`
+# should be `false` (we're at the bottom of the reachable range).
+{
+  checkpoints(first: 2) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":2}
+# C: paginate forward from a cursor below the pruning watermark.
+# `c` is the view-at checkpoint, `s` is the cursor's sequence number. A cursor
+# below the watermark means the referenced data has been pruned -- the request
+# is rejected with DATA_PRUNED, telling the client to retry from scratch.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":42}
+# C2: cursor above the upper bound (viewed_at is 9, but cursor seq is 42).
+# The cursor contradicts its own `checkpoint_viewed_at`, so it's malformed --
+# return BAD_USER_INPUT.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql --cursors {"c":9,"s":7}
+# D: paginate forward from a cursor sitting at the lower bound (s=7, the
+# lowest unpruned seq). The boundary is in-range, so the page returns the
+# items strictly above it.
+{
+  checkpoints(first: 2, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { sequenceNumber }
+  }
+}
+
+//# run-graphql
+# E: Query.checkpoint(seq) for a pruned seq.
+# Should resolve to `null` -- the DataLoader can't find the row in either
+# Postgres or the (absent) fallback.
+{
+  pruned: checkpoint(id: { sequenceNumber: 0 }) {
+    sequenceNumber
+  }
+}
+
+//# run-graphql
+# F: Query.checkpoint(seq) for an unpruned seq -- resolves to the row.
+{
+  unpruned: checkpoint(id: { sequenceNumber: 7 }) {
+    sequenceNumber
+  }
+}
+
+//# run-graphql
+# G: nested Epoch.checkpoints on a fully-pruned epoch.
+# Epoch 0's range is entirely below the watermark; without a fallback we have
+# no way to serve any of its checkpoints. `epochId` resolves, the
+# `checkpoints` sub-field errors with DATA_PRUNED.
+{
+  epoch(id: 0) {
+    epochId
+    checkpoints {
+      pageInfo { hasPreviousPage hasNextPage }
+      nodes { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql
+# H: nested Epoch.checkpoints on the unpruned epoch -- paginates normally.
+{
+  epoch(id: 3) {
+    epochId
+    checkpoints {
+      pageInfo { hasPreviousPage hasNextPage }
+      nodes { sequenceNumber }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/checkpoint_pagination.snap
@@ -1,0 +1,236 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 20 tasks
+
+task 1, lines 13-16:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 3374400
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 18:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, line 20:
+//# advance-epoch
+Epoch advanced: 1
+
+task 4, line 22:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 5, line 24:
+//# advance-epoch
+Epoch advanced: 2
+
+task 6, line 26:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 7, line 28:
+//# advance-epoch
+Epoch advanced: 3
+
+task 8, line 30:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 9, line 32:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 10, line 34:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 11, lines 36-46:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 12, lines 48-57:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 7
+        },
+        {
+          "sequenceNumber": 8
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 13, lines 59-69:
+//# run-graphql --cursors {"c":9,"s":2}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: `after` cursor (seq 2) is below the available range 7..=9",
+      "locations": [
+        {
+          "line": 6,
+          "column": 3
+        }
+      ],
+      "path": [
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 14, lines 71-80:
+//# run-graphql --cursors {"c":9,"s":42}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "`after` cursor (seq 42) is above the available range 7..=9",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 15, lines 82-91:
+//# run-graphql --cursors {"c":9,"s":7}
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 8
+        },
+        {
+          "sequenceNumber": 9
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 16, lines 93-101:
+//# run-graphql
+Response: {
+  "data": {
+    "pruned": null
+  }
+}
+
+task 17, lines 103-109:
+//# run-graphql
+Response: {
+  "data": {
+    "unpruned": {
+      "sequenceNumber": 7
+    }
+  }
+}
+
+task 18, lines 111-124:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "epochId": 0
+    }
+  },
+  "errors": [
+    {
+      "message": "Requested data has been pruned: all checkpoints in the requested range have been pruned",
+      "locations": [
+        {
+          "line": 8,
+          "column": 5
+        }
+      ],
+      "path": [
+        "epoch",
+        "checkpoints"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 19, lines 126-136:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 7
+          },
+          {
+            "sequenceNumber": 8
+          },
+          {
+            "sequenceNumber": 9
+          }
+        ],
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        }
+      },
+      "epochId": 3
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.move
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL event queries filtered by transaction digest under
+// pruning, with no historical fallback configured. Covers:
+// - `Query.events(filter: { transactionDigest })`
+// - `TransactionBlockEffects.events`
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    use iota::event;
+
+    public struct Foo has key, store { id: UID, v: u64 }
+    public struct Bumped has copy, drop { v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+
+    public entry fun bump(foo: &mut Foo, times: u64) {
+        let mut i = 0;
+        while (i < times) {
+            foo.v = foo.v + 1;
+            event::emit(Bumped { v: foo.v });
+            i = i + 1;
+        }
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# run Test::M::bump --sender A --args object(2,0) 3
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run Test::M::bump --sender A --args object(2,0) 3
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: Query.events on a pruned transaction — no fallback.
+# The transaction has been pruned, so the request errors with DATA_PRUNED.
+{
+  events(filter: { transactionDigest: "@{digest_3}" }) {
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# B: Query.events on an unpruned transaction resolves. The cursors printed
+# here are the inputs for the window in D.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }) {
+    pageInfo { hasPreviousPage hasNextPage startCursor endCursor }
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# C: TransactionBlockEffects.events on an unpruned transaction.
+{
+  transactionBlock(digest: "@{digest_11}") {
+    effects {
+      events {
+        nodes { json }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"tx":7,"e":0,"c":10} {"tx":7,"e":2,"c":10}
+# D: both cursors set — the window between the first and the last event of
+# the transaction. Only the middle event is inside the window (cursors are
+# exclusive). Both page flags are true because events exist at the cursor
+# positions, outside the window.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}
+
+//# run-graphql --cursors {"tx":5,"e":0,"c":10}
+# E: `after` cursor from a different transaction. No event of this
+# transaction sits at the cursor, so the bound is invalid and the connection
+# comes back empty, as for other event queries.
+{
+  events(filter: { transactionDigest: "@{digest_11}" }, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}
+
+//# run-graphql
+# F: digest combined with another filter — served by the lookup-table path,
+# without fallback support.
+{
+  events(filter: { transactionDigest: "@{digest_11}", sender: "@{A}" }) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { json }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/events_by_tx_digest.snap
@@ -1,0 +1,240 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 21 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-30:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 6604400
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 32:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, line 34:
+//# run Test::M::bump --sender A --args object(2,0) 3
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AQAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AgAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AwAAAAAAAAA=" }
+mutated: object(0,0), object(2,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 2257200
+└── Non-Refundable Storage Fee: 0
+
+task 4, line 36:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, line 38:
+//# advance-epoch
+Epoch advanced: 1
+
+task 6, line 40:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 42:
+//# advance-epoch
+Epoch advanced: 2
+
+task 8, line 44:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 9, line 46:
+//# advance-epoch
+Epoch advanced: 3
+
+task 10, line 48:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 11, line 50:
+//# run Test::M::bump --sender A --args object(2,0) 3
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BAAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BQAAAAAAAAA=" }, Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "BgAAAAAAAAA=" }
+mutated: object(0,0), object(2,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 2257200
+└── Non-Refundable Storage Fee: 0
+
+task 12, line 52:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 13, line 54:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 14, line 56:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 15, lines 58-65:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: data for tx BFJpQE4QdDmhuC72E6cqJMmvhBhiA8gTdqH5AZ8NRhHk potentially pruned",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "events"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 16, lines 67-75:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "4"
+          }
+        },
+        {
+          "json": {
+            "v": "5"
+          }
+        },
+        {
+          "json": {
+            "v": "6"
+          }
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJ0eCI6NywiZSI6MiwiYyI6MTB9",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "eyJ0eCI6NywiZSI6MCwiYyI6MTB9"
+      }
+    }
+  }
+}
+
+task 17, lines 77-87:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlock": {
+      "effects": {
+        "events": {
+          "nodes": [
+            {
+              "json": {
+                "v": "4"
+              }
+            },
+            {
+              "json": {
+                "v": "5"
+              }
+            },
+            {
+              "json": {
+                "v": "6"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 18, lines 89-99:
+//# run-graphql --cursors {"tx":7,"e":0,"c":10} {"tx":7,"e":2,"c":10}
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "5"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 19, lines 101-110:
+//# run-graphql --cursors {"tx":5,"e":0,"c":10}
+Response: {
+  "data": {
+    "events": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 20, lines 112-120:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "json": {
+            "v": "4"
+          }
+        },
+        {
+          "json": {
+            "v": "5"
+          }
+        },
+        {
+          "json": {
+            "v": "6"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.move
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL object-at-version queries under pruning, with no
+// historical fallback configured. Covers:
+// - `Query.object(address, version)`
+// - `Owner.dynamicField` at a `rootVersion`
+
+//# init --protocol-version 12 --addresses P0=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module P0::m {
+    use iota::dynamic_field as field;
+
+    public struct Foo has key, store { id: UID, value: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), value: 0 }, ctx.sender())
+    }
+
+    public entry fun bump(foo: &mut Foo) {
+        foo.value = foo.value + 1;
+    }
+
+    public entry fun add_df(foo: &mut Foo, name: u64, value: u64) {
+        field::add(&mut foo.id, name, value);
+    }
+
+    public entry fun mutate_df(foo: &mut Foo, name: u64, value: u64) {
+        *field::borrow_mut<u64, u64>(&mut foo.id, name) = value;
+    }
+}
+
+//# run P0::m::create --sender A
+
+//# run P0::m::add_df --sender A --args object(2,0) 42 1
+
+//# create-checkpoint
+
+//# run P0::m::mutate_df --sender A --args object(2,0) 42 2
+
+//# run P0::m::bump --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: Query.object at a version whose row content has been pruned — no
+# fallback. The version is known to `objects_version`, so the request errors
+# with DATA_PRUNED.
+{
+  object(address: "@{obj_2_0}", version: 3) {
+    version
+    status
+  }
+}
+
+//# run-graphql
+# B: Query.object at the current version resolves.
+{
+  object(address: "@{obj_2_0}", version: 5) {
+    version
+    status
+    asMoveObject {
+      contents { json }
+    }
+  }
+}
+
+//# run-graphql
+# C: Query.object at a version that never existed resolves as non-existent.
+{
+  object(address: "@{obj_2_0}", version: 100) {
+    version
+    status
+  }
+}
+
+//# run-graphql
+# D: a dynamic field looked up at a pruned parent version — the field
+# object's history at that version has been pruned, so the field errors with
+# DATA_PRUNED.
+{
+  owner(address: "@{obj_2_0}", rootVersion: 3) {
+    dynamicField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+      value {
+        ... on MoveValue { json }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# E: the same dynamic field at the current parent version resolves.
+{
+  owner(address: "@{obj_2_0}", rootVersion: 5) {
+    dynamicField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+      value {
+        ... on MoveValue { json }
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/objects_at_version.snap
@@ -1,0 +1,190 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 21 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-32:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 6703200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 34:
+//# run P0::m::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, line 36:
+//# run P0::m::add_df --sender A --args object(2,0) 42 1
+created: object(3,0)
+mutated: object(0,0), object(2,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 3716400
+├── Storage Rebate: 2257200
+└── Non-Refundable Storage Fee: 0
+
+task 4, line 38:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, line 40:
+//# run P0::m::mutate_df --sender A --args object(2,0) 42 2
+mutated: object(0,0), object(2,0), object(3,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 3716400
+├── Storage Rebate: 3716400
+└── Non-Refundable Storage Fee: 0
+
+task 6, line 42:
+//# run P0::m::bump --sender A --args object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 2257200
+└── Non-Refundable Storage Fee: 0
+
+task 7, line 44:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, line 46:
+//# advance-epoch
+Epoch advanced: 1
+
+task 9, line 48:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 10, line 50:
+//# advance-epoch
+Epoch advanced: 2
+
+task 11, line 52:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 12, line 54:
+//# advance-epoch
+Epoch advanced: 3
+
+task 13, line 56:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 14, line 58:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 15, line 60:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 16, lines 62-71:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: data for object 0x843c5fd93fafc7cfca2e5650b9a80981090d17f139f52833326078623e814353 potentially pruned",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "object"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 17, lines 73-83:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x843c5fd93fafc7cfca2e5650b9a80981090d17f139f52833326078623e814353",
+            "value": "1"
+          }
+        }
+      },
+      "status": "INDEXED",
+      "version": 5
+    }
+  }
+}
+
+task 18, lines 85-92:
+//# run-graphql
+Response: {
+  "data": {
+    "object": null
+  }
+}
+
+task 19, lines 94-106:
+//# run-graphql
+Response: {
+  "data": {
+    "owner": null
+  },
+  "errors": [
+    {
+      "message": "Requested data has been pruned: data for object 0xac52fe97efc94b3b3426355ae8545a236c90588040d60efe51e600aa08302bc5 potentially pruned",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "owner",
+        "dynamicField"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 20, lines 108-118:
+//# run-graphql
+Response: {
+  "data": {
+    "owner": {
+      "dynamicField": {
+        "value": {
+          "json": "2"
+        }
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.move
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transaction-by-digest queries under pruning, with no
+// historical fallback configured. Covers:
+// - `Query.transactionBlock(digest)` for pruned and unpruned digests
+// - `Query.transactionBlocksByDigests` for pruned and unpruned digests
+// - `Event.transactionBlock` on an event from an unpruned tx
+// - `MoveObject.previousTransactionBlock` where the prior-tx digest is pruned
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    use iota::event;
+
+    public struct Foo has key, store { id: UID, v: u64 }
+    public struct Bumped has copy, drop { v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+
+    public entry fun bump(foo: &mut Foo) {
+        foo.v = foo.v + 1;
+        event::emit(Bumped { v: foo.v })
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M::bump --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: pruned digest resolves to null (no fallback).
+{
+  pruned: transactionBlock(digest: "@{digest_2}") { digest }
+}
+
+//# run-graphql
+# B: unpruned digest resolves correctly
+{
+  unpruned: transactionBlock(digest: "@{digest_10}") { digest }
+}
+
+//# run-graphql
+# C: mixed case - one pruned and one unpruned
+{
+  transactionBlocksByDigests(digests: ["@{digest_2}", "@{digest_10}"]) {
+    digest
+  }
+}
+
+//# run-graphql
+# D: Event.transactionBlock on an event from an unpruned tx
+{
+  events(filter: { sender: "@{A}" }, last: 1) {
+    nodes {
+      transactionBlock { digest }
+    }
+  }
+}
+
+//# run-graphql
+# E: MoveObject.previousTransactionBlock where the tx is pruned.
+{
+  object(address: "@{obj_5_0}") {
+    asMoveObject {
+      previousTransactionBlock { digest }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_block_pruning.snap
@@ -1,0 +1,146 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 19 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 13-28:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 6285200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 30:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, line 32:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 34:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, line 36:
+//# run Test::M::create --sender A
+created: object(5,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 6, line 38:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 40:
+//# advance-epoch
+Epoch advanced: 2
+
+task 8, line 42:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 9, line 44:
+//# advance-epoch
+Epoch advanced: 3
+
+task 10, line 46:
+//# run Test::M::bump --sender A --args object(2,0)
+events: Event { package_id: ObjectId("Test"), module: Identifier("M"), sender: Address("A"), type_: StructTag { address: Address("Test"), module: Identifier("M"), name: Identifier("Bumped"), type_params: [] }, contents: "AQAAAAAAAAA=" }
+mutated: object(0,0), object(2,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 2257200
+└── Non-Refundable Storage Fee: 0
+
+task 11, line 48:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 12, line 50:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 13, line 52:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 14, lines 54-58:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "pruned": null
+  }
+}
+
+task 15, lines 60-64:
+//# run-graphql
+Response: {
+  "data": {
+    "unpruned": {
+      "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+    }
+  }
+}
+
+task 16, lines 66-72:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocksByDigests": [
+      null,
+      {
+        "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+      }
+    ]
+  }
+}
+
+task 17, lines 74-82:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "nodes": [
+        {
+          "transactionBlock": {
+            "digest": "Dzp7aBcjmNpenbvokfi9uHwtcQXbseQ9guBKJrRvJWSG"
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 18, lines 84-92:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "previousTransactionBlock": null
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.move
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transaction queries filtered by affected address under
+// pruning, with no historical fallback configured. Covers:
+// - `Query.transactionBlocks(filter: { affectedAddress })`
+// - `Address.transactionBlocks` with the `AFFECTED` relation
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A B --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public struct Foo has key, store { id: UID, v: u64 }
+
+    public entry fun send(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, recipient)
+    }
+}
+
+//# run Test::M::send --sender A --args @B
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run Test::M::send --sender A --args @B
+
+//# run Test::M::send --sender A --args @B
+
+//# run Test::M::send --sender A --args @B
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: paginating forward starts at the earliest transaction that affected the
+# address, which has been pruned — no fallback, so the request errors with
+# DATA_PRUNED.
+{
+  transactionBlocks(filter: { affectedAddress: "@{A}" }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# B: paginating backward starts at the most recent transactions, which are
+# still in the database. The cursors printed here are the inputs for the
+# window in D.
+{
+  transactionBlocks(last: 3, filter: { affectedAddress: "@{B}" }) {
+    pageInfo { startCursor endCursor hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# C: the AFFECTED relation on Address paginates the same way.
+{
+  address(address: "@{B}") {
+    transactionBlocks(last: 2, relation: AFFECTED) {
+      pageInfo { hasPreviousPage hasNextPage }
+      nodes { digest }
+    }
+  }
+}
+
+//# run-graphql --cursors {"c":10,"t":6,"i":false} {"c":10,"t":8,"i":false}
+# D: both cursors set — the window between the first and the last of the
+# recent transactions. Only the middle transaction is inside the window
+# (cursors are exclusive). Both page flags are true because transactions
+# exist at the cursor positions, outside the window.
+{
+  transactionBlocks(filter: { affectedAddress: "@{B}" }, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":10,"t":2,"i":false}
+# E: paginating backward from a cursor in the pruned range — no fallback, so
+# the request errors with DATA_PRUNED.
+{
+  transactionBlocks(last: 2, filter: { affectedAddress: "@{B}" }, before: "@{cursor_0}") {
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":10,"t":2,"i":false}
+# F: paginating forward from a cursor in the pruned range — no fallback, so
+# the request errors with DATA_PRUNED.
+{
+  transactionBlocks(filter: { affectedAddress: "@{B}" }, after: "@{cursor_0}") {
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":1,"t":1,"i":false}
+# G: the cursor is viewed at a checkpoint that has been pruned from the
+# `checkpoints` table, so the request errors with DATA_PRUNED.
+{
+  transactionBlocks(filter: { affectedAddress: "@{B}" }, after: "@{cursor_0}") {
+    nodes { digest }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_affected_address.snap
@@ -1,0 +1,261 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 23 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-18:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 5099600
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 20:
+//# run Test::M::send --sender A --args @B
+created: object(2,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 24:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, line 26:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 6, line 28:
+//# advance-epoch
+Epoch advanced: 2
+
+task 7, line 30:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 8, line 32:
+//# advance-epoch
+Epoch advanced: 3
+
+task 9, line 34:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 10, line 36:
+//# run Test::M::send --sender A --args @B
+created: object(10,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 11, line 38:
+//# run Test::M::send --sender A --args @B
+created: object(11,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 12, line 40:
+//# run Test::M::send --sender A --args @B
+created: object(12,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 13, line 42:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 14, line 44:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 15, line 46:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 16, lines 48-56:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: DB may be missing earliest history for address 0x8cca4e1ce0ba5904cea61df9242da2f7d29e3ef328fb7ec07c086b3bf47ca61a due to pruning",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 17, lines 58-67:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "AdhXLxRHeWpRMVc5eQUZ3D4t9vFbQUnre9uQYp4Jidyj"
+        },
+        {
+          "digest": "DqfAehDoUapzpCYwh6HjJDhGWj6TAxsDZeYg7MfdTxEM"
+        },
+        {
+          "digest": "4r2EosDh4SAmuDk5qEMm19z8Yqi7kPtNTLxdmPdtuJwr"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJjIjoxMCwidCI6OCwiaSI6ZmFsc2V9",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "eyJjIjoxMCwidCI6NiwiaSI6ZmFsc2V9"
+      }
+    }
+  }
+}
+
+task 18, lines 69-78:
+//# run-graphql
+Response: {
+  "data": {
+    "address": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "DqfAehDoUapzpCYwh6HjJDhGWj6TAxsDZeYg7MfdTxEM"
+          },
+          {
+            "digest": "4r2EosDh4SAmuDk5qEMm19z8Yqi7kPtNTLxdmPdtuJwr"
+          }
+        ],
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": true
+        }
+      }
+    }
+  }
+}
+
+task 19, lines 80-90:
+//# run-graphql --cursors {"c":10,"t":6,"i":false} {"c":10,"t":8,"i":false}
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "DqfAehDoUapzpCYwh6HjJDhGWj6TAxsDZeYg7MfdTxEM"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 20, lines 92-99:
+//# run-graphql --cursors {"c":10,"t":2,"i":false}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: transaction 2 has been pruned (min available: 6)",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 21, lines 101-108:
+//# run-graphql --cursors {"c":10,"t":2,"i":false}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: transaction 2 has been pruned (min available: 6)",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 22, lines 110-117:
+//# run-graphql --cursors {"c":1,"t":1,"i":false}
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: checkpoint 1 has been pruned",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.move
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transaction queries filtered by checkpoint under
+// pruning, with no historical fallback configured. Covers:
+// - `Query.transactionBlocks(filter: { atCheckpoint })`
+// - `Checkpoint.transactionBlocks`
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public struct Foo has key, store { id: UID, v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: Query.transactionBlocks(filter: { atCheckpoint: <pruned> }) — no fallback.
+# The checkpoint has been pruned, so the request errors with DATA_PRUNED.
+{
+  transactionBlocks(filter: { atCheckpoint: 1 }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# B: Query.transactionBlocks(filter: { atCheckpoint: <unpruned> }) resolves.
+{
+  transactionBlocks(filter: { atCheckpoint: 8 }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# C: Checkpoint.transactionBlocks on a pruned checkpoint — no fallback.
+# The parent `checkpoint(...)` resolves to null, so no nested field is
+# fetched.
+{
+  checkpoint(id: { sequenceNumber: 1 }) {
+    transactionBlocks {
+      nodes { digest }
+    }
+  }
+}
+
+//# run-graphql
+# D: Checkpoint.transactionBlocks on an unpruned checkpoint.
+{
+  checkpoint(id: { sequenceNumber: 8 }) {
+    transactionBlocks {
+      nodes { digest }
+    }
+  }
+}
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# run-graphql
+# E: a checkpoint holding several transactions. The cursors printed here are
+# the inputs for the window in F.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }) {
+    pageInfo { startCursor endCursor }
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":11,"t":7,"i":false} {"c":11,"t":9,"i":false}
+# F: both cursors set — the window between the first and the last transaction
+# of checkpoint 11. Only the middle transaction is inside the window
+# (cursors are exclusive). Both page flags are true because transactions
+# exist at the cursor positions, outside the window.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql --cursors {"c":11,"t":3,"i":false}
+# G: `after` cursor below the checkpoint's transaction range. No transaction
+# in this checkpoint sits at the cursor, so the bound is invalid and the
+# connection comes back empty, as for other transaction queries.
+{
+  transactionBlocks(filter: { atCheckpoint: 11 }, after: "@{cursor_0}") {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_checkpoint.snap
@@ -1,0 +1,234 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 25 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-18:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 5236400
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 20:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 24:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, line 26:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 6, line 28:
+//# advance-epoch
+Epoch advanced: 2
+
+task 7, line 30:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 8, line 32:
+//# advance-epoch
+Epoch advanced: 3
+
+task 9, line 34:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 10, line 36:
+//# run Test::M::create --sender A
+created: object(10,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 11, line 38:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 12, line 40:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 13, line 42:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 14, lines 44-51:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data has been pruned: checkpoint 1 has been pruned (min available: 7)",
+      "locations": [
+        {
+          "line": 4,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlocks"
+      ],
+      "extensions": {
+        "code": "DATA_PRUNED"
+      }
+    }
+  ]
+}
+
+task 15, lines 53-59:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        }
+      ]
+    }
+  }
+}
+
+task 16, lines 61-71:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": null
+  }
+}
+
+task 17, lines 73-81:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 18, line 83:
+//# run Test::M::create --sender A
+created: object(18,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 19, line 85:
+//# run Test::M::create --sender A
+created: object(19,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 20, line 87:
+//# run Test::M::create --sender A
+created: object(20,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 21, line 89:
+//# create-checkpoint
+Checkpoint created: 11
+
+task 22, lines 91-99:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        },
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        },
+        {
+          "digest": "ACqVVgcSRS3QDERCcJm7arkawv2rGbu153oNrTcGTiuy"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJjIjoxMSwidCI6OSwiaSI6ZmFsc2V9",
+        "startCursor": "eyJjIjoxMSwidCI6NywiaSI6ZmFsc2V9"
+      }
+    }
+  }
+}
+
+task 23, lines 101-111:
+//# run-graphql --cursors {"c":11,"t":7,"i":false} {"c":11,"t":9,"i":false}
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 24, lines 113-122:
+//# run-graphql --cursors {"c":11,"t":3,"i":false}
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.move
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises GraphQL transactions filtered by transaction IDs under pruning,
+// with no historical fallback configured. Covers:
+// - `Query.transactionBlocks(filter: { transactionIds })` for pruned and
+//   unpruned digests
+// - pagination over the selected transactions
+
+//# init --protocol-version 12 --addresses Test=0x0 --accounts A --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M {
+    public struct Foo has key, store { id: UID, v: u64 }
+
+    public entry fun create(ctx: &mut TxContext) {
+        transfer::public_transfer(Foo { id: object::new(ctx), v: 0 }, ctx.sender())
+    }
+}
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# run Test::M::create --sender A
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 6
+# A: a pruned digest and an unpruned digest requested together. Without a
+# fallback the pruned transaction is dropped from the result, and only the
+# unpruned one is returned.
+{
+  transactionBlocks(filter: { transactionIds: ["@{digest_2}", "@{digest_9}"] }) {
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# B: the three unpruned transactions, ordered by sequence number.
+{
+  transactionBlocks(filter: { transactionIds: ["@{digest_9}", "@{digest_10}", "@{digest_11}"] }) {
+    pageInfo { startCursor endCursor }
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# C: forward page limited to two transactions.
+{
+  transactionBlocks(filter: { transactionIds: ["@{digest_9}", "@{digest_10}", "@{digest_11}"] }, first: 2) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}
+
+//# run-graphql
+# D: backward page limited to two transactions.
+{
+  transactionBlocks(filter: { transactionIds: ["@{digest_9}", "@{digest_10}", "@{digest_11}"] }, last: 2) {
+    pageInfo { hasPreviousPage hasNextPage }
+    nodes { digest }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.snap
+++ b/crates/iota-graphql-e2e-tests/tests/prune/transaction_blocks_by_ids.snap
@@ -1,0 +1,178 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 19 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 12-19:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 5236400
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 21:
+//# run Test::M::create --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, line 23:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 25:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, line 27:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 6, line 29:
+//# advance-epoch
+Epoch advanced: 2
+
+task 7, line 31:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 8, line 33:
+//# advance-epoch
+Epoch advanced: 3
+
+task 9, line 35:
+//# run Test::M::create --sender A
+created: object(9,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 10, line 37:
+//# run Test::M::create --sender A
+created: object(10,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 11, line 39:
+//# run Test::M::create --sender A
+created: object(11,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2257200
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 12, line 41:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 13, line 43:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 14, line 45:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 15, lines 47-55:
+//# run-graphql --wait-for-checkpoint-pruned 6
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        }
+      ]
+    }
+  }
+}
+
+task 16, lines 57-64:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        },
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        },
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJjIjo5LCJ0Ijo4LCJpIjpmYWxzZX0",
+        "startCursor": "eyJjIjo5LCJ0Ijo2LCJpIjpmYWxzZX0"
+      }
+    }
+  }
+}
+
+task 17, lines 66-73:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "6EpX3qAkM42gFcP6SypLLLuQNmS64zraTBdi8jYNrnsF"
+        },
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 18, lines 75-82:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "digest": "8gGsTdQ5LkWFDUhEz6Qp7b6okVijw1tdXX4fh23gg1q2"
+        },
+        {
+          "digest": "6WUKjvngBU6rgEwe8BJPAxQf8C6TUmLQivDf39e8gTpm"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.move
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests the `affectedAddress` filter: a transaction affects an address when
+// the address is the sender or a recipient. Also tests the AFFECTED relation
+// on `Address.transactionBlocks` and combining the filter with other filters.
+
+//# init --protocol-version 15 --addresses Test=0x0 --accounts A B C --simulator
+
+//# programmable --sender A --inputs 1000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender B --inputs 2000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender B --inputs 3000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+query {
+  affectedAsSender: transactionBlocks(filter: { affectedAddress: "@{A}" }) {
+    nodes { digest }
+  }
+  affectedAsRecipient: transactionBlocks(filter: { affectedAddress: "@{C}" }) {
+    nodes { digest }
+  }
+  affectedBoth: transactionBlocks(filter: { affectedAddress: "@{B}" }) {
+    nodes { digest }
+  }
+  combinedWithKind: transactionBlocks(filter: { affectedAddress: "@{B}", kind: PROGRAMMABLE_TX }, scanLimit: 10) {
+    nodes { digest }
+  }
+  combinedWithSent: transactionBlocks(filter: { affectedAddress: "@{B}", sentAddress: "@{B}" }) {
+    nodes { digest }
+  }
+  combinedWithOtherSent: transactionBlocks(filter: { affectedAddress: "@{C}", sentAddress: "@{B}" }) {
+    nodes { digest }
+  }
+  affectedViaAddress: address(address: "@{B}") {
+    transactionBlocks(relation: AFFECTED) {
+      nodes { digest }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.snap
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/filters/affected_address.snap
@@ -1,0 +1,141 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 10-12:
+//# programmable --sender A --inputs 1000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 1960800
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, lines 14-16:
+//# programmable --sender B --inputs 2000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 1960800
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 3, lines 18-20:
+//# programmable --sender B --inputs 3000000 @B
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 1960800
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 4, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 24-49:
+//# run-graphql
+Response: {
+  "data": {
+    "affectedAsRecipient": {
+      "nodes": [
+        {
+          "digest": "6JMNrTEhpNEP9r9XGcHJxU8SNZidgXgx27KKmVGnT4gw"
+        },
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        }
+      ]
+    },
+    "affectedAsSender": {
+      "nodes": [
+        {
+          "digest": "6JMNrTEhpNEP9r9XGcHJxU8SNZidgXgx27KKmVGnT4gw"
+        },
+        {
+          "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
+        }
+      ]
+    },
+    "affectedBoth": {
+      "nodes": [
+        {
+          "digest": "6JMNrTEhpNEP9r9XGcHJxU8SNZidgXgx27KKmVGnT4gw"
+        },
+        {
+          "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
+        },
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        },
+        {
+          "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
+        }
+      ]
+    },
+    "affectedViaAddress": {
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "6JMNrTEhpNEP9r9XGcHJxU8SNZidgXgx27KKmVGnT4gw"
+          },
+          {
+            "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
+          },
+          {
+            "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+          },
+          {
+            "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
+          }
+        ]
+      }
+    },
+    "combinedWithKind": {
+      "nodes": [
+        {
+          "digest": "H839zjkRueyvCZ7wAknEGDzVATF9iifpgrWdYxm8Fhmu"
+        },
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        },
+        {
+          "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
+        }
+      ]
+    },
+    "combinedWithOtherSent": {
+      "nodes": [
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        }
+      ]
+    },
+    "combinedWithSent": {
+      "nodes": [
+        {
+          "digest": "H1AZsRNmZifH1VCkD3x8afmewn151RZhhUi9XkfZBQ5N"
+        },
+        {
+          "digest": "7uTN8JCRtZNcEkLT2tr78sxYFT94cs5FHaXaTcb2zTxn"
+        }
+      ]
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -42,6 +42,7 @@ toml.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+url.workspace = true
 uuid.workspace = true
 
 # internal dependencies

--- a/crates/iota-graphql-rpc/README.md
+++ b/crates/iota-graphql-rpc/README.md
@@ -123,6 +123,52 @@ To run it with the `iota-localnet start` subcommand, switch to the root director
 `cargo run --features indexer --bin iota-localnet start --with-indexer --pg-port 5432 --pg-db-name iota_indexer --with-graphql=0.0.0.0:8000`
 ```
 
+## Historic fallback (REST KV store)
+
+The GraphQL server supports an experimental historic fallback feature via the `--fallback-kv-url` flag.
+The Indexer prunes historical data below a retention watermark, so by default the server cannot read checkpoints, transactions, events, or object versions older than that watermark.
+When a [REST KV store](../../dev-tools/iota-rest-kv/README.md) is configured, the server falls back to it for reads that miss the pruned Postgres data, so pruned history stays queryable.
+It depends on the API served by the `iota-rest-kv` crate, which is still being finalized and subject to change.
+
+> [!WARNING]
+> This is an experimental feature and is subject to change without notice.
+
+### Enabling
+
+Pass the REST KV store URL when starting the server:
+
+```sh
+iota-graphql-rpc start-server \
+  --db-url postgres://<user>:<password>@<host>:5432/<db> \
+  --node-rpc-url http://<fullnode>:<grpc-port> \
+  --fallback-kv-url http://<rest-kv-host>:<port>
+```
+
+Without `--fallback-kv-url` (the default), no fallback is performed and pruned data is unreachable.
+
+The remaining options tune batching, concurrency, and caching of the fallback requests:
+
+| Flag                                   | Env var                              | Default  | Description                                                  |
+| -------------------------------------- | ------------------------------------ | -------- | ------------------------------------------------------------ |
+| `--fallback-kv-url`                    | —                                    | _(none)_ | REST KV store URL. Enables the fallback when set.            |
+| `--fallback-kv-multi-fetch-batch-size` | `FALLBACK_KV_MULTI_FETCH_BATCH_SIZE` | `100`    | Maximum number of keys per batch request to the KV store.    |
+| `--fallback-kv-concurrent-fetches`     | `FALLBACK_KV_CONCURRENT_FETCHES`     | `10`     | Maximum number of concurrent batch requests to the KV store. |
+| `--fallback-kv-cache-size`             | `FALLBACK_KV_CACHE_SIZE`             | `100000` | Number of entries cached from the KV store.                  |
+
+### Queries with fallback
+
+These queries use the fallback when the requested data has been pruned from Postgres:
+
+- Checkpoints: `checkpoint(id)` (by sequence number or digest), `checkpoints`, `Epoch.checkpoints`
+- Transactions by digest: `transactionBlock(digest)`, `transactionBlocksByDigests`
+- Transactions by filter: `transactionBlocks(filter: { atCheckpoint })` and `Checkpoint.transactionBlocks`; `transactionBlocks(filter: { affectedAddress })` and `Address.transactionBlocks(relation: AFFECTED)`; `transactionBlocks(filter: { transactionIds })`
+- Events of a transaction: `events(filter: { transactionDigest })`
+- Objects at a past version: `object(address, version)`, including dynamic fields resolved at a parent object's version
+
+Resolving a dynamic field or dynamic object field at a parent object's version needs that version recorded in the indexer's `objects_version` table. On indexers restored from a snapshot, versions below the restore point cannot be served this way and return `DATA_PRUNED`.
+
+Other read paths are served only from Postgres and cannot see pruned data.
+
 ## Running tests
 
 The crate provides test coverage for server functionality, covering client validation, query validation, reading and writing data, query limits, and health checks.

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -110,7 +110,8 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sent or received.
+The possible relationship types for a transaction block: sent, received,
+or affected.
 """
 enum AddressTransactionBlockRelationship {
 	"""
@@ -121,6 +122,11 @@ enum AddressTransactionBlockRelationship {
 	Transactions that sent objects to this address.
 	"""
 	RECV
+	"""
+	Transactions that affected this address (the address is the sender,
+	a recipient, or the owner of the gas payment).
+	"""
+	AFFECTED
 }
 
 """
@@ -4564,6 +4570,11 @@ input TransactionBlockFilter {
 	Limit to transactions that sent an object to the given address.
 	"""
 	recvAddress: IotaAddress
+	"""
+	Limit to transactions that affected the given address (the address is
+	the sender, a recipient, or the owner of the gas payment).
+	"""
+	affectedAddress: IotaAddress
 	"""
 	Limit to transactions that accepted the given object as an input.
 	"""

--- a/crates/iota-graphql-rpc/src/commands.rs
+++ b/crates/iota-graphql-rpc/src/commands.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use clap::*;
 
-use crate::config::{ConnectionConfig, Ide, TxExecFullNodeConfig};
+use crate::config::{ConnectionConfig, HistoricFallbackOptions, Ide, TxExecFullNodeConfig};
 
 #[derive(Parser)]
 #[command(name = "iota-graphql-rpc", about = "IOTA GraphQL RPC", author)]
@@ -28,6 +28,9 @@ pub enum Command {
 
         #[command(flatten)]
         connection: ConnectionConfig,
+
+        #[command(flatten)]
+        historic_fallback: Box<HistoricFallbackOptions>,
 
         /// Path to TOML file containing configuration for service.
         #[arg(short, long)]

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -8,6 +8,7 @@ use async_graphql::*;
 use iota_graphql_config::GraphQLConfig;
 use iota_names::config::IotaNamesConfig;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::functional_group::FunctionalGroup;
 
@@ -23,6 +24,7 @@ pub struct ServerConfig {
     pub internal_features: InternalFeatureConfig,
     pub tx_exec_full_node: TxExecFullNodeConfig,
     pub ide: Ide,
+    pub historic_fallback: HistoricFallbackOptions,
 }
 
 /// Configuration for connections for the RPC, passed in as command-line
@@ -64,6 +66,59 @@ pub struct ConnectionConfig {
         env = "MAX_AVAILABLE_RANGE",
     )]
     pub max_available_range: u64,
+}
+
+/// CLI options that control the archival fallback used when Postgres data has
+/// been pruned.
+#[GraphQLConfig]
+#[derive(clap::Args, Debug, Clone)]
+pub struct HistoricFallbackOptions {
+    #[arg(
+        long,
+        help = "Experimental: REST KV store URL for historic fallback. Depends on the iota-rest-kv API which is still being finalized."
+    )]
+    pub fallback_kv_url: Option<Url>,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_MULTI_FETCH_BATCH_SIZE,
+        env = "FALLBACK_KV_MULTI_FETCH_BATCH_SIZE",
+        help = "Experimental: Maximum number of keys per batch request to fallback KV store."
+    )]
+    pub fallback_kv_multi_fetch_batch_size: usize,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_CONCURRENT_FETCHES,
+        env = "FALLBACK_KV_CONCURRENT_FETCHES",
+        help = "Experimental: Maximum number of concurrent batch requests to fallback KV store."
+    )]
+    pub fallback_kv_concurrent_fetches: usize,
+
+    #[arg(
+        long,
+        default_value_t = HistoricFallbackOptions::DEFAULT_CACHE_SIZE,
+        env = "FALLBACK_KV_CACHE_SIZE",
+        help = "Experimental: Cache size for historic fallback."
+    )]
+    pub fallback_kv_cache_size: u64,
+}
+
+impl HistoricFallbackOptions {
+    pub const DEFAULT_MULTI_FETCH_BATCH_SIZE: usize = 100;
+    pub const DEFAULT_CONCURRENT_FETCHES: usize = 10;
+    pub const DEFAULT_CACHE_SIZE: u64 = 100_000;
+}
+
+impl Default for HistoricFallbackOptions {
+    fn default() -> Self {
+        Self {
+            fallback_kv_url: None,
+            fallback_kv_multi_fetch_batch_size: Self::DEFAULT_MULTI_FETCH_BATCH_SIZE,
+            fallback_kv_concurrent_fetches: Self::DEFAULT_CONCURRENT_FETCHES,
+            fallback_kv_cache_size: Self::DEFAULT_CACHE_SIZE,
+        }
+    }
 }
 
 /// Configuration on features supported by the GraphQL service, passed in a

--- a/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/iota-graphql-rpc/src/context_data/db_data_provider.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use iota_indexer::{
     apis::GovernanceReadApi,
     db::ConnectionPoolConfig,
+    historical_fallback::HistoricalFallbackReader,
     metrics::IndexerMetrics,
     pruning::watermark_task::{WatermarkCache, WatermarkTask},
     read::IndexerReader,
@@ -17,9 +18,11 @@ use iota_types::{
     governance::StakedIota as NativeStakedIota,
     iota_system_state::iota_system_state_summary::IotaSystemStateSummary as NativeIotaSystemStateSummary,
 };
+use prometheus_filtered::Registry;
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
-use crate::error::Error;
+use crate::{config::HistoricFallbackOptions, error::Error};
 
 pub(crate) struct PgManager {
     pub inner: IndexerReader,
@@ -31,13 +34,17 @@ impl PgManager {
     }
 
     /// Create a new underlying reader, which is used by this type as well as
-    /// other data providers.
+    /// other data providers. If `historic_fallback` carries a URL, an archival
+    /// fallback reader is attached so reads can be served from the REST KV
+    /// store if Postgres data is pruned.
     pub(crate) fn reader_with_config(
         db_url: impl Into<String>,
         pool_size: u32,
         timeout_ms: u64,
         indexer_metrics: IndexerMetrics,
         cancellation_token: CancellationToken,
+        historic_fallback: &HistoricFallbackOptions,
+        registry: &Registry,
     ) -> Result<IndexerReader, Error> {
         let mut config = ConnectionPoolConfig::default();
         config.set_pool_size(pool_size);
@@ -56,7 +63,35 @@ impl PgManager {
         watermark_task.start(cancellation_token);
 
         // Create reader with watermark cache
-        Ok(IndexerReader::new(connection_pool, watermark_cache))
+        let mut reader = IndexerReader::new(connection_pool, watermark_cache);
+
+        if let HistoricFallbackOptions {
+            fallback_kv_url: Some(url),
+            fallback_kv_multi_fetch_batch_size,
+            fallback_kv_concurrent_fetches,
+            fallback_kv_cache_size,
+        } = historic_fallback
+        {
+            let fallback = HistoricalFallbackReader::new(
+                url.as_str(),
+                *fallback_kv_cache_size,
+                reader.package_resolver().clone(),
+                *fallback_kv_multi_fetch_batch_size,
+                *fallback_kv_concurrent_fetches,
+                registry,
+            )
+            .map_err(|e| {
+                Error::Internal(format!(
+                    "Failed to construct historical fallback reader: {e}"
+                ))
+            })?;
+            info!("HistoricalFallbackReader initialized with URL: {url}");
+            reader.with_fallback_reader(fallback);
+        } else {
+            info!("No config for HistoricalFallbackReader provided, skipping...");
+        }
+
+        Ok(reader)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/error.rs
+++ b/crates/iota-graphql-rpc/src/error.rs
@@ -14,6 +14,7 @@ use iota_names::error::IotaNamesError;
 pub(crate) mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
     pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
+    pub const DATA_PRUNED: &str = "DATA_PRUNED";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";
     pub const REQUEST_TIMEOUT: &str = "REQUEST_TIMEOUT";
     pub const UNKNOWN: &str = "UNKNOWN";
@@ -77,6 +78,8 @@ pub enum Error {
     // Catch-all for client-fault errors
     #[error("{0}")]
     Client(String),
+    #[error("Requested data has been pruned: {0}")]
+    DataPruned(String),
     #[error("Internal error occurred while processing request: {0}")]
     Internal(String),
     #[error(transparent)]
@@ -96,6 +99,9 @@ impl ErrorExtensions for Error {
             | Error::Client(_) => {
                 e.set("code", code::BAD_USER_INPUT);
             }
+            Error::DataPruned(_) => {
+                e.set("code", code::DATA_PRUNED);
+            }
             Error::Internal(_) => {
                 e.set("code", code::INTERNAL_SERVER_ERROR);
             }
@@ -114,7 +120,10 @@ impl ErrorExtensions for Error {
 
 impl From<IndexerError> for Error {
     fn from(e: IndexerError) -> Self {
-        Error::Internal(e.to_string())
+        match e {
+            IndexerError::DataPruned(msg) => Error::DataPruned(msg),
+            _ => Error::Internal(e.to_string()),
+        }
     }
 }
 

--- a/crates/iota-graphql-rpc/src/main.rs
+++ b/crates/iota-graphql-rpc/src/main.rs
@@ -53,6 +53,7 @@ async fn main() {
         Command::StartServer {
             ide,
             connection,
+            historic_fallback,
             config,
             tx_exec_full_node,
         } => {
@@ -69,6 +70,7 @@ async fn main() {
                 service: service_config,
                 ide,
                 tx_exec_full_node,
+                historic_fallback: *historic_fallback,
                 ..ServerConfig::default()
             };
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -447,8 +447,10 @@ impl ServerBuilder {
             config.service.limits.request_timeout_ms.into(),
             indexer_metrics.clone(),
             cancellation_token,
+            &config.historic_fallback,
+            &registry,
         )
-        .map_err(|e| Error::ServerInit(format!("Failed to create pg connection pool: {e}")))?;
+        .map_err(|e| Error::ServerInit(format!("Failed to initialize indexer reader: {e}")))?;
 
         if !config.connection.skip_migration_consistency_check {
             // Compatibility check
@@ -795,7 +797,7 @@ pub mod tests {
 
     use super::*;
     use crate::{
-        config::{ConnectionConfig, Limits, ServiceConfig, Version},
+        config::{ConnectionConfig, HistoricFallbackOptions, Limits, ServiceConfig, Version},
         context_data::db_data_provider::PgManager,
         extensions::{query_limits_checker::QueryLimitsChecker, timeout::Timeout},
         test_infra::cluster::Cluster,
@@ -811,12 +813,15 @@ pub mod tests {
         let connection_config = connection_config.unwrap_or_default();
         let service_config = service_config.unwrap_or_default();
 
+        let registry = prometheus_filtered::Registry::new();
         let reader = PgManager::reader_with_config(
             connection_config.db_url.clone(),
             connection_config.db_pool_size,
             service_config.limits.request_timeout_ms.into(),
-            IndexerMetrics::new(&prometheus_filtered::Registry::new()),
+            IndexerMetrics::new(&registry),
             CancellationToken::new(),
+            &HistoricFallbackOptions::default(),
+            &registry,
         )
         .expect("failed to create pg connection pool");
 

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -29,13 +29,17 @@ pub(crate) struct Address {
     pub checkpoint_viewed_at: u64,
 }
 
-/// The possible relationship types for a transaction block: sent or received.
+/// The possible relationship types for a transaction block: sent, received,
+/// or affected.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum AddressTransactionBlockRelationship {
     /// Transactions this address has sent.
     Sent,
     /// Transactions that sent objects to this address.
     Recv,
+    /// Transactions that affected this address (the address is the sender,
+    /// a recipient, or the owner of the gas payment).
+    Affected,
 }
 
 /// The 32-byte address that is an account address (corresponding to a public
@@ -197,6 +201,11 @@ impl Address {
 
             Some(R::Recv) => TransactionBlockFilter {
                 recv_address: Some(self.address),
+                ..Default::default()
+            },
+
+            Some(R::Affected) => TransactionBlockFilter {
+                affected_address: Some(self.address),
                 ..Default::default()
             },
         }) else {

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -399,8 +399,8 @@ impl Checkpoint {
     /// If the `Page<Cursor>` is set, then this function will defer to the
     /// `checkpoint_viewed_at` in the cursor if they are consistent.
     ///
-    /// Specifying cursor or requesting epoch from the pruned range will result
-    /// in an error.
+    /// A cursor or epoch in the pruned range is served from the fallback KV
+    /// store when configured, otherwise the request errors.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    ops::RangeInclusive,
+};
 
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
@@ -11,7 +14,9 @@ use async_graphql::{
 };
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
-use iota_indexer::{models::checkpoints::StoredCheckpoint, schema::checkpoints};
+use iota_indexer::{
+    models::checkpoints::StoredCheckpoint, pruning::CommitterTables, schema::checkpoints,
+};
 use iota_sdk_types::{CheckpointDigest, CheckpointSummary};
 use serde::{Deserialize, Serialize};
 
@@ -19,11 +24,11 @@ use crate::{
     config::DEFAULT_PAGE_SIZE,
     connection::ScanConnection,
     consistency::Checkpointed,
-    data::{self, Conn, DataLoader, Db, DbConnection, QueryExecutor},
+    data::{Conn, DataLoader, Db, DbConnection, QueryExecutor},
     error::Error,
     types::{
         base64::Base64,
-        cursor::{self, Page, Paginated, ScanLimited, Target},
+        cursor::{self, Page, ScanLimited, Target},
         date_time::DateTime,
         digest::Digest,
         epoch::Epoch,
@@ -71,7 +76,6 @@ pub(crate) struct Checkpoint {
 }
 
 pub(crate) type Cursor = cursor::JsonCursor<CheckpointCursor>;
-type Query<ST, GB> = data::Query<ST, checkpoints::table, GB>;
 
 /// The cursor returned for each `Checkpoint` in a connection's page of results.
 /// The `checkpoint_viewed_at` will set the consistent upper bound for
@@ -342,6 +346,44 @@ impl Checkpoint {
         Ok(stored as u64)
     }
 
+    /// Returns the inclusive `[lo, hi]` checkpoint sequence-number range to
+    /// paginate over, given the `checkpoint_viewed_at` and optional `epoch`
+    /// filter. Returns `None` when `filter` targets an epoch that does not
+    /// exist.
+    ///
+    /// The `epochs` table is never pruned but an in-progress epoch's
+    /// `last_checkpoint_id` is NULL - in that case the upper bound is
+    /// capped at `checkpoint_viewed_at`.
+    async fn pagination_range(
+        db: &Db,
+        filter: Option<u64>,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Option<(u64, u64)>, Error> {
+        let Some(epoch) = filter else {
+            return Ok(Some((0, checkpoint_viewed_at)));
+        };
+
+        let row: Option<(i64, Option<i64>)> = db
+            .execute(move |conn| {
+                use iota_indexer::schema::epochs::dsl as e;
+                conn.first(move || {
+                    e::epochs
+                        .select((e::first_checkpoint_id, e::last_checkpoint_id))
+                        .filter(e::epoch.eq(epoch as i64))
+                })
+                .optional()
+            })
+            .await
+            .map_err(|err| Error::Internal(format!("Failed to fetch epoch range: {err}")))?;
+
+        Ok(row.map(|(first, last)| {
+            let hi = last
+                .map(|l| std::cmp::min(l as u64, checkpoint_viewed_at))
+                .unwrap_or(checkpoint_viewed_at);
+            (first as u64, hi)
+        }))
+    }
+
     /// Query the database for a `page` of checkpoints. The Page uses the
     /// checkpoint sequence number of the stored checkpoint and the
     /// checkpoint at which this was viewed at as the cursor, and
@@ -356,37 +398,89 @@ impl Checkpoint {
     ///
     /// If the `Page<Cursor>` is set, then this function will defer to the
     /// `checkpoint_viewed_at` in the cursor if they are consistent.
+    ///
+    /// Specifying cursor or requesting epoch from the pruned range will result
+    /// in an error.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
         filter: Option<u64>,
         checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, Checkpoint>, Error> {
-        use checkpoints::dsl;
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredCheckpoint, _, _, _>(
-                    conn,
-                    checkpoint_viewed_at,
-                    move || {
-                        let mut query = dsl::checkpoints.into_boxed();
-                        query = query.filter(dsl::sequence_number.le(checkpoint_viewed_at as i64));
-                        if let Some(epoch) = filter {
-                            query = query.filter(dsl::epoch.eq(epoch as i64));
-                        }
-                        query
-                    },
-                )
-            })
-            .await?;
+        if page.limit() == 0 {
+            return Ok(Connection::new(false, false));
+        }
 
-        // The "checkpoint viewed at" sets a consistent upper bound for the nested
-        // queries.
-        let mut conn = Connection::new(prev, next);
-        for stored in results {
+        let Some((mut absolute_lo_incl, absolute_hi_incl)) =
+            Self::pagination_range(db, filter, checkpoint_viewed_at).await?
+        else {
+            return Ok(Connection::new(false, false));
+        };
+
+        // Without a fallback, anything below the pruning watermark is unreachable
+        if !db.inner.is_fallback_enabled() {
+            if let Some(lowest_unpruned_cp) = db
+                .inner
+                .watermark_cache()
+                .get_lowest_available_cp_for_tables(&[CommitterTables::Checkpoints])
+                .map(|w| w as u64)
+            {
+                absolute_lo_incl = absolute_lo_incl.max(lowest_unpruned_cp);
+            }
+        }
+
+        let available_range = absolute_lo_incl..=absolute_hi_incl;
+
+        if available_range.is_empty() {
+            return Err(Error::DataPruned(
+                "all checkpoints in the requested range have been pruned".into(),
+            ));
+        }
+
+        let Some(page_range) = page.narrow_to_available_range(&available_range)? else {
+            return Ok(Connection::new(false, false));
+        };
+
+        // Take `limit` sequence numbers from the appropriate end of the page range.
+        let limit = page.limit();
+        let picked_seqs: Vec<u64> = if page.is_from_front() {
+            page_range.take(limit).collect()
+        } else {
+            page_range.rev().take(limit).collect()
+        };
+        let mut all_rows: Vec<StoredCheckpoint> = db
+            .inner
+            .get_stored_checkpoints_by_seqs_with_fallback(picked_seqs.clone())
+            .await
+            .map_err(|err| Error::Internal(format!("Failed to fetch checkpoints: {err}")))?
+            .into_iter()
+            .flatten()
+            .collect();
+        all_rows.sort_by_key(|s| s.sequence_number);
+
+        // We validated the available range earlier, unpruned range should be present in
+        // the DB, rest should be present in fallback KV if configured. In such case we
+        // expect all checkpoints to be returned.
+        if all_rows.len() < picked_seqs.len() {
+            let picked: BTreeSet<u64> = picked_seqs.iter().copied().collect();
+            let returned: BTreeSet<u64> =
+                all_rows.iter().map(|r| r.sequence_number as u64).collect();
+            let misses: Vec<u64> = picked.difference(&returned).copied().collect();
+            return Err(Error::Internal(format!(
+                "checkpoints {misses:?} expected to be available but not found"
+            )));
+        }
+
+        let fetched_lo = all_rows.first().expect("checked non-empty").sequence_number as u64;
+        let fetched_hi = all_rows.last().expect("checked non-empty").sequence_number as u64;
+        let has_prev = fetched_lo > absolute_lo_incl;
+        let has_next = fetched_hi < absolute_hi_incl;
+
+        let mut conn = Connection::new(has_prev, has_next);
+        for stored in all_rows {
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
             conn.edges.push(Edge::new(
                 cursor,
@@ -398,27 +492,6 @@ impl Checkpoint {
         }
 
         Ok(conn)
-    }
-}
-
-impl Paginated<Cursor> for StoredCheckpoint {
-    type Source = checkpoints::table;
-
-    fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.ge(cursor.sequence_number as i64))
-    }
-
-    fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.le(cursor.sequence_number as i64))
-    }
-
-    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
-        use checkpoints::dsl;
-        if asc {
-            query.order(dsl::sequence_number)
-        } else {
-            query.order(dsl::sequence_number.desc())
-        }
     }
 }
 
@@ -439,35 +512,82 @@ impl Checkpointed for Cursor {
 
 impl ScanLimited for Cursor {}
 
+impl Page<Cursor> {
+    /// Narrow page range to the `available` range and return the inclusive
+    /// range this page should cover, or `None` if the range is empty.
+    ///
+    /// A cursor below `available.start()` returns `Error::DataPruned` (the
+    /// data was pruned since the cursor was issued). A cursor above
+    /// `available.end()` returns `Error::Client` (the cursor is malformed).
+    /// When `after > before` the range is empty and no error is returned.
+    fn narrow_to_available_range(
+        &self,
+        available: &RangeInclusive<u64>,
+    ) -> Result<Option<RangeInclusive<u64>>, Error> {
+        let lo = *available.start();
+        let hi = *available.end();
+
+        let after = self.after().map(|c| ("after", c.sequence_number));
+        let before = self.before().map(|c| ("before", c.sequence_number));
+
+        // If `after > before`, the range is empty; skip cursor validation.
+        if let (Some((_, after_seq)), Some((_, before_seq))) = (after, before) {
+            if after_seq > before_seq {
+                return Ok(None);
+            }
+        }
+
+        // Since `after <= before`, it's enough to check if the smaller cursor is below
+        // `lo`. Analogously for `hi`.
+        if let Some((name, seq)) = after.or(before) {
+            if seq < lo {
+                return Err(Error::DataPruned(format!(
+                    "`{name}` cursor (seq {seq}) is below the available range {available:?}"
+                )));
+            }
+        }
+        if let Some((name, seq)) = before.or(after) {
+            if seq > hi {
+                return Err(Error::Client(format!(
+                    "`{name}` cursor (seq {seq}) is above the available range {available:?}"
+                )));
+            }
+        }
+
+        // Cursors are exclusive.
+        let page_lo = after.map(|(_, seq)| seq.saturating_add(1)).unwrap_or(lo);
+        let page_hi = before.map(|(_, seq)| seq.saturating_sub(1)).unwrap_or(hi);
+        let range = page_lo..=page_hi;
+        if range.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(range))
+        }
+    }
+}
+
 impl Loader<SeqNumKey> for Db {
     type Value = Checkpoint;
     type Error = Error;
 
     async fn load(&self, keys: &[SeqNumKey]) -> Result<HashMap<SeqNumKey, Checkpoint>, Error> {
-        use checkpoints::dsl;
-
-        let checkpoint_ids: BTreeSet<_> = keys
+        // Drop keys querying for a checkpoint after their own consistency cursor.
+        let seqs: Vec<u64> = keys
             .iter()
-            .filter_map(|key| {
-                // Filter out keys querying for checkpoints after their own consistency cursor.
-                (key.checkpoint_viewed_at >= key.sequence_number)
-                    .then_some(key.sequence_number as i64)
-            })
+            .filter(|key| key.checkpoint_viewed_at >= key.sequence_number)
+            .map(|key| key.sequence_number)
             .collect();
 
-        let checkpoints: Vec<StoredCheckpoint> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    dsl::checkpoints
-                        .filter(dsl::sequence_number.eq_any(checkpoint_ids.iter().cloned()))
-                })
-            })
+        let rows = self
+            .inner
+            .get_stored_checkpoints_by_seqs_with_fallback(seqs.clone())
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoints: {e}")))?;
 
-        let checkpoint_id_to_stored: BTreeMap<_, _> = checkpoints
+        let checkpoint_id_to_stored: BTreeMap<u64, StoredCheckpoint> = seqs
             .into_iter()
-            .map(|stored| (stored.sequence_number as u64, stored))
+            .zip(rows)
+            .filter_map(|(seq, row)| row.map(|stored| (seq, stored)))
             .collect();
 
         Ok(keys
@@ -495,22 +615,18 @@ impl Loader<DigestKey> for Db {
     type Error = Error;
 
     async fn load(&self, keys: &[DigestKey]) -> Result<HashMap<DigestKey, Checkpoint>, Error> {
-        use checkpoints::dsl;
+        let digests: Vec<CheckpointDigest> = keys.iter().map(|key| key.digest.into()).collect();
 
-        let digests: BTreeSet<_> = keys.iter().map(|key| key.digest.to_vec()).collect();
-
-        let checkpoints: Vec<StoredCheckpoint> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    dsl::checkpoints.filter(dsl::checkpoint_digest.eq_any(digests.iter().cloned()))
-                })
-            })
+        let rows = self
+            .inner
+            .get_stored_checkpoints_by_digests_with_fallback(digests.clone())
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoints: {e}")))?;
 
-        let checkpoint_id_to_stored: BTreeMap<_, _> = checkpoints
+        let checkpoint_id_to_stored: BTreeMap<Vec<u8>, StoredCheckpoint> = digests
             .into_iter()
-            .map(|stored| (stored.checkpoint_digest.clone(), stored))
+            .zip(rows)
+            .filter_map(|(digest, row)| row.map(|stored| (digest.inner().to_vec(), stored)))
             .collect();
 
         Ok(keys

--- a/crates/iota-graphql-rpc/src/types/cursor.rs
+++ b/crates/iota-graphql-rpc/src/types/cursor.rs
@@ -411,7 +411,11 @@ impl<C: CursorType + ScanLimited + Eq + Clone + Send + Sync + 'static> Page<C> {
     /// in the range, followed by an iterator of values in the page, fetched
     /// from the database. The values returned implement `Target<C>`, so are
     /// able to compute their own cursors.
-    fn paginate_results<T>(
+    ///
+    /// `results` must be sorted in ascending cursor order and fetched with
+    /// inclusive cursor bounds, so that the rows at the `after`/`before`
+    /// cursors are part of the result set (see [`Page::apply`]).
+    pub(crate) fn paginate_results<T>(
         &self,
         f_cursor: Option<C>,
         l_cursor: Option<C>,

--- a/crates/iota-graphql-rpc/src/types/digest.rs
+++ b/crates/iota-graphql-rpc/src/types/digest.rs
@@ -25,10 +25,6 @@ pub(crate) enum Error {
 }
 
 impl Digest {
-    pub(crate) fn to_vec(self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
     pub(crate) fn as_slice(&self) -> &[u8] {
         &self.0
     }

--- a/crates/iota-graphql-rpc/src/types/digest.rs
+++ b/crates/iota-graphql-rpc/src/types/digest.rs
@@ -6,7 +6,7 @@ use std::{fmt, str::FromStr};
 
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
-use iota_sdk_types::{ObjectDigest, TransactionDigest};
+use iota_sdk_types::{CheckpointDigest, ObjectDigest, TransactionDigest};
 
 use crate::types::string_input::impl_string_input;
 
@@ -72,6 +72,12 @@ impl From<Digest> for ObjectDigest {
 impl From<Digest> for TransactionDigest {
     fn from(digest: Digest) -> Self {
         TransactionDigest::new(digest.0)
+    }
+}
+
+impl From<Digest> for CheckpointDigest {
+    fn from(digest: Digest) -> Self {
+        CheckpointDigest::new(digest.0)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/event/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/event/filter.rs
@@ -50,3 +50,14 @@ pub(crate) struct EventFilter {
     // pub all
     // pub not
 }
+
+impl EventFilter {
+    /// Returns the transaction digest when `transaction_digest` is the only
+    /// filter set.
+    pub(crate) fn only_transaction_digest(&self) -> Option<Digest> {
+        if self.sender.is_some() || self.emitting_module.is_some() || self.event_type.is_some() {
+            return None;
+        }
+        self.transaction_digest
+    }
+}

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -29,9 +29,10 @@ use crate::{
         base64::Base64,
         cursor::{Page, Target},
         date_time::DateTime,
+        digest::Digest,
         move_module::MoveModule,
         move_value::MoveValue,
-        transaction_block::{SeqKey, TransactionBlock},
+        transaction_block::{DigestKey, TransactionBlock},
     },
 };
 
@@ -44,18 +45,22 @@ pub(crate) use filter::EventFilter;
 /// An event emitted in a transaction that has been checkpointed.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct CheckpointedEventInfo {
-    /// The sequence number of the parent transaction.
-    tx_sequence_number: u64,
+    /// The digest of the parent transaction.
+    tx_digest: Digest,
     /// The timestamp of the parent transaction.
     timestamp_ms: i64,
 }
 
-impl From<&StoredEvent> for CheckpointedEventInfo {
-    fn from(value: &StoredEvent) -> Self {
-        Self {
-            tx_sequence_number: value.tx_sequence_number as u64,
+impl TryFrom<&StoredEvent> for CheckpointedEventInfo {
+    type Error = Error;
+
+    fn try_from(value: &StoredEvent) -> Result<Self, Self::Error> {
+        let tx_digest = Digest::try_from(value.transaction_digest.as_slice())
+            .map_err(|e| Error::Internal(format!("Bad transaction digest on event: {e}")))?;
+        Ok(Self {
+            tx_digest,
             timestamp_ms: value.timestamp_ms,
-        }
+        })
     }
 }
 
@@ -89,9 +94,9 @@ impl Event {
         let Some(checkpointed) = &self.checkpointed_info else {
             return Ok(None);
         };
-        let key = SeqKey::new(checkpointed.tx_sequence_number, self.checkpoint_viewed_at);
+        let key = DigestKey::new(checkpointed.tx_digest, self.checkpoint_viewed_at);
 
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     /// The Move module containing some function that when called by
@@ -279,8 +284,10 @@ impl Event {
             ))
         })?;
 
+        let tx_digest = Digest::try_from(stored_tx.transaction_digest.as_slice())
+            .map_err(|e| Error::Internal(format!("Bad transaction digest on transaction: {e}")))?;
         let checkpointed = CheckpointedEventInfo {
-            tx_sequence_number: stored_tx.tx_sequence_number as u64,
+            tx_digest,
             timestamp_ms: stored_tx.timestamp_ms,
         };
         Ok(Self {
@@ -297,7 +304,7 @@ impl Event {
         let Some(Some(sender_bytes)) = stored.senders.first() else {
             return Err(Error::Internal("No senders found for event".to_string()));
         };
-        let checkpointed = CheckpointedEventInfo::from(&stored);
+        let checkpointed = CheckpointedEventInfo::try_from(&stored)?;
         let sender =
             NativeAddress::from_bytes(sender_bytes).map_err(|e| Error::Internal(e.to_string()))?;
         let package_id =

--- a/crates/iota-graphql-rpc/src/types/event/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/event/mod.rs
@@ -16,7 +16,7 @@ use iota_indexer::{
     schema::{checkpoints, events},
 };
 use iota_sdk_types::{Address as NativeAddress, Event as NativeEvent, Identifier, ObjectId};
-use iota_types::parse_iota_struct_tag;
+use iota_types::{event::EventID, parse_iota_struct_tag};
 use lookups::{add_bounds, select_emit_module, select_event_type, select_sender};
 
 use crate::{
@@ -171,6 +171,30 @@ impl Event {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);
 
+        use checkpoints::dsl;
+        // Exclusive upperbound, we cannot return newer data than `checkpoint_viewed_at`
+        let tx_hi: i64 = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    dsl::checkpoints
+                        .select(dsl::network_total_transactions)
+                        .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
+                })
+            })
+            .await?;
+
+        // For the only-`transactionDigest` case, we support fallback.
+        if let Some(tx_digest) = filter.only_transaction_digest() {
+            return Self::paginate_by_tx_digest_with_fallback(
+                db,
+                page,
+                tx_digest,
+                checkpoint_viewed_at,
+                tx_hi,
+            )
+            .await;
+        }
+
         // Construct tx and ev sequence number query with table-relevant filters, if
         // they exist. The resulting query will look something like `SELECT
         // tx_sequence_number, event_sequence_number FROM lookup_table WHERE
@@ -188,14 +212,8 @@ impl Event {
             }
         };
 
-        use checkpoints::dsl;
         let (prev, next, results) = db
             .execute(move |conn| {
-                let tx_hi: i64 = conn.first(move || {
-                    dsl::checkpoints.select(dsl::network_total_transactions)
-                        .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
-                })?;
-
                 let (prev, next, mut events): (bool, bool, Vec<StoredEvent>) =
                     if let Some(filter_query) =  query_constraint {
                         let query = add_bounds(filter_query, &filter.transaction_digest, &page, tx_hi);
@@ -262,6 +280,80 @@ impl Event {
             ));
         }
 
+        Ok(conn)
+    }
+
+    /// Paginates events of a single transaction with fallback support.
+    ///
+    /// `tx_hi` is the exclusive upperbound on transaction sequence numbers
+    async fn paginate_by_tx_digest_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        tx_digest: Digest,
+        checkpoint_viewed_at: u64,
+        tx_hi: i64,
+    ) -> Result<Connection<String, Event>, Error> {
+        // Page cursors are inclusive, we need to convert them to exclusive
+        let cursor = if page.is_from_front() {
+            // Cannot do -1 when cursor=0
+            page.after().and_then(|cursor| {
+                cursor.e.checked_sub(1).map(|event_seq| EventID {
+                    tx_digest: tx_digest.into(),
+                    event_seq,
+                })
+            })
+        } else {
+            // Cannot do +1 when cursor=`u64::MAX`
+            page.before().and_then(|cursor| {
+                cursor.e.checked_add(1).map(|event_seq| EventID {
+                    tx_digest: tx_digest.into(),
+                    event_seq,
+                })
+            })
+        };
+
+        // we fetch with limit+2, so that we receive back both cursors in case of full
+        // page, as required by `page.paginate_results`
+        let mut results = db
+            .inner
+            .query_stored_events_by_tx_digest_with_fallback(
+                tx_digest.into(),
+                cursor,
+                page.limit() + 2,
+                !page.is_from_front(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !page.is_from_front() {
+            results.reverse();
+        }
+
+        // Initial fetch above honored only the start cursor. We filter the result to
+        // also honor the end cursor and the `tx_hi`
+        results.retain(|ev| {
+            let key = (
+                ev.tx_sequence_number as u64,
+                ev.event_sequence_number as u64,
+            );
+            ev.tx_sequence_number < tx_hi
+                && page.after().is_none_or(|c| (c.tx, c.e) <= key)
+                && page.before().is_none_or(|c| key <= (c.tx, c.e))
+        });
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = Connection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            conn.edges.push(Edge::new(
+                cursor,
+                Event::try_from_stored_event(stored, checkpoint_viewed_at)?,
+            ));
+        }
         Ok(conn)
     }
 

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -663,7 +663,7 @@ impl ObjectImpl<'_> {
         let digest = native.previous_transaction;
         let key = transaction_block::DigestKey::new(digest.into(), self.0.checkpoint_viewed_at);
 
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     pub(crate) async fn storage_rebate(&self) -> Option<BigInt> {

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -14,11 +14,14 @@ use async_graphql::{
 };
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, SelectableHelper, sql_types};
 use iota_indexer::{
+    ingestion::common::CommitterTables,
     models::objects::{StoredHistoryObject, StoredObject},
     schema::objects,
     types::{ObjectStatus as NativeObjectStatus, OwnerType},
 };
-use iota_sdk_types::{MoveStruct as NativeMoveStruct, Owner as NativeOwner, StructTag, TypeTag};
+use iota_sdk_types::{
+    MoveStruct as NativeMoveStruct, ObjectId, Owner as NativeOwner, StructTag, TypeTag, Version,
+};
 use iota_types::object::{Object as NativeObject, bounded_visitor::BoundedVisitor};
 use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout};
 use serde::{Deserialize, Serialize};
@@ -918,32 +921,31 @@ impl Object {
             ObjectLookup::VersionAt {
                 version,
                 checkpoint_viewed_at,
-            } => {
-                loader
-                    .load_one(HistoricalKey {
-                        id,
-                        version,
-                        checkpoint_viewed_at,
-                    })
-                    .await
-            }
+            } => loader
+                .load_one(HistoricalKey {
+                    id,
+                    version,
+                    checkpoint_viewed_at,
+                })
+                .await?
+                .transpose(),
 
-            ObjectLookup::OptimisticVersion { version } => {
-                loader.load_one(OptimisticKey { id, version }).await
-            }
+            ObjectLookup::OptimisticVersion { version } => loader
+                .load_one(OptimisticKey { id, version })
+                .await?
+                .transpose(),
 
             ObjectLookup::UnderParent {
                 parent_version,
                 checkpoint_viewed_at,
-            } => {
-                loader
-                    .load_one(ParentVersionKey {
-                        id,
-                        parent_version,
-                        checkpoint_viewed_at,
-                    })
-                    .await
-            }
+            } => loader
+                .load_one(ParentVersionKey {
+                    id,
+                    parent_version,
+                    checkpoint_viewed_at,
+                })
+                .await?
+                .transpose(),
 
             ObjectLookup::LatestAt {
                 checkpoint_viewed_at,
@@ -1009,6 +1011,7 @@ impl Object {
     pub(crate) fn try_from_stored_object(
         stored_object: StoredObject,
         checkpoint_viewed_at: u64,
+        root_version: Option<u64>,
     ) -> Result<Self, Error> {
         let active_object = ActiveObject {
             native: NativeObject::try_from(&stored_object)?,
@@ -1018,7 +1021,7 @@ impl Object {
         Ok(Self::from_active_object(
             active_object,
             checkpoint_viewed_at,
-            None,
+            root_version,
         ))
     }
 }
@@ -1392,11 +1395,121 @@ impl Target<Cursor> for StoredBackwardObject {
     }
 }
 
+/// Synthetic `object_status` for object versions that still exist in
+/// `objects_version` table, but are already pruned from
+/// `objects_backward_history`.
+const OBJECT_STATUS_PRUNED: i16 = -1;
+
+const OBJECT_STATUS_WRAPPED_OR_DELETED: i16 = NativeObjectStatus::WrappedOrDeleted as i16;
+
+const OBJECT_STATUS_ACTIVE: i16 = NativeObjectStatus::Active as i16;
+
+/// Supplies the parameters needed to build an [`Object`] from a row fetched
+/// from the historical fallback: the checkpoint it is viewed at, and the root
+/// version to record on it.
+trait FallbackObjectKey: Eq + std::hash::Hash {
+    /// The checkpoint the object is viewed at.
+    fn checkpoint_viewed_at(&self) -> u64;
+    /// The root version to record on the resulting object, if any.
+    fn root_version(&self) -> Option<u64>;
+}
+
+impl FallbackObjectKey for HistoricalKey {
+    fn checkpoint_viewed_at(&self) -> u64 {
+        self.checkpoint_viewed_at
+    }
+    fn root_version(&self) -> Option<u64> {
+        None
+    }
+}
+
+impl FallbackObjectKey for ParentVersionKey {
+    fn checkpoint_viewed_at(&self) -> u64 {
+        self.checkpoint_viewed_at
+    }
+    fn root_version(&self) -> Option<u64> {
+        Some(self.parent_version)
+    }
+}
+
+/// Checks if `objects_version` table covers the whole chain history.
+///
+/// This function currently returns false for indexer restored from snapshot.
+fn objects_version_complete(db: &Db) -> bool {
+    db.inner
+        .ensure_data_not_pruned_for_checkpoint(0, &[CommitterTables::ObjectsVersion])
+        .is_ok()
+}
+
+/// Fills the missing `results` entries with objects fetched from the
+/// historical fallback.
+///
+/// It stores nothing when the object does not exist at the requested version
+/// (e.g. when the object is wrapped or deleted). It stores
+/// [`Error::DataPruned`] per key when the historical fallback is not
+/// configured.
+async fn fill_missing_objects_from_fallback<K: FallbackObjectKey>(
+    db: &Db,
+    keys_with_refs: Vec<(K, (ObjectId, Version))>,
+    results: &mut HashMap<K, Result<Object, Error>>,
+) -> Result<(), Error> {
+    if keys_with_refs.is_empty() {
+        return Ok(());
+    }
+
+    let object_refs: Vec<(ObjectId, Version)> =
+        keys_with_refs.iter().map(|(_, obj_ref)| *obj_ref).collect();
+
+    let fetched: Vec<Result<Option<StoredObject>, Error>> = if db.inner.is_fallback_enabled() {
+        db.inner
+            .multi_get_fallback_objects(&object_refs, false)
+            .await
+            .map_err(Error::from)?
+            .into_iter()
+            .map(Ok)
+            .collect()
+    } else {
+        object_refs
+            .iter()
+            .map(|(id, _)| {
+                Err(Error::DataPruned(format!(
+                    "data for object {id} potentially pruned"
+                )))
+            })
+            .collect()
+    };
+
+    for ((key, _), fetched) in keys_with_refs.into_iter().zip(fetched) {
+        match fetched {
+            Ok(Some(stored)) => {
+                let object = Object::try_from_stored_object(
+                    stored,
+                    key.checkpoint_viewed_at(),
+                    key.root_version(),
+                )?;
+                results.insert(key, Ok(object));
+            }
+            // The object does not exist at the requested version.
+            Ok(None) => {}
+            // Only this key cannot be served.
+            Err(e) => {
+                results.insert(key, Err(e));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 impl Loader<HistoricalKey> for Db {
-    type Value = Object;
+    /// Error stored per key, e.g. when object version is pruned.
+    type Value = Result<Object, Error>;
     type Error = Error;
 
-    async fn load(&self, keys: &[HistoricalKey]) -> Result<HashMap<HistoricalKey, Object>, Error> {
+    async fn load(
+        &self,
+        keys: &[HistoricalKey],
+    ) -> Result<HashMap<HistoricalKey, Result<Object, Error>>, Error> {
         if keys.is_empty() {
             return Ok(HashMap::new());
         }
@@ -1408,22 +1521,27 @@ impl Loader<HistoricalKey> for Db {
             .into_iter()
             .unzip();
 
-        let active = NativeObjectStatus::Active as i16;
-
         // For each `(object_id, object_version)` pair, locate the row content
         // in `checkpointed_objects` (current state of the object) or
         // `objects_backward_history` (a superseded prior state). The
         // `objects_version` join confirms the version is real and supplies the
         // checkpoint at which it became current.
         //
-        // Only active rows are returned: wrapped or deleted tombstones (and
-        // versions present only in `objects_version`) fail the active status
-        // check, so such versions resolve as non-existent.
+        // A row is returned for every version found in `objects_version`.
+        // Wrapped-or-deleted status is reported for versions without row
+        // content that are in the retention window of
+        // `objects_backward_history`. Versions outside of this retention
+        // window are returned with the synthetic `OBJECT_STATUS_PRUNED`
+        // status.
         let sql = "SELECT \
                 v.object_id, \
                 v.object_version, \
                 v.cp_sequence_number AS checkpoint_sequence_number, \
-                COALESCE(co.object_status, bh.object_status) AS object_status, \
+                COALESCE(co.object_status, bh.object_status, \
+                    CASE WHEN v.cp_sequence_number >= COALESCE((\
+                        SELECT min_available_cp FROM watermarks \
+                        WHERE entity = 'objects_backward_history'), 0) \
+                    THEN $3 ELSE $4 END) AS object_status, \
                 COALESCE(co.object_digest, bh.object_digest) AS object_digest, \
                 COALESCE(co.owner_type, bh.owner_type) AS owner_type, \
                 COALESCE(co.owner_id, bh.owner_id) AS owner_id, \
@@ -1444,8 +1562,7 @@ impl Loader<HistoricalKey> for Db {
                   AND co.object_version = v.object_version \
             LEFT JOIN objects_backward_history bh \
                    ON bh.object_id = v.object_id \
-                  AND bh.object_version = v.object_version \
-            WHERE COALESCE(co.object_status, bh.object_status) = $3";
+                  AND bh.object_version = v.object_version";
 
         let objects: Vec<StoredHistoryObject> = self
             .execute(move |conn| {
@@ -1453,7 +1570,8 @@ impl Loader<HistoricalKey> for Db {
                     diesel::sql_query(sql)
                         .bind::<sql_types::Array<sql_types::Binary>, _>(ids.clone())
                         .bind::<sql_types::Array<sql_types::BigInt>, _>(versions.clone())
-                        .bind::<sql_types::SmallInt, _>(active)
+                        .bind::<sql_types::SmallInt, _>(OBJECT_STATUS_WRAPPED_OR_DELETED)
+                        .bind::<sql_types::SmallInt, _>(OBJECT_STATUS_PRUNED)
                 })
             })
             .await
@@ -1466,8 +1584,12 @@ impl Loader<HistoricalKey> for Db {
         }
 
         let mut result = HashMap::new();
+        let mut fallback_keys = Vec::new();
+        // Keys with no `objects_version` entry at all.
+        let mut unresolved_keys = Vec::new();
         for key in keys {
             let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) else {
+                unresolved_keys.push(*key);
                 continue;
             };
 
@@ -1478,22 +1600,47 @@ impl Loader<HistoricalKey> for Db {
                 continue;
             }
 
-            let active_object = ActiveObject::try_from(stored.clone())?;
+            let active_object = match stored.object_status {
+                OBJECT_STATUS_PRUNED => {
+                    fallback_keys.push(*key);
+                    continue;
+                }
+                OBJECT_STATUS_ACTIVE => ActiveObject::try_from(stored.clone())?,
+                // Wrapped, deleted, or not yet created: resolve as non-existent.
+                _ => continue,
+            };
             // This conversion will use the object's own version as the
             // `Object::root_version`.
             let object = Object::from_active_object(active_object, key.checkpoint_viewed_at, None);
-            result.insert(*key, object);
+            result.insert(*key, Ok(object));
         }
+
+        // When version history is complete, unresolved key = nonexisting object
+        // version. When history is incomplete we have to query the KV to know
+        // if object exists or not.
+        if !objects_version_complete(self) {
+            fallback_keys.append(&mut unresolved_keys);
+        }
+
+        let keys_with_refs = fallback_keys
+            .into_iter()
+            .map(|key| (key, (key.id.into(), Version::from(key.version))))
+            .collect();
+        fill_missing_objects_from_fallback(self, keys_with_refs, &mut result).await?;
 
         Ok(result)
     }
 }
 
 impl Loader<OptimisticKey> for Db {
-    type Value = Object;
+    /// Error stored per key, e.g. when object version is pruned.
+    type Value = Result<Object, Error>;
     type Error = Error;
 
-    async fn load(&self, keys: &[OptimisticKey]) -> Result<HashMap<OptimisticKey, Object>, Error> {
+    async fn load(
+        &self,
+        keys: &[OptimisticKey],
+    ) -> Result<HashMap<OptimisticKey, Result<Object, Error>>, Error> {
         use objects::dsl as o;
 
         if keys.is_empty() {
@@ -1531,8 +1678,8 @@ impl Loader<OptimisticKey> for Db {
         let mut missing_keys = Vec::new();
         for key in keys {
             if let Some(stored) = id_version_to_stored.get(&(key.id, key.version)) {
-                let object = Object::try_from_stored_object(stored.clone(), u64::MAX)?;
-                result.insert(*key, object);
+                let object = Object::try_from_stored_object(stored.clone(), u64::MAX, None)?;
+                result.insert(*key, Ok(object));
             } else {
                 missing_keys.push(*key);
             }
@@ -1549,7 +1696,7 @@ impl Loader<OptimisticKey> for Db {
                 })
                 .collect();
 
-            let historical_result: HashMap<HistoricalKey, Object> =
+            let historical_result: HashMap<HistoricalKey, Result<Object, Error>> =
                 self.load(&historical_keys).await?;
 
             for (historical_key, object) in historical_result {
@@ -1566,13 +1713,14 @@ impl Loader<OptimisticKey> for Db {
 }
 
 impl Loader<ParentVersionKey> for Db {
-    type Value = Object;
+    /// Error stored per key, e.g. when object version is pruned.
+    type Value = Result<Object, Error>;
     type Error = Error;
 
     async fn load(
         &self,
         keys: &[ParentVersionKey],
-    ) -> Result<HashMap<ParentVersionKey, Object>, Error> {
+    ) -> Result<HashMap<ParentVersionKey, Result<Object, Error>>, Error> {
         // Group keys by checkpoint viewed at and parent version -- we'll issue a
         // separate query for each group.
         #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
@@ -1594,18 +1742,18 @@ impl Loader<ParentVersionKey> for Db {
                 .insert(key.id.into_vec());
         }
 
-        let active = NativeObjectStatus::Active as i16;
-
         // For each id, pick the largest version `≤ parent_version` from
         // `objects_version` (versions table contains all current and past versions of
         // objects), then locate the row content in `checkpointed_objects`
         // (current state of the object) or `objects_backward_history` (a
         // superseded prior state).
         //
-        // Only active rows are returned: when the latest version `≤
-        // parent_version` is a wrapped or deleted tombstone (or exists only in
-        // `objects_version`), it fails the active status check and the object
-        // resolves as non-existent at `parent_version`.
+        // A row is returned for the largest version `≤ parent_version` found
+        // in `objects_version`. Wrapped-or-deleted status is reported for
+        // versions without row content that are in the retention window of
+        // `objects_backward_history`. Versions outside of this retention
+        // window are returned with the synthetic `OBJECT_STATUS_PRUNED`
+        // status.
         let sql = "WITH ids AS (SELECT unnest($1::bytea[]) AS object_id), \
                         latest_per_id AS (\
                        SELECT i.object_id, o.object_version, o.cp_sequence_number \
@@ -1621,7 +1769,11 @@ impl Loader<ParentVersionKey> for Db {
                        v.object_id, \
                        v.object_version, \
                        v.cp_sequence_number AS checkpoint_sequence_number, \
-                       COALESCE(co.object_status, bh.object_status) AS object_status, \
+                       COALESCE(co.object_status, bh.object_status, \
+                           CASE WHEN v.cp_sequence_number >= COALESCE((\
+                               SELECT min_available_cp FROM watermarks \
+                               WHERE entity = 'objects_backward_history'), 0) \
+                           THEN $3 ELSE $4 END) AS object_status, \
                        COALESCE(co.object_digest, bh.object_digest) AS object_digest, \
                        COALESCE(co.owner_type, bh.owner_type) AS owner_type, \
                        COALESCE(co.owner_id, bh.owner_id) AS owner_id, \
@@ -1639,8 +1791,7 @@ impl Loader<ParentVersionKey> for Db {
                          AND co.object_version = v.object_version \
                    LEFT JOIN objects_backward_history bh \
                           ON bh.object_id = v.object_id \
-                         AND bh.object_version = v.object_version \
-                   WHERE COALESCE(co.object_status, bh.object_status) = $3";
+                         AND bh.object_version = v.object_version";
 
         // Issue concurrent reads for each group of keys.
         let futures = keys_by_cursor_and_parent_version
@@ -1654,7 +1805,8 @@ impl Loader<ParentVersionKey> for Db {
                         diesel::sql_query(sql)
                             .bind::<sql_types::Array<sql_types::Binary>, _>(ids.clone())
                             .bind::<sql_types::BigInt, _>(parent_version)
-                            .bind::<sql_types::SmallInt, _>(active)
+                            .bind::<sql_types::SmallInt, _>(OBJECT_STATUS_WRAPPED_OR_DELETED)
+                            .bind::<sql_types::SmallInt, _>(OBJECT_STATUS_PRUNED)
                     })?;
 
                     Ok::<_, diesel::result::Error>(
@@ -1669,35 +1821,74 @@ impl Loader<ParentVersionKey> for Db {
         // Wait for the reads to all finish, and gather them into the result map.
         let groups = futures::future::join_all(futures).await;
 
-        let mut results = HashMap::new();
+        let mut key_to_stored = HashMap::new();
         for group in groups {
             for (group_key, stored) in
                 group.map_err(|e| Error::Internal(format!("Failed to fetch objects: {e}")))?
             {
-                // This particular object is invalid -- it didn't exist at the checkpoint we are
-                // viewing at.
-                if group_key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                    continue;
-                }
-
-                let active_object = ActiveObject::try_from(stored)?;
-                // If `LatestAtKey::parent_version` is set, it must have been correctly
-                // propagated from the `Object::root_version` of some object.
-                let object = Object::from_active_object(
-                    active_object,
-                    group_key.checkpoint_viewed_at,
-                    Some(group_key.parent_version),
-                );
-
                 let key = ParentVersionKey {
-                    id: object.address,
+                    id: addr(&stored.object_id)?,
                     checkpoint_viewed_at: group_key.checkpoint_viewed_at,
                     parent_version: group_key.parent_version,
                 };
-
-                results.insert(key, object);
+                key_to_stored.insert(key, stored);
             }
         }
+
+        let mut results = HashMap::new();
+        let mut fallback_keys = Vec::new();
+        // Keys with no version `≤ parent_version` in `objects_version` at all.
+        let mut unresolved_keys = Vec::new();
+        for key in keys {
+            let Some(stored) = key_to_stored.get(key) else {
+                unresolved_keys.push(*key);
+                continue;
+            };
+
+            // This version didn't exist at the checkpoint we are viewing at.
+            if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                continue;
+            }
+
+            let active_object = match stored.object_status {
+                OBJECT_STATUS_PRUNED => {
+                    let object_ref = (key.id.into(), Version::from(stored.object_version as u64));
+                    fallback_keys.push((*key, object_ref));
+                    continue;
+                }
+                OBJECT_STATUS_ACTIVE => ActiveObject::try_from(stored.clone())?,
+                // Wrapped, deleted, or not yet created: resolve as non-existent.
+                _ => continue,
+            };
+            // If `LatestAtKey::parent_version` is set, it must have been correctly
+            // propagated from the `Object::root_version` of some object.
+            let object = Object::from_active_object(
+                active_object,
+                key.checkpoint_viewed_at,
+                Some(key.parent_version),
+            );
+
+            results.insert(*key, Ok(object));
+        }
+
+        // When version history is complete, unresolved key = nonexisting object
+        // version. When history is incomplete we return DataPruned for such
+        // cases, since this cannot be handled by KV currently: before_version
+        // query will not work properly since we don't store wrapped-or-deleted
+        // version in the KV.
+        if !objects_version_complete(self) {
+            for key in unresolved_keys {
+                let id = key.id;
+                results.insert(
+                    key,
+                    Err(Error::DataPruned(format!(
+                        "data for object {id} potentially pruned"
+                    ))),
+                );
+            }
+        }
+
+        fill_missing_objects_from_fallback(self, fallback_keys, &mut results).await?;
 
         Ok(results)
     }

--- a/crates/iota-graphql-rpc/src/types/query.rs
+++ b/crates/iota-graphql-rpc/src/types/query.rs
@@ -362,7 +362,7 @@ impl Query {
     ) -> Result<Option<TransactionBlock>> {
         let Watermark { checkpoint, .. } = *ctx.data()?;
         let key = transaction_block::DigestKey::new(digest, checkpoint);
-        TransactionBlock::query(ctx, key.into()).await.extend()
+        TransactionBlock::query(ctx, key).await.extend()
     }
 
     /// Fetch multiple transaction blocks by their digests.

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -130,6 +130,16 @@ impl TransactionBlockFilter {
             || self.transaction_ids.is_some()
     }
 
+    /// Returns the checkpoint sequence number when `at_checkpoint` is the
+    /// only filter set.
+    pub(crate) fn only_at_checkpoint(&self) -> Option<UInt53> {
+        if self.has_filters() || self.after_checkpoint.is_some() || self.before_checkpoint.is_some()
+        {
+            return None;
+        }
+        self.at_checkpoint
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.before_checkpoint == Some(UInt53::from(0))
             || matches!(

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -34,6 +34,9 @@ pub(crate) struct TransactionBlockFilter {
     pub sent_address: Option<IotaAddress>,
     /// Limit to transactions that sent an object to the given address.
     pub recv_address: Option<IotaAddress>,
+    /// Limit to transactions that affected the given address (the address is
+    /// the sender, a recipient, or the owner of the gas payment).
+    pub affected_address: Option<IotaAddress>,
     /// Limit to transactions that accepted the given object as an input.
     pub input_object: Option<IotaAddress>,
     /// Limit to transactions that output a version of this object.
@@ -67,6 +70,7 @@ impl TransactionBlockFilter {
 
             sent_address: intersect!(sent_address, intersect::by_eq)?,
             recv_address: intersect!(recv_address, intersect::by_eq)?,
+            affected_address: intersect!(affected_address, intersect::by_eq)?,
             input_object: intersect!(input_object, intersect::by_eq)?,
             changed_object: intersect!(changed_object, intersect::by_eq)?,
             wrapped_or_deleted_object: intersect!(wrapped_or_deleted_object, intersect::by_eq)?,
@@ -88,6 +92,7 @@ impl TransactionBlockFilter {
             self.function.is_some(),
             self.kind.is_some(),
             self.recv_address.is_some(),
+            self.affected_address.is_some(),
             self.input_object.is_some(),
             self.changed_object.is_some(),
             self.wrapped_or_deleted_object.is_some(),
@@ -107,6 +112,7 @@ impl TransactionBlockFilter {
         if self.function.is_none()
             && self.kind.is_none()
             && self.recv_address.is_none()
+            && self.affected_address.is_none()
             && self.input_object.is_none()
             && self.changed_object.is_none()
             && self.wrapped_or_deleted_object.is_none()
@@ -124,6 +130,7 @@ impl TransactionBlockFilter {
             || self.kind.is_some()
             || self.sent_address.is_some()
             || self.recv_address.is_some()
+            || self.affected_address.is_some()
             || self.input_object.is_some()
             || self.changed_object.is_some()
             || self.wrapped_or_deleted_object.is_some()

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -147,6 +147,26 @@ impl TransactionBlockFilter {
         self.at_checkpoint
     }
 
+    /// Returns the affected address when `affected_address` is the only
+    /// filter set.
+    pub(crate) fn only_affected_address(&self) -> Option<IotaAddress> {
+        if self.function.is_some()
+            || self.kind.is_some()
+            || self.sent_address.is_some()
+            || self.recv_address.is_some()
+            || self.input_object.is_some()
+            || self.changed_object.is_some()
+            || self.wrapped_or_deleted_object.is_some()
+            || self.transaction_ids.is_some()
+            || self.after_checkpoint.is_some()
+            || self.at_checkpoint.is_some()
+            || self.before_checkpoint.is_some()
+        {
+            return None;
+        }
+        self.affected_address
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.before_checkpoint == Some(UInt53::from(0))
             || matches!(

--- a/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/filter.rs
@@ -167,6 +167,26 @@ impl TransactionBlockFilter {
         self.affected_address
     }
 
+    /// Returns the transaction digests when `transactionIds` is the only
+    /// filter set.
+    pub(crate) fn only_transaction_ids(&self) -> Option<&Vec<Digest>> {
+        let no_other_filters = self.function.is_none()
+            && self.kind.is_none()
+            && self.sent_address.is_none()
+            && self.recv_address.is_none()
+            && self.affected_address.is_none()
+            && self.input_object.is_none()
+            && self.changed_object.is_none()
+            && self.wrapped_or_deleted_object.is_none()
+            && self.after_checkpoint.is_none()
+            && self.at_checkpoint.is_none()
+            && self.before_checkpoint.is_none();
+
+        no_other_filters
+            .then_some(self.transaction_ids.as_ref())
+            .flatten()
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.before_checkpoint == Some(UInt53::from(0))
             || matches!(

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -7,18 +7,19 @@ use std::collections::{BTreeMap, HashMap};
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
 use cursor::TxLookup;
-use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
+use diesel::{ExpressionMethods, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{
     apis::ReadApi,
     models::transactions::{OptimisticTransaction, StoredTransaction},
-    schema::{optimistic_transactions, transactions, tx_digests, tx_global_order},
+    read::TransactionRead,
+    schema::transactions,
 };
 use iota_json_rpc_api::ReadApiServer;
 use iota_sdk_types::{
     Address as NativeAddress, Event as NativeEvent,
     SenderSignedTransaction as NativeSenderSignedTransaction, Transaction as NativeTransactionData,
-    TransactionEffects as NativeTransactionEffects, TransactionExpiration,
+    TransactionDigest, TransactionEffects as NativeTransactionEffects, TransactionExpiration,
 };
 use iota_types::{message_envelope::Message, transaction::TransactionAPI};
 use serde::{Deserialize, Serialize};
@@ -147,41 +148,6 @@ impl DigestKey {
             digest,
             checkpoint_viewed_at,
         }
-    }
-}
-
-/// `DataLoader` key for fetching a `TransactionBlock` by its sequence number,
-/// constrained by a consistency cursor.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub(crate) struct SeqKey {
-    pub tx_sequence_number: u64,
-    pub checkpoint_viewed_at: u64,
-}
-
-impl SeqKey {
-    pub fn new(tx_sequence_number: u64, checkpoint_viewed_at: u64) -> Self {
-        Self {
-            tx_sequence_number,
-            checkpoint_viewed_at,
-        }
-    }
-}
-
-/// Filter for a point query of a TransactionBlock.
-pub(crate) enum TransactionBlockLookup {
-    ByDigest(DigestKey),
-    BySeq(SeqKey),
-}
-
-impl From<DigestKey> for TransactionBlockLookup {
-    fn from(key: DigestKey) -> Self {
-        TransactionBlockLookup::ByDigest(key)
-    }
-}
-
-impl From<SeqKey> for TransactionBlockLookup {
-    fn from(key: SeqKey) -> Self {
-        TransactionBlockLookup::BySeq(key)
     }
 }
 
@@ -346,15 +312,9 @@ impl TransactionBlock {
     /// or sequence number. Treats it as if it is being viewed at the
     /// `checkpoint_viewed_at` (e.g. the state of all relevant addresses
     /// will be at that checkpoint).
-    pub(crate) async fn query(
-        ctx: &Context<'_>,
-        key: TransactionBlockLookup,
-    ) -> Result<Option<Self>, Error> {
+    pub(crate) async fn query(ctx: &Context<'_>, key: DigestKey) -> Result<Option<Self>, Error> {
         let DataLoader(loader) = ctx.data_unchecked();
-        match key {
-            TransactionBlockLookup::ByDigest(digest_key) => loader.load_one(digest_key).await,
-            TransactionBlockLookup::BySeq(seq_key) => loader.load_one(seq_key).await,
-        }
+        loader.load_one(key).await
     }
 
     /// Look up multiple `TransactionBlock`s by their digests. Returns a map
@@ -544,145 +504,41 @@ impl Loader<DigestKey> for Db {
         &self,
         keys: &[DigestKey],
     ) -> Result<HashMap<DigestKey, TransactionBlock>, Error> {
-        use optimistic_transactions::dsl as opt_tx;
-        use transactions::dsl as tx;
-        use tx_digests::dsl as ds;
-        use tx_global_order::dsl as tx_global;
+        let digests: Vec<TransactionDigest> = keys.iter().map(|k| k.digest.into()).collect();
 
-        let digests: Vec<_> = keys.iter().map(|k| k.digest.to_vec()).collect();
-
-        // First, fetch from the main transactions table
-        let transactions: Vec<StoredTransaction> = self
-            .execute(move |conn| {
-                conn.results(move || {
-                    let join = ds::tx_sequence_number.eq(tx::tx_sequence_number);
-
-                    tx::transactions
-                        .inner_join(ds::tx_digests.on(join))
-                        .select(StoredTransaction::as_select())
-                        .filter(ds::tx_digest.eq_any(digests.clone()))
-                })
-            })
+        let by_digest: BTreeMap<Vec<u8>, TransactionRead> = self
+            .inner
+            .multi_get_transactions_with_fallback(&digests)
             .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
-
-        let transaction_digest_to_stored: BTreeMap<Vec<u8>, StoredTransaction> = transactions
+            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?
             .into_iter()
-            .map(|tx| (tx.transaction_digest.clone(), tx))
+            .map(|tx| (tx.transaction_digest().to_vec(), tx))
             .collect();
 
-        // Process stored transactions and collect missing digests
         let mut results = HashMap::new();
-        let mut missing_digests = Vec::new();
-
         for key in keys {
-            let digest_bytes = key.digest.as_slice();
-
-            if let Some(stored) = transaction_digest_to_stored.get(digest_bytes) {
-                let mut checkpoint_viewed_at = key.checkpoint_viewed_at;
-                if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                    checkpoint_viewed_at = UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER;
-                }
-                let tx_block = TransactionBlock {
-                    inner: TransactionBlockInner::try_from(stored.clone())?,
-                    checkpoint_viewed_at,
-                };
-                results.insert(*key, tx_block);
-            } else {
-                missing_digests.push(key.digest.to_vec());
-            }
-        }
-
-        if !missing_digests.is_empty() {
-            let optimistic_transactions: Vec<OptimisticTransaction> = self
-                .execute(move |conn| {
-                    conn.results(move || {
-                        opt_tx::optimistic_transactions
-                            .inner_join(
-                                tx_global::tx_global_order.on(opt_tx::global_sequence_number
-                                    .eq(tx_global::global_sequence_number)
-                                    .and(
-                                        opt_tx::optimistic_sequence_number
-                                            .eq(tx_global::optimistic_sequence_number),
-                                    )),
-                            )
-                            // Filter by digest on tx_global_order table because it is indexed by
-                            // digest, optimistic_transactions table is not
-                            .filter(tx_global::tx_digest.eq_any(missing_digests.clone()))
-                            .select(OptimisticTransaction::as_select())
-                    })
-                })
-                .await
-                .map_err(|e| {
-                    Error::Internal(format!("Failed to fetch optimistic transactions: {e}"))
-                })?;
-
-            let transaction_digest_to_optimistic: BTreeMap<Vec<u8>, OptimisticTransaction> =
-                optimistic_transactions
-                    .into_iter()
-                    .map(|opt_tx| (opt_tx.transaction_digest.clone(), opt_tx))
-                    .collect();
-
-            for key in keys {
-                let digest_bytes = key.digest.as_slice();
-                if let Some(optimistic) = transaction_digest_to_optimistic.get(digest_bytes) {
-                    let tx_block = TransactionBlock {
-                        inner: TransactionBlockInner::try_from(optimistic.clone())?,
-                        checkpoint_viewed_at: UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER,
-                    };
-                    results.insert(*key, tx_block);
-                }
-            }
-        }
-
-        Ok(results)
-    }
-}
-
-impl Loader<SeqKey> for Db {
-    type Value = TransactionBlock;
-    type Error = Error;
-
-    async fn load(&self, keys: &[SeqKey]) -> Result<HashMap<SeqKey, TransactionBlock>, Error> {
-        use transactions::dsl as tx;
-
-        let tx_seqs = keys
-            .iter()
-            .map(|k| k.tx_sequence_number as i64)
-            .collect::<Vec<_>>();
-        let transactions: Vec<StoredTransaction> = self
-            .execute(move |conn| {
-                conn.results(|| {
-                    tx::transactions
-                        .select(StoredTransaction::as_select())
-                        .filter(tx::tx_sequence_number.eq_any(tx_seqs.clone()))
-                })
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch transactions: {e}")))?;
-
-        let seq_num_to_tx: HashMap<i64, StoredTransaction> = transactions
-            .into_iter()
-            .map(|tx| (tx.tx_sequence_number, tx))
-            .collect();
-
-        let mut results = HashMap::with_capacity(keys.len());
-        for key in keys {
-            let Some(stored) = seq_num_to_tx.get(&(key.tx_sequence_number as i64)) else {
+            let Some(tx) = by_digest.get(key.digest.as_slice()) else {
                 continue;
             };
-
-            let mut checkpoint_viewed_at = key.checkpoint_viewed_at;
-            if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
-                checkpoint_viewed_at = UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER;
-            }
-            results.insert(
-                *key,
-                TransactionBlock {
-                    inner: TransactionBlockInner::try_from(stored.clone())?,
-                    checkpoint_viewed_at,
+            let block = match tx {
+                TransactionRead::Checkpointed(stored) => {
+                    let checkpoint_viewed_at =
+                        if key.checkpoint_viewed_at < stored.checkpoint_sequence_number as u64 {
+                            UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
+                        } else {
+                            key.checkpoint_viewed_at
+                        };
+                    TransactionBlock {
+                        inner: TransactionBlockInner::try_from(stored.clone())?,
+                        checkpoint_viewed_at,
+                    }
+                }
+                TransactionRead::Optimistic(opt) => TransactionBlock {
+                    inner: TransactionBlockInner::try_from(opt.clone())?,
+                    checkpoint_viewed_at: UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER,
                 },
-            );
+            };
+            results.insert(*key, block);
         }
 
         Ok(results)

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -456,7 +456,7 @@ impl TransactionBlock {
 
                     (prev, next, iter.collect())
                 } else {
-                    let subquery = subqueries(&filter, tx_bounds).unwrap();
+                    let subquery = subqueries(&filter, tx_bounds, &page).unwrap();
                     let (prev, next, results) =
                         page.paginate_raw_query::<TxLookup>(conn, checkpoint_viewed_at, subquery)?;
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Bound,
+};
 
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
@@ -401,6 +404,18 @@ impl TransactionBlock {
         let db: &Db = ctx.data_unchecked();
         let is_from_front = page.is_from_front();
 
+        // For the only-`atCheckpoint` case, we support fallback.
+        // `scan_limit` is ignored here
+        if let Some(at_checkpoint) = filter.only_at_checkpoint() {
+            return Self::paginate_at_checkpoint_with_fallback(
+                db,
+                page,
+                u64::from(at_checkpoint),
+                checkpoint_viewed_at,
+            )
+            .await;
+        }
+
         use transactions::dsl as tx;
         let (prev, next, transactions, tx_bounds): (
             bool,
@@ -493,6 +508,61 @@ impl TransactionBlock {
     /// Returns whether this transaction block is within the available range.
     pub(crate) fn is_available(&self) -> bool {
         self.checkpoint_viewed_at < UNAVAILABLE_CHECKPOINT_SEQUENCE_NUMBER
+    }
+
+    /// Paginates transactions in a single checkpoint with fallback support.
+    async fn paginate_at_checkpoint_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        at_checkpoint: u64,
+        checkpoint_viewed_at: u64,
+    ) -> Result<ScanConnection<String, TransactionBlock>, Error> {
+        if at_checkpoint > checkpoint_viewed_at {
+            return Ok(ScanConnection::new(false, false));
+        }
+
+        // Fetch the page plus the rows at the cursors, to later compute
+        // `has_next`/`has_prev` via `paginate_results`. The bounds are
+        // inclusive so that the cursor rows themselves are fetched.
+        let tx_seq_range = (
+            page.after()
+                .map_or(Bound::Unbounded, |c| Bound::Included(c.tx_sequence_number)),
+            page.before()
+                .map_or(Bound::Unbounded, |c| Bound::Included(c.tx_sequence_number)),
+        );
+        let mut results = db
+            .inner
+            .query_stored_transactions_by_checkpoint_seq_with_fallback(
+                at_checkpoint,
+                tx_seq_range,
+                page.limit() + 2,
+                !page.is_from_front(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !page.is_from_front() {
+            results.reverse();
+        }
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = ScanConnection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            let inner = TransactionBlockInner::try_from(stored)?;
+            conn.edges.push(Edge::new(
+                cursor,
+                TransactionBlock {
+                    inner,
+                    checkpoint_viewed_at,
+                },
+            ));
+        }
+        Ok(conn)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -10,13 +10,13 @@ use std::{
 use async_graphql::{connection::CursorType, dataloader::Loader, *};
 use connection::Edge;
 use cursor::TxLookup;
-use diesel::{ExpressionMethods, QueryDsl};
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
 use iota_indexer::{
     apis::ReadApi,
     models::transactions::{OptimisticTransaction, StoredTransaction},
     read::TransactionRead,
-    schema::transactions,
+    schema::{checkpoints, transactions},
 };
 use iota_json_rpc_api::ReadApiServer;
 use iota_sdk_types::{
@@ -416,6 +416,18 @@ impl TransactionBlock {
             .await;
         }
 
+        // For the only-`affectedAddress` case, we support fallback.
+        // `scan_limit` is ignored here
+        if let Some(address) = filter.only_affected_address() {
+            return Self::paginate_by_affected_address_with_fallback(
+                db,
+                page,
+                address,
+                checkpoint_viewed_at,
+            )
+            .await;
+        }
+
         use transactions::dsl as tx;
         let (prev, next, transactions, tx_bounds): (
             bool,
@@ -543,6 +555,86 @@ impl TransactionBlock {
         if !page.is_from_front() {
             results.reverse();
         }
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = ScanConnection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            let inner = TransactionBlockInner::try_from(stored)?;
+            conn.edges.push(Edge::new(
+                cursor,
+                TransactionBlock {
+                    inner,
+                    checkpoint_viewed_at,
+                },
+            ));
+        }
+        Ok(conn)
+    }
+
+    /// Paginates the transactions that affect `address`, with fallback
+    /// support when part of the history has been pruned from Postgres.
+    async fn paginate_by_affected_address_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        address: IotaAddress,
+        checkpoint_viewed_at: u64,
+    ) -> Result<ScanConnection<String, TransactionBlock>, Error> {
+        use checkpoints::dsl;
+        // Exclusive upperbound, we cannot return newer data than
+        // `checkpoint_viewed_at`.
+        let tx_hi: i64 = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    dsl::checkpoints
+                        .select(dsl::network_total_transactions)
+                        .filter(dsl::sequence_number.eq(checkpoint_viewed_at as i64))
+                })
+                .optional()
+            })
+            .await?
+            .ok_or_else(|| {
+                Error::DataPruned(format!("checkpoint {checkpoint_viewed_at} has been pruned"))
+            })?;
+
+        // Page cursors are inclusive, we need to convert them to exclusive
+        let cursor = if page.is_from_front() {
+            page.after()
+                .and_then(|c| c.tx_sequence_number.checked_sub(1))
+        } else {
+            Some(match page.before() {
+                Some(c) => (tx_hi as u64).min(c.tx_sequence_number.saturating_add(1)),
+                None => tx_hi as u64,
+            })
+        };
+
+        let mut results = db
+            .inner
+            .query_stored_transactions_by_affected_addresses_with_fallback(
+                address.into(),
+                cursor,
+                page.limit() + 2,
+                !page.is_from_front(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !page.is_from_front() {
+            results.reverse();
+        }
+
+        // Initial fetch above honored only the start cursor. We filter the result to
+        // also honor the end cursor and the `tx_hi`
+        results.retain(|tx| {
+            let tx_seq = tx.tx_sequence_number as u64;
+            tx.tx_sequence_number < tx_hi
+                && page.after().is_none_or(|c| c.tx_sequence_number <= tx_seq)
+                && page.before().is_none_or(|c| tx_seq <= c.tx_sequence_number)
+        });
 
         let (prev, next, results) = page.paginate_results(
             results.first().map(|f| f.cursor(checkpoint_viewed_at)),

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -428,6 +428,18 @@ impl TransactionBlock {
             .await;
         }
 
+        // For the only-`transactionIds` case, we support fallback.
+        // `scan_limit` is ignored here
+        if let Some(transaction_ids) = filter.only_transaction_ids() {
+            return Self::paginate_by_transaction_ids_with_fallback(
+                db,
+                page,
+                transaction_ids,
+                checkpoint_viewed_at,
+            )
+            .await;
+        }
+
         use transactions::dsl as tx;
         let (prev, next, transactions, tx_bounds): (
             bool,
@@ -635,6 +647,61 @@ impl TransactionBlock {
                 && page.after().is_none_or(|c| c.tx_sequence_number <= tx_seq)
                 && page.before().is_none_or(|c| tx_seq <= c.tx_sequence_number)
         });
+
+        let (prev, next, results) = page.paginate_results(
+            results.first().map(|f| f.cursor(checkpoint_viewed_at)),
+            results.last().map(|l| l.cursor(checkpoint_viewed_at)),
+            results,
+        );
+
+        let mut conn = ScanConnection::new(prev, next);
+        for stored in results {
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
+            let inner = TransactionBlockInner::try_from(stored)?;
+            conn.edges.push(Edge::new(
+                cursor,
+                TransactionBlock {
+                    inner,
+                    checkpoint_viewed_at,
+                },
+            ));
+        }
+        Ok(conn)
+    }
+
+    /// Paginates transactions selected by digest, with fallback support.
+    async fn paginate_by_transaction_ids_with_fallback(
+        db: &Db,
+        page: Page<Cursor>,
+        transaction_ids: &[Digest],
+        checkpoint_viewed_at: u64,
+    ) -> Result<ScanConnection<String, TransactionBlock>, Error> {
+        let digests: Vec<TransactionDigest> = transaction_ids.iter().map(|d| (*d).into()).collect();
+
+        let mut results: Vec<StoredTransaction> = db
+            .inner
+            .multi_get_transactions_with_fallback(&digests)
+            .await
+            .map_err(Error::from)?
+            .into_iter()
+            .filter_map(|tx| match tx {
+                TransactionRead::Checkpointed(stored) => Some(stored),
+                // Optimistic transactions are not yet in a checkpoint, so they
+                // have no `tx_sequence_number` to order and paginate.
+                TransactionRead::Optimistic(_) => None,
+            })
+            .collect();
+
+        // The fetch above returns every requested transaction. Keep only the
+        // ones visible at `checkpoint_viewed_at` and inside the inclusive
+        // cursors range, to satisfy requirements of `page.paginate_results`.
+        results.retain(|tx| {
+            let tx_seq = tx.tx_sequence_number as u64;
+            tx.checkpoint_sequence_number as u64 <= checkpoint_viewed_at
+                && page.after().is_none_or(|c| c.tx_sequence_number <= tx_seq)
+                && page.before().is_none_or(|c| tx_seq <= c.tx_sequence_number)
+        });
+        results.sort_by_key(|tx| tx.tx_sequence_number);
 
         let (prev, next, results) = page.paginate_results(
             results.first().map(|f| f.cursor(checkpoint_viewed_at)),

--- a/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/tx_lookups.rs
@@ -323,8 +323,13 @@ fn min_option<T: Ord>(xs: impl IntoIterator<Item = Option<T>>) -> Option<T> {
 
 /// Constructs a `RawQuery` as a join over all relevant side tables, filtered on
 /// their own filter condition, plus optionally a sender, plus optionally tx/cp
-/// bounds.
-pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -> Option<RawQuery> {
+/// bounds. An `affected_address` filter without a `sender` filter is a special
+/// case, handled by `select_affected`.
+pub(crate) fn subqueries(
+    filter: &TransactionBlockFilter,
+    tx_bounds: TxBounds,
+    page: &Page<Cursor>,
+) -> Option<RawQuery> {
     let sender = filter.sent_address;
 
     let mut subqueries = vec![];
@@ -371,6 +376,30 @@ pub(crate) fn subqueries(filter: &TransactionBlockFilter, tx_bounds: TxBounds) -
         subqueries.push(("tx_digests", select_ids(txs, tx_bounds)));
     }
 
+    if let Some(affected) = &filter.affected_address {
+        match sender {
+            // A `sender` filter equal to `affected` can only match transactions
+            // where `affected` is the sender.
+            Some(sender) if sender == *affected => {
+                subqueries.push(("tx_affected", select_sender(affected, tx_bounds)));
+            }
+            // A `sender` filter different from `affected` can only match
+            // transactions where `affected` is the recipient.
+            Some(_) => {
+                subqueries.push(("tx_affected", select_recipient(affected, sender, tx_bounds)));
+            }
+            // Otherwise `affected` can be either the sender or a recipient,
+            // so we query both.
+            None => return Some(select_affected(affected, subqueries, tx_bounds, page)),
+        }
+    }
+
+    join_subqueries(subqueries)
+}
+
+/// Joins `subqueries` on `tx_sequence_number` into a single query, or `None` if
+/// there are no subqueries.
+fn join_subqueries(mut subqueries: Vec<(&str, RawQuery)>) -> Option<RawQuery> {
     let (_, mut subquery) = subqueries.pop()?;
 
     if !subqueries.is_empty() {
@@ -480,6 +509,40 @@ fn select_recipient(recv: &IotaAddress, sender: Option<IotaAddress>, bound: TxBo
     filter!(
         select_tx(sender, bound, "tx_recipients"),
         format!("recipient = {}", bytea_literal(recv.as_slice()))
+    )
+}
+
+/// Selects transactions where `affected` is the sender or a recipient, as a
+/// `UNION` of the `tx_senders` and `tx_recipients` tables.
+///
+/// To avoid full table scans on `UNION` we apply order and limit on the
+/// subqueries before `UNION`. For the result to be correct we need to apply all
+/// other filters on the subquery level, by joining each subquery with all
+/// `other_subqueries`.
+fn select_affected(
+    affected: &IotaAddress,
+    other_subqueries: Vec<(&str, RawQuery)>,
+    bound: TxBounds,
+    page: &Page<Cursor>,
+) -> RawQuery {
+    let bounded_subquery = |from: RawQuery, other_subqueries: Vec<(&str, RawQuery)>| {
+        let mut all = vec![("tx_affected", from)];
+        all.extend(other_subqueries);
+        join_subqueries(all)
+            .expect("subqueries list is not empty")
+            .order_by(format!(
+                "tx_sequence_number {}",
+                if page.is_from_front() { "ASC" } else { "DESC" }
+            ))
+            // The same limit that `Page::apply` puts on the overall query: the
+            // page size plus the two rows pointed at by the page's cursors.
+            .limit(page.limit() as i64 + 2)
+    };
+
+    query!(
+        "SELECT tx_sequence_number FROM (({}) UNION ({})) AS affected",
+        bounded_subquery(select_sender(affected, bound), other_subqueries.clone()),
+        bounded_subquery(select_recipient(affected, None, bound), other_subqueries)
     )
 }
 

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -114,7 +114,8 @@ type AddressOwner {
 }
 
 """
-The possible relationship types for a transaction block: sent or received.
+The possible relationship types for a transaction block: sent, received,
+or affected.
 """
 enum AddressTransactionBlockRelationship {
 	"""
@@ -125,6 +126,11 @@ enum AddressTransactionBlockRelationship {
 	Transactions that sent objects to this address.
 	"""
 	RECV
+	"""
+	Transactions that affected this address (the address is the sender,
+	a recipient, or the owner of the gas payment).
+	"""
+	AFFECTED
 }
 
 """
@@ -4568,6 +4574,11 @@ input TransactionBlockFilter {
 	Limit to transactions that sent an object to the given address.
 	"""
 	recvAddress: IotaAddress
+	"""
+	Limit to transactions that affected the given address (the address is
+	the sender, a recipient, or the owner of the gas payment).
+	"""
+	affectedAddress: IotaAddress
 	"""
 	Limit to transactions that accepted the given object as an input.
 	"""

--- a/crates/iota-indexer/src/historical_fallback/client.rs
+++ b/crates/iota-indexer/src/historical_fallback/client.rs
@@ -288,6 +288,20 @@ impl HttpRestKVClient {
     }
 
     async fn fetch_batch(&self, request: MultiGetRequest) -> IndexerResult<Vec<Option<Bytes>>> {
+        let item_type = request.item_type;
+        self.metrics.record_request(item_type);
+
+        let result = self.fetch_batch_inner(request).await;
+        if result.is_err() {
+            self.metrics.record_request_error(item_type);
+        }
+        result
+    }
+
+    async fn fetch_batch_inner(
+        &self,
+        request: MultiGetRequest,
+    ) -> IndexerResult<Vec<Option<Bytes>>> {
         let url = self.base_url.join(&request.item_type.to_string())?;
 
         trace!(
@@ -347,6 +361,27 @@ impl HttpRestKVClient {
             IndexerError::HistoricalFallbackInput("limit must be greater than 0".into())
         })?;
 
+        let item_type = key.item_type();
+        self.metrics.record_request(item_type);
+
+        let result = self.paginate_inner(key, cursor, limit, reversed).await;
+        if result.is_err() {
+            self.metrics.record_request_error(item_type);
+        }
+        result
+    }
+
+    async fn paginate_inner<C, T>(
+        &self,
+        key: Key,
+        cursor: Option<C>,
+        limit: NonZeroUsize,
+        reversed: bool,
+    ) -> IndexerResult<Vec<T>>
+    where
+        C: Display,
+        T: for<'de> Deserialize<'de>,
+    {
         let (item_type, encoded_key) = key.to_path_elements();
         let mut url = self.base_url.join(&format!("{item_type}/{encoded_key}"))?;
 
@@ -454,6 +489,20 @@ impl HttpRestKVClient {
     }
 
     async fn fetch_objects_before_version_batch(
+        &self,
+        request: MultiGetRequest,
+    ) -> IndexerResult<Vec<Option<Bytes>>> {
+        let item_type = request.item_type;
+        self.metrics.record_request(item_type);
+
+        let result = self.fetch_objects_before_version_batch_inner(request).await;
+        if result.is_err() {
+            self.metrics.record_request_error(item_type);
+        }
+        result
+    }
+
+    async fn fetch_objects_before_version_batch_inner(
         &self,
         request: MultiGetRequest,
     ) -> IndexerResult<Vec<Option<Bytes>>> {

--- a/crates/iota-indexer/src/historical_fallback/convert.rs
+++ b/crates/iota-indexer/src/historical_fallback/convert.rs
@@ -14,7 +14,9 @@ use iota_package_resolver::{PackageStore, Resolver};
 use iota_sdk_types::{TransactionDigest, TransactionEvents, checkpoint::CheckpointContents};
 use iota_types::{
     full_checkpoint_content::CheckpointTransaction,
-    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContentsExt},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContentsExt, CheckpointSequenceNumber,
+    },
     object::Object,
 };
 use prometheus_filtered::Registry;
@@ -25,10 +27,11 @@ use crate::{
     metrics::IndexerMetrics,
     models::{
         checkpoints::StoredCheckpoint,
+        events::StoredEvent,
         objects::StoredObject,
         transactions::{StoredTransaction, tx_events_to_iota_tx_events},
     },
-    types::{IndexedCheckpoint, IndexedObject},
+    types::{IndexedCheckpoint, IndexedEvent, IndexedObject},
 };
 
 /// Alias for an [`Object`] fetched from historical fallback storage.
@@ -65,21 +68,52 @@ impl From<HistoricalFallbackCheckpoint> for StoredCheckpoint {
 /// Wrapper for [`TransactionEvents`] and additional data fetched from
 /// historical fallback storage.
 ///
-/// Contains all data needed to reconstruct [`IotaEvent`]s.
+/// Contains all data needed to reconstruct [`IotaEvent`]s or [`StoredEvent`]s.
 #[derive(Debug, Clone)]
 pub struct HistoricalFallbackEvents {
     /// Events emitted during transaction execution.
     events: TransactionEvents,
+    /// Digest of the transaction that emitted the events.
+    tx_digest: TransactionDigest,
+    /// Sequence number of the transaction that emitted the events.
+    tx_sequence_number: u64,
+    /// Sequence number of the checkpoint the transaction is part of.
+    checkpoint_sequence_number: CheckpointSequenceNumber,
     /// Checkpoint timestamp.
     timestamp: u64,
 }
 
 impl HistoricalFallbackEvents {
-    pub fn new(events: TransactionEvents, checkpoint_summary: CertifiedCheckpointSummary) -> Self {
-        Self {
+    /// Creates the wrapper from the events of the `tx_digest` transaction and
+    /// the checkpoint the transaction is part of.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IndexerError::HistoricalFallbackStorageError`] when
+    /// transaction is not part of the provided checkpoint.
+    pub fn new(
+        events: TransactionEvents,
+        tx_digest: TransactionDigest,
+        checkpoint_summary: &CertifiedCheckpointSummary,
+        checkpoint_contents: &CheckpointContents,
+    ) -> IndexerResult<Self> {
+        let Some(tx_sequence_number) = checkpoint_contents
+            .enumerate_transactions(checkpoint_summary)
+            .find(|(_, execution_digest)| execution_digest.transaction == tx_digest)
+            .map(|(seq, _)| seq)
+        else {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "cannot find transaction sequence number to transaction: {tx_digest}"
+            )));
+        };
+
+        Ok(Self {
             events,
+            tx_digest,
+            tx_sequence_number,
+            checkpoint_sequence_number: checkpoint_summary.sequence_number,
             timestamp: checkpoint_summary.timestamp_ms,
-        }
+        })
     }
 
     /// Converts the raw [`TransactionEvents`] into JSON RPC compatible
@@ -87,16 +121,33 @@ impl HistoricalFallbackEvents {
     pub(crate) async fn into_iota_events(
         self,
         package_resolver: &Arc<Resolver<impl PackageStore>>,
-        tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
         tx_events_to_iota_tx_events(
             self.events,
             package_resolver,
-            tx_digest,
+            self.tx_digest,
             Some(self.timestamp),
         )
         .await
         .map(|tx_block_event| tx_block_event.data)
+    }
+
+    /// Converts the raw [`TransactionEvents`] into [`StoredEvent`]s.
+    pub(crate) fn into_stored_events(self) -> Vec<StoredEvent> {
+        self.events
+            .iter()
+            .enumerate()
+            .map(|(idx, event)| {
+                StoredEvent::from(IndexedEvent::from_event(
+                    self.tx_sequence_number,
+                    idx as u64,
+                    self.checkpoint_sequence_number,
+                    self.tx_digest,
+                    event,
+                    self.timestamp,
+                ))
+            })
+            .collect()
     }
 }
 

--- a/crates/iota-indexer/src/historical_fallback/metrics.rs
+++ b/crates/iota-indexer/src/historical_fallback/metrics.rs
@@ -13,6 +13,8 @@ pub struct HistoricalFallbackClientMetrics {
     pub(crate) cache_misses: IntCounterVec,
     pub(crate) cache_object_before_version_hits: IntCounter,
     pub(crate) cache_object_before_version_misses: IntCounter,
+    pub(crate) requests: IntCounterVec,
+    pub(crate) request_errors: IntCounterVec,
 }
 
 impl HistoricalFallbackClientMetrics {
@@ -44,6 +46,20 @@ impl HistoricalFallbackClientMetrics {
                 registry,
             )
             .unwrap(),
+            requests: register_int_counter_vec_with_registry!(
+                "historical_fallback_requests",
+                "Historical fallback requests to the KV store",
+                &["resource"],
+                registry,
+            )
+            .unwrap(),
+            request_errors: register_int_counter_vec_with_registry!(
+                "historical_fallback_request_errors",
+                "Historical fallback requests to the KV store that failed",
+                &["resource"],
+                registry,
+            )
+            .unwrap(),
         }
     }
 
@@ -65,5 +81,17 @@ impl HistoricalFallbackClientMetrics {
 
     pub(crate) fn record_cache_object_before_version_miss(&self) {
         self.cache_object_before_version_misses.inc();
+    }
+
+    pub(crate) fn record_request(&self, item_type: ItemType) {
+        self.requests
+            .with_label_values(&[&item_type.to_string()])
+            .inc();
+    }
+
+    pub(crate) fn record_request_error(&self, item_type: ItemType) {
+        self.request_errors
+            .with_label_values(&[&item_type.to_string()])
+            .inc();
     }
 }

--- a/crates/iota-indexer/src/historical_fallback/mod.rs
+++ b/crates/iota-indexer/src/historical_fallback/mod.rs
@@ -12,3 +12,5 @@ pub(crate) mod client;
 pub(crate) mod convert;
 pub(crate) mod metrics;
 pub(crate) mod reader;
+
+pub use reader::HistoricalFallbackReader;

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use futures::future;
 use iota_json_rpc_types::{CheckpointId, IotaEvent};
 use iota_sdk_types::{
-    Address, ObjectId, TransactionDigest, TransactionEffects, Version,
+    Address, CheckpointDigest, ObjectId, TransactionDigest, TransactionEffects, Version,
     checkpoint::CheckpointContents,
 };
 use iota_types::{
@@ -267,6 +267,61 @@ impl HistoricalFallbackReader {
             .collect();
 
         Ok(checkpoints)
+    }
+
+    /// Fetches multiple checkpoints by their digests from the historical
+    /// fallback storage. The returned vector has the same length as `digests`
+    /// and preserves its order; missing entries become `None`.
+    ///
+    /// # NOTE
+    /// As with [`checkpoints`](Self::checkpoints),
+    /// `StoredCheckpoint.successful_tx_num` is hardcoded to 0 in
+    /// fallback-returned data.
+    pub(crate) async fn checkpoints_by_digests(
+        &self,
+        digests: Vec<CheckpointDigest>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let summaries = self
+            .client
+            .multi_get_checkpoints_summaries_by_digests(&digests)
+            .await?;
+
+        let mut seqs_for_contents: Vec<CheckpointSequenceNumber> = summaries
+            .iter()
+            .filter_map(|s| s.as_ref().map(|s| s.sequence_number))
+            .collect();
+        seqs_for_contents.sort_unstable();
+        seqs_for_contents.dedup();
+
+        if seqs_for_contents.is_empty() {
+            return Ok(vec![None; digests.len()]);
+        }
+
+        let contents = self
+            .client
+            .multi_get_checkpoints_contents(&seqs_for_contents)
+            .await?;
+        let content_by_seq: HashMap<CheckpointSequenceNumber, CheckpointContents> =
+            seqs_for_contents
+                .iter()
+                .zip(contents)
+                .filter_map(|(seq, content)| content.map(|c| (*seq, c)))
+                .collect();
+
+        let result = summaries
+            .into_iter()
+            .map(|summary| {
+                let summary = summary?;
+                let content = content_by_seq.get(&summary.sequence_number)?.clone();
+                Some(StoredCheckpoint::from((summary, content)))
+            })
+            .collect();
+
+        Ok(result)
     }
 
     /// Fetches all events belonging to the provided transaction digest.

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -62,7 +62,7 @@ pub type OutputObjects = Vec<Object>;
 /// when the indexer is unable to fetch data from the database, which is
 /// especially useful when pruning is enabled.
 #[derive(Clone)]
-pub(crate) struct HistoricalFallbackReader {
+pub struct HistoricalFallbackReader {
     /// Client responsible for fetching data from the historical fallback
     /// storage through REST API interface.
     client: HttpRestKVClient,

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -9,7 +9,10 @@
 //! the indexer is unable to fetch data from the database, which is especially
 //! useful when pruning is enabled.
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    ops::{Bound, RangeBounds},
+};
 
 use futures::future;
 use iota_json_rpc_types::{CheckpointId, IotaEvent};
@@ -493,14 +496,64 @@ impl HistoricalFallbackReader {
             .collect::<Vec<TransactionDigest>>();
 
         let transactions = self.transactions(&tx_digests).await?;
-
         if transactions.iter().any(|tx| tx.is_none()) {
             return Err(IndexerError::HistoricalFallbackStorageError(format!(
                 "KV doesn't have full transaction data for checkpoint {checkpoint_sequence_number}"
             )));
         }
+        Ok(transactions.into_iter().flatten().collect())
+    }
 
-        Ok(transactions.into_iter().flatten().collect::<Vec<_>>())
+    /// Fetches transactions belonging to a specific checkpoint whose
+    /// `tx_sequence_number` falls within the given range.
+    ///
+    /// Returns up to `limit` transactions ordered by `tx_sequence_number`,
+    /// in order determined by `is_descending`.
+    pub(crate) async fn checkpoint_transactions_in_seq_range(
+        &self,
+        checkpoint_sequence_number: CheckpointSequenceNumber,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+
+        let seqs = [checkpoint_sequence_number];
+        let (summaries, contents) = tokio::try_join!(
+            self.client
+                .multi_get_checkpoints_summaries_by_sequence_numbers(&seqs),
+            self.client.multi_get_checkpoints_contents(&seqs),
+        )?;
+        let (Some(Some(summary)), Some(Some(contents))) =
+            (summaries.into_iter().next(), contents.into_iter().next())
+        else {
+            return Ok(vec![]);
+        };
+
+        // digests sorted by tx_sequence_number, ascending
+        let in_range = contents
+            .enumerate_transactions(&summary)
+            .filter(|(seq, _)| tx_seq_range.contains(seq))
+            .map(|(_, digests)| digests.transaction);
+
+        let tx_digests: Vec<TransactionDigest> = if is_descending {
+            let mut tx_digests: Vec<_> = in_range.collect();
+            tx_digests.reverse();
+            tx_digests.truncate(limit);
+            tx_digests
+        } else {
+            in_range.take(limit).collect()
+        };
+
+        let transactions = self.transactions(&tx_digests).await?;
+        if transactions.iter().any(|tx| tx.is_none()) {
+            return Err(IndexerError::HistoricalFallbackStorageError(format!(
+                "KV doesn't have full transaction data for checkpoint {checkpoint_sequence_number}"
+            )));
+        }
+        Ok(transactions.into_iter().flatten().collect())
     }
 
     /// Fetches events for a specific transaction.

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -46,7 +46,8 @@ use crate::{
         metrics::HistoricalFallbackClientMetrics,
     },
     models::{
-        checkpoints::StoredCheckpoint, objects::StoredObject, transactions::StoredTransaction,
+        checkpoints::StoredCheckpoint, events::StoredEvent, objects::StoredObject,
+        transactions::StoredTransaction,
     },
     read::PackageResolver,
 };
@@ -332,31 +333,37 @@ impl HistoricalFallbackReader {
         &self,
         tx_digest: TransactionDigest,
     ) -> IndexerResult<Vec<IotaEvent>> {
+        self.fetch_events(tx_digest)
+            .await?
+            .into_iota_events(&self.package_resolver)
+            .await
+    }
+
+    /// Fetches the events of a transaction from the historical fallback
+    /// storage, together with the transaction and checkpoint data needed to
+    /// convert them to other formats.
+    async fn fetch_events(
+        &self,
+        tx_digest: TransactionDigest,
+    ) -> IndexerResult<HistoricalFallbackEvents> {
         let tx_digests = &[tx_digest];
-        let (events, checkpoint_summaries) = tokio::try_join!(
+        let (events, checkpoints) = tokio::try_join!(
             self.client.multi_get_events_by_tx_digests(tx_digests),
             self.resolve_checkpoints(tx_digests)
         )?;
 
         // check first if transaction exists, all valid transaction are part of a
         // checkpoint, if not found then the provided digest is invalid.
-        let (summary, _) = checkpoint_summaries
-            .get(&tx_digest)
-            .cloned()
-            .ok_or_else(|| {
-                IndexerError::HistoricalFallbackStorageError(format!(
-                    "transaction: {tx_digest} does not exist"
-                ))
-            })?;
+        let (summary, contents) = checkpoints.get(&tx_digest).cloned().ok_or_else(|| {
+            IndexerError::HistoricalFallbackStorageError(format!(
+                "transaction: {tx_digest} does not exist"
+            ))
+        })?;
 
-        let Some(Some(events)) = events.into_iter().next() else {
-            // transaction does not have associated events.
-            return Ok(vec![]);
-        };
+        // the transaction did not emit any events when `None`.
+        let events = events.into_iter().next().flatten().unwrap_or_default();
 
-        HistoricalFallbackEvents::new(events, summary)
-            .into_iota_events(&self.package_resolver, tx_digest)
-            .await
+        HistoricalFallbackEvents::new(events, tx_digest, &summary, &contents)
     }
 
     /// Fetches transactions from the provided transaction digests.
@@ -578,7 +585,7 @@ impl HistoricalFallbackReader {
         cursor: Option<EventID>,
         limit: usize,
         descending_order: bool,
-    ) -> IndexerResult<Vec<IotaEvent>> {
+    ) -> IndexerResult<Vec<StoredEvent>> {
         if limit == 0 {
             return Ok(vec![]);
         }
@@ -596,25 +603,25 @@ impl HistoricalFallbackReader {
             None
         };
 
-        let events = self.all_events(tx_digest).await?;
+        let events = self.fetch_events(tx_digest).await?.into_stored_events();
 
         // apply ordering, cursor, and limit
         let events = if descending_order {
             events
                 .into_iter()
-                .enumerate()
                 .rev() // reverse for descending
-                .filter(|(idx, _)| start_seq.is_none_or(|seq| (*idx as u64) < seq))
+                .filter(|event| {
+                    start_seq.is_none_or(|seq| (event.event_sequence_number as u64) < seq)
+                })
                 .take(limit)
-                .map(|(_, event)| event)
                 .collect()
         } else {
             events
                 .into_iter()
-                .enumerate()
-                .filter(|(idx, _)| start_seq.is_none_or(|seq| (*idx as u64) > seq))
+                .filter(|event| {
+                    start_seq.is_none_or(|seq| (event.event_sequence_number as u64) > seq)
+                })
                 .take(limit)
-                .map(|(_, event)| event)
                 .collect()
         };
 

--- a/crates/iota-indexer/src/historical_fallback/reader.rs
+++ b/crates/iota-indexer/src/historical_fallback/reader.rs
@@ -668,18 +668,10 @@ impl HistoricalFallbackReader {
     pub(crate) async fn paginate_transaction_digests_by_address(
         &self,
         address: Address,
-        cursor: Option<TransactionDigest>,
+        cursor: Option<TransactionSequenceNumber>,
         limit: usize,
         oldest_first: bool,
     ) -> IndexerResult<Vec<TransactionDigest>> {
-        let cursor = match cursor {
-            Some(digest) => match self.cursor_cache.get(&digest) {
-                Some(tx_sequence_number) => Some(tx_sequence_number),
-                None => Some(self.resolve_transaction_sequence_number(digest).await?),
-            },
-            None => None,
-        };
-
         let pairs = self
             .client
             .transaction_digests_by_address(address, cursor, limit, oldest_first)
@@ -694,11 +686,23 @@ impl HistoricalFallbackReader {
             .collect())
     }
 
+    /// Resolves the `tx_sequence_number` of the given cursor digest, through
+    /// the cursor cache or the checkpoint data in the fallback storage.
+    pub(crate) async fn resolve_cursor_tx_sequence_number(
+        &self,
+        digest: TransactionDigest,
+    ) -> IndexerResult<TransactionSequenceNumber> {
+        match self.cursor_cache.get(&digest) {
+            Some(tx_sequence_number) => Ok(tx_sequence_number),
+            None => self.resolve_transaction_sequence_number(digest).await,
+        }
+    }
+
     /// Fetches a paginated list of transactions that affect a given address.
     pub(crate) async fn transactions_by_address(
         &self,
         address: Address,
-        cursor: Option<TransactionDigest>,
+        cursor: Option<TransactionSequenceNumber>,
         limit: usize,
         oldest_first: bool,
     ) -> IndexerResult<Vec<Option<StoredTransaction>>> {

--- a/crates/iota-indexer/src/ingestion/common/mod.rs
+++ b/crates/iota-indexer/src/ingestion/common/mod.rs
@@ -5,3 +5,5 @@ pub(crate) mod connection;
 pub(crate) mod orchestration;
 pub(crate) mod persist;
 pub mod prepare;
+
+pub use persist::CommitterTables;

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -302,6 +302,7 @@ impl OptimisticTransactionExecutor {
             .multi_get_transactions(&[tx_digest])
             .await?
             .pop()
+            .map(StoredTransaction::from)
             .ok_or_else(|| {
                 IndexerError::PersistentStorageDataCorruption(format!(
                     "transaction {tx_digest} not found in the DB after being marked as indexed."

--- a/crates/iota-indexer/src/pruning/mod.rs
+++ b/crates/iota-indexer/src/pruning/mod.rs
@@ -4,3 +4,5 @@
 
 pub mod pruner;
 pub mod watermark_task;
+
+pub use crate::ingestion::common::persist::CommitterTables;

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -212,6 +212,13 @@ impl IndexerReader {
         self.fallback.as_ref()
     }
 
+    /// Returns `true` if a historical fallback reader is configured on this
+    /// `IndexerReader`. Callers can use this to decide whether pruned-range
+    /// reads will be served by the fallback.
+    pub fn is_fallback_enabled(&self) -> bool {
+        self.fallback.is_some()
+    }
+
     /// Accesses the watermark cache.
     pub fn watermark_cache(&self) -> &WatermarkCache {
         &self.watermark_cache
@@ -813,6 +820,87 @@ impl IndexerReader {
             .flatten()
             .map(iota_json_rpc_types::Checkpoint::try_from)
             .collect()
+    }
+
+    /// Fetches a batch of checkpoints by sequence number. Each requested seq
+    /// resolves to `Some(StoredCheckpoint)` if it lives in Postgres or in the
+    /// historical fallback (when enabled), or to `None` otherwise. The
+    /// returned vector has the same length as `seqs` and preserves its order.
+    pub async fn get_stored_checkpoints_by_seqs_with_fallback(
+        &self,
+        seqs: Vec<CheckpointSequenceNumber>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if seqs.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let db_rows = self.db().multi_get_checkpoints_by_seqs(&seqs).await?;
+        let mut by_seq: HashMap<CheckpointSequenceNumber, StoredCheckpoint> = db_rows
+            .into_iter()
+            .map(|c| (c.sequence_number as u64, c))
+            .collect();
+
+        let missing: Vec<CheckpointSequenceNumber> = seqs
+            .iter()
+            .copied()
+            .filter(|s| !by_seq.contains_key(s))
+            .collect();
+        if !missing.is_empty() {
+            if let Some(fallback) = self.fallback_reader() {
+                for stored in fallback.checkpoints(missing).await?.into_iter().flatten() {
+                    by_seq.insert(stored.sequence_number as u64, stored);
+                }
+            }
+        }
+
+        Ok(seqs.into_iter().map(|s| by_seq.get(&s).cloned()).collect())
+    }
+
+    /// Fetches a batch of checkpoints by digest. Each requested digest
+    /// resolves to `Some(StoredCheckpoint)` if it lives in Postgres or in the
+    /// historical fallback (when enabled), or to `None` otherwise. The
+    /// returned vector has the same length as `digests` and preserves its
+    /// order.
+    pub async fn get_stored_checkpoints_by_digests_with_fallback(
+        &self,
+        digests: Vec<CheckpointDigest>,
+    ) -> IndexerResult<Vec<Option<StoredCheckpoint>>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let digest_bytes: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
+        let db_rows = self
+            .db()
+            .multi_get_checkpoints_by_digests(&digest_bytes)
+            .await?;
+        let mut by_digest: HashMap<Vec<u8>, StoredCheckpoint> = db_rows
+            .into_iter()
+            .map(|c| (c.checkpoint_digest.clone(), c))
+            .collect();
+
+        let missing: Vec<CheckpointDigest> = digests
+            .iter()
+            .filter(|d| !by_digest.contains_key(d.inner().as_slice()))
+            .copied()
+            .collect();
+        if !missing.is_empty() {
+            if let Some(fallback) = self.fallback_reader() {
+                for stored in fallback
+                    .checkpoints_by_digests(missing)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                {
+                    by_digest.insert(stored.checkpoint_digest.clone(), stored);
+                }
+            }
+        }
+
+        Ok(digests
+            .into_iter()
+            .map(|d| by_digest.get(d.inner().as_slice()).cloned())
+            .collect())
     }
 
     /// Fetches multiple transactions from the database.
@@ -3007,6 +3095,42 @@ impl<'a> DBReader<'a> {
         }
 
         Ok(checkpoint)
+    }
+
+    /// Fetches from the `checkpoints` table by sequence numbers list.
+    /// Pruned/missing seqs are simply absent from the result.
+    async fn multi_get_checkpoints_by_seqs(
+        &self,
+        seqs: &[CheckpointSequenceNumber],
+    ) -> IndexerResult<Vec<StoredCheckpoint>> {
+        if seqs.is_empty() {
+            return Ok(vec![]);
+        }
+        let seqs_i64: Vec<i64> = seqs.iter().map(|s| *s as i64).collect();
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            checkpoints::dsl::checkpoints
+                .filter(checkpoints::sequence_number.eq_any(seqs_i64))
+                .load::<StoredCheckpoint>(conn)
+        })
+    }
+
+    /// Fetches from the `checkpoints` table by digests list.
+    /// Pruned/missing digests are simply absent from the result.
+    async fn multi_get_checkpoints_by_digests(
+        &self,
+        digests: &[Vec<u8>],
+    ) -> IndexerResult<Vec<StoredCheckpoint>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+        let digests = digests.to_vec();
+        let pool = self.main_reader.get_pool();
+        run_query_async!(&pool, move |conn| {
+            checkpoints::dsl::checkpoints
+                .filter(checkpoints::checkpoint_digest.eq_any(digests))
+                .load::<StoredCheckpoint>(conn)
+        })
     }
 
     async fn get_checkpoints(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -299,6 +299,34 @@ impl IndexerReader {
     }
 }
 
+/// A transaction returned by `IndexerReader::multi_get_transactions` or
+/// [`IndexerReader::multi_get_transactions_with_fallback`]. Each row is
+/// either checkpointed (from Postgres or the historical fallback) or
+/// optimistic (from Postgres).
+pub enum TransactionRead {
+    Checkpointed(StoredTransaction),
+    Optimistic(OptimisticTransaction),
+}
+
+impl TransactionRead {
+    /// Raw transaction digest bytes, common to both variants.
+    pub fn transaction_digest(&self) -> &[u8] {
+        match self {
+            Self::Checkpointed(s) => &s.transaction_digest,
+            Self::Optimistic(o) => &o.transaction_digest,
+        }
+    }
+}
+
+impl From<TransactionRead> for StoredTransaction {
+    fn from(tx: TransactionRead) -> Self {
+        match tx {
+            TransactionRead::Checkpointed(s) => s,
+            TransactionRead::Optimistic(o) => o.into(),
+        }
+    }
+}
+
 // Impl for reading data from the DB
 impl IndexerReader {
     fn get_object_from_db(
@@ -903,101 +931,71 @@ impl IndexerReader {
             .collect())
     }
 
-    /// Fetches multiple transactions from the database.
+    /// Fetches multiple transactions from the database. Each row is returned
+    /// as [`TransactionRead::Checkpointed`] or [`TransactionRead::Optimistic`]
+    /// depending on which table it came from.
     ///
-    ///  Retrieval order:
+    /// Retrieval order per digest:
     /// 1. Checkpointed data (finalized transactions)
     /// 2. Optimistic data (pending transactions not yet checkpointed)
     pub(crate) async fn multi_get_transactions(
         &self,
         digests: &[TransactionDigest],
-    ) -> IndexerResult<Vec<StoredTransaction>> {
-        let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
-        let checkpointed_txs = self
+    ) -> IndexerResult<Vec<TransactionRead>> {
+        let digest_bytes: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
+        let mut found: Vec<TransactionRead> = self
             .db()
-            .get_checkpointed_transactions(digests.clone())
-            .await?;
-
-        if checkpointed_txs.len() == digests.len() {
-            return Ok(checkpointed_txs);
-        }
-
-        let missing_digests = Self::check_for_missing_tx_digests(&digests, &checkpointed_txs);
-        let optimistic_txs = self
-            .db()
-            .get_optimistic_transactions(missing_digests)
-            .await?;
-
-        Ok(checkpointed_txs
-            .into_iter()
-            .chain(optimistic_txs.into_iter().map(Into::into))
-            .collect::<Vec<StoredTransaction>>())
-    }
-
-    /// Fetches multiple transactions from the indexer storage.
-    ///
-    /// Retrieval order:
-    /// 1. Checkpointed data (finalized transactions)
-    /// 2. Optimistic data (pending transactions not yet checkpointed)
-    /// 3. Historical fallback storage (if enabled)
-    async fn multi_get_transactions_with_fallback(
-        &self,
-        digests: &[TransactionDigest],
-    ) -> IndexerResult<Vec<StoredTransaction>> {
-        let fetched_transactions = self.multi_get_transactions(digests).await?;
-
-        // fallback to historical storage
-        let Some(fallback) = self
-            .fallback_reader()
-            // As for now we don't have a way to identify if the user requested pruned or invalid
-            // transaction digests. As a measure, we check if the number of requested transactions
-            // matches the number of fetched transactions. In case of missing transactions,
-            // if fallback is enabled, we use it to fetch the missing ones.
-            .filter(|_| fetched_transactions.len() != digests.len())
-        else {
-            // return data from database.
-            return Ok(fetched_transactions);
-        };
-
-        let digests: Vec<Vec<u8>> = digests.iter().map(|d| d.inner().to_vec()).collect();
-        let missing_digests = Self::check_for_missing_tx_digests(&digests, &fetched_transactions)
-            .iter()
-            .map(|digest| {
-                TransactionDigest::from_bytes(digest.as_slice()).map_err(|e| {
-                    IndexerError::PersistentStorageDataCorruption(format!(
-                        "can't convert {digest:?} as tx_digest. Error: {e}",
-                    ))
-                })
-            })
-            .collect::<IndexerResult<Vec<TransactionDigest>>>()?;
-
-        let historical_transactions = fallback
-            .transactions(&missing_digests)
+            .get_checkpointed_transactions(digest_bytes)
             .await?
             .into_iter()
-            .flatten()
-            .collect::<Vec<StoredTransaction>>();
+            .map(TransactionRead::Checkpointed)
+            .collect();
 
-        Ok(fetched_transactions
-            .into_iter()
-            .chain(historical_transactions)
-            .collect())
+        let missing = Self::check_for_missing_tx_digests(digests, &found);
+        if !missing.is_empty() {
+            let missing_bytes: Vec<Vec<u8>> = missing.iter().map(|d| d.inner().to_vec()).collect();
+            for opt in self.db().get_optimistic_transactions(missing_bytes).await? {
+                found.push(TransactionRead::Optimistic(opt));
+            }
+        }
+        Ok(found)
     }
 
-    /// Checks for missing transaction digests in the fetched transactions.
+    /// Same as `Self::multi_get_transactions`, but also reads from the
+    /// historical fallback (when configured) for digests not found in
+    /// Postgres. Fallback rows are returned as
+    /// [`TransactionRead::Checkpointed`].
+    pub async fn multi_get_transactions_with_fallback(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> IndexerResult<Vec<TransactionRead>> {
+        let mut found = self.multi_get_transactions(digests).await?;
+
+        if found.len() == digests.len() {
+            return Ok(found);
+        }
+        let Some(fallback) = self.fallback_reader() else {
+            return Ok(found);
+        };
+
+        let missing = Self::check_for_missing_tx_digests(digests, &found);
+        for stored in fallback.transactions(&missing).await?.into_iter().flatten() {
+            found.push(TransactionRead::Checkpointed(stored));
+        }
+        Ok(found)
+    }
+
+    /// Returns the `requested` digests that are not in `found`.
     fn check_for_missing_tx_digests(
-        requested_digests: &[Vec<u8>],
-        fetched_txs: &[StoredTransaction],
-    ) -> Vec<Vec<u8>> {
-        let fetched_txs_digests_set = fetched_txs
+        requested: &[TransactionDigest],
+        found: &[TransactionRead],
+    ) -> Vec<TransactionDigest> {
+        let found_set: HashSet<&[u8]> = found.iter().map(|t| t.transaction_digest()).collect();
+        requested
             .iter()
-            .map(|tx| &tx.transaction_digest)
-            .collect::<HashSet<&Vec<u8>>>();
-        requested_digests
-            .iter()
-            .filter(|digest| !fetched_txs_digests_set.contains(digest))
-            .cloned()
-            .collect::<Vec<Vec<u8>>>()
+            .filter(|d| !found_set.contains(d.inner().as_slice()))
+            .copied()
+            .collect()
     }
 
     /// This method tries to transform [`StoredTransaction`] values
@@ -1753,7 +1751,12 @@ impl IndexerReader {
         digests: &[TransactionDigest],
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
     ) -> Result<Vec<iota_json_rpc_types::IotaTransactionBlockResponse>, IndexerError> {
-        let stored_txes = self.multi_get_transactions_with_fallback(digests).await?;
+        let stored_txes: Vec<StoredTransaction> = self
+            .multi_get_transactions_with_fallback(digests)
+            .await?
+            .into_iter()
+            .map(StoredTransaction::from)
+            .collect();
         self.stored_transaction_to_transaction_block(stored_txes, options)
             .await
     }

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -521,6 +521,28 @@ impl IndexerReader {
         }
     }
 
+    /// Fetches objects by their ID and version from the historical fallback
+    /// storage. Returns one entry per requested pair in the same order, `None`
+    /// when the fallback does not have the object.
+    ///
+    /// - If `before_version` is `false`, it looks for the exact version.
+    /// - If `true`, it finds the latest version before the given one.
+    ///
+    /// Returns [`IndexerError::NotSupported`] when the historical fallback is
+    /// not configured; check [`Self::is_fallback_enabled`] before calling.
+    pub async fn multi_get_fallback_objects(
+        &self,
+        object_refs: &[(ObjectId, Version)],
+        before_version: bool,
+    ) -> IndexerResult<Vec<Option<StoredObject>>> {
+        let Some(kv_reader) = self.fallback_reader() else {
+            return Err(IndexerError::NotSupported(
+                "historical fallback is not configured".to_string(),
+            ));
+        };
+        kv_reader.objects(object_refs, before_version).await
+    }
+
     pub async fn get_package(&self, package_id: ObjectId) -> Result<Package, IndexerError> {
         let store = self.package_resolver.package_store();
         let pkg = store

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -1366,45 +1366,37 @@ impl IndexerReader {
 
     /// Fetches a paginated list of transactions that affect a given address,
     /// using the fallback storage if the database is pruned.
-    async fn query_transactions_by_affected_addresses_with_fallback(
+    pub async fn query_stored_transactions_by_affected_addresses_with_fallback(
         &self,
         address: Address,
-        cursor: Option<TransactionDigest>,
+        cursor_tx_seq: Option<u64>,
         limit: usize,
         is_descending: bool,
-        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
-    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+    ) -> IndexerResult<Vec<StoredTransaction>> {
         let watermark = self.affected_addresses_tx_watermark();
 
-        // fast path: cursor is known to KV (cached) and in pruned territory
-        // (below watermark). Serve directly from KV until pagination crosses
-        // into the unpruned DB range.
-        if let Some((cursor, kv_reader)) = cursor.zip(self.fallback_reader()).filter(|(c, kv)| {
-            kv.cursor_cache
-                .get(c)
-                .is_some_and(|s| (s as i64) < watermark)
-        }) {
-            let stored_txs = kv_reader
-                .transactions_by_address(address, Some(cursor), limit, !is_descending)
+        // fast path: the cursor is in pruned territory (below the watermark).
+        // Serve directly from KV until pagination crosses into the unpruned
+        // DB range.
+        if let Some((cursor_tx_seq, kv_reader)) = cursor_tx_seq
+            .zip(self.fallback_reader())
+            .filter(|(c, _)| (*c as i64) < watermark)
+        {
+            return Ok(kv_reader
+                .transactions_by_address(address, Some(cursor_tx_seq), limit, !is_descending)
                 .await?
                 .into_iter()
                 .flatten()
-                .collect();
-
-            return self
-                .stored_transaction_to_transaction_block(stored_txs, options)
-                .await;
+                .collect());
         };
 
         let db_res = self
             .db()
-            .query_transactions_by_affected_addresses(address, cursor, limit, is_descending)
+            .query_transactions_by_affected_addresses(address, cursor_tx_seq, limit, is_descending)
             .await;
 
         let Some(kv_reader) = self.fallback_reader() else {
-            return self
-                .stored_transaction_to_transaction_block(db_res?, options)
-                .await;
+            return db_res;
         };
 
         let (mut rows, id_db_pruned) = match db_res {
@@ -1419,20 +1411,9 @@ impl IndexerReader {
             // Continue pagination from the last DB row, or from the original
             // cursor if the DB returned nothing. Avoids restarting KV from the
             // top of history and re-fetching rows the user already saw.
-            let kv_cursor = if let Some(tx) = rows.last() {
-                let digest =
-                    TransactionDigest::from_bytes(&tx.transaction_digest).map_err(|e| {
-                        IndexerError::PersistentStorageDataCorruption(format!(
-                            "failed to decode transaction digest: {:?} with err: {e:?}",
-                            tx.transaction_digest
-                        ))
-                    })?;
-                kv_reader
-                    .cursor_cache
-                    .insert(digest, tx.tx_sequence_number as u64);
-                Some(digest)
-            } else {
-                cursor
+            let kv_cursor = match rows.last() {
+                Some(tx) => Some(tx.tx_sequence_number as u64),
+                None => cursor_tx_seq,
             };
 
             let kv_rows = kv_reader
@@ -1442,6 +1423,60 @@ impl IndexerReader {
                 .flatten();
             rows.extend(kv_rows);
         }
+
+        Ok(rows)
+    }
+
+    /// Fetches a paginated list of transactions that affect a given address,
+    /// using the fallback storage if the database is pruned.
+    async fn query_transactions_by_affected_addresses_with_fallback(
+        &self,
+        address: Address,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let cursor_tx_seq = match cursor {
+            None => None,
+            Some(digest) => {
+                Some(
+                    match self
+                        .db()
+                        .resolve_cursor_tx_digest_to_seq_num_maybe(digest)
+                        .await?
+                    {
+                        Some(tx_seq) => tx_seq as u64,
+                        // The digest is not in Postgres: resolve it through the
+                        // fallback (which checks its cursor cache first).
+                        None => match self.fallback_reader() {
+                            Some(kv_reader) => {
+                                kv_reader.resolve_cursor_tx_sequence_number(digest).await?
+                            }
+                            None if self.affected_addresses_tx_watermark() > 0 => {
+                                return Err(IndexerError::DataPruned(format!(
+                                    "unable to resolve cursor digest: {digest} potentially pruned"
+                                )));
+                            }
+                            None => {
+                                return Err(IndexerError::InvalidArgument(format!(
+                                    "cursor with digest {digest} not found"
+                                )));
+                            }
+                        },
+                    },
+                )
+            }
+        };
+
+        let rows = self
+            .query_stored_transactions_by_affected_addresses_with_fallback(
+                address,
+                cursor_tx_seq,
+                limit,
+                is_descending,
+            )
+            .await?;
 
         self.stored_transaction_to_transaction_block(rows, options)
             .await
@@ -3604,51 +3639,36 @@ impl<'a> DBReader<'a> {
     ///
     /// # Errors
     ///
-    /// * [`IndexerError::DataPruned`] — signals the caller to fall back to the
-    ///   historical store. Two triggers:
-    ///   * `cursor` resolves to a sequence number below the pruning
-    ///     min_available_tx.
-    ///   * `cursor = None && is_descending = false && min_available_tx > 0`:
-    ///     the DB cannot tell whether the address has pre-watermark history.
-    /// * [`IndexerError::InvalidArgument`]: the cursor is invalid (digest
-    ///   absent from `tx_digests` AND the database is not pruned).
+    /// [`IndexerError::DataPruned`] — signals the caller to fall back to the
+    /// historical store. Two triggers:
+    /// * the first transaction of the page is below the pruning
+    ///   min_available_tx.
+    /// * `cursor_tx_seq = None && is_descending = false && min_available_tx >
+    ///   0`: the DB cannot tell whether the address has pre-watermark history.
     async fn query_transactions_by_affected_addresses(
         &self,
         addr: Address,
-        cursor: Option<TransactionDigest>,
+        cursor_tx_seq: Option<u64>,
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
         let min_available_tx = self.main_reader.affected_addresses_tx_watermark();
 
-        let cursor_tx_seq = if let Some(cursor) = cursor {
-            match self
-                .resolve_cursor_tx_digest_to_seq_num_maybe(cursor)
-                .await?
-            {
-                Some(tx_seq) => {
-                    self.main_reader.ensure_data_not_pruned_for_tx(
-                        tx_seq,
-                        IndexerReader::TRANSACTIONS_BY_ADDRESS_TABLES,
-                    )?;
-                    Some(tx_seq)
-                }
-                None if min_available_tx > 0 => {
-                    return Err(IndexerError::DataPruned(format!(
-                        "unable to resolve cursor digest: {cursor} potentially pruned"
-                    )));
-                }
-                None => {
-                    return Err(IndexerError::InvalidArgument(format!(
-                        "cursor with digest {cursor} not found"
-                    )));
-                }
-            }
-        } else {
-            None
-        };
+        if let Some(cursor_tx_seq) = cursor_tx_seq {
+            // The page starts right after/before cursor in the pagination direction.
+            // The cursor row itself is allowed to be pruned.
+            let page_start = if is_descending {
+                cursor_tx_seq.saturating_sub(1)
+            } else {
+                cursor_tx_seq.saturating_add(1)
+            };
+            self.main_reader.ensure_data_not_pruned_for_tx(
+                page_start as i64,
+                IndexerReader::TRANSACTIONS_BY_ADDRESS_TABLES,
+            )?;
+        }
 
-        if !is_descending && cursor.is_none() && min_available_tx > 0 {
+        if !is_descending && cursor_tx_seq.is_none() && min_available_tx > 0 {
             return Err(IndexerError::DataPruned(format!(
                 "DB may be missing earliest history for address {addr} due to pruning"
             )));

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -203,7 +203,7 @@ impl IndexerReader {
     ///
     /// In case the IndexerReader fails to retrieve data, the fallback reader
     /// will be used to retrieve the data.
-    pub(crate) fn with_fallback_reader(&mut self, fallback: HistoricalFallbackReader) {
+    pub fn with_fallback_reader(&mut self, fallback: HistoricalFallbackReader) {
         self.fallback = Some(fallback);
     }
 

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -2020,13 +2020,16 @@ impl IndexerReader {
             .map(|iota_tx_event| iota_tx_event.data)
     }
 
-    async fn query_events_by_tx_digest_with_fallback(
+    /// Fetches events belonging to a transaction, paginated by an exclusive
+    /// `cursor`. Falls back to the historical storage (when configured) if the
+    /// transaction has been pruned from Postgres.
+    pub async fn query_stored_events_by_tx_digest_with_fallback(
         &self,
         tx_digest: TransactionDigest,
         cursor: Option<EventID>,
         limit: usize,
         descending_order: bool,
-    ) -> IndexerResult<Vec<IotaEvent>> {
+    ) -> IndexerResult<Vec<StoredEvent>> {
         let db_res = self
             .db()
             .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
@@ -2035,27 +2038,45 @@ impl IndexerReader {
         if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
             (db_res.as_ref(), self.fallback_reader())
         {
-            kv_reader
+            return kv_reader
                 .events(tx_digest, cursor, limit, descending_order)
                 .await
-                .context(&format!("fallback triggered by {err}"))
-        } else {
-            let mut iota_event_futures = vec![];
-            for stored_event in db_res? {
-                iota_event_futures.push(tokio::task::spawn(
-                    stored_event.try_into_iota_event(self.package_resolver.clone()),
-                ));
-            }
-
-            futures::future::join_all(iota_event_futures)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
+                .context(&format!("fallback triggered by {err}"));
         }
+        db_res
+    }
+
+    async fn query_events_by_tx_digest_with_fallback(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<IotaEvent>> {
+        let stored_events = self
+            .query_stored_events_by_tx_digest_with_fallback(
+                tx_digest,
+                cursor,
+                limit,
+                descending_order,
+            )
+            .await?;
+
+        let mut iota_event_futures = vec![];
+        for stored_event in stored_events {
+            iota_event_futures.push(tokio::task::spawn(
+                stored_event.try_into_iota_event(self.package_resolver.clone()),
+            ));
+        }
+
+        futures::future::join_all(iota_event_futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("failed to join iota event futures: {e}"))?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("failed to collect iota event futures: {e}"))
     }
 
     pub(crate) async fn query_only_checkpointed_events_in_blocking_task(

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -7,6 +7,7 @@ use std::{
     cmp::Reverse,
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
+    ops::Bound,
     sync::{Arc, Mutex},
 };
 
@@ -1303,6 +1304,42 @@ impl IndexerReader {
         };
         self.stored_transaction_to_transaction_block(stored_txs, options)
             .await
+    }
+
+    /// Fetches transactions belonging to a checkpoint whose
+    /// `tx_sequence_number` falls within the given range. Falls back to the
+    /// historical storage (when configured) if the checkpoint has been pruned
+    /// from Postgres.
+    pub async fn query_stored_transactions_by_checkpoint_seq_with_fallback(
+        &self,
+        checkpoint_seq: u64,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
+        let db_res = self
+            .db()
+            .query_transactions_by_checkpoint_seq_in_range(
+                checkpoint_seq,
+                tx_seq_range,
+                limit,
+                is_descending,
+            )
+            .await;
+        if let (Err(IndexerError::DataPruned(err)), Some(kv_reader)) =
+            (db_res.as_ref(), self.fallback_reader())
+        {
+            return kv_reader
+                .checkpoint_transactions_in_seq_range(
+                    checkpoint_seq,
+                    tx_seq_range,
+                    limit,
+                    is_descending,
+                )
+                .await
+                .context(&format!("fallback triggered by {err}"));
+        }
+        db_res
     }
 
     /// Fetches a paginated list of transactions that affect a given address,
@@ -2876,6 +2913,35 @@ impl<'a> DBReader<'a> {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<StoredTransaction>> {
+        let tx_seq_range = match cursor {
+            Some(cursor) => {
+                let cursor_tx_seq = self.resolve_cursor_tx_digest_to_seq_num(cursor).await? as u64;
+                if is_descending {
+                    (Bound::Unbounded, Bound::Excluded(cursor_tx_seq))
+                } else {
+                    (Bound::Excluded(cursor_tx_seq), Bound::Unbounded)
+                }
+            }
+            None => (Bound::Unbounded, Bound::Unbounded),
+        };
+        self.query_transactions_by_checkpoint_seq_in_range(
+            checkpoint_seq,
+            tx_seq_range,
+            limit,
+            is_descending,
+        )
+        .await
+    }
+
+    /// Same as [`Self::query_transactions_by_checkpoint_seq`], but bounded by
+    /// a `tx_sequence_number` range instead of a digest cursor.
+    async fn query_transactions_by_checkpoint_seq_in_range(
+        &self,
+        checkpoint_seq: u64,
+        tx_seq_range: (Bound<u64>, Bound<u64>),
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<StoredTransaction>> {
         self.main_reader.ensure_data_not_pruned_for_checkpoint(
             checkpoint_seq,
             &[
@@ -2899,24 +2965,29 @@ impl<'a> DBReader<'a> {
         })
         .context("failed to get transaction range from pruner_cp_watermark table")?;
 
-        let cursor_tx_seq = if let Some(cursor) = cursor {
-            Some(self.resolve_cursor_tx_digest_to_seq_num(cursor).await?)
-        } else {
-            None
-        };
-
         let mut query = transactions::dsl::transactions
             .filter(transactions::tx_sequence_number.between(tx_range.0, tx_range.1))
             .into_boxed();
 
-        // Translate transaction digest cursor to tx sequence number
-        if let Some(cursor_tx_seq) = cursor_tx_seq {
-            if is_descending {
-                query = query.filter(transactions::dsl::tx_sequence_number.lt(cursor_tx_seq));
-            } else {
-                query = query.filter(transactions::dsl::tx_sequence_number.gt(cursor_tx_seq));
+        let (min_tx_seq, max_tx_seq) = tx_seq_range;
+        query = match min_tx_seq {
+            Bound::Included(min) => {
+                query.filter(transactions::dsl::tx_sequence_number.ge(min as i64))
             }
-        }
+            Bound::Excluded(min) => {
+                query.filter(transactions::dsl::tx_sequence_number.gt(min as i64))
+            }
+            Bound::Unbounded => query,
+        };
+        query = match max_tx_seq {
+            Bound::Included(max) => {
+                query.filter(transactions::dsl::tx_sequence_number.le(max as i64))
+            }
+            Bound::Excluded(max) => {
+                query.filter(transactions::dsl::tx_sequence_number.lt(max as i64))
+            }
+            Bound::Unbounded => query,
+        };
         if is_descending {
             query = query.order(transactions::dsl::tx_sequence_number.desc());
         } else {

--- a/docs/content/operator/extended-data-services/graphql.mdx
+++ b/docs/content/operator/extended-data-services/graphql.mdx
@@ -24,7 +24,7 @@ The GraphQL service holds no state of its own. Multiple instances can run in par
 
 - An indexer Postgres database. The schema version in the database must match the one compiled into the GraphQL binary; otherwise the GraphQL service refuses to start. For the `executeTransactionBlock` operation to work properly the indexer writer should be running and synced with the tip of the network. See [IOTA Indexer](./iota-indexer.mdx) for details on running the indexer writer.
 - A fullnode gRPC endpoint. Required at start-up — the server fails to start if `--node-rpc-url` is not set, even when no client issues a mutation or a dry run.
-- Note that currently fallback service cannot be configured for GraphQL, so data pruned by indexer writer is not accessible through GraphQL. See [Pruning](./iota-indexer.mdx#pruning) for the indexer-side retention model.
+- An optional REST KV store for historic fallback. When configured, it lets the GraphQL service serve data already pruned by the indexer writer. Currently experimental. See [Pruned data](#pruned-data) below and [Pruning](./iota-indexer.mdx#pruning) for the indexer-side retention model.
 
 ## Hardware requirements
 
@@ -71,6 +71,34 @@ The most important settings are covered in subsections below. All settings are l
 ### Fullnode endpoint
 
 `--node-rpc-url` is the gRPC URL of a fullnode that the GraphQL service forwards `executeTransactionBlock` and `dryRunTransactionBlock` to. It is required at start-up.
+
+### Pruned data
+
+:::warning Experimental
+
+The historic fallback depends on the API from the `iota-rest-kv` crate which is still being finalised. Treat the flags below as experimental — they may change or be replaced.
+
+:::
+
+Data already [pruned](./iota-indexer.mdx#pruning) by the indexer writer can be served by the GraphQL service using a historic fallback feature.
+To use it, the operator runs a separate self-hosted REST KV store and points the GraphQL service at it via `--fallback-kv-url`.
+When `--fallback-kv-url` is unset (the default), no fallback is performed and pruned data is unreachable via GraphQL.
+
+These queries fall back to the KV store when their data has been pruned from the database:
+
+- `checkpoint`, `checkpoints`, `Epoch.checkpoints`
+- `transactionBlock`, `transactionBlocksByDigests`
+- `transactionBlocks` with filter `atCheckpoint`, `affectedAddress`, or `transactionIds`, and the matching `Checkpoint.transactionBlocks` and `Address.transactionBlocks` (`AFFECTED` relation)
+- `events` with filter `transactionDigest`
+- `object` at a past version, including dynamic fields resolved at a parent object's version
+
+:::note
+
+Resolving a dynamic field or dynamic object field at a parent object's version needs that version recorded in the indexer's `objects_version` table. On indexers restored from a snapshot, versions below the restore point cannot be served this way and return `DATA_PRUNED`.
+
+:::
+
+The `--fallback-kv-multi-fetch-batch-size`, `--fallback-kv-concurrent-fetches`, and `--fallback-kv-cache-size` knobs tune the KV client's request batching, concurrency, and in-memory cache.
 
 ### HTTP server
 
@@ -158,6 +186,10 @@ reverse-registry-id = "0x..."
 | `--skip-migration-consistency-check`  | `false`                                                  | Skip the start-up check that local migrations match the database.                                 |
 | `--max-available-range`               | `9000`                                                   | Maximum window (in checkpoints) in which consistent view on objects can be served. Also `MAX_AVAILABLE_RANGE` env var. |
 | `--node-rpc-url`                      | _(required)_                                             | Fullnode gRPC URL used for `executeTransactionBlock` and `dryRunTransactionBlock`.                |
+| `--fallback-kv-url`                   | _(none)_                                                 | Experimental. REST KV store URL for historic fallback. Disabled when unset.                       |
+| `--fallback-kv-multi-fetch-batch-size` | `100`                                                   | Experimental. Maximum number of keys per batch request to the fallback KV store. Also `FALLBACK_KV_MULTI_FETCH_BATCH_SIZE` env var. |
+| `--fallback-kv-concurrent-fetches`    | `10`                                                     | Experimental. Maximum number of concurrent batch requests to the fallback KV store. Also `FALLBACK_KV_CONCURRENT_FETCHES` env var. |
+| `--fallback-kv-cache-size`            | `100000`                                                 | Experimental. In-memory cache size for historic fallback. Also `FALLBACK_KV_CACHE_SIZE` env var.  |
 | `--ide-title`, `-i`                   | `IOTA GraphQL IDE`                                       | Title displayed at the top of the GraphiQL IDE.                                                   |
 | `--config`, `-c`                      | _(none)_                                                 | Path to a TOML file with service configuration; see below.                                        |
 


### PR DESCRIPTION
# Description of change

Merge of the `infra/feat/graphql-historical-fallback` feature branch.
Enables archival key-value (KV) store usage in GraphQL.

All included PRs have already been reviewed separately, each has release notes for the part of feature that it adds:

- #11949 — wires the fallback configuration (`--fallback-kv-url`) and the archival KV store reader.
- #11989 — checkpoint queries read pruned checkpoints from the KV store.
- #12074 — fetching transactions by digest reads pruned transactions from the KV store.
- #12184 — transactions filtered by checkpoint use the fallback.
- #12214 — adds the `affectedAddress` transaction filter for reading transactions that affect an address.
- #12272 — events filtered by transaction digest use the fallback.
- #12300 — object lookups at a historical version (including dynamic fields at a parent version) use the fallback.
- #12553 — transactions filtered by affected address use the fallback, and a cursor at a pruned checkpoint returns `DATA_PRUNED`.
- #12571 — adds request metrics for the KV store fallback.
- #12616 — transactions filtered by transaction IDs use the fallback.
- #12617 — updates the `Checkpoint::paginate` comment for the fallback.
- #12644 — documents the fallback feature in the GraphQL README and the operator docs.

## Links to any relevant issues

fixes #11855

## How the change has been tested

- The graphql-e2e and graphql-rpc test suites pass on the branch (rebased on develop).
- Manual QA against a pruned testnet indexer database and the testnet KV store, covering every fallback query over the pruned range, the recent range, and pages crossing the pruning watermark.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
