### PR TITLE
chore(doc): Remove RocksDB snapshot documentation

### DIFF
--- a/docs/content/developer/references/cli/iota-tool.mdx
+++ b/docs/content/developer/references/cli/iota-tool.mdx
@@ -161,7 +161,6 @@ Run `iota-tool --help` to see all available commands, including:
 - `fetch-transaction` — Fetch transaction effects
 - `db-tool` — Read validator and node databases
 - `verify-archive` — Verify the archive store
-- `download-db-snapshot` — Download a database snapshot
 - `download-formal-snapshot` — Download a formal snapshot
 - `backfill-checkpoint-summaries` — Backfill the full checkpoint summary history from the archive into a stopped node
 - `dump-packages` — Download all packages from a GraphQL service

--- a/docs/content/operator/common/pruning.mdx
+++ b/docs/content/operator/common/pruning.mdx
@@ -127,8 +127,6 @@ This configuration manages the full object history while still pruning historic 
 
 The main caveat is that the current setup enables the **transaction pruner** to go ahead of the **object pruner**. The object pruner might not be able to properly clean up the objects modified by the transactions that have been already pruned. You should closely monitor the disk space growth on a full node with this configuration.
 
-In addition to the regular (pruned) snapshots, the IOTA Foundation also maintains special RocksDB snapshots with the full history of object versions available for the operators using this configuration.
-
 ```yaml
 authority-store-pruning-config:
   # No pruning of object versions (use u64::max for num of epochs)

--- a/docs/content/operator/common/snapshots.mdx
+++ b/docs/content/operator/common/snapshots.mdx
@@ -1,6 +1,6 @@
 import FormalSnapshotPicker from '@site/src/components/FormalSnapshotPicker';
 
-Snapshots provide a point-in-time view of a database's store. In IOTA, the database snapshot captures a running database's view of the IOTA network from a particular node at the end of an epoch. 
+Snapshots capture a node's view of the IOTA network at the end of an epoch.
 
 :::info
 
@@ -12,11 +12,7 @@ Snapshots of the IOTA network enable full node operators a way to bootstrap a fu
 
 To maintain a healthy IOTA network, IOTA encourages the IOTA community to bring up additional snapshots to ensure stronger data availability across the network.
 
-## Supported snapshot types
-
-IOTA supports two types of snapshots:
-- RocksDB snapshots
-- Formal snapshots
+## Formal snapshots
 
 :::info
 
@@ -24,16 +20,7 @@ Formal snapshots are not suitable for use if you are running an RPC node that do
 
 :::
 
-You can configure a full node snapshot to generate a state snapshot at the end of each epoch.
-A single full node can generate RocksDB snapshots, Formal snapshots, or both.
-
-### RocksDB snapshots 
-
-RocksDB snapshots are a point-in-time view of a database store. This means that the snapshot keeps the state of the system at the moment it generates the snapshot, including non-pruned data, additional indices, and other data.
-
-### Formal snapshots
-
-Formal snapshots are database-agnostic, minimalistic snapshots containing only essential data for node restoration at a specific epoch. They offer smaller storage footprint and faster restoration compared to database snapshots.  Natively supported by IOTA protocol, this means the snapshot contents can be cryptographically verified against the committee's epoch-end commitment, a process that occurs automatically during restoration (unless explicitly bypassed).
+Formal snapshots are database-agnostic, minimalistic snapshots containing only essential data for node restoration at a specific epoch, keeping their storage footprint small and restoration fast. Natively supported by IOTA protocol, this means the snapshot contents can be cryptographically verified against the committee's epoch-end commitment, a process that occurs automatically during restoration (unless explicitly bypassed).
 
 The formal snapshots have the following properties:
 
@@ -52,27 +39,6 @@ Follow these steps to change the configs for the node:
 1. Stop your node, if it's running.
 2. Open your `fullnode.yaml` file and apply config updates as the following. Using Amazon's S3 service as an example:
 
-   <Tabs groupId="snapshots">
-
-   <TabItem label="RocksDB snapshots" value="db-snapshots">
-
-   ```yaml
-   db-checkpoint-config:
-      perform-db-checkpoints-at-epoch-end: true
-      perform-index-db-checkpoints-at-epoch-end: true
-      object-store-config:
-         object-store: "S3"
-         bucket: "`<BUCKET-NAME>`"
-         aws-access-key-id: "`<ACCESS-KEY>`"
-         aws-secret-access-key: "`<SHARED-KEY>`"
-         aws-region: "`<BUCKET-REGION>`"
-         object-store-connection-limit: 20
-   ```
-
-   </TabItem>
-
-   <TabItem label="Formal snapshots" value="formal-snapshots">
-
    ```yaml
    state-snapshot-write-config:
       object-store-config:
@@ -85,10 +51,6 @@ Follow these steps to change the configs for the node:
       concurrency: 10
    ```
 
-   </TabItem>
-
-   </Tabs>
-
    - `object-store`: The remote object store to upload snapshots. Set as Amazon's `S3` service in the example.
    - `bucket`: The S3 bucket name to store the snapshots.
    - `aws-access-key-id` and `aws-secret-access-key`: AWS authentication information with write access to the bucket.
@@ -100,93 +62,6 @@ Follow these steps to change the configs for the node:
    
 
 ## Restoring a full node from snapshots
-
-### Restoring from RocksDB snapshots
-
-To restore from a RocksDB snapshot, follow these steps:
-
-1. Empty the snapshot directory specified by the `db-path` in your `fullnode.yaml`.
-2. Set the `AWS_SNAPSHOT_ENDPOINT` environment variable to the target snapshot URL. If not set, the default values are endpoints provided by the IOTA Foundation with public access:
-3. **Download the snapshot** for your target epoch to your local disk. Snapshots are stored per epoch in S3 buckets. The Docker commands mount `$PWD/data/db`, the database directory used by the [Docker setup](../full-node/docker.mdx), so run them from that setup's directory or adjust the mount to your own `db-path`. For example, if you're restoring the latest epoch:
-
-   <Tabs groupId="rocksdb-snapshot-command" queryString>
-      <TabItem label="Mainnet (Binary)" value="mainnet-binary">
-      ```shell
-      iota-tool download-db-snapshot \
-         --latest \
-         --network mainnet \
-         --path "<PATH-TO-NODE-DB>" \
-         --num-parallel-downloads 25 \
-         --skip-indexes \
-         --no-sign-request \
-         --verbose
-      ```
-      </TabItem>
-      <TabItem label="Mainnet (Docker)" value="mainnet-docker">
-      ```shell
-      docker run --rm \
-         -v "$PWD/data/db":/opt/iota/db \
-         iotaledger/iota-tools:mainnet \
-         /bin/sh -c "/usr/local/bin/iota-tool download-db-snapshot \
-            --latest \
-            --network mainnet \
-            --path /opt/iota/db \
-            --num-parallel-downloads 25 \
-            --skip-indexes \
-            --no-sign-request \
-            --verbose"
-      ```
-      </TabItem>
-      <TabItem label="Testnet (Binary)" value="testnet-binary">
-      ```shell
-      iota-tool download-db-snapshot \
-         --latest \
-         --network testnet \
-         --path "<PATH-TO-NODE-DB>" \
-         --num-parallel-downloads 25 \
-         --skip-indexes \
-         --no-sign-request \
-         --verbose
-      ```
-      </TabItem>
-      <TabItem label="Testnet (Docker)" value="testnet-docker">
-      ```shell
-      docker run --rm \
-         -v "$PWD/data/db":/opt/iota/db \
-         iotaledger/iota-tools:testnet \
-         /bin/sh -c "/usr/local/bin/iota-tool download-db-snapshot \
-            --latest \
-            --network testnet \
-            --path /opt/iota/db \
-            --num-parallel-downloads 25 \
-            --skip-indexes \
-            --no-sign-request \
-            --verbose"
-      ```
-      </TabItem>
-   </Tabs>
-
-   **iota-tool options:**
-   - `--epoch`: The epoch that you want to download, for example `200`. The buckets hosted by the IOTA Foundation will only keep the last 90 epochs, you can check the most recent epoch on the [IOTA Explorer](https://explorer.iota.org).
-   - `--latest`: Rather than explicitly passing a epoch via `--epoch`, you can pass the `--latest` flag, which will automatically select the latest snapshot`
-   - `--network`: Network to download snapshot for. Defaults to "mainnet".
-   - `--path`: Path to snapshot directory on local filesystem.
-   - `--skip-indexes`: Skips downloading the very large `indexes/` dir, used by jsonrpc on the fullnode.
-
-4. **Move the snapshot**: The snapshot will be located in the `epoch_[NUM]` directory at your specified path. Move it to the snapshot directory specified by the `db-path` in your `fullnode.yaml` and mark the snapshot as `live`.
-For example, if `db-path` is `/opt/iota/db` and epoch_10 directory locates in `/opt/iota/db`, move the snapshot:
-   ```shell
-   mv /opt/iota/db/epoch_10 /opt/iota/db/live
-   ```
-
-5. **Update ownership**: Make sure you update the ownership of the downloaded directory to the `iota` user (or whichever linux user you run `iota-node` as):
-   ```shell
-   sudo chown -R iota:iota /opt/iota/db/live
-   ```
-
-6. **Start your IOTA node**.
-
-### Restoring from Formal snapshots
 
 To restore from a Formal snapshot, use the `iota-tool` binary. `iota-tool` can be downloaded along with other iota binaries.
 See [Install IOTA](../../developer/getting-started/install-iota.mdx#install-from-binaries) for more details.
@@ -233,19 +108,16 @@ The IOTA Foundation provides the public snapshot access:
 
 <TabItem label="Mainnet" value="mainnet-default-snapshot-endpoint">
 
-- **RocksDB**: https://rocksdb-snapshot.mainnet.iota.cafe
 - **Formal**: https://formal-snapshot.mainnet.iota.cafe
 
 </TabItem>
 <TabItem label="Testnet" value="testnet-default-snapshot-endpoint">
 
-- **RocksDB**: https://rocksdb-snapshot.testnet.iota.cafe
 - **Formal**: https://formal-snapshot.testnet.iota.cafe
 
 </TabItem>
 <TabItem label="Devnet" value="devnet-default-snapshot-endpoint">
 
-- **RocksDB**: https://rocksdb-snapshot.devnet.iota.cafe
 - **Formal**: https://formal-snapshot.devnet.iota.cafe
 
 </TabItem>

--- a/docs/content/operator/extended-data-services/iota-indexer.mdx
+++ b/docs/content/operator/extended-data-services/iota-indexer.mdx
@@ -243,7 +243,7 @@ Several tables hold data that is retained for the full lifetime of the database.
 
 ## Restoring from a formal snapshot
 
-The IOTA Indexer has the ability to initialize the database from a [formal snapshot](../common/snapshots.mdx#formal-snapshots) of the network instead of ingesting every checkpoint from genesis. A formal snapshot is a minimal, cryptographically verifiable capture of the end-of-epoch object state. Full nodes bootstrap from the same snapshots (see [formal-snapshot restore](../common/snapshots.mdx#restoring-from-formal-snapshots)).
+The IOTA Indexer has the ability to initialize the database from a [formal snapshot](../common/snapshots.mdx#formal-snapshots) of the network instead of ingesting every checkpoint from genesis. A formal snapshot is a minimal, cryptographically verifiable capture of the end-of-epoch object state. Full nodes bootstrap from the same snapshots (see [formal-snapshot restore](../common/snapshots.mdx#restoring-a-full-node-from-snapshots)).
 
 For a target epoch, restoring the Indexer involves downloading the snapshot, verifying it against the committee chain, and writing the live object state plus the epoch, protocol, and other data derived from it (display, packages, object-version mapping).
 

--- a/docs/content/operator/full-node/configuration.mdx
+++ b/docs/content/operator/full-node/configuration.mdx
@@ -57,7 +57,7 @@ Learn how to configure archive settings for your node [here](configs/archives.md
 ### Snapshots (optional)
 
 If your node fails, it can catch up faster from a recent database snapshot (on restart) than replaying all past transactions since genesis. 
-Learn how to configure formal and RocksDB snapshots [here](configs/snapshots.mdx).
+Learn how to configure formal snapshots [here](configs/snapshots.mdx).
 
 ### Data storage paths (optional)
 

--- a/docs/content/operator/validator-node/configuration.mdx
+++ b/docs/content/operator/validator-node/configuration.mdx
@@ -28,5 +28,5 @@ For more specific guidance on how to configure your node to suit your needs, e.g
 
 - [Network](configs/network.mdx) - Peering configuration for the node.
 - [Pruning](configs/pruning.mdx) - How to prune your validator node to leverage storage space.
-- [Snapshots](configs/snapshots.mdx) - How to configure formal and RocksDB snapshots for your validator node.
+- [Snapshots](configs/snapshots.mdx) - How to configure formal snapshots for your validator node.
 - [Archives](configs/archives.mdx) - How to configure archives for your validator node.

--- a/docs/content/operator/validator-node/troubleshooting.mdx
+++ b/docs/content/operator/validator-node/troubleshooting.mdx
@@ -48,7 +48,7 @@ If you customized them at setup, replace the previous paths with the ones you sp
 ### Restore from formal snapshot
 
 Follow the steps in this document:  
-https://docs.iota.org/operator/validator-node/configs/snapshots#restoring-from-formal-snapshots
+https://docs.iota.org/operator/validator-node/configs/snapshots#restoring-a-full-node-from-snapshots
 
 ### Start the validator node
 


### PR DESCRIPTION
# Description of change

RocksDB snapshots are no longer provided, so remove their documentation:

- Drop the "Restoring from RocksDB snapshots" section from the operator snapshots page — formal snapshots are the only documented restore path now.
- Remove `download-db-snapshot` from the `iota-tool` CLI reference.
- Remove the mention of IOTA Foundation-maintained full-history RocksDB snapshots from the pruning page.
- Update snapshot wording in the full-node and validator configuration pages, and fix the restore link anchor in validator troubleshooting.

## Links to any relevant issues
Close #12533 