### PR TITLE
fix(starfish): recover committed empty payloads

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1608,10 +1608,18 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let store_transactions = if !below_gc.is_empty() {
             let refs: Vec<GenericTransactionRef> =
                 below_gc.iter().copied().map(Into::into).collect();
-            self.store
-                .read_serialized_transactions(&refs)?
+            let transactions = self.store.read_serialized_transactions(&refs)?;
+            transactions
                 .into_iter()
                 .zip(below_gc)
+                .map(|(transaction, transaction_ref)| {
+                    let transaction = transaction.or_else(|| {
+                        self.context
+                            .empty_transactions_for_ref(transaction_ref.into())
+                            .map(|empty| empty.serialized().clone())
+                    });
+                    (transaction, transaction_ref)
+                })
                 .collect::<Vec<_>>()
         } else {
             vec![]
@@ -4551,7 +4559,7 @@ mod tests {
         let rounds = 10;
         let validators = 4;
         let (context, key_pairs) = Context::new_for_test(validators);
-        let context = Context {
+        let mut context = Context {
             parameters: Parameters {
                 max_transactions_per_transaction_sync_fetch: 20,
                 max_transactions_per_commit_sync_fetch: 10,
@@ -4560,6 +4568,7 @@ mod tests {
             },
             ..context
         };
+        context.protocol_config.set_gc_depth_for_testing(5);
         let context = Arc::new(context);
         let block_verifier = Arc::new(SignedBlockVerifier::new(
             context.clone(),
@@ -4741,6 +4750,37 @@ mod tests {
         // Verify that we received zero transactions since they are not present in the
         // dag
         assert!(serialized_transactions.is_empty());
+
+        let leader = all_block_headers[(2 * rounds) as usize][0].reference();
+        dag_state
+            .write()
+            .update_last_solid_subdag_base(crate::commit::SubDagBase {
+                leader,
+                headers: vec![],
+                committed_header_refs: vec![],
+                timestamp_ms: 0,
+                commit_ref: crate::commit::CommitRef::new(1, crate::commit::CommitDigest::MIN),
+                reputation_scores_desc: vec![],
+            });
+        let empty_ref = TransactionRef {
+            round: 1,
+            author: AuthorityIndex::new_for_test(0),
+            transactions_commitment: TransactionsCommitment::compute_empty_transactions_commitment(
+                &context.committee,
+            ),
+        };
+        assert!(empty_ref.round < dag_state.read().gc_round_for_last_solid_commit());
+
+        let serialized_transactions = authority_service
+            .handle_fetch_transactions(peer, vec![empty_ref], TransactionFetchMode::FastCommitSync)
+            .await
+            .unwrap();
+        let returned: SerializedTransactionsV2 =
+            bcs::from_bytes(&serialized_transactions[0]).unwrap();
+        let transactions: Vec<Transaction> =
+            bcs::from_bytes(&returned.serialized_transactions).unwrap();
+        assert_eq!(returned.transaction_ref, empty_ref);
+        assert!(transactions.is_empty());
     }
 
     /// Tests that handle_fetch_headers preserves the original request order

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -17,8 +17,8 @@ use itertools::Itertools as _;
 use rs_merkle::{MerkleProof, MerkleTree};
 use serde::{Deserialize, Serialize};
 use starfish_config::{
-    AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction, DefaultHashFunctionWrapper, Epoch,
-    ProtocolKeyPair, ProtocolKeySignature, ProtocolPublicKey,
+    AuthorityIndex, Committee, DIGEST_LENGTH, DefaultHashFunction, DefaultHashFunctionWrapper,
+    Epoch, ProtocolKeyPair, ProtocolKeySignature, ProtocolPublicKey,
 };
 use tracing::instrument;
 
@@ -26,7 +26,7 @@ use crate::{
     authority_set::AuthoritySet,
     commit::CommitVote,
     context::Context,
-    encoder::{ShardEncoder, create_encoder},
+    encoder::{ShardEncoder, create_encoder_for_committee},
     error::{ConsensusError, ConsensusResult},
     transaction_ref::{GenericTransactionRef, TransactionRef},
 };
@@ -943,13 +943,24 @@ impl TransactionsCommitment {
     /// Commitment over an empty transaction list. The value depends on the
     /// committee size through the erasure-coding shard counts.
     pub(crate) fn compute_empty_transactions_commitment(
-        context: &Arc<Context>,
+        committee: &Committee,
     ) -> TransactionsCommitment {
-        let mut encoder = create_encoder(context);
+        let info_length = committee.info_length();
+        let parity_length = committee.size() - info_length;
+        let mut encoder = create_encoder_for_committee(committee);
         let serialized = Transaction::serialize(&[])
             .expect("Serializing an empty transaction list should not fail");
-        Self::compute_transactions_commitment(&serialized, context, &mut encoder)
+        let encoded_shards = encoder
+            .encode_serialized_data(&serialized, info_length, parity_length)
+            .expect("Encoding empty transactions should not fail");
+        let authority = committee
+            .authorities()
+            .next()
+            .expect("Committee should not be empty")
+            .0;
+        Self::compute_merkle_root_and_proof(&encoded_shards, authority)
             .expect("Computing the empty transactions commitment should not fail")
+            .0
     }
 }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -652,6 +652,13 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             );
         })?;
 
+        // Empty payloads can be recovered from their commitments.
+        fill_missing_empty_transactions(
+            &inner.context,
+            &mut committed_tx_refs,
+            &mut fetched_transactions,
+        );
+
         // The response may be missing transactions for a suffix of the commits,
         // e.g. when the stream was cut off by the response byte limit or a
         // mid-stream network error. Keep the prefix of commits whose
@@ -996,6 +1003,20 @@ fn process_serialized_transactions(
     Ok(fetched_transactions)
 }
 
+fn fill_missing_empty_transactions(
+    context: &Context,
+    committed_tx_refs: &mut BTreeSet<TransactionRef>,
+    fetched_transactions: &mut BTreeMap<TransactionRef, Bytes>,
+) {
+    committed_tx_refs.retain(|transaction_ref| {
+        let Some(empty) = context.empty_transactions_for_ref((*transaction_ref).into()) else {
+            return true;
+        };
+        fetched_transactions.insert(*transaction_ref, empty.serialized().clone());
+        false
+    });
+}
+
 /// Truncates verified `commits` (and their aligned per-commit transaction
 /// refs in `commits_tx_refs`) to the longest prefix whose committed
 /// transactions are all present in `fetched_transactions`, and drops fetched
@@ -1145,14 +1166,26 @@ mod tests {
         pub(crate) fn two_commit_response(
             context: &Arc<Context>,
         ) -> (Vec<Bytes>, Vec<Bytes>, Vec<Bytes>) {
+            two_commit_response_with_payloads(
+                context,
+                [
+                    vec![Transaction::new(vec![1u8; 16])],
+                    vec![Transaction::new(vec![2u8; 16])],
+                ],
+            )
+        }
+
+        fn two_commit_response_with_payloads(
+            context: &Arc<Context>,
+            transactions: [Vec<Transaction>; 2],
+        ) -> (Vec<Bytes>, Vec<Bytes>, Vec<Bytes>) {
             let mut encoder = create_encoder(context);
 
             // Two chained commits, each committing one transaction.
             let mut transaction_refs = Vec::new();
             let mut serialized_transactions = Vec::new();
-            for round in 1..=2u32 {
-                let serialized =
-                    Transaction::serialize(&[Transaction::new(vec![round as u8; 16])]).unwrap();
+            for (round, transactions) in (1..=2u32).zip(transactions) {
+                let serialized = Transaction::serialize(&transactions).unwrap();
                 let commitment = TransactionsCommitment::compute_transactions_commitment(
                     &serialized,
                     context,
@@ -1274,6 +1307,38 @@ mod tests {
                     .get(),
                 1
             );
+        }
+
+        #[tokio::test]
+        async fn fills_empty_payload_omitted_by_peer() {
+            let context = fast_sync_context();
+            let (commits, vote_headers, mut response_transactions) =
+                two_commit_response_with_payloads(
+                    &context,
+                    [vec![], vec![Transaction::new(vec![2u8; 16])]],
+                );
+            response_transactions.remove(0);
+
+            let network_client = Arc::new(FakeNetworkClient {
+                commits_and_transactions: Some((commits, vote_headers, response_transactions)),
+                ..Default::default()
+            });
+            let inner = make_inner(context.clone(), network_client);
+
+            let output = FastCommitSyncer::fetch_once(
+                inner,
+                AuthorityIndex::new_for_test(1),
+                (1..=2).into(),
+                Duration::from_millis(100),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(output.commits.len(), 2);
+            assert_eq!(output.committed_subdags.len(), 2);
+            assert_eq!(output.committed_subdags[0].transactions.len(), 1);
+            assert!(!output.committed_subdags[0].transactions[0].has_transactions());
+            assert!(output.committed_subdags[1].transactions[0].has_transactions());
         }
 
         /// Runs `fetch_once` against a preset response served by authority 1

--- a/crates/starfish/core/src/context.rs
+++ b/crates/starfish/core/src/context.rs
@@ -15,9 +15,12 @@ use tokio::time::Instant;
 #[cfg(test)]
 use crate::metrics::test_metrics;
 use crate::{
-    block_header::{BlockTimestampMs, Round},
+    block_header::{
+        BlockTimestampMs, CommitmentVerifiedTransactions, Round, TransactionsCommitment,
+    },
     metrics::Metrics,
     peer_responsiveness::PeerResponsiveness,
+    transaction_ref::GenericTransactionRef,
 };
 
 /// Context contains per-epoch configuration and metrics shared by all
@@ -41,6 +44,8 @@ pub(crate) struct Context {
     /// Tracks per-peer responsiveness and ranks candidates for synchronizer
     /// peer selection. Shared per epoch.
     pub peer_responsiveness: Arc<PeerResponsiveness>,
+    /// Commitment over an empty transaction list for this committee.
+    pub(crate) empty_transactions_commitment: TransactionsCommitment,
 }
 
 impl Context {
@@ -54,6 +59,8 @@ impl Context {
         clock: Arc<Clock>,
     ) -> Self {
         let peer_responsiveness = PeerResponsiveness::new(&committee, metrics.clone());
+        let empty_transactions_commitment =
+            TransactionsCommitment::compute_empty_transactions_commitment(&committee);
         Self {
             epoch_start_timestamp_ms,
             own_index,
@@ -63,11 +70,23 @@ impl Context {
             metrics,
             clock,
             peer_responsiveness,
+            empty_transactions_commitment,
         }
     }
 
     pub(crate) fn authority_hostname(&self, authority: AuthorityIndex) -> &str {
         self.committee.authority(authority).hostname.as_str()
+    }
+
+    pub(crate) fn empty_transactions_for_ref(
+        &self,
+        transaction_ref: GenericTransactionRef,
+    ) -> Option<CommitmentVerifiedTransactions> {
+        let GenericTransactionRef::TransactionRef(transaction_ref) = transaction_ref else {
+            return None;
+        };
+        (transaction_ref.transactions_commitment == self.empty_transactions_commitment)
+            .then(|| CommitmentVerifiedTransactions::new_empty_from_ref(transaction_ref, None))
     }
 
     /// Lower bound (inclusive) on the round of an acknowledgment or non-own
@@ -121,6 +140,8 @@ impl Context {
 
     #[cfg(test)]
     pub(crate) fn with_committee(mut self, committee: Committee) -> Self {
+        self.empty_transactions_commitment =
+            TransactionsCommitment::compute_empty_transactions_commitment(&committee);
         self.committee = committee;
         self
     }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -365,9 +365,6 @@ pub(crate) struct DagState {
     /// leader rounds, keyed by leader round.
     starfish_speed_leader_hints: BTreeMap<Round, StarfishSpeedLeaderRoundHints>,
 
-    /// Commitment over an empty transaction list for this committee.
-    empty_transactions_commitment: TransactionsCommitment,
-
     /// Broadcast sender for DAG visualizer events.
     #[cfg(feature = "dag-visualizer")]
     dag_visualizer_sender: Option<tokio::sync::broadcast::Sender<DagVisualizerEvent>>,
@@ -463,9 +460,6 @@ impl DagState {
             unscored_committed_subdags.len()
         );
 
-        let empty_transactions_commitment =
-            TransactionsCommitment::compute_empty_transactions_commitment(&context);
-
         let mut state = Self {
             context,
             genesis,
@@ -497,7 +491,6 @@ impl DagState {
             evicted_rounds: vec![0; num_authorities],
             cordial_knowledge_senders: None,
             starfish_speed_leader_hints: BTreeMap::new(),
-            empty_transactions_commitment,
             #[cfg(feature = "dag-visualizer")]
             dag_visualizer_sender: None,
         };
@@ -1144,7 +1137,7 @@ impl DagState {
                 transactions[index] = Some(transaction.clone());
                 continue;
             }
-            if let Some(empty) = self.empty_transactions_for_ref(transactions_ref) {
+            if let Some(empty) = self.context.empty_transactions_for_ref(*transactions_ref) {
                 transactions[index] = Some(empty);
                 continue;
             }
@@ -1201,7 +1194,7 @@ impl DagState {
                 transactions[index] = Some(transaction.serialized().clone());
                 continue;
             }
-            if let Some(empty) = self.empty_transactions_for_ref(transactions_ref) {
+            if let Some(empty) = self.context.empty_transactions_for_ref(*transactions_ref) {
                 transactions[index] = Some(empty.serialized().clone());
                 continue;
             }
@@ -2070,7 +2063,7 @@ impl DagState {
                 exist[index] = self.get_genesis_block(tx_ref).is_some();
                 continue;
             }
-            if self.empty_transactions_for_ref(&tx_ref).is_some() {
+            if self.context.empty_transactions_for_ref(tx_ref).is_some() {
                 exist[index] = true;
                 continue;
             }
@@ -2263,15 +2256,19 @@ impl DagState {
         let Some(header) = self.recent_block_headers.get(block_ref) else {
             return false;
         };
-        // An empty payload is fully determined by the header's commitment.
-        if header.transactions_commitment() == self.empty_transactions_commitment {
-            return true;
-        }
-        let transaction_ref = GenericTransactionRef::from(TransactionRef {
+        let transaction_ref = TransactionRef {
             round: block_ref.round,
             author: block_ref.author,
             transactions_commitment: header.transactions_commitment(),
-        });
+        };
+        if self
+            .context
+            .empty_transactions_for_ref(transaction_ref.into())
+            .is_some()
+        {
+            return true;
+        }
+        let transaction_ref = GenericTransactionRef::from(transaction_ref);
         self.recent_transactions_by_authority[block_ref.author].contains_key(&transaction_ref)
     }
 
@@ -2980,23 +2977,6 @@ impl DagState {
                     .base
             })
             .collect()
-    }
-
-    /// Returns the empty transactions object for `tx_ref` when its commitment
-    /// is the commitment over an empty transaction list, `None` otherwise.
-    fn empty_transactions_for_ref(
-        &self,
-        tx_ref: &GenericTransactionRef,
-    ) -> Option<CommitmentVerifiedTransactions> {
-        match tx_ref {
-            GenericTransactionRef::TransactionRef(tx_ref) => (tx_ref.transactions_commitment
-                == self.empty_transactions_commitment)
-                .then(|| CommitmentVerifiedTransactions::new_empty_from_ref(*tx_ref, None)),
-            // The legacy BlockRef form carries no commitment; commits that
-            // use it derive refs from acknowledgments, which never include
-            // empty blocks.
-            GenericTransactionRef::BlockRef(_) => None,
-        }
     }
 
     /// Rounds the last commit's leader is ahead of the last solid commit's

--- a/crates/starfish/core/src/encoder.rs
+++ b/crates/starfish/core/src/encoder.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 pub(crate) use reed_solomon_simd::ReedSolomonEncoder;
+use starfish_config::Committee;
 
 use crate::{block_header::Shard, context::Context, error::ConsensusError};
 
@@ -128,8 +129,14 @@ fn create_shards_from_serialized_transactions(
     data
 }
 pub(crate) fn create_encoder(context: &Arc<Context>) -> Box<dyn ShardEncoder + Send + Sync> {
-    let info_length = context.committee.info_length();
-    let parity_length = context.committee.size() - info_length;
+    create_encoder_for_committee(&context.committee)
+}
+
+pub(crate) fn create_encoder_for_committee(
+    committee: &Committee,
+) -> Box<dyn ShardEncoder + Send + Sync> {
+    let info_length = committee.info_length();
+    let parity_length = committee.size() - info_length;
     if info_length == 0 {
         panic!("Info length must be greater than 0");
     }


### PR DESCRIPTION
# Description of change

While investigating frequent `FetchedTransactionsMismatch` warnings in fast commit sync, we separated two failure modes using 24 hours of validator logs from the current epoch. 

1. PR #12732 covers cut streams: all 333 responses with `received == 0` followed a stream failure. The abortion of stream led to this error.
2. The other much more frequent appearance of this error is due to the empty payload, not served by the peer.

**Key issue**: StarfishSpeed can optimistically commit an empty leader payload from its header and strong votes. A validator that learns only the header does not fetch shards or persist a payload row. When serving the transactions in the fast commit path, it omits that entry, and the fast-sync client treats it as missing.

Both paths now use `Context::empty_transactions_for_ref` to reconstruct a committed empty payload from its canonical commitment. 

## Links to any relevant issues

Closes #12748

Related: #12731, #12732

Follow-up: #12750

## How the change has been tested

- [x] Basic tests: formatting and `cargo clippy -p starfish-core --lib -- -D warnings`
- [x] Added a fast-sync regression test for an omitted committed empty payload
- [x] Added below-GC server coverage for an empty reference without a storage row
- [x] Ran all 512 `starfish-core` library tests
