### PR TITLE
fix(cli): honor the display selection for transaction effects

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3515,7 +3515,7 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
                 .quorum_driver_api()
                 .execute_transaction_block(
                     transaction,
-                    opts_from_cli(display),
+                    opts_from_cli(&display),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await?;
@@ -3529,6 +3529,11 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
             })?;
             if let IotaExecutionStatus::Failure { error } = effects.status() {
                 bail!("Error executing transaction '{}': {error}", response.digest);
+            }
+            // Effects are always requested for the status check above, so drop
+            // them here when the display selection excludes them.
+            if !display.is_empty() && !display.contains(&DisplayOption::Effects) {
+                response.effects = None;
             }
             Ok(IotaClientCommandResult::TransactionBlock(response))
         }
@@ -3579,7 +3584,7 @@ pub(crate) async fn prerender_clever_errors(
     }
 }
 
-fn opts_from_cli(opts: HashSet<DisplayOption>) -> IotaTransactionBlockResponseOptions {
+fn opts_from_cli(opts: &HashSet<DisplayOption>) -> IotaTransactionBlockResponseOptions {
     if opts.is_empty() {
         IotaTransactionBlockResponseOptions::new()
             .with_input()
@@ -3591,6 +3596,9 @@ fn opts_from_cli(opts: HashSet<DisplayOption>) -> IotaTransactionBlockResponseOp
         IotaTransactionBlockResponseOptions {
             show_input: opts.contains(&DisplayOption::Input),
             show_raw_input: false,
+            // Effects are always requested because the execution status check
+            // needs them; they are dropped from the response afterwards when
+            // the display selection excludes them.
             show_effects: true,
             show_raw_effects: false,
             show_events: opts.contains(&DisplayOption::Events),

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -275,6 +275,13 @@ impl PTB {
                 .map(|x| Address::new(x.value.into_bytes())),
         };
 
+        let mut display = self.display;
+        if program_metadata.summary_set {
+            // The summary is derived from the effects, so keep them in the
+            // response even when the display selection excludes them.
+            display.insert(DisplayOption::Effects);
+        }
+
         let processing = TxProcessingArgs {
             tx_digest: program_metadata.tx_digest_set,
             dry_run: program_metadata.dry_run_set,
@@ -284,7 +291,7 @@ impl PTB {
             sender: program_metadata
                 .sender
                 .map(|x| Address::new(x.value.into_bytes())),
-            display: self.display,
+            display,
             auth_call_args,
             auth_type_args,
             sponsor_auth_call_args,
@@ -329,33 +336,29 @@ impl PTB {
             }
         }
 
-        if program_metadata.json_set || program_metadata.summary_set {
-            let summary = {
-                let effects = transaction_response.effects.as_ref().ok_or_else(|| {
-                    anyhow!("Internal error: no transaction effects after PTB was executed.")
-                })?;
-                Summary {
-                    digest: transaction_response.digest,
-                    status: effects.status().clone(),
-                    gas_cost: effects.gas_cost_summary().clone(),
-                }
+        if program_metadata.summary_set {
+            let effects = transaction_response.effects.as_ref().ok_or_else(|| {
+                anyhow!("Internal error: no transaction effects after PTB was executed.")
+            })?;
+            let summary = Summary {
+                digest: transaction_response.digest,
+                status: effects.status().clone(),
+                gas_cost: effects.gas_cost_summary().clone(),
             };
 
             if program_metadata.json_set {
-                if program_metadata.summary_set {
-                    Ok(PTBCommandResult::Json(
-                        serde_json::to_value(&summary)
-                            .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?,
-                    ))
-                } else {
-                    Ok(PTBCommandResult::Json(
-                        serde_json::to_value(&transaction_response)
-                            .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?,
-                    ))
-                }
+                Ok(PTBCommandResult::Json(
+                    serde_json::to_value(&summary)
+                        .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?,
+                ))
             } else {
                 Ok(PTBCommandResult::Summary(summary))
             }
+        } else if program_metadata.json_set {
+            Ok(PTBCommandResult::Json(
+                serde_json::to_value(&transaction_response)
+                    .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?,
+            ))
         } else {
             Ok(PTBCommandResult::CommandResult(Box::new(
                 IotaClientCommandResult::TransactionBlock(transaction_response),

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -5812,10 +5812,9 @@ async fn test_call_command_display_args() -> Result<(), anyhow::Error> {
     if let Some(tx_block_response) = start_call_result.tx_block_response() {
         // Assert Balance Changes are present in the response
         assert!(tx_block_response.balance_changes.is_some());
-        // effects are always in the response
-        assert!(tx_block_response.effects.is_some());
 
         // Assert every other field is not present in the response
+        assert!(tx_block_response.effects.is_none());
         assert!(tx_block_response.object_changes.is_none());
         assert!(tx_block_response.events.is_none());
         assert!(tx_block_response.transaction.is_none());
@@ -5954,7 +5953,8 @@ async fn test_ptb_display_args() -> Result<(), anyhow::Error> {
     };
 
     assert!(res.transaction.is_some());
-    assert!(res.effects.is_some());
+    // `DisplayOption::Effects` wasn't provided, so there are no effects
+    assert!(res.effects.is_none());
 
     let ptb_string = r#"
         --make-move-vec <u8> "[1]"
@@ -5974,7 +5974,45 @@ async fn test_ptb_display_args() -> Result<(), anyhow::Error> {
     };
     // `DisplayOption::Input` wasn't provided, so there is no `Transaction Data`
     assert!(res.transaction.is_none());
+    assert!(res.effects.is_none());
+
+    let ptb_string = r#"
+        --make-move-vec <u8> "[1]"
+        "#;
+    let args = shlex::split(ptb_string).unwrap();
+    let PTBCommandResult::CommandResult(res) = iota::client_ptb::ptb::PTB {
+        args,
+        display: HashSet::from([DisplayOption::Effects]),
+    }
+    .execute(context)
+    .await?
+    else {
+        panic!("unexpected PTB result");
+    };
+    let IotaClientCommandResult::TransactionBlock(res) = *res else {
+        panic!("unexpected PTB result");
+    };
+    // `DisplayOption::Effects` was provided, so the effects are present
+    assert!(res.transaction.is_none());
     assert!(res.effects.is_some());
+
+    // The summary is derived from the effects, so it works even when the
+    // display selection excludes them
+    let ptb_string = r#"
+        --make-move-vec <u8> "[1]"
+        --summary
+        "#;
+    let args = shlex::split(ptb_string).unwrap();
+    let PTBCommandResult::Summary(summary) = iota::client_ptb::ptb::PTB {
+        args,
+        display: HashSet::from([DisplayOption::Input]),
+    }
+    .execute(context)
+    .await?
+    else {
+        panic!("unexpected PTB result");
+    };
+    assert_eq!(summary.status, IotaExecutionStatus::Success);
 
     Ok(())
 }


### PR DESCRIPTION
# Description of change

`iota client` commands and `iota client ptb` always returned and printed the transaction effects, even when `--display` was given without `effects` — the option had no way to exclude them.

- Effects are still always requested from the node (the CLI needs them to check the execution status and bail on failure), but they are now dropped from the response afterwards when the display selection excludes them.
- The PTB `--summary` output is derived from the effects, so they are force-kept in that mode; the summary is also now only built when `--summary` is actually set, so `--json` alone honors the display selection too.
- Extended `test_call_command_display_args` and `test_ptb_display_args` to assert both presence and absence of effects, including the `--summary` + `--display input` interaction.

## Links to any relevant issues

fixes #6935

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] CLI: `--display` now excludes the transaction effects from the response when `effects` is not part of the selection; previously effects were always returned and printed.

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)