### PR TITLE
fix(iota-core,iota-json-rpc): surface validator overload retry hints from the transaction driver (#12445)

### DIFF
--- a/crates/iota-core/src/transaction_driver/error.rs
+++ b/crates/iota-core/src/transaction_driver/error.rs
@@ -43,6 +43,17 @@ pub(crate) enum TransactionRequestError {
 }
 
 impl TransactionRequestError {
+    /// Retry delay requested by an overloaded validator.
+    fn retry_after_secs(&self) -> Option<u64> {
+        match self {
+            TransactionRequestError::RejectedAtValidator(error)
+            | TransactionRequestError::Aborted(error) => error
+                .is_retryable_overload()
+                .then(|| error.retry_after_secs()),
+            _ => None,
+        }
+    }
+
     pub(crate) fn categorize(&self) -> ErrorCategory {
         match self {
             TransactionRequestError::TimedOutSubmittingTransaction => ErrorCategory::Unavailable,
@@ -116,6 +127,36 @@ pub enum TransactionDriverError {
 impl TransactionDriverError {
     pub(crate) fn is_submission_retriable(&self) -> bool {
         self.categorize().is_submission_retriable()
+    }
+
+    /// True when the overloaded stake of an aborted attempt exceeds all
+    /// other error stake combined. Single rule shared by the driver's
+    /// overload backoff and the client-facing overload mapping. `categorize`
+    /// is unsuitable here: it reads only the largest message bucket and must
+    /// keep preferring retriable errors for retriability.
+    pub(crate) fn is_overload_dominated(&self) -> bool {
+        let TransactionDriverError::Aborted {
+            submission_non_retriable_errors,
+            submission_retriable_errors,
+            ..
+        } = self
+        else {
+            return false;
+        };
+        let mut overloaded = 0;
+        let mut other = 0;
+        for (_, _, stake, category) in submission_retriable_errors
+            .errors
+            .iter()
+            .chain(submission_non_retriable_errors.errors.iter())
+        {
+            if *category == ErrorCategory::ValidatorOverloaded {
+                overloaded += *stake;
+            } else {
+                other += *stake;
+            }
+        }
+        overloaded > 0 && overloaded > other
     }
 
     pub fn categorize(&self) -> ErrorCategory {
@@ -298,6 +339,28 @@ pub struct AggregatedRequestErrors {
     pub errors: Vec<(String, Vec<AuthorityName>, StakeUnit, ErrorCategory)>,
     // The total stake of all errors.
     pub total_stake: StakeUnit,
+    /// Stake per requested retry delay in seconds. Mirrors the aggregator's
+    /// `RetryableOverloadInfo`.
+    pub stake_requested_retry_after: BTreeMap<u64, StakeUnit>,
+}
+
+impl AggregatedRequestErrors {
+    /// Upper stake-weighted median of the requested retry delays. A minority
+    /// of the hinting stake cannot dictate the result.
+    pub fn median_retry_after_secs(&self) -> Option<u64> {
+        let total: StakeUnit = self.stake_requested_retry_after.values().sum();
+        if total == 0 {
+            return None;
+        }
+        let mut cumulative = 0;
+        for (secs, stake) in &self.stake_requested_retry_after {
+            cumulative += stake;
+            if cumulative * 2 > total {
+                return Some(*secs);
+            }
+        }
+        None
+    }
 }
 
 impl std::fmt::Display for AggregatedRequestErrors {
@@ -335,9 +398,13 @@ pub(crate) fn aggregate_request_errors(
     let mut total_stake = 0;
     let mut aggregated_errors =
         BTreeMap::<String, (Vec<AuthorityName>, StakeUnit, ErrorCategory)>::new();
+    let mut stake_requested_retry_after = BTreeMap::new();
 
     for (name, stake, error) in errors {
         total_stake += stake;
+        if let Some(secs) = error.retry_after_secs() {
+            *stake_requested_retry_after.entry(secs).or_default() += stake;
+        }
         let key = format_transaction_request_error(&error);
         let entry = aggregated_errors
             .entry(key)
@@ -355,6 +422,7 @@ pub(crate) fn aggregate_request_errors(
     AggregatedRequestErrors {
         errors,
         total_stake,
+        stake_requested_retry_after,
     }
 }
 
@@ -386,5 +454,99 @@ impl AggregatedEffectsDigests {
     #[cfg(test)]
     pub fn total_stake(&self) -> StakeUnit {
         self.digests.iter().map(|(_, _, stake)| stake).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_types::crypto::{AuthorityPublicKey, AuthorityPublicKeyBytes};
+
+    use super::*;
+
+    /// Aggregation records stake per requested delay. The median ignores
+    /// low-stake outliers.
+    #[test]
+    fn aggregation_records_stake_per_retry_hint() {
+        use fastcrypto::traits::VerifyingKey;
+
+        let name = |i: u8| AuthorityPublicKeyBytes([i; AuthorityPublicKey::LENGTH]);
+        let overloaded = |secs| {
+            TransactionRequestError::RejectedAtValidator(IotaError::ValidatorOverloadedRetryAfter {
+                retry_after_secs: secs,
+            })
+        };
+        let aggregated = aggregate_request_errors(vec![
+            (name(0), 4000, overloaded(10)),
+            (name(1), 3000, overloaded(10)),
+            (name(2), 1000, overloaded(3600)),
+            (
+                name(3),
+                1000,
+                TransactionRequestError::TimedOutSubmittingTransaction,
+            ),
+        ]);
+        assert_eq!(
+            aggregated.stake_requested_retry_after,
+            BTreeMap::from([(10, 7000), (3600, 1000)])
+        );
+        assert_eq!(aggregated.total_stake, 9000);
+        assert_eq!(aggregated.median_retry_after_secs(), Some(10));
+
+        let aggregated = aggregate_request_errors(vec![(
+            name(0),
+            1000,
+            TransactionRequestError::TimedOutSubmittingTransaction,
+        )]);
+        assert!(aggregated.stake_requested_retry_after.is_empty());
+        assert_eq!(aggregated.median_retry_after_secs(), None);
+    }
+
+    /// Dominance requires overloaded stake to exceed all other error stake
+    /// combined.
+    #[test]
+    fn overload_dominance_sums_stake_per_category() {
+        use fastcrypto::traits::VerifyingKey;
+
+        let name = |i: u8| AuthorityPublicKeyBytes([i; AuthorityPublicKey::LENGTH]);
+        let overloaded = |secs| {
+            TransactionRequestError::RejectedAtValidator(IotaError::ValidatorOverloadedRetryAfter {
+                retry_after_secs: secs,
+            })
+        };
+        let aborted = |retriable: Vec<_>| TransactionDriverError::Aborted {
+            submission_non_retriable_errors: AggregatedRequestErrors::default(),
+            submission_retriable_errors: aggregate_request_errors(retriable),
+            observed_effects_digests: AggregatedEffectsDigests { digests: vec![] },
+        };
+
+        // Overload split across delays still outweighs a larger single
+        // bucket.
+        let dominated = aborted(vec![
+            (
+                name(0),
+                4000,
+                TransactionRequestError::TimedOutSubmittingTransaction,
+            ),
+            (name(1), 2500, overloaded(10)),
+            (name(2), 2500, overloaded(30)),
+        ]);
+        assert!(dominated.is_overload_dominated());
+
+        // An overload plurality that is an aggregate minority does not
+        // dominate.
+        let not_dominated = aborted(vec![
+            (name(0), 3500, overloaded(10)),
+            (
+                name(1),
+                3000,
+                TransactionRequestError::TimedOutSubmittingTransaction,
+            ),
+            (
+                name(2),
+                2500,
+                TransactionRequestError::TimedOutGettingFullEffectsAtValidator,
+            ),
+        ]);
+        assert!(!not_dominated.is_overload_dominated());
     }
 }

--- a/crates/iota-core/src/transaction_driver/error.rs
+++ b/crates/iota-core/src/transaction_driver/error.rs
@@ -345,17 +345,23 @@ pub struct AggregatedRequestErrors {
 }
 
 impl AggregatedRequestErrors {
-    /// Upper stake-weighted median of the requested retry delays. A minority
-    /// of the hinting stake cannot dictate the result.
+    /// Upper stake-weighted median of the requested retry delays over all
+    /// overloaded stake. Returns `None` when no delay is backed by a
+    /// majority of that stake.
     pub fn median_retry_after_secs(&self) -> Option<u64> {
-        let total: StakeUnit = self.stake_requested_retry_after.values().sum();
-        if total == 0 {
+        let overloaded_stake: StakeUnit = self
+            .errors
+            .iter()
+            .filter(|(_, _, _, category)| *category == ErrorCategory::ValidatorOverloaded)
+            .map(|(_, _, stake, _)| *stake)
+            .sum();
+        if overloaded_stake == 0 {
             return None;
         }
         let mut cumulative = 0;
         for (secs, stake) in &self.stake_requested_retry_after {
             cumulative += stake;
-            if cumulative * 2 > total {
+            if cumulative * 2 > overloaded_stake {
                 return Some(*secs);
             }
         }

--- a/crates/iota-core/src/transaction_driver/mod.rs
+++ b/crates/iota-core/src/transaction_driver/mod.rs
@@ -17,7 +17,7 @@ use std::{
 use arc_swap::ArcSwap;
 use effects_certifier::*;
 /// Exports
-pub use error::{AggregatedRequestErrors, TransactionDriverError};
+pub use error::{AggregatedEffectsDigests, AggregatedRequestErrors, TransactionDriverError};
 use iota_common::{backoff::ExponentialBackoff, debug_fatal};
 use iota_metrics::{monitored_future, spawn_logged_monitored_task};
 use iota_sdk_types::{TransactionDigest, TransactionEvents};
@@ -228,12 +228,9 @@ where
                     }
                 }
 
-                use iota_types::error::ErrorCategory;
-                let overload = if let Some(e) = &latest_retriable_error {
-                    e.categorize() == ErrorCategory::ValidatorOverloaded
-                } else {
-                    false
-                };
+                let overload = latest_retriable_error
+                    .as_ref()
+                    .is_some_and(|e| e.is_overload_dominated());
                 let delay = if overload {
                     // Increase delay during overload.
                     const OVERLOAD_ADDITIONAL_DELAY: Duration = Duration::from_secs(10);

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -35,9 +35,9 @@ use iota_types::{
     messages_checkpoint::CheckpointSequenceNumber,
     quorum_driver_types::{
         EffectsFinalityInfo, ExecuteTransactionRequestType, ExecuteTransactionRequestV1,
-        ExecuteTransactionResponseV1, FinalizedEffects, IsTransactionExecutedLocally,
-        QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResponse,
-        QuorumDriverResult,
+        ExecuteTransactionResponseV1, FinalizedEffects, GroupedErrors,
+        IsTransactionExecutedLocally, QuorumDriverEffectsQueueResult, QuorumDriverError,
+        QuorumDriverResponse, QuorumDriverResult,
     },
     transaction::{SenderSignedTransactionAPI, VerifiedTransaction},
     transaction_driver_types::{
@@ -1447,6 +1447,8 @@ fn convert_td_to_qd_effects(td: TdFinalizedEffects) -> FinalizedEffects {
 /// `QuorumDriverInternal`, `FailedWithTransientErrorAfterMaximumAttempts`,
 /// and `TimeoutBeforeFinality`, but treat `InvalidTransaction`,
 /// `InvalidUserSignature`, and `RejectedByValidators` as terminal.
+/// An overload-dominated timeout maps to the retriable `SystemOverload` or
+/// `SystemOverloadRetryAfter` instead of `TimeoutBeforeFinality`.
 /// Submission-time rejections that cannot succeed on resubmission must
 /// therefore not be reported as internal.
 fn map_td_error_to_qd(e: TransactionDriverError) -> QuorumDriverError {
@@ -1455,7 +1457,9 @@ fn map_td_error_to_qd(e: TransactionDriverError) -> QuorumDriverError {
         ValidationFailed { error } => {
             QuorumDriverError::InvalidUserSignature(IotaError::InvalidSignature { error })
         }
-        TimeoutWithLastRetriableError { .. } => QuorumDriverError::TimeoutBeforeFinality,
+        TimeoutWithLastRetriableError { last_error, .. } => last_error
+            .and_then(|e| map_overload_to_qd(&e))
+            .unwrap_or(QuorumDriverError::TimeoutBeforeFinality),
         RejectedByValidators {
             submission_non_retriable_errors,
             ..
@@ -1511,6 +1515,54 @@ fn map_td_error_to_qd(e: TransactionDriverError) -> QuorumDriverError {
             QuorumDriverError::QuorumDriverInternal(IotaError::Unknown(msg))
         }
     }
+}
+
+/// Maps an overload-dominated aborted attempt to an overload error, so the
+/// validators' retry hints reach the client instead of a generic timeout.
+fn map_overload_to_qd(e: &TransactionDriverError) -> Option<QuorumDriverError> {
+    use iota_types::{base_types::ConciseableName, error::ErrorCategory};
+
+    if !e.is_overload_dominated() {
+        return None;
+    }
+    let TransactionDriverError::Aborted {
+        submission_retriable_errors,
+        submission_non_retriable_errors,
+        ..
+    } = e
+    else {
+        return None;
+    };
+    let mut overloaded_stake = 0;
+    let mut errors: GroupedErrors = Vec::new();
+    for (msg, names, stake, category) in submission_retriable_errors
+        .errors
+        .iter()
+        .chain(submission_non_retriable_errors.errors.iter())
+    {
+        if *category != ErrorCategory::ValidatorOverloaded {
+            continue;
+        }
+        overloaded_stake += *stake;
+        errors.push((
+            IotaError::Unknown(msg.clone()),
+            *stake,
+            names.iter().map(|n| n.concise_owned()).collect(),
+        ));
+    }
+    Some(
+        match submission_retriable_errors.median_retry_after_secs() {
+            Some(retry_after_secs) => QuorumDriverError::SystemOverloadRetryAfter {
+                overload_stake: overloaded_stake,
+                errors,
+                retry_after_secs,
+            },
+            None => QuorumDriverError::SystemOverload {
+                overloaded_stake,
+                errors,
+            },
+        },
+    )
 }
 
 fn count_validator_attempts(errors: &AggregatedRequestErrors) -> u32 {
@@ -2149,6 +2201,7 @@ mod tests {
                     ErrorCategory::LockConflict,
                 )],
                 total_stake: 3334,
+                stake_requested_retry_after: Default::default(),
             },
             submission_retriable_errors: AggregatedRequestErrors::default(),
         };
@@ -2159,5 +2212,147 @@ mod tests {
         };
         assert!(inner.to_string().contains("Object lock conflict"));
         assert_eq!(qd_error.reason(), "rejected_by_validators");
+    }
+
+    fn timeout_with_last_error(last_error: Option<TransactionDriverError>) -> QuorumDriverError {
+        map_td_error_to_qd(TransactionDriverError::TimeoutWithLastRetriableError {
+            last_error: last_error.map(Box::new),
+            attempts: 3,
+            timeout: std::time::Duration::from_secs(60),
+        })
+    }
+
+    fn aborted_with_retriable(retriable_errors: AggregatedRequestErrors) -> TransactionDriverError {
+        TransactionDriverError::Aborted {
+            submission_non_retriable_errors: AggregatedRequestErrors::default(),
+            submission_retriable_errors: retriable_errors,
+            observed_effects_digests: crate::transaction_driver::AggregatedEffectsDigests {
+                digests: vec![],
+            },
+        }
+    }
+
+    fn bucket(
+        msg: &str,
+        stake: u64,
+        category: iota_types::error::ErrorCategory,
+    ) -> (
+        String,
+        Vec<iota_types::base_types::AuthorityName>,
+        u64,
+        iota_types::error::ErrorCategory,
+    ) {
+        (msg.to_string(), vec![], stake, category)
+    }
+
+    /// Overload split across delays still beats a larger single bucket. The
+    /// 50/50 hint split resolves to the longer delay.
+    #[test]
+    fn map_overloaded_timeout_to_retry_after() {
+        use std::collections::BTreeMap;
+
+        use iota_types::error::ErrorCategory;
+
+        let qd_error =
+            timeout_with_last_error(Some(aborted_with_retriable(AggregatedRequestErrors {
+                errors: vec![
+                    bucket("validator unavailable", 4000, ErrorCategory::Unavailable),
+                    bucket("overloaded 10s", 2500, ErrorCategory::ValidatorOverloaded),
+                    bucket("overloaded 30s", 2500, ErrorCategory::ValidatorOverloaded),
+                ],
+                total_stake: 9000,
+                stake_requested_retry_after: BTreeMap::from([(10, 2500), (30, 2500)]),
+            })));
+        let QuorumDriverError::SystemOverloadRetryAfter {
+            overload_stake,
+            retry_after_secs,
+            ..
+        } = qd_error
+        else {
+            panic!("expected SystemOverloadRetryAfter, got {qd_error:?}");
+        };
+        assert_eq!(overload_stake, 5000);
+        assert_eq!(retry_after_secs, 30);
+    }
+
+    /// A low-stake validator must not dictate the retry hint.
+    #[test]
+    fn map_overloaded_timeout_ignores_low_stake_outlier() {
+        use std::collections::BTreeMap;
+
+        use iota_types::error::ErrorCategory;
+
+        let qd_error =
+            timeout_with_last_error(Some(aborted_with_retriable(AggregatedRequestErrors {
+                errors: vec![
+                    bucket("overloaded 10s", 7000, ErrorCategory::ValidatorOverloaded),
+                    bucket("overloaded 3600s", 1000, ErrorCategory::ValidatorOverloaded),
+                ],
+                total_stake: 8000,
+                stake_requested_retry_after: BTreeMap::from([(10, 7000), (3600, 1000)]),
+            })));
+        assert!(
+            matches!(
+                qd_error,
+                QuorumDriverError::SystemOverloadRetryAfter {
+                    retry_after_secs: 10,
+                    ..
+                }
+            ),
+            "expected the 10s majority hint, got {qd_error:?}"
+        );
+    }
+
+    /// Overload without hints maps to `SystemOverload`. Non-dominant or
+    /// absent overload keeps mapping to `TimeoutBeforeFinality`.
+    #[test]
+    fn map_overloaded_timeout_without_hint_and_non_overload() {
+        use iota_types::error::ErrorCategory;
+
+        let qd_error =
+            timeout_with_last_error(Some(aborted_with_retriable(AggregatedRequestErrors {
+                errors: vec![bucket(
+                    "too many transactions pending",
+                    5000,
+                    ErrorCategory::ValidatorOverloaded,
+                )],
+                total_stake: 5000,
+                stake_requested_retry_after: Default::default(),
+            })));
+        assert!(
+            matches!(qd_error, QuorumDriverError::SystemOverload { overloaded_stake, .. } if overloaded_stake == 5000),
+            "expected SystemOverload, got {qd_error:?}"
+        );
+
+        let qd_error =
+            timeout_with_last_error(Some(aborted_with_retriable(AggregatedRequestErrors {
+                errors: vec![
+                    bucket("overloaded 10s", 3500, ErrorCategory::ValidatorOverloaded),
+                    bucket("timed out submitting", 3000, ErrorCategory::Unavailable),
+                    bucket(
+                        "timed out getting effects",
+                        2500,
+                        ErrorCategory::Unavailable,
+                    ),
+                ],
+                total_stake: 9000,
+                stake_requested_retry_after: Default::default(),
+            })));
+        assert!(matches!(qd_error, QuorumDriverError::TimeoutBeforeFinality));
+
+        let qd_error =
+            timeout_with_last_error(Some(aborted_with_retriable(AggregatedRequestErrors {
+                errors: vec![bucket(
+                    "validator unavailable",
+                    5000,
+                    ErrorCategory::Unavailable,
+                )],
+                total_stake: 5000,
+                stake_requested_retry_after: Default::default(),
+            })));
+        assert!(matches!(qd_error, QuorumDriverError::TimeoutBeforeFinality));
+
+        let qd_error = timeout_with_last_error(None);
+        assert!(matches!(qd_error, QuorumDriverError::TimeoutBeforeFinality));
     }
 }

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -1445,10 +1445,10 @@ fn convert_td_to_qd_effects(td: TdFinalizedEffects) -> FinalizedEffects {
 /// Map a `TransactionDriverError` to a `QuorumDriverError` for client
 /// reporting. The variant choice signals retriability: clients retry on
 /// `QuorumDriverInternal`, `FailedWithTransientErrorAfterMaximumAttempts`,
-/// and `TimeoutBeforeFinality`, but treat `InvalidTransaction` /
-/// `InvalidUserSignature` as terminal. Submission-time rejections that
-/// cannot succeed on resubmission must therefore not be reported as
-/// internal.
+/// and `TimeoutBeforeFinality`, but treat `InvalidTransaction`,
+/// `InvalidUserSignature`, and `RejectedByValidators` as terminal.
+/// Submission-time rejections that cannot succeed on resubmission must
+/// therefore not be reported as internal.
 fn map_td_error_to_qd(e: TransactionDriverError) -> QuorumDriverError {
     use TransactionDriverError::*;
     match e {
@@ -1462,15 +1462,17 @@ fn map_td_error_to_qd(e: TransactionDriverError) -> QuorumDriverError {
         } => {
             // f+1 stake of validators returned non-retriable errors during
             // submission (bad signature, malformed tx, lock conflict, ...).
-            // f+1 means at least one honest validator considered this tx
-            // invalid, so resubmitting the same bytes cannot succeed.
+            // Some verdicts depend on validator-local state, so this does not
+            // prove the transaction can never execute; the variant is kept
+            // distinct from `InvalidTransaction` so clients can tell the two
+            // apart.
             let representative = submission_non_retriable_errors
                 .errors
                 .into_iter()
                 .next()
                 .map(|(msg, _, _, _)| msg)
                 .unwrap_or_else(|| "transaction rejected as invalid during submission".to_string());
-            QuorumDriverError::InvalidTransaction(IotaError::Unknown(format!(
+            QuorumDriverError::RejectedByValidators(IotaError::Unknown(format!(
                 "Transaction was rejected as invalid by more than 1/3 of validator stake \
                  during submission (non-retriable): {representative}"
             )))
@@ -2126,5 +2128,36 @@ mod tests {
             Err(QuorumDriverError::QuorumDriverInternal(_))
         ));
         assert!(orchestrator.subscribe_to_effects_queue().is_none());
+    }
+
+    /// Validator rejections must map to `RejectedByValidators`, not
+    /// `InvalidTransaction`: the verdicts can be validator-local, so clients
+    /// must be able to tell them apart from a locally proven invalid
+    /// transaction.
+    #[test]
+    fn map_validator_rejections_to_distinct_variant() {
+        use iota_types::error::ErrorCategory;
+
+        use crate::transaction_driver::AggregatedRequestErrors;
+
+        let td_error = TransactionDriverError::RejectedByValidators {
+            submission_non_retriable_errors: AggregatedRequestErrors {
+                errors: vec![(
+                    "Object lock conflict".to_string(),
+                    vec![],
+                    3334,
+                    ErrorCategory::LockConflict,
+                )],
+                total_stake: 3334,
+            },
+            submission_retriable_errors: AggregatedRequestErrors::default(),
+        };
+
+        let qd_error = map_td_error_to_qd(td_error);
+        let QuorumDriverError::RejectedByValidators(inner) = &qd_error else {
+            panic!("expected RejectedByValidators, got {qd_error:?}");
+        };
+        assert!(inner.to_string().contains("Object lock conflict"));
+        assert_eq!(qd_error.reason(), "rejected_by_validators");
     }
 }

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -2324,6 +2324,25 @@ mod tests {
             "expected SystemOverload, got {qd_error:?}"
         );
 
+        // A hint backed by a minority of the overloaded stake is not exposed.
+        let qd_error =
+            timeout_with_last_error(Some(aborted_with_retriable(AggregatedRequestErrors {
+                errors: vec![
+                    bucket(
+                        "too many transactions pending",
+                        6000,
+                        ErrorCategory::ValidatorOverloaded,
+                    ),
+                    bucket("overloaded 3600s", 100, ErrorCategory::ValidatorOverloaded),
+                ],
+                total_stake: 6100,
+                stake_requested_retry_after: std::collections::BTreeMap::from([(3600, 100)]),
+            })));
+        assert!(
+            matches!(qd_error, QuorumDriverError::SystemOverload { overloaded_stake, .. } if overloaded_stake == 6100),
+            "expected SystemOverload without a hint, got {qd_error:?}"
+        );
+
         let qd_error =
             timeout_with_last_error(Some(aborted_with_retriable(AggregatedRequestErrors {
                 errors: vec![

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -975,8 +975,8 @@ async fn test_pcool_duplicate_submission_inherits_failure() -> Result<(), anyhow
     let first_err = first.expect_err("transaction spending a stale gas object must fail");
     let second_err = second.expect_err("transaction spending a stale gas object must fail");
     assert!(
-        matches!(first_err, QuorumDriverError::InvalidTransaction(_)),
-        "expected the submission to be rejected as invalid, got {first_err:?}"
+        matches!(first_err, QuorumDriverError::RejectedByValidators(_)),
+        "expected the submission to be rejected by validators, got {first_err:?}"
     );
     assert_eq!(
         first_err, second_err,

--- a/crates/iota-grpc-server/src/error.rs
+++ b/crates/iota-grpc-server/src/error.rs
@@ -156,6 +156,11 @@ impl ErrorDetails {
         self
     }
 
+    pub fn with_error_info(mut self, error_info: ErrorInfo) -> Self {
+        self.error_info = Some(error_info);
+        self
+    }
+
     pub fn with_retry_info(mut self, retry_info: RetryInfo) -> Self {
         self.retry_info = Some(retry_info);
         self
@@ -282,6 +287,9 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RpcError {
         use iota_types::{error::IotaError, quorum_driver_types::QuorumDriverError::*};
         use itertools::Itertools;
 
+        // gRPC mirror of the JSON-RPC `data.reason` discriminant.
+        let reason = error.reason().to_uppercase();
+
         match error {
             InvalidUserSignature(err) => {
                 let message = {
@@ -293,7 +301,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RpcError {
                 };
                 RpcError::new(Code::InvalidArgument, message)
             }
-            InvalidTransaction(err) => {
+            InvalidTransaction(err) | RejectedByValidators(err) => {
                 let message = {
                     let err = match err {
                         IotaError::UserInput { error } => error.to_string(),
@@ -301,7 +309,16 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RpcError {
                     };
                     format!("Invalid transaction: {err}")
                 };
-                RpcError::new(Code::InvalidArgument, message)
+                let details = ErrorDetails::new().with_error_info(ErrorInfo {
+                    reason,
+                    domain: "iota.grpc".to_string(),
+                    ..Default::default()
+                });
+                RpcError {
+                    code: Code::InvalidArgument,
+                    message: Some(message),
+                    details: Some(Box::new(details)),
+                }
             }
             QuorumDriverInternal(err) => RpcError::new(Code::Internal, err.to_string()),
             ObjectsDoubleUsed { conflicting_txes } => {

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -163,16 +163,21 @@ impl From<Error> for RpcError {
             },
             Error::QuorumDriver(err) => {
                 let error_msg = err.to_error_message();
+                // Machine-readable discriminant: the codes below are shared
+                // between variants, so clients disambiguate via
+                // `data.reason` instead of parsing the message.
+                let reason = serde_json::json!({ "reason": err.reason() });
 
                 match err {
                     QuorumDriverError::InvalidUserSignature { .. }
                     | QuorumDriverError::InvalidTransaction { .. }
+                    | QuorumDriverError::RejectedByValidators { .. }
                     | QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures
                     | QuorumDriverError::NonRecoverableTransactionError { .. } => {
-                        let error_object = ErrorObject::owned::<()>(
+                        let error_object = ErrorObject::owned(
                             TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
                             error_msg,
-                            None,
+                            Some(reason),
                         );
                         RpcError::Call(error_object)
                     }
@@ -199,7 +204,7 @@ impl From<Error> for RpcError {
                     | QuorumDriverError::SystemOverload { .. }
                     | QuorumDriverError::SystemOverloadRetryAfter { .. } => {
                         let error_object =
-                            ErrorObject::owned::<()>(TRANSIENT_ERROR_CODE, error_msg, None);
+                            ErrorObject::owned(TRANSIENT_ERROR_CODE, error_msg, Some(reason));
                         RpcError::Call(error_object)
                     }
                     QuorumDriverError::QuorumDriverInternal(_) => {
@@ -332,6 +337,36 @@ mod tests {
                 "Invalid user signature: Signature is not valid: Test inner invalid signature"
             ];
             expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"invalid_user_signature"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
+        }
+
+        #[test]
+        fn test_invalid_transaction_vs_rejected_by_validators() {
+            // Same rendered code and message; only `data.reason` tells a
+            // locally proven invalid transaction apart from one rejected by
+            // the polled validators.
+            let inner = || IotaError::Unknown("Test rejection".to_string());
+
+            let error_object = error_object_from_rpc(
+                Error::QuorumDriver(QuorumDriverError::InvalidTransaction(inner())).into(),
+            );
+            let expected_code = expect!["-32002"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect!["Invalid transaction: unknown error: Test rejection"];
+            expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"invalid_transaction"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
+
+            let error_object = error_object_from_rpc(
+                Error::QuorumDriver(QuorumDriverError::RejectedByValidators(inner())).into(),
+            );
+            let expected_code = expect!["-32002"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect!["Invalid transaction: unknown error: Test rejection"];
+            expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"rejected_by_validators"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
 
         #[test]
@@ -345,6 +380,8 @@ mod tests {
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect!["Transaction timed out before reaching finality"];
             expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"timeout_before_finality"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
 
         #[test]
@@ -363,6 +400,9 @@ mod tests {
                 "Transaction failed to reach finality with transient error after 10 attempts."
             ];
             expected_message.assert_eq(error_object.message());
+            let expected_data =
+                expect![[r#"{"reason":"failed_with_transient_error_after_maximum_attempts"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
 
         #[test]
@@ -482,6 +522,8 @@ mod tests {
                 "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n- Balance of gas object 10 is lower than the needed amount: 100\n- Object ID 0x0000000000000000000000000000000000000000000000000000000000000000 Version 0 Digest 11111111111111111111111111111111 is not available for consumption, current version: 10"
             ];
             expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"non_recoverable_transaction_error"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
 
         #[test]
@@ -547,6 +589,8 @@ mod tests {
                 "Transaction is not processed because 10 of validators by stake are overloaded with certificates pending execution."
             ];
             expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[r#"{"reason":"system_overload"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
     }
 }

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -165,8 +165,15 @@ impl From<Error> for RpcError {
                 let error_msg = err.to_error_message();
                 // Machine-readable discriminant: the codes below are shared
                 // between variants, so clients disambiguate via
-                // `data.reason` instead of parsing the message.
-                let reason = serde_json::json!({ "reason": err.reason() });
+                // `data.reason` instead of parsing the message. Overload
+                // hints are added as `data.retry_after_secs`.
+                let mut data = serde_json::json!({ "reason": err.reason() });
+                if let QuorumDriverError::SystemOverloadRetryAfter {
+                    retry_after_secs, ..
+                } = &err
+                {
+                    data["retry_after_secs"] = (*retry_after_secs).into();
+                }
 
                 match err {
                     QuorumDriverError::InvalidUserSignature { .. }
@@ -177,7 +184,7 @@ impl From<Error> for RpcError {
                         let error_object = ErrorObject::owned(
                             TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
                             error_msg,
-                            Some(reason),
+                            Some(data),
                         );
                         RpcError::Call(error_object)
                     }
@@ -204,7 +211,7 @@ impl From<Error> for RpcError {
                     | QuorumDriverError::SystemOverload { .. }
                     | QuorumDriverError::SystemOverloadRetryAfter { .. } => {
                         let error_object =
-                            ErrorObject::owned(TRANSIENT_ERROR_CODE, error_msg, Some(reason));
+                            ErrorObject::owned(TRANSIENT_ERROR_CODE, error_msg, Some(data));
                         RpcError::Call(error_object)
                     }
                     QuorumDriverError::QuorumDriverInternal(_) => {
@@ -590,6 +597,28 @@ mod tests {
             ];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[r#"{"reason":"system_overload"}"#]];
+            expected_data.assert_eq(&error_object.data().unwrap().to_string());
+        }
+
+        #[test]
+        fn test_system_overload_retry_after() {
+            let quorum_driver_error = QuorumDriverError::SystemOverloadRetryAfter {
+                overload_stake: 4000,
+                errors: vec![(IotaError::UnexpectedMessage, 0, vec![])],
+                retry_after_secs: 30,
+            };
+
+            let rpc_error: RpcError = Error::QuorumDriver(quorum_driver_error).into();
+
+            let error_object = error_object_from_rpc(rpc_error);
+            let expected_code = expect!["-32050"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect![
+                "Transaction is not processed because 4000 of validators are overloaded and asked client to retry after 30."
+            ];
+            expected_message.assert_eq(error_object.message());
+            let expected_data =
+                expect![[r#"{"reason":"system_overload_retry_after","retry_after_secs":30}"#]];
             expected_data.assert_eq(&error_object.data().unwrap().to_string());
         }
     }

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -38,6 +38,8 @@ pub enum QuorumDriverError {
     QuorumDriverInternal(IotaError),
     #[error("Invalid user signature: {0}.")]
     InvalidUserSignature(IotaError),
+    /// The fullnode's local validity check proved the transaction invalid.
+    /// The same bytes can never execute.
     #[error("Invalid transaction: {0}.")]
     InvalidTransaction(IotaError),
     #[error(
@@ -72,15 +74,48 @@ pub enum QuorumDriverError {
         errors: GroupedErrors,
         retry_after_secs: u64,
     },
+    /// Over 1/3 of validator stake rejected the transaction during
+    /// submission. The verdicts may depend on validator-local state, and an
+    /// earlier submission attempt may already be in consensus, so the
+    /// transaction may still execute.
+    #[error("Invalid transaction: {0}.")]
+    RejectedByValidators(IotaError),
 }
 
 impl QuorumDriverError {
+    /// Stable machine-readable discriminant for clients. The JSON-RPC layer
+    /// exposes it as the error object's `data.reason` field on errors whose
+    /// `data` was previously empty. `ObjectsDoubleUsed` is the exception: it
+    /// keeps its pre-existing conflicting-transactions `data` payload.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            QuorumDriverError::QuorumDriverInternal(_) => "internal",
+            QuorumDriverError::InvalidUserSignature(_) => "invalid_user_signature",
+            QuorumDriverError::InvalidTransaction(_) => "invalid_transaction",
+            QuorumDriverError::RejectedByValidators(_) => "rejected_by_validators",
+            QuorumDriverError::ObjectsDoubleUsed { .. } => "objects_double_used",
+            QuorumDriverError::TimeoutBeforeFinality => "timeout_before_finality",
+            QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. } => {
+                "failed_with_transient_error_after_maximum_attempts"
+            }
+            QuorumDriverError::NonRecoverableTransactionError { .. } => {
+                "non_recoverable_transaction_error"
+            }
+            QuorumDriverError::SystemOverload { .. } => "system_overload",
+            QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {
+                "tx_already_finalized_with_different_user_signatures"
+            }
+            QuorumDriverError::SystemOverloadRetryAfter { .. } => "system_overload_retry_after",
+        }
+    }
+
     pub fn to_error_message(&self) -> String {
         match self {
             QuorumDriverError::InvalidUserSignature(err) => {
                 format!("Invalid user signature: {err}")
             }
-            QuorumDriverError::InvalidTransaction(err) => {
+            QuorumDriverError::InvalidTransaction(err)
+            | QuorumDriverError::RejectedByValidators(err) => {
                 format!("Invalid transaction: {err}")
             }
             QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {


### PR DESCRIPTION
# Description of change

- Validators tell overloaded clients when to come back via `retry_after_secs`, but the TransactionDriver path drops the hint. This plumbs it through to clients again.
- `AggregatedRequestErrors` now records the stake behind each requested retry delay, mirroring the aggregator's `RetryableOverloadInfo`.
- A driver timeout maps to `SystemOverloadRetryAfter`, or to `SystemOverload` without hints, when the overloaded stake exceeds all other observed error stake combined. The hint is the upper stake-weighted median of the requested delays, so a minority of the hinting stake cannot dictate client backoff.
- gRPC already renders `SystemOverloadRetryAfter` as `Unavailable` with `RetryInfo`, so that rendering becomes reachable on the P-COOL path. JSON-RPC additionally exposes `data.retry_after_secs`.

Stacked on #12744.

## Links to any relevant issues

Fixes #12445.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [x] JSON-RPC: overload errors on the P-COOL submission path carry `data.retry_after_secs`.
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] gRPC: `RetryInfo` retry hints are populated again on the P-COOL submission path during overload.
