### PR TITLE
fix(consensus): bound shard-reconstructor memory per relaying authority

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -482,8 +482,9 @@ impl Parameters {
     }
 
     pub(crate) fn default_shard_budget_per_authority() -> u32 {
-        // ~20 rounds of full-committee reconstruction depth (honest need is a
-        // few rounds); worst-case pool ≈ 1.5 MB × budget across authorities.
+        // Honest need per authority is one shard per slot times a few rounds
+        // until decode, well under the budget at any realistic committee size.
+        // Worst-case total pool ≈ 3 × budget × the maximum payload size.
         1000
     }
 }

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -189,7 +189,7 @@ pub struct Parameters {
 
     /// Maximum number of shards from one relaying authority retained across
     /// all pending shard accumulators. At the budget, admitting a new shard
-    /// from the authority evicts its stalest retained one, so reconstructor
+    /// from the authority evicts its oldest retained one, so reconstructor
     /// memory stays bounded by `committee size × budget × shard size`
     /// regardless of how far commits run ahead of solidification.
     #[serde(default = "Parameters::default_shard_budget_per_authority")]

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -186,6 +186,14 @@ pub struct Parameters {
     /// bundles and restricts header fetching, until solidification catches up.
     #[serde(default = "Parameters::default_solid_commit_lag_threshold")]
     pub solid_commit_lag_threshold: u32,
+
+    /// Maximum number of shards from one relaying authority retained across
+    /// all pending shard accumulators. At the budget, admitting a new shard
+    /// from the authority evicts its stalest retained one, so reconstructor
+    /// memory stays bounded by `committee size × budget × shard size`
+    /// regardless of how far commits run ahead of solidification.
+    #[serde(default = "Parameters::default_shard_budget_per_authority")]
+    pub shard_budget_per_authority: u32,
 }
 
 impl Parameters {
@@ -316,6 +324,10 @@ impl Parameters {
             (
                 "tonic.keepalive_interval",
                 self.tonic.keepalive_interval.as_nanos(),
+            ),
+            (
+                "shard_budget_per_authority",
+                self.shard_budget_per_authority as u128,
             ),
         ];
         for (name, value) in positive_fields {
@@ -468,6 +480,14 @@ impl Parameters {
         // stall can keep widening the shard/payload retention window.
         500
     }
+
+    pub(crate) fn default_shard_budget_per_authority() -> u32 {
+        // Honest need is the reconstruction pipeline depth: committee-size
+        // shards per round times a few rounds until decode. 1000 covers ~20
+        // rounds of full-committee reconstruction with a worst-case pool of
+        // ~1.5 MB × budget across all authorities.
+        1000
+    }
 }
 
 impl Default for Parameters {
@@ -508,6 +528,7 @@ impl Default for Parameters {
                 Parameters::default_enable_peer_responsiveness_ranking(),
             dag_visualizer_port: None,
             solid_commit_lag_threshold: Parameters::default_solid_commit_lag_threshold(),
+            shard_budget_per_authority: Parameters::default_shard_budget_per_authority(),
         }
     }
 }

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -482,10 +482,8 @@ impl Parameters {
     }
 
     pub(crate) fn default_shard_budget_per_authority() -> u32 {
-        // Honest need is the reconstruction pipeline depth: committee-size
-        // shards per round times a few rounds until decode. 1000 covers ~20
-        // rounds of full-committee reconstruction with a worst-case pool of
-        // ~1.5 MB × budget across all authorities.
+        // ~20 rounds of full-committee reconstruction depth (honest need is a
+        // few rounds); worst-case pool ≈ 1.5 MB × budget across authorities.
         1000
     }
 }

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -57,3 +57,4 @@ enable_starfish_speed_adaptive_acknowledgments: true
 enable_peer_responsiveness_ranking: true
 dag_visualizer_port: ~
 solid_commit_lag_threshold: 500
+shard_budget_per_authority: 1000

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -1494,7 +1494,7 @@ impl NodeMetrics {
             ).unwrap(),
             shard_reconstructor_dropped_shards: register_int_counter_vec_with_registry!(
                 "shard_reconstructor_dropped_shards",
-                "Number of shards dropped by the reconstructor's admission rules, by reason: the relaying peer already contributed a shard in the slot, the slot already holds the maximum number of accumulators, the slot is already resolved, or the peer's retained-shard budget evicted its stalest shard",
+                "Number of shards dropped by the reconstructor's admission rules, by reason: the relaying peer already contributed a shard in the slot, the slot already holds the maximum number of accumulators, the slot is already resolved, or the peer's retained-shard budget evicted its oldest shard",
                 &["reason"],
                 registry;
                 MetricLevel::Warn,

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -1494,7 +1494,7 @@ impl NodeMetrics {
             ).unwrap(),
             shard_reconstructor_dropped_shards: register_int_counter_vec_with_registry!(
                 "shard_reconstructor_dropped_shards",
-                "Number of shards dropped by the reconstructor's admission rules, by reason: the relaying peer already contributed a shard in the slot, the slot already holds the maximum number of accumulators, or the peer's retained-shard budget evicted its stalest shard",
+                "Number of shards dropped by the reconstructor's admission rules, by reason: the relaying peer already contributed a shard in the slot, the slot already holds the maximum number of accumulators, the slot is already resolved, or the peer's retained-shard budget evicted its stalest shard",
                 &["reason"],
                 registry;
                 MetricLevel::Warn,

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -1494,7 +1494,7 @@ impl NodeMetrics {
             ).unwrap(),
             shard_reconstructor_dropped_shards: register_int_counter_vec_with_registry!(
                 "shard_reconstructor_dropped_shards",
-                "Number of shards dropped by the reconstructor's admission rules, by reason: the relaying peer already contributed a shard in the slot, or the slot already holds the maximum number of accumulators",
+                "Number of shards dropped by the reconstructor's admission rules, by reason: the relaying peer already contributed a shard in the slot, the slot already holds the maximum number of accumulators, or the peer's retained-shard budget evicted its stalest shard",
                 &["reason"],
                 registry;
                 MetricLevel::Warn,

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -887,11 +887,8 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
     /// At the authority's shard budget, evicts its oldest (lowest-round)
     /// shard held in an accumulator with fewer than half of `info_length`
     /// shards; when the authority has no such shard, its oldest one overall.
-    /// The fallback exists because an accumulator can hold stake just below
-    /// the validity threshold yet never decode, so well-filled accumulators
-    /// must remain evictable. Whatever eviction costs stays fetchable via the
-    /// transaction synchronizer, since a decodable payload's relayers hold it
-    /// in full.
+    /// Whatever eviction costs stays fetchable via the transaction
+    /// synchronizer, since a decodable payload's relayers hold it in full.
     fn make_room_in_peer_budget(&mut self, shard_index: usize) {
         let retained = &self.retained_shards_by_authority[shard_index];
         if retained.len() < self.shard_budget_per_authority {

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -885,11 +885,13 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
     }
 
     /// At the authority's shard budget, evicts its oldest (lowest-round)
-    /// retained shard, preferring accumulators holding fewer than half of
-    /// `info_length` shards. Well-filled accumulators are not exempt: an
-    /// accumulator can hold stake just below the validity threshold yet never
-    /// decode. Whatever eviction costs stays fetchable via the transaction
-    /// synchronizer, since a decodable payload's relayers hold it in full.
+    /// shard held in an accumulator with fewer than half of `info_length`
+    /// shards; when the authority has no such shard, its oldest one overall.
+    /// The fallback exists because an accumulator can hold stake just below
+    /// the validity threshold yet never decode, so well-filled accumulators
+    /// must remain evictable. Whatever eviction costs stays fetchable via the
+    /// transaction synchronizer, since a decodable payload's relayers hold it
+    /// in full.
     fn make_room_in_peer_budget(&mut self, shard_index: usize) {
         let retained = &self.retained_shards_by_authority[shard_index];
         if retained.len() < self.shard_budget_per_authority {

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -884,17 +884,12 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         Ok(())
     }
 
-    /// Frees one budget place for the authority when it is at
-    /// `shard_budget_per_authority`, evicting its stalest retained shard: the
-    /// lowest-round one held in an accumulator that has collected fewer than
-    /// half of `info_length` shards, or the lowest-round one overall when none
-    /// is below that. Stuck accumulators can sit near-full by construction
-    /// (their relayer stake must stay below the validity threshold or they
-    /// would decode and free themselves), so fill level alone must not shield
-    /// a shard from eviction. Eviction never loses a decodable payload: an
-    /// accumulator that can reach the validity threshold has f+1 stake of
-    /// relayers each holding the full payload, which the transaction
-    /// synchronizer can fetch.
+    /// At the authority's shard budget, evicts its stalest retained shard:
+    /// the lowest-round one in an accumulator holding fewer than half of
+    /// `info_length` shards, or the lowest-round one overall — stuck
+    /// accumulators sit near-full by construction, so fill level alone must
+    /// not shield a shard. An evicted decodable payload stays fetchable via
+    /// the transaction synchronizer, since its relayers hold it in full.
     fn make_room_in_peer_budget(&mut self, shard_index: usize) {
         let retained = &self.retained_shards_by_authority[shard_index];
         if retained.len() < self.shard_budget_per_authority {
@@ -932,12 +927,10 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
     }
 
     /// Marks the slot of `tx_ref` resolved and releases every accumulator in
-    /// it. A resolved slot's payload is author-signed — a `FullTransaction`
-    /// comes from a verified block, and a decode reached f+1 relayer stake, so
-    /// an honest relayer erasure-coded it from the author's signed payload.
-    /// Any other commitment in the slot is fabricated, except an equivocating
-    /// twin, whose payload the transaction synchronizer can fetch in full from
-    /// the f+1 stake of relayers any decodable accumulator requires.
+    /// it. Both triggers pin an author-signed payload (a decode reached f+1
+    /// relayer stake, so an honest relayer coded it from the signed payload);
+    /// every other commitment in the slot is fabricated, except an
+    /// equivocating twin, which the transaction synchronizer can still fetch.
     fn resolve_slot(&mut self, tx_ref: TransactionRef) {
         self.resolved_slots.insert((tx_ref.round, tx_ref.author));
         let slot_start = TransactionRef {

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -885,26 +885,15 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
     }
 
     /// At the authority's shard budget, evicts its oldest (lowest-round)
-    /// shard held in an accumulator with fewer than half of `info_length`
-    /// shards; when the authority has no such shard, its oldest one overall.
-    /// Whatever eviction costs stays fetchable via the transaction
-    /// synchronizer, since a decodable payload's relayers hold it in full.
+    /// retained shard to admit the new one. Whatever eviction costs stays
+    /// fetchable via the transaction synchronizer, since a decodable
+    /// payload's relayers hold it in full.
     fn make_room_in_peer_budget(&mut self, shard_index: usize) {
         let retained = &self.retained_shards_by_authority[shard_index];
         if retained.len() < self.shard_budget_per_authority {
             return;
         }
-        let fill_cutoff = self.info_length / 2;
-        let Some(victim_ref) = retained
-            .iter()
-            .find(|tx_ref| {
-                self.shard_accumulators
-                    .get(tx_ref)
-                    .is_some_and(|accumulator| accumulator.number_shards < fill_cutoff)
-            })
-            .or_else(|| retained.iter().next())
-            .copied()
-        else {
+        let Some(victim_ref) = retained.first().copied() else {
             return;
         };
         self.retained_shards_by_authority[shard_index].remove(&victim_ref);
@@ -2387,76 +2376,54 @@ mod tests {
         assert_eq!(evicted_shards.get(), 1);
     }
 
-    /// The eviction victim is the lowest-round shard in an accumulator below
-    /// the fill cutoff; a near-complete accumulator loses a shard only when
-    /// the peer has nothing below the cutoff, and then keeps the other peers'
-    /// shards.
+    /// Evicting a shard from a multi-shard accumulator removes only the
+    /// evicted peer's shard; the accumulator keeps the other peers'.
     #[tokio::test]
-    async fn test_peer_budget_victim_selection_prefers_low_fill_accumulators() {
+    async fn test_peer_budget_eviction_keeps_other_peers_shards() {
         telemetry_subscribers::init_for_testing();
-        // Committee of 10: info_length = 4, so the fill cutoff is 2 shards.
         let (context, mut reconstructor) = new_reconstructor_with_budget(10, 2);
         let mut encoder = create_encoder(&context);
 
-        // Peer 0's budget: a round-5 accumulator peer 1 also fills to the
-        // cutoff, and a single-shard round-6 one.
-        let protected = shard_for_slot(&context, &mut encoder, 5, 1, 1, 0);
-        let protected_ref = protected.transaction_ref();
+        // Peers 0 and 1 share the round-5 accumulator; peer 0 also holds a
+        // round-6 shard, filling its budget.
+        let shared = shard_for_slot(&context, &mut encoder, 5, 1, 1, 0);
+        let shared_ref = shared.transaction_ref();
         reconstructor
-            .handle_transaction_message(protected)
+            .handle_transaction_message(shared)
             .await
             .unwrap();
         reconstructor
             .handle_transaction_message(shard_for_slot(&context, &mut encoder, 5, 1, 1, 1))
             .await
             .unwrap();
-        let below_cutoff = shard_for_slot(&context, &mut encoder, 6, 1, 2, 0);
-        let below_cutoff_ref = below_cutoff.transaction_ref();
+        let kept = shard_for_slot(&context, &mut encoder, 6, 1, 2, 0);
+        let kept_ref = kept.transaction_ref();
         reconstructor
-            .handle_transaction_message(below_cutoff)
+            .handle_transaction_message(kept)
             .await
             .unwrap();
 
-        // The younger round-6 shard is the victim, not the older
-        // near-complete round-5 one.
+        // Peer 0's next shard evicts its oldest — the round-5 one — while the
+        // accumulator keeps peer 1's shard.
         let admitted = shard_for_slot(&context, &mut encoder, 7, 1, 3, 0);
         let admitted_ref = admitted.transaction_ref();
         reconstructor
             .handle_transaction_message(admitted)
             .await
             .unwrap();
-        assert!(
-            reconstructor
-                .shard_accumulators
-                .contains_key(&protected_ref)
-        );
-        assert!(
-            !reconstructor
-                .shard_accumulators
-                .contains_key(&below_cutoff_ref)
-        );
-
-        // With every accumulator of peer 0 at the cutoff, the lowest-round one
-        // loses peer 0's shard but keeps peer 1's.
-        reconstructor
-            .handle_transaction_message(shard_for_slot(&context, &mut encoder, 7, 1, 3, 1))
-            .await
-            .unwrap();
-        let fallback = shard_for_slot(&context, &mut encoder, 8, 1, 4, 0);
-        let fallback_ref = fallback.transaction_ref();
-        reconstructor
-            .handle_transaction_message(fallback)
-            .await
-            .unwrap();
-        let protected_accumulator = reconstructor
+        let shared_accumulator = reconstructor
             .shard_accumulators
-            .get(&protected_ref)
+            .get(&shared_ref)
             .expect("the accumulator keeps peer 1's shard");
-        assert!(!protected_accumulator.contains_shard_at_index(0));
-        assert!(protected_accumulator.contains_shard_at_index(1));
+        assert!(!shared_accumulator.contains_shard_at_index(0));
+        assert!(shared_accumulator.contains_shard_at_index(1));
         assert_eq!(
             reconstructor.retained_shards_by_authority[0],
-            BTreeSet::from([admitted_ref, fallback_ref])
+            BTreeSet::from([kept_ref, admitted_ref])
+        );
+        assert_eq!(
+            reconstructor.retained_shards_by_authority[1],
+            BTreeSet::from([shared_ref])
         );
     }
 

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -399,6 +399,10 @@ pub struct ShardReconstructor<C: CoreThreadDispatcher> {
     /// relayed. Enforces the per-authority shard budget: at the budget, the
     /// authority's stalest retained shard is evicted to admit a new one.
     retained_shards_by_authority: Vec<BTreeSet<TransactionRef>>,
+    /// Slots whose genuine payload is already known, from a successful decode
+    /// or a directly received full payload. Their accumulators are purged and
+    /// further shards for them are dropped. Periodically evicted by round.
+    resolved_slots: BTreeSet<(Round, AuthorityIndex)>,
     /// Maximum number of shards from one relaying authority retained across
     /// all accumulators.
     shard_budget_per_authority: usize,
@@ -440,6 +444,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             shard_accumulators: BTreeMap::new(),
             transaction_message_receiver,
             retained_shards_by_authority: vec![BTreeSet::new(); total_length],
+            resolved_slots: BTreeSet::new(),
             shard_budget_per_authority,
         };
 
@@ -562,6 +567,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                         self.reconstruction_queue.remove(&tx_ref);
                         if let Ok(verified_transactions) = result {
                             self.reconstructed_transactions.insert(tx_ref, verified_transactions);
+                            self.resolve_slot(tx_ref);
                         }
                     }
 
@@ -616,8 +622,8 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         self.evict_below(transaction_gc_round);
     }
 
-    /// Evict accumulators, processed and reconstructed transactions, and
-    /// retained-shard bookkeeping below the given round.
+    /// Evict accumulators, processed and reconstructed transactions, resolved
+    /// slots, and retained-shard bookkeeping below the given round.
     fn evict_below(&mut self, transaction_gc_round: Round) {
         // Update the internal transaction_gc_round
         self.transaction_gc_round = transaction_gc_round;
@@ -632,6 +638,9 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         self.reconstructed_transactions = self.reconstructed_transactions.split_off(&lower_bound);
         self.shard_accumulators = self.shard_accumulators.split_off(&lower_bound);
         self.reconstruction_queue = self.reconstruction_queue.split_off(&lower_bound);
+        self.resolved_slots = self
+            .resolved_slots
+            .split_off(&(transaction_gc_round, AuthorityIndex::ZERO));
         for retained in &mut self.retained_shards_by_authority {
             *retained = retained.split_off(&lower_bound);
         }
@@ -722,6 +731,19 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
 
         match msg {
             TransactionMessage::Shard(shard_msg) => {
+                // The slot's genuine payload is already known, so this shard
+                // can only re-grow an accumulator the resolution purged.
+                if self.resolved_slots.contains(&(tx_ref.round, tx_ref.author)) {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .shard_reconstructor_dropped_shards
+                        .with_label_values(&["slot_resolved"])
+                        .inc();
+                    debug!("Dropping shard for {tx_ref:?}: its slot is already resolved");
+                    return Ok(());
+                }
+
                 // Relaying two shards for one slot is the peer's own fault;
                 // exceeding the accumulator limit is not, as others may have
                 // filled the slot.
@@ -809,14 +831,10 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
 
             TransactionMessage::FullTransaction(tx_ref) => {
                 self.processed_transactions.insert(tx_ref);
-                // The full payload arrived through the direct path, so a
-                // partially filled accumulator for it can never be needed
-                // again — release it instead of waiting for round eviction.
-                if let Some(accumulator) = self.shard_accumulators.remove(&tx_ref) {
-                    for shard_index in accumulator.collected_shard_indices() {
-                        self.retained_shards_by_authority[shard_index].remove(&tx_ref);
-                    }
-                }
+                // The full payload arrived through the direct path, so no
+                // accumulator in the slot can ever be needed again — release
+                // them instead of waiting for round eviction.
+                self.resolve_slot(tx_ref);
                 return Ok(());
             }
         }
@@ -911,6 +929,39 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         debug!(
             "Evicted the stalest retained shard of peer index {shard_index} ({victim_ref:?}) to admit a new one"
         );
+    }
+
+    /// Marks the slot of `tx_ref` resolved and releases every accumulator in
+    /// it. A resolved slot's payload is author-signed — a `FullTransaction`
+    /// comes from a verified block, and a decode reached f+1 relayer stake, so
+    /// an honest relayer erasure-coded it from the author's signed payload.
+    /// Any other commitment in the slot is fabricated, except an equivocating
+    /// twin, whose payload the transaction synchronizer can fetch in full from
+    /// the f+1 stake of relayers any decodable accumulator requires.
+    fn resolve_slot(&mut self, tx_ref: TransactionRef) {
+        self.resolved_slots.insert((tx_ref.round, tx_ref.author));
+        let slot_start = TransactionRef {
+            round: tx_ref.round,
+            author: tx_ref.author,
+            transactions_commitment: TransactionsCommitment::MIN,
+        };
+        let slot_end = TransactionRef {
+            round: tx_ref.round,
+            author: tx_ref.author,
+            transactions_commitment: TransactionsCommitment::MAX,
+        };
+        let purged_refs: Vec<TransactionRef> = self
+            .shard_accumulators
+            .range(slot_start..=slot_end)
+            .map(|(purged_ref, _)| *purged_ref)
+            .collect();
+        for purged_ref in purged_refs {
+            if let Some(accumulator) = self.shard_accumulators.remove(&purged_ref) {
+                for shard_index in accumulator.collected_shard_indices() {
+                    self.retained_shards_by_authority[shard_index].remove(&purged_ref);
+                }
+            }
+        }
     }
 }
 
@@ -2464,6 +2515,150 @@ mod tests {
                 .iter()
                 .all(|retained| retained.is_empty())
         );
+    }
+
+    /// A directly received full payload resolves its whole slot: sibling
+    /// accumulators for other commitments are purged, later shards for the
+    /// slot are dropped, and the resolved slot is itself evicted by round.
+    #[tokio::test]
+    async fn test_full_transaction_resolves_slot_purging_and_rejecting_siblings() {
+        telemetry_subscribers::init_for_testing();
+        let (context, mut reconstructor) = new_reconstructor_with_budget(10, 100);
+        let mut encoder = create_encoder(&context);
+
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build()).reference();
+        let (real_commitment, real_shards) = encode_payload_for_slot(&context, &mut encoder, 1);
+        let real_ref = TransactionRef::new(block_ref, real_commitment);
+
+        // A partially filled accumulator for the real commitment and a
+        // fabricated sibling in the same slot.
+        reconstructor
+            .handle_transaction_message(TransactionMessage::Shard(ShardMessage {
+                transaction_ref: real_ref,
+                block_digest: Some(block_ref.digest),
+                shard: real_shards[0].clone(),
+                shard_index: 0,
+            }))
+            .await
+            .unwrap();
+        reconstructor
+            .handle_transaction_message(shard_for_slot(&context, &mut encoder, 5, 1, 2, 1))
+            .await
+            .unwrap();
+        assert_eq!(reconstructor.shard_accumulators.len(), 2);
+
+        // The full payload resolves the slot: both accumulators are released.
+        reconstructor
+            .handle_transaction_message(TransactionMessage::FullTransaction(real_ref))
+            .await
+            .unwrap();
+        assert!(reconstructor.shard_accumulators.is_empty());
+        assert!(
+            reconstructor
+                .retained_shards_by_authority
+                .iter()
+                .all(|retained| retained.is_empty())
+        );
+        assert!(
+            reconstructor
+                .resolved_slots
+                .contains(&(5, block_ref.author))
+        );
+
+        // A later shard for a third commitment in the slot opens nothing.
+        reconstructor
+            .handle_transaction_message(shard_for_slot(&context, &mut encoder, 5, 1, 3, 2))
+            .await
+            .unwrap();
+        assert!(reconstructor.shard_accumulators.is_empty());
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["slot_resolved"])
+                .get(),
+            1,
+        );
+
+        // Resolved slots below the gc floor are themselves evicted.
+        reconstructor.evict_below(6);
+        assert!(reconstructor.resolved_slots.is_empty());
+    }
+
+    /// A successful decode resolves the slot the same way: fabricated sibling
+    /// accumulators are purged and later shards for the slot are dropped.
+    #[tokio::test]
+    async fn test_decode_resolves_slot_and_purges_siblings() {
+        telemetry_subscribers::init_for_testing();
+        let h = TestHarness::new(10);
+        let context = h.context.clone();
+        let tx = h.tx.clone();
+        let mut encoder = create_encoder(&context);
+        let info_length = context.committee.info_length();
+
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build()).reference();
+        let (real_commitment, real_shards) = encode_payload_for_slot(&context, &mut encoder, 1);
+        let (sibling_commitment, sibling_shards) =
+            encode_payload_for_slot(&context, &mut encoder, 2);
+
+        // A fabricated sibling accumulator first, then enough real shards to
+        // decode, from disjoint peers.
+        let mut batch = vec![TransactionMessage::Shard(ShardMessage {
+            transaction_ref: TransactionRef::new(block_ref, sibling_commitment),
+            block_digest: Some(block_ref.digest),
+            shard: sibling_shards[info_length].clone(),
+            shard_index: info_length,
+        })];
+        for (i, shard) in real_shards.iter().enumerate().take(info_length) {
+            batch.push(TransactionMessage::Shard(ShardMessage {
+                transaction_ref: TransactionRef::new(block_ref, real_commitment),
+                block_digest: Some(block_ref.digest),
+                shard: shard.clone(),
+                shard_index: i,
+            }));
+        }
+        tx.send(batch).await.unwrap();
+
+        // Wait past the eviction tick so the accumulator gauge refreshes.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        assert_eq!(
+            h.core_dispatcher.get_and_drain_transactions().await.len(),
+            1,
+            "the real commitment must reconstruct"
+        );
+        assert_eq!(
+            context.metrics.node_metrics.shard_accumulators.get(),
+            0,
+            "the fabricated sibling must be purged when the slot's decode succeeds"
+        );
+
+        // A later shard for yet another commitment in the resolved slot is
+        // dropped without opening an accumulator.
+        let (third_commitment, third_shards) = encode_payload_for_slot(&context, &mut encoder, 3);
+        tx.send(vec![TransactionMessage::Shard(ShardMessage {
+            transaction_ref: TransactionRef::new(block_ref, third_commitment),
+            block_digest: Some(block_ref.digest),
+            shard: third_shards[info_length + 1].clone(),
+            shard_index: info_length + 1,
+        })])
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["slot_resolved"])
+                .get(),
+            1,
+        );
+        assert_eq!(context.metrics.node_metrics.shard_accumulators.get(), 0);
+
+        h.handle.stop().await.unwrap();
     }
 
     /// Fresh slots still reconstruct while every relaying peer sits at its

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -729,106 +729,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
 
         let total_length = self.total_length;
 
-        match msg {
-            TransactionMessage::Shard(shard_msg) => {
-                // The slot's genuine payload is already known, so this shard
-                // can only re-grow an accumulator the resolution purged.
-                if self.resolved_slots.contains(&(tx_ref.round, tx_ref.author)) {
-                    self.context
-                        .metrics
-                        .node_metrics
-                        .shard_reconstructor_dropped_shards
-                        .with_label_values(&["slot_resolved"])
-                        .inc();
-                    debug!("Dropping shard for {tx_ref:?}: its slot is already resolved");
-                    return Ok(());
-                }
-
-                // Relaying two shards for one slot is the peer's own fault;
-                // exceeding the accumulator limit is not, as others may have
-                // filled the slot.
-                // TODO: charge the peer for the former once every validator
-                // runs the per-slot header cap.
-                let slot_start = TransactionRef {
-                    round: tx_ref.round,
-                    author: tx_ref.author,
-                    transactions_commitment: TransactionsCommitment::MIN,
-                };
-                let slot_end = TransactionRef {
-                    round: tx_ref.round,
-                    author: tx_ref.author,
-                    transactions_commitment: TransactionsCommitment::MAX,
-                };
-                let mut accumulators_in_slot = 0usize;
-                let mut peer_in_other_accumulator = false;
-                for (existing_ref, accumulator) in
-                    self.shard_accumulators.range(slot_start..=slot_end)
-                {
-                    accumulators_in_slot += 1;
-                    if *existing_ref != tx_ref
-                        && accumulator.contains_shard_at_index(shard_msg.shard_index)
-                    {
-                        peer_in_other_accumulator = true;
-                    }
-                }
-
-                // One shard per (relaying peer, slot), across all accumulators:
-                // an honest peer holds exactly one shard per slot, so a peer
-                // whose index already appears in another accumulator of the
-                // slot has spent the contribution it was entitled to.
-                if peer_in_other_accumulator {
-                    self.context
-                        .metrics
-                        .node_metrics
-                        .shard_reconstructor_dropped_shards
-                        .with_label_values(&["peer_already_in_slot"])
-                        .inc();
-                    debug!(
-                        "Dropping shard for {tx_ref:?}: peer index {} already contributed a shard in this slot",
-                        shard_msg.shard_index
-                    );
-                    return Ok(());
-                }
-
-                let shard_index = shard_msg.shard_index;
-                let occupies_new_position = match self.shard_accumulators.get(&tx_ref) {
-                    Some(accumulator) => !accumulator.contains_shard_at_index(shard_index),
-                    None => {
-                        // With one shard per (peer, slot), a slot holding
-                        // `parity_length + 1` accumulators has too few
-                        // uncommitted peers left for any further commitment to
-                        // ever gather `info_length` contributors — a new
-                        // accumulator would be dead weight by construction.
-                        let max_accumulators_per_slot = self.context.committee.parity_length() + 1;
-                        if accumulators_in_slot >= max_accumulators_per_slot {
-                            self.context
-                                .metrics
-                                .node_metrics
-                                .shard_reconstructor_dropped_shards
-                                .with_label_values(&["slot_full"])
-                                .inc();
-                            debug!(
-                                "Dropping shard for {tx_ref:?}: slot already holds {accumulators_in_slot} accumulators"
-                            );
-                            return Ok(());
-                        }
-                        true
-                    }
-                };
-                if occupies_new_position {
-                    self.make_room_in_peer_budget(shard_index);
-                    self.retained_shards_by_authority[shard_index].insert(tx_ref);
-                }
-                match self.shard_accumulators.entry(tx_ref) {
-                    Entry::Vacant(v) => {
-                        v.insert(ShardAccumulator::new_with_shard(shard_msg, total_length));
-                    }
-                    Entry::Occupied(mut o) => {
-                        o.get_mut().update_with_shard(shard_msg);
-                    }
-                }
-            }
-
+        let shard_msg = match msg {
             TransactionMessage::FullTransaction(tx_ref) => {
                 self.processed_transactions.insert(tx_ref);
                 // The full payload arrived through the direct path, so no
@@ -836,6 +737,101 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                 // them instead of waiting for round eviction.
                 self.resolve_slot(tx_ref);
                 return Ok(());
+            }
+            TransactionMessage::Shard(shard_msg) => shard_msg,
+        };
+
+        // The slot's genuine payload is already known, so this shard
+        // can only re-grow an accumulator the resolution purged.
+        if self.resolved_slots.contains(&(tx_ref.round, tx_ref.author)) {
+            self.context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["slot_resolved"])
+                .inc();
+            debug!("Dropping shard for {tx_ref:?}: its slot is already resolved");
+            return Ok(());
+        }
+
+        // Relaying two shards for one slot is the peer's own fault;
+        // exceeding the accumulator limit is not, as others may have
+        // filled the slot.
+        // TODO: charge the peer for the former once every validator
+        // runs the per-slot header cap.
+        let slot_start = TransactionRef {
+            round: tx_ref.round,
+            author: tx_ref.author,
+            transactions_commitment: TransactionsCommitment::MIN,
+        };
+        let slot_end = TransactionRef {
+            round: tx_ref.round,
+            author: tx_ref.author,
+            transactions_commitment: TransactionsCommitment::MAX,
+        };
+        let mut accumulators_in_slot = 0usize;
+        let mut peer_in_other_accumulator = false;
+        for (existing_ref, accumulator) in self.shard_accumulators.range(slot_start..=slot_end) {
+            accumulators_in_slot += 1;
+            if *existing_ref != tx_ref && accumulator.contains_shard_at_index(shard_msg.shard_index)
+            {
+                peer_in_other_accumulator = true;
+            }
+        }
+
+        // One shard per (relaying peer, slot), across all accumulators:
+        // an honest peer holds exactly one shard per slot, so a peer
+        // whose index already appears in another accumulator of the
+        // slot has spent the contribution it was entitled to.
+        if peer_in_other_accumulator {
+            self.context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["peer_already_in_slot"])
+                .inc();
+            debug!(
+                "Dropping shard for {tx_ref:?}: peer index {} already contributed a shard in this slot",
+                shard_msg.shard_index
+            );
+            return Ok(());
+        }
+
+        let shard_index = shard_msg.shard_index;
+        let occupies_new_position = match self.shard_accumulators.get(&tx_ref) {
+            Some(accumulator) => !accumulator.contains_shard_at_index(shard_index),
+            None => {
+                // With one shard per (peer, slot), a slot holding
+                // `parity_length + 1` accumulators has too few
+                // uncommitted peers left for any further commitment to
+                // ever gather `info_length` contributors — a new
+                // accumulator would be dead weight by construction.
+                let max_accumulators_per_slot = self.context.committee.parity_length() + 1;
+                if accumulators_in_slot >= max_accumulators_per_slot {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .shard_reconstructor_dropped_shards
+                        .with_label_values(&["slot_full"])
+                        .inc();
+                    debug!(
+                        "Dropping shard for {tx_ref:?}: slot already holds {accumulators_in_slot} accumulators"
+                    );
+                    return Ok(());
+                }
+                true
+            }
+        };
+        if occupies_new_position {
+            self.make_room_in_peer_budget(shard_index);
+            self.retained_shards_by_authority[shard_index].insert(tx_ref);
+        }
+        match self.shard_accumulators.entry(tx_ref) {
+            Entry::Vacant(v) => {
+                v.insert(ShardAccumulator::new_with_shard(shard_msg, total_length));
+            }
+            Entry::Occupied(mut o) => {
+                o.get_mut().update_with_shard(shard_msg);
             }
         }
 

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -397,7 +397,7 @@ pub struct ShardReconstructor<C: CoreThreadDispatcher> {
     reconstruction_result_receiver: Receiver<ReconstructionResult>,
     /// For each authority, the accumulators currently retaining a shard it
     /// relayed. Enforces the per-authority shard budget: at the budget, the
-    /// authority's stalest retained shard is evicted to admit a new one.
+    /// authority's oldest retained shard is evicted to admit a new one.
     retained_shards_by_authority: Vec<BTreeSet<TransactionRef>>,
     /// Slots whose genuine payload is already known, from a successful decode
     /// or a directly received full payload. Their accumulators are purged and
@@ -884,12 +884,12 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         Ok(())
     }
 
-    /// At the authority's shard budget, evicts its stalest retained shard:
-    /// the lowest-round one in an accumulator holding fewer than half of
-    /// `info_length` shards, or the lowest-round one overall — stuck
-    /// accumulators sit near-full by construction, so fill level alone must
-    /// not shield a shard. An evicted decodable payload stays fetchable via
-    /// the transaction synchronizer, since its relayers hold it in full.
+    /// At the authority's shard budget, evicts its oldest (lowest-round)
+    /// retained shard, preferring accumulators holding fewer than half of
+    /// `info_length` shards. Well-filled accumulators are not exempt: an
+    /// accumulator can hold stake just below the validity threshold yet never
+    /// decode. Whatever eviction costs stays fetchable via the transaction
+    /// synchronizer, since a decodable payload's relayers hold it in full.
     fn make_room_in_peer_budget(&mut self, shard_index: usize) {
         let retained = &self.retained_shards_by_authority[shard_index];
         if retained.len() < self.shard_budget_per_authority {
@@ -922,7 +922,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             .with_label_values(&["peer_budget_evicted"])
             .inc();
         debug!(
-            "Evicted the stalest retained shard of peer index {shard_index} ({victim_ref:?}) to admit a new one"
+            "Evicted the oldest retained shard of peer index {shard_index} ({victim_ref:?}) to admit a new one"
         );
     }
 
@@ -2334,10 +2334,10 @@ mod tests {
     }
 
     /// At the per-authority budget, admitting a new shard evicts the
-    /// authority's stalest retained one instead of dropping the new one, and
+    /// authority's oldest retained one instead of dropping the new one, and
     /// other authorities' budgets are unaffected.
     #[tokio::test]
-    async fn test_peer_budget_evicts_stalest_shard_to_admit_new_one() {
+    async fn test_peer_budget_evicts_oldest_shard_to_admit_new_one() {
         telemetry_subscribers::init_for_testing();
         let (context, mut reconstructor) = new_reconstructor_with_budget(10, 2);
         let mut encoder = create_encoder(&context);

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -212,6 +212,13 @@ impl ShardAccumulator {
     fn contains_shard_at_index(&self, shard_index: usize) -> bool {
         self.collected_shards[shard_index].is_some()
     }
+
+    /// Remove the shard collected at the given index, if any.
+    fn remove_shard_at_index(&mut self, shard_index: usize) {
+        if self.collected_shards[shard_index].take().is_some() {
+            self.number_shards -= 1;
+        }
+    }
 }
 
 /// Attributes a reconstructed payload that failed the transaction validity
@@ -388,6 +395,13 @@ pub struct ShardReconstructor<C: CoreThreadDispatcher> {
     reconstruction_result_sender: Sender<ReconstructionResult>,
     /// Job results are received by this channel
     reconstruction_result_receiver: Receiver<ReconstructionResult>,
+    /// For each authority, the accumulators currently retaining a shard it
+    /// relayed. Enforces the per-authority shard budget: at the budget, the
+    /// authority's stalest retained shard is evicted to admit a new one.
+    retained_shards_by_authority: Vec<BTreeSet<TransactionRef>>,
+    /// Maximum number of shards from one relaying authority retained across
+    /// all accumulators.
+    shard_budget_per_authority: usize,
 }
 
 impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
@@ -400,6 +414,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
     ) -> (Self, Sender<Vec<TransactionMessage>>) {
         let info_length = context.committee.info_length();
         let total_length = context.committee.size();
+        let shard_budget_per_authority = context.parameters.shard_budget_per_authority as usize;
 
         let (transaction_message_sender, transaction_message_receiver) = mpsc::channel(1000);
         let (ready_sender, ready_receiver) = mpsc::channel(1000);
@@ -424,6 +439,8 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             reconstructed_transactions: BTreeMap::new(),
             shard_accumulators: BTreeMap::new(),
             transaction_message_receiver,
+            retained_shards_by_authority: vec![BTreeSet::new(); total_length],
+            shard_budget_per_authority,
         };
 
         (reconstructor, transaction_message_sender)
@@ -596,7 +613,12 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             .set(self.processed_transactions.len() as i64);
 
         let transaction_gc_round = self.dag_state.read().gc_round_for_last_solid_commit();
+        self.evict_below(transaction_gc_round);
+    }
 
+    /// Evict accumulators, processed and reconstructed transactions, and
+    /// retained-shard bookkeeping below the given round.
+    fn evict_below(&mut self, transaction_gc_round: Round) {
         // Update the internal transaction_gc_round
         self.transaction_gc_round = transaction_gc_round;
 
@@ -610,6 +632,9 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         self.reconstructed_transactions = self.reconstructed_transactions.split_off(&lower_bound);
         self.shard_accumulators = self.shard_accumulators.split_off(&lower_bound);
         self.reconstruction_queue = self.reconstruction_queue.split_off(&lower_bound);
+        for retained in &mut self.retained_shards_by_authority {
+            *retained = retained.split_off(&lower_bound);
+        }
     }
 
     fn get_transactions_with_headers_in_dag_state(
@@ -743,8 +768,10 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                     return Ok(());
                 }
 
-                match self.shard_accumulators.entry(tx_ref) {
-                    Entry::Vacant(v) => {
+                let shard_index = shard_msg.shard_index;
+                let occupies_new_position = match self.shard_accumulators.get(&tx_ref) {
+                    Some(accumulator) => !accumulator.contains_shard_at_index(shard_index),
+                    None => {
                         // With one shard per (peer, slot), a slot holding
                         // `parity_length + 1` accumulators has too few
                         // uncommitted peers left for any further commitment to
@@ -763,6 +790,15 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                             );
                             return Ok(());
                         }
+                        true
+                    }
+                };
+                if occupies_new_position {
+                    self.make_room_in_peer_budget(shard_index);
+                    self.retained_shards_by_authority[shard_index].insert(tx_ref);
+                }
+                match self.shard_accumulators.entry(tx_ref) {
+                    Entry::Vacant(v) => {
                         v.insert(ShardAccumulator::new_with_shard(shard_msg, total_length));
                     }
                     Entry::Occupied(mut o) => {
@@ -776,7 +812,11 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                 // The full payload arrived through the direct path, so a
                 // partially filled accumulator for it can never be needed
                 // again — release it instead of waiting for round eviction.
-                self.shard_accumulators.remove(&tx_ref);
+                if let Some(accumulator) = self.shard_accumulators.remove(&tx_ref) {
+                    for shard_index in accumulator.collected_shard_indices() {
+                        self.retained_shards_by_authority[shard_index].remove(&tx_ref);
+                    }
+                }
                 return Ok(());
             }
         }
@@ -789,6 +829,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             self.info_length,
             &self.context.committee,
             &tx_ref,
+            &mut self.retained_shards_by_authority,
         )
         .await?;
 
@@ -804,6 +845,7 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
         info_length: usize,
         committee: &Committee,
         tx_ref: &TransactionRef,
+        retained_shards_by_authority: &mut [BTreeSet<TransactionRef>],
     ) -> ConsensusResult<()> {
         if let Some(acc) = accumulators.get(tx_ref) {
             if acc.is_ready_to_reconstruct(info_length, committee) {
@@ -811,6 +853,9 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                 let acc = accumulators
                     .remove(tx_ref)
                     .expect("We should expect the shard accumulator to be present");
+                for shard_index in acc.collected_shard_indices() {
+                    retained_shards_by_authority[shard_index].remove(tx_ref);
+                }
                 sender
                     .send(acc)
                     .await
@@ -819,6 +864,53 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             }
         }
         Ok(())
+    }
+
+    /// Frees one budget place for the authority when it is at
+    /// `shard_budget_per_authority`, evicting its stalest retained shard: the
+    /// lowest-round one held in an accumulator that has collected fewer than
+    /// half of `info_length` shards, or the lowest-round one overall when none
+    /// is below that. Stuck accumulators can sit near-full by construction
+    /// (their relayer stake must stay below the validity threshold or they
+    /// would decode and free themselves), so fill level alone must not shield
+    /// a shard from eviction. Eviction never loses a decodable payload: an
+    /// accumulator that can reach the validity threshold has f+1 stake of
+    /// relayers each holding the full payload, which the transaction
+    /// synchronizer can fetch.
+    fn make_room_in_peer_budget(&mut self, shard_index: usize) {
+        let retained = &self.retained_shards_by_authority[shard_index];
+        if retained.len() < self.shard_budget_per_authority {
+            return;
+        }
+        let fill_cutoff = self.info_length / 2;
+        let Some(victim_ref) = retained
+            .iter()
+            .find(|tx_ref| {
+                self.shard_accumulators
+                    .get(tx_ref)
+                    .is_some_and(|accumulator| accumulator.number_shards < fill_cutoff)
+            })
+            .or_else(|| retained.iter().next())
+            .copied()
+        else {
+            return;
+        };
+        self.retained_shards_by_authority[shard_index].remove(&victim_ref);
+        if let Entry::Occupied(mut occupied) = self.shard_accumulators.entry(victim_ref) {
+            occupied.get_mut().remove_shard_at_index(shard_index);
+            if occupied.get().number_shards == 0 {
+                occupied.remove();
+            }
+        }
+        self.context
+            .metrics
+            .node_metrics
+            .shard_reconstructor_dropped_shards
+            .with_label_values(&["peer_budget_evicted"])
+            .inc();
+        debug!(
+            "Evicted the stalest retained shard of peer index {shard_index} ({victim_ref:?}) to admit a new one"
+        );
     }
 }
 
@@ -832,7 +924,7 @@ mod tests {
 
     use parking_lot::RwLock;
     use rand::{seq::SliceRandom, thread_rng};
-    use starfish_config::AuthorityIndex;
+    use starfish_config::{AuthorityIndex, Parameters};
     use tokio::sync::{Mutex, mpsc::Sender};
 
     use crate::{
@@ -2151,5 +2243,289 @@ mod tests {
             .stop()
             .await
             .expect("We should expect graceful shutdown");
+    }
+
+    /// Builds a reconstructor without starting its run loop, for tests that
+    /// drive `handle_transaction_message` directly and inspect internal state.
+    fn new_reconstructor_with_budget(
+        committee_size: usize,
+        shard_budget_per_authority: u32,
+    ) -> (Arc<Context>, ShardReconstructor<MockCoreThreadDispatcher>) {
+        let (context, _) = Context::new_for_test(committee_size);
+        let context = Arc::new(context.with_parameters(Parameters {
+            shard_budget_per_authority,
+            ..Default::default()
+        }));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (reconstructor, _sender) = ShardReconstructor::new(
+            context.clone(),
+            dag_state,
+            Arc::new(MockCoreThreadDispatcher::new()),
+            Arc::new(NoopBlockVerifier),
+        );
+        (context, reconstructor)
+    }
+
+    /// A shard message for the (round, author) slot: `marker` selects the
+    /// payload (and thus the commitment), `shard_index` the relaying peer.
+    fn shard_for_slot(
+        context: &Arc<Context>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
+        round: Round,
+        author: u8,
+        marker: u8,
+        shard_index: usize,
+    ) -> TransactionMessage {
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build())
+                .reference();
+        let (commitment, shards) = encode_payload_for_slot(context, encoder, marker);
+        TransactionMessage::Shard(ShardMessage {
+            transaction_ref: TransactionRef::new(block_ref, commitment),
+            block_digest: Some(block_ref.digest),
+            shard: shards[shard_index].clone(),
+            shard_index,
+        })
+    }
+
+    /// At the per-authority budget, admitting a new shard evicts the
+    /// authority's stalest retained one instead of dropping the new one, and
+    /// other authorities' budgets are unaffected.
+    #[tokio::test]
+    async fn test_peer_budget_evicts_stalest_shard_to_admit_new_one() {
+        telemetry_subscribers::init_for_testing();
+        let (context, mut reconstructor) = new_reconstructor_with_budget(10, 2);
+        let mut encoder = create_encoder(&context);
+        let evicted_shards = context
+            .metrics
+            .node_metrics
+            .shard_reconstructor_dropped_shards
+            .with_label_values(&["peer_budget_evicted"]);
+
+        // Peer 0 fills its budget with single-shard accumulators at rounds 5, 6.
+        let old = shard_for_slot(&context, &mut encoder, 5, 1, 1, 0);
+        let old_ref = old.transaction_ref();
+        reconstructor.handle_transaction_message(old).await.unwrap();
+        let kept = shard_for_slot(&context, &mut encoder, 6, 1, 2, 0);
+        let kept_ref = kept.transaction_ref();
+        reconstructor
+            .handle_transaction_message(kept)
+            .await
+            .unwrap();
+        assert_eq!(evicted_shards.get(), 0);
+
+        // A further shard from peer 0 evicts the round-5 one, and the emptied
+        // accumulator with it.
+        let new = shard_for_slot(&context, &mut encoder, 7, 1, 3, 0);
+        let new_ref = new.transaction_ref();
+        reconstructor.handle_transaction_message(new).await.unwrap();
+        assert!(!reconstructor.shard_accumulators.contains_key(&old_ref));
+        assert!(reconstructor.shard_accumulators.contains_key(&kept_ref));
+        assert!(reconstructor.shard_accumulators.contains_key(&new_ref));
+        assert_eq!(
+            reconstructor.retained_shards_by_authority[0],
+            BTreeSet::from([kept_ref, new_ref])
+        );
+        assert_eq!(evicted_shards.get(), 1);
+
+        // Peer 1 is below its own budget: its shard for the evicted slot is
+        // admitted without an eviction.
+        let other_peer = shard_for_slot(&context, &mut encoder, 5, 1, 1, 1);
+        reconstructor
+            .handle_transaction_message(other_peer)
+            .await
+            .unwrap();
+        assert!(reconstructor.shard_accumulators.contains_key(&old_ref));
+        assert_eq!(
+            reconstructor.retained_shards_by_authority[1],
+            BTreeSet::from([old_ref])
+        );
+        assert_eq!(evicted_shards.get(), 1);
+    }
+
+    /// The eviction victim is the lowest-round shard in an accumulator below
+    /// the fill cutoff; a near-complete accumulator loses a shard only when
+    /// the peer has nothing below the cutoff, and then keeps the other peers'
+    /// shards.
+    #[tokio::test]
+    async fn test_peer_budget_victim_selection_prefers_low_fill_accumulators() {
+        telemetry_subscribers::init_for_testing();
+        // Committee of 10: info_length = 4, so the fill cutoff is 2 shards.
+        let (context, mut reconstructor) = new_reconstructor_with_budget(10, 2);
+        let mut encoder = create_encoder(&context);
+
+        // Peer 0's budget: a round-5 accumulator peer 1 also fills to the
+        // cutoff, and a single-shard round-6 one.
+        let protected = shard_for_slot(&context, &mut encoder, 5, 1, 1, 0);
+        let protected_ref = protected.transaction_ref();
+        reconstructor
+            .handle_transaction_message(protected)
+            .await
+            .unwrap();
+        reconstructor
+            .handle_transaction_message(shard_for_slot(&context, &mut encoder, 5, 1, 1, 1))
+            .await
+            .unwrap();
+        let below_cutoff = shard_for_slot(&context, &mut encoder, 6, 1, 2, 0);
+        let below_cutoff_ref = below_cutoff.transaction_ref();
+        reconstructor
+            .handle_transaction_message(below_cutoff)
+            .await
+            .unwrap();
+
+        // The younger round-6 shard is the victim, not the older
+        // near-complete round-5 one.
+        let admitted = shard_for_slot(&context, &mut encoder, 7, 1, 3, 0);
+        let admitted_ref = admitted.transaction_ref();
+        reconstructor
+            .handle_transaction_message(admitted)
+            .await
+            .unwrap();
+        assert!(
+            reconstructor
+                .shard_accumulators
+                .contains_key(&protected_ref)
+        );
+        assert!(
+            !reconstructor
+                .shard_accumulators
+                .contains_key(&below_cutoff_ref)
+        );
+
+        // With every accumulator of peer 0 at the cutoff, the lowest-round one
+        // loses peer 0's shard but keeps peer 1's.
+        reconstructor
+            .handle_transaction_message(shard_for_slot(&context, &mut encoder, 7, 1, 3, 1))
+            .await
+            .unwrap();
+        let fallback = shard_for_slot(&context, &mut encoder, 8, 1, 4, 0);
+        let fallback_ref = fallback.transaction_ref();
+        reconstructor
+            .handle_transaction_message(fallback)
+            .await
+            .unwrap();
+        let protected_accumulator = reconstructor
+            .shard_accumulators
+            .get(&protected_ref)
+            .expect("the accumulator keeps peer 1's shard");
+        assert!(!protected_accumulator.contains_shard_at_index(0));
+        assert!(protected_accumulator.contains_shard_at_index(1));
+        assert_eq!(
+            reconstructor.retained_shards_by_authority[0],
+            BTreeSet::from([admitted_ref, fallback_ref])
+        );
+    }
+
+    /// The retained-shard bookkeeping empties when accumulators leave the map
+    /// through reconstruction dequeue and through round eviction.
+    #[tokio::test]
+    async fn test_peer_budget_bookkeeping_cleared_when_accumulators_leave() {
+        telemetry_subscribers::init_for_testing();
+        let (context, mut reconstructor) = new_reconstructor_with_budget(10, 100);
+        let mut encoder = create_encoder(&context);
+        let info_length = context.committee.info_length();
+
+        // Reconstruction dequeue: info_length shards reach the validity
+        // threshold and the accumulator moves to the workers' queue.
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 1).build()).reference();
+        let (commitment, shards) = encode_payload_for_slot(&context, &mut encoder, 1);
+        for (i, shard) in shards.iter().enumerate().take(info_length) {
+            reconstructor
+                .handle_transaction_message(TransactionMessage::Shard(ShardMessage {
+                    transaction_ref: TransactionRef::new(block_ref, commitment),
+                    block_digest: Some(block_ref.digest),
+                    shard: shard.clone(),
+                    shard_index: i,
+                }))
+                .await
+                .unwrap();
+        }
+        assert!(reconstructor.shard_accumulators.is_empty());
+        assert!(
+            reconstructor
+                .retained_shards_by_authority
+                .iter()
+                .all(|retained| retained.is_empty())
+        );
+
+        // Round eviction: pending shards below the floor drop with their
+        // bookkeeping.
+        reconstructor
+            .handle_transaction_message(shard_for_slot(&context, &mut encoder, 6, 1, 2, 0))
+            .await
+            .unwrap();
+        reconstructor.evict_below(7);
+        assert!(reconstructor.shard_accumulators.is_empty());
+        assert!(
+            reconstructor
+                .retained_shards_by_authority
+                .iter()
+                .all(|retained| retained.is_empty())
+        );
+    }
+
+    /// Fresh slots still reconstruct while every relaying peer sits at its
+    /// budget: admission evicts the stale shard instead of dropping the new
+    /// one.
+    #[tokio::test]
+    async fn test_reconstruction_completes_while_peers_at_budget() {
+        telemetry_subscribers::init_for_testing();
+        let (context, _) = Context::new_for_test(10);
+        let context = Arc::new(context.with_parameters(Parameters {
+            shard_budget_per_authority: 1,
+            ..Default::default()
+        }));
+        let h = TestHarness::new_with_block_verifier(context.clone(), Arc::new(NoopBlockVerifier));
+        let tx = h.tx.clone();
+        let mut encoder = create_encoder(&context);
+        let info_length = context.committee.info_length();
+
+        // Each relaying peer's budget is filled by a shard stuck in its own
+        // undecodable slot (a distinct author per peer, one shard each).
+        let stuck: Vec<_> = (0..info_length)
+            .map(|i| shard_for_slot(&context, &mut encoder, 5, (i + 2) as u8, (10 + i) as u8, i))
+            .collect();
+        tx.send(stuck).await.unwrap();
+
+        // A fresh slot backed by the same peers reconstructs regardless.
+        let block_ref =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(6, 1).build()).reference();
+        let (commitment, shards) = encode_payload_for_slot(&context, &mut encoder, 1);
+        let batch: Vec<_> = (0..info_length)
+            .map(|i| {
+                TransactionMessage::Shard(ShardMessage {
+                    transaction_ref: TransactionRef::new(block_ref, commitment),
+                    block_digest: Some(block_ref.digest),
+                    shard: shards[i].clone(),
+                    shard_index: i,
+                })
+            })
+            .collect();
+        tx.send(batch).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        let fetched = h.core_dispatcher.get_and_drain_transactions().await;
+        assert_eq!(
+            fetched.len(),
+            1,
+            "a fresh slot must reconstruct while its relayers sit at their budgets"
+        );
+        assert_eq!(
+            fetched[0].transaction_ref().transactions_commitment,
+            commitment
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .shard_reconstructor_dropped_shards
+                .with_label_values(&["peer_budget_evicted"])
+                .get(),
+            info_length as u64,
+        );
+
+        h.handle.stop().await.unwrap();
     }
 }


### PR DESCRIPTION
# Description of change

Follow-up to #12726, which bounded how wide the shard/payload retention window can grow during a solidification stall; this bounds what the shard pool inside the window can cost, independent of the window size:

- Per-authority budget on retained shards (`shard_budget_per_authority`, node-local, default 1000). At the budget, the authority's oldest retained shard is evicted to admit the new one. Eviction rather than rejection, because how long a shard stays retained is adversary-controlled (payloads withheld from most of the committee) while the honest send rate is not — rejecting at a cap would let stuck shards switch reconstruction off. Worst-case pool drops from ~48 GB to ~1.4 GB at committee size 50.
- Once a slot's genuine payload is known (successful decode, or the full payload received directly), the whole (round, author) slot is resolved: sibling accumulators for other commitments are purged and later shards for the slot are dropped.

Anything either mechanism gives up stays reachable through the transaction synchronizer: any decodable payload is held in full by f+1 stake of relayers.

## Links to any relevant issues

Fixes iotaledger/iota-private#489 together with #12726.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

