### PR TITLE
fix(starfish): preserve transaction fetch order

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -1631,15 +1631,20 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             vec![]
         };
 
-        // Combine and serialize the results
+        let transactions_by_ref: BTreeMap<_, _> = store_transactions
+            .into_iter()
+            .chain(dag_transactions)
+            .filter_map(|(transaction, transaction_ref)| {
+                transaction.map(|transaction| (transaction_ref, transaction))
+            })
+            .collect();
+
         let mut result = Vec::new();
-        for (opt_serialized_tx, transaction_ref) in
-            store_transactions.into_iter().chain(dag_transactions)
-        {
-            if let Some(serialized_tx) = opt_serialized_tx {
+        for transaction_ref in committed_transactions_refs {
+            if let Some(serialized_tx) = transactions_by_ref.get(&transaction_ref) {
                 let serialized = bcs::to_bytes(&SerializedTransactionsV2 {
                     transaction_ref,
-                    serialized_transactions: serialized_tx,
+                    serialized_transactions: serialized_tx.clone(),
                 })
                 .map_err(ConsensusError::SerializationFailure)?;
                 result.push(Bytes::from(serialized));
@@ -4743,13 +4748,9 @@ mod tests {
         assert!(serialized_transactions.is_empty());
     }
 
-    /// Tests that handle_fetch_headers preserves the original request order
-    /// of block refs when they span the GC boundary — i.e. some are fetched
-    /// from the persistent store (below GC) and others from in-memory
-    /// dag_state (at or above GC). The interleaved input order must be
-    /// maintained in the response.
+    /// Tests request order across the GC boundary.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_handle_fetch_headers_commit_sync_order_across_gc_boundary() {
+    async fn test_handle_fetch_data_commit_sync_order_across_gc_boundary() {
         // GIVEN
         let rounds = 20;
         let validators = 4;
@@ -4858,6 +4859,7 @@ mod tests {
                 ..WriteBatch::default()
             })
             .expect("Failed to write block headers to store");
+        dag_state.write().flush();
 
         // Set last_solid_subdag_base so gc_round_for_last_solid_commit() is ~10.
         // gc_round = leader_round.saturating_sub(gc_depth * 2) = 20 - 10 = 10
@@ -4951,6 +4953,33 @@ mod tests {
                 verified_block_header.reference()
             );
         }
+
+        let transaction_refs_by_block: BTreeMap<_, _> = headers_by_round
+            .iter()
+            .flatten()
+            .map(|header| (header.reference(), header.transaction_ref()))
+            .collect();
+        let transaction_refs: Vec<_> = interleaved_refs
+            .iter()
+            .map(|block_ref| transaction_refs_by_block[block_ref])
+            .collect();
+        let returned_transactions = authority_service
+            .handle_fetch_transactions(
+                peer,
+                transaction_refs.clone(),
+                TransactionFetchMode::FastCommitSync,
+            )
+            .await
+            .unwrap();
+        let returned_refs: Vec<TransactionRef> = returned_transactions
+            .iter()
+            .map(|transaction| {
+                bcs::from_bytes::<SerializedTransactionsV2>(transaction)
+                    .unwrap()
+                    .transaction_ref
+            })
+            .collect();
+        assert_eq!(returned_refs, transaction_refs);
     }
 
     #[test]


### PR DESCRIPTION
# Description of change

`handle_fetch_transactions` partitions requested references around the GC boundary, reads older entries from storage and recent entries from `DagState`, then previously emitted those two groups in partition order. An interleaved request therefore received all below-GC entries before all recent entries.

Fast commit-sync responses are byte limited, and the client can only use the longest commit prefix whose payloads arrived. Reordering can spend the response budget on later commits while an earlier payload is still missing.

Index fetched payloads by `TransactionRef` and serialize them in the original request order. Missing entries remain omitted, and the storage and `DagState` reads are unchanged.

This PR is stacked on #12749 and should be retargeted to `develop` after #12749 merges.

## Links to any relevant issues

Follow-up to #12748

Stacked on #12749

## How the change has been tested

- [x] Basic tests: formatting and `cargo clippy -p starfish-core --lib -- -D warnings`
- [x] Extended the GC-boundary regression test with interleaved transaction references
- [x] Ran all 512 `starfish-core` library tests on the stacked changes
