### PR TITLE
fix(iota-core): cancel abandoned transaction status waiters

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1882,6 +1882,11 @@ impl AuthorityPerEpochStore {
             .await
     }
 
+    #[cfg(test)]
+    pub(crate) fn pending_dropped_digest_requests_for_testing(&self) -> usize {
+        self.dropped_tx_status_cache.num_pending_for_testing()
+    }
+
     /// Sets the pre-consensus soft lock table. Called once during validator
     /// setup. Gating on `enable_pcool_flow` is the caller's
     /// responsibility — when the flow is disabled, releases simply produce no

--- a/crates/iota-core/src/authority/dropped_tx_status_cache.rs
+++ b/crates/iota-core/src/authority/dropped_tx_status_cache.rs
@@ -86,6 +86,11 @@ impl DroppedTxStatusCache {
         }
         registration.await
     }
+
+    #[cfg(test)]
+    pub(crate) fn num_pending_for_testing(&self) -> usize {
+        self.notify_read.num_pending()
+    }
 }
 
 #[cfg(test)]

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -441,16 +441,20 @@ impl ValidatorService {
             let epoch_store = epoch_store.clone();
             let tx_sender = tx_sender.clone();
             spawn_monitored_task!(async move {
-                let (update, weight) = Self::wait_for_tx_finality(
-                    &state,
-                    &epoch_store,
-                    query.transaction_digest,
-                    query.include_details,
-                )
-                .await;
-                let _ = tx_sender
-                    .send(Ok(((query.transaction_digest, update), weight)))
-                    .await;
+                tokio::select! {
+                    biased;
+                    _ = tx_sender.closed() => {}
+                    (update, weight) = Self::wait_for_tx_finality(
+                        &state,
+                        &epoch_store,
+                        query.transaction_digest,
+                        query.include_details,
+                    ) => {
+                        let _ = tx_sender
+                            .send(Ok(((query.transaction_digest, update), weight)))
+                            .await;
+                    }
+                }
             });
         }
 

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -1739,6 +1739,42 @@ async fn test_v2_get_tx_status_unknown_digest_expires() {
     );
 }
 
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn v2_get_tx_status_stops_waiting_when_stream_is_dropped() {
+    telemetry_subscribers::init_for_testing();
+
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config
+    });
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let epoch_store = authority_state.epoch_store_for_testing();
+    let consensus_adapter = Arc::new(ConsensusAdapter::new_for_testing_with_authority_name(
+        authority_state.name,
+    ));
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state,
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let response = validator_service
+        .get_tx_status(make_v2_get_tx_status_request(vec![(
+            TransactionDigest::random(),
+            false,
+        )]))
+        .await
+        .expect("get_tx_status should succeed");
+
+    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    assert_eq!(epoch_store.pending_dropped_digest_requests_for_testing(), 1);
+
+    drop(response);
+    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    assert_eq!(epoch_store.pending_dropped_digest_requests_for_testing(), 0);
+}
+
 // ── ValidatorV2 notify_capabilities tests
 // ─────────────────────────────────────
 


### PR DESCRIPTION
# Description of change

- Stop get_tx_status waiters when the client drops the response stream.
- Release pending notification registrations immediately instead of waiting for the 30-second timeout.

Fixes #12449.

## How the change has been tested

- [x] cargo +nightly fmt --all -- --check
- [x] cargo clippy -p iota-core --lib --tests -- -D warnings
- [x] cargo check -p iota-core
- [x] IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-core --lib (767 passed)