### PR TITLE
refactor(consensus): disambiguate commitment vs validity check naming

### DIFF
--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -938,8 +938,8 @@ mod tests {
     };
     use prometheus_filtered::Registry;
     use starfish_core::{
-        BlockHeaderAPI, CommitDigest, CommitRef, CommittedSubDag, TestBlockHeader,
-        VerifiedBlockHeader, VerifiedTransactions,
+        BlockHeaderAPI, CommitDigest, CommitRef, CommitmentVerifiedTransactions, CommittedSubDag,
+        TestBlockHeader, VerifiedBlockHeader,
     };
 
     use super::*;
@@ -1010,7 +1010,7 @@ mod tests {
                 TestBlockHeader::new(100 + i as u32, (i % consensus_committee.size()) as u8)
                     .build(),
             );
-            let tx_batch = VerifiedTransactions::new_for_test(
+            let tx_batch = CommitmentVerifiedTransactions::new_for_test(
                 &header,
                 vec![starfish_core::Transaction::new(transaction_bytes)],
             );
@@ -1172,7 +1172,7 @@ mod tests {
                 TestBlockHeader::new(100 + i as u32, (i % consensus_committee.size()) as u8)
                     .build(),
             );
-            let tx_batch = VerifiedTransactions::new_for_test(
+            let tx_batch = CommitmentVerifiedTransactions::new_for_test(
                 &header,
                 vec![starfish_core::Transaction::new(transaction_bytes)],
             );

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -235,16 +235,16 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         let verified_block_header =
             VerifiedBlockHeader::new_verified(signed_block_header, serialized_block_header);
 
-        self.block_verifier
-            .verify_transactions_validity(&transactions)
-            .inspect_err(|e| self.record_invalid_transactions(peer, peer_hostname, e))?;
-
         let verified_transactions = CommitmentVerifiedTransactions::new(
             transactions,
             verified_block_header.transaction_ref(),
             Some(verified_block_header.digest()),
             serialized_transactions,
         );
+        self.block_verifier
+            .verify_transactions_validity(&verified_transactions)
+            .inspect_err(|e| self.record_invalid_transactions(peer, peer_hostname, e))?;
+
         let has_transactions = verified_transactions.has_transactions();
         let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
         let block_ref = verified_block.reference();

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -24,9 +24,9 @@ use tracing::{debug, error, info, warn};
 use crate::{
     CommitIndex, Round, VerifiedBlockHeader,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, ShardWithProof,
-        ShardWithProofAPI, SignedBlockHeader, TransactionsCommitment, VerifiedBlock,
-        VerifiedOwnShard, VerifiedTransactions,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, CommitmentVerifiedTransactions, GENESIS_ROUND,
+        ShardWithProof, ShardWithProofAPI, SignedBlockHeader, TransactionsCommitment,
+        VerifiedBlock, VerifiedOwnShard,
     },
     block_verifier::{BlockVerifier, max_shard_bytes},
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
@@ -236,10 +236,10 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             VerifiedBlockHeader::new_verified(signed_block_header, serialized_block_header);
 
         self.block_verifier
-            .check_and_verify_transactions(&transactions)
+            .verify_transactions_validity(&transactions)
             .inspect_err(|e| self.record_invalid_transactions(peer, peer_hostname, e))?;
 
-        let verified_transactions = VerifiedTransactions::new(
+        let verified_transactions = CommitmentVerifiedTransactions::new(
             transactions,
             verified_block_header.transaction_ref(),
             Some(verified_block_header.digest()),
@@ -1788,9 +1788,9 @@ mod tests {
             AuthorityService, BroadcastedBlockStream, MAX_FILTER_SIZE, SubscriptionCounter,
         },
         block_header::{
-            BlockHeaderAPI, BlockHeaderDigest, BlockRef, GENESIS_ROUND, SignedBlockHeader,
-            TestBlockHeader, TestBlockHeaderVersion, TransactionsCommitment, VerifiedBlock,
-            VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
+            BlockHeaderAPI, BlockHeaderDigest, BlockRef, CommitmentVerifiedTransactions,
+            GENESIS_ROUND, SignedBlockHeader, TestBlockHeader, TestBlockHeaderVersion,
+            TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard,
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
@@ -2648,7 +2648,7 @@ mod tests {
 
         async fn add_transactions(
             &self,
-            _transactions: Vec<VerifiedTransactions>,
+            _transactions: Vec<CommitmentVerifiedTransactions>,
             _source: DataSource,
         ) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")
@@ -2820,7 +2820,7 @@ mod tests {
             DagBuilder::new(context.clone()).set_protocol_keypair(protocol_keypairs);
         dag_builder.layers(1..=rounds).build();
         let mut all_headers: Vec<Vec<VerifiedBlockHeader>> = vec![];
-        let mut all_transactions: Vec<Vec<VerifiedTransactions>> = vec![];
+        let mut all_transactions: Vec<Vec<CommitmentVerifiedTransactions>> = vec![];
         for round in 0..=rounds {
             all_headers.push(dag_builder.block_headers(round..=round));
             all_transactions.push(dag_builder.transactions(round..=round));
@@ -2989,7 +2989,7 @@ mod tests {
             DagBuilder::new(context.clone()).set_protocol_keypair(protocol_keypairs);
         dag_builder.layers(1..=rounds).build();
         let mut all_headers: Vec<Vec<VerifiedBlockHeader>> = vec![];
-        let mut all_transactions: Vec<Vec<VerifiedTransactions>> = vec![];
+        let mut all_transactions: Vec<Vec<CommitmentVerifiedTransactions>> = vec![];
         for round in 0..=rounds {
             all_headers.push(dag_builder.block_headers(round..=round));
             all_transactions.push(dag_builder.transactions(round..=round));
@@ -3275,7 +3275,7 @@ mod tests {
             let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
                 .map_err(ConsensusError::MalformedTransactions)
                 .unwrap();
-            let verified_transactions = VerifiedTransactions::new(
+            let verified_transactions = CommitmentVerifiedTransactions::new(
                 transactions,
                 verified_block_header.transaction_ref(),
                 Some(verified_block_header.digest()),
@@ -3353,7 +3353,7 @@ mod tests {
             let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
                 .map_err(ConsensusError::MalformedTransactions)
                 .unwrap();
-            let verified_transactions = VerifiedTransactions::new(
+            let verified_transactions = CommitmentVerifiedTransactions::new(
                 transactions,
                 verified_block_header.transaction_ref(),
                 Some(verified_block_header.digest()),

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1399,9 +1399,8 @@ impl CommitmentVerifiedTransactions {
         self.transaction_ref
     }
 
-    /// Returns the leader round of the sub-dag.
-    pub fn transactions(&self) -> Vec<Transaction> {
-        self.transactions.clone()
+    pub fn transactions(&self) -> &[Transaction] {
+        &self.transactions
     }
 
     pub fn serialized(&self) -> &Bytes {

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -1307,9 +1307,11 @@ impl fmt::Debug for VerifiedBlockHeader {
     }
 }
 
-/// VerifiedTransactions are transactions that correspond to an existing block
+/// Transactions whose serialized bytes match the transactions commitment in
+/// `transaction_ref`: they are the bytes the author committed to. Transaction
+/// validity is a separate check, run on the ingest routes.
 #[derive(Clone, Debug)]
-pub struct VerifiedTransactions {
+pub struct CommitmentVerifiedTransactions {
     transactions: Vec<Transaction>,
 
     /// Commitment of transactions in the block
@@ -1326,13 +1328,13 @@ pub struct VerifiedTransactions {
     serialized: Bytes,
 }
 
-impl PartialEq for VerifiedTransactions {
+impl PartialEq for CommitmentVerifiedTransactions {
     fn eq(&self, other: &Self) -> bool {
         self.transactions_commitment() == other.transactions_commitment()
     }
 }
 
-impl VerifiedTransactions {
+impl CommitmentVerifiedTransactions {
     pub(crate) fn new(
         transactions: Vec<Transaction>,
         transaction_ref: TransactionRef,
@@ -1348,10 +1350,11 @@ impl VerifiedTransactions {
     }
 
     /// Test-only constructor. Wraps `transactions` against the slot of
-    /// `header` so the resulting `VerifiedTransactions` can be dropped into a
-    /// test-constructed `CommittedSubDag`. Used by downstream crates'
-    /// consensus-handler tests; production code must go through
-    /// `VerifiedTransactions::new` during block reception.
+    /// `header` so the resulting `CommitmentVerifiedTransactions` can be
+    /// dropped into a test-constructed `CommittedSubDag`. Used by
+    /// downstream crates' consensus-handler tests; production code must go
+    /// through `CommitmentVerifiedTransactions::new` during block
+    /// reception.
     pub fn new_for_test(header: &VerifiedBlockHeader, transactions: Vec<Transaction>) -> Self {
         let serialized: Bytes = bcs::to_bytes(&transactions)
             .expect("Serialization should not fail")
@@ -1428,13 +1431,13 @@ pub struct VerifiedBlock {
     pub verified_block_header: VerifiedBlockHeader,
 
     /// The transactions in the block.
-    pub verified_transactions: VerifiedTransactions,
+    pub verified_transactions: CommitmentVerifiedTransactions,
 }
 
 impl VerifiedBlock {
     pub fn new(
         verified_block_header: VerifiedBlockHeader,
-        verified_transactions: VerifiedTransactions,
+        verified_transactions: CommitmentVerifiedTransactions,
     ) -> Self {
         Self {
             verified_block_header,
@@ -1445,7 +1448,7 @@ impl VerifiedBlock {
     #[cfg(test)]
     pub fn new_for_test(block_header: BlockHeader) -> Self {
         let verified_block_header = VerifiedBlockHeader::new_for_test(block_header);
-        let verified_transactions = VerifiedTransactions::new(
+        let verified_transactions = CommitmentVerifiedTransactions::new(
             vec![],
             verified_block_header.transaction_ref(),
             Some(verified_block_header.digest()),
@@ -1460,7 +1463,7 @@ impl VerifiedBlock {
     #[cfg(test)]
     pub fn new_with_transaction_for_test(block_header: BlockHeader, tx: u8) -> Self {
         let verified_block_header = VerifiedBlockHeader::new_for_test(block_header);
-        let verified_transactions = VerifiedTransactions::new(
+        let verified_transactions = CommitmentVerifiedTransactions::new(
             vec![],
             verified_block_header.transaction_ref(),
             Some(verified_block_header.digest()),
@@ -1517,7 +1520,7 @@ pub(crate) fn genesis_blocks(context: &Context) -> Vec<VerifiedBlock> {
             let verified_block_header = VerifiedBlockHeader::new_verified(signed_block, serialized);
             VerifiedBlock {
                 verified_block_header: verified_block_header.clone(),
-                verified_transactions: VerifiedTransactions::new_empty_from_ref(
+                verified_transactions: CommitmentVerifiedTransactions::new_empty_from_ref(
                     verified_block_header.transaction_ref(),
                     Some(verified_block_header.digest()),
                 ),

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -24,8 +24,8 @@ pub(crate) mod block_suspender;
 use crate::{
     Round,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, VerifiedBlock, VerifiedBlockHeader,
-        VerifiedTransactions,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, CommitmentVerifiedTransactions, VerifiedBlock,
+        VerifiedBlockHeader,
     },
     block_manager::block_suspender::BlockSuspender,
     context::Context,
@@ -71,11 +71,11 @@ pub(crate) struct BlockManager {
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
 
-    /// Keeps VerifiedTransactions of blocks whose headers have been suspended.
-    /// Bounded by the GC sweep in `maybe_evict_below_gc_floor`: any entry whose
-    /// block round is at or below `gc_round_for_last_commit` cannot be
-    /// sequenced and is dropped.
-    suspended_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
+    /// Keeps CommitmentVerifiedTransactions of blocks whose headers have been
+    /// suspended. Bounded by the GC sweep in `maybe_evict_below_gc_floor`:
+    /// any entry whose block round is at or below
+    /// `gc_round_for_last_commit` cannot be sequenced and is dropped.
+    suspended_transactions: BTreeMap<BlockRef, CommitmentVerifiedTransactions>,
     block_suspender: BlockSuspender,
     /// A vector that holds a tuple of (lowest_round, highest_round) of received
     /// blocks per authority. This is used for metrics reporting purposes
@@ -318,7 +318,7 @@ impl BlockManager {
     fn write_block_headers_and_transactions_to_dag_state(
         &self,
         block_headers: Vec<VerifiedBlockHeader>,
-        transactions: Vec<VerifiedTransactions>,
+        transactions: Vec<CommitmentVerifiedTransactions>,
         source: DataSource,
     ) {
         let mut write_guard = self.dag_state.write();
@@ -339,7 +339,7 @@ impl BlockManager {
         block_headers_to_be_accepted: &[VerifiedBlockHeader],
         present_headers_and_ancestor_refs_in_dag_state: &BTreeSet<BlockRef>,
         blocks: Option<Vec<VerifiedBlock>>,
-    ) -> Vec<VerifiedTransactions> {
+    ) -> Vec<CommitmentVerifiedTransactions> {
         let block_refs_to_be_accepted = block_headers_to_be_accepted
             .iter()
             .map(|h| h.reference())
@@ -1484,7 +1484,7 @@ mod tests {
 
         let far_round = context.parameters.far_future_round_ceiling(0) + 1;
         let h = header(far_round, 1, vec![block_ref(far_round - 1, 0)]);
-        let txs = crate::block_header::VerifiedTransactions::new_for_test(
+        let txs = crate::block_header::CommitmentVerifiedTransactions::new_for_test(
             &h,
             vec![crate::block_header::Transaction::new(vec![1u8; 16])],
         );
@@ -1545,7 +1545,7 @@ mod tests {
         // Build a header at that round and a non-empty transactions payload so
         // the existing "skip empty" optimization isn't what saves us.
         let h = header(gc_floor, 1, vec![]);
-        let txs = crate::block_header::VerifiedTransactions::new_for_test(
+        let txs = crate::block_header::CommitmentVerifiedTransactions::new_for_test(
             &h,
             vec![crate::block_header::Transaction::new(vec![1u8; 16])],
         );
@@ -1617,7 +1617,10 @@ mod tests {
         let stale_ref = stale_header.reference();
         block_manager.suspended_transactions.insert(
             stale_ref,
-            crate::block_header::VerifiedTransactions::new_for_test(&stale_header, vec![]),
+            crate::block_header::CommitmentVerifiedTransactions::new_for_test(
+                &stale_header,
+                vec![],
+            ),
         );
         assert_eq!(block_manager.suspended_transactions.len(), 1);
 

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -676,7 +676,10 @@ mod tests {
 
     use crate::{
         Round,
-        block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
+        block_header::{
+            BlockHeaderAPI, BlockRef, CommitmentVerifiedTransactions, Transaction, VerifiedBlock,
+            VerifiedBlockHeader,
+        },
         block_manager::{BlockManager, merge_accepted_round_ascending},
         context::Context,
         dag_state::{DagState, DataSource},
@@ -1484,11 +1487,9 @@ mod tests {
 
         let far_round = context.parameters.far_future_round_ceiling(0) + 1;
         let h = header(far_round, 1, vec![block_ref(far_round - 1, 0)]);
-        let txs = crate::block_header::CommitmentVerifiedTransactions::new_for_test(
-            &h,
-            vec![crate::block_header::Transaction::new(vec![1u8; 16])],
-        );
-        let block = crate::block_header::VerifiedBlock::new(h, txs);
+        let txs =
+            CommitmentVerifiedTransactions::new_for_test(&h, vec![Transaction::new(vec![1u8; 16])]);
+        let block = VerifiedBlock::new(h, txs);
 
         let (accepted, missing) =
             block_manager.try_accept_blocks(vec![block], DataSource::BlockStreaming);
@@ -1545,11 +1546,9 @@ mod tests {
         // Build a header at that round and a non-empty transactions payload so
         // the existing "skip empty" optimization isn't what saves us.
         let h = header(gc_floor, 1, vec![]);
-        let txs = crate::block_header::CommitmentVerifiedTransactions::new_for_test(
-            &h,
-            vec![crate::block_header::Transaction::new(vec![1u8; 16])],
-        );
-        let block = crate::block_header::VerifiedBlock::new(h, txs);
+        let txs =
+            CommitmentVerifiedTransactions::new_for_test(&h, vec![Transaction::new(vec![1u8; 16])]);
+        let block = VerifiedBlock::new(h, txs);
         let (accepted, _) = block_manager.try_accept_blocks(vec![block], DataSource::Test);
 
         assert!(accepted.is_empty(), "header at GC floor must be dropped");
@@ -1617,10 +1616,7 @@ mod tests {
         let stale_ref = stale_header.reference();
         block_manager.suspended_transactions.insert(
             stale_ref,
-            crate::block_header::CommitmentVerifiedTransactions::new_for_test(
-                &stale_header,
-                vec![],
-            ),
+            CommitmentVerifiedTransactions::new_for_test(&stale_header, vec![]),
         );
         assert_eq!(block_manager.suspended_transactions.len(), 1);
 

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -32,7 +32,9 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
         serialized_transactions: &[u8],
     ) -> ConsensusResult<Vec<Transaction>>;
 
-    fn check_and_verify_transactions(&self, transactions: &[Transaction]) -> ConsensusResult<()>;
+    /// Checks protocol limits on the transactions and runs the application's
+    /// transaction verifier.
+    fn verify_transactions_validity(&self, transactions: &[Transaction]) -> ConsensusResult<()>;
 }
 
 /// `SignedBlockVerifier` checks the validity of a block.
@@ -313,7 +315,7 @@ impl BlockVerifier for SignedBlockVerifier {
         bcs::from_bytes(serialized_transactions).map_err(ConsensusError::MalformedTransactions)
     }
 
-    fn check_and_verify_transactions(&self, transactions: &[Transaction]) -> ConsensusResult<()> {
+    fn verify_transactions_validity(&self, transactions: &[Transaction]) -> ConsensusResult<()> {
         let batch: Vec<_> = transactions.iter().map(|t| t.data()).collect();
         self.check_transactions(&batch)?;
         self.transaction_verifier
@@ -370,7 +372,7 @@ impl BlockVerifier for NoopBlockVerifier {
         bcs::from_bytes(serialized_transactions).map_err(ConsensusError::MalformedTransactions)
     }
 
-    fn check_and_verify_transactions(&self, _transactions: &[Transaction]) -> ConsensusResult<()> {
+    fn verify_transactions_validity(&self, _transactions: &[Transaction]) -> ConsensusResult<()> {
         Ok(())
     }
 }

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -9,8 +9,8 @@ use tracing::instrument;
 use crate::{
     Transaction,
     block_header::{
-        BlockHeader, BlockHeaderAPI, BlockRef, GENESIS_ROUND, SignedBlockHeader,
-        genesis_block_headers,
+        BlockHeader, BlockHeaderAPI, BlockRef, CommitmentVerifiedTransactions, GENESIS_ROUND,
+        SignedBlockHeader, genesis_block_headers,
     },
     context::Context,
     encoder::shard_bytes,
@@ -34,7 +34,10 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
 
     /// Checks protocol limits on the transactions and runs the application's
     /// transaction verifier.
-    fn verify_transactions_validity(&self, transactions: &[Transaction]) -> ConsensusResult<()>;
+    fn verify_transactions_validity(
+        &self,
+        transactions: &CommitmentVerifiedTransactions,
+    ) -> ConsensusResult<()>;
 }
 
 /// `SignedBlockVerifier` checks the validity of a block.
@@ -315,8 +318,15 @@ impl BlockVerifier for SignedBlockVerifier {
         bcs::from_bytes(serialized_transactions).map_err(ConsensusError::MalformedTransactions)
     }
 
-    fn verify_transactions_validity(&self, transactions: &[Transaction]) -> ConsensusResult<()> {
-        let batch: Vec<_> = transactions.iter().map(|t| t.data()).collect();
+    fn verify_transactions_validity(
+        &self,
+        transactions: &CommitmentVerifiedTransactions,
+    ) -> ConsensusResult<()> {
+        let batch: Vec<_> = transactions
+            .transactions()
+            .iter()
+            .map(|t| t.data())
+            .collect();
         self.check_transactions(&batch)?;
         self.transaction_verifier
             .verify_batch(&batch)
@@ -372,7 +382,10 @@ impl BlockVerifier for NoopBlockVerifier {
         bcs::from_bytes(serialized_transactions).map_err(ConsensusError::MalformedTransactions)
     }
 
-    fn verify_transactions_validity(&self, _transactions: &[Transaction]) -> ConsensusResult<()> {
+    fn verify_transactions_validity(
+        &self,
+        _transactions: &CommitmentVerifiedTransactions,
+    ) -> ConsensusResult<()> {
         Ok(())
     }
 }

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -20,8 +20,8 @@ use tracing::debug;
 
 use crate::{
     block_header::{
-        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, SERIALIZED_BLOCK_REF_BYTES, Slot,
-        VerifiedBlockHeader, VerifiedTransactions, format_block_digests, uleb128_len,
+        BlockHeaderAPI, BlockRef, BlockTimestampMs, CommitmentVerifiedTransactions, Round,
+        SERIALIZED_BLOCK_REF_BYTES, Slot, VerifiedBlockHeader, format_block_digests, uleb128_len,
     },
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -497,14 +497,14 @@ impl CertifiedCommits {
 pub(crate) struct CertifiedCommit {
     commit: Arc<TrustedCommit>,
     verified_block_headers: Vec<VerifiedBlockHeader>,
-    verified_transactions: Vec<VerifiedTransactions>,
+    verified_transactions: Vec<CommitmentVerifiedTransactions>,
 }
 
 impl CertifiedCommit {
     pub(crate) fn new_certified(
         commit: TrustedCommit,
         verified_block_headers: Vec<VerifiedBlockHeader>,
-        verified_transactions: Vec<VerifiedTransactions>,
+        verified_transactions: Vec<CommitmentVerifiedTransactions>,
     ) -> Self {
         Self {
             commit: Arc::new(commit),
@@ -517,7 +517,7 @@ impl CertifiedCommit {
         &self.verified_block_headers
     }
 
-    pub fn transactions(&self) -> &[VerifiedTransactions] {
+    pub fn transactions(&self) -> &[CommitmentVerifiedTransactions] {
         &self.verified_transactions
     }
 }
@@ -704,7 +704,7 @@ pub struct CommittedSubDag {
     /// Common fields shared with PendingSubDag
     pub base: SubDagBase,
     /// All the committed blocks that are part of this sub-dag
-    pub transactions: Vec<VerifiedTransactions>,
+    pub transactions: Vec<CommitmentVerifiedTransactions>,
     /// Absolute per-authority misbehavior counts (`persisted + in_memory`)
     /// snapshotted from `MisbehaviorStore` at emission. Indexed by
     /// `AuthorityIndex`; consumers diff for deltas.
@@ -717,7 +717,7 @@ impl CommittedSubDag {
         leader: BlockRef,
         headers: Vec<VerifiedBlockHeader>,
         committed_header_refs: Vec<BlockRef>,
-        transactions: Vec<VerifiedTransactions>,
+        transactions: Vec<CommitmentVerifiedTransactions>,
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -28,14 +28,14 @@ use tracing::{debug, info, warn};
 
 use crate::{
     CommitConsumerMonitor, CommitIndex, VerifiedBlockHeader,
-    block_header::VerifiedTransactions,
+    block_header::CommitmentVerifiedTransactions,
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, CommittedSubDag, TrustedCommit},
     commit_syncer::{
         CommitSyncType, CommitSyncerHandle, FetchedCommits, Inner, fetch_loop as shared_fetch_loop,
         handle_fetch_join_error, requeue_partial_range, schedule_commit_ranges,
         try_start_fetches as shared_try_start_fetches, verify_fetched_headers,
-        verify_transactions_with_transactions_refs,
+        verify_transactions_commitments,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -672,14 +672,14 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 .inc();
         }
 
-        // 5. Verify transactions
+        // 5. Verify the transactions against their commitments
         let mut transactions_map = if !fetched_transactions.is_empty() {
             Handle::current()
                 .spawn_blocking({
                     let context = inner.context.clone();
 
                     move || {
-                        verify_transactions_with_transactions_refs(
+                        verify_transactions_commitments(
                             &context,
                             target_authority,
                             fetched_transactions,
@@ -708,7 +708,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             let reputation_scores = commit.reputation_scores().to_vec();
 
             // Collect transactions for this commit
-            let commit_transactions: Vec<VerifiedTransactions> = commit_tx_refs
+            let commit_transactions: Vec<CommitmentVerifiedTransactions> = commit_tx_refs
                 .iter()
                 .filter_map(|tx_ref| transactions_map.remove(tx_ref))
                 .collect();

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -55,8 +55,8 @@ use tracing::{info, warn};
 use crate::{
     BlockRef, CommitConsumerMonitor, CommitIndex, Transaction, VerifiedBlockHeader,
     block_header::{
-        BlockHeaderAPI, GENESIS_ROUND, SignedBlockHeader, TransactionsCommitment,
-        VerifiedTransactions,
+        BlockHeaderAPI, CommitmentVerifiedTransactions, GENESIS_ROUND, SignedBlockHeader,
+        TransactionsCommitment,
     },
     block_verifier::{BlockVerifier, serialized_transactions_size_limit},
     commit::{
@@ -424,12 +424,13 @@ pub(crate) fn verify_commits(
     Ok((trusted_commits, verified_voting_headers))
 }
 
-/// Verifies transactions and returns them keyed by transaction reference.
-pub(crate) fn verify_transactions_with_transactions_refs(
+/// Verifies each payload against the transactions commitment in its ref and
+/// returns the payloads keyed by transaction reference.
+pub(crate) fn verify_transactions_commitments(
     context: &Arc<Context>,
     peer: AuthorityIndex,
     serialized_transactions: BTreeMap<TransactionRef, Bytes>,
-) -> ConsensusResult<BTreeMap<TransactionRef, VerifiedTransactions>> {
+) -> ConsensusResult<BTreeMap<TransactionRef, CommitmentVerifiedTransactions>> {
     let mut verified_transactions_map = BTreeMap::new();
     let mut encoder = create_encoder(context);
     let size_limit = serialized_transactions_size_limit(context);
@@ -472,8 +473,8 @@ pub(crate) fn verify_transactions_with_transactions_refs(
         let transactions: Vec<Transaction> = bcs::from_bytes(&inner_serialized_transactions)
             .map_err(ConsensusError::MalformedTransactions)?;
 
-        // Step 3: Create a VerifiedTransactions instance and insert into map
-        let verified_transactions = VerifiedTransactions::new(
+        // Step 3: Create a CommitmentVerifiedTransactions instance and insert into map
+        let verified_transactions = CommitmentVerifiedTransactions::new(
             transactions,
             transaction_ref,
             None,
@@ -1099,7 +1100,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn verify_transactions_rejects_oversized_payload_before_encoding() {
+    async fn verify_transactions_commitments_rejects_oversized_payload_before_encoding() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let peer = AuthorityIndex::new_for_test(1);
@@ -1112,8 +1113,7 @@ pub(crate) mod tests {
         let serialized_transactions =
             BTreeMap::from([(transaction_ref, Bytes::from(vec![0u8; size_limit + 1]))]);
 
-        let result =
-            verify_transactions_with_transactions_refs(&context, peer, serialized_transactions);
+        let result = verify_transactions_commitments(&context, peer, serialized_transactions);
         assert!(matches!(
             result,
             Err(ConsensusError::SerializedTransactionsTooLarge { size, limit })
@@ -1122,7 +1122,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn verify_transactions_rejects_out_of_range_author() {
+    async fn verify_transactions_commitments_rejects_out_of_range_author() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let peer = AuthorityIndex::new_for_test(1);
@@ -1145,8 +1145,7 @@ pub(crate) mod tests {
         let serialized_transactions =
             BTreeMap::from([(transaction_ref, inner_serialized_transactions)]);
 
-        let result =
-            verify_transactions_with_transactions_refs(&context, peer, serialized_transactions);
+        let result = verify_transactions_commitments(&context, peer, serialized_transactions);
         assert!(matches!(
             result,
             Err(ConsensusError::InvalidAuthorityIndexRequested {
@@ -1158,7 +1157,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn verify_transactions_rejects_genesis_round() {
+    async fn verify_transactions_commitments_rejects_genesis_round() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let peer = AuthorityIndex::new_for_test(1);
@@ -1180,8 +1179,7 @@ pub(crate) mod tests {
         let serialized_transactions =
             BTreeMap::from([(transaction_ref, inner_serialized_transactions)]);
 
-        let result =
-            verify_transactions_with_transactions_refs(&context, peer, serialized_transactions);
+        let result = verify_transactions_commitments(&context, peer, serialized_transactions);
         assert!(matches!(
             result,
             Err(ConsensusError::UnexpectedGenesisRequested { peer: error_peer })

--- a/crates/starfish/core/src/commit_syncer/regular.rs
+++ b/crates/starfish/core/src/commit_syncer/regular.rs
@@ -31,7 +31,7 @@ use crate::{
         fast::{FastSyncPauseSource, paused_by_fast_sync},
         fetch_loop as shared_fetch_loop, handle_fetch_join_error, requeue_partial_range,
         schedule_commit_ranges, try_start_fetches as shared_try_start_fetches,
-        verify_fetched_headers, verify_transactions_with_transactions_refs,
+        verify_fetched_headers, verify_transactions_commitments,
     },
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -346,7 +346,7 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
                     expected_transactions.insert(gen_tx_ref);
                 }
 
-                // Collect available transactions from VerifiedTransactions
+                // Collect available transactions from CommitmentVerifiedTransactions
                 for verified_txns in certified_commit.transactions() {
                     let gen_tx_ref =
                         GenericTransactionRef::TransactionRef(verified_txns.transaction_ref());
@@ -697,14 +697,14 @@ impl<C: NetworkClient> RegularCommitSyncer<C> {
             }
         }
 
-        // 13. Verify transactions
+        // 13. Verify the transactions against their commitments
         let mut transactions_map = if !fetched_transactions.is_empty() {
             Handle::current()
                 .spawn_blocking({
                     let context = inner.context.clone();
 
                     move || {
-                        verify_transactions_with_transactions_refs(
+                        verify_transactions_commitments(
                             &context,
                             target_authority,
                             fetched_transactions,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -36,8 +36,8 @@ use crate::{
     authority_set::AuthoritySet,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockHeaderV2, BlockRef, BlockTimestampMs,
-        GENESIS_ROUND, Round, SignedBlockHeader, Slot, StrongVote, TransactionsCommitment,
-        VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
+        CommitmentVerifiedTransactions, GENESIS_ROUND, Round, SignedBlockHeader, Slot, StrongVote,
+        TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard,
     },
     block_manager::BlockManager,
     block_rate_limiter::BlockRateLimiter,
@@ -508,7 +508,7 @@ impl Core {
     /// fetched from peers.
     pub(crate) fn add_transactions(
         &mut self,
-        transactions: Vec<VerifiedTransactions>,
+        transactions: Vec<CommitmentVerifiedTransactions>,
         source: DataSource,
     ) -> ConsensusResult<()> {
         let _scope = monitored_scope("Core::add_transactions");
@@ -580,7 +580,7 @@ impl Core {
         // First, collect and add all transactions from certified commits.
         // Transactions must be added before processing commits to ensure they are
         // available when creating new commits.
-        let all_transactions: Vec<VerifiedTransactions> = certified_commits
+        let all_transactions: Vec<CommitmentVerifiedTransactions> = certified_commits
             .commits()
             .iter()
             .flat_map(|commit| commit.transactions())
@@ -1197,7 +1197,7 @@ impl Core {
         }
 
         // Construct verified transactions to be used for storing and broadcasting
-        let verified_transactions = VerifiedTransactions::new(
+        let verified_transactions = CommitmentVerifiedTransactions::new(
             transactions,
             verified_block_header.transaction_ref(),
             Some(verified_block_header.digest()),

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -20,7 +20,9 @@ use tracing::{info, warn};
 
 use crate::{
     VerifiedBlockHeader,
-    block_header::{BlockRef, Round, VerifiedBlock, VerifiedOwnShard, VerifiedTransactions},
+    block_header::{
+        BlockRef, CommitmentVerifiedTransactions, Round, VerifiedBlock, VerifiedOwnShard,
+    },
     commit::CertifiedCommits,
     commit_syncer::fast::FastSyncOutput,
     context::Context,
@@ -74,7 +76,11 @@ enum CoreThreadCommand {
     /// that have these blocks.
     GetMissingBlocks(oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>),
     /// Add transactions to be processed and accepted
-    AddTransactions(Vec<VerifiedTransactions>, oneshot::Sender<()>, DataSource),
+    AddTransactions(
+        Vec<CommitmentVerifiedTransactions>,
+        oneshot::Sender<()>,
+        DataSource,
+    ),
     /// Add shards to the dag_state
     AddShards(Vec<VerifiedOwnShard>, oneshot::Sender<()>),
     /// Get missing transaction data that need to be synced
@@ -132,7 +138,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
 
     async fn add_transactions(
         &self,
-        transactions: Vec<VerifiedTransactions>,
+        transactions: Vec<CommitmentVerifiedTransactions>,
         source: DataSource,
     ) -> Result<(), CoreError>;
 
@@ -453,7 +459,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 
     async fn add_transactions(
         &self,
-        transactions: Vec<VerifiedTransactions>,
+        transactions: Vec<CommitmentVerifiedTransactions>,
         source: DataSource,
     ) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
@@ -664,7 +670,7 @@ pub(crate) mod tests {
 
         async fn add_transactions(
             &self,
-            _transactions: Vec<VerifiedTransactions>,
+            _transactions: Vec<CommitmentVerifiedTransactions>,
             _source: DataSource,
         ) -> Result<(), CoreError> {
             unimplemented!()

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -27,9 +27,9 @@ use crate::dag_visualizer::grpc_streamer::DagVisualizerEvent;
 use crate::{
     authority_set::AuthoritySet,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard,
-        VerifiedTransactions, genesis_blocks,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs,
+        CommitmentVerifiedTransactions, GENESIS_ROUND, Round, Slot, TransactionsCommitment,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard, genesis_blocks,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRange, CommitRef, CommitVote,
@@ -258,7 +258,8 @@ pub(crate) struct DagState {
     /// entry with index transaction_ref.author. Evicted using the minimum
     /// between GC round for the last solid leader round evicted rounds by
     /// authority.
-    recent_transactions_by_authority: Vec<BTreeMap<GenericTransactionRef, VerifiedTransactions>>,
+    recent_transactions_by_authority:
+        Vec<BTreeMap<GenericTransactionRef, CommitmentVerifiedTransactions>>,
     /// Contains recent own serialized shards with their Merkle proofs per
     /// authority. To access own shard for a given transaction_ref, one
     /// needs to read first the entry with index transaction_ref.author.
@@ -328,7 +329,7 @@ pub(crate) struct DagState {
     pending_acknowledgments: BTreeSet<BlockRef>,
 
     /// Transactions to be flushed to storage.
-    transactions_to_write: Vec<VerifiedTransactions>,
+    transactions_to_write: Vec<CommitmentVerifiedTransactions>,
     block_headers_to_write: Vec<VerifiedBlockHeader>,
     commits_to_write: Vec<TrustedCommit>,
 
@@ -792,7 +793,7 @@ impl DagState {
 
     pub(crate) fn add_transactions(
         &mut self,
-        transactions: VerifiedTransactions,
+        transactions: CommitmentVerifiedTransactions,
         source: DataSource,
     ) {
         let transaction_ref = transactions.transaction_ref();
@@ -990,7 +991,7 @@ impl DagState {
 
     fn update_transaction_metadata(
         &mut self,
-        transactions: &VerifiedTransactions,
+        transactions: &CommitmentVerifiedTransactions,
         source: DataSource,
     ) {
         let transaction_ref = transactions.transaction_ref();
@@ -1115,7 +1116,7 @@ impl DagState {
     pub(crate) fn get_verified_transactions(
         &self,
         transactions_refs: &[GenericTransactionRef],
-    ) -> Vec<Option<VerifiedTransactions>> {
+    ) -> Vec<Option<CommitmentVerifiedTransactions>> {
         self.try_get_verified_transactions(transactions_refs)
             .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"))
     }
@@ -1127,7 +1128,7 @@ impl DagState {
     pub(crate) fn try_get_verified_transactions(
         &self,
         transactions_refs: &[GenericTransactionRef],
-    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
+    ) -> ConsensusResult<Vec<Option<CommitmentVerifiedTransactions>>> {
         let mut transactions = vec![None; transactions_refs.len()];
         let mut missing = Vec::new();
 
@@ -2988,11 +2989,11 @@ impl DagState {
     fn empty_transactions_for_ref(
         &self,
         tx_ref: &GenericTransactionRef,
-    ) -> Option<VerifiedTransactions> {
+    ) -> Option<CommitmentVerifiedTransactions> {
         match tx_ref {
             GenericTransactionRef::TransactionRef(tx_ref) => (tx_ref.transactions_commitment
                 == self.empty_transactions_commitment)
-                .then(|| VerifiedTransactions::new_empty_from_ref(*tx_ref, None)),
+                .then(|| CommitmentVerifiedTransactions::new_empty_from_ref(*tx_ref, None)),
             // The legacy BlockRef form carries no commitment; commits that
             // use it derive refs from acknowledgments, which never include
             // empty blocks.
@@ -4795,7 +4796,7 @@ mod test {
                         &mut encoder,
                     )
                     .unwrap();
-                let verified_transaction = VerifiedTransactions::new(
+                let verified_transaction = CommitmentVerifiedTransactions::new(
                     transactions,
                     TransactionRef::new(block_ref, transaction_commitment),
                     Some(block_ref.digest),

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -1850,8 +1850,8 @@ mod tests {
         CommitDigest, CommitIndex,
         authority_service::COMMIT_LAG_MULTIPLIER,
         block_header::{
-            BlockHeaderDigest, BlockRef, GENESIS_ROUND, Round, TestBlockHeader, VerifiedBlock,
-            VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
+            BlockHeaderDigest, BlockRef, CommitmentVerifiedTransactions, GENESIS_ROUND, Round,
+            TestBlockHeader, VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard,
         },
         block_verifier::NoopBlockVerifier,
         commit::{CertifiedCommits, CommitRange, CommitVote, TrustedCommit},
@@ -3153,7 +3153,7 @@ mod tests {
 
         async fn add_transactions(
             &self,
-            _transactions: Vec<VerifiedTransactions>,
+            _transactions: Vec<CommitmentVerifiedTransactions>,
             _source: DataSource,
         ) -> Result<(), CoreError> {
             unimplemented!("Unimplemented")

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -72,7 +72,8 @@ pub use authority_node::ConsensusAuthority;
 pub use block_header::{BlockHeaderAPI, BlockRef, Round};
 /// Exported API for testing.
 pub use block_header::{
-    BlockTimestampMs, TestBlockHeader, Transaction, VerifiedBlockHeader, VerifiedTransactions,
+    BlockTimestampMs, CommitmentVerifiedTransactions, TestBlockHeader, Transaction,
+    VerifiedBlockHeader,
 };
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -234,7 +234,8 @@ impl MisbehaviorStore {
         }
     }
 
-    /// Attributes a transaction payload that failed verification.
+    /// Attributes a transaction payload that failed the commitment check or
+    /// the transaction validity check.
     ///
     /// `author` is charged with a provable fault only when `authored` is true,
     /// i.e. a verified, author-signed block header commits to this payload, so

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -474,7 +474,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                             Err(tx_ref)
                         }
                         Ok(verified_transactions) => match block_verifier
-                            .verify_transactions_validity(&verified_transactions.transactions())
+                            .verify_transactions_validity(&verified_transactions)
                         {
                             Ok(()) => {
                                 debug!("Successfully reconstructed transactions for {tx_ref:?}");

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -22,8 +22,8 @@ use tracing::{debug, error, warn};
 use crate::{
     Round, Transaction,
     block_header::{
-        BlockHeaderDigest, GENESIS_ROUND, Shard, ShardWithProof, ShardWithProofAPI,
-        TransactionsCommitment, VerifiedBlock, VerifiedTransactions,
+        BlockHeaderDigest, CommitmentVerifiedTransactions, GENESIS_ROUND, Shard, ShardWithProof,
+        ShardWithProofAPI, TransactionsCommitment, VerifiedBlock,
     },
     block_verifier::BlockVerifier,
     context::Context,
@@ -166,11 +166,14 @@ impl ShardAccumulator {
             .filter_map(|(i, shard)| shard.as_ref().map(|_| i))
     }
 
-    /// We use Codec to decode the transaction data from collected shards. Once
-    /// reconstructed, we encode and verify that the transaction commitment
-    /// was computed correctly. Consumes the accumulator, so the collected
-    /// shards move into the decoder rather than being copied.
-    fn decode_by_codec(self, codec: &mut Codec) -> ConsensusResult<VerifiedTransactions> {
+    /// Decodes the transaction data from the collected shards and verifies
+    /// the reconstructed bytes against the transactions commitment in the
+    /// ref. Consumes the accumulator, so the collected shards move into the
+    /// decoder rather than being copied.
+    fn decode_and_verify_commitment(
+        self,
+        codec: &mut Codec,
+    ) -> ConsensusResult<CommitmentVerifiedTransactions> {
         let Self {
             transaction_ref,
             block_digest,
@@ -197,7 +200,7 @@ impl ShardAccumulator {
             return Err(ConsensusError::TransactionCommitmentMismatch { transaction_ref });
         }
 
-        Ok(VerifiedTransactions::new(
+        Ok(CommitmentVerifiedTransactions::new(
             transactions,
             transaction_ref,
             block_digest,
@@ -211,22 +214,24 @@ impl ShardAccumulator {
     }
 }
 
-/// Attributes a reconstructed payload that failed verification.
+/// Attributes a reconstructed payload that failed the transaction validity
+/// check.
 ///
 /// A peer must hold the full payload to erasure-code its shard, so every peer
-/// that contributed a shard could have verified the transactions and is charged
-/// an unprovable fault for relaying invalid bytes. The commitment here is
-/// peer-supplied, so without a verified author-signed header for this ref a
-/// coalition of peers could reconstruct invalid transactions under a fabricated
-/// commitment to frame the author; charge the author a provable fault only when
-/// such a header exists, as he then committed to the invalid transactions.
+/// that contributed a shard could have checked the transactions' validity and
+/// is charged an unprovable fault for relaying invalid bytes. The commitment
+/// here is peer-supplied, so without a verified author-signed header for this
+/// ref a coalition of peers could reconstruct invalid transactions under a
+/// fabricated commitment to frame the author; charge the author a provable
+/// fault only when such a header exists, as he then committed to the invalid
+/// transactions.
 ///
 /// Attribution is one-shot: a header arriving only after this failure does not
 /// retroactively charge the author (the failed ref is marked processed and not
 /// revisited until garbage collection). Such an author is instead charged on
 /// the direct primary-block route, where the full payload is verified against
 /// the author.
-fn record_reconstruction_verification_failure(
+fn record_reconstruction_validity_failure(
     dag_state: &RwLock<DagState>,
     misbehavior_store: &MisbehaviorStore,
     tx_ref: TransactionRef,
@@ -239,7 +244,7 @@ fn record_reconstruction_verification_failure(
         .contains_verified_block_headers_for_transaction_refs(&[tx_ref])[0];
     misbehavior_store.record_faulty_transactions(author, authored, relayers);
     error!(
-        "Reconstructed transactions for {:?} failed verification: {:?}",
+        "Reconstructed transactions for {:?} failed the validity check: {:?}",
         tx_ref, err
     );
 }
@@ -333,7 +338,7 @@ impl<C: CoreThreadDispatcher + 'static> ShardReconstructor<C> {
 
 /// Result of a reconstruction job: the verified transactions on success, or
 /// the failed job's transaction reference so its queue entry can be dropped.
-type ReconstructionResult = Result<VerifiedTransactions, TransactionRef>;
+type ReconstructionResult = Result<CommitmentVerifiedTransactions, TransactionRef>;
 
 /// The main structure responsible for collecting shards and reconstructing
 /// transaction data once enough shards are collected. Keeps track of already
@@ -354,7 +359,7 @@ pub struct ShardReconstructor<C: CoreThreadDispatcher> {
     processed_transactions: BTreeSet<TransactionRef>,
     /// A cache of reconstructed transactions that will be periodically sent in
     /// the core
-    reconstructed_transactions: BTreeMap<TransactionRef, VerifiedTransactions>,
+    reconstructed_transactions: BTreeMap<TransactionRef, CommitmentVerifiedTransactions>,
     /// A map of all shard accumulators. Periodically evicted. Keyed by
     /// TransactionRef which uniquely identifies transactions via
     /// transactions_commitment
@@ -448,7 +453,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                         .collected_shard_indices()
                         .filter_map(|i| context.committee.to_authority_index(i))
                         .collect();
-                    let result = match shard_accumulator.decode_by_codec(&mut codec) {
+                    let result = match shard_accumulator.decode_and_verify_commitment(&mut codec) {
                         // Validity-threshold relayer stake guarantees an honest
                         // relayer and thus a genuine commitment, so a decode
                         // failure indicates a codec bug or Byzantine stake
@@ -469,14 +474,14 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                             Err(tx_ref)
                         }
                         Ok(verified_transactions) => match block_verifier
-                            .check_and_verify_transactions(&verified_transactions.transactions())
+                            .verify_transactions_validity(&verified_transactions.transactions())
                         {
                             Ok(()) => {
                                 debug!("Successfully reconstructed transactions for {tx_ref:?}");
                                 Ok(verified_transactions)
                             }
                             Err(err) => {
-                                record_reconstruction_verification_failure(
+                                record_reconstruction_validity_failure(
                                     &dag_state,
                                     &misbehavior_store,
                                     tx_ref,
@@ -607,7 +612,9 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         self.reconstruction_queue = self.reconstruction_queue.split_off(&lower_bound);
     }
 
-    fn get_transactions_with_headers_in_dag_state(&mut self) -> Vec<VerifiedTransactions> {
+    fn get_transactions_with_headers_in_dag_state(
+        &mut self,
+    ) -> Vec<CommitmentVerifiedTransactions> {
         let transactions_map = std::mem::take(&mut self.reconstructed_transactions);
         // In most cases, all reconstructed transactions will go to the core
         let mut ready_to_be_sent_transactions = Vec::new();
@@ -831,8 +838,8 @@ mod tests {
     use crate::{
         BlockRef, Round, TestBlockHeader, Transaction, VerifiedBlockHeader,
         block_header::{
-            Shard, ShardWithProof, TransactionsCommitment, VerifiedBlock, VerifiedOwnShard,
-            VerifiedTransactions,
+            CommitmentVerifiedTransactions, Shard, ShardWithProof, TransactionsCommitment,
+            VerifiedBlock, VerifiedOwnShard,
         },
         block_verifier::{
             BlockVerifier, NoopBlockVerifier, SignedBlockVerifier, test::TxnSizeVerifier,
@@ -866,7 +873,7 @@ mod tests {
         }
 
         /// Builds the harness with a caller-supplied `block_verifier`, so
-        /// tests can exercise the transaction-verification rejection path
+        /// tests can exercise the transaction-validity rejection path
         /// with a verifier stricter than the default no-op. `context` is
         /// taken from the caller so it can build a `block_verifier` bound to
         /// the same committee and protocol config.
@@ -896,7 +903,7 @@ mod tests {
 
     #[derive(Default)]
     struct MockCoreThreadDispatcher {
-        transactions: Mutex<Vec<VerifiedTransactions>>,
+        transactions: Mutex<Vec<CommitmentVerifiedTransactions>>,
     }
 
     impl MockCoreThreadDispatcher {
@@ -904,7 +911,7 @@ mod tests {
             Self::default()
         }
 
-        async fn get_and_drain_transactions(&self) -> Vec<VerifiedTransactions> {
+        async fn get_and_drain_transactions(&self) -> Vec<CommitmentVerifiedTransactions> {
             let mut guard = self.transactions.lock().await;
             guard.drain(..).collect()
         }
@@ -914,7 +921,7 @@ mod tests {
     impl CoreThreadDispatcher for MockCoreThreadDispatcher {
         async fn add_transactions(
             &self,
-            txs: Vec<VerifiedTransactions>,
+            txs: Vec<CommitmentVerifiedTransactions>,
             _source: DataSource,
         ) -> Result<(), CoreError> {
             let mut guard = self.transactions.lock().await;
@@ -1585,7 +1592,7 @@ mod tests {
         let fetched = h.core_dispatcher.get_and_drain_transactions().await;
         assert!(
             fetched.is_empty(),
-            "A reconstructed payload failing verification must never reach Core"
+            "A reconstructed payload failing the validity check must never reach Core"
         );
 
         let counts = h.dag_state.read().misbehavior_store().snapshot_totals();
@@ -1606,7 +1613,7 @@ mod tests {
     /// otherwise frame them); every peer that relayed a shard is charged an
     /// unprovable fault.
     #[tokio::test]
-    async fn test_reconstruction_rejects_transactions_failing_verification() {
+    async fn test_reconstruction_rejects_transactions_failing_validity_check() {
         let (counts, author, info_length) = reconstruct_failing_payload(false).await;
 
         let MisbehaviorCounts::V1(author_counts) = &counts[author.value()];

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -14,8 +14,8 @@ use starfish_config::AuthorityIndex;
 use super::{Store, WriteBatch};
 use crate::{
     block_header::{
-        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, Slot, TransactionsCommitment,
-        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, CommitmentVerifiedTransactions, Round,
+        Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRange, CommitRef,
@@ -34,7 +34,7 @@ pub(crate) struct MemStore {
 
 struct Inner {
     transactions_by_tx_refs:
-        BTreeMap<(Round, AuthorityIndex, TransactionsCommitment), VerifiedTransactions>,
+        BTreeMap<(Round, AuthorityIndex, TransactionsCommitment), CommitmentVerifiedTransactions>,
     block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
     digests_by_authorities: BTreeSet<(AuthorityIndex, Round, BlockHeaderDigest)>,
     transaction_commitments_by_authorities:
@@ -149,7 +149,7 @@ impl Store for MemStore {
     fn read_verified_transactions(
         &self,
         refs: &[GenericTransactionRef],
-    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
+    ) -> ConsensusResult<Vec<Option<CommitmentVerifiedTransactions>>> {
         if !check_ref_consistency(refs) {
             return Err(ConsensusError::InconsistentTransactionRefVariants);
         }

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -16,7 +16,9 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     CommitIndex,
-    block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions},
+    block_header::{
+        BlockRef, CommitmentVerifiedTransactions, Round, VerifiedBlock, VerifiedBlockHeader,
+    },
     commit::{CommitDigest, CommitInfo, CommitRange, CommitRef, TrustedCommit},
     error::ConsensusResult,
     misbehavior_store::MisbehaviorCounts,
@@ -48,7 +50,7 @@ pub(crate) trait Store: Send + Sync {
     fn read_verified_transactions(
         &self,
         refs: &[GenericTransactionRef],
-    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>>;
+    ) -> ConsensusResult<Vec<Option<CommitmentVerifiedTransactions>>>;
 
     /// Read and get serialized transactions for the given refs.
     fn read_serialized_transactions(
@@ -102,7 +104,7 @@ pub(crate) trait Store: Send + Sync {
         &self,
         author: AuthorityIndex,
         start_round: Round,
-    ) -> ConsensusResult<Vec<VerifiedTransactions>> {
+    ) -> ConsensusResult<Vec<CommitmentVerifiedTransactions>> {
         let refs = self
             .scan_transaction_references_by_author(author, start_round)?
             .into_iter()
@@ -186,7 +188,7 @@ pub(crate) trait Store: Send + Sync {
 /// Represents data to be written to the store together atomically.
 #[derive(Debug, Default)]
 pub(crate) struct WriteBatch {
-    pub(crate) transactions: Vec<VerifiedTransactions>,
+    pub(crate) transactions: Vec<CommitmentVerifiedTransactions>,
     pub(crate) block_headers: Vec<VerifiedBlockHeader>,
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
@@ -199,7 +201,10 @@ impl WriteBatch {
     // Test setters.
 
     #[cfg(test)]
-    pub(crate) fn transactions(mut self, transactions: Vec<VerifiedTransactions>) -> Self {
+    pub(crate) fn transactions(
+        mut self,
+        transactions: Vec<CommitmentVerifiedTransactions>,
+    ) -> Self {
         self.transactions = transactions;
         self
     }

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -18,8 +18,8 @@ use super::{CommitInfo, Store, WriteBatch};
 use crate::{
     Transaction,
     block_header::{
-        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, TransactionsCommitment,
-        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, CommitmentVerifiedTransactions, Round,
+        TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
@@ -328,7 +328,7 @@ impl Store for RocksDBStore {
     fn read_verified_transactions(
         &self,
         refs: &[GenericTransactionRef],
-    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
+    ) -> ConsensusResult<Vec<Option<CommitmentVerifiedTransactions>>> {
         if !check_ref_consistency(refs) {
             return Err(ConsensusError::InconsistentTransactionRefVariants);
         }
@@ -349,8 +349,12 @@ impl Store for RocksDBStore {
                     .map_err(ConsensusError::MalformedTransactions)?;
                 // We don't check the transactions commitment from the header as it's loaded
                 // from storage. Assemble verified transactions
-                let verified_transactions =
-                    VerifiedTransactions::new(transactions, *tx_ref, None, serialized_transactions);
+                let verified_transactions = CommitmentVerifiedTransactions::new(
+                    transactions,
+                    *tx_ref,
+                    None,
+                    serialized_transactions,
+                );
                 result.push(Some(verified_transactions));
             } else {
                 result.push(None);

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -16,9 +16,10 @@ use crate::{
     CommitRef, CommittedSubDag,
     authority_set::AuthoritySet,
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        StrongVote, TestBlockHeader, TestBlockHeaderVersion, Transaction, TransactionsCommitment,
-        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions, genesis_block_headers,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs,
+        CommitmentVerifiedTransactions, GENESIS_ROUND, Round, Slot, StrongVote, TestBlockHeader,
+        TestBlockHeaderVersion, Transaction, TransactionsCommitment, VerifiedBlock,
+        VerifiedBlockHeader, genesis_block_headers,
     },
     commit::{CertifiedCommit, CommitAPI, CommitDigest, TrustedCommit, WAVE_LENGTH},
     context::Context,
@@ -109,7 +110,7 @@ pub(crate) struct DagBuilder {
     // All blocks created by dag builder. Will be used to pretty print or to be
     // retrieved for testing/persiting to dag state.
     pub(crate) block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
-    pub(crate) transactions: BTreeMap<BlockRef, VerifiedTransactions>,
+    pub(crate) transactions: BTreeMap<BlockRef, CommitmentVerifiedTransactions>,
     // All the committed sub dags created by the dag builder.
     pub(crate) committed_sub_dags: Vec<(CommittedSubDag, TrustedCommit)>,
     pub(crate) last_committed_rounds: Vec<Round>,
@@ -214,7 +215,10 @@ impl DagBuilder {
             .collect::<Vec<VerifiedBlockHeader>>()
     }
 
-    pub(crate) fn transactions(&self, rounds: RangeInclusive<Round>) -> Vec<VerifiedTransactions> {
+    pub(crate) fn transactions(
+        &self,
+        rounds: RangeInclusive<Round>,
+    ) -> Vec<CommitmentVerifiedTransactions> {
         assert!(
             !self.transactions.is_empty(),
             "No transactions have been created, please make sure that you have called build method"
@@ -227,7 +231,7 @@ impl DagBuilder {
                     .then_some(verified_transactions)
             })
             .cloned()
-            .collect::<Vec<VerifiedTransactions>>()
+            .collect::<Vec<CommitmentVerifiedTransactions>>()
     }
 
     pub(crate) fn all_block_headers(&self) -> Vec<VerifiedBlockHeader> {
@@ -631,7 +635,7 @@ impl DagBuilder {
             )
             .unwrap();
 
-            let verified_transactions = VerifiedTransactions::new(
+            let verified_transactions = CommitmentVerifiedTransactions::new(
                 transactions,
                 TransactionRef::new(block_ref, commitment),
                 Some(block_ref.digest),
@@ -750,7 +754,7 @@ pub struct LayerBuilder<'a> {
 
     // Accumulated blocks to write to dag state
     block_headers: Vec<VerifiedBlockHeader>,
-    pub(crate) transactions: Vec<VerifiedTransactions>,
+    pub(crate) transactions: Vec<CommitmentVerifiedTransactions>,
 }
 
 #[expect(unused)]
@@ -1193,7 +1197,7 @@ impl<'a> LayerBuilder<'a> {
                         VerifiedBlockHeader::new_for_test(test_block_header)
                     };
 
-                let verified_transactions = VerifiedTransactions::new(
+                let verified_transactions = CommitmentVerifiedTransactions::new(
                     transactions,
                     block_header.transaction_ref(),
                     Some(block_header.digest()),

--- a/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_metastate_tests.rs
@@ -12,8 +12,8 @@ use crate::{
         BaseCommitter, BaseCommitterOptions, base_committer_builder::BaseCommitterBuilder,
     },
     block_header::{
-        BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        StrongVote, TransactionsCommitment, VerifiedBlockHeader, VerifiedTransactions,
+        BlockHeader, BlockHeaderV2, BlockRef, BlockTimestampMs, CommitmentVerifiedTransactions,
+        GENESIS_ROUND, Round, Slot, StrongVote, TransactionsCommitment, VerifiedBlockHeader,
         genesis_block_headers,
     },
     commit::{CommitMetastate, DecidedLeader, LeaderStatus},
@@ -88,7 +88,7 @@ fn pin_strong_vote(
 /// Marks `header`'s transactions as locally available, so
 /// `DagState::are_transactions_available` returns true for that ref.
 fn add_transactions_for(dag_state: &Arc<RwLock<DagState>>, header: &VerifiedBlockHeader) {
-    let verified = VerifiedTransactions::new_for_test(header, vec![]);
+    let verified = CommitmentVerifiedTransactions::new_for_test(header, vec![]);
     dag_state
         .write()
         .add_transactions(verified, DataSource::Test);

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -1172,9 +1172,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         // Run the same checks here so a payload violating them can't be
         // acknowledged and become committable via this route either.
         for verified_transactions in &transactions {
-            if let Err(err) =
-                block_verifier.verify_transactions_validity(&verified_transactions.transactions())
-            {
+            if let Err(err) = block_verifier.verify_transactions_validity(verified_transactions) {
                 let author = verified_transactions.author();
                 metrics
                     .invalid_transactions

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -29,7 +29,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     block_verifier::BlockVerifier,
-    commit_syncer::verify_transactions_with_transactions_refs,
+    commit_syncer::verify_transactions_commitments,
     context::Context,
     core_thread::CoreThreadDispatcher,
     dag_state::{DagState, DataSource},
@@ -1132,7 +1132,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 let context_cloned = context.clone();
 
                 move || {
-                    verify_transactions_with_transactions_refs(
+                    verify_transactions_commitments(
                         &context_cloned,
                         peer_index,
                         serialized_transactions_map,
@@ -1173,7 +1173,7 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
         // acknowledged and become committable via this route either.
         for verified_transactions in &transactions {
             if let Err(err) =
-                block_verifier.check_and_verify_transactions(&verified_transactions.transactions())
+                block_verifier.verify_transactions_validity(&verified_transactions.transactions())
             {
                 let author = verified_transactions.author();
                 metrics
@@ -1255,8 +1255,8 @@ mod tests {
     use crate::{
         Round, TestBlockHeader, Transaction,
         block_header::{
-            BlockRef, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedOwnShard,
-            VerifiedTransactions,
+            BlockRef, CommitmentVerifiedTransactions, TransactionsCommitment, VerifiedBlock,
+            VerifiedBlockHeader, VerifiedOwnShard,
         },
         block_verifier::{NoopBlockVerifier, SignedBlockVerifier, test::TxnSizeVerifier},
         commit::{CertifiedCommits, CommitRange},
@@ -1321,7 +1321,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(
+                CommitmentVerifiedTransactions::new(
                     transactions,
                     header.transaction_ref(),
                     Some(header.digest()),
@@ -1385,7 +1385,7 @@ mod tests {
     /// Core. Otherwise it could be acknowledged and become committable while
     /// diverging from nodes that received the same payload directly.
     #[tokio::test]
-    async fn live_syncing_rejects_transactions_failing_verification() {
+    async fn live_syncing_rejects_transactions_failing_validity_check() {
         telemetry_subscribers::init_for_testing();
         // GIVEN a block_verifier that rejects transactions shorter than 4
         // bytes.
@@ -1428,7 +1428,7 @@ mod tests {
                 .build(),
         );
 
-        let verified_transactions = VerifiedTransactions::new(
+        let verified_transactions = CommitmentVerifiedTransactions::new(
             transactions,
             header.transaction_ref(),
             Some(header.digest()),
@@ -1465,7 +1465,7 @@ mod tests {
         let fetched_transactions = core_dispatcher.get_and_drain_transactions().await;
         assert!(
             fetched_transactions.is_empty(),
-            "A fetched payload failing verification must never reach Core"
+            "A fetched payload failing the validity check must never reach Core"
         );
 
         let counts = dag_state.read().misbehavior_store().snapshot_totals();
@@ -1603,7 +1603,7 @@ mod tests {
 
             block_headers.push(header.clone());
 
-            let verified_transaction = VerifiedTransactions::new(
+            let verified_transaction = CommitmentVerifiedTransactions::new(
                 transactions,
                 header.transaction_ref(),
                 Some(header.digest()),
@@ -1728,7 +1728,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(
+                CommitmentVerifiedTransactions::new(
                     transactions,
                     header.transaction_ref(),
                     Some(header.digest()),
@@ -1856,7 +1856,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(
+                CommitmentVerifiedTransactions::new(
                     transactions,
                     header.transaction_ref(),
                     Some(header.digest()),
@@ -1973,7 +1973,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(
+                CommitmentVerifiedTransactions::new(
                     transactions,
                     header.transaction_ref(),
                     Some(header.digest()),
@@ -2092,7 +2092,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(
+                CommitmentVerifiedTransactions::new(
                     transactions,
                     header.transaction_ref(),
                     Some(header.digest()),
@@ -2230,7 +2230,7 @@ mod tests {
             &mut encoder,
         )
         .unwrap();
-        let unrequested_transaction = VerifiedTransactions::new(
+        let unrequested_transaction = CommitmentVerifiedTransactions::new(
             unrequested_txs,
             TransactionRef {
                 round: 9,
@@ -2336,7 +2336,7 @@ mod tests {
 
                 block_headers.push(header.clone());
 
-                VerifiedTransactions::new(
+                CommitmentVerifiedTransactions::new(
                     transactions,
                     header.transaction_ref(),
                     Some(header.digest()),
@@ -2544,7 +2544,7 @@ mod tests {
                         .build(),
                 );
                 block_headers.push(header.clone());
-                VerifiedTransactions::new(
+                CommitmentVerifiedTransactions::new(
                     transactions,
                     header.transaction_ref(),
                     Some(header.digest()),
@@ -2790,7 +2790,7 @@ mod tests {
 
         async fn stub_fetch_transactions(
             &self,
-            transactions: Vec<VerifiedTransactions>,
+            transactions: Vec<CommitmentVerifiedTransactions>,
             peer: AuthorityIndex,
         ) {
             let mut transactions_map = self.transactions.lock().await;
@@ -2833,7 +2833,7 @@ mod tests {
         // are not requested
         async fn stub_unrequested_transactions(
             &self,
-            transactions: Vec<VerifiedTransactions>,
+            transactions: Vec<CommitmentVerifiedTransactions>,
             peer: AuthorityIndex,
         ) {
             let mut unrequested = self.unrequested_transactions.lock().await;
@@ -2860,7 +2860,7 @@ mod tests {
     // TransactionsSynchronizer tests
     #[derive(Default)]
     struct MockCoreThreadDispatcher {
-        transactions: Mutex<Vec<VerifiedTransactions>>,
+        transactions: Mutex<Vec<CommitmentVerifiedTransactions>>,
         missing_transactions: Mutex<BTreeMap<GenericTransactionRef, BTreeSet<AuthorityIndex>>>,
     }
 
@@ -2872,7 +2872,7 @@ mod tests {
             }
         }
 
-        async fn get_and_drain_transactions(&self) -> Vec<VerifiedTransactions> {
+        async fn get_and_drain_transactions(&self) -> Vec<CommitmentVerifiedTransactions> {
             let mut transactions = self.transactions.lock().await;
             transactions.drain(0..).collect()
         }
@@ -2918,7 +2918,7 @@ mod tests {
 
         async fn add_transactions(
             &self,
-            transactions: Vec<VerifiedTransactions>,
+            transactions: Vec<CommitmentVerifiedTransactions>,
             _source: DataSource,
         ) -> Result<(), CoreError> {
             let mut txns = self.transactions.lock().await;


### PR DESCRIPTION
# Description of change

The sync/reconstruction paths run two distinct checks on fetched payloads, and both were called "verify" — although they have opposite misbehavior attribution (commitment mismatch → unprovable peer/relayer fault; validity failure → provable author fault). Give each check a distinct name so call sites can't be confused, and enforce their order through the type system. No behavior change.

- Commitment check: `verify_transactions_commitments` (was `verify_transactions_with_transactions_refs`), `decode_and_verify_commitment` (was `decode_by_codec`), and the `CommitmentVerifiedTransactions` type (was `VerifiedTransactions`).
- Validity check: `BlockVerifier::verify_transactions_validity` (was `check_and_verify_transactions`); attribution helpers, test names, and comments follow the same split.
- `verify_transactions_validity` now takes `&CommitmentVerifiedTransactions`, so validity can only run on a payload that already passed the commitment check; `transactions()` returns a borrowed slice instead of cloning the vec.

## Links to any relevant issues

fixes #12360

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
