### PR TITLE
refactor(iota-types): replace ExecutionErrorInner with the SDK ExecutionFailure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=5118a2404330fd05b5138c6da7f32abfc2e899d9#5118a2404330fd05b5138c6da7f32abfc2e899d9"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7593,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=5118a2404330fd05b5138c6da7f32abfc2e899d9#5118a2404330fd05b5138c6da7f32abfc2e899d9"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7625,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=5118a2404330fd05b5138c6da7f32abfc2e899d9#5118a2404330fd05b5138c6da7f32abfc2e899d9"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7633,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=5118a2404330fd05b5138c6da7f32abfc2e899d9#5118a2404330fd05b5138c6da7f32abfc2e899d9"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=5118a2404330fd05b5138c6da7f32abfc2e899d9#5118a2404330fd05b5138c6da7f32abfc2e899d9"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=5118a2404330fd05b5138c6da7f32abfc2e899d9#5118a2404330fd05b5138c6da7f32abfc2e899d9"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=5118a2404330fd05b5138c6da7f32abfc2e899d9#5118a2404330fd05b5138c6da7f32abfc2e899d9"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,9 +401,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "bdffc966f761252ebc21d8d64f946ebade044f60" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "5118a2404330fd05b5138c6da7f32abfc2e899d9" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "bdffc966f761252ebc21d8d64f946ebade044f60" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "5118a2404330fd05b5138c6da7f32abfc2e899d9" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -443,10 +443,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "5118a2404330fd05b5138c6da7f32abfc2e899d9", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "5118a2404330fd05b5138c6da7f32abfc2e899d9", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "5118a2404330fd05b5138c6da7f32abfc2e899d9", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "5118a2404330fd05b5138c6da7f32abfc2e899d9", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }
@@ -509,3 +509,4 @@ typed-store-error = { path = "crates/typed-store-error" }
 # so the workspace shares a single fastcrypto instead of two conflicting copies.
 [patch."https://github.com/MystenLabs/fastcrypto"]
 fastcrypto = "=0.1.11"
+

--- a/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
+++ b/crates/iota-grpc-server/src/transaction_execution_service/simulate.rs
@@ -298,32 +298,26 @@ async fn simulate_single_transaction(
                 if let Some(error_mask) =
                     result_mask.subtree(SimulatedTransaction::EXECUTION_ERROR_FIELD.name)
                 {
+                    let failure = execution_error.to_execution_failure();
                     let mut exec_error = ExecutionError::default();
 
                     // Serialize the execution error kind as BCS
                     if error_mask.contains(ExecutionError::BCS_KIND_FIELD.name) {
-                        exec_error.bcs_kind = Some(
-                            grpc_bcs::BcsData::serialize(execution_error.kind()).map_err(|e| {
+                        exec_error.bcs_kind =
+                            Some(grpc_bcs::BcsData::serialize(&failure.error).map_err(|e| {
                                 RpcError::new(
                                     tonic::Code::Internal,
                                     format!("failed to serialize execution error kind: {e}"),
                                 )
-                            })?,
-                        );
+                            })?);
                     }
 
                     if error_mask.contains(ExecutionError::SOURCE_FIELD.name) {
-                        exec_error.source = execution_error
-                            .source()
-                            .as_ref()
-                            .map(|source| source.to_string());
+                        exec_error.source = failure.source;
                     }
 
-                    // Set the command index if available
                     if error_mask.contains(ExecutionError::COMMAND_INDEX_FIELD.name) {
-                        if let Some(command_idx) = execution_error.command() {
-                            exec_error.command_index = Some(command_idx);
-                        }
+                        exec_error.command_index = failure.command;
                     }
 
                     response.execution_result = Some(

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -1033,24 +1033,13 @@ pub type ExecutionErrorKind = ExecutionFailureStatus;
 
 #[derive(Debug)]
 pub struct ExecutionError {
-    inner: Box<ExecutionErrorInner>,
-}
-
-#[derive(Debug)]
-struct ExecutionErrorInner {
-    kind: ExecutionErrorKind,
-    source: Option<BoxError>,
-    command: Option<u64>,
+    inner: Box<iota_sdk_types::ExecutionFailure<BoxError>>,
 }
 
 impl ExecutionError {
     pub fn new(kind: ExecutionErrorKind, source: Option<BoxError>) -> Self {
         Self {
-            inner: Box::new(ExecutionErrorInner {
-                kind,
-                source,
-                command: None,
-            }),
+            inner: Box::new(iota_sdk_types::ExecutionFailure::new(kind, source, None)),
         }
     }
 
@@ -1067,6 +1056,15 @@ impl ExecutionError {
         self
     }
 
+    /// The client-facing view of this error, with the source stringified.
+    pub fn to_execution_failure(&self) -> iota_sdk_types::ExecutionFailure {
+        iota_sdk_types::ExecutionFailure::new(
+            self.kind().clone(),
+            self.source().as_ref().map(|source| source.to_string()),
+            self.command(),
+        )
+    }
+
     /// Rewrap this error, produced while executing a Move authenticator, as a
     /// [`ExecutionFailureStatus::MoveAuthentication`]. The command index
     /// is dropped: it referred to a command of the authenticator's own
@@ -1074,10 +1072,10 @@ impl ExecutionError {
     /// effects, where it would otherwise collide with the first command of the
     /// programmable transaction.
     pub fn into_move_authentication_error(self) -> Self {
-        let ExecutionErrorInner { kind, source, .. } = *self.inner;
+        let iota_sdk_types::ExecutionFailure { error, source, .. } = *self.inner;
         Self::new(
             ExecutionFailureStatus::MoveAuthentication {
-                error: Box::new(kind),
+                error: Box::new(error),
             },
             source,
         )
@@ -1088,7 +1086,7 @@ impl ExecutionError {
     }
 
     pub fn kind(&self) -> &ExecutionErrorKind {
-        &self.inner.kind
+        &self.inner.error
     }
 
     pub fn command(&self) -> Option<u64> {
@@ -1106,14 +1104,7 @@ impl ExecutionError {
 
 impl std::fmt::Display for ExecutionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", self.inner.kind.as_ref(), self.inner.kind)?;
-        if let Some(source) = self.inner.source.as_ref() {
-            write!(f, "; caused by: {source}")?;
-        }
-        if let Some(command) = self.inner.command {
-            write!(f, "; at command index: {command}")?;
-        }
-        Ok(())
+        std::fmt::Display::fmt(&self.inner, f)
     }
 }
 
@@ -1134,4 +1125,17 @@ pub fn command_argument_error(e: CommandArgumentError, arg_idx: usize) -> Execut
         e,
         arg_idx as u16,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_failure_display_matches_execution_error() {
+        let error =
+            ExecutionError::new_with_source(ExecutionFailureStatus::InsufficientGas, "out of gas")
+                .with_command_index(2);
+        assert_eq!(error.to_execution_failure().to_string(), error.to_string());
+    }
 }


### PR DESCRIPTION
# Description of change

Replaces the internal `ExecutionErrorInner` with the SDK's new `ExecutionFailure` type (iotaledger/iota-rust-sdk#1361), so the structure of an execution failure — error kind, source, command index — and its `Display` format exist once, shared between the node and what clients get from the gRPC simulate response.

- `iota-types`: `ExecutionError` now wraps `iota_sdk_types::ExecutionFailure<BoxError>` (live error object as the source); the public accessors are unchanged. `to_execution_failure()` returns the client-facing form with the source stringified.
- `iota-grpc-server`: the simulate endpoint builds the error response from `to_execution_failure()` instead of extracting the fields by hand.
- A test pins that the internal error and its client-facing form render identically, so error strings are unchanged.

**Note:** the SDK rev currently points at the PR branch of iotaledger/iota-rust-sdk#1361; it will be bumped to the merge commit once that PR lands.

## Links to any relevant issues

fixes #10404

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-types -p iota-grpc-server --lib` (243 passed), `cargo check -p iota-adapter-latest`, clippy and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
