### PR TITLE
fix(starfish): cap shortfall-scaled success samples at the failure penalty

### DIFF
--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -1446,6 +1446,33 @@ mod tests {
             );
         }
 
+        /// However large the shortfall, a delivering peer records no worse
+        /// than the loop's failure penalty, so it can never rank behind a peer
+        /// that failed outright.
+        #[tokio::test(start_paused = true)]
+        async fn success_records_no_worse_than_the_failure_penalty() {
+            let context = fast_sync_context(4);
+            let (commits, vote_headers, transactions) = two_commit_response(&context);
+            let network_client = Arc::new(FakeNetworkClient {
+                commits_and_transactions: Some((commits, vote_headers, transactions)),
+                response_delay: Duration::from_millis(200),
+                ..Default::default()
+            });
+            let inner = make_inner(context.clone(), network_client.clone());
+
+            fetch_loop(inner, (1..=1_000).into(), 2, FastCommitSyncer::fetch_once).await;
+
+            // Two of a thousand commits delivered in 200ms would scale to
+            // 100s; the record is capped at the failure penalty of this loop.
+            let requested = network_client.requested_peers.lock().clone();
+            assert_eq!(
+                context
+                    .peer_responsiveness
+                    .effective_latency_ms(DataSource::FastCommitSyncer, requested[0]),
+                Some(1_000.0)
+            );
+        }
+
         /// The ranked order is what runs in production, so pin that the loop
         /// reaches it: a peer the tracker has never seen fail leads the rounds,
         /// which the plain committee order would never produce.

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -655,13 +655,19 @@ where
             .await
             {
                 Ok(Ok(data)) => {
+                    // A failure is the ceiling of the scale: however short the
+                    // delivery, a peer that returned something never records
+                    // worse than one that failed.
                     inner.context.peer_responsiveness.record_success(
                         data_source,
                         authority,
-                        started.elapsed().mul_f64(shortfall_factor(
-                            commit_range.size(),
-                            data.delivered_commits(),
-                        )),
+                        started
+                            .elapsed()
+                            .mul_f64(shortfall_factor(
+                                commit_range.size(),
+                                data.delivered_commits(),
+                            ))
+                            .min(failure_penalty),
                     );
                     info!(
                         "[{}] Finished fetching commits in {commit_range:?}",

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -905,10 +905,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             } else {
                 1.0
             };
+            // Capped at the failure penalty: a partial delivery never records
+            // worse than a failed fetch.
             context.peer_responsiveness.record_success(
                 DataSource::HeaderSynchronizerRequested,
                 peer_index,
-                elapsed.mul_f64(factor),
+                elapsed.mul_f64(factor).min(FETCH_REQUEST_TIMEOUT),
             );
         }
 
@@ -4291,6 +4293,38 @@ mod tests {
             (elapsed_ms * 4.0..elapsed_ms * 4.0 + 100.0).contains(&recorded),
             "one of four requested headers delivered should scale the fetch-plus-verify \
              latency by four, got {recorded}"
+        );
+
+        // The same peer delivers one of four again, slowly enough that the
+        // scaled latency would exceed the failure penalty: the sample is
+        // capped there, so a delivering peer never records worse than a
+        // failing one.
+        let requested_headers = (40..44)
+            .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
+            .collect::<Vec<_>>();
+        let blocks_guard = inflight_blocks_map
+            .lock_headers(
+                requested_headers
+                    .iter()
+                    .map(|header| header.reference())
+                    .collect(),
+                padding_peer,
+                SyncMethod::Live,
+            )
+            .expect("the headers are free to lock");
+        let fetched = FetchedHeaders {
+            serialized_headers: vec![requested_headers[0].serialized().clone()],
+            elapsed: Duration::from_millis(1_900),
+            holds_requested: true,
+        };
+        let result = process(fetched, blocks_guard, padding_peer).await;
+        assert!(result.is_ok());
+        let capped = latency(padding_peer).expect("the delivery is recorded");
+        let expected = 0.7 * recorded + 0.3 * FETCH_REQUEST_TIMEOUT.as_millis() as f64;
+        assert!(
+            (capped - expected).abs() < 1.0,
+            "the scaled sample must be capped at the failure penalty, got {capped}, \
+             expected {expected}"
         );
 
         // Peer 3 pads its response with a header from an author we did not

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -188,7 +188,10 @@ impl PeerResponsiveness {
     /// a response that returned nothing (or a small fraction of what was
     /// requested) should be reported via [`Self::record_failure_with_timeout`]
     /// (or with a latency scaled up by the shortfall), so a peer cannot look
-    /// fast by replying quickly with little.
+    /// fast by replying quickly with little. A shortfall-scaled latency must be
+    /// capped at the operation's failure penalty: the failure is the ceiling of
+    /// the scale, and a peer that delivered something must never record worse
+    /// than one that failed.
     pub(crate) fn record_success(
         &self,
         source: DataSource,

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -865,10 +865,15 @@ impl<C: NetworkClient, D: CoreThreadDispatcher> TransactionsSynchronizer<C, D> {
                 Ok(stats) if stats.matched_requested > 0 => {
                     let shortfall_factor =
                         (stats.requested as f64 / stats.matched_requested as f64).max(1.0);
+                    // Capped at the failure penalty: a partial delivery never
+                    // records worse than a failed fetch.
                     context.peer_responsiveness.record_success(
                         DataSource::TransactionSynchronizer,
                         peer,
-                        stats.latency.mul_f64(shortfall_factor),
+                        stats
+                            .latency
+                            .mul_f64(shortfall_factor)
+                            .min(FETCH_REQUEST_TIMEOUT),
                     );
                 }
                 Ok(_) => {


### PR DESCRIPTION
# Description of change

`PeerResponsiveness` mixed two scales in one effective-latency value: a success was recorded as elapsed time inflated by the delivery shortfall with no upper bound, while a failure was recorded as a fixed timeout-scale penalty. A peer delivering a partial response could thus be recorded orders of magnitude worse than a peer erroring instantly, and inside the failed group (sorted fastest-first) the erroring peer outranked the delivering one — the opposite of the selection goal.

Cap the shortfall-scaled success sample at the same operation's failure penalty in all three ranked fetch paths — the commit syncers' shared `fetch_loop`, the transactions synchronizer, and the header synchronizer — making the failure penalty the ceiling of the scale: a peer that delivered something never records worse than one that failed.

## Links to any relevant issues

Fixes #12724

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes