### PR TITLE
fix(iota-traffic-controller): stop delegating blocks to the firewall while dry-run is enabled

### DIFF
--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -533,11 +533,11 @@ async fn test_validator_traffic_control_error_delegated() -> Result<(), anyhow::
     let tmp_dir = iota_common::tempdir();
     let firewall_config = RemoteFirewallConfig {
         remote_fw_url: format!("http://127.0.0.1:{port}"),
-        delegate_spam_blocking: true,
-        delegate_error_blocking: false,
+        delegate_spam_blocking: false,
+        delegate_error_blocking: true,
         destination_port: 8080,
         drain_path: tmp_dir.path().join("drain"),
-        drain_timeout_secs: 10,
+        drain_timeout_secs: 300,
     };
     let network_config = ConfigBuilder::new_with_temp_dir()
         .committee_size(NonZeroUsize::new(4).unwrap())
@@ -569,23 +569,34 @@ async fn test_validator_traffic_control_error_delegated() -> Result<(), anyhow::
     // await for the server to start
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
-    // it should take no more than 4 requests to be added to the blocklist
+    // The error policy blocks on the fourth tally, thus the firewall gets the
+    // block before the loop ends.
     for _ in 0..n {
-        let response = auth_client.handle_transaction(tx.clone(), None).await;
-        if let Err(err) = response {
-            if err.to_string().contains("Too many requests") {
-                return Ok(());
-            }
-        }
+        // The firewall holds the block, thus the node never rejects the request
+        // itself.
+        let err = auth_client
+            .handle_transaction(tx.clone(), None)
+            .await
+            .expect_err("Expected the bad signature to be rejected");
+        assert!(
+            !err.to_string().contains("Too many requests"),
+            "Expected the firewall to hold the block, not the node: {err}"
+        );
         // Yield to the async executor so that the background `run_tally_loop` task
         // can process the pending tally and update the blocklist before the next
         // request. Without this, the single-threaded tokio test runtime may never
         // schedule the tally loop between iterations, causing the test to be flaky.
         tokio::task::yield_now().await;
     }
-    // Allow time for the async HTTP delegation to the firewall server to complete.
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-    let fw_blocklist = server.list_addresses_rpc().await;
+    // The delegation request to the firewall server is asynchronous.
+    let mut fw_blocklist = Vec::new();
+    for _ in 0..50 {
+        fw_blocklist = server.list_addresses_rpc().await;
+        if !fw_blocklist.is_empty() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
     assert!(
         !fw_blocklist.is_empty(),
         "Expected blocklist to be non-empty"

--- a/crates/iota-traffic-controller/src/lib.rs
+++ b/crates/iota-traffic-controller/src/lib.rs
@@ -1162,15 +1162,29 @@ mod tests {
     /// Tallies one breaching request against a controller whose firewall config
     /// delegates both policies.
     async fn tally_one_breach(dry_run: bool, kind: PolicyKind) -> Outcome {
-        // Keep this directory. The tally loop reads `drain_path`.
+        let (_tmp_dir, controller) = delegating_controller(dry_run, kind).await;
+        controller.tally(breach(kind));
+        wait_for_block(&controller).await
+    }
+
+    /// Makes a controller that delegates both policies. Keep the directory: the
+    /// tally loop reads `drain_path` in it.
+    async fn delegating_controller(
+        dry_run: bool,
+        kind: PolicyKind,
+    ) -> (impl Drop, TrafficController) {
         let tmp_dir = iota_common::tempdir();
         let controller = TrafficController::init_for_test(
             policy_config(dry_run, kind),
             Some(fw_config(tmp_dir.path().join("drain"))),
         )
         .await;
-        controller.tally(breach(kind));
+        (tmp_dir, controller)
+    }
 
+    /// Waits for the tally loop to record the block, then reports where it
+    /// went.
+    async fn wait_for_block(controller: &TrafficController) -> Outcome {
         let metrics = &controller.metrics;
         for _ in 0..100 {
             let outcome = Outcome {
@@ -1188,6 +1202,50 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         panic!("the tally loop recorded no block in one second");
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_reports_the_block_it_does_not_apply() {
+        let (_tmp_dir, controller) = delegating_controller(true, PolicyKind::Spam).await;
+        controller.tally(breach(PolicyKind::Spam));
+        assert_eq!(
+            wait_for_block(&controller).await,
+            Outcome {
+                blocked_locally: 1,
+                delegated: 0,
+            }
+        );
+
+        // Dry run lets the request through, but it counts the client that the
+        // node would block.
+        assert!(controller.check(&Some(CLIENT), &None).await);
+        assert_eq!(controller.metrics.num_dry_run_blocked_requests.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_the_admin_api_turns_dry_run_off_at_once() {
+        let (_tmp_dir, controller) = delegating_controller(true, PolicyKind::Spam).await;
+        controller.tally(breach(PolicyKind::Spam));
+        assert_eq!(wait_for_block(&controller).await.delegated, 0);
+
+        controller
+            .admin_reconfigure(TrafficControlReconfigParams {
+                error_threshold: None,
+                spam_threshold: None,
+                dry_run: Some(false),
+            })
+            .await
+            .expect("the request changes only the dry-run flag");
+
+        // The tally loop must read the new value, not the value it started with.
+        for _ in 0..100 {
+            controller.tally(breach(PolicyKind::Spam));
+            if controller.metrics.blocks_delegated_to_firewall.get() > 0 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("the node delegated no block after the admin API turned dry run off");
     }
 
     #[tokio::test]

--- a/crates/iota-traffic-controller/src/lib.rs
+++ b/crates/iota-traffic-controller/src/lib.rs
@@ -1132,8 +1132,7 @@ mod tests {
                 PolicyType::NoOp
             },
             spam_sample_rate: Weight::one(),
-            // Do not use the default of zero. It makes the policy clear its
-            // counts in a busy loop.
+            // The default of zero clears the counts every second.
             connection_blocklist_ttl_sec: 120,
             dry_run,
             ..Default::default()

--- a/crates/iota-traffic-controller/src/lib.rs
+++ b/crates/iota-traffic-controller/src/lib.rs
@@ -170,10 +170,8 @@ impl TrafficController {
         let policy_config = { self.policy_config.read().await.clone() };
         Self::set_policy_config_metrics(&policy_config, self.metrics.clone());
         let (tx, rx) = mpsc::channel(policy_config.channel_capacity);
-        // Memoized drainfile existence state. This is passed into delegation
-        // functions to prevent them from continuing to populate blocklists
-        // if drain is set, as otherwise it will grow without bounds
-        // without the firewall running to periodically clear it.
+        // Drain file state, refreshed by the tally loop. While the firewall
+        // drains, the node blocks locally instead of delegating.
         let mem_drainfile_present = self
             .fw_config
             .as_ref()
@@ -528,15 +526,11 @@ async fn run_tally_loop(
             _ = tokio::time::sleep(tokio::time::Duration::from_secs(timeout)) => {
                 if let Some(fw_config) = &fw_config {
                     error!("No traffic tallies received in {} seconds.", timeout);
-                    if mem_drainfile_present {
-                        continue;
-                    }
                     if !fw_config.drain_path.exists() {
-                        mem_drainfile_present = true;
                         warn!("Draining Node firewall.");
-                        File::create(&fw_config.drain_path)
-                            .expect("Failed to touch nodefw drain file");
-                        metrics.deadmans_switch_enabled.set(1);
+                        if let Err(err) = File::create(&fw_config.drain_path) {
+                            error!("Failed to touch nodefw drain file: {err}");
+                        }
                     }
                 }
             }
@@ -545,6 +539,19 @@ async fn run_tally_loop(
         // every N seconds, we update metrics and logging that would be too
         // spammy to be handled while processing each tally
         if metric_timer.elapsed() > Duration::from_secs(METRICS_INTERVAL_SECS) {
+            // The operator can add or remove the drain file at any time. The
+            // loop reads it again, thus delegation restarts after a drain. An
+            // I/O error keeps the last known state, because `exists` cannot
+            // tell an error from a removal.
+            if let Some(fw_config) = &fw_config {
+                match fw_config.drain_path.try_exists() {
+                    Ok(drainfile_present) => mem_drainfile_present = drainfile_present,
+                    Err(err) => warn!("Failed to read the nodefw drain file: {err}"),
+                }
+                metrics
+                    .deadmans_switch_enabled
+                    .set(mem_drainfile_present as i64);
+            }
             if let TrafficControlPolicy::FreqThreshold(ref spam_policy) = *spam_policy.lock().await
             {
                 if let Some(highest_direct_rate) = spam_policy.highest_direct_rate() {
@@ -1090,13 +1097,14 @@ pub fn get_client_ip(
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::{net::Ipv4Addr, path::PathBuf};
 
     use super::*;
 
     const CLIENT: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
 
     /// The policy that the request breaches.
+    #[derive(Clone, Copy)]
     enum PolicyKind {
         Spam,
         Error,
@@ -1109,11 +1117,11 @@ mod tests {
         delegated: u64,
     }
 
-    /// Tallies one breaching request. The controller delegates both policies.
-    async fn tally_one_breach(dry_run: bool, kind: PolicyKind) -> Outcome {
+    /// Blocks the direct client on every tally of the given policy.
+    fn policy_config(dry_run: bool, kind: PolicyKind) -> PolicyConfig {
         let error = matches!(kind, PolicyKind::Error);
         let blocking_policy = PolicyType::TestNConnIP(1);
-        let policy_config = PolicyConfig {
+        PolicyConfig {
             spam_policy_type: if error {
                 PolicyType::NoOp
             } else {
@@ -1129,27 +1137,39 @@ mod tests {
             connection_blocklist_ttl_sec: 120,
             dry_run,
             ..Default::default()
-        };
-        // Keep this directory. The tally loop reads `drain_path`.
-        let tmp_dir = iota_common::tempdir();
-        let fw_config = RemoteFirewallConfig {
-            // No server listens here. The metrics show if the node delegates a
-            // block.
+        }
+    }
+
+    /// Delegates both policies. No server listens on the firewall URL, thus the
+    /// metrics show if the node delegates a block.
+    fn fw_config(drain_path: PathBuf) -> RemoteFirewallConfig {
+        RemoteFirewallConfig {
             remote_fw_url: "http://127.0.0.1:1".to_string(),
             destination_port: 8080,
             delegate_spam_blocking: true,
             delegate_error_blocking: true,
-            drain_path: tmp_dir.path().join("drain"),
+            drain_path,
             drain_timeout_secs: 300,
-        };
-        let controller = TrafficController::init_for_test(policy_config, Some(fw_config)).await;
-        let error_info = error.then(|| (Weight::one(), "error".to_string()));
-        controller.tally(TrafficTally::new(
-            Some(CLIENT),
-            None,
-            error_info,
-            Weight::one(),
-        ));
+        }
+    }
+
+    fn breach(kind: PolicyKind) -> TrafficTally {
+        let error_info =
+            matches!(kind, PolicyKind::Error).then(|| (Weight::one(), "error".to_string()));
+        TrafficTally::new(Some(CLIENT), None, error_info, Weight::one())
+    }
+
+    /// Tallies one breaching request against a controller whose firewall config
+    /// delegates both policies.
+    async fn tally_one_breach(dry_run: bool, kind: PolicyKind) -> Outcome {
+        // Keep this directory. The tally loop reads `drain_path`.
+        let tmp_dir = iota_common::tempdir();
+        let controller = TrafficController::init_for_test(
+            policy_config(dry_run, kind),
+            Some(fw_config(tmp_dir.path().join("drain"))),
+        )
+        .await;
+        controller.tally(breach(kind));
 
         let metrics = &controller.metrics;
         for _ in 0..100 {
@@ -1168,6 +1188,41 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         panic!("the tally loop recorded no block in one second");
+    }
+
+    #[tokio::test]
+    async fn test_delegation_restarts_when_the_drain_file_goes_away() {
+        let tmp_dir = iota_common::tempdir();
+        let drain_path = tmp_dir.path().join("drain");
+        File::create(&drain_path).expect("the drain file is created");
+        let controller = TrafficController::init_for_test(
+            policy_config(false, PolicyKind::Spam),
+            Some(fw_config(drain_path.clone())),
+        )
+        .await;
+        let metrics = &controller.metrics;
+
+        // The firewall drains, thus the node blocks locally.
+        controller.tally(breach(PolicyKind::Spam));
+        for _ in 0..100 {
+            if metrics.connection_ip_blocklist_len.get() > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(metrics.connection_ip_blocklist_len.get(), 1);
+        assert_eq!(metrics.blocks_delegated_to_firewall.get(), 0);
+
+        // The operator removes the drain file, thus delegation restarts.
+        fs::remove_file(&drain_path).expect("the drain file is removed");
+        for _ in 0..100 {
+            controller.tally(breach(PolicyKind::Spam));
+            if metrics.blocks_delegated_to_firewall.get() > 0 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        panic!("the node delegated no block in ten seconds");
     }
 
     #[tokio::test]

--- a/crates/iota-traffic-controller/src/lib.rs
+++ b/crates/iota-traffic-controller/src/lib.rs
@@ -175,7 +175,9 @@ impl TrafficController {
         let mem_drainfile_present = self
             .fw_config
             .as_ref()
-            .map(|config| config.drain_path.exists())
+            // An unreadable path counts as a drain, thus the node does not
+            // delegate while it cannot tell.
+            .map(|config| config.drain_path.try_exists().unwrap_or(true))
             .unwrap_or(false);
         self.metrics
             .deadmans_switch_enabled
@@ -526,7 +528,7 @@ async fn run_tally_loop(
             _ = tokio::time::sleep(tokio::time::Duration::from_secs(timeout)) => {
                 if let Some(fw_config) = &fw_config {
                     error!("No traffic tallies received in {} seconds.", timeout);
-                    if !fw_config.drain_path.exists() {
+                    if !fw_config.drain_path.try_exists().unwrap_or(true) {
                         warn!("Draining Node firewall.");
                         if let Err(err) = File::create(&fw_config.drain_path) {
                             error!("Failed to touch nodefw drain file: {err}");
@@ -1246,6 +1248,30 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         panic!("the node delegated no block after the admin API turned dry run off");
+    }
+
+    #[tokio::test]
+    async fn test_an_unreadable_drain_path_stops_delegation() {
+        // The drain path goes through a file, thus `try_exists` gives an error
+        // and the node cannot tell if the firewall drains.
+        let tmp_dir = iota_common::tempdir();
+        let blocker = tmp_dir.path().join("blocker");
+        File::create(&blocker).expect("the file is created");
+        let controller = TrafficController::init_for_test(
+            policy_config(false, PolicyKind::Spam),
+            Some(fw_config(blocker.join("drain"))),
+        )
+        .await;
+        controller.tally(breach(PolicyKind::Spam));
+
+        // The node keeps the block, because the firewall possibly drains.
+        assert_eq!(
+            wait_for_block(&controller).await,
+            Outcome {
+                blocked_locally: 1,
+                delegated: 0,
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/iota-traffic-controller/src/lib.rs
+++ b/crates/iota-traffic-controller/src/lib.rs
@@ -257,7 +257,7 @@ impl TrafficController {
             self.metrics
                 .error_client_threshold
                 .set(error_threshold as i64);
-            Self::update_policy_threshold(policy, error_threshold, dry_run).await?;
+            Self::update_policy_threshold(policy, error_threshold).await?;
         }
         if let Some(spam_threshold) = spam_threshold {
             let policy = self.spam_policy.as_ref().ok_or_else(|| {
@@ -268,7 +268,7 @@ impl TrafficController {
             self.metrics
                 .spam_client_threshold
                 .set(spam_threshold as i64);
-            Self::update_policy_threshold(policy, spam_threshold, dry_run).await?;
+            Self::update_policy_threshold(policy, spam_threshold).await?;
         }
         if let Some(dry_run) = dry_run {
             self.metrics.dry_run_enabled.set(dry_run as i64);
@@ -281,21 +281,14 @@ impl TrafficController {
     async fn update_policy_threshold(
         policy: &Arc<Mutex<TrafficControlPolicy>>,
         threshold: u64,
-        dry_run: Option<bool>,
     ) -> Result<(), IotaError> {
         match *policy.lock().await {
             TrafficControlPolicy::FreqThreshold(ref mut policy) => {
                 policy.client_threshold = threshold;
-                if let Some(dry_run) = dry_run {
-                    policy.config.dry_run = dry_run;
-                }
                 Ok(())
             }
             TrafficControlPolicy::TestNConnIP(ref mut policy) => {
                 policy.threshold = threshold;
-                if let Some(dry_run) = dry_run {
-                    policy.config.dry_run = dry_run;
-                }
                 Ok(())
             }
             _ => Err(IotaError::InvalidAdminRequest(

--- a/crates/iota-traffic-controller/src/lib.rs
+++ b/crates/iota-traffic-controller/src/lib.rs
@@ -190,6 +190,7 @@ impl TrafficController {
         let tally_loop_metrics = self.metrics.clone();
         let clear_loop_metrics = self.metrics.clone();
         let tally_loop_fw_config = self.fw_config.clone();
+        let tally_loop_dry_run = self.dry_run.clone();
 
         let spam_policy = self
             .spam_policy
@@ -209,6 +210,7 @@ impl TrafficController {
             tally_loop_blocklists,
             tally_loop_metrics,
             mem_drainfile_present,
+            tally_loop_dry_run,
         ));
         spawn_monitored_task!(run_clear_blocklists_loop(blocklists, clear_loop_metrics));
         self.open_tally_channel(tx);
@@ -471,6 +473,7 @@ async fn run_tally_loop(
     blocklists: Blocklists,
     metrics: Arc<TrafficControllerMetrics>,
     mut mem_drainfile_present: bool,
+    dry_run: Arc<AtomicBool>,
 ) {
     let spam_blocklists = Arc::new(blocklists.clone());
     let error_blocklists = Arc::new(blocklists);
@@ -490,6 +493,10 @@ async fn run_tally_loop(
                 metrics.tallies.inc();
                 match received {
                     Some(tally) => {
+                        // The firewall must receive no blocks during a drain
+                        // or a dry run.
+                        let delegation_allowed = !mem_drainfile_present
+                            && !dry_run.load(Ordering::Relaxed);
                         // TODO: spawn a task to handle tallying concurrently
                         if let Err(err) = handle_spam_tally(
                             spam_policy.clone(),
@@ -499,7 +506,7 @@ async fn run_tally_loop(
                             tally.clone(),
                             spam_blocklists.clone(),
                             metrics.clone(),
-                            mem_drainfile_present,
+                            delegation_allowed,
                         )
                         .await {
                             warn!("Error handling spam tally: {}", err);
@@ -512,7 +519,7 @@ async fn run_tally_loop(
                             tally,
                             error_blocklists.clone(),
                             metrics.clone(),
-                            mem_drainfile_present,
+                            delegation_allowed,
                         )
                         .await {
                             warn!("Error handling error tally: {}", err);
@@ -598,7 +605,7 @@ async fn handle_error_tally(
     tally: TrafficTally,
     blocklists: Arc<Blocklists>,
     metrics: Arc<TrafficControllerMetrics>,
-    mem_drainfile_present: bool,
+    delegation_allowed: bool,
 ) -> Result<(), reqwest::Error> {
     let Some((error_weight, error_type)) = tally.clone().error_info else {
         return Ok(());
@@ -617,7 +624,7 @@ async fn handle_error_tally(
     let resp = policy.lock().await.handle_tally(tally);
     metrics.error_tally_handled.inc();
     if let Some(fw_config) = fw_config {
-        if fw_config.delegate_error_blocking && !mem_drainfile_present {
+        if fw_config.delegate_error_blocking && delegation_allowed {
             let client = nodefw_client
                 .as_ref()
                 .expect("Expected NodeFWClient for blocklist delegation");
@@ -643,7 +650,7 @@ async fn handle_spam_tally(
     tally: TrafficTally,
     blocklists: Arc<Blocklists>,
     metrics: Arc<TrafficControllerMetrics>,
-    mem_drainfile_present: bool,
+    delegation_allowed: bool,
 ) -> Result<(), reqwest::Error> {
     if !(tally.spam_weight.is_sampled() && policy_config.spam_sample_rate.is_sampled()) {
         return Ok(());
@@ -651,7 +658,7 @@ async fn handle_spam_tally(
     let resp = policy.lock().await.handle_tally(tally.clone());
     metrics.tally_handled.inc();
     if let Some(fw_config) = fw_config {
-        if fw_config.delegate_spam_blocking && !mem_drainfile_present {
+        if fw_config.delegate_spam_blocking && delegation_allowed {
             let client = nodefw_client
                 .as_ref()
                 .expect("Expected NodeFWClient for blocklist delegation");
@@ -1085,5 +1092,133 @@ pub fn get_client_ip(
                 None => ClientIpStatus::XForwardedForUnparsable,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    const CLIENT: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+    /// The policy that the request breaches.
+    enum PolicyKind {
+        Spam,
+        Error,
+    }
+
+    /// Where the block for one breaching request went.
+    #[derive(Debug, PartialEq)]
+    struct Outcome {
+        blocked_locally: i64,
+        delegated: u64,
+    }
+
+    /// Tallies one breaching request. The controller delegates both policies.
+    async fn tally_one_breach(dry_run: bool, kind: PolicyKind) -> Outcome {
+        let error = matches!(kind, PolicyKind::Error);
+        let blocking_policy = PolicyType::TestNConnIP(1);
+        let policy_config = PolicyConfig {
+            spam_policy_type: if error {
+                PolicyType::NoOp
+            } else {
+                blocking_policy.clone()
+            },
+            error_policy_type: if error {
+                blocking_policy
+            } else {
+                PolicyType::NoOp
+            },
+            spam_sample_rate: Weight::one(),
+            // Do not use the default of zero. It makes the policy clear its
+            // counts in a busy loop.
+            connection_blocklist_ttl_sec: 120,
+            dry_run,
+            ..Default::default()
+        };
+        // Keep this directory. The tally loop reads `drain_path`.
+        let tmp_dir = iota_common::tempdir();
+        let fw_config = RemoteFirewallConfig {
+            // No server listens here. The metrics show if the node delegates a
+            // block.
+            remote_fw_url: "http://127.0.0.1:1".to_string(),
+            destination_port: 8080,
+            delegate_spam_blocking: true,
+            delegate_error_blocking: true,
+            drain_path: tmp_dir.path().join("drain"),
+            drain_timeout_secs: 300,
+        };
+        let controller = TrafficController::init_for_test(policy_config, Some(fw_config)).await;
+        let error_info = error.then(|| (Weight::one(), "error".to_string()));
+        controller.tally(TrafficTally::new(
+            Some(CLIENT),
+            None,
+            error_info,
+            Weight::one(),
+        ));
+
+        let metrics = &controller.metrics;
+        for _ in 0..100 {
+            let outcome = Outcome {
+                blocked_locally: metrics.connection_ip_blocklist_len.get(),
+                delegated: metrics.blocks_delegated_to_firewall.get(),
+            };
+            if outcome
+                != (Outcome {
+                    blocked_locally: 0,
+                    delegated: 0,
+                })
+            {
+                return outcome;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("the tally loop recorded no block in one second");
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_keeps_spam_blocks_local() {
+        assert_eq!(
+            tally_one_breach(true, PolicyKind::Spam).await,
+            Outcome {
+                blocked_locally: 1,
+                delegated: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_keeps_error_blocks_local() {
+        assert_eq!(
+            tally_one_breach(true, PolicyKind::Error).await,
+            Outcome {
+                blocked_locally: 1,
+                delegated: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_spam_blocks_are_delegated_without_dry_run() {
+        assert_eq!(
+            tally_one_breach(false, PolicyKind::Spam).await,
+            Outcome {
+                blocked_locally: 0,
+                delegated: 1,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_error_blocks_are_delegated_without_dry_run() {
+        assert_eq!(
+            tally_one_breach(false, PolicyKind::Error).await,
+            Outcome {
+                blocked_locally: 0,
+                delegated: 1,
+            }
+        );
     }
 }

--- a/crates/iota-traffic-controller/src/policies.rs
+++ b/crates/iota-traffic-controller/src/policies.rs
@@ -494,8 +494,10 @@ impl TestNConnIPPolicy {
 }
 
 async fn run_clear_frequencies(frequencies: Arc<RwLock<HashMap<IpAddr, u64>>>, window_secs: u64) {
+    // A window of zero seconds clears the counts in a busy loop.
+    let window = Duration::from_secs(window_secs.max(1));
     loop {
-        tokio::time::sleep(tokio::time::Duration::from_secs(window_secs)).await;
+        tokio::time::sleep(window).await;
         frequencies.write().clear();
     }
 }

--- a/crates/iota-traffic-controller/src/policies.rs
+++ b/crates/iota-traffic-controller/src/policies.rs
@@ -458,7 +458,7 @@ impl TestNConnIPPolicy {
         let frequencies_clone = frequencies.clone();
         spawn_monitored_task!(run_clear_frequencies(
             frequencies_clone,
-            config.connection_blocklist_ttl_sec * 2,
+            config.connection_blocklist_ttl_sec.saturating_mul(2),
         ));
         Self {
             config,

--- a/docs/content/operator/activate_DoS_protection_for_validators.mdx
+++ b/docs/content/operator/activate_DoS_protection_for_validators.mdx
@@ -227,11 +227,12 @@ policy-config:
 
 After enabling the `TrafficController`, monitor your node's metrics to ensure legitimate traffic isn't being blocked. Key metrics to watch:
 
-- `traffic_controller_tallies`
-- `traffic_controller_connection_ip_blocklist_len`
-- `traffic_controller_proxy_ip_blocklist_len`
-- `traffic_controller_requests_blocked_at_protocol`
-- `traffic_controller_num_dry_run_blocked_requests`
+- `tallies`
+- `connection_ip_blocklist_len`
+- `proxy_ip_blocklist_len`
+- `requests_blocked_at_protocol`
+- `blocks_delegated_to_firewall`
+- `traffic_control_num_dry_run_blocked_requests`
 
 Start with `dry-run: true` to observe what would be blocked without actually blocking traffic, then adjust thresholds as needed before setting `dry-run: false`.
 

--- a/docs/content/operator/activate_DoS_protection_for_validators.mdx
+++ b/docs/content/operator/activate_DoS_protection_for_validators.mdx
@@ -97,6 +97,8 @@ firewall-config:
   drain-timeout-secs: 300
 ```
 
+While `dry-run` is enabled, the node sends no blocks to the firewall. Set `dry-run: false` in `policy-config` to start delegating.
+
 ## Non-Proxy Mode Configuration
 
 If your validator node receives traffic directly from clients (no proxy or load balancer in front), use this configuration:


### PR DESCRIPTION
# Description of change

`dry-run: true` stopped the node from blocking a breaching client locally, but it never stopped the node from delegating that block to a remote firewall. With `firewall-config` set, a breaching client was blocked at the network level while the node reported nothing — the local blocklist stayed empty, so `traffic_control_num_dry_run_blocked_requests`, the metric the operator guide points at, stayed at zero.

- Skip firewall delegation while dry-run is on, so the block stays local and the request is still allowed. The dry-run counter now reports what would be blocked on both the local and the delegated path.
- The runtime dry-run flag is threaded into the tally loop, so toggling dry-run through the admin API takes effect immediately. The tally loop decides once whether delegation is allowed, instead of each handler re-deriving it.
- Document in the operator guide that dry-run also covers the remote firewall.

The PR also carries five adjacent fixes the change surfaced, one per commit:

- Restart firewall delegation once the drain file goes away. `mem_drainfile_present` latched on, so one quiet period disabled delegation for the rest of the process, and `dry-run: false` did not bring it back.
- Stop the `TestNConnIP` policy from clearing its counts in a busy loop when `connection_blocklist_ttl_sec` is `0`, which is the `PolicyConfig::default()` value.
- Drop the `dry_run` writes on the policy config that nothing reads, so the atomic flag is the only source of truth.
- Correct the metric names in the operator guide. Four of the five listed carried a `traffic_controller_` prefix that the registry never exposes, so an operator building a dashboard from that list got empty panels.
- Make the error delegation e2e test actually delegate error blocks, which it never did despite its name.

Note for operators: `dry-run` defaults to `true`, so a node that enabled `delegate-spam-blocking` or `delegate-error-blocking` without setting `dry-run: false` stops delegating after this change. Setting `dry-run: false` restores the previous behavior exactly.

One known limit: a dry-run block is only visible while it sits in the local blocklist, so `connection_blocklist_ttl_sec` must be greater than zero. Every documented setup satisfies that — the field's serde default is 60 and the guide's examples set it explicitly — but `PolicyConfig::default()` hard-codes `0`, which a node that omits `policy-config` altogether inherits. On such a node the block expires at the instant it is inserted and the dry-run counter stays at zero. #12337 already corrects that default, so this PR does not duplicate the change.

The metric names themselves are left alone on purpose. The registry exposes most traffic control metrics unprefixed (`tallies`, `connection_ip_blocklist_len`) and four with a `traffic_control_` prefix, which is inconsistent — but renaming them would silently blank every operator dashboard and alert built on the current names, for a cosmetic gain and well outside the scope of a dry-run fix. The guide is corrected to match what the node actually exposes; a rename can be its own PR with its own release note.

## Links to any relevant issues

fixes #12713

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Four unit tests drive a `TrafficController` through `tally()` and assert where the block went, covering both policies with dry-run on and off:

- `test_dry_run_keeps_spam_blocks_local` — blocked locally, nothing delegated
- `test_dry_run_keeps_error_blocks_local` — blocked locally, nothing delegated
- `test_spam_blocks_are_delegated_without_dry_run` — nothing local, one block delegated
- `test_error_blocks_are_delegated_without_dry_run` — nothing local, one block delegated

The delegating cases are what keep the dry-run cases from passing without the controller reaching its threshold. Dropping the dry-run term from the delegation check fails both dry-run tests and leaves the delegating ones green. `test_fullnode_traffic_control_spam_delegated` still passes unchanged, so delegation is unchanged when dry-run is off. `test_validator_traffic_control_error_delegated` is rewritten here: it now enables `delegate-error-blocking`, asserts the node does not block the client itself, and polls the firewall server instead of waiting a fixed time. Turning `delegate-error-blocking` off makes it fail.

### Release Notes

- [x] Nodes (Validators and Full nodes): Traffic control dry-run now also covers remote firewall delegation. No blocks are sent to the firewall while dry-run is enabled. Please set `dry-run: false` to keep delegating.