### PR TITLE
fix(consensus): bound the gap between last commit and last solid commit

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -180,6 +180,12 @@ pub struct Parameters {
     /// Disabled by default (None).
     #[serde(default)]
     pub dag_visualizer_port: Option<u16>,
+
+    /// Maximum number of rounds the last commit's leader may run ahead of the
+    /// last solid commit's leader before the node stops accepting new block
+    /// bundles and restricts header fetching, until solidification catches up.
+    #[serde(default = "Parameters::default_solid_commit_lag_threshold")]
+    pub solid_commit_lag_threshold: u32,
 }
 
 impl Parameters {
@@ -453,6 +459,13 @@ impl Parameters {
     pub(crate) fn default_enable_peer_responsiveness_ranking() -> bool {
         true
     }
+
+    pub(crate) fn default_solid_commit_lag_threshold() -> u32 {
+        // The healthy gap is a few rounds at most; 500 rounds (a few minutes of
+        // commits) is far above live jitter yet caps how long a solidification
+        // stall can keep widening the shard/payload retention window.
+        500
+    }
 }
 
 impl Default for Parameters {
@@ -492,6 +505,7 @@ impl Default for Parameters {
             enable_peer_responsiveness_ranking:
                 Parameters::default_enable_peer_responsiveness_ranking(),
             dag_visualizer_port: None,
+            solid_commit_lag_threshold: Parameters::default_solid_commit_lag_threshold(),
         }
     }
 }

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -56,3 +56,4 @@ enable_commit_sync_peer_selection_by_commit_votes: true
 enable_starfish_speed_adaptive_acknowledgments: true
 enable_peer_responsiveness_ranking: true
 dag_visualizer_port: ~
+solid_commit_lag_threshold: 500

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -684,6 +684,39 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             }
         }
     }
+
+    /// Rejects the block when local commits run too far ahead of the last
+    /// solid commit, i.e. transaction payloads are not keeping up. New headers
+    /// would only widen the round window in which shards and payloads are
+    /// retained, so ingestion pauses until the transactions synchronizer
+    /// closes the gap.
+    fn ensure_solid_commit_lag_within_threshold(&self, block_ref: BlockRef) -> ConsensusResult<()> {
+        let solid_commit_lag = self.dag_state.read().solid_commit_lag_rounds();
+        if solid_commit_lag <= self.context.parameters.solid_commit_lag_threshold {
+            return Ok(());
+        }
+        // During fast sync commits are applied in bulk while their payloads
+        // are still being fetched, so a large gap is expected. Checked only
+        // when the gap is already over the threshold: it reads the store.
+        if self.dag_state.read().fast_sync_ongoing() {
+            return Ok(());
+        }
+        self.context
+            .metrics
+            .node_metrics
+            .rejected_blocks
+            .with_label_values(&["solid_commit_lagging"])
+            .inc();
+        debug!(
+            "Block {block_ref:?} is rejected because the last solid commit is lagging the last commit by {solid_commit_lag} rounds",
+        );
+        Err(ConsensusError::BlockRejected {
+            block_ref,
+            reason: format!(
+                "Last solid commit is lagging the last commit by {solid_commit_lag} rounds",
+            ),
+        })
+    }
 }
 
 /// Rejects a deserialized `ShardWithProof` that is not the current `V2`
@@ -876,11 +909,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         };
 
         // 7. Reject blocks when local commit index is lagging too far from quorum
-        //    commit index.
+        //    commit index, or when local commits run too far ahead of the last solid
+        //    commit.
         //
         // IMPORTANT: this must be done after observing votes from the block, otherwise
         // observed quorum commit will no longer progress.
         self.ensure_commit_lag_within_threshold(block_ref)?;
+        self.ensure_solid_commit_lag_within_threshold(block_ref)?;
 
         self.context
             .metrics

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -691,16 +691,13 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
     /// retained, so ingestion pauses until the transactions synchronizer
     /// closes the gap.
     fn ensure_solid_commit_lag_within_threshold(&self, block_ref: BlockRef) -> ConsensusResult<()> {
-        let solid_commit_lag = self.dag_state.read().solid_commit_lag_rounds();
-        if solid_commit_lag <= self.context.parameters.solid_commit_lag_threshold {
-            return Ok(());
-        }
-        // During fast sync commits are applied in bulk while their payloads
-        // are still being fetched, so a large gap is expected. Checked only
-        // when the gap is already over the threshold: it reads the store.
-        if self.dag_state.read().fast_sync_ongoing() {
-            return Ok(());
-        }
+        let solid_commit_lag = {
+            let dag_state = self.dag_state.read();
+            if !dag_state.is_solidification_lagging() {
+                return Ok(());
+            }
+            dag_state.solid_commit_lag_rounds()
+        };
         self.context
             .metrics
             .node_metrics

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -472,8 +472,11 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             .inc_by(verified_shards.len() as u64);
         Ok(verified_shards)
     }
-    fn ensure_commit_lag_within_threshold(&self, block_ref: BlockRef) -> ConsensusResult<()> {
-        let last_commit_index = self.dag_state.read().last_commit_index();
+    fn ensure_commit_lag_within_threshold(
+        &self,
+        block_ref: BlockRef,
+        last_commit_index: CommitIndex,
+    ) -> ConsensusResult<()> {
         let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
         // The threshold to ignore block should be larger than commit_sync_batch_size,
         // to avoid excessive block rejections and synchronizations.
@@ -690,13 +693,13 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
     /// would only widen the round window in which shards and payloads are
     /// retained, so ingestion pauses until the transactions synchronizer
     /// closes the gap.
-    fn ensure_solid_commit_lag_within_threshold(&self, block_ref: BlockRef) -> ConsensusResult<()> {
-        let solid_commit_lag = {
-            let dag_state = self.dag_state.read();
-            if !dag_state.is_solidification_lagging() {
-                return Ok(());
-            }
-            dag_state.solid_commit_lag_rounds()
+    fn ensure_solid_commit_lag_within_threshold(
+        &self,
+        block_ref: BlockRef,
+        solid_commit_lag: Option<Round>,
+    ) -> ConsensusResult<()> {
+        let Some(solid_commit_lag) = solid_commit_lag else {
+            return Ok(());
         };
         self.context
             .metrics
@@ -911,8 +914,18 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         //
         // IMPORTANT: this must be done after observing votes from the block, otherwise
         // observed quorum commit will no longer progress.
-        self.ensure_commit_lag_within_threshold(block_ref)?;
-        self.ensure_solid_commit_lag_within_threshold(block_ref)?;
+        //
+        // Read both lag inputs under a single short dag_state lock, then decide without
+        // holding it — the threshold comparisons, metrics and errors need no lock.
+        let (last_commit_index, solid_commit_lag) = {
+            let dag_state = self.dag_state.read();
+            let solid_commit_lag = dag_state
+                .is_solidification_lagging()
+                .then(|| dag_state.solid_commit_lag_rounds());
+            (dag_state.last_commit_index(), solid_commit_lag)
+        };
+        self.ensure_commit_lag_within_threshold(block_ref, last_commit_index)?;
+        self.ensure_solid_commit_lag_within_threshold(block_ref, solid_commit_lag)?;
 
         self.context
             .metrics

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1829,7 +1829,9 @@ mod tests {
         },
         block_manager::BlockManager,
         block_verifier::SignedBlockVerifier,
-        commit::{CertifiedCommits, CommitDigest, CommitRange, CommitRef},
+        commit::{
+            CertifiedCommits, CommitDigest, CommitRange, CommitRef, SubDagBase, TrustedCommit,
+        },
         commit_observer::CommitObserver,
         commit_syncer::CommitSyncType,
         commit_vote_monitor::CommitVoteMonitor,
@@ -2200,6 +2202,232 @@ mod tests {
         assert_eq!(
             counts.faulty_blocks_provable, 1,
             "two signed headers for one slot are provable equivocation"
+        );
+    }
+
+    /// A bundle is rejected while local commits run further ahead of the last
+    /// solid commit than `solid_commit_lag_threshold`, and accepted again once
+    /// solidification catches up to the threshold.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_subscribed_block_bundle_rejects_when_solid_commit_lags() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context.with_parameters(Parameters {
+            solid_commit_lag_threshold: 10,
+            ..Default::default()
+        }));
+        let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
+        let (tx_message_sender, mut tx_message_receiver) = mpsc::channel(100);
+        let network_client = Arc::new(FakeNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+        let header_synchronizer = HeaderSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            false,
+            None,
+            Arc::new(MisbehaviorStore::new(&context)),
+        );
+        let authority_service = Arc::new(AuthorityService::new(
+            context.clone(),
+            block_verifier,
+            commit_vote_monitor,
+            header_synchronizer,
+            transactions_synchronizer,
+            core_dispatcher.clone(),
+            rx_block_broadcast,
+            dag_state.clone(),
+            store,
+            Arc::new(MisbehaviorStore::new(&context)),
+            tx_message_sender,
+            cordial_knowledge,
+        ));
+        let mut encoder = create_encoder(&context);
+
+        // Commit up to leader round 12 with nothing solid yet, so the solid
+        // commit lag (12 rounds) exceeds the 10-round threshold.
+        {
+            let mut d = dag_state.write();
+            for index in 1..=12u32 {
+                d.add_commit(TrustedCommit::new_for_test(
+                    &context,
+                    index,
+                    CommitDigest::MIN,
+                    0,
+                    BlockRef::new(
+                        index,
+                        AuthorityIndex::new_for_test(0),
+                        BlockHeaderDigest::MIN,
+                    ),
+                    vec![],
+                    vec![],
+                ));
+            }
+        }
+
+        let peer = context.committee.to_authority_index(0).unwrap();
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
+        );
+        let bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
+
+        let result = authority_service
+            .handle_subscribed_block_bundle(peer, bundle.clone(), &mut encoder)
+            .await;
+        assert!(
+            matches!(result, Err(ConsensusError::BlockRejected { .. })),
+            "expected BlockRejected while solidification lags, got {result:?}"
+        );
+        assert!(
+            tx_message_receiver.try_recv().is_err(),
+            "a rejected bundle must not feed the shard reconstructor"
+        );
+        assert!(
+            core_dispatcher.get_blocks().is_empty(),
+            "a rejected block must not be forwarded to the core"
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .rejected_blocks
+                .with_label_values(&["solid_commit_lagging"])
+                .get(),
+            1,
+        );
+
+        // Solidify up to leader round 2: the lag is exactly the threshold,
+        // which is accepted.
+        dag_state.write().update_last_solid_subdag_base(SubDagBase {
+            leader: BlockRef::new(2, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+            headers: vec![],
+            committed_header_refs: vec![],
+            timestamp_ms: 0,
+            commit_ref: CommitRef::new(2, CommitDigest::MIN),
+            reputation_scores_desc: vec![],
+        });
+
+        authority_service
+            .handle_subscribed_block_bundle(peer, bundle, &mut encoder)
+            .await
+            .unwrap();
+        assert_eq!(core_dispatcher.get_blocks(), vec![input_block]);
+    }
+
+    /// During fast sync commits are applied in bulk before their payloads
+    /// arrive, so the solid commit lag does not reject bundles.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_subscribed_block_bundle_allows_solid_commit_lag_during_fast_sync() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context.with_parameters(Parameters {
+            solid_commit_lag_threshold: 10,
+            ..Default::default()
+        }));
+        let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
+        let (tx_message_sender, _tx_message_receiver) = mpsc::channel(100);
+        let network_client = Arc::new(FakeNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+        let header_synchronizer = HeaderSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            false,
+            None,
+            Arc::new(MisbehaviorStore::new(&context)),
+        );
+        let authority_service = Arc::new(AuthorityService::new(
+            context.clone(),
+            block_verifier,
+            commit_vote_monitor,
+            header_synchronizer,
+            transactions_synchronizer,
+            core_dispatcher.clone(),
+            rx_block_broadcast,
+            dag_state.clone(),
+            store.clone(),
+            Arc::new(MisbehaviorStore::new(&context)),
+            tx_message_sender,
+            cordial_knowledge,
+        ));
+        let mut encoder = create_encoder(&context);
+
+        // Commit up to leader round 12 with nothing solid, but mark fast sync
+        // as ongoing.
+        {
+            let mut d = dag_state.write();
+            for index in 1..=12u32 {
+                d.add_commit(TrustedCommit::new_for_test(
+                    &context,
+                    index,
+                    CommitDigest::MIN,
+                    0,
+                    BlockRef::new(
+                        index,
+                        AuthorityIndex::new_for_test(0),
+                        BlockHeaderDigest::MIN,
+                    ),
+                    vec![],
+                    vec![],
+                ));
+            }
+        }
+        store
+            .write(WriteBatch {
+                fast_commit_sync_flag: Some(true),
+                ..WriteBatch::default()
+            })
+            .unwrap();
+
+        let peer = context.committee.to_authority_index(0).unwrap();
+        let input_block = VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
+        );
+        let bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
+
+        authority_service
+            .handle_subscribed_block_bundle(peer, bundle, &mut encoder)
+            .await
+            .unwrap();
+        assert_eq!(core_dispatcher.get_blocks(), vec![input_block]);
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .rejected_blocks
+                .with_label_values(&["solid_commit_lagging"])
+                .get(),
+            0,
         );
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3008,6 +3008,16 @@ impl DagState {
         self.last_commit_round()
             .saturating_sub(last_solid_leader_round)
     }
+
+    /// Whether local commits run further ahead of the last solid commit than
+    /// `solid_commit_lag_threshold` allows. Ignored during fast sync, where
+    /// commits are applied in bulk before their payloads arrive.
+    pub(crate) fn is_solidification_lagging(&self) -> bool {
+        // The fast-sync flag reads the store, so check it only when the gap
+        // is already over the threshold.
+        self.solid_commit_lag_rounds() > self.context.parameters.solid_commit_lag_threshold
+            && !self.fast_sync_ongoing()
+    }
 }
 #[cfg(test)]
 mod test {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -849,9 +849,7 @@ impl DagState {
             .unwrap_or_else(|e| panic!("Failed to read from storage: {e:?}"))
     }
 
-    /// Returns the leader round of the last solid commit (backward
-    /// compatibility).
-    #[cfg_attr(not(test), expect(dead_code))]
+    /// Returns the leader round of the last solid commit.
     pub(crate) fn last_solid_commit_leader_round(&self) -> Option<Round> {
         self.last_solid_subdag_base.as_ref().map(|s| s.leader.round)
     }
@@ -2998,6 +2996,17 @@ impl DagState {
             // empty blocks.
             GenericTransactionRef::BlockRef(_) => None,
         }
+    }
+
+    /// Rounds the last commit's leader is ahead of the last solid commit's
+    /// leader. Zero before anything is committed; while nothing is solid yet,
+    /// the whole committed range counts as lag.
+    pub(crate) fn solid_commit_lag_rounds(&self) -> Round {
+        let last_solid_leader_round = self
+            .last_solid_commit_leader_round()
+            .unwrap_or(GENESIS_ROUND);
+        self.last_commit_round()
+            .saturating_sub(last_solid_leader_round)
     }
 }
 #[cfg(test)]

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -1386,7 +1386,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         // in which shards and payloads are retained (fetched headers raise the
         // accepted frontier), so the scheduler stands down entirely until the
         // transactions synchronizer closes the gap.
-        if self.is_solidification_lagging() {
+        if self.dag_state.read().is_solidification_lagging() {
             trace!(
                 "Scheduled synchronizer temporarily disabled as the last solid commit is lagging the last commit too much."
             );
@@ -1844,15 +1844,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         }
 
         results
-    }
-
-    /// Whether local commits run further ahead of the last solid commit than
-    /// `solid_commit_lag_threshold` allows. Ignored during fast sync, where
-    /// commits are applied in bulk before their payloads arrive.
-    fn is_solidification_lagging(&self) -> bool {
-        let dag_state = self.dag_state.read();
-        dag_state.solid_commit_lag_rounds() > self.context.parameters.solid_commit_lag_threshold
-            && !dag_state.fast_sync_ongoing()
     }
 }
 

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -1382,6 +1382,23 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
             return Ok(());
         }
 
+        // While solidification lags, new headers only widen the round window
+        // in which shards and payloads are retained (fetched headers raise the
+        // accepted frontier), so the scheduler stands down entirely until the
+        // transactions synchronizer closes the gap.
+        if self.is_solidification_lagging() {
+            trace!(
+                "Scheduled synchronizer temporarily disabled as the last solid commit is lagging the last commit too much."
+            );
+            self.context
+                .metrics
+                .node_metrics
+                .synchronizer_fetch_block_headers_scheduler_skipped
+                .with_label_values(&["solid_commit_lagging"])
+                .inc();
+            return Ok(());
+        }
+
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let block_verifier = self.block_verifier.clone();
@@ -1827,6 +1844,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> HeaderSynchron
         }
 
         results
+    }
+
+    /// Whether local commits run further ahead of the last solid commit than
+    /// `solid_commit_lag_threshold` allows. Ignored during fast sync, where
+    /// commits are applied in bulk before their payloads arrive.
+    fn is_solidification_lagging(&self) -> bool {
+        let dag_state = self.dag_state.read();
+        dag_state.solid_commit_lag_rounds() > self.context.parameters.solid_commit_lag_threshold
+            && !dag_state.fast_sync_ongoing()
     }
 }
 

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -1880,7 +1880,7 @@ mod tests {
             VerifiedBlockHeader, VerifiedOwnShard, VerifiedTransactions,
         },
         block_verifier::NoopBlockVerifier,
-        commit::{CertifiedCommits, CommitRange, CommitVote, TrustedCommit},
+        commit::{CertifiedCommits, CommitRange, CommitRef, CommitVote, SubDagBase, TrustedCommit},
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
         core::ReasonToCreateBlock,
@@ -2969,11 +2969,148 @@ mod tests {
                 d.last_commit_index(),
                 commit_vote_monitor.quorum_commit_index()
             );
+
+            // Solidify up to the last commit so the solid commit lag does not
+            // keep the scheduler disabled.
+            d.update_last_solid_subdag_base(SubDagBase {
+                leader: BlockRef::new(
+                    commit_index,
+                    AuthorityIndex::new_for_test(0),
+                    BlockHeaderDigest::MIN,
+                ),
+                headers: vec![],
+                committed_header_refs: vec![],
+                timestamp_ms: 0,
+                commit_ref: CommitRef::new(commit_index, CommitDigest::MIN),
+                reputation_scores_desc: vec![],
+            });
         }
 
         // Now stub again the missing blocks to fetch the exact same ones.
         core_dispatcher
             .stub_missing_block_headers(missing_blocks_refs.clone())
+            .await;
+
+        sleep(2 * FETCH_REQUEST_TIMEOUT).await;
+
+        // THEN the missing blocks should now be fetched and added to core
+        let mut added_blocks = core_dispatcher.get_and_drain_block_headers().await;
+
+        added_blocks.sort_by_key(|block| block.reference());
+        expected_headers.sort_by_key(|block| block.reference());
+
+        assert_eq!(added_blocks, expected_headers);
+
+        // Stop synchronizer and ensure that no panic occurred
+        if let Err(err) = handle.stop().await {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn synchronizer_periodic_task_when_solidification_lagging_gets_disabled() {
+        // GIVEN
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context.with_parameters(Parameters {
+            solid_commit_lag_threshold: 10,
+            ..Default::default()
+        }));
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let network_client = Arc::new(MockNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+
+        // AND stub some missing blocks and the fetch responses for them.
+        let mut expected_headers = (1..=5u32)
+            .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
+            .collect::<Vec<_>>();
+        let missing_blocks_refs = expected_headers
+            .iter()
+            .map(|block| block.reference())
+            .collect::<BTreeSet<_>>();
+        core_dispatcher
+            .stub_missing_block_headers(missing_blocks_refs.clone())
+            .await;
+        network_client
+            .stub_fetch_headers_response(
+                expected_headers.clone(),
+                AuthorityIndex::new_for_test(1),
+                Some(FETCH_REQUEST_TIMEOUT),
+            )
+            .await;
+        network_client
+            .stub_fetch_headers_response(
+                expected_headers.clone(),
+                AuthorityIndex::new_for_test(2),
+                None,
+            )
+            .await;
+
+        // AND commit up to leader round 12 with nothing solid yet, so the
+        // solid commit lag (12 rounds) exceeds the 10-round threshold.
+        {
+            let mut d = dag_state.write();
+            for index in 1..=12u32 {
+                d.add_commit(TrustedCommit::new_for_test(
+                    &context,
+                    index,
+                    CommitDigest::MIN,
+                    0,
+                    BlockRef::new(
+                        index,
+                        AuthorityIndex::new_for_test(0),
+                        BlockHeaderDigest::MIN,
+                    ),
+                    vec![],
+                    vec![],
+                ));
+            }
+        }
+
+        let handle = HeaderSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer,
+            block_verifier,
+            dag_state.clone(),
+            false,
+            None,
+            Arc::new(MisbehaviorStore::new(&context)),
+        );
+
+        sleep(4 * FETCH_REQUEST_TIMEOUT).await;
+
+        // While solidification lags, the scheduler stands down entirely, so
+        // nothing is fetched.
+        let added_blocks = core_dispatcher.get_and_drain_block_headers().await;
+        assert_eq!(added_blocks, vec![]);
+
+        // AND solidify up to the last commit, closing the gap.
+        dag_state.write().update_last_solid_subdag_base(SubDagBase {
+            leader: BlockRef::new(12, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+            headers: vec![],
+            committed_header_refs: vec![],
+            timestamp_ms: 0,
+            commit_ref: CommitRef::new(12, CommitDigest::MIN),
+            reputation_scores_desc: vec![],
+        });
+
+        // Now stub again the missing blocks to fetch the exact same ones.
+        core_dispatcher
+            .stub_missing_block_headers(missing_blocks_refs)
             .await;
 
         sleep(2 * FETCH_REQUEST_TIMEOUT).await;


### PR DESCRIPTION
# Description of change

Consensus commits on header availability while solidification waits for transaction payloads, and nothing bounds how far the two can diverge: the round window in which shards and payloads are retained has its floor frozen at the last solid commit while its ceiling keeps rising with accepted headers, so a solidification stall grows memory without limit.

Mirror the existing commit-lag rejection with a check in the opposite direction:

- reject incoming block bundles when the last commit's leader runs more than `solid_commit_lag_threshold` rounds (default 500) ahead of the last solid commit's leader;
- stand the header synchronizer's periodic scheduler down entirely under the same condition (the commit-lag restricted mode would keep ratcheting the accepted frontier, and with it the retention ceiling);
- skip both during fast sync, where the lag is by design.

The transactions synchronizer, which fetches the missing payloads and closes the gap, is not gated, so recovery always progresses. This bounds how wide the retention window can grow during a stall; shrinking what a bounded window costs (eviction floor, byte caps) is follow-up work.

## Links to any relevant issues

Fixes iotaledger/iota-private#489 together with the follow-up PR bounding the shard pool.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

