### PR TITLE
refactor(iota): migrate CLI PTB command to the gRPC transaction builder

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -19,7 +19,10 @@ use colored::Colorize;
 use fastcrypto::encoding::{Base64, Encoding};
 use futures::{StreamExt, TryStreamExt};
 use iota_config::verifier_signing_config::VerifierSigningConfig;
-use iota_grpc_client::read_mask_fields::{ObjectField, OwnedObjectReadMask};
+use iota_grpc_client::{
+    Client as GrpcClient,
+    read_mask_fields::{ObjectField, OwnedObjectReadMask},
+};
 use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
     Coin, DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, DynamicFieldPage,
@@ -3299,7 +3302,7 @@ pub async fn max_gas_budget(client: &IotaClient) -> Result<u64, anyhow::Error> {
 
 /// Fetch the current object references for the given object IDs over gRPC.
 pub(crate) async fn grpc_input_refs(
-    client: &iota_grpc_client::Client,
+    client: &GrpcClient,
     object_ids: &[ObjectId],
 ) -> Result<Vec<ObjectReference>, anyhow::Error> {
     if object_ids.is_empty() {
@@ -3321,7 +3324,7 @@ pub(crate) async fn grpc_input_refs(
 /// Fetch the coin with the given ID over gRPC, as a reference pinning the
 /// version its type was read at, and the `T` of its `Coin<T>`.
 async fn grpc_coin(
-    client: &iota_grpc_client::Client,
+    client: &GrpcClient,
     coin_id: ObjectId,
 ) -> Result<(ObjectReference, TypeTag), anyhow::Error> {
     let object = client

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3298,7 +3298,7 @@ pub async fn max_gas_budget(client: &IotaClient) -> Result<u64, anyhow::Error> {
 }
 
 /// Fetch the current object references for the given object IDs over gRPC.
-async fn grpc_input_refs(
+pub(crate) async fn grpc_input_refs(
     client: &iota_grpc_client::Client,
     object_ids: &[ObjectId],
 ) -> Result<Vec<ObjectReference>, anyhow::Error> {

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -7,6 +7,7 @@ use std::{collections::BTreeMap, path::Path};
 use anyhow::Result;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
+use iota_grpc_client::Client as GrpcClient;
 use iota_json::{is_receiving_argument, primitive_type};
 use iota_move::manage_package::resolve_lock_file_path;
 use iota_move_build::CompiledPackage;
@@ -244,7 +245,7 @@ pub struct PTBBuilder<'a> {
     context: &'a WalletContext,
     /// gRPC client for reading objects from chain. Needed for object
     /// resolution.
-    grpc_client: &'a iota_grpc_client::Client,
+    grpc_client: &'a GrpcClient,
     /// The last command that we have added. This is used to support assignment
     /// commands.
     last_command: Option<Argument>,
@@ -304,7 +305,7 @@ impl<'a> PTBBuilder<'a> {
     pub fn new(
         starting_env: BTreeMap<String, AccountAddress>,
         context: &'a WalletContext,
-        grpc_client: &'a iota_grpc_client::Client,
+        grpc_client: &'a GrpcClient,
     ) -> Self {
         Self {
             addresses: starting_env,

--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -8,13 +8,13 @@ use anyhow::Result;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use iota_json::{is_receiving_argument, primitive_type};
-use iota_json_rpc_types::{IotaObjectData, IotaObjectDataOptions, IotaRawData};
 use iota_move::manage_package::resolve_lock_file_path;
 use iota_move_build::CompiledPackage;
-use iota_sdk::apis::ReadApi;
+use iota_sdk::wallet_context::WalletContext;
+use iota_sdk_transaction_builder::TransactionBuilderClient;
 use iota_sdk_types::{
-    Address, Argument, Command, Identifier, ObjectId, Owner, ProgrammableTransaction,
-    SharedObjectReference, TypeTag, move_package::MovePackage,
+    Address, Argument, Command, Identifier, Object, ObjectData, ObjectId, Owner,
+    ProgrammableTransaction, SharedObjectReference, TypeTag, move_package::MovePackage,
 };
 use iota_types::{
     base_types::{TxContext, TxContextKind, is_primitive_type_tag},
@@ -125,20 +125,17 @@ impl<'a> Resolver<'a> for ToObject {
         loc: Span,
         obj_id: ObjectId,
     ) -> PTBResult<Argument> {
-        // Get the object from the reader to get metadata about the object.
+        // Get the object from the chain to get metadata about the object.
         let obj = builder.get_object(obj_id, loc).await?;
-        let owner = obj
-            .owner
-            .ok_or_else(|| err!(loc, "Unable to get owner info for object {obj_id}"))?;
         let object_ref = obj.object_ref();
         // Depending on the ownership of the object, we resolve it to different types of
         // object arguments for the transaction.
-        let obj_arg = match owner {
+        let obj_arg = match obj.owner() {
             Owner::Address(_) if self.is_receiving => CallArg::Receiving(object_ref),
             Owner::Immutable | Owner::Address(_) => CallArg::ImmutableOrOwned(object_ref),
             Owner::Shared(initial_shared_version) => CallArg::Shared(SharedObjectReference::new(
                 object_ref.object_id,
-                initial_shared_version,
+                *initial_shared_version,
                 self.is_mut,
             )),
             Owner::Object(_) => {
@@ -242,8 +239,12 @@ pub struct PTBBuilder<'a> {
     /// The arguments that we have resolved. This is a map from identifiers to
     /// the actual transaction arguments.
     resolved_arguments: BTreeMap<String, Argument>,
-    /// Read API for reading objects from chain. Needed for object resolution.
-    reader: &'a ReadApi,
+    /// Wallet context, used to create a JSON-RPC client on demand for the
+    /// package compilation paths of the publish and upgrade commands.
+    context: &'a WalletContext,
+    /// gRPC client for reading objects from chain. Needed for object
+    /// resolution.
+    grpc_client: &'a iota_grpc_client::Client,
     /// The last command that we have added. This is used to support assignment
     /// commands.
     last_command: Option<Argument>,
@@ -300,14 +301,19 @@ impl ArgWithHistory {
 }
 
 impl<'a> PTBBuilder<'a> {
-    pub fn new(starting_env: BTreeMap<String, AccountAddress>, reader: &'a ReadApi) -> Self {
+    pub fn new(
+        starting_env: BTreeMap<String, AccountAddress>,
+        context: &'a WalletContext,
+        grpc_client: &'a iota_grpc_client::Client,
+    ) -> Self {
         Self {
             addresses: starting_env,
             identifiers: BTreeMap::new(),
             arguments_to_resolve: BTreeMap::new(),
             resolved_arguments: BTreeMap::new(),
             ptb: ProgrammableTransactionBuilder::new(),
-            reader,
+            context,
+            grpc_client,
             last_command: None,
             errors: Vec::new(),
             stored_compile_upgrade: None,
@@ -449,44 +455,12 @@ impl<'a> PTBBuilder<'a> {
     }
 
     /// Resolve an object ID to a Move package.
-    async fn resolve_to_package(
-        &mut self,
-        package_id: ObjectId,
-        loc: Span,
-    ) -> PTBResult<MovePackage> {
-        let object = self
-            .reader
-            .get_object_with_options(package_id, IotaObjectDataOptions::bcs_lossless())
-            .await
-            .map_err(|e| err!(loc, "{e}"))?
-            .into_object()
-            .map_err(|e| err!(loc, "{e}"))?;
-        let Some(IotaRawData::Package(package)) = object.bcs else {
-            error!(
-                loc,
-                "BCS field in object '{}' is missing or not a package.", package_id
-            );
+    async fn resolve_to_package(&self, package_id: ObjectId, loc: Span) -> PTBResult<MovePackage> {
+        let object = self.get_object(package_id, loc).await?;
+        let ObjectData::Package(package) = object.data() else {
+            error!(loc, "Object '{}' is not a package.", package_id);
         };
-
-        MovePackage::new(
-            package.id,
-            package.version.into(),
-            package
-                .module_map
-                .into_iter()
-                .map(|(k, v)| (Identifier::new_unchecked(k), v))
-                .collect(),
-            // This package came from on-chain and the tool runs locally, so don't worry about
-            // trying to enforce the package size limit.
-            u64::MAX,
-            package.type_origin_table,
-            package
-                .linkage_table
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
-        )
-        .map_err(|e| err!(loc, "{e}"))
+        Ok(package.clone())
     }
 
     /// Resolves the argument to the move call based on the type information of
@@ -814,20 +788,14 @@ impl<'a> PTBBuilder<'a> {
         }
     }
 
-    /// Fetch the `IotaObjectData` for an object ID -- this is used for object
-    /// resolution.
-    async fn get_object(&self, object_id: ObjectId, obj_loc: Span) -> PTBResult<IotaObjectData> {
-        let res = self
-            .reader
-            .get_object_with_options(
-                object_id,
-                IotaObjectDataOptions::new().with_type().with_owner(),
-            )
+    /// Fetch the [`Object`] with the given ID over gRPC -- this is used for
+    /// object resolution.
+    async fn get_object(&self, object_id: ObjectId, obj_loc: Span) -> PTBResult<Object> {
+        self.grpc_client
+            .object(object_id, None)
             .await
             .map_err(|e| err!(obj_loc, "{e}"))?
-            .into_object()
-            .map_err(|e| err!(obj_loc, "{e}"))?;
-        Ok(res)
+            .ok_or_else(|| err!(obj_loc, "Object {object_id} does not exist"))
     }
 
     /// Create a "did you mean" message for an identifier with the context of
@@ -997,7 +965,12 @@ impl<'a> PTBBuilder<'a> {
                     );
                 }
 
-                let chain_id = self.reader.get_chain_identifier().await.ok();
+                let client = self
+                    .context
+                    .get_client()
+                    .await
+                    .map_err(|e| err!(pkg_loc, "{e}"))?;
+                let chain_id = client.read_api().get_chain_identifier().await.ok();
                 let initial_dir = std::env::current_dir()
                     .map_err(|e| err!(pkg_loc, "Failed to get current directory: {e}"))?;
                 let build_config =
@@ -1016,7 +989,7 @@ impl<'a> PTBBuilder<'a> {
                 };
 
                 let compile_result = compile_package(
-                    self.reader,
+                    client.read_api(),
                     build_config.clone(),
                     package_path,
                     false, // with_unpublished_dependencies
@@ -1234,7 +1207,12 @@ impl<'a> PTBBuilder<'a> {
             .canonicalize()
             .map_err(|e| err!(path_loc, "Failed to canonicalize package path: {e}"))?;
 
-        let chain_id = self.reader.get_chain_identifier().await.ok();
+        let client = self
+            .context
+            .get_client()
+            .await
+            .map_err(|e| err!(path_loc, "{e}"))?;
+        let chain_id = client.read_api().get_chain_identifier().await.ok();
         let build_config = MoveBuildConfig::default();
 
         let initial_dir = std::env::current_dir()
@@ -1254,7 +1232,7 @@ impl<'a> PTBBuilder<'a> {
         };
 
         let upgrade_result = upgrade_package(
-            self.reader,
+            client.read_api(),
             build_config.clone(),
             &package_path,
             ObjectId::new(upgrade_cap_id.into_bytes()),

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 
 use anyhow::{Error, anyhow, bail, ensure};
 use clap::{Args, ValueHint, arg, builder::StyledStr};
+use iota_grpc_client::Client as GrpcClient;
 use iota_json_rpc_types::{DevInspectResults, IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
 use iota_keys::keystore::AccountKeystore;
 use iota_sdk::wallet_context::WalletContext;
@@ -367,7 +368,7 @@ impl PTB {
     pub async fn build_ptb(
         program: Program,
         context: &WalletContext,
-        grpc_client: iota_grpc_client::Client,
+        grpc_client: GrpcClient,
     ) -> (
         Result<ProgrammableTransaction, Vec<PTBError>>,
         Vec<PTBError>,

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -8,7 +8,7 @@ use anyhow::{Error, anyhow, bail, ensure};
 use clap::{Args, ValueHint, arg, builder::StyledStr};
 use iota_json_rpc_types::{DevInspectResults, IotaExecutionStatus, IotaTransactionBlockEffectsAPI};
 use iota_keys::keystore::AccountKeystore;
-use iota_sdk::{IotaClient, wallet_context::WalletContext};
+use iota_sdk::wallet_context::WalletContext;
 use iota_sdk_types::{
     Address, ProgrammableTransaction, TransactionDigest, TransactionKind, gas::GasCostSummary,
 };
@@ -19,7 +19,7 @@ use super::{ast::ProgramMetadata, lexer::Lexer, parser::ProgramParser};
 use crate::{
     client_commands::{
         DisplayOption, GasDataArgs, IotaClientCommandResult, TxProcessingArgs,
-        dry_run_or_execute_or_serialize, parse_display_option,
+        dry_run_or_execute_or_serialize, grpc_input_refs, parse_display_option,
     },
     client_ptb::{
         ast::{ParsedProgram, Program},
@@ -221,9 +221,9 @@ impl PTB {
             }));
         }
 
-        let client = context.get_client().await?;
+        let grpc_client = context.get_grpc_client().await?;
 
-        let (res, warnings) = Self::build_ptb(program, context, client.clone()).await;
+        let (res, warnings) = Self::build_ptb(program, context, grpc_client.clone()).await;
 
         // Render warnings
         if !warnings.is_empty() {
@@ -291,7 +291,7 @@ impl PTB {
             sponsor_auth_type_args,
         };
 
-        let gas_payment = client.transaction_builder().input_refs(&gas).await?;
+        let gas_payment = grpc_input_refs(&grpc_client, &gas).await?;
 
         let transaction_response = dry_run_or_execute_or_serialize(
             sender,
@@ -367,7 +367,7 @@ impl PTB {
     pub async fn build_ptb(
         program: Program,
         context: &WalletContext,
-        client: IotaClient,
+        grpc_client: iota_grpc_client::Client,
     ) -> (
         Result<ProgrammableTransaction, Vec<PTBError>>,
         Vec<PTBError>,
@@ -379,7 +379,7 @@ impl PTB {
             .into_iter()
             .map(|(sa, alias)| (alias.alias.clone(), AccountAddress::new(sa.into_bytes())))
             .collect();
-        let builder = PTBBuilder::new(starting_addresses, client.read_api());
+        let builder = PTBBuilder::new(starting_addresses, context, &grpc_client);
         builder.build(program).await
     }
 

--- a/crates/iota/tests/ptb_files_tests.rs
+++ b/crates/iota/tests/ptb_files_tests.rs
@@ -63,9 +63,9 @@ async fn test_ptb_files(path: &Path) -> datatest_stable::Result<()> {
     let test_cluster = TestClusterBuilder::new().build().await;
 
     let context = &test_cluster.wallet;
-    let client = context.get_client().await?;
+    let grpc_client = context.get_grpc_client().await?;
 
-    let (built_ptb, warnings) = PTB::build_ptb(preview.program, context, client).await;
+    let (built_ptb, warnings) = PTB::build_ptb(preview.program, context, grpc_client).await;
 
     if !warnings.is_empty() {
         let rendered = build_error_reports(&file_contents, warnings);


### PR DESCRIPTION
# Description of change

Fourth slice of the CLI migration to the gRPC-driven transaction building (one command family per PR): the `ptb` command.

- Object resolution in `PTBBuilder` now reads over gRPC: `get_object` (owner-based resolution to owned / shared / receiving inputs) and `resolve_to_package` (move-call argument resolution). The gRPC read returns the SDK `Object` whose `ObjectData::Package` is exactly the `MovePackage` the code previously reconstructed by hand from JSON-RPC raw BCS.
- Gas payment references now come from `grpc_input_refs` instead of `client.transaction_builder().input_refs()` — the PTB path's last JSON-RPC transaction-builder call.
- The JSON-RPC client is no longer created upfront for every PTB: `PTBBuilder` holds the wallet context and creates it on demand only inside the package compilation paths of `--publish` / `--upgrade` / `--compile-upgrade` (protocol config, chain identifier, tree shaking, dependency verification, upgrade-policy lookup), which stay on JSON-RPC per the issue's constraints — same carve-out as #12659. `PTB::build_ptb` lost its `IotaClient` parameter accordingly.
- The "Object … does not exist" error text is preserved verbatim, so PTB error reports and all `ptb_files_tests` snapshots are unchanged. Only the not-a-package message changed (it referred to the JSON-RPC BCS response field).

Still on the JSON-RPC client, by design: JSON-arg `move_call`, the shared package compilation/verification stack, and the execution / dry-run / dev-inspect path.

## Links to any relevant issues

Part of #12099 (task: PTB command).

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo clippy -p iota --all-targets --all-features -- -D warnings` and `cargo +nightly fmt` clean.

- `cargo nextest run -p iota --test ptb_files_tests` — 49 passed, all snapshots unchanged.
- `cargo nextest run -p iota --test cli_tests -E 'test(ptb)'` — 11 passed, including `test_ptb_publish_upgrade`, `test_ptb_compile_upgrade_execute`, `test_ptb_upgrade_backward_compat` and `test_ptb_publish_and_complex_arg_resolution`.
- `cargo simtest -p iota --test cli_tests` on the same PTB tests — 11 passed.
- `cargo nextest run -p iota --lib` — 66 passed.

### Release Notes

- [x] CLI: `iota client ptb` now resolves objects and builds transactions via the gRPC API; the active environment needs a `grpc` URL (default environments already include one, older config files must add it).