### PR TITLE
fix(core): Remove events table from AuthorityPerpetualTables

### DIFF
--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -100,12 +100,6 @@ pub struct AuthorityPerpetualTables {
     /// table. When we revert transactions, we remove them from both tables.
     pub(crate) executed_effects: DBMap<TransactionDigest, TransactionEffectsDigest>,
 
-    /// Deprecated: events keyed by events digest moved to `events_2`.
-    /// TODO: <https://github.com/iotaledger/iota/issues/12423>
-    #[allow(dead_code)]
-    #[deprecated_db_map]
-    events: Option<DBMap<(), ()>>,
-
     // Events keyed by the digest of the transaction that produced them.
     pub(crate) events_2: DBMap<TransactionDigest, TransactionEvents>,
 


### PR DESCRIPTION
# Description of change

- Removes the deprecated `events` field from `AuthorityPerpetualTables`.
- The table was deprecated in #12418 (shipped in v1.29.0): `#[deprecated_db_map]`
  drops the column family on node startup, freeing the space.

## Links to any relevant issues

fixes #12423

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
