### PR TITLE
refactor(iota-core): return EpochEnded from within_alive_epoch

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1432,7 +1432,6 @@ impl AuthorityState {
                 certificate,
             ))
             .await
-            .map_err(|_| IotaError::EpochEnded(epoch_store.epoch()))
             .and_then(|r| r)
     }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3338,23 +3338,22 @@ impl AuthorityPerEpochStore {
     /// This function executes given future until epoch_terminated is called
     /// If future finishes before epoch_terminated is called, future result is
     /// returned If epoch_terminated is called before future is resolved,
-    /// error is returned
+    /// `IotaError::EpochEnded` is returned
     ///
     /// In addition to the early termination guarantee, this function also
     /// prevents epoch_terminated() if future is being executed.
-    #[allow(clippy::result_unit_err)]
-    pub async fn within_alive_epoch<F: Future + Send>(&self, f: F) -> Result<F::Output, ()> {
+    pub async fn within_alive_epoch<F: Future + Send>(&self, f: F) -> IotaResult<F::Output> {
         // This guard is kept in the future until it resolves, preventing
         // `epoch_terminated` to acquire a write lock
         let guard = self.epoch_alive.read().await;
         if !*guard {
-            return Err(());
+            return Err(IotaError::EpochEnded(self.epoch()));
         }
         // The hot path here -- epoch is alive, future resolves first -- is now a
         // single atomic load inside CancellationToken's `cancelled()` future,
         // instead of mutex + Arc clone + two `.boxed()` heap allocations per call.
         tokio::select! {
-            _ = self.epoch_alive_token.cancelled() => Err(()),
+            _ = self.epoch_alive_token.cancelled() => Err(IotaError::EpochEnded(self.epoch())),
             result = f => Ok(result),
         }
     }

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -511,7 +511,7 @@ impl ValidatorService {
 
         let update = match result {
             // Epoch ended before execution or rejection.
-            Ok(Err(())) => TxStatusUpdate::Expired {
+            Ok(Err(_)) => TxStatusUpdate::Expired {
                 epoch: epoch_store.epoch(),
             },
             Ok(Ok(Either::Left(effects_digests))) => {


### PR DESCRIPTION
# Description of change

Replace `within_alive_epoch`'s `Result<_, ()>` with `IotaResult`, erring with `IotaError::EpochEnded`. This drops the `clippy::result_unit_err` allow the Rust 1.98 bump had to add, plus the caller-side mapping to the same error.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
