### PR TITLE
refactor: use the SDK clients' transaction_builder constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7593,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7625,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7633,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "base64ct",
  "bcs",
@@ -8312,7 +8312,6 @@ dependencies = [
  "iota-protocol-config",
  "iota-sdk-graphql-client",
  "iota-sdk-grpc-client",
- "iota-sdk-transaction-builder",
  "iota-sdk-types",
  "iota-transaction-checks",
  "iota-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,9 +401,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "bdffc966f761252ebc21d8d64f946ebade044f60" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "bdffc966f761252ebc21d8d64f946ebade044f60" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -443,10 +443,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-source-validation/src/tests.rs
+++ b/crates/iota-source-validation/src/tests.rs
@@ -15,7 +15,7 @@ use iota_json_rpc_types::{
 };
 use iota_move_build::{BuildConfig, CompiledPackage, IotaPackageHooks};
 use iota_sdk::wallet_context::WalletContext;
-use iota_sdk_transaction_builder::{TransactionBuilder, assigned};
+use iota_sdk_transaction_builder::assigned;
 use iota_sdk_types::{Address, MovePackageData, ObjectId, ObjectReference, TransactionDigest};
 use iota_test_transaction_builder::{make_publish_transaction, make_publish_transaction_with_deps};
 use iota_types::{
@@ -879,7 +879,7 @@ pub async fn upgrade_package_with_wallet(
     let transaction = {
         let package_data = MovePackageData::new(all_module_bytes, dep_ids);
 
-        let mut builder = TransactionBuilder::new(sender).with_client(&grpc_client);
+        let mut builder = grpc_client.transaction_builder(sender);
         builder.gas_price(gas_price);
         builder.gas_budget(TEST_ONLY_GAS_UNIT_FOR_PUBLISH * 2 * gas_price);
 

--- a/crates/iota-test-transaction-builder/src/lib.rs
+++ b/crates/iota-test-transaction-builder/src/lib.rs
@@ -15,7 +15,7 @@ use iota_sdk::{
     wallet_context::WalletContext,
 };
 use iota_sdk_crypto::Signer;
-use iota_sdk_transaction_builder::{PTBArgumentList, TransactionBuilder};
+use iota_sdk_transaction_builder::PTBArgumentList;
 use iota_sdk_types::{
     Address, Identifier, Input, ObjectId, ObjectReference, Owner, ProgrammableTransaction,
     SharedObjectReference, StructTag, Transaction, TransactionDigest, TransactionKind, TypeTag,
@@ -799,7 +799,8 @@ pub async fn delete_nft(
 
 /// Fetch one IOTA coin owned by `sender` to use as an explicit gas coin.
 ///
-/// Without an explicit gas coin, [`TransactionBuilder::finish`] auto-adds
+/// Without an explicit gas coin,
+/// [`TransactionBuilder::finish`](iota_sdk_transaction_builder::TransactionBuilder::finish) auto-adds
 /// every IOTA coin the sender owns as gas inputs and merges the leftover into
 /// one output coin, breaking tests that observe the sender's coin count.
 pub async fn select_gas_coin(grpc_client: &iota_grpc_client::Client, sender: Address) -> ObjectId {
@@ -840,7 +841,7 @@ pub async fn move_call_tx<A: PTBArgumentList>(
     args: A,
     gas_budget: u64,
 ) -> Transaction {
-    let mut builder = TransactionBuilder::new(sender).with_client(grpc_client);
+    let mut builder = grpc_client.transaction_builder(sender);
 
     builder
         .move_call(package_id, module, function)
@@ -888,7 +889,7 @@ pub async fn split_coin_equal_tx(
     let amount_per_split = coin_balance / num_coins;
     let split_amounts: Vec<u64> = vec![amount_per_split; (num_coins - 1) as usize];
 
-    let mut builder = TransactionBuilder::new(sender).with_client(grpc_client);
+    let mut builder = grpc_client.transaction_builder(sender);
 
     // Split off the new coin and transfer it back to the sender; an untransferred
     // `Coin` would be an unused PTB value (coins have no `drop`) and the

--- a/crates/iota-vm-sdk/Cargo.toml
+++ b/crates/iota-vm-sdk/Cargo.toml
@@ -67,7 +67,6 @@ serde-wasm-bindgen = { version = "0.6", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 
 [dev-dependencies]
-# external dependencies
 anyhow.workspace = true
 fastcrypto.workspace = true
 serde.workspace = true

--- a/crates/iota-vm-sdk/Cargo.toml
+++ b/crates/iota-vm-sdk/Cargo.toml
@@ -73,9 +73,6 @@ fastcrypto.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
-# internal dependencies
-iota-sdk-transaction-builder.workspace = true
-
 [[example]]
 name = "offline_dev_inspect"
 path = "examples/offline_dev_inspect.rs"
@@ -94,11 +91,6 @@ required-features = ["grpc"]
 name = "stake_graphql"
 path = "examples/stake_graphql.rs"
 required-features = ["graphql"]
-
-[package.metadata.cargo-udeps.ignore]
-development = [
-  "iota-sdk-transaction-builder",
-]
 
 [lints]
 workspace = true

--- a/crates/iota-vm-sdk/examples/stake_graphql.rs
+++ b/crates/iota-vm-sdk/examples/stake_graphql.rs
@@ -14,7 +14,6 @@
 
 use anyhow::{Context, Result};
 use iota_sdk_graphql_client::Client;
-use iota_sdk_transaction_builder::TransactionBuilder;
 use iota_sdk_types::Address;
 use iota_vm_sdk::{ExecuteOptions, LocalVm, Transaction, graphql::GraphQLStore};
 
@@ -30,7 +29,7 @@ async fn main() -> Result<()> {
 
     // Build the staking transaction.
     let client = Client::new_testnet();
-    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+    let mut builder = client.transaction_builder(sender);
     builder.stake(stake_amount_nanos, validator);
     let tx: Transaction = builder.finish().await.context("resolve staking tx")?;
 

--- a/crates/iota-vm-sdk/examples/stake_grpc.rs
+++ b/crates/iota-vm-sdk/examples/stake_grpc.rs
@@ -14,7 +14,6 @@
 
 use anyhow::{Context, Result};
 use iota_grpc_client::Client;
-use iota_sdk_transaction_builder::TransactionBuilder;
 use iota_sdk_types::Address;
 use iota_vm_sdk::{ExecuteOptions, LocalVm, Transaction, grpc::GrpcStore};
 
@@ -30,7 +29,7 @@ async fn main() -> Result<()> {
 
     // Build the staking transaction.
     let client = Client::new_testnet().context("connect testnet gRPC client")?;
-    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+    let mut builder = client.transaction_builder(sender);
     builder.stake(stake_amount_nanos, validator);
     let tx: Transaction = builder.finish().await.context("resolve staking tx")?;
 

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -52,7 +52,7 @@ use iota_sdk::{
     iota_client_config::{IotaClientConfig, IotaEnv},
     wallet_context::WalletContext,
 };
-use iota_sdk_transaction_builder::{TransactionBuilder, TransactionBuilderClient, unresolved};
+use iota_sdk_transaction_builder::{TransactionBuilderClient, unresolved};
 use iota_sdk_types::{
     Address, Identifier, MoveAuthenticatorV1, MovePackageData, ObjectId, ObjectReference, Owner,
     SenderSignedTransaction, SharedObjectReference, SignatureScheme, StructTag, Transaction,
@@ -1011,7 +1011,7 @@ impl IotaClientCommands {
                 }
 
                 let grpc_client = context.get_grpc_client().await?;
-                let mut builder = TransactionBuilder::new(sender).with_client(&grpc_client);
+                let mut builder = grpc_client.transaction_builder(sender);
                 builder.upgrade_package(
                     package_id,
                     package_data,
@@ -1135,7 +1135,7 @@ impl IotaClientCommands {
                 );
 
                 let grpc_client = context.get_grpc_client().await?;
-                let mut builder = TransactionBuilder::new(sender).with_client(&grpc_client);
+                let mut builder = grpc_client.transaction_builder(sender);
                 let upgrade_cap = builder.publish_package(package_data).result();
                 builder.transfer_objects(sender, [upgrade_cap]);
                 let tx_kind = builder.finish_kind().await?;
@@ -1362,7 +1362,7 @@ impl IotaClientCommands {
                 let signer = context.get_object_owner(&object_id).await?;
                 let to = get_identity_address(Some(to), context).await?;
                 let client = context.get_grpc_client().await?;
-                let mut builder = TransactionBuilder::new(signer).with_client(&client);
+                let mut builder = client.transaction_builder(signer);
                 builder.transfer_objects(to, [object_id]);
                 let tx_kind = builder.finish_kind().await?;
                 let gas_payment = grpc_input_refs(&client, &payment.gas).await?;
@@ -1412,7 +1412,7 @@ impl IotaClientCommands {
                     .await?;
                 let signer = context.get_object_owner(&input_coins[0]).await?;
                 let client = context.get_grpc_client().await?;
-                let mut builder = TransactionBuilder::new(signer).with_client(&client);
+                let mut builder = client.transaction_builder(signer);
                 builder.pay(input_coins.clone(), recipients.into_iter().zip(amounts));
                 let tx_kind = builder.finish_kind().await?;
                 let gas_payment = grpc_input_refs(&client, &payment.gas).await?;
@@ -1458,7 +1458,7 @@ impl IotaClientCommands {
                 let signer =
                     get_identity_address(processing.sender.map(Into::into), context).await?;
                 let client = context.get_grpc_client().await?;
-                let mut builder = TransactionBuilder::new(signer).with_client(&client);
+                let mut builder = client.transaction_builder(signer);
                 builder.pay_iota(recipients.into_iter().zip(amounts.iter().copied()));
                 let tx_kind = builder.finish_kind().await?;
 
@@ -1515,7 +1515,7 @@ impl IotaClientCommands {
                 let recipient = get_identity_address(Some(recipient), context).await?;
                 let signer = context.get_object_owner(&input_coins[0]).await?;
                 let client = context.get_grpc_client().await?;
-                let mut builder = TransactionBuilder::new(signer).with_client(&client);
+                let mut builder = client.transaction_builder(signer);
                 builder.transfer_objects(recipient, [unresolved::Argument::Gas]);
                 let tx_kind = builder.finish_kind().await?;
                 let gas_payment = grpc_input_refs(&client, &input_coins).await?;
@@ -1677,7 +1677,7 @@ impl IotaClientCommands {
                     && iota_coins.next_page_token.is_none()
                     && iota_coins.items[0].id() == &coin_id;
 
-                let mut builder = TransactionBuilder::new(signer).with_client(&client);
+                let mut builder = client.transaction_builder(signer);
                 let (coin, coin_type) = if split_from_gas {
                     (
                         builder.apply_argument(unresolved::Argument::Gas),
@@ -1734,7 +1734,7 @@ impl IotaClientCommands {
                 let signer = context.get_object_owner(&primary_coin).await?;
                 let client = context.get_grpc_client().await?;
 
-                let mut builder = TransactionBuilder::new(signer).with_client(&client);
+                let mut builder = client.transaction_builder(signer);
                 builder.merge_coins(primary_coin, [coin_to_merge]);
                 let tx_kind = builder.finish_kind().await?;
                 let gas_payment = grpc_input_refs(&client, &payment.gas).await?;

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=bdffc966f761252ebc21d8d64f946ebade044f60#bdffc966f761252ebc21d8d64f946ebade044f60"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "bdffc966f761252ebc21d8d64f946ebade044f60" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
# Description of change

Adopts the `transaction_builder` constructors added to the SDK's gRPC and GraphQL clients in iotaledger/iota-rust-sdk#1359, so the client a builder resolves against is visible at the call site.

- Bump the `iota-rust-sdk` pin to the merge commit of that PR (the only other commit in between is FFI-bindings-only).
- Replace `TransactionBuilder::new(sender).with_client(client)` with `client.transaction_builder(sender)` in the CLI commands, `iota-test-transaction-builder`, the source-validation tests, and the `iota-vm-sdk` staking examples (which also drop a client clone).
- Remove the now-unused `iota-sdk-transaction-builder` dev-dependency of `iota-vm-sdk` and its cargo-udeps ignore entry.

`TestCluster::grpc_transaction_builder` keeps the old pattern: it returns a builder owning its client, while the new constructor borrows it.

## Links to any relevant issues

-

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)