### PR TITLE
fix(starfish): report a cut commit fetch stream as a connection failure

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1993,7 +1993,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -594,7 +594,12 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // 1. Fetch commits, voting headers, and transactions in the commit range from
         //    the target authority. Each transaction is serialized as
         //    SerializedTransactionsV2 which includes the TransactionRef.
-        let (serialized_commits, serialized_proof_for_last_commit, serialized_transactions) = inner
+        let (
+            serialized_commits,
+            serialized_proof_for_last_commit,
+            serialized_transactions,
+            stream_error,
+        ) = inner
             .network_client
             .fetch_commits_and_transactions(target_authority, commit_range.clone(), timeout)
             .await?;
@@ -659,12 +664,17 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         // the scheduler requeues the range after the prefix.
         if !committed_tx_refs.is_empty() {
             let fetched_commits = commits.len();
-            truncate_to_fully_fetched_prefix(
+            if let Err(mismatch) = truncate_to_fully_fetched_prefix(
                 target_authority,
                 &mut commits,
                 &mut commits_tx_refs,
                 &mut fetched_transactions,
-            )?;
+            ) {
+                // A cut stream explains the empty covered prefix: report the
+                // connection failure rather than transactions the peer was
+                // never able to send.
+                return Err(stream_error.unwrap_or(mismatch));
+            }
             info!(
                 "[{}] Fetched transactions cover only {} out of {} commits received from {}, processing the covered prefix",
                 inner.sync_type.as_str(),
@@ -1406,6 +1416,36 @@ mod tests {
 
             assert!(
                 matches!(err, ConsensusError::FetchedTransactionsMismatch { .. }),
+                "unexpected error: {err:?}"
+            );
+            assert_unprovable_faults(&inner, vec![0; 4]);
+        }
+
+        /// When no commit is covered because the response stream was cut, the
+        /// fetch reports the connection failure, not a transaction mismatch
+        /// blamed on the peer.
+        #[tokio::test]
+        async fn cut_stream_covering_no_commit_reports_the_cut() {
+            let context = fast_sync_context();
+            let (commits, vote_headers, _) = two_commit_response(&context);
+            let network_client = Arc::new(FakeNetworkClient {
+                commits_and_transactions: Some((commits, vote_headers, vec![])),
+                stream_error_message: Some("stream cut".to_string()),
+                ..Default::default()
+            });
+            let inner = make_inner(context, network_client);
+
+            let err = FastCommitSyncer::fetch_once(
+                inner.clone(),
+                AuthorityIndex::new_for_test(1),
+                (1..=2).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap_err();
+
+            assert!(
+                matches!(err, ConsensusError::NetworkRequest(_)),
                 "unexpected error: {err:?}"
             );
             assert_unprovable_faults(&inner, vec![0; 4]);

--- a/crates/starfish/core/src/commit_syncer/mod.rs
+++ b/crates/starfish/core/src/commit_syncer/mod.rs
@@ -948,6 +948,9 @@ pub(crate) mod tests {
     #[derive(Default)]
     pub(crate) struct FakeNetworkClient {
         pub(crate) commits_and_transactions: Option<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)>,
+        /// When set, the canned response is served as a stream cut by this
+        /// error, the way the tonic client reports a mid-stream failure.
+        pub(crate) stream_error_message: Option<String>,
         /// Waited out before answering, so a test can pin the latency the fetch
         /// loop records.
         pub(crate) response_delay: Duration,
@@ -1015,11 +1018,18 @@ pub(crate) mod tests {
             peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)> {
             self.requested_peers.lock().push(peer);
             sleep(self.response_delay).await;
             match &self.commits_and_transactions {
-                Some(response) => Ok(response.clone()),
+                Some((commits, headers, transactions)) => Ok((
+                    commits.clone(),
+                    headers.clone(),
+                    transactions.clone(),
+                    self.stream_error_message
+                        .clone()
+                        .map(ConsensusError::NetworkRequest),
+                )),
                 None => Err(ConsensusError::NoCommitReceived { peer }),
             }
         }

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -2037,7 +2037,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)> {
             unimplemented!("fetch_commits_and_transactions not implemented in mock")
         }
     }

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -227,7 +227,7 @@ mod tests {
         core_thread::tests::MockCoreThreadDispatcher,
         dag_state::DagState,
         encoder::create_encoder,
-        error::ConsensusResult,
+        error::{ConsensusError, ConsensusResult},
         leader_timeout::LeaderTimeoutTask,
         network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
@@ -292,7 +292,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -131,12 +131,17 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
     /// Returns serialized commits, serialized headers voting for the last
     /// commit, and serialized transactions (as SerializedTransactionsV2 which
     /// includes TransactionRef). Used in the fast commit syncer.
+    ///
+    /// When the response stream is cut by an error after commits were
+    /// received, the buffers hold what arrived and the error is returned
+    /// alongside them, so the caller can attribute missing transactions to
+    /// the connection rather than to the peer's data.
     async fn fetch_commits_and_transactions(
         &self,
         peer: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)>;
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)>;
 
     /// Fetches the latest block from `peer` for the requested `authorities`.
     /// The latest blocks are returned in the serialised format of

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -12,7 +12,7 @@ use std::{
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::{Stream, StreamExt as _, stream};
+use futures::{Stream, StreamExt as _, TryStreamExt as _, stream};
 use iota_http::ServerHandle;
 use iota_network_stack::{
     Multiaddr,
@@ -422,14 +422,14 @@ impl NetworkClient for TonicClient {
         peer: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)> {
         let mut client = self.get_client(peer, timeout).await?;
         let mut request = Request::new(FetchCommitsAndTransactionsRequest {
             start: commit_range.start(),
             end: commit_range.end(),
         });
         request.set_timeout(timeout);
-        let mut stream = client
+        let stream = client
             .fetch_commits_and_transactions(request)
             .await
             .map_err(|e| {
@@ -445,135 +445,155 @@ impl NetworkClient for TonicClient {
             })?
             .into_inner();
 
-        // First chunk contains commits and certifier headers.
-        //
-        // Bound the response per element and per category while streaming, since
-        // `verify_commits` only runs on the fully-received buffers and so cannot
-        // protect them from a malicious server. Commits and certifier headers
-        // carry the same count caps `verify_commits` applies
-        // (`2 * fast_commit_sync_batch_size` and two headers per authority).
-        // Transactions have no count cap on the fast path — the server returns
-        // every transaction the committed range references — so only their
-        // per-element size is enforced here; their count is validated against
-        // the commits downstream, and the coarse total below bounds the buffer.
-        let committee_size = self.context.committee.size();
-        let gc_depth = self.context.protocol_config.gc_depth() as usize;
-        let max_commits = CommitSyncType::Fast.max_commits_per_response(&self.context);
-        let max_certifier_headers =
-            committee_size.saturating_mul(MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY);
-        let max_commit_size = max_commit_bytes(committee_size, gc_depth);
-        let max_header_size = max_signed_block_header_bytes(committee_size);
-        let max_transaction_size = serialized_transactions_size_limit(&self.context);
-        // Coarse total backstop for the buffer. The commit and certifier-header
-        // terms reuse the per-category caps above so the total never trips
-        // before them; the transaction term uses the commit-sync fetch cap as a
-        // coarse allowance, since the fast path has no transaction count cap.
-        let max_allowed_bytes = max_commits
-            .saturating_mul(max_commit_size)
-            .saturating_add(max_certifier_headers.saturating_mul(max_header_size))
-            .saturating_add(
-                self.context
-                    .parameters
-                    .max_transactions_per_commit_sync_fetch
-                    .saturating_mul(max_transaction_size),
-            );
+        collect_commits_and_transactions(&self.context, peer, stream).await
+    }
+}
 
-        let mut commits = Vec::new();
-        let mut certifier_block_headers = Vec::new();
-        let mut transactions = Vec::new();
-        let mut total_fetched_bytes = 0;
+/// Collects the chunks of a `fetch_commits_and_transactions` response stream
+/// into the commit, certifier-header and transaction buffers. A stream cut by
+/// an error after commits arrived yields the delivered chunks plus the error.
+async fn collect_commits_and_transactions<S>(
+    context: &Context,
+    peer: AuthorityIndex,
+    mut stream: S,
+) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)>
+where
+    S: Stream<Item = Result<FetchCommitsAndTransactionsResponse, tonic::Status>> + Unpin,
+{
+    // First chunk contains commits and certifier headers.
+    //
+    // Bound the response per element and per category while streaming, since
+    // `verify_commits` only runs on the fully-received buffers and so cannot
+    // protect them from a malicious server. Commits and certifier headers
+    // carry the same count caps `verify_commits` applies
+    // (`2 * fast_commit_sync_batch_size` and two headers per authority).
+    // Transactions have no count cap on the fast path — the server returns
+    // every transaction the committed range references — so only their
+    // per-element size is enforced here; their count is validated against
+    // the commits downstream, and the coarse total below bounds the buffer.
+    let committee_size = context.committee.size();
+    let gc_depth = context.protocol_config.gc_depth() as usize;
+    let max_commits = CommitSyncType::Fast.max_commits_per_response(context);
+    let max_certifier_headers =
+        committee_size.saturating_mul(MAX_COMMIT_VOTE_HEADERS_PER_AUTHORITY);
+    let max_commit_size = max_commit_bytes(committee_size, gc_depth);
+    let max_header_size = max_signed_block_header_bytes(committee_size);
+    let max_transaction_size = serialized_transactions_size_limit(context);
+    // Coarse total backstop for the buffer. The commit and certifier-header
+    // terms reuse the per-category caps above so the total never trips
+    // before them; the transaction term uses the commit-sync fetch cap as a
+    // coarse allowance, since the fast path has no transaction count cap.
+    let max_allowed_bytes = max_commits
+        .saturating_mul(max_commit_size)
+        .saturating_add(max_certifier_headers.saturating_mul(max_header_size))
+        .saturating_add(
+            context
+                .parameters
+                .max_transactions_per_commit_sync_fetch
+                .saturating_mul(max_transaction_size),
+        );
 
-        loop {
-            match stream.message().await {
-                Ok(Some(response)) => {
-                    // Commits (typically in the first chunk): count cap + per-element size.
-                    if commits.len() + response.commits.len() > max_commits {
-                        return Err(ConsensusError::TooManyCommitsFromPeer {
-                            peer,
-                            count: (commits.len() + response.commits.len()) as CommitIndex,
-                            limit: max_commits as CommitIndex,
-                        });
-                    }
-                    for c in &response.commits {
-                        if c.len() > max_commit_size {
-                            return Err(ConsensusError::SerializedCommitTooLarge {
-                                peer,
-                                size: c.len(),
-                                limit: max_commit_size,
-                            });
-                        }
-                        total_fetched_bytes += c.len();
-                    }
-                    commits.extend(response.commits);
+    let mut commits = Vec::new();
+    let mut certifier_block_headers = Vec::new();
+    let mut transactions = Vec::new();
+    let mut total_fetched_bytes = 0;
+    let mut stream_error = None;
 
-                    // Certifier headers: count cap + per-element size.
-                    if certifier_block_headers.len() + response.certifier_block_headers.len()
-                        > max_certifier_headers
-                    {
-                        return Err(ConsensusError::TooManyCommitVoteHeaders {
-                            peer,
-                            count: certifier_block_headers.len()
-                                + response.certifier_block_headers.len(),
-                            limit: max_certifier_headers,
-                        });
-                    }
-                    for h in &response.certifier_block_headers {
-                        if h.len() > max_header_size {
-                            return Err(ConsensusError::SerializedBlockHeaderTooLarge {
-                                peer,
-                                size: h.len(),
-                                limit: max_header_size,
-                            });
-                        }
-                        total_fetched_bytes += h.len();
-                    }
-                    certifier_block_headers.extend(response.certifier_block_headers);
-
-                    // Transactions (streamed in subsequent chunks): per-element size only.
-                    for t in &response.transactions {
-                        if t.len() > max_transaction_size {
-                            return Err(ConsensusError::SerializedTransactionsTooLarge {
-                                size: t.len(),
-                                limit: max_transaction_size,
-                            });
-                        }
-                        total_fetched_bytes += t.len();
-                    }
-                    transactions.extend(response.transactions);
-
-                    // Coarse total backstop bounding the transaction buffer, which
-                    // has no precise count cap on the fast path.
-                    if total_fetched_bytes > max_allowed_bytes {
-                        info!(
-                            "fetch_commits_and_transactions() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, max_allowed_bytes,
-                        );
-                        break;
-                    }
+    loop {
+        match stream.try_next().await {
+            Ok(Some(response)) => {
+                // Commits (typically in the first chunk): count cap + per-element size.
+                if commits.len() + response.commits.len() > max_commits {
+                    return Err(ConsensusError::TooManyCommitsFromPeer {
+                        peer,
+                        count: (commits.len() + response.commits.len()) as CommitIndex,
+                        limit: max_commits as CommitIndex,
+                    });
                 }
-                Ok(None) => {
+                for c in &response.commits {
+                    if c.len() > max_commit_size {
+                        return Err(ConsensusError::SerializedCommitTooLarge {
+                            peer,
+                            size: c.len(),
+                            limit: max_commit_size,
+                        });
+                    }
+                    total_fetched_bytes += c.len();
+                }
+                commits.extend(response.commits);
+
+                // Certifier headers: count cap + per-element size.
+                if certifier_block_headers.len() + response.certifier_block_headers.len()
+                    > max_certifier_headers
+                {
+                    return Err(ConsensusError::TooManyCommitVoteHeaders {
+                        peer,
+                        count: certifier_block_headers.len()
+                            + response.certifier_block_headers.len(),
+                        limit: max_certifier_headers,
+                    });
+                }
+                for h in &response.certifier_block_headers {
+                    if h.len() > max_header_size {
+                        return Err(ConsensusError::SerializedBlockHeaderTooLarge {
+                            peer,
+                            size: h.len(),
+                            limit: max_header_size,
+                        });
+                    }
+                    total_fetched_bytes += h.len();
+                }
+                certifier_block_headers.extend(response.certifier_block_headers);
+
+                // Transactions (streamed in subsequent chunks): per-element size only.
+                for t in &response.transactions {
+                    if t.len() > max_transaction_size {
+                        return Err(ConsensusError::SerializedTransactionsTooLarge {
+                            size: t.len(),
+                            limit: max_transaction_size,
+                        });
+                    }
+                    total_fetched_bytes += t.len();
+                }
+                transactions.extend(response.transactions);
+
+                // Coarse total backstop bounding the transaction buffer, which
+                // has no precise count cap on the fast path.
+                if total_fetched_bytes > max_allowed_bytes {
+                    info!(
+                        "fetch_commits_and_transactions() fetched bytes exceeded limit: {} > {}, terminating stream.",
+                        total_fetched_bytes, max_allowed_bytes,
+                    );
                     break;
                 }
-                Err(e) => {
-                    if commits.is_empty() {
-                        if e.code() == tonic::Code::DeadlineExceeded {
-                            return Err(ConsensusError::NetworkRequestTimeout(format!(
-                                "fetch_commits_and_transactions failed mid-stream: {e:?}"
-                            )));
-                        }
-                        return Err(ConsensusError::NetworkRequest(format!(
-                            "fetch_commits_and_transactions failed mid-stream: {e:?}"
-                        )));
-                    } else {
-                        warn!("fetch_commits_and_transactions failed mid-stream: {e:?}");
-                        break;
-                    }
+            }
+            Ok(None) => {
+                break;
+            }
+            Err(e) => {
+                let error = if e.code() == tonic::Code::DeadlineExceeded {
+                    ConsensusError::NetworkRequestTimeout(format!(
+                        "fetch_commits_and_transactions failed mid-stream: {e:?}"
+                    ))
+                } else {
+                    ConsensusError::NetworkRequest(format!(
+                        "fetch_commits_and_transactions failed mid-stream: {e:?}"
+                    ))
+                };
+                if commits.is_empty() {
+                    return Err(error);
                 }
+                // Keep what arrived and surface the cut alongside it: only
+                // the caller can tell whether the delivered chunks cover
+                // anything usable.
+                warn!("fetch_commits_and_transactions from {peer} failed mid-stream: {e:?}");
+                stream_error = Some(error);
+                break;
             }
         }
-
-        Ok((commits, certifier_block_headers, transactions))
     }
+
+    Ok((commits, certifier_block_headers, transactions, stream_error))
 }
 
 // Tonic channel wrapped with layers.
@@ -1655,11 +1675,106 @@ fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
 mod tests {
     use std::sync::Arc;
 
-    use super::{max_fetch_block_headers_response_bytes, max_fetch_transactions_response_bytes};
+    use bytes::Bytes;
+    use futures::stream;
+    use starfish_config::AuthorityIndex;
+
+    use super::{
+        FetchCommitsAndTransactionsResponse, collect_commits_and_transactions,
+        max_fetch_block_headers_response_bytes, max_fetch_transactions_response_bytes,
+    };
     use crate::{
         block_header::max_signed_block_header_bytes,
         block_verifier::serialized_transactions_size_limit, context::Context,
+        error::ConsensusError,
     };
+
+    fn chunk(commits: usize, transactions: usize) -> FetchCommitsAndTransactionsResponse {
+        FetchCommitsAndTransactionsResponse {
+            commits: vec![Bytes::from_static(b"commit"); commits],
+            certifier_block_headers: vec![],
+            transactions: vec![Bytes::from_static(b"transaction"); transactions],
+        }
+    }
+
+    /// A stream cut before anything arrived delivers nothing to keep, so the
+    /// fetch fails outright.
+    #[tokio::test]
+    async fn cut_before_any_commit_fails_the_fetch() {
+        let (context, _keys) = Context::new_for_test(4);
+        let peer = AuthorityIndex::new_for_test(1);
+        let cut = stream::iter([Err(tonic::Status::unknown("h2 protocol error"))]);
+
+        let result = collect_commits_and_transactions(&context, peer, cut).await;
+
+        assert!(matches!(result, Err(ConsensusError::NetworkRequest(_))));
+    }
+
+    /// A cut after commits arrived keeps the delivered chunks and returns the
+    /// error alongside them, so the caller can attribute missing transactions
+    /// to the connection instead of the peer's data.
+    #[tokio::test]
+    async fn cut_after_commits_keeps_the_delivered_chunks_and_the_error() {
+        let (context, _keys) = Context::new_for_test(4);
+        let peer = AuthorityIndex::new_for_test(1);
+        let cut = stream::iter([
+            Ok(chunk(2, 0)),
+            Ok(chunk(0, 3)),
+            Err(tonic::Status::unknown("h2 protocol error")),
+        ]);
+
+        let (commits, _headers, transactions, stream_error) =
+            collect_commits_and_transactions(&context, peer, cut)
+                .await
+                .expect("a cut after commits arrived keeps them");
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(transactions.len(), 3);
+        assert!(matches!(
+            stream_error,
+            Some(ConsensusError::NetworkRequest(_))
+        ));
+    }
+
+    /// A stream that ends cleanly carries no error, so missing transactions
+    /// stay attributable to the peer.
+    #[tokio::test]
+    async fn clean_end_carries_no_error() {
+        let (context, _keys) = Context::new_for_test(4);
+        let peer = AuthorityIndex::new_for_test(1);
+        let clean = stream::iter([Ok(chunk(2, 3))]);
+
+        let (commits, _headers, transactions, stream_error) =
+            collect_commits_and_transactions(&context, peer, clean)
+                .await
+                .expect("a clean stream is kept in full");
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(transactions.len(), 3);
+        assert!(stream_error.is_none());
+    }
+
+    /// A deadline reached mid-stream is reported as a timeout, so the caller
+    /// can tell an expired request from a broken connection.
+    #[tokio::test]
+    async fn cut_by_the_deadline_reports_a_timeout() {
+        let (context, _keys) = Context::new_for_test(4);
+        let peer = AuthorityIndex::new_for_test(1);
+        let cut = stream::iter([
+            Ok(chunk(2, 0)),
+            Err(tonic::Status::deadline_exceeded("deadline")),
+        ]);
+
+        let (_commits, _headers, _transactions, stream_error) =
+            collect_commits_and_transactions(&context, peer, cut)
+                .await
+                .expect("a cut after commits arrived keeps them");
+
+        assert!(matches!(
+            stream_error,
+            Some(ConsensusError::NetworkRequestTimeout(_))
+        ));
+    }
 
     /// The per-fetch response budgets track the matching server-side count cap:
     /// the value is the cap times the maximum per-item size, depends only on

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -348,7 +348,7 @@ mod test {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -3131,7 +3131,7 @@ mod tests {
             _peer: AuthorityIndex,
             _commit_range: CommitRange,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>, Vec<Bytes>, Option<ConsensusError>)> {
             unimplemented!("fetch_commits_and_transactions not implemented in mock")
         }
     }


### PR DESCRIPTION
# Description of change

When `fetch_commits_and_transactions` received commits before its response stream failed, the network client returned the partial response without the stream error. If the received transactions covered no commit, fast commit sync then reported `FetchedTransactionsMismatch` instead of the underlying network error.

Preserve the stream error alongside the partial response. Report it when no usable commit prefix exists; otherwise continue processing the covered prefix as before.

This changes error reporting and metrics only. Retry, peer ranking, and partial-progress behavior are unchanged.

On a testnet validator, all 333 mismatches with `received == 0` over 24 hours were preceded by a swallowed mid-stream error; 415 such errors occurred in total.

## Links to any relevant issues

Fixes #12731

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests
- [x] Added tests covering cut and cleanly completed streams