### PR TITLE
refactor(iota-config): validate the node config at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7197,6 +7197,7 @@ dependencies = [
  "reqwest",
  "rustc_version_runtime",
  "serde",
+ "serde_yaml",
  "tap",
  "telemetry-subscribers",
  "tokio",

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -827,8 +827,9 @@ impl NodeConfig {
         self.consensus_config.is_some()
     }
 
-    /// Validate the node config. This fails if a node could not start with
-    /// the config, or if it would start and ignore part of the config.
+    /// Validate the node config. The checks reject a config a node could
+    /// not start with. They also reject the known cases where a node would
+    /// start and ignore part of the config.
     pub fn validate(&self) -> Result<()> {
         // Validators do not expose the gRPC API. Only an explicit
         // `grpc-api-config: null` reaches this. An absent key deserializes to

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -225,8 +225,8 @@ pub struct NodeConfig {
     ///
     /// With the key absent the default denial-of-service protection policy
     /// applies, an explicit `null` turns traffic control off, and a value
-    /// configures it. A node that turns it off must drop `firewall_config`
-    /// too; `validate` rejects a firewall without a policy.
+    /// configures it. A node that turns it off must also drop
+    /// `firewall_config`. `validate` rejects a firewall without a policy.
     #[serde(
         skip_serializing_if = "is_default_traffic_controller_policy_config",
         default = "default_traffic_controller_policy_config"
@@ -827,11 +827,12 @@ impl NodeConfig {
         self.consensus_config.is_some()
     }
 
-    /// Validate the node config, returning an error if a node could not
-    /// start with this config or would start ignoring part of it.
+    /// Validate the node config. This fails if a node could not start with
+    /// the config, or if it would start and ignore part of the config.
     pub fn validate(&self) -> Result<()> {
-        // Validators do not expose the gRPC API. Only an explicit `grpc-api-config:
-        // null` reaches this; an absent key deserializes to the default config.
+        // Validators do not expose the gRPC API. Only an explicit
+        // `grpc-api-config: null` reaches this. An absent key deserializes to
+        // the default config.
         if !self.is_validator() && self.enable_grpc_api && self.grpc_api_config.is_none() {
             anyhow::bail!(
                 "`enable-grpc-api` is set but `grpc-api-config` is missing; set \
@@ -1766,7 +1767,7 @@ mod tests {
         config.grpc_api_config = Some(GrpcApiConfig::default());
         config.validate().unwrap();
 
-        // Validators do not expose the gRPC API; the check does not apply.
+        // Validators do not expose the gRPC API. The check does not apply.
         config.grpc_api_config = None;
         config.consensus_config = Some(consensus_config());
         config.validate().unwrap();

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -830,10 +830,8 @@ impl NodeConfig {
     /// Validate the node config, returning an error if a node could not
     /// start with this config or would start ignoring part of it.
     pub fn validate(&self) -> Result<()> {
-        // Validators do not expose the gRPC API, so these two fields are only
-        // checked on a fullnode. An absent `grpc-api-config` key deserializes
-        // to a default config, so this mostly guards configs assembled in
-        // process, such as by the builders.
+        // Validators do not expose the gRPC API. Only an explicit `grpc-api-config:
+        // null` reaches this; an absent key deserializes to the default config.
         if !self.is_validator() && self.enable_grpc_api && self.grpc_api_config.is_none() {
             anyhow::bail!(
                 "`enable-grpc-api` is set but `grpc-api-config` is missing; set \

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -831,13 +831,26 @@ impl NodeConfig {
     /// not start with. They also reject the known cases where a node would
     /// start and ignore part of the config.
     pub fn validate(&self) -> Result<()> {
-        // A validator never starts the gRPC server, so an enabled API there
-        // is a setting the node would ignore.
-        if self.is_validator() && self.enable_grpc_api {
-            anyhow::bail!(
-                "`enable-grpc-api` is set, but validators do not expose the gRPC API; turn it \
-                 off, or move the API to a fullnode"
-            );
+        // The settings a validator must not carry: it never starts the gRPC
+        // server, and snapshot publication is a fullnode role.
+        if self.is_validator() {
+            if self.enable_grpc_api {
+                anyhow::bail!(
+                    "`enable-grpc-api` is set, but validators do not expose the gRPC API; turn \
+                     it off, or move the API to a fullnode"
+                );
+            }
+            if self
+                .state_snapshot_write_config
+                .object_store_config
+                .is_some()
+            {
+                anyhow::bail!(
+                    "`state-snapshot-write-config.object-store-config` is set, but snapshot \
+                     upload is only supported on fullnodes; remove the setting or move the \
+                     upload to a fullnode"
+                );
+            }
         }
         // In a file, an absent key deserializes to the default config, and a
         // config built in code carries it too. `None` here therefore means an
@@ -846,19 +859,6 @@ impl NodeConfig {
             anyhow::bail!(
                 "`enable-grpc-api` is set but `grpc-api-config` is `null`; give it a value, \
                  remove the key to take the default config, or turn off `enable-grpc-api`"
-            );
-        }
-        // Snapshot publication is a fullnode-only role.
-        if self.is_validator()
-            && self
-                .state_snapshot_write_config
-                .object_store_config
-                .is_some()
-        {
-            anyhow::bail!(
-                "`state-snapshot-write-config.object-store-config` is set, but snapshot upload \
-                 is only supported on fullnodes; remove the setting or move the upload to a \
-                 fullnode"
             );
         }
         // The uploader builds the store at startup, which needs a backend.

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -839,12 +839,13 @@ impl NodeConfig {
                  off, or move the API to a fullnode"
             );
         }
-        // In a file, an absent key deserializes to the default config. `None`
-        // here therefore means an explicit `null`, or a config built in code.
+        // In a file, an absent key deserializes to the default config, and a
+        // config built in code carries it too. `None` here therefore means an
+        // explicit `null`.
         if self.enable_grpc_api && self.grpc_api_config.is_none() {
             anyhow::bail!(
-                "`enable-grpc-api` is set but `grpc-api-config` is missing; set \
-                 `grpc-api-config` or turn off `enable-grpc-api`"
+                "`enable-grpc-api` is set but `grpc-api-config` is `null`; give it a value, \
+                 remove the key to take the default config, or turn off `enable-grpc-api`"
             );
         }
         // Snapshot publication is a fullnode-only role.
@@ -1765,13 +1766,15 @@ mod tests {
 
     #[test]
     fn validate_requires_a_grpc_config_when_the_api_is_enabled() {
+        // An absent key gives the default config, so only an explicit `null`
+        // reaches this rule.
         let mut config = template_config();
         config.grpc_api_config = None;
         config.validate().unwrap();
 
         config.enable_grpc_api = true;
         let err = config.validate().unwrap_err().to_string();
-        assert!(err.contains("`grpc-api-config` is missing"), "{err}");
+        assert!(err.contains("`grpc-api-config` is `null`"), "{err}");
 
         config.grpc_api_config = Some(GrpcApiConfig::default());
         config.validate().unwrap();

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1708,7 +1708,7 @@ mod tests {
     }
 
     fn consensus_config() -> super::ConsensusConfig {
-        serde_yaml::from_str("db-path: consensus-db").unwrap()
+        serde_yaml::from_str("db-path: /opt/iota/consensus-db").unwrap()
     }
 
     fn object_store_config() -> ObjectStoreConfig {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -831,9 +831,9 @@ impl NodeConfig {
     /// not start with. They also reject the known cases where a node would
     /// start and ignore part of the config.
     pub fn validate(&self) -> Result<()> {
-        // Validators do not expose the gRPC API. Only an explicit
-        // `grpc-api-config: null` reaches this. An absent key deserializes to
-        // the default config.
+        // Validators do not expose the gRPC API. In a file, an absent key
+        // deserializes to the default config. `None` here therefore means an
+        // explicit `null`, or a config built in code.
         if !self.is_validator() && self.enable_grpc_api && self.grpc_api_config.is_none() {
             anyhow::bail!(
                 "`enable-grpc-api` is set but `grpc-api-config` is missing; set \
@@ -866,8 +866,9 @@ impl NodeConfig {
             );
         }
         // The firewall is driven by the traffic controller, which only runs
-        // when a policy is set. An unmentioned `policy-config` deserializes to
-        // the default policy, so only an explicit `null` reaches this.
+        // when a policy is set. In a file, an absent `policy-config`
+        // deserializes to the default policy. `None` here therefore means an
+        // explicit `null`, or a config built in code.
         if self.firewall_config.is_some() && self.policy_config.is_none() {
             anyhow::bail!(
                 "`firewall-config` is set but `policy-config` is `null`; the firewall is driven \

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -831,10 +831,17 @@ impl NodeConfig {
     /// not start with. They also reject the known cases where a node would
     /// start and ignore part of the config.
     pub fn validate(&self) -> Result<()> {
-        // Validators do not expose the gRPC API. In a file, an absent key
-        // deserializes to the default config. `None` here therefore means an
-        // explicit `null`, or a config built in code.
-        if !self.is_validator() && self.enable_grpc_api && self.grpc_api_config.is_none() {
+        // A validator never starts the gRPC server, so an enabled API there
+        // is a setting the node would ignore.
+        if self.is_validator() && self.enable_grpc_api {
+            anyhow::bail!(
+                "`enable-grpc-api` is set, but validators do not expose the gRPC API; turn it \
+                 off, or move the API to a fullnode"
+            );
+        }
+        // In a file, an absent key deserializes to the default config. `None`
+        // here therefore means an explicit `null`, or a config built in code.
+        if self.enable_grpc_api && self.grpc_api_config.is_none() {
             anyhow::bail!(
                 "`enable-grpc-api` is set but `grpc-api-config` is missing; set \
                  `grpc-api-config` or turn off `enable-grpc-api`"
@@ -1769,9 +1776,26 @@ mod tests {
         config.grpc_api_config = Some(GrpcApiConfig::default());
         config.validate().unwrap();
 
-        // Validators do not expose the gRPC API. The check does not apply.
+        // Validators do not expose the gRPC API, so the config check does
+        // not apply to them and the API itself is rejected instead.
         config.grpc_api_config = None;
         config.consensus_config = Some(consensus_config());
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("validators do not expose"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_the_grpc_api_on_a_validator() {
+        let mut config = template_config();
+        config.consensus_config = Some(consensus_config());
+        config.validate().unwrap();
+
+        config.enable_grpc_api = true;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("validators do not expose"), "{err}");
+
+        // The same config is valid for a fullnode.
+        config.consensus_config = None;
         config.validate().unwrap();
     }
 

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -225,7 +225,8 @@ pub struct NodeConfig {
     ///
     /// With the key absent the default denial-of-service protection policy
     /// applies, an explicit `null` turns traffic control off, and a value
-    /// configures it.
+    /// configures it. A node that turns it off must drop `firewall_config`
+    /// too; `validate` rejects a firewall without a policy.
     #[serde(
         skip_serializing_if = "is_default_traffic_controller_policy_config",
         default = "default_traffic_controller_policy_config"
@@ -818,6 +819,63 @@ impl NodeConfig {
 
     pub fn jsonrpc_server_type(&self) -> ServerType {
         self.jsonrpc_server_type.unwrap_or(ServerType::Http)
+    }
+
+    /// A config selects the validator role exactly when it has a consensus
+    /// config.
+    pub fn is_validator(&self) -> bool {
+        self.consensus_config.is_some()
+    }
+
+    /// Validate the node config, returning an error if a node could not
+    /// start with this config or would start ignoring part of it.
+    pub fn validate(&self) -> Result<()> {
+        // Validators do not expose the gRPC API, so these two fields are only
+        // checked on a fullnode. An absent `grpc-api-config` key deserializes
+        // to a default config, so this mostly guards configs assembled in
+        // process, such as by the builders.
+        if !self.is_validator() && self.enable_grpc_api && self.grpc_api_config.is_none() {
+            anyhow::bail!(
+                "`enable-grpc-api` is set but `grpc-api-config` is missing; set \
+                 `grpc-api-config` or turn off `enable-grpc-api`"
+            );
+        }
+        // Snapshot publication is a fullnode-only role.
+        if self.is_validator()
+            && self
+                .state_snapshot_write_config
+                .object_store_config
+                .is_some()
+        {
+            anyhow::bail!(
+                "`state-snapshot-write-config.object-store-config` is set, but snapshot upload \
+                 is only supported on fullnodes; remove the setting or move the upload to a \
+                 fullnode"
+            );
+        }
+        // The uploader builds the store at startup, which needs a backend.
+        if self
+            .state_snapshot_write_config
+            .object_store_config
+            .as_ref()
+            .is_some_and(|store| store.object_store.is_none())
+        {
+            anyhow::bail!(
+                "`state-snapshot-write-config.object-store-config` has no `object-store`; \
+                 snapshot upload needs a storage backend"
+            );
+        }
+        // The firewall is driven by the traffic controller, which only runs
+        // when a policy is set. An unmentioned `policy-config` deserializes to
+        // the default policy, so only an explicit `null` reaches this.
+        if self.firewall_config.is_some() && self.policy_config.is_none() {
+            anyhow::bail!(
+                "`firewall-config` is set but `policy-config` is `null`; the firewall is driven \
+                 by the traffic controller, which does not run without a policy; remove \
+                 `firewall-config` or set a `policy-config`"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -1616,17 +1674,17 @@ mod tests {
         crypto::{
             AuthorityKeyPair, NetworkKeyPair, get_key_pair_from_rng, network_to_simple_keypair,
         },
-        traffic_control::PolicyConfig,
+        traffic_control::{PolicyConfig, RemoteFirewallConfig},
     };
     use rand::{SeedableRng, rngs::StdRng};
     use serde::Serialize;
     use serde_yaml::Value;
 
     use super::{
-        Genesis, GrpcApiConfig, default_grpc_api_config,
+        Genesis, GrpcApiConfig, ObjectStoreConfig, default_grpc_api_config,
         default_periodic_compaction_threshold_days, default_traffic_controller_policy_config,
     };
-    use crate::NodeConfig;
+    use crate::{NodeConfig, object_storage_config::ObjectStoreType};
 
     const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
 
@@ -1639,6 +1697,18 @@ mod tests {
 
     fn template_config() -> NodeConfig {
         serde_yaml::from_str(TEMPLATE).unwrap()
+    }
+
+    fn consensus_config() -> super::ConsensusConfig {
+        serde_yaml::from_str("db-path: consensus-db").unwrap()
+    }
+
+    fn object_store_config() -> ObjectStoreConfig {
+        ObjectStoreConfig {
+            object_store: Some(ObjectStoreType::File),
+            directory: Some(PathBuf::from("/opt/iota/snapshots")),
+            ..Default::default()
+        }
     }
 
     fn round_trip(config: &NodeConfig) -> NodeConfig {
@@ -1683,6 +1753,68 @@ mod tests {
         const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
 
         let _template: NodeConfig = serde_yaml::from_str(TEMPLATE).unwrap();
+    }
+
+    #[test]
+    fn validate_requires_a_grpc_config_when_the_api_is_enabled() {
+        let mut config = template_config();
+        config.grpc_api_config = None;
+        config.validate().unwrap();
+
+        config.enable_grpc_api = true;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("`grpc-api-config` is missing"), "{err}");
+
+        config.grpc_api_config = Some(GrpcApiConfig::default());
+        config.validate().unwrap();
+
+        // Validators do not expose the gRPC API; the check does not apply.
+        config.grpc_api_config = None;
+        config.consensus_config = Some(consensus_config());
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_snapshot_upload_on_a_validator() {
+        let mut config = template_config();
+        config.state_snapshot_write_config.object_store_config = Some(object_store_config());
+        config.validate().unwrap();
+
+        config.consensus_config = Some(consensus_config());
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("snapshot upload"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_a_snapshot_store_without_a_backend() {
+        let mut config = template_config();
+        config.state_snapshot_write_config.object_store_config = Some(ObjectStoreConfig::default());
+
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("storage backend"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_a_firewall_without_a_policy() {
+        let mut config = template_config();
+        config.firewall_config = Some(RemoteFirewallConfig {
+            remote_fw_url: "http://localhost:65000".to_owned(),
+            destination_port: 8080,
+            delegate_spam_blocking: false,
+            delegate_error_blocking: false,
+            drain_path: PathBuf::from("/tmp/drain"),
+            drain_timeout_secs: 300,
+        });
+
+        // The template leaves `policy-config` unmentioned, so the default
+        // policy applies and drives the firewall.
+        config.validate().unwrap();
+
+        // `policy-config: null` turns traffic control off, which leaves
+        // nothing to drive the firewall.
+        config.policy_config = None;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("`firewall-config` is set"), "{err}");
     }
 
     #[test]

--- a/crates/iota-core/src/runtime.rs
+++ b/crates/iota-core/src/runtime.rs
@@ -60,7 +60,7 @@ pub struct IotaRuntimes {
 
 impl IotaRuntimes {
     pub fn new(config: &NodeConfig) -> Self {
-        let is_validator = config.consensus_config().is_some();
+        let is_validator = config.is_validator();
         let (node_threads, serving_threads) =
             size_worker_threads(available_cpu_cores(), is_validator);
 

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -64,6 +64,9 @@ prometheus-filtered.workspace = true
 telemetry-subscribers.workspace = true
 typed-store.workspace = true
 
+[dev-dependencies]
+serde_yaml.workspace = true
+
 [build-dependencies]
 rustc_version_runtime = "0.3"
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2481,8 +2481,7 @@ fn build_kv_store(
 }
 
 /// Builds and starts the gRPC server for the IOTA node based on the node's
-/// configuration. Validators return early as they do not expose the gRPC
-/// API.
+/// configuration.
 ///
 /// Returns `None` on a validator and when the gRPC API is disabled.
 ///

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2567,7 +2567,7 @@ pub async fn build_http_server(
     prometheus_registry: &Registry,
 ) -> Result<Option<iota_http::ServerHandle>> {
     // Validators do not expose these APIs
-    if config.consensus_config().is_some() {
+    if config.is_validator() {
         return Ok(None);
     }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2481,14 +2481,14 @@ fn build_kv_store(
 }
 
 /// Builds and starts the gRPC server for the IOTA node based on the node's
-/// configuration; validators return early as they do not expose the gRPC
+/// configuration. Validators return early as they do not expose the gRPC
 /// API.
 ///
 /// Returns `None` on a validator and when the gRPC API is disabled.
 ///
 /// # Panics
 ///
-/// Panics if the gRPC API is enabled without a `grpc-api-config`;
+/// Panics if the gRPC API is enabled without a `grpc-api-config`.
 /// [`NodeConfig::validate`] rejects such a config at startup.
 async fn build_grpc_server(
     config: &NodeConfig,
@@ -2820,9 +2820,9 @@ mod config_tests {
 
     use super::IotaNode;
 
-    /// `start_async` validates the config before it does anything else, which
-    /// is what keeps the `expect` in `build_grpc_server` and the
-    /// `debug_assert` in `start_state_snapshot` unreachable.
+    /// `start_async` validates the config before it does anything else. That
+    /// keeps the `expect` in `build_grpc_server` and the `debug_assert` in
+    /// `start_state_snapshot` unreachable.
     #[tokio::test]
     async fn start_rejects_a_config_no_node_could_start_with() {
         let mut config: NodeConfig = serde_yaml::from_str(

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -348,13 +348,13 @@ impl IotaNode {
     }
 
     pub async fn start_async(
-        config: NodeConfig,
+        mut config: NodeConfig,
         registry_service: RegistryService,
         server_version: ServerVersion,
         serving_rt_handle: tokio::runtime::Handle,
     ) -> Result<Arc<IotaNode>> {
+        config.validate()?;
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
-        let mut config = config.clone();
         if config.supported_protocol_versions.is_none() {
             info!(
                 "populating config.supported_protocol_versions with default {:?}",
@@ -364,7 +364,7 @@ impl IotaNode {
         }
 
         let run_with_range = config.run_with_range;
-        let is_validator = config.consensus_config().is_some();
+        let is_validator = config.is_validator();
         let is_full_node = !is_validator;
         let prometheus_registry = registry_service.default_registry();
 
@@ -659,12 +659,8 @@ impl IotaNode {
 
         info!("start snapshot upload");
         // Start uploading state snapshot to remote store
-        let state_snapshot_handle = Self::start_state_snapshot(
-            &config,
-            &prometheus_registry,
-            checkpoint_store.clone(),
-            is_full_node,
-        )?;
+        let state_snapshot_handle =
+            Self::start_state_snapshot(&config, &prometheus_registry, checkpoint_store.clone())?;
 
         let checkpoint_progress_tracker = Arc::new(CheckpointProgressTracker::new());
 
@@ -987,22 +983,18 @@ impl IotaNode {
         self.close_epoch(&epoch_store).await
     }
 
-    /// Creates a StateSnapshotUploader and starts it if the StateSnapshotConfig
-    /// is set.
+    /// Creates a StateSnapshotUploader and starts it if
+    /// `state-snapshot-write-config.object-store-config` is set. Snapshot
+    /// publication is a fullnode-only role.
     fn start_state_snapshot(
         config: &NodeConfig,
         prometheus_registry: &Registry,
         checkpoint_store: Arc<CheckpointStore>,
-        is_full_node: bool,
     ) -> Result<Option<tokio::sync::broadcast::Sender<()>>> {
         if let Some(remote_store_config) = &config.state_snapshot_write_config.object_store_config {
-            // Snapshot publication is a fullnode-only role.
-            anyhow::ensure!(
-                is_full_node,
-                "Snapshot upload is configured, but this node is a validator. \
-                 Snapshot publication is only supported on fullnodes. Remove the \
-                 `state_snapshot_write_config.object_store_config` setting, or move \
-                 the upload to a fullnode."
+            debug_assert!(
+                !config.is_validator(),
+                "`NodeConfig::validate` rejects snapshot upload on a validator"
             );
             let snapshot_uploader = StateSnapshotUploader::new(
                 &config.db_checkpoint_path(),
@@ -2489,19 +2481,15 @@ fn build_kv_store(
 }
 
 /// Builds and starts the gRPC server for the IOTA node based on the node's
-/// configuration.
+/// configuration; validators return early as they do not expose the gRPC
+/// API.
 ///
-/// This function performs the following tasks:
-/// 1. Checks if the node is a validator by inspecting the consensus
-///    configuration; if so, it returns early as validators do not expose gRPC
-///    APIs.
-/// 2. Checks if gRPC is enabled in the configuration.
-/// 3. Creates broadcast channels for checkpoint streaming.
-/// 4. Initializes the gRPC checkpoint service.
-/// 5. Spawns the gRPC server to listen for incoming connections.
+/// Returns `None` on a validator and when the gRPC API is disabled.
 ///
-/// Returns a tuple of optional broadcast channels for checkpoint summary and
-/// data.
+/// # Panics
+///
+/// Panics if the gRPC API is enabled without a `grpc-api-config`;
+/// [`NodeConfig::validate`] rejects such a config at startup.
 async fn build_grpc_server(
     config: &NodeConfig,
     state: Arc<AuthorityState>,
@@ -2510,14 +2498,17 @@ async fn build_grpc_server(
     prometheus_registry: &Registry,
     server_version: ServerVersion,
 ) -> Result<Option<GrpcServerHandle>> {
-    // Validators do not expose gRPC APIs
-    if config.consensus_config().is_some() || !config.enable_grpc_api {
+    // Validators do not expose gRPC APIs. This return must agree with the
+    // gRPC rule in `NodeConfig::validate`, which is what makes the `expect`
+    // below unreachable.
+    if config.is_validator() || !config.enable_grpc_api {
         return Ok(None);
     }
 
-    let Some(grpc_config) = &config.grpc_api_config else {
-        return Err(anyhow!("gRPC API is enabled but no configuration provided"));
-    };
+    let grpc_config = config
+        .grpc_api_config
+        .as_ref()
+        .expect("`NodeConfig::validate` rejects an enabled gRPC API without a config");
 
     // Get chain identifier from state directly
     let chain_id = state.get_chain_identifier();
@@ -2818,5 +2809,41 @@ mod runtime_split_tests {
             caller_pool, bind_pool,
             "the fix must move the bind off the caller (node-core) runtime onto serving"
         );
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use iota_config::NodeConfig;
+    use iota_metrics::RegistryService;
+    use prometheus_filtered::Registry;
+
+    use super::IotaNode;
+
+    /// `start_async` validates the config before it does anything else, which
+    /// is what keeps the `expect` in `build_grpc_server` and the
+    /// `debug_assert` in `start_state_snapshot` unreachable.
+    #[tokio::test]
+    async fn start_rejects_a_config_no_node_could_start_with() {
+        let mut config: NodeConfig = serde_yaml::from_str(
+            r#"
+db-path: /nonexistent/db
+network-address: /dns/localhost/tcp/8080/http
+metrics-address: "0.0.0.0:9184"
+json-rpc-address: "0.0.0.0:9000"
+genesis:
+  genesis-file-location: /nonexistent/genesis.blob
+"#,
+        )
+        .unwrap();
+        config.enable_grpc_api = true;
+        config.grpc_api_config = None;
+
+        let err = IotaNode::start(config, RegistryService::new(Registry::new()))
+            .await
+            .unwrap_err();
+
+        let err = format!("{err:#}");
+        assert!(err.contains("`grpc-api-config` is missing"), "{err}");
     }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2843,6 +2843,6 @@ genesis:
             .unwrap_err();
 
         let err = format!("{err:#}");
-        assert!(err.contains("`grpc-api-config` is missing"), "{err}");
+        assert!(err.contains("`grpc-api-config` is `null`"), "{err}");
     }
 }

--- a/crates/iota-node/src/main.rs
+++ b/crates/iota-node/src/main.rs
@@ -57,6 +57,12 @@ fn main() {
 
     let args = Args::parse();
     let mut config = NodeConfig::load(&args.config_path).unwrap();
+    // `start_async` validates too, but at this point no runtime, metrics
+    // server or telemetry has started, so a bad config fails cleanly.
+    if let Err(err) = config.validate() {
+        eprintln!("invalid node config {:?}: {err:#}", args.config_path);
+        std::process::exit(1);
+    }
     assert!(
         config.supported_protocol_versions.is_none(),
         "supported_protocol_versions cannot be read from the config file"

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -679,7 +679,7 @@ impl Swarm {
     pub fn validator_nodes(&self) -> impl Iterator<Item = &Node> {
         self.nodes
             .values()
-            .filter(|node| node.config().consensus_config.is_some())
+            .filter(|node| node.config().is_validator())
     }
 
     pub fn validator_node_handles(&self) -> Vec<IotaNodeHandle> {
@@ -712,7 +712,7 @@ impl Swarm {
     pub fn fullnodes(&self) -> impl Iterator<Item = &Node> {
         self.nodes
             .values()
-            .filter(|node| node.config().consensus_config.is_none())
+            .filter(|node| !node.config().is_validator())
     }
 
     pub async fn spawn_new_node(&mut self, config: NodeConfig) -> IotaNodeHandle {


### PR DESCRIPTION
# Description of change

The node refuses some impossible configs. But each refusal is in a different place. Some bad configs start, and the node ignores part of the file. `NodeConfig::validate()` puts these rules in one function. The node calls it before it starts.

- Adds `NodeConfig::validate()` with five rules:
  - a validator must not set `enable-grpc-api`, because a validator does not serve the gRPC API;
  - a fullnode with `enable-grpc-api` must have a `grpc-api-config`;
  - `state-snapshot-write-config.object-store-config` is for fullnodes only;
  - that object store config must have an `object-store`;
  - `firewall-config` is rejected when `policy-config` is `null`, because the traffic controller drives the firewall.
- `main.rs` validates the config after it reads the file. At this point no runtime, metrics server or telemetry is started, so a bad config fails cleanly. `IotaNode::start_async` validates again before it opens a store. This covers a config that code builds.
- The old refusal sites become an `expect` (`build_grpc_server`) and a `debug_assert` (`start_state_snapshot`). `validate()` makes them unreachable. A test starts a node with the bad config to keep them unreachable.
- Adds `NodeConfig::is_validator()`. A config is a validator config when it has a `consensus-config`. The call sites in `iota-core`, `iota-node` and `iota-swarm` use it instead of the same test written by hand.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/12429. Replaces #12648.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo +nightly fmt`, `cargo ci-clippy` and `IOTA_SKIP_SIMTESTS=1 cargo nextest run -p iota-config -p iota-node --all-features`: 22 tests, all pass. There is one new test for each rule. One more test calls `IotaNode::start` with a config that breaks the gRPC rule. No snapshot changes.

## Change checklist

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

### Release Notes

- [x] Nodes (Validators and Full nodes): a config that sets `firewall-config` while `policy-config` is `null` is now rejected at startup instead of starting with the firewall silently ignored.