### PR TITLE
fix(iota-core,iota-types,iota-json-rpc): distinguish validator rejections from locally invalid transactions in client errors (#12444)

### DIFF
--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -1445,10 +1445,10 @@ fn convert_td_to_qd_effects(td: TdFinalizedEffects) -> FinalizedEffects {
 /// Map a `TransactionDriverError` to a `QuorumDriverError` for client
 /// reporting. The variant choice signals retriability: clients retry on
 /// `QuorumDriverInternal`, `FailedWithTransientErrorAfterMaximumAttempts`,
-/// and `TimeoutBeforeFinality`, but treat `InvalidTransaction` /
-/// `InvalidUserSignature` as terminal. Submission-time rejections that
-/// cannot succeed on resubmission must therefore not be reported as
-/// internal.
+/// and `TimeoutBeforeFinality`, but treat `InvalidTransaction`,
+/// `InvalidUserSignature`, and `RejectedByValidators` as terminal.
+/// Submission-time rejections that cannot succeed on resubmission must
+/// therefore not be reported as internal.
 fn map_td_error_to_qd(e: TransactionDriverError) -> QuorumDriverError {
     use TransactionDriverError::*;
     match e {
@@ -1462,15 +1462,17 @@ fn map_td_error_to_qd(e: TransactionDriverError) -> QuorumDriverError {
         } => {
             // f+1 stake of validators returned non-retriable errors during
             // submission (bad signature, malformed tx, lock conflict, ...).
-            // f+1 means at least one honest validator considered this tx
-            // invalid, so resubmitting the same bytes cannot succeed.
+            // Some verdicts depend on validator-local state, so this does not
+            // prove the transaction can never execute; the variant is kept
+            // distinct from `InvalidTransaction` so clients can tell the two
+            // apart.
             let representative = submission_non_retriable_errors
                 .errors
                 .into_iter()
                 .next()
                 .map(|(msg, _, _, _)| msg)
                 .unwrap_or_else(|| "transaction rejected as invalid during submission".to_string());
-            QuorumDriverError::InvalidTransaction(IotaError::Unknown(format!(
+            QuorumDriverError::RejectedByValidators(IotaError::Unknown(format!(
                 "Transaction was rejected as invalid by more than 1/3 of validator stake \
                  during submission (non-retriable): {representative}"
             )))
@@ -2126,5 +2128,36 @@ mod tests {
             Err(QuorumDriverError::QuorumDriverInternal(_))
         ));
         assert!(orchestrator.subscribe_to_effects_queue().is_none());
+    }
+
+    /// Validator rejections must map to `RejectedByValidators`, not
+    /// `InvalidTransaction`: the verdicts can be validator-local, so clients
+    /// must be able to tell them apart from a locally proven invalid
+    /// transaction.
+    #[test]
+    fn map_validator_rejections_to_distinct_variant() {
+        use iota_types::error::ErrorCategory;
+
+        use crate::transaction_driver::AggregatedRequestErrors;
+
+        let td_error = TransactionDriverError::RejectedByValidators {
+            submission_non_retriable_errors: AggregatedRequestErrors {
+                errors: vec![(
+                    "Object lock conflict".to_string(),
+                    vec![],
+                    3334,
+                    ErrorCategory::LockConflict,
+                )],
+                total_stake: 3334,
+            },
+            submission_retriable_errors: AggregatedRequestErrors::default(),
+        };
+
+        let qd_error = map_td_error_to_qd(td_error);
+        let QuorumDriverError::RejectedByValidators(inner) = &qd_error else {
+            panic!("expected RejectedByValidators, got {qd_error:?}");
+        };
+        assert!(inner.to_string().contains("Object lock conflict"));
+        assert_eq!(qd_error.reason(), "rejected_by_validators");
     }
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -971,8 +971,8 @@ async fn test_pcool_duplicate_submission_inherits_failure() -> Result<(), anyhow
     let first_err = first.expect_err("transaction spending a stale gas object must fail");
     let second_err = second.expect_err("transaction spending a stale gas object must fail");
     assert!(
-        matches!(first_err, QuorumDriverError::InvalidTransaction(_)),
-        "expected the submission to be rejected as invalid, got {first_err:?}"
+        matches!(first_err, QuorumDriverError::RejectedByValidators(_)),
+        "expected the submission to be rejected by validators, got {first_err:?}"
     );
     assert_eq!(
         first_err, second_err,

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -975,8 +975,8 @@ async fn test_pcool_duplicate_submission_inherits_failure() -> Result<(), anyhow
     let first_err = first.expect_err("transaction spending a stale gas object must fail");
     let second_err = second.expect_err("transaction spending a stale gas object must fail");
     assert!(
-        matches!(first_err, QuorumDriverError::InvalidTransaction(_)),
-        "expected the submission to be rejected as invalid, got {first_err:?}"
+        matches!(first_err, QuorumDriverError::RejectedByValidators(_)),
+        "expected the submission to be rejected by validators, got {first_err:?}"
     );
     assert_eq!(
         first_err, second_err,

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -156,6 +156,11 @@ impl ErrorDetails {
         self
     }
 
+    pub fn with_error_info(mut self, error_info: ErrorInfo) -> Self {
+        self.error_info = Some(error_info);
+        self
+    }
+
     pub fn with_retry_info(mut self, retry_info: RetryInfo) -> Self {
         self.retry_info = Some(retry_info);
         self
@@ -282,6 +287,9 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RpcError {
         use iota_types::{error::IotaError, quorum_driver_types::QuorumDriverError::*};
         use itertools::Itertools;
 
+        // gRPC mirror of the JSON-RPC `data.reason` discriminant.
+        let reason = error.reason().to_uppercase();
+
         match error {
             InvalidUserSignature(err) => {
                 let message = {
@@ -293,7 +301,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RpcError {
                 };
                 RpcError::new(Code::InvalidArgument, message)
             }
-            InvalidTransaction(err) => {
+            InvalidTransaction(err) | RejectedByValidators(err) => {
                 let message = {
                     let err = match err {
                         IotaError::UserInput { error } => error.to_string(),
@@ -301,7 +309,16 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RpcError {
                     };
                     format!("Invalid transaction: {err}")
                 };
-                RpcError::new(Code::InvalidArgument, message)
+                let details = ErrorDetails::new().with_error_info(ErrorInfo {
+                    reason,
+                    domain: "iota.grpc".to_string(),
+                    ..Default::default()
+                });
+                RpcError {
+                    code: Code::InvalidArgument,
+                    message: Some(message),
+                    details: Some(Box::new(details)),
+                }
             }
             QuorumDriverInternal(err) => RpcError::new(Code::Internal, err.to_string()),
             ObjectsDoubleUsed { conflicting_txes } => {

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -163,16 +163,21 @@ impl From<Error> for RpcError {
             },
             Error::QuorumDriver(err) => {
                 let error_msg = err.to_error_message();
+                // Machine-readable discriminant: the codes below are shared
+                // between variants, so clients disambiguate via
+                // `data.reason` instead of parsing the message.
+                let reason = serde_json::json!({ "reason": err.reason() });
 
                 match err {
                     QuorumDriverError::InvalidUserSignature { .. }
                     | QuorumDriverError::InvalidTransaction { .. }
+                    | QuorumDriverError::RejectedByValidators { .. }
                     | QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures
                     | QuorumDriverError::NonRecoverableTransactionError { .. } => {
-                        let error_object = ErrorObject::owned::<()>(
+                        let error_object = ErrorObject::owned(
                             TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
                             error_msg,
-                            None,
+                            Some(reason),
                         );
                         RpcError::Call(error_object)
                     }
@@ -199,7 +204,7 @@ impl From<Error> for RpcError {
                     | QuorumDriverError::SystemOverload { .. }
                     | QuorumDriverError::SystemOverloadRetryAfter { .. } => {
                         let error_object =
-                            ErrorObject::owned::<()>(TRANSIENT_ERROR_CODE, error_msg, None);
+                            ErrorObject::owned(TRANSIENT_ERROR_CODE, error_msg, Some(reason));
                         RpcError::Call(error_object)
                     }
                     QuorumDriverError::QuorumDriverInternal(_) => {
@@ -332,6 +337,36 @@ mod tests {
                 "Invalid user signature: Signature is not valid: Test inner invalid signature"
             ];
             expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"invalid_user_signature"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
+        }
+
+        #[test]
+        fn test_invalid_transaction_vs_rejected_by_validators() {
+            // Same rendered code and message; only `data.reason` tells a
+            // locally proven invalid transaction apart from one rejected by
+            // the polled validators.
+            let inner = || IotaError::Unknown("Test rejection".to_string());
+
+            let error_object = error_object_from_rpc(
+                Error::QuorumDriver(QuorumDriverError::InvalidTransaction(inner())).into(),
+            );
+            let expected_code = expect!["-32002"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect!["Invalid transaction: unknown error: Test rejection"];
+            expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"invalid_transaction"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
+
+            let error_object = error_object_from_rpc(
+                Error::QuorumDriver(QuorumDriverError::RejectedByValidators(inner())).into(),
+            );
+            let expected_code = expect!["-32002"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect!["Invalid transaction: unknown error: Test rejection"];
+            expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"rejected_by_validators"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
 
         #[test]
@@ -345,6 +380,8 @@ mod tests {
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect!["Transaction timed out before reaching finality"];
             expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"timeout_before_finality"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
 
         #[test]
@@ -363,6 +400,9 @@ mod tests {
                 "Transaction failed to reach finality with transient error after 10 attempts."
             ];
             expected_message.assert_eq(error_object.message());
+            let expected_data =
+                expect![[r#"{"reason":"failed_with_transient_error_after_maximum_attempts"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
 
         #[test]
@@ -482,6 +522,8 @@ mod tests {
                 "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n- Balance of gas object 10 is lower than the needed amount: 100\n- Object ID 0x0000000000000000000000000000000000000000000000000000000000000000 Version 0 Digest 11111111111111111111111111111111 is not available for consumption, current version: 10"
             ];
             expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"non_recoverable_transaction_error"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
 
         #[test]
@@ -547,6 +589,8 @@ mod tests {
                 "Transaction is not processed because 10 of validators by stake are overloaded with certificates pending execution."
             ];
             expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"system_overload"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
     }
 }

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -38,6 +38,8 @@ pub enum QuorumDriverError {
     QuorumDriverInternal(IotaError),
     #[error("Invalid user signature: {0}.")]
     InvalidUserSignature(IotaError),
+    /// The fullnode's local validity check proved the transaction invalid.
+    /// The same bytes can never execute.
     #[error("Invalid transaction: {0}.")]
     InvalidTransaction(IotaError),
     #[error(
@@ -72,15 +74,48 @@ pub enum QuorumDriverError {
         errors: GroupedErrors,
         retry_after_secs: u64,
     },
+    /// Over 1/3 of validator stake rejected the transaction during
+    /// submission. The verdicts may depend on validator-local state, and an
+    /// earlier submission attempt may already be in consensus, so the
+    /// transaction may still execute.
+    #[error("Invalid transaction: {0}.")]
+    RejectedByValidators(IotaError),
 }
 
 impl QuorumDriverError {
+    /// Stable machine-readable discriminant for clients. The JSON-RPC layer
+    /// exposes it as the error object's `data.reason` field on errors whose
+    /// `data` was previously empty. `ObjectsDoubleUsed` is the exception: it
+    /// keeps its pre-existing conflicting-transactions `data` payload.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            QuorumDriverError::QuorumDriverInternal(_) => "internal",
+            QuorumDriverError::InvalidUserSignature(_) => "invalid_user_signature",
+            QuorumDriverError::InvalidTransaction(_) => "invalid_transaction",
+            QuorumDriverError::RejectedByValidators(_) => "rejected_by_validators",
+            QuorumDriverError::ObjectsDoubleUsed { .. } => "objects_double_used",
+            QuorumDriverError::TimeoutBeforeFinality => "timeout_before_finality",
+            QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. } => {
+                "failed_with_transient_error_after_maximum_attempts"
+            }
+            QuorumDriverError::NonRecoverableTransactionError { .. } => {
+                "non_recoverable_transaction_error"
+            }
+            QuorumDriverError::SystemOverload { .. } => "system_overload",
+            QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {
+                "tx_already_finalized_with_different_user_signatures"
+            }
+            QuorumDriverError::SystemOverloadRetryAfter { .. } => "system_overload_retry_after",
+        }
+    }
+
     pub fn to_error_message(&self) -> String {
         match self {
             QuorumDriverError::InvalidUserSignature(err) => {
                 format!("Invalid user signature: {err}")
             }
-            QuorumDriverError::InvalidTransaction(err) => {
+            QuorumDriverError::InvalidTransaction(err)
+            | QuorumDriverError::RejectedByValidators(err) => {
                 format!("Invalid transaction: {err}")
             }
             QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {


### PR DESCRIPTION
# Description of change

- Split the client-visible invalid-transaction error by provenance. `InvalidTransaction` now means the fullnode's local validity check proved the bytes can never execute. The new `QuorumDriverError::RejectedByValidators` covers f+1 validator-stake rejections during P-COOL submission.
- Validator verdicts can depend on validator-local state. An earlier attempt of the same submission may already be in consensus, so a rejected transaction may still execute. Clients must not treat the two cases the same way.
- Error codes and message text are unchanged. JSON-RPC errors on the shared -32002 and -32050 codes now carry a machine-readable `data.reason` field, so clients disambiguate without parsing messages. `ObjectsDoubleUsed` is the exception: it keeps its pre-existing conflicting-transactions `data` payload unchanged.
- gRPC mirrors the discriminant: both variants keep `InvalidArgument`, and the status details now carry `google.rpc.ErrorInfo` with reason `INVALID_TRANSACTION` or `REJECTED_BY_VALIDATORS`.

## Links to any relevant issues

Fixes #12444.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: transaction execution errors now include a machine-readable `data.reason` field, and validator rejections are distinguishable from locally proven invalid transactions; `ObjectsDoubleUsed` keeps its existing conflicting-transactions `data` payload.
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] gRPC: invalid-transaction errors now carry `google.rpc.ErrorInfo`, distinguishing locally proven invalid transactions from validator rejections.

