### PR TITLE
chore: update SDK rev after private SenderSignedTransaction field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7593,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7625,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7633,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,9 +401,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "41f38c43f3c1e8003cb67c82ecef38ee928ab67f" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "d1acf60090f6cd669bc2785c36f3cf2e225c7de2" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "41f38c43f3c1e8003cb67c82ecef38ee928ab67f" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "d1acf60090f6cd669bc2785c36f3cf2e225c7de2" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -443,10 +443,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "41f38c43f3c1e8003cb67c82ecef38ee928ab67f", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "41f38c43f3c1e8003cb67c82ecef38ee928ab67f", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "41f38c43f3c1e8003cb67c82ecef38ee928ab67f", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "41f38c43f3c1e8003cb67c82ecef38ee928ab67f", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d1acf60090f6cd669bc2785c36f3cf2e225c7de2", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d1acf60090f6cd669bc2785c36f3cf2e225c7de2", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d1acf60090f6cd669bc2785c36f3cf2e225c7de2", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d1acf60090f6cd669bc2785c36f3cf2e225c7de2", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1952,12 +1952,14 @@ impl SenderSignedTransactionAPI for SenderSignedTransaction {
     }
 
     fn add_signature(&mut self, new_signature: SimpleSignature) {
-        self.0.signatures.push(new_signature.into());
+        self.signed_transaction_mut()
+            .signatures
+            .push(new_signature.into());
     }
 
     fn get_signer_sig_mapping(&self) -> IotaResult<BTreeMap<Address, &UserSignature>> {
         let mut mapping = BTreeMap::new();
-        for sig in &self.0.signatures {
+        for sig in &self.signed_transaction().signatures {
             let address = sig.derive_address();
             mapping.insert(address, sig);
         }
@@ -1969,11 +1971,11 @@ impl SenderSignedTransactionAPI for SenderSignedTransaction {
     }
 
     fn transaction_mut_for_testing(&mut self) -> &mut Transaction {
-        &mut self.0.transaction
+        &mut self.signed_transaction_mut().transaction
     }
 
     fn tx_signatures_mut_for_testing(&mut self) -> &mut Vec<UserSignature> {
-        &mut self.0.signatures
+        &mut self.signed_transaction_mut().signatures
     }
 
     fn serialized_size(&self) -> IotaResult<usize> {

--- a/crates/iota-vm-sdk/src/executor/local_vm.rs
+++ b/crates/iota-vm-sdk/src/executor/local_vm.rs
@@ -197,7 +197,7 @@ impl LocalVm {
         let auth_digests = signed
             .compute_auth_digests()
             .map_err(|e| VmSdkError::SignatureVerification(e.into()))?;
-        let transaction = signed.0.transaction;
+        let transaction = signed.into_signed_transaction().transaction;
 
         // A `MoveAuthenticator` on a protocol version that predates Move
         // authentication cannot be run; reject it with a typed error rather
@@ -303,7 +303,7 @@ impl LocalVm {
         let auth_digests = signed
             .compute_auth_digests()
             .map_err(|e| VmSdkError::SignatureVerification(e.into()))?;
-        let transaction = signed.0.transaction;
+        let transaction = signed.into_signed_transaction().transaction;
 
         let env = ExecutionEnv::new(self, &DebugConfig::default())?;
         let backend = StoreBackend::new(self.store.as_ref());

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -486,7 +486,8 @@ impl KeyToolCommand {
                         let tx = SenderSignedTransaction::from_base64(&sig).map_err(|e| {
                             anyhow!("Failed to decode as signature or transaction: {e}")
                         })?;
-                        tx.0.signatures
+                        tx.into_signed_transaction()
+                            .signatures
                             .into_iter()
                             .next()
                             .ok_or_else(|| anyhow!("Transaction has no signatures"))?
@@ -917,7 +918,7 @@ impl KeyToolCommand {
                     Ok(tx) => tx,
                     Err(_) => {
                         SenderSignedTransaction::from_base64(&tx_bytes)?
-                            .0
+                            .into_signed_transaction()
                             .transaction
                     }
                 };

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=41f38c43f3c1e8003cb67c82ecef38ee928ab67f#41f38c43f3c1e8003cb67c82ecef38ee928ab67f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d1acf60090f6cd669bc2785c36f3cf2e225c7de2#d1acf60090f6cd669bc2785c36f3cf2e225c7de2"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "41f38c43f3c1e8003cb67c82ecef38ee928ab67f" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d1acf60090f6cd669bc2785c36f3cf2e225c7de2" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/abstract_account/authenticator-inputs-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-inputs-cryptographic-protection.rs
@@ -418,7 +418,7 @@ pub fn swap_blacklist_in_transaction(
         false,
     ));
 
-    let new_sig = match &transaction.0.signatures[0] {
+    let new_sig = match &transaction.signed_transaction().signatures[0] {
         UserSignature::MoveAuthenticator(move_authenticator) => {
             let raw_value_call_arg = move_authenticator.call_args()[1].clone();
             let signature_call_arg = move_authenticator.call_args()[2].clone();
@@ -450,7 +450,7 @@ pub fn swap_blacklist_in_transaction(
         _ => panic!("Expected MoveAuthenticator signature"),
     };
 
-    transaction.0.signatures[0] = new_sig;
+    transaction.signed_transaction_mut().signatures[0] = new_sig;
 
     transaction
 }
@@ -462,7 +462,7 @@ pub fn swap_raw_value_in_transaction(
 ) -> TransactionEnvelope {
     let new_raw_value_call_arg = CallArg::Pure(bcs::to_bytes(&new_raw_value).unwrap());
 
-    let new_sig = match &transaction.0.signatures[0] {
+    let new_sig = match &transaction.signed_transaction().signatures[0] {
         UserSignature::MoveAuthenticator(move_authenticator) => {
             let blacklist_call_arg = move_authenticator.call_args()[0].clone();
             let signature_call_arg = move_authenticator.call_args()[2].clone();
@@ -494,7 +494,7 @@ pub fn swap_raw_value_in_transaction(
         _ => panic!("Expected MoveAuthenticator signature"),
     };
 
-    transaction.0.signatures[0] = new_sig;
+    transaction.signed_transaction_mut().signatures[0] = new_sig;
 
     transaction
 }

--- a/docs/examples/rust/abstract_account/authenticator-shared-object-swap.rs
+++ b/docs/examples/rust/abstract_account/authenticator-shared-object-swap.rs
@@ -441,7 +441,7 @@ pub fn swap_blacklist_in_transaction(
         false,
     ));
 
-    let new_sig = match &transaction.0.signatures[0] {
+    let new_sig = match &transaction.signed_transaction().signatures[0] {
         UserSignature::MoveAuthenticator(move_authenticator) => {
             let signature_call_arg = move_authenticator.call_args()[0].clone();
 
@@ -468,7 +468,7 @@ pub fn swap_blacklist_in_transaction(
         _ => panic!("Expected MoveAuthenticator signature"),
     };
 
-    transaction.0.signatures[0] = new_sig;
+    transaction.signed_transaction_mut().signatures[0] = new_sig;
 
     transaction
 }

--- a/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
+++ b/docs/examples/rust/abstract_account/authenticator-tx-data-cryptographic-protection.rs
@@ -233,7 +233,7 @@ pub fn swap_recipient_in_transaction(
     mut transaction: TransactionEnvelope,
     attacker: Address,
 ) -> TransactionEnvelope {
-    match &mut transaction.0.transaction {
+    match &mut transaction.signed_transaction_mut().transaction {
         Transaction::V1(tx) => match &mut tx.kind {
             TransactionKind::Programmable(ptb) => {
                 ptb.inputs[0] = CallArg::Pure(bcs::to_bytes(&attacker).unwrap());

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "41f38c43f3c1e8003cb67c82ecef38ee928ab67f" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d1acf60090f6cd669bc2785c36f3cf2e225c7de2" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
# Description of change

Bump the `iota-rust-sdk` rev to `d1acf60` and adapt to the breaking change in
[iotaledger/iota-rust-sdk#1351](https://github.com/iotaledger/iota-rust-sdk/pull/1351),
which makes the inner field of `SenderSignedTransaction` private.

- Replace the `.0` tuple accesses with the new `signed_transaction()` /
  `signed_transaction_mut()` / `into_signed_transaction()` accessors in
  `iota-types`, `iota-vm-sdk` and the `iota` CLI keytool.
- Update the rev in `Cargo.toml`, `Cargo.lock`, and the two standalone example
  manifests (`docs/examples/rust`, `examples/tic-tac-toe/cli`).

No behaviour change.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
