### PR TITLE
fix(starfish): let fast commit sync run its configured fetch parallelism

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -418,9 +418,11 @@ impl Parameters {
             // Exercise fast commit sync.
             5
         } else {
-            // With ~10KB per commit and 4MB max message size, 1000 commits (~10MB) requires
-            // chunking. The server will chunk commits across multiple response messages.
-            1000
+            // Sized so that commit_sync_parallel_fetches ranges fit under the
+            // unhandled-commits threshold (8 x 400 <= 3200), letting fast sync
+            // actually run its fetches in parallel. The server chunks larger
+            // responses across multiple messages either way.
+            400
         }
     }
 

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -49,7 +49,7 @@ tonic:
   subscribe_request_timeout:
     secs: 30
     nanos: 0
-fast_commit_sync_batch_size: 1000
+fast_commit_sync_batch_size: 400
 commit_sync_gap_threshold: 1000
 enable_fast_commit_syncer: true
 enable_commit_sync_peer_selection_by_commit_votes: true


### PR DESCRIPTION
# Description of change

Fast commit sync schedules 1000-commit ranges against the unhandled-commits backpressure threshold of 3200 (`commit_sync_batch_size` 100 × `commit_sync_batches_ahead` 32), so at most 3 ranges fit beyond the highest handled commit and at most 3 of the configured 8 parallel fetches ever run.

Reduce `fast_commit_sync_batch_size` from 1000 to 400 so that all 8 parallel fetches fit under the threshold (8 × 400 = 3200), keeping the memory bound the threshold encodes. Ranges are cut from the synced index while the threshold is anchored at the handled index, so one range is lost while the consumer trails the fetch frontier — 7 concurrent fetches in that state, still far above today's 3.

## Links to any relevant issues

Fixes #12728

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes