### PR TITLE
fix(core): Exit reconfig observers gracefully when the reconfig channel closes

### DIFF
--- a/crates/iota-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/iota-core/src/quorum_driver/reconfig_observer.rs
@@ -93,12 +93,10 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
                     continue;
                 }
                 Err(RecvError::Closed) => {
-                    // Closing the channel only happens in simtest when a node is shut down.
-                    if cfg!(msim) {
-                        return;
-                    } else {
-                        panic!("Do not expect the channel to be closed")
-                    }
+                    // The sender lives in `IotaNode`, so a closed channel means the node
+                    // was dropped.
+                    warn!("Reconfig channel closed, exiting reconfig observer");
+                    return;
                 }
             }
         }

--- a/crates/iota-core/src/transaction_driver/reconfig_observer.rs
+++ b/crates/iota-core/src/transaction_driver/reconfig_observer.rs
@@ -87,12 +87,10 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
                     continue;
                 }
                 Err(RecvError::Closed) => {
-                    // Closing the channel only happens in simtest when a node is shut down.
-                    if cfg!(msim) {
-                        return;
-                    } else {
-                        panic!("Do not expect the channel to be closed")
-                    }
+                    // The sender lives in `IotaNode`, so a closed channel means the node
+                    // was dropped.
+                    warn!("Reconfig channel closed, exiting reconfig observer");
+                    return;
                 }
             }
         }


### PR DESCRIPTION
# Description of change

- In release builds (`panic = 'abort'`) that panic aborted the process before the startup error could be reported: e.g. a `build_grpc_server` bind failure surfaced as `panicked at ...reconfig_observer.rs: Do not expect the channel to be closed` instead of `Failed to start node: Address already in use`.
- The observers now log a warning and exit their loop, letting the startup error propagate to `main` where it is logged before exiting.

## Links to any relevant issues

fixes #8982

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have checked that new and existing unit tests pass locally with my changes


### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): A node that fails during startup now exits with the actual error logged instead of aborting with an unrelated panic.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC: