### PR TITLE
fix(consensus): expose decided_leaders_total on validators

### DIFF
--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -944,7 +944,8 @@ impl NodeMetrics {
                 "decided_leaders_total",
                 "Total number of (direct or indirect, skip or commit) decided leaders per authority",
                 &["authority", "commit_type"],
-                registry,
+                registry;
+                MetricLevel::Warn,
             ).unwrap(),
             last_committed_authority_round: register_int_gauge_vec_with_registry!(
                 "last_committed_authority_round",


### PR DESCRIPTION
# Description of change

`decided_leaders_total` was registered without a `MetricLevel`, so it defaulted to `Debug` and reached Mimir only from nodes running a verbose metrics filter — one validator on testnet. It carries the commit-type distribution of the optimistic commit rule (direct / upgraded / indirect × optimistic / standard / skip), which is the primary signal for how often a leader goes Pending and how it resolves; with a single publisher it cannot be cross-checked between observers.

Cardinality, measured on an ordinary testnet validator: the metric is 193 series, against the 9328 that validator already publishes, so it adds ~2%. That makes it the ninth-largest metric on the host, next to `core_skipped_transactions` (185) and `synchronizer_requested_block_headers_by_authority` (204), and 13x smaller than the largest one already exposed there (`cordial_knowledge_useful_headers_authors`, 2532). Both labels are load-bearing: `commit_type` is the distribution itself, and `authority` — the leader of the decided slot — is what shows that some leaders sit near 15% Pending against a ~5% network average.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
