### PR TITLE
feat(iota-localnet): derive node configs from a persisted GenesisConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6863,6 +6863,7 @@ dependencies = [
  "msim",
  "prometheus-filtered",
  "rand 0.8.6",
+ "serde_yaml",
  "telemetry-subscribers",
  "tempfile",
  "tokio",

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -5,7 +5,7 @@
 use std::{net::SocketAddr, path::Path};
 
 use async_trait::async_trait;
-use iota_config::{Config, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME, node};
+use iota_config::{Config, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME, node::Genesis};
 use iota_graphql_rpc::{
     config::ConnectionConfig, test_infra::cluster::start_graphql_server_with_fn_rpc,
 };

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -184,7 +184,7 @@ impl Cluster for LocalNewCluster {
             // Derive the node configs of the network from its persisted state.
             let network_config = PersistedNetworkConfig::read(&config_dir)?.into_network_config(
                 &config_dir,
-                node::Genesis::new_from_file(config_dir.join(IOTA_GENESIS_FILENAME)),
+                Genesis::new_from_file(config_dir.join(IOTA_GENESIS_FILENAME)),
             )?;
             cluster_builder = cluster_builder.set_network_config(network_config);
 

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -5,10 +5,7 @@
 use std::{net::SocketAddr, path::Path};
 
 use async_trait::async_trait;
-use iota_config::{
-    Config, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG, PersistedConfig,
-    genesis::Genesis,
-};
+use iota_config::{Config, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME, node};
 use iota_graphql_rpc::{
     config::ConnectionConfig, test_infra::cluster::start_graphql_server_with_fn_rpc,
 };
@@ -19,10 +16,7 @@ use iota_sdk::{
     wallet_context::WalletContext,
 };
 use iota_swarm::memory::Swarm;
-use iota_swarm_config::{
-    genesis_config::GenesisConfig,
-    network_config::{NetworkConfig, NetworkConfigLight},
-};
+use iota_swarm_config::{genesis_config::GenesisConfig, network_config::PersistedNetworkConfig};
 use iota_types::crypto::AccountPrivateKey;
 use tempfile::tempdir;
 use test_cluster::{TestCluster, TestClusterBuilder};
@@ -187,26 +181,11 @@ impl Cluster for LocalNewCluster {
         // Check if we already have a config directory that is passed
         if let Some(config_dir) = options.config_dir.clone() {
             assert!(options.epoch_duration_ms.is_none());
-            // Load the config of the IOTA authority.
-            let network_config_path = config_dir.join(IOTA_NETWORK_CONFIG);
-            let NetworkConfigLight {
-                validator_configs,
-                account_keys,
-                committee_with_network: _,
-            } = PersistedConfig::read(&network_config_path).map_err(|err| {
-                err.context(format!(
-                    "cannot open IOTA network config file at {network_config_path:?}"
-                ))
-            })?;
-
-            // Add genesis objects
-            let genesis_path = config_dir.join(IOTA_GENESIS_FILENAME);
-            let genesis = Genesis::load(genesis_path)?;
-            let network_config = NetworkConfig {
-                validator_configs,
-                account_keys,
-                genesis,
-            };
+            // Derive the node configs of the network from its persisted state.
+            let network_config = PersistedNetworkConfig::read(&config_dir)?.into_network_config(
+                &config_dir,
+                node::Genesis::new_from_file(config_dir.join(IOTA_GENESIS_FILENAME)),
+            )?;
             cluster_builder = cluster_builder.set_network_config(network_config);
 
             cluster_builder = cluster_builder.with_config_dir(config_dir);

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -373,7 +373,7 @@ const PRE_V32_VALIDATOR_LOW_STAKE_GRACE_PERIOD: u64 = 7;
 const PRE_V32_MAX_VALIDATOR_COUNT: u64 = 150;
 
 /// Initial set of parameters for a chain.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct GenesisCeremonyParameters {
     #[serde(default = "GenesisCeremonyParameters::default_timestamp_ms")]
     pub chain_start_timestamp_ms: u64,

--- a/crates/iota-localnet/Cargo.toml
+++ b/crates/iota-localnet/Cargo.toml
@@ -17,6 +17,7 @@ clap.workspace = true
 colored.workspace = true
 fastcrypto.workspace = true
 rand.workspace = true
+serde_yaml.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 tracing.workspace = true

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -6,18 +6,18 @@ use std::{
     fs,
     net::{AddrParseError, IpAddr, Ipv4Addr, SocketAddr},
     num::NonZeroUsize,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
-use anyhow::{anyhow, bail, ensure};
+use anyhow::{Context, anyhow, bail, ensure};
 use clap::*;
 use colored::Colorize;
 use fastcrypto::traits::KeyPair;
 use iota_config::{
     Config, IOTA_BENCHMARK_GENESIS_GAS_KEYSTORE_FILENAME, IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG,
     IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG, NodeConfig,
-    PersistedConfig, genesis_blob_exists, iota_config_dir,
+    PersistedConfig, genesis_blob_exists, iota_config_dir, local_ip_utils,
     node::{Genesis, GrpcApiConfig},
     p2p::SeedPeer,
 };
@@ -35,10 +35,12 @@ use iota_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use iota_sdk::iota_client_config::{IotaClientConfig, IotaEnv};
 use iota_sdk_crypto::simple::SimpleKeypair;
 use iota_sdk_types::Address;
-use iota_swarm::memory::Swarm;
+use iota_swarm::memory::{Node, Swarm};
 use iota_swarm_config::{
-    genesis_config::GenesisConfig,
-    network_config::{NetworkConfig, NetworkConfigLight},
+    genesis_config::{
+        GenesisConfig, SsfnGenesisConfig, ValidatorGenesisConfig, ValidatorGenesisConfigBuilder,
+    },
+    network_config::{NetworkConfig, PersistedNetworkConfig},
     network_config_builder::ConfigBuilder,
     node_config_builder::FullnodeConfigBuilder,
     node_config_override::{
@@ -49,7 +51,7 @@ use iota_swarm_config::{
 use iota_types::traffic_control::PolicyConfig;
 use rand::rngs::OsRng;
 use tempfile::tempdir;
-use tracing::{info, warn};
+use tracing::info;
 
 const CONCURRENCY_LIMIT: usize = 30;
 const DEFAULT_COMMITTEE_SIZE: usize = 1;
@@ -293,6 +295,14 @@ pub enum LocalnetCommand {
         /// genesis with the desired number of validators.
         #[arg(long, help = "The number of validators in the network.")]
         committee_size: Option<usize>,
+        /// Write the node config every node of this run would start with to
+        /// the given directory, then exit without starting the network.
+        ///
+        /// The configs are the ones the run would use, overrides included,
+        /// and each is runnable with `iota-node --config-path`. Nothing reads
+        /// them back: editing one does not change what `start` runs.
+        #[arg(long, value_name = "DIR")]
+        write_config: Option<PathBuf>,
     },
     /// Bootstrap and initialize a new IOTA network
     Genesis {
@@ -367,6 +377,7 @@ impl LocalnetCommand {
                 node_config_override,
                 committee_size,
                 epoch_duration_ms,
+                write_config,
             } => {
                 start(
                     config_dir.clone(),
@@ -385,6 +396,7 @@ impl LocalnetCommand {
                     disable_fullnode_pruning,
                     node_config_override,
                     committee_size,
+                    write_config,
                 )
                 .await
             }
@@ -436,6 +448,7 @@ async fn start(
     disable_fullnode_pruning: bool,
     node_config_override: Vec<String>,
     committee_size: Option<usize>,
+    write_config: Option<PathBuf>,
 ) -> Result<(), anyhow::Error> {
     // Parsed here rather than by clap, whose error would echo the whole
     // argument. These errors name the path only.
@@ -453,6 +466,20 @@ async fn start(
 
     if with_grpc.is_some() {
         ensure!(!no_full_node, "Cannot enable gRPC without a fullnode.");
+    }
+
+    if write_config.is_some() {
+        ensure!(
+            with_faucet.is_none(),
+            "Cannot pass `--with-faucet` and `--write-config` at the same time: the faucet is a \
+             service, and `--write-config` starts nothing."
+        );
+        ensure!(
+            !force_regenesis,
+            "Cannot pass `--force-regenesis` and `--write-config` at the same time: the written \
+             configs would point at a temporary directory that is removed on exit. Pass \
+             `--network.config <DIR>` or run `iota-localnet genesis` first."
+        );
     }
 
     #[cfg(feature = "indexer")]
@@ -508,6 +535,10 @@ async fn start(
     }
 
     let mut swarm_builder = Swarm::builder();
+    // The entry the fullnode's config is derived from. A persisted network
+    // keeps it, so that the fullnode's key pairs, ports and db path are the
+    // same on every run.
+    let mut fullnode_config_info = None;
 
     if disable_fullnode_pruning {
         swarm_builder = swarm_builder.with_disable_fullnode_pruning();
@@ -569,90 +600,28 @@ async fn start(
             );
         }
 
-        let NetworkConfigLight {
-            validator_configs,
-            account_keys,
-            ..
-        } = PersistedConfig::read(&network_config_path).map_err(|err| {
-            err.context(format!(
-                "Cannot open IOTA network config file at {network_config_path:?}"
-            ))
-        })?;
-        let first_validator_config = validator_configs.first().ok_or(anyhow!(
-            "IOTA network config file must contain at least one validator config"
-        ))?;
-        let genesis = first_validator_config.genesis.clone();
-        let migration_tx_data_path = first_validator_config.migration_tx_data_path.clone();
-        ensure!(
-            validator_configs
-                .iter()
-                .all(|config| genesis.eq(&config.genesis)),
-            "All validators in IOTA network config must use the same genesis blob"
-        );
-        ensure!(
-            validator_configs
-                .iter()
-                .all(|config| migration_tx_data_path.eq(&config.migration_tx_data_path)),
-            "All validators in IOTA network config must use the same migration blob"
-        );
-
-        let fullnode_config_path = config_path.join(IOTA_FULLNODE_CONFIG);
-        if fullnode_config_path.exists() {
-            info!(
-                "Loading IOTA-Names options from fullnode config file at {fullnode_config_path:?}"
-            );
-
-            let NodeConfig {
-                iota_names_config,
-                enable_grpc_api,
-                grpc_api_config,
-                db_path,
-                genesis: fullnode_genesis,
-                migration_tx_data_path: fullnode_migration_tx_data_path,
-                ..
-            } = PersistedConfig::read(&fullnode_config_path).map_err(|err| {
-                err.context(format!(
-                    "Cannot open fullnode config file at {fullnode_config_path:?}"
-                ))
-            })?;
-            ensure!(
-                genesis.eq(&fullnode_genesis),
-                "Fullnode must use the same genesis blob as validators in IOTA network config"
-            );
-            ensure!(
-                migration_tx_data_path.eq(&fullnode_migration_tx_data_path),
-                "Fullnode must use the same migration blob as validators in IOTA network config"
-            );
-            swarm_builder = swarm_builder.with_fullnode_db_path(db_path);
-
-            if let Some(iota_names_config) = iota_names_config {
-                swarm_builder = swarm_builder.with_iota_names_config(iota_names_config);
-            }
-
-            swarm_builder = swarm_builder.with_fullnode_enable_grpc_api(enable_grpc_api);
-            if enable_grpc_api {
-                // Apply gRPC configuration if enabled
-                if let Some(grpc_config) = grpc_api_config {
-                    info!("Enabling gRPC API for fullnode with config: {grpc_config:?}");
-                    swarm_builder = swarm_builder.with_fullnode_grpc_api_config(grpc_config);
-                } else {
-                    warn!("gRPC API enabled but no grpc-api-config provided, using default");
-                    swarm_builder =
-                        swarm_builder.with_fullnode_grpc_api_config(GrpcApiConfig::default());
-                }
-            }
-        }
-
-        let network_config = NetworkConfig {
-            validator_configs,
-            account_keys,
-            genesis: genesis.genesis()?.clone(),
-        };
+        let mut persisted_network_config = PersistedNetworkConfig::read(&config_path)?;
+        fullnode_config_info = persisted_network_config
+            .genesis_config
+            .fullnode_config_info
+            .take();
+        // The genesis blob is read, never rebuilt: it is the network's
+        // identity, and the node configs only point at it.
+        let genesis = Genesis::new_from_file(config_path.join(IOTA_GENESIS_FILENAME));
+        let network_config = persisted_network_config.into_network_config(&config_path, genesis)?;
 
         swarm_builder = swarm_builder
             .dir(config_path.clone())
             .with_network_config(network_config);
     }
+
+    // A derived node config is a real node's, so it gets the default
+    // denial-of-service protection the swarm builders leave unset. Set in both
+    // modes, and before the overrides, so `policy-config=null` still clears it.
+    let policy_config = PolicyConfig::default_dos_protection_policy();
+    swarm_builder = swarm_builder
+        .with_validator_policy_config(Some(policy_config.clone()))
+        .with_fullnode_policy_config(Some(policy_config));
 
     // the indexer and GraphQL services communicate with the fullnode via gRPC, we
     // must enable it by default.
@@ -666,10 +635,17 @@ async fn start(
     // the indexer requires to set the fullnode's data ingestion directory
     // note that this overrides the default configuration that is set when running
     // the genesis command, which sets data_ingestion_dir to None.
+    //
+    // The directory is owned here until the network launches, so that
+    // `--write-config`, which starts nothing, leaves none behind.
     #[cfg(feature = "indexer")]
-    if with_indexer.is_some() && data_ingestion_dir.is_none() {
-        data_ingestion_dir = Some(tempdir()?.keep())
-    }
+    let data_ingestion_tempdir = if with_indexer.is_some() && data_ingestion_dir.is_none() {
+        let tempdir = tempdir()?;
+        data_ingestion_dir = Some(tempdir.path().to_path_buf());
+        Some(tempdir)
+    } else {
+        None
+    };
 
     #[cfg(feature = "indexer")]
     if let Some(ref dir) = data_ingestion_dir {
@@ -688,11 +664,25 @@ async fn start(
         swarm_builder = swarm_builder
             .with_fullnode_count(1)
             .with_fullnode_rpc_addr(fullnode_url)
-            .with_deterministic_fullnode_ports(FULLNODE_PORT_BASE);
+            .with_fullnode_genesis_config(
+                fullnode_config_info.unwrap_or_else(|| fullnode_genesis_config(&mut OsRng, None)),
+            );
     }
 
     let mut swarm = tokio::task::spawn_blocking(move || swarm_builder.try_build()).await??;
     log_applied_node_config_overrides(&swarm);
+
+    if let Some(directory) = write_config {
+        return write_node_configs(&swarm, &directory);
+    }
+
+    // The fullnode writes to the data ingestion directory for as long as it
+    // runs, so it outlives this function from here on.
+    #[cfg(feature = "indexer")]
+    if let Some(tempdir) = data_ingestion_tempdir {
+        let _ = tempdir.keep();
+    }
+
     swarm.launch().await?;
     // Let nodes connect to one another
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
@@ -1078,7 +1068,8 @@ async fn genesis(
         builder = builder.with_admin_interface_address(address);
     }
 
-    let network_config = tokio::task::spawn_blocking(move || builder.build()).await?;
+    let (network_config, mut genesis_config) =
+        tokio::task::spawn_blocking(move || builder.build_with_genesis_config()).await?;
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;
     for key in &network_config.account_keys {
         keystore.add_key(None, SimpleKeypair::from(key.clone()))?;
@@ -1090,102 +1081,35 @@ async fn genesis(
         account_keys,
         genesis,
     } = network_config;
-    let mut network_config = NetworkConfigLight::new(validator_configs, account_keys, &genesis);
     genesis.save(&genesis_path)?;
-    let genesis = iota_config::node::Genesis::new_from_file(&genesis_path);
-    for validator in &mut network_config.validator_configs {
-        validator.genesis = genesis.clone();
-        // A written config starts a real node, which should get the safe
-        // default; the builders leave `policy-config` unset because in-memory
-        // swarm nodes run without a traffic controller.
-        validator.policy_config = Some(PolicyConfig::default_dos_protection_policy());
-    }
+    let genesis = Genesis::new_from_file(&genesis_path);
+
+    // The fullnode is not part of the genesis committee, but its entry is
+    // persisted with the validators' so that `start` derives the same fullnode
+    // config, and reuses its database, on every run.
+    genesis_config.fullnode_config_info.get_or_insert_with(|| {
+        fullnode_genesis_config(&mut OsRng, admin_interface_address_with_port)
+    });
 
     info!("Network genesis completed.");
-    network_config.save(&network_path)?;
+    PersistedNetworkConfig {
+        version: PersistedNetworkConfig::VERSION,
+        genesis_config,
+        account_keys,
+    }
+    .save(&network_path)?;
     info!("Network config file is stored in {:?}.", network_path);
 
     info!("Client keystore is stored in {:?}.", keystore_path);
 
-    let fullnode_config = FullnodeConfigBuilder::new()
-        .with_config_directory(iota_config_dir.to_path_buf())
-        .with_rpc_addr(iota_config::node::default_json_rpc_address())
-        .with_genesis(genesis.clone())
-        .with_admin_interface_address(admin_interface_address_with_port)
-        .with_policy_config(Some(PolicyConfig::default_dos_protection_policy()))
-        .with_deterministic_ports(FULLNODE_PORT_BASE)
-        .try_build_from_parts(&mut OsRng, network_config.validator_configs(), genesis)?;
-
-    fullnode_config.save(iota_config_dir.join(IOTA_FULLNODE_CONFIG))?;
-    let mut ssfn_nodes = vec![];
     if let Some(ssfn_info) = ssfn_info {
-        for (i, ssfn) in ssfn_info.into_iter().enumerate() {
-            let path =
-                iota_config_dir.join(iota_config::ssfn_config_file(ssfn.p2p_address.clone(), i));
-            // join base fullnode config with each SsfnGenesisConfig entry
-            let genesis = Genesis::new_from_file("/opt/iota/config/genesis.blob");
-            let ssfn_config = FullnodeConfigBuilder::new()
-                .with_config_directory(iota_config_dir.to_path_buf())
-                .with_p2p_external_address(ssfn.p2p_address)
-                .with_network_key_pair(ssfn.network_key_pair)
-                .with_p2p_listen_address(([0, 0, 0, 0], 8084))
-                .with_db_path(PathBuf::from("/opt/iota/db/authorities_db/full_node_db"))
-                .with_network_address("/ip4/0.0.0.0/tcp/8080/http".parse()?)
-                .with_metrics_address(([0, 0, 0, 0], 9184))
-                .with_admin_interface_address(admin_interface_address_with_port)
-                .with_json_rpc_address(([0, 0, 0, 0], 9000))
-                .with_genesis(genesis.clone())
-                .with_policy_config(Some(PolicyConfig::default_dos_protection_policy()))
-                .try_build_from_parts(&mut OsRng, network_config.validator_configs(), genesis)?;
-            ssfn_nodes.push(ssfn_config.clone());
-            ssfn_config.save(path)?;
-        }
-
-        let ssfn_seed_peers = ssfn_nodes
-            .iter()
-            .enumerate()
-            .map(|(index, config)| {
-                let address = config.p2p_config.external_address.clone().ok_or_else(|| {
-                    anyhow!(
-                        "state sync fullnode {index} has no `p2p-config.external-address`, which \
-                         the validators need to derive their seed peers"
-                    )
-                })?;
-                Ok(SeedPeer {
-                    peer_id: Some(anemo::PeerId(
-                        config.network_key_pair().public().0.to_bytes(),
-                    )),
-                    address,
-                })
-            })
-            .collect::<Result<Vec<SeedPeer>, anyhow::Error>>()?;
-
-        for (i, mut validator) in network_config
-            .into_validator_configs()
-            .into_iter()
-            .enumerate()
-        {
-            let path = iota_config_dir.join(iota_config::validator_config_file(
-                validator.network_address.clone(),
-                i,
-            ));
-            let mut val_p2p = validator.p2p_config.clone();
-            val_p2p.seed_peers.clone_from(&ssfn_seed_peers);
-            validator.p2p_config = val_p2p;
-            validator.save(path)?;
-        }
-    } else {
-        for (i, validator) in network_config
-            .into_validator_configs()
-            .into_iter()
-            .enumerate()
-        {
-            let path = iota_config_dir.join(iota_config::validator_config_file(
-                validator.network_address.clone(),
-                i,
-            ));
-            validator.save(path)?;
-        }
+        write_state_sync_fullnode_configs(
+            iota_config_dir,
+            ssfn_info,
+            validator_configs,
+            &genesis,
+            admin_interface_address_with_port,
+        )?;
     }
 
     let mut client_config = if client_path.exists() {
@@ -1201,19 +1125,15 @@ async fn genesis(
     // On windows, using 0.0.0.0 will usually yield in an networking error. This
     // localnet ip address must bind to 127.0.0.1 if the default 0.0.0.0 is
     // used.
-    let localnet_ip =
-        if fullnode_config.json_rpc_address.ip() == IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)) {
-            "127.0.0.1".to_string()
-        } else {
-            fullnode_config.json_rpc_address.ip().to_string()
-        };
+    let json_rpc_address = iota_config::node::default_json_rpc_address();
+    let localnet_ip = if json_rpc_address.ip() == IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)) {
+        "127.0.0.1".to_string()
+    } else {
+        json_rpc_address.ip().to_string()
+    };
     client_config.set_env(IotaEnv::new(
         "localnet",
-        format!(
-            "http://{}:{}",
-            localnet_ip,
-            fullnode_config.json_rpc_address.port()
-        ),
+        format!("http://{}:{}", localnet_ip, json_rpc_address.port()),
     ));
     client_config.add_env(IotaEnv::devnet());
 
@@ -1225,6 +1145,158 @@ async fn genesis(
     info!("Client config file is stored in {:?}.", client_path);
 
     Ok(())
+}
+
+/// Build the genesis config entry the network's fullnode is derived from: its
+/// key pairs, its metrics, admin interface and p2p addresses at the fixed
+/// localnet ports, and a network address on a currently-free port.
+///
+/// Only the ports are fixed. The addresses stay on the IP the fullnode would
+/// have used anyway, which is localhost outside the simulator and one address
+/// of its own inside it.
+fn fullnode_genesis_config<R: rand::RngCore + rand::CryptoRng>(
+    rng: &mut R,
+    admin_interface_address: Option<SocketAddr>,
+) -> ValidatorGenesisConfig {
+    let mut config = ValidatorGenesisConfigBuilder::new().build(rng);
+    let node_ip = config.network_address.to_socket_addr().unwrap().ip();
+    config.metrics_address = SocketAddr::new(node_ip, FULLNODE_PORT_BASE);
+    config.admin_interface_address =
+        admin_interface_address.unwrap_or(SocketAddr::new(node_ip, FULLNODE_PORT_BASE + 1));
+    config.p2p_address = local_ip_utils::new_deterministic_udp_address_for_testing(
+        &node_ip.to_string(),
+        FULLNODE_PORT_BASE + 2,
+    );
+    config.p2p_listen_address = None;
+    config
+}
+
+/// Write a node config file per state sync fullnode entry, and the validator
+/// config files that name them as seed peers.
+///
+/// These are templates for a deployment, not configs a local network runs:
+/// their paths and addresses are the ones a packaged node uses.
+fn write_state_sync_fullnode_configs(
+    config_directory: &Path,
+    ssfn_info: Vec<SsfnGenesisConfig>,
+    validator_configs: Vec<NodeConfig>,
+    genesis: &Genesis,
+    admin_interface_address: Option<SocketAddr>,
+) -> Result<(), anyhow::Error> {
+    let mut ssfn_configs = vec![];
+    for (index, ssfn) in ssfn_info.into_iter().enumerate() {
+        let path = config_directory.join(iota_config::ssfn_config_file(
+            ssfn.p2p_address.clone(),
+            index,
+        ));
+        // join base fullnode config with each SsfnGenesisConfig entry
+        let deployed_genesis = Genesis::new_from_file("/opt/iota/config/genesis.blob");
+        let ssfn_config = FullnodeConfigBuilder::new()
+            .with_config_directory(config_directory.to_path_buf())
+            .with_p2p_external_address(ssfn.p2p_address)
+            .with_network_key_pair(ssfn.network_key_pair)
+            .with_p2p_listen_address(([0, 0, 0, 0], 8084))
+            .with_db_path(PathBuf::from("/opt/iota/db/authorities_db/full_node_db"))
+            .with_network_address("/ip4/0.0.0.0/tcp/8080/http".parse()?)
+            .with_metrics_address(([0, 0, 0, 0], 9184))
+            .with_admin_interface_address(admin_interface_address)
+            .with_json_rpc_address(([0, 0, 0, 0], 9000))
+            .with_genesis(deployed_genesis.clone())
+            .with_policy_config(Some(PolicyConfig::default_dos_protection_policy()))
+            .try_build_from_parts(&mut OsRng, &validator_configs, deployed_genesis)?;
+        ssfn_config.save(path)?;
+        ssfn_configs.push(ssfn_config);
+    }
+
+    let ssfn_seed_peers = ssfn_configs
+        .iter()
+        .enumerate()
+        .map(|(index, config)| {
+            let address = config.p2p_config.external_address.clone().ok_or_else(|| {
+                anyhow!(
+                    "state sync fullnode {index} has no `p2p-config.external-address`, which the \
+                     validators need to derive their seed peers"
+                )
+            })?;
+            Ok(SeedPeer {
+                peer_id: Some(anemo::PeerId(
+                    config.network_key_pair().public().0.to_bytes(),
+                )),
+                address,
+            })
+        })
+        .collect::<Result<Vec<SeedPeer>, anyhow::Error>>()?;
+
+    for (index, mut validator) in validator_configs.into_iter().enumerate() {
+        let path = config_directory.join(iota_config::validator_config_file(
+            validator.network_address.clone(),
+            index,
+        ));
+        validator.genesis = genesis.clone();
+        validator.policy_config = Some(PolicyConfig::default_dos_protection_policy());
+        validator.p2p_config.seed_peers.clone_from(&ssfn_seed_peers);
+        validator.save(path)?;
+    }
+    Ok(())
+}
+
+/// Prepended to every node config `--write-config` writes. `serde_yaml` drops
+/// comments, so the file is this text followed by the serialized config.
+const NODE_CONFIG_HEADER: &str = "\
+# Generated by `iota-localnet start --write-config`. Editing this file does not
+# change what `iota-localnet start` runs; pass `--node-config-override` to that
+# command instead.
+#
+# A key that is absent from this file is at its default. For `policy-config`
+# and `grpc-api-config` an explicit `null`, not an absent key, is what turns
+# the feature off.
+#
+# The key pairs below are not redacted: a node config only runs with them, and
+# they are the keys a persisted network already holds in plaintext in its
+# `network.yaml`.
+";
+
+/// Write the config of every node of `swarm` to `directory`, under the file
+/// names the config directory of a local network uses.
+fn write_node_configs(swarm: &Swarm, directory: &Path) -> Result<(), anyhow::Error> {
+    fs::create_dir_all(directory).map_err(|err| {
+        anyhow!(err).context(format!(
+            "Cannot create node config dir {}",
+            directory.display()
+        ))
+    })?;
+
+    for (index, config) in swarm.config().validator_configs().iter().enumerate() {
+        let path = directory.join(iota_config::validator_config_file(
+            config.network_address.clone(),
+            index,
+        ));
+        write_node_config(config, &path)?;
+    }
+
+    // The swarm keeps its nodes in a map, so sort them to give the same node
+    // the same file name on every run.
+    let mut fullnodes: Vec<&Node> = swarm.fullnodes().collect();
+    fullnodes.sort_by_key(|fullnode| fullnode.name());
+    for (index, fullnode) in fullnodes.iter().enumerate() {
+        let name = if index == 0 {
+            IOTA_FULLNODE_CONFIG.to_owned()
+        } else {
+            format!("fullnode-{index}.yaml")
+        };
+        write_node_config(&fullnode.config(), &directory.join(name))?;
+    }
+
+    info!("Node configs written to {}", directory.display());
+    Ok(())
+}
+
+fn write_node_config(config: &NodeConfig, path: &Path) -> Result<(), anyhow::Error> {
+    let mut contents = NODE_CONFIG_HEADER.to_owned();
+    contents.push('\n');
+    contents.push_str(&serde_yaml::to_string(config)?);
+    fs::write(path, contents)
+        .with_context(|| format!("Cannot write node config to {}", path.display()))
 }
 
 /// Translate the deprecated `--with-grpc` value into node config overrides.

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -1307,11 +1307,10 @@ fn write_node_configs(swarm: &Swarm, directory: &Path) -> Result<(), anyhow::Err
         ))
     })?;
 
+    // Named by index rather than by host and port: a caller that reads these
+    // files back knows the validator index, not the address genesis gave it.
     for (index, config) in swarm.config().validator_configs().iter().enumerate() {
-        let path = directory.join(iota_config::validator_config_file(
-            config.network_address.clone(),
-            index,
-        ));
+        let path = directory.join(format!("validator-{index}.yaml"));
         write_node_config(config, &path)?;
     }
 

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -479,6 +479,15 @@ async fn start(
              configs would point at a temporary directory that is removed on exit. Pass \
              `--network.config <DIR>` or run `iota-localnet genesis` first."
         );
+        #[cfg(feature = "indexer")]
+        ensure!(
+            data_ingestion_dir.is_some()
+                || (indexer_feature_args.with_indexer.is_none()
+                    && indexer_feature_args.with_graphql.is_none()),
+            "Cannot pass `--with-indexer` or `--with-graphql` and `--write-config` at the same \
+             time: the written fullnode config would point at a temporary data ingestion \
+             directory that is removed on exit. Pass `--data-ingestion-dir <DIR>`."
+        );
     }
 
     #[cfg(feature = "indexer")]
@@ -626,9 +635,12 @@ async fn start(
     // must enable it by default.
     #[cfg(feature = "indexer")]
     if with_indexer.is_some() || with_graphql.is_some() {
-        // the gRPC api uses default values if config is not provided,
-        // allowing to not override it when provided in fullnode config.
-        swarm_builder = swarm_builder.with_fullnode_enable_grpc_api(true);
+        // The gRPC API config is given rather than left out, since the builder
+        // would otherwise put the API on a free port, which differs on every
+        // run. A `--node-config-override` still wins over it.
+        swarm_builder = swarm_builder
+            .with_fullnode_enable_grpc_api(true)
+            .with_fullnode_grpc_api_config(GrpcApiConfig::default());
     }
 
     // the indexer requires to set the fullnode's data ingestion directory
@@ -1039,6 +1051,11 @@ async fn genesis(
 
     let validator_info = genesis_conf.validator_config_info.take();
     let ssfn_info = genesis_conf.ssfn_config_info.take();
+    // A genesis config that names its validators is a deployment's, and the
+    // node config files of that deployment are written below. A plain `genesis`
+    // names none and writes none: the configs a local network runs come from
+    // `start --write-config`.
+    let write_deployment_configs = validator_info.is_some();
 
     if let Some(epoch_duration_ms) = epoch_duration_ms {
         genesis_conf.parameters.epoch_duration_ms = epoch_duration_ms;
@@ -1101,13 +1118,21 @@ async fn genesis(
 
     info!("Client keystore is stored in {:?}.", keystore_path);
 
-    if let Some(ssfn_info) = ssfn_info {
-        write_state_sync_fullnode_configs(
+    if write_deployment_configs {
+        let ssfn_seed_peers = match ssfn_info {
+            Some(ssfn_info) => write_state_sync_fullnode_configs(
+                iota_config_dir,
+                ssfn_info,
+                &validator_configs,
+                admin_interface_address_with_port,
+            )?,
+            None => Vec::new(),
+        };
+        write_validator_configs(
             iota_config_dir,
-            ssfn_info,
             validator_configs,
             &genesis,
-            admin_interface_address_with_port,
+            &ssfn_seed_peers,
         )?;
     }
 
@@ -1169,18 +1194,17 @@ fn fullnode_genesis_config<R: rand::RngCore + rand::CryptoRng>(
     config
 }
 
-/// Write a node config file per state sync fullnode entry, and the validator
-/// config files that name them as seed peers.
+/// Write a node config file per state sync fullnode entry, and return the seed
+/// peers the validators reach them through.
 ///
 /// These are templates for a deployment, not configs a local network runs:
 /// their paths and addresses are the ones a packaged node uses.
 fn write_state_sync_fullnode_configs(
     config_directory: &Path,
     ssfn_info: Vec<SsfnGenesisConfig>,
-    validator_configs: Vec<NodeConfig>,
-    genesis: &Genesis,
+    validator_configs: &[NodeConfig],
     admin_interface_address: Option<SocketAddr>,
-) -> Result<(), anyhow::Error> {
+) -> Result<Vec<SeedPeer>, anyhow::Error> {
     let mut ssfn_configs = vec![];
     for (index, ssfn) in ssfn_info.into_iter().enumerate() {
         let path = config_directory.join(iota_config::ssfn_config_file(
@@ -1201,12 +1225,12 @@ fn write_state_sync_fullnode_configs(
             .with_json_rpc_address(([0, 0, 0, 0], 9000))
             .with_genesis(deployed_genesis.clone())
             .with_policy_config(Some(PolicyConfig::default_dos_protection_policy()))
-            .try_build_from_parts(&mut OsRng, &validator_configs, deployed_genesis)?;
+            .try_build_from_parts(&mut OsRng, validator_configs, deployed_genesis)?;
         ssfn_config.save(path)?;
         ssfn_configs.push(ssfn_config);
     }
 
-    let ssfn_seed_peers = ssfn_configs
+    ssfn_configs
         .iter()
         .enumerate()
         .map(|(index, config)| {
@@ -1223,8 +1247,20 @@ fn write_state_sync_fullnode_configs(
                 address,
             })
         })
-        .collect::<Result<Vec<SeedPeer>, anyhow::Error>>()?;
+        .collect()
+}
 
+/// Write a node config file per validator, naming `ssfn_seed_peers` as their
+/// seed peers.
+///
+/// These are templates for a deployment, not configs a local network runs:
+/// their paths and addresses are the ones a packaged node uses.
+fn write_validator_configs(
+    config_directory: &Path,
+    validator_configs: Vec<NodeConfig>,
+    genesis: &Genesis,
+    ssfn_seed_peers: &[SeedPeer],
+) -> Result<(), anyhow::Error> {
     for (index, mut validator) in validator_configs.into_iter().enumerate() {
         let path = config_directory.join(iota_config::validator_config_file(
             validator.network_address.clone(),
@@ -1232,7 +1268,7 @@ fn write_state_sync_fullnode_configs(
         ));
         validator.genesis = genesis.clone();
         validator.policy_config = Some(PolicyConfig::default_dos_protection_policy());
-        validator.p2p_config.seed_peers.clone_from(&ssfn_seed_peers);
+        validator.p2p_config.seed_peers = ssfn_seed_peers.to_vec();
         validator.save(path)?;
     }
     Ok(())

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -69,8 +69,7 @@ const DEFAULT_GRAPHQL_PORT: u16 = 9125;
 const DEFAULT_GRAPHQL_METRICS_PORT: u16 = 9126;
 #[cfg(feature = "indexer")]
 const DEFAULT_INDEXER_PORT: u16 = 9124;
-/// Port base of the fullnode layout, see
-/// [`FullnodeConfigBuilder::with_deterministic_ports`].
+/// Port base of the fullnode layout, see [`fullnode_genesis_config`].
 const FULLNODE_PORT_BASE: u16 = 9184;
 /// Port base of the validator layout, see
 /// [`ConfigBuilder::with_deterministic_ports`].
@@ -1167,7 +1166,6 @@ fn fullnode_genesis_config<R: rand::RngCore + rand::CryptoRng>(
         &node_ip.to_string(),
         FULLNODE_PORT_BASE + 2,
     );
-    config.p2p_listen_address = None;
     config
 }
 

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -613,6 +613,13 @@ async fn start(
             .genesis_config
             .fullnode_config_info
             .take();
+        // Without the persisted entry the fullnode would get a fresh random
+        // identity, and so a fresh database, on every run.
+        ensure!(
+            no_full_node || fullnode_config_info.is_some(),
+            "the network config in {} has no fullnode entry. Re-create the configuration with `iota-localnet genesis --force`.",
+            config_path.display()
+        );
         // The genesis blob is read, never rebuilt: it is the network's
         // identity, and the node configs only point at it.
         let genesis = Genesis::new_from_file(config_path.join(IOTA_GENESIS_FILENAME));

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -635,7 +635,7 @@ async fn start(
     // must enable it by default.
     #[cfg(feature = "indexer")]
     if with_indexer.is_some() || with_graphql.is_some() {
-        // The gRPC API config is given rather than left out, since the builder
+        // The gRPC API config is given rather than left out. The builder
         // would otherwise put the API on a free port, which differs on every
         // run. A `--node-config-override` still wins over it.
         swarm_builder = swarm_builder
@@ -1101,7 +1101,7 @@ async fn genesis(
     let genesis = Genesis::new_from_file(&genesis_path);
 
     // The fullnode is not part of the genesis committee, but its entry is
-    // persisted with the validators' so that `start` derives the same fullnode
+    // persisted with the validators'. `start` then derives the same fullnode
     // config, and reuses its database, on every run.
     genesis_config.fullnode_config_info.get_or_insert_with(|| {
         fullnode_genesis_config(&mut OsRng, admin_interface_address_with_port)
@@ -1176,8 +1176,8 @@ async fn genesis(
 /// localnet ports, and a network address on a currently-free port.
 ///
 /// Only the ports are fixed. The addresses stay on the IP the fullnode would
-/// have used anyway, which is localhost outside the simulator and one address
-/// of its own inside it.
+/// have used anyway. That IP is localhost outside the simulator, and one
+/// address of its own inside it.
 fn fullnode_genesis_config<R: rand::RngCore + rand::CryptoRng>(
     rng: &mut R,
     admin_interface_address: Option<SocketAddr>,

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -447,9 +447,9 @@ async fn write_config_writes_runnable_configs_and_starts_nothing() -> Result<(),
     assert_eq!(
         written,
         vec![
-            "127.0.0.1-9200.yaml".to_owned(),
-            "127.0.0.1-9210.yaml".to_owned(),
             IOTA_FULLNODE_CONFIG.to_owned(),
+            "validator-0.yaml".to_owned(),
+            "validator-1.yaml".to_owned(),
         ]
     );
 
@@ -490,7 +490,7 @@ async fn write_config_writes_runnable_configs_and_starts_nothing() -> Result<(),
         PersistedConfig::<NodeConfig>::read(&config_dir.join(IOTA_FULLNODE_CONFIG)).unwrap();
     assert!(!fullnode.enable_index_processing);
     let validator =
-        PersistedConfig::<NodeConfig>::read(&config_dir.join("127.0.0.1-9200.yaml")).unwrap();
+        PersistedConfig::<NodeConfig>::read(&config_dir.join("validator-0.yaml")).unwrap();
     assert!(validator.enable_index_processing);
 
     tmp_dir.close()?;

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -389,6 +389,40 @@ async fn a_network_config_this_build_cannot_read_is_rejected() -> Result<(), any
     Ok(())
 }
 
+/// A hand-edited config without the fullnode entry must not fall back to a
+/// fresh random fullnode identity, which would resync from genesis on every
+/// run. `genesis` always writes the entry.
+#[tokio::test]
+async fn a_network_config_without_a_fullnode_entry_is_rejected() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+    genesis_command(working_dir, 1).execute().await?;
+
+    let network_config_path = working_dir.join(IOTA_NETWORK_CONFIG);
+    let mut network_config: serde_yaml::Value =
+        serde_yaml::from_str(&fs::read_to_string(&network_config_path)?)?;
+    let removed = network_config["genesis_config"]
+        .as_mapping_mut()
+        .unwrap()
+        .remove(&serde_yaml::Value::from("fullnode_config_info"));
+    assert!(removed.is_some());
+    fs::write(
+        &network_config_path,
+        serde_yaml::to_string(&network_config)?,
+    )?;
+
+    let err = start_command(working_dir, None, vec![])
+        .execute()
+        .await
+        .unwrap_err();
+    let err = format!("{err:#}");
+    assert!(err.contains("has no fullnode entry"), "{err}");
+    assert!(err.contains("iota-localnet genesis --force"), "{err}");
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
 /// `--write-config` writes the configs the run would have started, and nothing
 /// else: no network, no database, no data ingestion directory.
 #[tokio::test]

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -130,9 +130,9 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Genesis pins the fullnode's ports, not its address. The simulator gives
-/// every node an address of its own and routes loopback addresses back to the
-/// caller, so a fullnode entry on 127.0.0.1 could never reach the validators.
+/// Genesis does not pin the fullnode's address. The simulator gives every node
+/// an address of its own and routes loopback addresses back to the caller, so a
+/// fullnode entry on 127.0.0.1 could never reach the validators.
 #[sim_test]
 async fn the_persisted_fullnode_entry_keeps_its_own_address() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
@@ -142,16 +142,6 @@ async fn the_persisted_fullnode_entry_keeps_its_own_address() -> Result<(), anyh
     let genesis_config = PersistedNetworkConfig::read(working_dir)?.genesis_config;
     let fullnode = genesis_config.fullnode_config_info.unwrap();
     let node_ip = fullnode.network_address.to_socket_addr().unwrap().ip();
-
-    assert_eq!(fullnode.metrics_address, SocketAddr::new(node_ip, 9184));
-    assert_eq!(
-        fullnode.admin_interface_address,
-        SocketAddr::new(node_ip, 9185)
-    );
-    assert_eq!(
-        fullnode.p2p_address.to_string(),
-        format!("/ip4/{node_ip}/udp/9186/http")
-    );
 
     // Outside the simulator every node is on localhost, inside it none is.
     for validator in genesis_config.validator_config_info.unwrap() {
@@ -518,10 +508,6 @@ async fn two_runs_derive_the_same_node_configs() -> Result<(), anyhow::Error> {
         );
     }
 
-    // The fullnode's database is the one the first run would have created.
-    let fullnode = PersistedConfig::<NodeConfig>::read(&first.join(IOTA_FULLNODE_CONFIG))?;
-    assert!(fullnode.db_path.starts_with(working_dir));
-
     tmp_dir.close()?;
     config_tmp_dir.close()?;
     Ok(())
@@ -579,31 +565,13 @@ async fn start_works_with_a_committee_of_two() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
     let working_dir = tmp_dir.path();
 
-    if let Ok(res) = tokio::time::timeout(
-        Duration::from_secs(10),
-        LocalnetCommand::Start {
-            #[cfg(feature = "indexer")]
-            data_ingestion_dir: None,
-            config_dir: Some(working_dir.to_path_buf()),
-            no_full_node: false,
-            disable_fullnode_pruning: false,
-            force_regenesis: false,
-            with_faucet: None,
-            faucet_amount: None,
-            faucet_coin_count: None,
-            with_grpc: None,
-            node_config_override: vec![],
-            fullnode_rpc_port: FULLNODE_RPC_PORT,
-            committee_size: Some(2),
-            epoch_duration_ms: None,
-            #[cfg(feature = "indexer")]
-            indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
-            write_config: None,
-        }
-        .execute(),
-    )
-    .await
-    {
+    let mut command = start_command(working_dir, None, vec![]);
+    let LocalnetCommand::Start { committee_size, .. } = &mut command else {
+        unreachable!("start_command builds a start command")
+    };
+    *committee_size = Some(2);
+
+    if let Ok(res) = tokio::time::timeout(Duration::from_secs(10), command.execute()).await {
         res.unwrap();
     };
 

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -173,8 +173,8 @@ async fn genesis_from_config_writes_the_validator_configs() -> Result<(), anyhow
 }
 
 /// Genesis does not pin the fullnode's address. The simulator gives every node
-/// an address of its own and routes loopback addresses back to the caller, so a
-/// fullnode entry on 127.0.0.1 could never reach the validators.
+/// an address of its own, and routes loopback addresses back to the caller. A
+/// fullnode entry on 127.0.0.1 could therefore never reach the validators.
 #[sim_test]
 async fn the_persisted_fullnode_entry_keeps_its_own_address() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
@@ -204,7 +204,7 @@ async fn the_persisted_fullnode_entry_keeps_its_own_address() -> Result<(), anyh
 }
 
 /// The persisted network config is what every later run derives its node
-/// configs from, so reading and writing it must not change it.
+/// configs from. A read followed by a write must not change it.
 #[tokio::test]
 async fn the_persisted_network_config_round_trips() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
@@ -448,8 +448,8 @@ async fn write_config_writes_runnable_configs_and_starts_nothing() -> Result<(),
 }
 
 /// A `--force-regenesis` run keeps its state in a temporary directory that is
-/// gone once the command exits, so the configs would name paths that no longer
-/// exist.
+/// gone once the command exits. The configs would therefore name paths that no
+/// longer exist.
 #[tokio::test]
 async fn write_config_is_rejected_under_force_regenesis() {
     let tmp_dir = iota_common::tempdir();

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -10,6 +10,8 @@ use std::{
     time::Duration,
 };
 
+#[cfg(feature = "indexer")]
+use clap::Parser;
 use iota_config::{
     Config, IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME,
     IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG, NodeConfig, PersistedConfig,
@@ -125,6 +127,46 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         .execute()
         .await;
     assert!(matches!(result, Err(..)));
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+/// A genesis config that names its validators is a deployment's, and `genesis`
+/// writes its validator config files. The private network's `bootstrap.sh`
+/// mounts them, and its template names no state sync fullnodes.
+#[tokio::test]
+async fn genesis_from_config_writes_the_validator_configs() -> Result<(), anyhow::Error> {
+    let source_dir = iota_common::tempdir();
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+
+    genesis_command(source_dir.path(), 2).execute().await?;
+    let genesis_config = PersistedNetworkConfig::read(source_dir.path())?.genesis_config;
+    assert!(genesis_config.ssfn_config_info.is_none());
+    let validator_configs: Vec<String> = genesis_config
+        .validator_config_info
+        .iter()
+        .flatten()
+        .enumerate()
+        .map(|(index, validator)| {
+            iota_config::validator_config_file(validator.network_address.clone(), index)
+        })
+        .collect();
+    let config_path = source_dir.path().join("genesis-config.yaml");
+    genesis_config.persisted(&config_path).save()?;
+
+    let mut command = genesis_command(working_dir, 2);
+    let LocalnetCommand::Genesis { from_config, .. } = &mut command else {
+        unreachable!("genesis_command builds a genesis command")
+    };
+    *from_config = Some(config_path);
+    command.execute().await?;
+
+    let files = file_names(working_dir);
+    for name in validator_configs {
+        assert!(files.contains(&name), "{files:?}");
+    }
 
     tmp_dir.close()?;
     Ok(())
@@ -430,6 +472,32 @@ async fn write_config_is_rejected_under_force_regenesis() {
     let err = format!("{:#}", command.execute().await.unwrap_err());
     assert!(
         err.contains("`--force-regenesis` and `--write-config`"),
+        "{err}"
+    );
+}
+
+/// A `--with-indexer` run without `--data-ingestion-dir` keeps the fullnode's
+/// data ingestion directory in a temporary directory that is gone once the
+/// command exits.
+#[cfg(feature = "indexer")]
+#[tokio::test]
+async fn write_config_is_rejected_with_the_indexer() {
+    let tmp_dir = iota_common::tempdir();
+    let config_dir = tmp_dir.path().to_str().unwrap();
+    let node_configs = tmp_dir.path().join("node-configs");
+    let command = LocalnetCommand::parse_from([
+        "iota-localnet",
+        "start",
+        "--with-indexer",
+        "--network.config",
+        config_dir,
+        "--write-config",
+        node_configs.to_str().unwrap(),
+    ]);
+
+    let err = format!("{:#}", command.execute().await.unwrap_err());
+    assert!(
+        err.contains("`--with-indexer` or `--with-graphql`"),
         "{err}"
     );
 }

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -493,6 +493,28 @@ async fn write_config_is_rejected_under_force_regenesis() {
     );
 }
 
+/// The faucet is a service of a running network, and `--write-config` starts
+/// no network to serve.
+#[tokio::test]
+async fn write_config_is_rejected_with_the_faucet() {
+    let tmp_dir = iota_common::tempdir();
+    let mut command = start_command(
+        tmp_dir.path(),
+        Some(tmp_dir.path().join("node-configs")),
+        vec![],
+    );
+    let LocalnetCommand::Start { with_faucet, .. } = &mut command else {
+        unreachable!("start_command builds a start command")
+    };
+    *with_faucet = Some("0.0.0.0:9123".to_owned());
+
+    let err = format!("{:#}", command.execute().await.unwrap_err());
+    assert!(
+        err.contains("`--with-faucet` and `--write-config`"),
+        "{err}"
+    );
+}
+
 /// A `--with-indexer` run without `--data-ingestion-dir` keeps the fullnode's
 /// data ingestion directory in a temporary directory that is gone once the
 /// command exits.

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -351,22 +351,39 @@ async fn a_network_config_this_build_cannot_read_is_rejected() -> Result<(), any
     let version_line = format!("version: {}\n", PersistedNetworkConfig::VERSION);
     assert!(network_config.contains(&version_line), "{network_config}");
 
-    for network_config in [
+    // A file without a version predates the field and reads as older.
+    fs::write(
+        &network_config_path,
         network_config.replace(&version_line, ""),
+    )?;
+    let err = start_command(working_dir, None, vec![])
+        .execute()
+        .await
+        .unwrap_err();
+    let err = format!("{err:#}");
+    assert!(
+        err.contains("was created by an older version of iota-localnet"),
+        "{err}"
+    );
+    assert!(err.contains("iota-localnet genesis --force"), "{err}");
+
+    // A newer version must not advise `genesis --force`, which deletes the
+    // newer network's state.
+    fs::write(
+        &network_config_path,
         network_config.replace(&version_line, "version: 4294967295\n"),
-    ] {
-        fs::write(&network_config_path, &network_config)?;
-        let err = start_command(working_dir, None, vec![])
-            .execute()
-            .await
-            .unwrap_err();
-        let err = format!("{err:#}");
-        assert!(
-            err.contains("was created by an older version of iota-localnet"),
-            "{err}"
-        );
-        assert!(err.contains("iota-localnet genesis --force"), "{err}");
-    }
+    )?;
+    let err = start_command(working_dir, None, vec![])
+        .execute()
+        .await
+        .unwrap_err();
+    let err = format!("{err:#}");
+    assert!(
+        err.contains("was created by a newer version of iota-localnet"),
+        "{err}"
+    );
+    assert!(err.contains("Update iota-localnet"), "{err}");
+    assert!(!err.contains("genesis --force"), "{err}");
 
     tmp_dir.close()?;
     Ok(())

--- a/crates/iota-localnet/tests/cli_tests.rs
+++ b/crates/iota-localnet/tests/cli_tests.rs
@@ -2,11 +2,17 @@
 // Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, fs::read_dir, net::SocketAddr, time::Duration};
+use std::{
+    collections::BTreeSet,
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use iota_config::{
-    IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
-    IOTA_NETWORK_CONFIG, NodeConfig, PersistedConfig,
+    Config, IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME,
+    IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG, NodeConfig, PersistedConfig,
 };
 use iota_keys::keystore::AccountKeystore;
 #[cfg(feature = "indexer")]
@@ -15,16 +21,11 @@ use iota_localnet::commands::{LocalnetCommand, parse_host_port};
 use iota_macros::sim_test;
 use iota_sdk::iota_client_config::IotaClientConfig;
 use iota_swarm_config::{
-    genesis_config::DEFAULT_NUMBER_OF_AUTHORITIES, network_config::NetworkConfigLight,
+    genesis_config::DEFAULT_NUMBER_OF_AUTHORITIES, network_config::PersistedNetworkConfig,
 };
 use iota_types::traffic_control::PolicyConfig;
 
-#[sim_test]
-async fn test_genesis() -> Result<(), anyhow::Error> {
-    let tmp_dir = iota_common::tempdir();
-    let working_dir = tmp_dir.path();
-
-    // Genesis
+fn genesis_command(working_dir: &Path, committee_size: usize) -> LocalnetCommand {
     LocalnetCommand::Genesis {
         working_dir: Some(working_dir.to_path_buf()),
         write_config: None,
@@ -33,30 +34,83 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         epoch_duration_ms: None,
         benchmark_ips: None,
         with_faucet: false,
-        committee_size: DEFAULT_NUMBER_OF_AUTHORITIES,
+        committee_size,
         num_additional_gas_accounts: None,
         chain_start_timestamp_ms: None,
         admin_interface_address: None,
     }
-    .execute()
-    .await?;
+}
+
+/// The port `start_command` gives the fullnode's JSON-RPC endpoint.
+const FULLNODE_RPC_PORT: u16 = 9000;
+
+fn start_command(
+    config_dir: &Path,
+    write_config: Option<PathBuf>,
+    node_config_override: Vec<String>,
+) -> LocalnetCommand {
+    LocalnetCommand::Start {
+        #[cfg(feature = "indexer")]
+        data_ingestion_dir: None,
+        config_dir: Some(config_dir.to_path_buf()),
+        no_full_node: false,
+        disable_fullnode_pruning: false,
+        force_regenesis: false,
+        with_faucet: None,
+        faucet_amount: None,
+        faucet_coin_count: None,
+        with_grpc: None,
+        node_config_override,
+        fullnode_rpc_port: FULLNODE_RPC_PORT,
+        committee_size: None,
+        epoch_duration_ms: None,
+        #[cfg(feature = "indexer")]
+        indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
+        write_config,
+    }
+}
+
+fn file_names(directory: &Path) -> Vec<String> {
+    fs::read_dir(directory)
+        .unwrap()
+        .flat_map(|entry| entry.map(|entry| entry.file_name().to_str().unwrap().to_owned()))
+        .collect()
+}
+
+#[sim_test]
+async fn test_genesis() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+
+    // Genesis
+    genesis_command(working_dir, DEFAULT_NUMBER_OF_AUTHORITIES)
+        .execute()
+        .await?;
 
     // Get all the new file names
-    let files = read_dir(working_dir)?
-        .flat_map(|r| r.map(|file| file.file_name().to_str().unwrap().to_owned()))
-        .collect::<Vec<_>>();
+    let files = file_names(working_dir);
 
-    assert_eq!(9, files.len());
+    // Genesis writes the network's state, not the node configs derived from
+    // it: those come from `iota-localnet start --write-config`.
+    assert_eq!(4, files.len(), "{files:?}");
     assert!(files.contains(&IOTA_CLIENT_CONFIG.to_string()));
     assert!(files.contains(&IOTA_NETWORK_CONFIG.to_string()));
-    assert!(files.contains(&IOTA_FULLNODE_CONFIG.to_string()));
     assert!(files.contains(&IOTA_GENESIS_FILENAME.to_string()));
     assert!(files.contains(&IOTA_KEYSTORE_FILENAME.to_string()));
+    assert!(!files.contains(&IOTA_FULLNODE_CONFIG.to_string()));
 
     // Check network config
-    let network_conf =
-        PersistedConfig::<NetworkConfigLight>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
-    assert_eq!(4, network_conf.validator_configs().len());
+    let network_config = PersistedNetworkConfig::read(working_dir)?;
+    assert_eq!(
+        DEFAULT_NUMBER_OF_AUTHORITIES,
+        network_config
+            .genesis_config
+            .validator_config_info
+            .as_ref()
+            .unwrap()
+            .len()
+    );
+    assert!(network_config.genesis_config.fullnode_config_info.is_some());
 
     // Check wallet config
     let wallet_conf =
@@ -67,22 +121,76 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     assert_eq!(5, wallet_conf.keystore().addresses().len());
 
     // Genesis 2nd time should fail
-    let result = LocalnetCommand::Genesis {
-        working_dir: Some(working_dir.to_path_buf()),
-        write_config: None,
-        force: false,
-        from_config: None,
-        epoch_duration_ms: None,
-        benchmark_ips: None,
-        with_faucet: false,
-        committee_size: DEFAULT_NUMBER_OF_AUTHORITIES,
-        num_additional_gas_accounts: None,
-        chain_start_timestamp_ms: None,
-        admin_interface_address: None,
-    }
-    .execute()
-    .await;
+    let result = genesis_command(working_dir, DEFAULT_NUMBER_OF_AUTHORITIES)
+        .execute()
+        .await;
     assert!(matches!(result, Err(..)));
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+/// Genesis pins the fullnode's ports, not its address. The simulator gives
+/// every node an address of its own and routes loopback addresses back to the
+/// caller, so a fullnode entry on 127.0.0.1 could never reach the validators.
+#[sim_test]
+async fn the_persisted_fullnode_entry_keeps_its_own_address() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+    genesis_command(working_dir, 2).execute().await?;
+
+    let genesis_config = PersistedNetworkConfig::read(working_dir)?.genesis_config;
+    let fullnode = genesis_config.fullnode_config_info.unwrap();
+    let node_ip = fullnode.network_address.to_socket_addr().unwrap().ip();
+
+    assert_eq!(fullnode.metrics_address, SocketAddr::new(node_ip, 9184));
+    assert_eq!(
+        fullnode.admin_interface_address,
+        SocketAddr::new(node_ip, 9185)
+    );
+    assert_eq!(
+        fullnode.p2p_address.to_string(),
+        format!("/ip4/{node_ip}/udp/9186/http")
+    );
+
+    // Outside the simulator every node is on localhost, inside it none is.
+    for validator in genesis_config.validator_config_info.unwrap() {
+        assert_eq!(
+            validator
+                .network_address
+                .to_socket_addr()
+                .unwrap()
+                .ip()
+                .is_loopback(),
+            node_ip.is_loopback(),
+            "the fullnode and the validators are not both on localhost"
+        );
+    }
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+/// The persisted network config is what every later run derives its node
+/// configs from, so reading and writing it must not change it.
+#[tokio::test]
+async fn the_persisted_network_config_round_trips() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+    genesis_command(working_dir, 2).execute().await?;
+
+    let network_config_path = working_dir.join(IOTA_NETWORK_CONFIG);
+    let written = fs::read_to_string(&network_config_path)?;
+    assert!(
+        written.contains("fullnode_config_info"),
+        "the fullnode entry is not persisted"
+    );
+
+    let network_config = PersistedNetworkConfig::read(working_dir)?;
+    let round_tripped_path = working_dir.join("round-tripped.yaml");
+    network_config.save(&round_tripped_path)?;
+
+    assert_eq!(written, fs::read_to_string(&round_tripped_path)?);
 
     tmp_dir.close()?;
     Ok(())
@@ -95,73 +203,46 @@ async fn genesis_gives_every_node_fixed_ports() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
     let working_dir = tmp_dir.path();
 
-    LocalnetCommand::Genesis {
-        working_dir: Some(working_dir.to_path_buf()),
-        write_config: None,
-        force: false,
-        from_config: None,
-        epoch_duration_ms: None,
-        benchmark_ips: None,
-        with_faucet: false,
-        committee_size: 4,
-        num_additional_gas_accounts: None,
-        chain_start_timestamp_ms: None,
-        admin_interface_address: None,
-    }
-    .execute()
-    .await?;
+    genesis_command(working_dir, 4).execute().await?;
 
-    let network_config =
-        PersistedConfig::<NetworkConfigLight>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
+    let network_config = PersistedNetworkConfig::read(working_dir)?;
+    let validators = network_config
+        .genesis_config
+        .validator_config_info
+        .as_ref()
+        .unwrap();
     let mut ports = Vec::new();
 
-    for (i, validator) in network_config.validator_configs().iter().enumerate() {
+    for (i, validator) in validators.iter().enumerate() {
         let base = 9200 + 10 * i as u16;
         assert_eq!(
             validator.network_address.to_string(),
             format!("/ip4/127.0.0.1/tcp/{base}/http")
         );
         assert_eq!(
-            validator
-                .p2p_config
-                .external_address
-                .as_ref()
-                .unwrap()
-                .to_string(),
+            validator.p2p_address.to_string(),
             format!("/ip4/127.0.0.1/udp/{}/http", base + 1)
-        );
-        assert_eq!(
-            validator.p2p_config.listen_address,
-            SocketAddr::from(([127, 0, 0, 1], base + 1))
         );
         assert_eq!(
             validator.metrics_address,
             SocketAddr::from(([127, 0, 0, 1], base + 2))
         );
         assert_eq!(
+            validator.primary_address.to_string(),
+            format!("/ip4/127.0.0.1/udp/{}/http", base + 3)
+        );
+        assert_eq!(
             validator.admin_interface_address,
             SocketAddr::from(([127, 0, 0, 1], base + 4))
         );
-        ports.extend([base, base + 1, base + 2, base + 4]);
+        ports.extend([base, base + 1, base + 2, base + 3, base + 4]);
     }
 
-    // The primary address is only kept in the committee metadata of the genesis
-    // blob, in an order of its own.
-    let genesis = network_config.validator_configs()[0].genesis.genesis()?;
-    let primary_addresses = genesis
-        .validator_set_for_tooling()
-        .iter()
-        .map(|validator| validator.verified_metadata().primary_address.to_string())
-        .collect::<BTreeSet<_>>();
-    assert_eq!(
-        primary_addresses,
-        (0..4)
-            .map(|i| format!("/ip4/127.0.0.1/udp/{}/http", 9203 + 10 * i))
-            .collect::<BTreeSet<_>>()
-    );
-    ports.extend((0..4).map(|i| 9203 + 10 * i));
-
-    let fullnode = PersistedConfig::<NodeConfig>::read(&working_dir.join(IOTA_FULLNODE_CONFIG))?;
+    let fullnode = network_config
+        .genesis_config
+        .fullnode_config_info
+        .as_ref()
+        .unwrap();
     assert_eq!(
         fullnode.metrics_address,
         SocketAddr::from(([127, 0, 0, 1], 9184))
@@ -171,66 +252,16 @@ async fn genesis_gives_every_node_fixed_ports() -> Result<(), anyhow::Error> {
         SocketAddr::from(([127, 0, 0, 1], 9185))
     );
     assert_eq!(
-        fullnode
-            .p2p_config
-            .external_address
-            .as_ref()
-            .unwrap()
-            .to_string(),
+        fullnode.p2p_address.to_string(),
         "/ip4/127.0.0.1/udp/9186/http"
     );
-    assert_eq!(
-        fullnode.p2p_config.listen_address,
-        SocketAddr::from(([127, 0, 0, 1], 9186))
-    );
-    assert_eq!(fullnode.json_rpc_address.port(), 9000);
-    ports.extend([9184, 9185, 9186, 9000]);
+    ports.extend([9184, 9185, 9186]);
 
     assert_eq!(
         ports.iter().collect::<BTreeSet<_>>().len(),
         ports.len(),
         "two nodes share a port: {ports:?}"
     );
-
-    tmp_dir.close()?;
-    Ok(())
-}
-
-// A node started from a written config gets the default
-// denial-of-service protection, matching what an absent `policy-config`
-// key deserializes to.
-#[tokio::test]
-async fn genesis_writes_the_default_traffic_control_policy() -> Result<(), anyhow::Error> {
-    let tmp_dir = iota_common::tempdir();
-    let working_dir = tmp_dir.path();
-
-    LocalnetCommand::Genesis {
-        working_dir: Some(working_dir.to_path_buf()),
-        write_config: None,
-        force: false,
-        from_config: None,
-        epoch_duration_ms: None,
-        benchmark_ips: None,
-        with_faucet: false,
-        committee_size: DEFAULT_NUMBER_OF_AUTHORITIES,
-        num_additional_gas_accounts: None,
-        chain_start_timestamp_ms: None,
-        admin_interface_address: None,
-    }
-    .execute()
-    .await?;
-
-    let expected = format!("{:?}", Some(PolicyConfig::default_dos_protection_policy()));
-
-    let network_conf =
-        PersistedConfig::<NetworkConfigLight>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
-    for validator in network_conf.validator_configs() {
-        assert_eq!(format!("{:?}", validator.policy_config), expected);
-    }
-
-    let fullnode_conf =
-        PersistedConfig::<NodeConfig>::read(&working_dir.join(IOTA_FULLNODE_CONFIG))?;
-    assert_eq!(format!("{:?}", fullnode_conf.policy_config), expected);
 
     tmp_dir.close()?;
     Ok(())
@@ -275,53 +306,259 @@ async fn wait_until_the_fullnode_syncs(_rpc_port: u16) {
     tokio::time::sleep(Duration::from_secs(10)).await;
 }
 
+/// A node config directory written before the format carried a version, and
+/// one written in a version this build does not know, are both rejected.
+#[tokio::test]
+async fn a_network_config_this_build_cannot_read_is_rejected() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+    genesis_command(working_dir, 1).execute().await?;
+
+    let network_config_path = working_dir.join(IOTA_NETWORK_CONFIG);
+    let network_config = fs::read_to_string(&network_config_path)?;
+    let version_line = format!("version: {}\n", PersistedNetworkConfig::VERSION);
+    assert!(network_config.contains(&version_line), "{network_config}");
+
+    for network_config in [
+        network_config.replace(&version_line, ""),
+        network_config.replace(&version_line, "version: 4294967295\n"),
+    ] {
+        fs::write(&network_config_path, &network_config)?;
+        let err = start_command(working_dir, None, vec![])
+            .execute()
+            .await
+            .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("was created by an older version of iota-localnet"),
+            "{err}"
+        );
+        assert!(err.contains("iota-localnet genesis --force"), "{err}");
+    }
+
+    tmp_dir.close()?;
+    Ok(())
+}
+
+/// `--write-config` writes the configs the run would have started, and nothing
+/// else: no network, no database, no data ingestion directory.
+#[tokio::test]
+async fn write_config_writes_runnable_configs_and_starts_nothing() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+    let config_tmp_dir = iota_common::tempdir();
+    let config_dir = config_tmp_dir.path().join("node-configs");
+    genesis_command(working_dir, 2).execute().await?;
+
+    let files_before = file_names(working_dir);
+    start_command(
+        working_dir,
+        Some(config_dir.clone()),
+        vec!["fullnode:enable-index-processing=false".to_owned()],
+    )
+    .execute()
+    .await?;
+
+    let mut written = file_names(&config_dir);
+    written.sort();
+    assert_eq!(
+        written,
+        vec![
+            "127.0.0.1-9200.yaml".to_owned(),
+            "127.0.0.1-9210.yaml".to_owned(),
+            IOTA_FULLNODE_CONFIG.to_owned(),
+        ]
+    );
+
+    // The run left no state behind: no database, no data ingestion directory,
+    // and no node config in the config directory either.
+    let mut files_after = file_names(working_dir);
+    files_after.sort();
+    let mut files_before = files_before;
+    files_before.sort();
+    assert_eq!(files_before, files_after);
+
+    for name in written {
+        let path = config_dir.join(&name);
+        let contents = fs::read_to_string(&path)?;
+        assert!(
+            contents.starts_with("# Generated by `iota-localnet start --write-config`"),
+            "{name} has no header: {contents:.200}"
+        );
+        assert!(
+            contents.contains("--node-config-override"),
+            "{name} does not say how to change what the run uses"
+        );
+        assert!(
+            contents.contains("an explicit `null`"),
+            "{name} does not say how an absent key reads"
+        );
+
+        // Runnable: a node reads its config with `PersistedConfig` and
+        // validates it before it starts.
+        let config = PersistedConfig::<NodeConfig>::read(&path)?;
+        config.validate()?;
+        assert_eq!(config.genesis.genesis()?.epoch(), 0);
+        assert!(config.db_path.starts_with(working_dir), "{name}");
+    }
+
+    // The override reached the fullnode, and only the fullnode.
+    let fullnode =
+        PersistedConfig::<NodeConfig>::read(&config_dir.join(IOTA_FULLNODE_CONFIG)).unwrap();
+    assert!(!fullnode.enable_index_processing);
+    let validator =
+        PersistedConfig::<NodeConfig>::read(&config_dir.join("127.0.0.1-9200.yaml")).unwrap();
+    assert!(validator.enable_index_processing);
+
+    tmp_dir.close()?;
+    config_tmp_dir.close()?;
+    Ok(())
+}
+
+/// A `--force-regenesis` run keeps its state in a temporary directory that is
+/// gone once the command exits, so the configs would name paths that no longer
+/// exist.
+#[tokio::test]
+async fn write_config_is_rejected_under_force_regenesis() {
+    let tmp_dir = iota_common::tempdir();
+    let mut command = start_command(
+        tmp_dir.path(),
+        Some(tmp_dir.path().join("node-configs")),
+        vec![],
+    );
+    let LocalnetCommand::Start {
+        config_dir,
+        force_regenesis,
+        ..
+    } = &mut command
+    else {
+        unreachable!("start_command builds a start command")
+    };
+    *config_dir = None;
+    *force_regenesis = true;
+
+    let err = format!("{:#}", command.execute().await.unwrap_err());
+    assert!(
+        err.contains("`--force-regenesis` and `--write-config`"),
+        "{err}"
+    );
+}
+
+/// A derived node is a real node, so it gets the default denial-of-service
+/// protection rather than the killswitch the swarm builders leave behind.
+#[tokio::test]
+async fn derived_node_configs_carry_the_default_traffic_control_policy() -> Result<(), anyhow::Error>
+{
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+    let config_tmp_dir = iota_common::tempdir();
+    let config_dir = config_tmp_dir.path().join("node-configs");
+    genesis_command(working_dir, 2).execute().await?;
+
+    start_command(working_dir, Some(config_dir.clone()), vec![])
+        .execute()
+        .await?;
+
+    // `PolicyConfig` has no `PartialEq`, and the serialized forms are what a
+    // node reads back anyway.
+    let expected = serde_yaml::to_string(&PolicyConfig::default_dos_protection_policy())?;
+    let names = file_names(&config_dir);
+    assert!(!names.is_empty());
+    for name in names {
+        let config = PersistedConfig::<NodeConfig>::read(&config_dir.join(&name))?;
+        let policy = config
+            .policy_config
+            .ok_or_else(|| anyhow::anyhow!("{name} has no traffic control policy"))?;
+        assert_eq!(serde_yaml::to_string(&policy)?, expected, "{name}");
+    }
+
+    // An override still reaches the policy, and can still clear it.
+    let cleared = config_tmp_dir.path().join("cleared");
+    start_command(
+        working_dir,
+        Some(cleared.clone()),
+        vec!["policy-config=".to_owned()],
+    )
+    .execute()
+    .await?;
+    for name in file_names(&cleared) {
+        let config = PersistedConfig::<NodeConfig>::read(&cleared.join(&name))?;
+        assert!(config.policy_config.is_none(), "{name}");
+    }
+
+    tmp_dir.close()?;
+    config_tmp_dir.close()?;
+    Ok(())
+}
+
+/// Two runs against one config directory derive the same node configs, which
+/// is what lets a persisted network keep its databases.
+#[tokio::test]
+async fn two_runs_derive_the_same_node_configs() -> Result<(), anyhow::Error> {
+    let tmp_dir = iota_common::tempdir();
+    let working_dir = tmp_dir.path();
+    let config_tmp_dir = iota_common::tempdir();
+    genesis_command(working_dir, 2).execute().await?;
+
+    let first = config_tmp_dir.path().join("first");
+    let second = config_tmp_dir.path().join("second");
+    for directory in [&first, &second] {
+        start_command(working_dir, Some(directory.clone()), vec![])
+            .execute()
+            .await?;
+    }
+
+    let names = file_names(&first);
+    assert!(!names.is_empty());
+    for name in names {
+        assert_eq!(
+            fs::read_to_string(first.join(&name))?,
+            fs::read_to_string(second.join(&name))?,
+            "the second run derived a different {name}"
+        );
+    }
+
+    // The fullnode's database is the one the first run would have created.
+    let fullnode = PersistedConfig::<NodeConfig>::read(&first.join(IOTA_FULLNODE_CONFIG))?;
+    assert!(fullnode.db_path.starts_with(working_dir));
+
+    tmp_dir.close()?;
+    config_tmp_dir.close()?;
+    Ok(())
+}
+
 #[sim_test]
 async fn test_start() -> Result<(), anyhow::Error> {
     let tmp_dir = iota_common::tempdir();
     let working_dir = tmp_dir.path();
-    let fullnode_rpc_port = 9000;
 
     // `start` runs until the network fails, so race it against the fullnode.
     tokio::select! {
-        result = LocalnetCommand::Start {
-            #[cfg(feature = "indexer")]
-            data_ingestion_dir: None,
-            config_dir: Some(working_dir.to_path_buf()),
-            no_full_node: false,
-            disable_fullnode_pruning: false,
-            force_regenesis: false,
-            with_faucet: None,
-            faucet_amount: None,
-            faucet_coin_count: None,
-            with_grpc: None,
-            node_config_override: vec![],
-            fullnode_rpc_port,
-            committee_size: None,
-            epoch_duration_ms: None,
-            #[cfg(feature = "indexer")]
-            indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
-        }
-        .execute() => {
+        result = start_command(working_dir, None, vec![]).execute() => {
             result?;
             unreachable!("the local network stops on failure only");
         }
-        () = wait_until_the_fullnode_syncs(fullnode_rpc_port) => {}
+        () = wait_until_the_fullnode_syncs(FULLNODE_RPC_PORT) => {}
     }
 
     // Get all the new file names
-    let files = read_dir(working_dir)?
-        .flat_map(|r| r.map(|file| file.file_name().to_str().unwrap().to_owned()))
-        .collect::<Vec<_>>();
+    let files = file_names(working_dir);
     assert!(files.contains(&IOTA_CLIENT_CONFIG.to_string()));
     assert!(files.contains(&IOTA_NETWORK_CONFIG.to_string()));
-    assert!(files.contains(&IOTA_FULLNODE_CONFIG.to_string()));
     assert!(files.contains(&IOTA_GENESIS_FILENAME.to_string()));
     assert!(files.contains(&IOTA_KEYSTORE_FILENAME.to_string()));
 
     // Check network config
-    let network_conf =
-        PersistedConfig::<NetworkConfigLight>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
-    assert_eq!(1, network_conf.validator_configs().len());
+    let network_config = PersistedNetworkConfig::read(working_dir)?;
+    assert_eq!(
+        1,
+        network_config
+            .genesis_config
+            .validator_config_info
+            .as_ref()
+            .unwrap()
+            .len()
+    );
 
     // Check wallet config
     let wallet_conf =
@@ -356,11 +593,12 @@ async fn start_works_with_a_committee_of_two() -> Result<(), anyhow::Error> {
             faucet_coin_count: None,
             with_grpc: None,
             node_config_override: vec![],
-            fullnode_rpc_port: 9000,
+            fullnode_rpc_port: FULLNODE_RPC_PORT,
             committee_size: Some(2),
             epoch_duration_ms: None,
             #[cfg(feature = "indexer")]
             indexer_feature_args: Box::new(IndexerFeatureArgs::for_testing()),
+            write_config: None,
         }
         .execute(),
     )
@@ -369,9 +607,16 @@ async fn start_works_with_a_committee_of_two() -> Result<(), anyhow::Error> {
         res.unwrap();
     };
 
-    let network_conf =
-        PersistedConfig::<NetworkConfigLight>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
-    assert_eq!(2, network_conf.validator_configs().len());
+    let network_config = PersistedNetworkConfig::read(working_dir)?;
+    assert_eq!(
+        2,
+        network_config
+            .genesis_config
+            .validator_config_info
+            .as_ref()
+            .unwrap()
+            .len()
+    );
 
     tmp_dir.close()?;
     Ok(())

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -264,7 +264,7 @@ pub struct GenesisConfig {
     pub ssfn_config_info: Option<Vec<SsfnGenesisConfig>>,
     pub validator_config_info: Option<Vec<ValidatorGenesisConfig>>,
     /// The key pairs and addresses of the network's fullnode. Unlike the
-    /// validators, a fullnode is not part of the genesis committee; the entry
+    /// validators, a fullnode is not part of the genesis committee. The entry
     /// exists so that its config is the same on every run.
     #[serde(default)]
     pub fullnode_config_info: Option<ValidatorGenesisConfig>,

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -62,6 +62,27 @@ pub struct ValidatorGenesisConfig {
 }
 
 impl ValidatorGenesisConfig {
+    /// A copy of this config. The key pair types do not implement `Clone`, so
+    /// this is not a `Clone` implementation.
+    pub fn copy(&self) -> Self {
+        Self {
+            authority_key_pair: self.authority_key_pair.copy(),
+            protocol_key_pair: self.protocol_key_pair.copy(),
+            account_key_pair: self.account_key_pair.clone(),
+            network_key_pair: self.network_key_pair.copy(),
+            network_address: self.network_address.clone(),
+            p2p_address: self.p2p_address.clone(),
+            p2p_listen_address: self.p2p_listen_address,
+            metrics_address: self.metrics_address,
+            admin_interface_address: self.admin_interface_address,
+            gas_price: self.gas_price,
+            commission_rate: self.commission_rate,
+            primary_address: self.primary_address.clone(),
+            stake: self.stake,
+            name: self.name.clone(),
+        }
+    }
+
     pub fn to_validator_info(&self, name: String) -> GenesisValidatorInfo {
         let authority_key: AuthorityPublicKeyBytes = self.authority_key_pair.public().into();
         let account_key = PublicKey::from(&self.account_key_pair);
@@ -242,6 +263,11 @@ impl ValidatorGenesisConfigBuilder {
 pub struct GenesisConfig {
     pub ssfn_config_info: Option<Vec<SsfnGenesisConfig>>,
     pub validator_config_info: Option<Vec<ValidatorGenesisConfig>>,
+    /// The key pairs and addresses of the network's fullnode. Unlike the
+    /// validators, a fullnode is not part of the genesis committee; the entry
+    /// exists so that its config is the same on every run.
+    #[serde(default)]
+    pub fullnode_config_info: Option<ValidatorGenesisConfig>,
     pub parameters: GenesisCeremonyParameters,
     pub accounts: Vec<AccountConfig>,
 }
@@ -480,6 +506,7 @@ impl GenesisConfig {
         GenesisConfig {
             ssfn_config_info: None,
             validator_config_info: Some(validator_config_info),
+            fullnode_config_info: None,
             parameters,
             accounts: account_configs,
         }

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -265,7 +265,9 @@ pub struct GenesisConfig {
     pub validator_config_info: Option<Vec<ValidatorGenesisConfig>>,
     /// The key pairs and addresses of the network's fullnode. Unlike the
     /// validators, a fullnode is not part of the genesis committee. The entry
-    /// exists so that its config is the same on every run.
+    /// exists so that its config is the same on every run. The derivation
+    /// reads only the key pairs and the addresses. The validator fields,
+    /// such as the stake and the gas price, are ignored.
     #[serde(default)]
     pub fullnode_config_info: Option<ValidatorGenesisConfig>,
     pub parameters: GenesisCeremonyParameters,

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -62,9 +62,10 @@ pub struct ValidatorGenesisConfig {
 }
 
 impl ValidatorGenesisConfig {
-    /// A copy of this config. The key pair types do not implement `Clone`, so
-    /// this is not a `Clone` implementation.
-    pub fn copy(&self) -> Self {
+    /// A copy of this config, key pairs included. The key pair types do not
+    /// implement `Clone`, which is why this is not a `Clone` implementation
+    /// and why the name says what it copies.
+    pub fn copy_with_private_keys(&self) -> Self {
         Self {
             authority_key_pair: self.authority_key_pair.copy(),
             protocol_key_pair: self.protocol_key_pair.copy(),

--- a/crates/iota-swarm-config/src/network_config.rs
+++ b/crates/iota-swarm-config/src/network_config.rs
@@ -81,7 +81,7 @@ impl NetworkConfig {
 /// of a local network are derived from, and the version of the format they are
 /// written in.
 ///
-/// The genesis blob is not derived from this; it is persisted beside it and
+/// The genesis blob is not derived from this. It is persisted beside it and
 /// only read.
 #[serde_as]
 #[derive(Deserialize, Serialize)]

--- a/crates/iota-swarm-config/src/network_config.rs
+++ b/crates/iota-swarm-config/src/network_config.rs
@@ -2,13 +2,18 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::Path;
+
+use anyhow::{Context, Result, ensure};
 use fastcrypto::encoding::{Base64, Encoding};
-use iota_config::{Config, NodeConfig, genesis, node};
+use iota_config::{Config, IOTA_NETWORK_CONFIG, NodeConfig, genesis, node};
 use iota_multiaddr::Multiaddr;
 use iota_sdk_crypto::ToFromBytes as _;
 use iota_types::{committee::CommitteeWithNetworkMetadata, crypto::AccountPrivateKey};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs, serde_as};
+
+use crate::{genesis_config::GenesisConfig, node_config_builder::ValidatorConfigBuilder};
 
 /// Serializes an account key as a base64 string of the raw 32-byte ed25519
 /// private key.
@@ -69,6 +74,99 @@ impl NetworkConfig {
             .first()
             .as_ref()
             .map(|validator| &validator.genesis)
+    }
+}
+
+/// What `iota-localnet` writes to `network.yaml`: everything the node configs
+/// of a local network are derived from, and the version of the format they are
+/// written in.
+///
+/// The genesis blob is not derived from this; it is persisted beside it and
+/// only read.
+#[serde_as]
+#[derive(Deserialize, Serialize)]
+pub struct PersistedNetworkConfig {
+    /// The version of this file's format. A file without one predates the
+    /// field and cannot be read.
+    pub version: u32,
+    pub genesis_config: GenesisConfig,
+    #[serde_as(as = "Vec<AccountPrivateKeyBase64>")]
+    pub account_keys: Vec<AccountPrivateKey>,
+}
+
+impl Config for PersistedNetworkConfig {}
+
+/// Reads only the format version, so that a file this build cannot read is
+/// rejected before its other fields are.
+#[derive(Deserialize)]
+struct NetworkConfigFormatVersion {
+    #[serde(default)]
+    version: Option<u32>,
+}
+
+impl PersistedNetworkConfig {
+    /// The format version this build writes and reads.
+    pub const VERSION: u32 = 1;
+
+    /// Read the network config from `network.yaml` in `config_directory`.
+    ///
+    /// # Errors
+    ///
+    /// - The file is missing or unreadable.
+    /// - It was written in a format version this build does not read, which
+    ///   includes every file written before the version field existed.
+    pub fn read(config_directory: &Path) -> Result<Self> {
+        let path = config_directory.join(IOTA_NETWORK_CONFIG);
+        let contents = std::fs::read_to_string(&path)
+            .with_context(|| format!("cannot open the IOTA network config file at {path:?}"))?;
+        let format_version: NetworkConfigFormatVersion = serde_yaml::from_str(&contents)
+            .with_context(|| format!("cannot read the IOTA network config file at {path:?}"))?;
+        ensure!(
+            format_version.version == Some(Self::VERSION),
+            "the configuration in {} was created by an older version of iota-localnet and cannot \
+             be read. Re-create it with `iota-localnet genesis --force`.",
+            config_directory.display()
+        );
+        serde_yaml::from_str(&contents)
+            .with_context(|| format!("cannot read the IOTA network config file at {path:?}"))
+    }
+
+    /// Derive the node config of every validator of this network, attaching
+    /// `genesis` to each rather than building a genesis from the genesis
+    /// config.
+    ///
+    /// # Errors
+    ///
+    /// - The network has no validator.
+    /// - `genesis` cannot be read.
+    pub fn into_network_config(
+        self,
+        config_directory: &Path,
+        genesis: node::Genesis,
+    ) -> Result<NetworkConfig> {
+        let validators = self
+            .genesis_config
+            .validator_config_info
+            .unwrap_or_default();
+        ensure!(
+            !validators.is_empty(),
+            "the IOTA network config must contain at least one validator"
+        );
+        let validator_configs = validators
+            .into_iter()
+            .map(|validator| {
+                let mut config = ValidatorConfigBuilder::new()
+                    .with_config_directory(config_directory.to_path_buf())
+                    .build_without_genesis(validator);
+                config.genesis = genesis.clone();
+                config
+            })
+            .collect();
+        Ok(NetworkConfig {
+            validator_configs,
+            account_keys: self.account_keys,
+            genesis: genesis.genesis()?.clone(),
+        })
     }
 }
 

--- a/crates/iota-swarm-config/src/network_config.rs
+++ b/crates/iota-swarm-config/src/network_config.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use fastcrypto::encoding::{Base64, Encoding};
 use iota_config::{Config, IOTA_NETWORK_CONFIG, NodeConfig, genesis, node};
 use iota_multiaddr::Multiaddr;
@@ -121,12 +121,22 @@ impl PersistedNetworkConfig {
             .with_context(|| format!("cannot open the IOTA network config file at {path:?}"))?;
         let format_version: NetworkConfigFormatVersion = serde_yaml::from_str(&contents)
             .with_context(|| format!("cannot read the IOTA network config file at {path:?}"))?;
-        ensure!(
-            format_version.version == Some(Self::VERSION),
-            "the configuration in {} was created by an older version of iota-localnet and cannot \
-             be read. Re-create it with `iota-localnet genesis --force`.",
-            config_directory.display()
-        );
+        if format_version.version != Some(Self::VERSION) {
+            // `genesis --force` deletes the directory, which is the wrong
+            // advice for a file a newer build wrote.
+            if format_version.version > Some(Self::VERSION) {
+                bail!(
+                    "the configuration in {} was created by a newer version of iota-localnet and \
+                     cannot be read. Update iota-localnet.",
+                    config_directory.display()
+                );
+            }
+            bail!(
+                "the configuration in {} was created by an older version of iota-localnet and \
+                 cannot be read. Re-create it with `iota-localnet genesis --force`.",
+                config_directory.display()
+            );
+        }
         serde_yaml::from_str(&contents)
             .with_context(|| format!("cannot read the IOTA network config file at {path:?}"))
     }

--- a/crates/iota-swarm-config/src/network_config.rs
+++ b/crates/iota-swarm-config/src/network_config.rs
@@ -231,3 +231,26 @@ impl NetworkConfigLight {
             .map(|validator| &validator.genesis)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `network.yaml` a hand edit left without validators is refused here,
+    /// rather than deeper in the launch of a network that has no committee.
+    #[test]
+    fn a_persisted_config_without_validators_is_rejected() {
+        let directory = tempfile::tempdir().unwrap();
+        let persisted = PersistedNetworkConfig {
+            version: PersistedNetworkConfig::VERSION,
+            genesis_config: GenesisConfig::for_local_testing(),
+            account_keys: vec![],
+        };
+
+        let err = persisted
+            .into_network_config(directory.path(), node::Genesis::new_empty())
+            .unwrap_err();
+
+        assert!(err.to_string().contains("at least one validator"), "{err}");
+    }
+}

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -489,7 +489,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
         genesis_config.validator_config_info = Some(
             validators
                 .iter()
-                .map(ValidatorGenesisConfig::copy)
+                .map(ValidatorGenesisConfig::copy_with_private_keys)
                 .collect(),
         );
 

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -392,6 +392,17 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
     // TODO right now we always randomize ports, we may want to have a default port
     // configuration
     pub fn build(self) -> NetworkConfig {
+        self.build_with_genesis_config().0
+    }
+
+    /// Build the network config, and return the genesis config it was built
+    /// from with `validator_config_info` filled in with the validator entries
+    /// it used.
+    ///
+    /// A caller that persists the returned genesis config can derive the same
+    /// validator node configs again, without building the genesis a second
+    /// time.
+    pub fn build_with_genesis_config(self) -> (NetworkConfig, GenesisConfig) {
         let committee = self.committee;
 
         let mut rng = self.rng.unwrap();
@@ -465,9 +476,22 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             }
         };
 
-        let genesis_config = self
+        let mut validators = validators;
+        if let Some(admin_interface_address) = self.admin_interface_address {
+            for validator in &mut validators {
+                validator.admin_interface_address = admin_interface_address;
+            }
+        }
+
+        let mut genesis_config = self
             .genesis_config
             .unwrap_or_else(GenesisConfig::for_local_testing);
+        genesis_config.validator_config_info = Some(
+            validators
+                .iter()
+                .map(ValidatorGenesisConfig::copy)
+                .collect(),
+        );
 
         let (account_keys, allocations) = genesis_config.generate_accounts(&mut rng).unwrap();
 
@@ -501,7 +525,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
 
         let genesis = {
             let mut builder = iota_genesis_builder::Builder::new()
-                .with_parameters(genesis_config.parameters)
+                .with_parameters(genesis_config.parameters.clone())
                 .add_objects(self.additional_objects);
 
             for (i, validator) in validators.iter().enumerate() {
@@ -526,7 +550,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
         let validator_configs = validators
             .into_iter()
             .enumerate()
-            .map(|(idx, mut validator)| {
+            .map(|(idx, validator)| {
                 let mut builder = ValidatorConfigBuilder::new()
                     .with_config_directory(self.config_directory.clone())
                     .with_policy_config(self.policy_config.clone())
@@ -581,9 +605,6 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                         builder = builder.with_unpruned_checkpoints();
                     }
                 }
-                if let Some(admin_interface_address) = self.admin_interface_address {
-                    validator.admin_interface_address = admin_interface_address;
-                }
                 if self.empty_validator_genesis {
                     builder.build_without_genesis(validator)
                 } else {
@@ -591,11 +612,14 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 }
             })
             .collect();
-        NetworkConfig {
-            validator_configs,
-            genesis,
-            account_keys,
-        }
+        (
+            NetworkConfig {
+                validator_configs,
+                genesis,
+                account_keys,
+            },
+            genesis_config,
+        )
     }
 }
 

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -758,7 +758,11 @@ mod tests {
 
         let config = FullnodeConfigBuilder::new()
             .with_config_directory(dir.path().to_path_buf())
-            .try_build_from_genesis_config(genesis_config.copy(), &[], Genesis::new_empty())
+            .try_build_from_genesis_config(
+                genesis_config.copy_with_private_keys(),
+                &[],
+                Genesis::new_empty(),
+            )
             .unwrap();
 
         assert_eq!(config.metrics_address.to_string(), "127.0.0.1:9184");

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -2,7 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf};
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
+    path::PathBuf,
+};
 
 use anyhow::anyhow;
 use fastcrypto::{
@@ -152,7 +156,6 @@ impl ValidatorConfigBuilder {
             .join(key_path.clone());
         let network_address = validator.network_address;
         let consensus_db_path = config_directory.join(CONSENSUS_DB_NAME).join(key_path);
-        let localhost = local_ip_utils::localhost_for_testing();
         let consensus_config = ConsensusConfig {
             db_path: consensus_db_path,
             db_retention_epochs: None,
@@ -202,13 +205,21 @@ impl ValidatorConfigBuilder {
             protocol_key_pair: KeyPairWithPath::new(network_to_simple_keypair(
                 &validator.protocol_key_pair,
             )),
+            // A validator serves no JSON-RPC (`build_http_server` returns
+            // early on one), so this address is never bound. It is derived
+            // from the network address rather than picked, so that the same
+            // genesis config always gives the same node config.
+            json_rpc_address: SocketAddr::new(
+                network_address
+                    .to_socket_addr()
+                    .map(|address| address.ip())
+                    .unwrap_or_else(|_| Ipv4Addr::LOCALHOST.into()),
+                network_address.port().unwrap_or_default().saturating_add(5),
+            ),
             db_path,
             network_address,
             metrics_address: validator.metrics_address,
             admin_interface_address: validator.admin_interface_address,
-            json_rpc_address: local_ip_utils::new_tcp_address_for_testing(&localhost)
-                .to_socket_addr()
-                .unwrap(),
             consensus_config: Some(consensus_config),
             enable_index_processing: default_enable_index_processing(),
             genesis: Genesis::new_empty(),
@@ -302,7 +313,6 @@ pub struct FullnodeConfigBuilder {
     grpc_api_config: Option<GrpcApiConfig>,
     discovery_config: Option<DiscoveryConfig>,
     chain_override: Option<Chain>,
-    deterministic_port_base: Option<u16>,
 }
 
 impl FullnodeConfigBuilder {
@@ -445,17 +455,6 @@ impl FullnodeConfigBuilder {
         self
     }
 
-    /// Give the fullnode fixed ports instead of currently-free ones:
-    /// `port_base` for the metrics endpoint, `port_base + 1` for the admin
-    /// interface and `port_base + 2` for p2p, all on the fullnode's own
-    /// address.
-    ///
-    /// Addresses set explicitly on this builder still win.
-    pub fn with_deterministic_ports(mut self, port_base: u16) -> Self {
-        self.deterministic_port_base = Some(port_base);
-        self
-    }
-
     /// Build the fullnode config against the given validator configs.
     ///
     /// # Panics
@@ -471,7 +470,28 @@ impl FullnodeConfigBuilder {
             .unwrap_or_else(|err| panic!("{err:#}"))
     }
 
-    /// Build the fullnode config against the given validator configs.
+    /// Build the fullnode config against the given validator configs, giving
+    /// the fullnode freshly generated key pairs and addresses.
+    ///
+    /// Fails and panics as [`Self::try_build_from_genesis_config`] does.
+    pub fn try_build_from_parts<R: rand::RngCore + rand::CryptoRng>(
+        self,
+        rng: &mut R,
+        validator_configs: &[NodeConfig],
+        genesis: iota_config::node::Genesis,
+    ) -> anyhow::Result<NodeConfig> {
+        // ValidatorGenesisConfig is the swarm config's type for a node's key
+        // pairs and addresses, on a fullnode as well as on a validator.
+        let genesis_config = ValidatorGenesisConfigBuilder::new().build(rng);
+        self.try_build_from_genesis_config(genesis_config, validator_configs, genesis)
+    }
+
+    /// Build the fullnode config against the given validator configs, taking
+    /// the fullnode's key pairs and addresses from `genesis_config`.
+    ///
+    /// Addresses set on this builder still win. A caller that persists
+    /// `genesis_config` gets the same node config, and the same db path, on
+    /// every build.
     ///
     /// Fails if a validator config has no `p2p-config.external-address`,
     /// which the fullnode's seed peers are derived from.
@@ -481,43 +501,26 @@ impl FullnodeConfigBuilder {
     /// Panics on failures the config cannot be built without: creating the
     /// temporary config directory, allocating a local port, or parsing a
     /// generated network address.
-    pub fn try_build_from_parts<R: rand::RngCore + rand::CryptoRng>(
+    pub fn try_build_from_genesis_config(
         self,
-        rng: &mut R,
+        genesis_config: ValidatorGenesisConfig,
         validator_configs: &[NodeConfig],
         genesis: iota_config::node::Genesis,
     ) -> anyhow::Result<NodeConfig> {
-        // Take advantage of ValidatorGenesisConfigBuilder to build the keypairs and
-        // addresses, even though this is a fullnode.
-        let validator_config = ValidatorGenesisConfigBuilder::new().build(rng);
-        let node_ip = validator_config
+        let ip = genesis_config
             .network_address
             .to_socket_addr()
             .unwrap()
-            .ip();
-        let ip = node_ip.to_string();
+            .ip()
+            .to_string();
 
-        let key_path = get_key_path(&validator_config.authority_key_pair);
+        let key_path = get_key_path(&genesis_config.authority_key_pair);
         let config_directory = self
             .config_directory
             .unwrap_or_else(|| iota_common::tempdir().keep());
 
         let migration_tx_data_path =
             Some(config_directory.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME));
-
-        let deterministic_port = |offset: u16| {
-            self.deterministic_port_base.map(|port_base| {
-                port_base.checked_add(offset).unwrap_or_else(|| {
-                    panic!("the fullnode port layout does not fit above port {port_base}")
-                })
-            })
-        };
-        let deterministic_metrics_address =
-            deterministic_port(0).map(|port| SocketAddr::new(node_ip, port));
-        let deterministic_admin_interface_address =
-            deterministic_port(1).map(|port| SocketAddr::new(node_ip, port));
-        let deterministic_p2p_address = deterministic_port(2)
-            .map(|port| local_ip_utils::new_deterministic_udp_address_for_testing(&ip, port));
 
         let p2p_config = {
             let seed_peers = validator_configs
@@ -541,25 +544,17 @@ impl FullnodeConfigBuilder {
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
             P2pConfig {
-                listen_address: self
-                    .p2p_listen_address
-                    .or_else(|| {
-                        deterministic_p2p_address
-                            .as_ref()
-                            .and_then(|address| address.udp_multiaddr_to_listen_address())
+                listen_address: self.p2p_listen_address.unwrap_or_else(|| {
+                    genesis_config.p2p_listen_address.unwrap_or_else(|| {
+                        genesis_config
+                            .p2p_address
+                            .udp_multiaddr_to_listen_address()
+                            .unwrap()
                     })
-                    .unwrap_or_else(|| {
-                        validator_config.p2p_listen_address.unwrap_or_else(|| {
-                            validator_config
-                                .p2p_address
-                                .udp_multiaddr_to_listen_address()
-                                .unwrap()
-                        })
-                    }),
+                }),
                 external_address: self
                     .p2p_external_address
-                    .or(deterministic_p2p_address)
-                    .or(Some(validator_config.p2p_address.clone())),
+                    .or(Some(genesis_config.p2p_address.clone())),
                 seed_peers,
                 // Set a shorter timeout for checkpoint content download in tests, since
                 // checkpoint pruning also happens much faster, and network is local.
@@ -610,28 +605,26 @@ impl FullnodeConfigBuilder {
         };
 
         Ok(NodeConfig {
-            authority_key_pair: AuthorityKeyPairWithPath::new(validator_config.authority_key_pair),
-            account_key_pair: KeyPairWithPath::new(validator_config.account_key_pair),
+            authority_key_pair: AuthorityKeyPairWithPath::new(genesis_config.authority_key_pair),
+            account_key_pair: KeyPairWithPath::new(genesis_config.account_key_pair),
             protocol_key_pair: KeyPairWithPath::new(network_to_simple_keypair(
-                &validator_config.protocol_key_pair,
+                &genesis_config.protocol_key_pair,
             )),
             network_key_pair: self.network_key_pair.unwrap_or(KeyPairWithPath::new(
-                network_to_simple_keypair(&validator_config.network_key_pair),
+                network_to_simple_keypair(&genesis_config.network_key_pair),
             )),
             db_path: self
                 .db_path
                 .unwrap_or(config_directory.join(FULL_NODE_DB_PATH).join(key_path)),
             network_address: self
                 .network_address
-                .unwrap_or(validator_config.network_address),
+                .unwrap_or(genesis_config.network_address),
             metrics_address: self
                 .metrics_address
-                .or(deterministic_metrics_address)
-                .unwrap_or_else(local_ip_utils::new_local_tcp_socket_for_testing),
+                .unwrap_or(genesis_config.metrics_address),
             admin_interface_address: self
                 .admin_interface_address
-                .or(deterministic_admin_interface_address)
-                .unwrap_or_else(local_ip_utils::new_local_tcp_socket_for_testing),
+                .unwrap_or(genesis_config.admin_interface_address),
             json_rpc_address,
             consensus_config: None,
             enable_index_processing: default_enable_index_processing(),
@@ -698,26 +691,39 @@ impl FullnodeConfigBuilder {
 
     /// Build the fullnode config against the given network config.
     ///
-    /// Fails if a validator config has no `p2p-config.external-address`,
-    /// which the fullnode's seed peers are derived from.
-    ///
-    /// # Panics
-    ///
-    /// Panics on failures the config cannot be built without: creating the
-    /// temporary config directory, allocating a local port, or parsing a
-    /// generated network address.
+    /// Fails and panics as [`Self::try_build_from_genesis_config`] does.
     pub fn try_build<R: rand::RngCore + rand::CryptoRng>(
         self,
         rng: &mut R,
         network_config: &NetworkConfig,
     ) -> anyhow::Result<NodeConfig> {
-        let genesis = self
-            .genesis
+        let genesis = self.genesis_for(network_config);
+        self.try_build_from_parts(rng, network_config.validator_configs(), genesis)
+    }
+
+    /// Build the fullnode config against the given network config, taking the
+    /// fullnode's key pairs and addresses from `genesis_config`.
+    ///
+    /// Fails and panics as [`Self::try_build_from_genesis_config`] does.
+    pub fn try_build_with_genesis_config(
+        self,
+        genesis_config: ValidatorGenesisConfig,
+        network_config: &NetworkConfig,
+    ) -> anyhow::Result<NodeConfig> {
+        let genesis = self.genesis_for(network_config);
+        self.try_build_from_genesis_config(
+            genesis_config,
+            network_config.validator_configs(),
+            genesis,
+        )
+    }
+
+    fn genesis_for(&self, network_config: &NetworkConfig) -> Genesis {
+        self.genesis
             .as_ref()
             .or_else(|| network_config.get_validator_genesis())
             .cloned()
-            .unwrap_or_else(|| iota_config::node::Genesis::new(network_config.genesis.clone()));
-        self.try_build_from_parts(rng, network_config.validator_configs(), genesis)
+            .unwrap_or_else(|| Genesis::new(network_config.genesis.clone()))
     }
 }
 
@@ -734,37 +740,65 @@ fn get_key_path(key_pair: &AuthorityKeyPair) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
-
     use rand::rngs::OsRng;
 
-    use super::{FullnodeConfigBuilder, Genesis};
+    use super::{FullnodeConfigBuilder, Genesis, ValidatorGenesisConfigBuilder};
 
+    /// The addresses and key pairs of a fullnode built from a genesis config
+    /// entry, which is what makes them the same on every build.
     #[test]
-    fn deterministic_ports_fill_the_three_slots_of_a_fullnode() {
-        let config = FullnodeConfigBuilder::new()
-            .with_deterministic_ports(9184)
-            .build_from_parts(&mut OsRng, &[], Genesis::new_empty());
-        let ip = config.network_address.to_socket_addr().unwrap().ip();
+    fn a_fullnode_takes_its_addresses_from_its_genesis_config() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut genesis_config = ValidatorGenesisConfigBuilder::new()
+            .with_ip("127.0.0.1".to_owned())
+            .build(&mut OsRng);
+        genesis_config.metrics_address = ([127, 0, 0, 1], 9184).into();
+        genesis_config.admin_interface_address = ([127, 0, 0, 1], 9185).into();
+        genesis_config.p2p_address = "/ip4/127.0.0.1/udp/9186/http".parse().unwrap();
 
-        assert_eq!(config.metrics_address, SocketAddr::new(ip, 9184));
-        assert_eq!(config.admin_interface_address, SocketAddr::new(ip, 9185));
+        let config = FullnodeConfigBuilder::new()
+            .with_config_directory(dir.path().to_path_buf())
+            .try_build_from_genesis_config(genesis_config.copy(), &[], Genesis::new_empty())
+            .unwrap();
+
+        assert_eq!(config.metrics_address.to_string(), "127.0.0.1:9184");
+        assert_eq!(config.admin_interface_address.to_string(), "127.0.0.1:9185");
         assert_eq!(
-            config.p2p_config.external_address.unwrap().to_string(),
-            format!("/ip4/{ip}/udp/9186/http")
+            config.p2p_config.external_address.as_ref().unwrap(),
+            &genesis_config.p2p_address
         );
-        assert_eq!(config.p2p_config.listen_address, SocketAddr::new(ip, 9186));
+        assert_eq!(
+            config.p2p_config.listen_address.to_string(),
+            "127.0.0.1:9186"
+        );
+
+        // The same entry gives the same node config, db path included.
+        let same = FullnodeConfigBuilder::new()
+            .with_config_directory(dir.path().to_path_buf())
+            .try_build_from_genesis_config(genesis_config, &[], Genesis::new_empty())
+            .unwrap();
+        assert_eq!(config.db_path, same.db_path);
+        assert_eq!(
+            config.authority_public_key(),
+            same.authority_public_key(),
+            "the fullnode's identity is not the one its genesis config gives it"
+        );
     }
 
     #[test]
-    fn an_address_set_on_the_builder_wins_over_the_deterministic_ports() {
+    fn an_address_set_on_the_builder_wins_over_the_genesis_config() {
+        let mut genesis_config = ValidatorGenesisConfigBuilder::new()
+            .with_ip("127.0.0.1".to_owned())
+            .build(&mut OsRng);
+        genesis_config.metrics_address = ([127, 0, 0, 1], 9184).into();
+        genesis_config.admin_interface_address = ([127, 0, 0, 1], 9185).into();
+
         let config = FullnodeConfigBuilder::new()
-            .with_deterministic_ports(9184)
             .with_admin_interface_address(Some(([127, 0, 0, 1], 1337)))
-            .build_from_parts(&mut OsRng, &[], Genesis::new_empty());
-        let ip = config.network_address.to_socket_addr().unwrap().ip();
+            .try_build_from_genesis_config(genesis_config, &[], Genesis::new_empty())
+            .unwrap();
 
         assert_eq!(config.admin_interface_address.to_string(), "127.0.0.1:1337");
-        assert_eq!(config.metrics_address, SocketAddr::new(ip, 9184));
+        assert_eq!(config.metrics_address.to_string(), "127.0.0.1:9184");
     }
 }

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -4,6 +4,7 @@ expression: genesis_config
 ---
 ssfn_config_info: ~
 validator_config_info: ~
+fullnode_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
   protocol_version: 34

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -463,7 +463,7 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
     /// and building the genesis (e.g. on invalid genesis parameters or a
     /// validator below the minimum stake).
     pub fn try_build(mut self) -> Result<Swarm> {
-        let fullnode_genesis_config = self.fullnode_genesis_config.take();
+        let mut fullnode_genesis_config = self.fullnode_genesis_config.take();
         let dir = if let Some(dir) = self.dir {
             SwarmDirectory::Persistent(dir)
         } else {
@@ -633,7 +633,6 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 fullnode_config_builder.with_grpc_api_config(grpc_config.clone());
         }
 
-        let mut fullnode_genesis_config = fullnode_genesis_config;
         for idx in 0..self.fullnode_count {
             let mut builder = fullnode_config_builder.clone();
             // Only the first fullnode is used as the rpc fullnode, and only it

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -1254,7 +1254,7 @@ mod test {
 
         let swarm = Swarm::builder()
             .with_fullnode_count(1)
-            .with_fullnode_genesis_config(fullnode_genesis_config.copy())
+            .with_fullnode_genesis_config(fullnode_genesis_config.copy_with_private_keys())
             .build();
 
         {

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -202,8 +202,8 @@ impl<R> SwarmBuilder<R> {
     }
 
     /// Take the first fullnode's key pairs and addresses from
-    /// `fullnode_genesis_config` instead of generating them, which gives it
-    /// the same config, and the same db path, on every build.
+    /// `fullnode_genesis_config` instead of generating them. This gives it the
+    /// same config, and the same db path, on every build.
     ///
     /// Further fullnodes keep generated key pairs and addresses, since an
     /// address can only be used once.

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -69,6 +69,7 @@ pub struct SwarmBuilder<R = OsRng> {
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
+    validator_policy_config: Option<PolicyConfig>,
     fullnode_policy_config: Option<PolicyConfig>,
     fullnode_fw_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
@@ -80,7 +81,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_grpc_api_config: Option<GrpcApiConfig>,
     disable_address_verification_cooldown: bool,
     deterministic_validator_port_base: Option<u16>,
-    deterministic_fullnode_port_base: Option<u16>,
+    fullnode_genesis_config: Option<ValidatorGenesisConfig>,
     node_config_overrides: Vec<NodeConfigOverride>,
 }
 
@@ -107,6 +108,7 @@ impl SwarmBuilder {
             execution_cache_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
+            validator_policy_config: None,
             fullnode_policy_config: None,
             fullnode_fw_config: None,
             max_submit_position: None,
@@ -118,7 +120,7 @@ impl SwarmBuilder {
             fullnode_grpc_api_config: None,
             disable_address_verification_cooldown: false,
             deterministic_validator_port_base: None,
-            deterministic_fullnode_port_base: None,
+            fullnode_genesis_config: None,
             node_config_overrides: vec![],
         }
     }
@@ -147,6 +149,7 @@ impl<R> SwarmBuilder<R> {
             execution_cache_config: self.execution_cache_config,
             data_ingestion_dir: self.data_ingestion_dir,
             fullnode_run_with_range: self.fullnode_run_with_range,
+            validator_policy_config: self.validator_policy_config,
             fullnode_policy_config: self.fullnode_policy_config,
             fullnode_fw_config: self.fullnode_fw_config,
             max_submit_position: self.max_submit_position,
@@ -158,7 +161,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_grpc_api_config: self.fullnode_grpc_api_config,
             disable_address_verification_cooldown: self.disable_address_verification_cooldown,
             deterministic_validator_port_base: self.deterministic_validator_port_base,
-            deterministic_fullnode_port_base: self.deterministic_fullnode_port_base,
+            fullnode_genesis_config: self.fullnode_genesis_config,
             node_config_overrides: self.node_config_overrides,
         }
     }
@@ -198,13 +201,17 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    /// Lay the first fullnode out as
-    /// [`FullnodeConfigBuilder::with_deterministic_ports`] describes.
+    /// Take the first fullnode's key pairs and addresses from
+    /// `fullnode_genesis_config` instead of generating them, which gives it
+    /// the same config, and the same db path, on every build.
     ///
-    /// Further fullnodes keep currently-free ports, since the three addresses
-    /// can only be used once.
-    pub fn with_deterministic_fullnode_ports(mut self, port_base: u16) -> Self {
-        self.deterministic_fullnode_port_base = Some(port_base);
+    /// Further fullnodes keep generated key pairs and addresses, since an
+    /// address can only be used once.
+    pub fn with_fullnode_genesis_config(
+        mut self,
+        fullnode_genesis_config: ValidatorGenesisConfig,
+    ) -> Self {
+        self.fullnode_genesis_config = Some(fullnode_genesis_config);
         self
     }
 
@@ -350,6 +357,13 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    /// Set the traffic control policy of every validator, whether the
+    /// committee is generated here or taken from a network config.
+    pub fn with_validator_policy_config(mut self, config: Option<PolicyConfig>) -> Self {
+        self.validator_policy_config = config;
+        self
+    }
+
     pub fn with_fullnode_policy_config(mut self, config: Option<PolicyConfig>) -> Self {
         self.fullnode_policy_config = config;
         self
@@ -448,7 +462,8 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
     /// directory, saving the genesis blob, parsing a generated network address,
     /// and building the genesis (e.g. on invalid genesis parameters or a
     /// validator below the minimum stake).
-    pub fn try_build(self) -> Result<Swarm> {
+    pub fn try_build(mut self) -> Result<Swarm> {
+        let fullnode_genesis_config = self.fullnode_genesis_config.take();
         let dir = if let Some(dir) = self.dir {
             SwarmDirectory::Persistent(dir)
         } else {
@@ -528,6 +543,12 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             }
             network_config
         });
+
+        if let Some(policy_config) = self.validator_policy_config {
+            for validator in &mut network_config.validator_configs {
+                validator.policy_config = Some(policy_config.clone());
+            }
+        }
 
         if self.disable_address_verification_cooldown {
             for validator in &mut network_config.validator_configs {
@@ -612,24 +633,29 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 fullnode_config_builder.with_grpc_api_config(grpc_config.clone());
         }
 
+        let mut fullnode_genesis_config = fullnode_genesis_config;
         for idx in 0..self.fullnode_count {
             let mut builder = fullnode_config_builder.clone();
-            if idx == 0 {
-                // Only the first fullnode is used as the rpc fullnode, we can only use the
-                // same address once.
+            // Only the first fullnode is used as the rpc fullnode, and only it
+            // takes the given genesis config: an address can only be used once.
+            let genesis_config = if idx == 0 {
                 if let Some(rpc_addr) = self.fullnode_rpc_addr {
                     builder = builder.with_rpc_addr(rpc_addr);
                 }
                 if let Some(rpc_port) = self.fullnode_rpc_port {
                     builder = builder.with_rpc_port(rpc_port);
                 }
-                if let Some(port_base) = self.deterministic_fullnode_port_base {
-                    builder = builder.with_deterministic_ports(port_base);
+                fullnode_genesis_config.take()
+            } else {
+                None
+            };
+            let mut config = match genesis_config {
+                Some(genesis_config) => {
+                    builder.try_build_with_genesis_config(genesis_config, &network_config)
                 }
+                None => builder.try_build(&mut OsRng, &network_config),
             }
-            let mut config = builder
-                .try_build(&mut OsRng, &network_config)
-                .context("failed to build the fullnode config")?;
+            .context("failed to build the fullnode config")?;
             apply_node_config_overrides(
                 overrides_for_fullnode(&self.node_config_overrides),
                 &mut config,
@@ -845,15 +871,41 @@ impl AsRef<Path> for SwarmDirectory {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeSet, net::SocketAddr, num::NonZeroUsize};
+    use std::{collections::BTreeSet, num::NonZeroUsize};
 
     use iota_swarm_config::{
+        genesis_config::ValidatorGenesisConfigBuilder,
         network_config::NetworkConfig,
         network_config_builder::ConfigBuilder,
         node_config_override::{NodeConfigOverride, apply_node_config_overrides},
     };
+    use iota_types::traffic_control::PolicyConfig;
 
     use super::Swarm;
+
+    #[test]
+    fn the_validator_policy_config_applies_before_the_overrides() {
+        let policy_config = PolicyConfig {
+            channel_capacity: 4242,
+            ..PolicyConfig::default()
+        };
+        let swarm = Swarm::builder()
+            .committee_size(NonZeroUsize::new(2).unwrap())
+            .with_validator_policy_config(Some(policy_config))
+            .with_node_config_overrides(vec!["validator-0:policy-config=".parse().unwrap()])
+            .build();
+
+        let validators = swarm.config().validator_configs();
+        assert!(validators[0].policy_config.is_none());
+        assert_eq!(
+            validators[1]
+                .policy_config
+                .as_ref()
+                .unwrap()
+                .channel_capacity,
+            4242
+        );
+    }
 
     #[test]
     fn node_config_overrides() {
@@ -1175,8 +1227,6 @@ mod test {
         let swarm = Swarm::builder()
             .committee_size(NonZeroUsize::new(2).unwrap())
             .with_deterministic_validator_ports(9200)
-            .with_fullnode_count(1)
-            .with_deterministic_fullnode_ports(9184)
             .build();
 
         let validator_ports = swarm
@@ -1191,14 +1241,45 @@ mod test {
             })
             .collect::<BTreeSet<_>>();
         assert_eq!(validator_ports, BTreeSet::from([9200, 9210]));
+    }
 
-        let fullnode = swarm.fullnodes().next().unwrap().config();
-        let ip = fullnode.network_address.to_socket_addr().unwrap().ip();
-        assert_eq!(fullnode.metrics_address, SocketAddr::new(ip, 9184));
-        assert_eq!(fullnode.admin_interface_address, SocketAddr::new(ip, 9185));
+    #[test]
+    fn the_first_fullnode_takes_the_given_genesis_config() {
+        let mut fullnode_genesis_config = ValidatorGenesisConfigBuilder::new()
+            .with_ip("127.0.0.1".to_owned())
+            .build(&mut rand::rngs::OsRng);
+        fullnode_genesis_config.metrics_address = ([127, 0, 0, 1], 19184).into();
+        fullnode_genesis_config.admin_interface_address = ([127, 0, 0, 1], 19185).into();
+        fullnode_genesis_config.p2p_address = "/ip4/127.0.0.1/udp/19186/http".parse().unwrap();
+        let db_path_of = |swarm: &Swarm| swarm.fullnodes().next().unwrap().config().db_path.clone();
+
+        let swarm = Swarm::builder()
+            .with_fullnode_count(1)
+            .with_fullnode_genesis_config(fullnode_genesis_config.copy())
+            .build();
+
+        {
+            let fullnode = swarm.fullnodes().next().unwrap().config();
+            assert_eq!(fullnode.metrics_address.to_string(), "127.0.0.1:19184");
+            assert_eq!(
+                fullnode.admin_interface_address.to_string(),
+                "127.0.0.1:19185"
+            );
+            assert_eq!(
+                fullnode.p2p_config.listen_address.to_string(),
+                "127.0.0.1:19186"
+            );
+        }
+
+        // The same entry gives the fullnode the same db path in a second
+        // network, which is what lets a persisted network reuse its database.
+        let same_swarm = Swarm::builder()
+            .with_fullnode_count(1)
+            .with_fullnode_genesis_config(fullnode_genesis_config)
+            .build();
         assert_eq!(
-            fullnode.p2p_config.listen_address,
-            SocketAddr::new(ip, 9186)
+            db_path_of(&swarm).file_name(),
+            db_path_of(&same_swarm).file_name()
         );
     }
 }

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -885,7 +885,7 @@ mod test {
     #[test]
     fn the_validator_policy_config_applies_before_the_overrides() {
         let policy_config = PolicyConfig {
-            channel_capacity: 4242,
+            connection_blocklist_ttl_sec: 4242,
             ..PolicyConfig::default()
         };
         let swarm = Swarm::builder()
@@ -901,7 +901,7 @@ mod test {
                 .policy_config
                 .as_ref()
                 .unwrap()
-                .channel_capacity,
+                .connection_blocklist_ttl_sec,
             4242
         );
     }

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1505,8 +1505,8 @@ impl TestClusterBuilder {
         let keystore_path = dir.join(IOTA_KEYSTORE_FILENAME);
 
         // A config directory the swarm was started from already holds the
-        // network config its node configs were derived from, in a format only
-        // the tool that wrote it reads back.
+        // network config its node configs were derived from. Only the tool
+        // that wrote that config reads it back.
         if !network_path.exists() {
             let network_config = swarm.config();
             // Create light config to save

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1504,15 +1504,20 @@ impl TestClusterBuilder {
         let wallet_path = dir.join(IOTA_CLIENT_CONFIG);
         let keystore_path = dir.join(IOTA_KEYSTORE_FILENAME);
 
-        let network_config = swarm.config();
-        // Create light config to save
-        let account_keys = network_config.account_keys.to_vec();
-        let network_config_light = NetworkConfigLight::new(
-            network_config.validator_configs.clone(),
-            account_keys,
-            &network_config.genesis,
-        );
-        network_config_light.save(network_path)?;
+        // A config directory the swarm was started from already holds the
+        // network config its node configs were derived from, in a format only
+        // the tool that wrote it reads back.
+        if !network_path.exists() {
+            let network_config = swarm.config();
+            // Create light config to save
+            let account_keys = network_config.account_keys.to_vec();
+            let network_config_light = NetworkConfigLight::new(
+                network_config.validator_configs.clone(),
+                account_keys,
+                &network_config.genesis,
+            );
+            network_config_light.save(network_path)?;
+        }
 
         let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
         for key in &swarm.config().account_keys {

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -55,6 +55,7 @@ iota-localnet start [OPTIONS]
 | `--no-full-node` | Start the network without a fullnode. |
 | `--disable-fullnode-pruning` | Keep the fullnode's full history instead of pruning old object versions and checkpoints. Cannot be combined with `--no-full-node`. |
 | `--node-config-override <[SCOPE:]PATH=VALUE>` | Override a node config field for this run. Repeatable; later overrides win. See [Node config overrides](#node-config-overrides). |
+| `--write-config <DIR>` | Write the node config of every node this run would start to `DIR`, then exit without starting the network. See [Node config files](#node-config-files). |
 | `--local-migration-snapshots <PATH>...` | Paths to local migration snapshot files. |
 | `--remote-migration-snapshots <URL>...` | Remotely stored migration snapshot URLs. |
 | `--delegator <ADDRESS>` | Specify the delegator address. |
@@ -126,6 +127,21 @@ The following are rejected:
 
 A field set inside a section the config leaves at its default starts from that section's own per-field defaults, which for `policy-config` are not the traffic control policy the node config defaults to. Set the whole section when the rest of it matters.
 
+### Node config files {#node-config-files}
+
+`iota-localnet start` derives the config of every node it starts from `network.yaml` in the config directory, which holds the key pairs, addresses and genesis parameters of the network — not the node configs themselves. Two runs against the same config directory therefore start the same nodes, with the same databases.
+
+`--write-config <DIR>` writes those derived configs to `DIR` as YAML files and exits without starting anything. The files are the ones the run would have used, `--node-config-override` and the indexer and GraphQL wiring included, and each one starts under `iota-node --config-path`:
+
+```shell
+iota-localnet start --write-config ./node-configs
+iota-node --config-path ./node-configs/fullnode.yaml
+```
+
+The fullnode is written as `fullnode.yaml` and each validator as `<host>-<port>.yaml`, for example `127.0.0.1-9200.yaml`. Nothing reads these files back: editing one does not change what `iota-localnet start` runs, so pass `--node-config-override` for that. They contain the nodes' key pairs, as `network.yaml` already does.
+
+A config directory created by an older version of `iota-localnet` is rejected, since its `network.yaml` holds node configs rather than the state they are derived from. Re-create it with `iota-localnet genesis --force`.
+
 :::info Indexer options
 
 When built with the `indexer` feature, additional options are available:
@@ -183,6 +199,8 @@ iota-localnet start --force-regenesis --with-faucet --epoch-duration-ms 30000 --
 
 Use `iota-localnet genesis` to generate a genesis configuration for a local network. The resulting config can then
 be used with `iota-localnet start --network.config <DIR>` to start a persisted network.
+
+It writes the genesis blob, the network state every node config is derived from (`network.yaml`), the client config and the keystore. It does not write node config files; `iota-localnet start --write-config <DIR>` does, see [Node config files](#node-config-files).
 
 ### Usage
 

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -200,7 +200,7 @@ iota-localnet start --force-regenesis --with-faucet --epoch-duration-ms 30000 --
 Use `iota-localnet genesis` to generate a genesis configuration for a local network. The resulting config can then
 be used with `iota-localnet start --network.config <DIR>` to start a persisted network.
 
-It writes the genesis blob, the network state every node config is derived from (`network.yaml`), the client config and the keystore. It does not write node config files; `iota-localnet start --write-config <DIR>` does, see [Node config files](#node-config-files).
+It writes the genesis blob, the network state every node config is derived from (`network.yaml`), the client config and the keystore. It does not write the node config files of a local network; `iota-localnet start --write-config <DIR>` does, see [Node config files](#node-config-files). A genesis config passed with `--from-config` names the validators of a deployment, and a run that is given one also writes a config file per validator, and per state sync fullnode it names.
 
 ### Usage
 

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -138,7 +138,7 @@ iota-localnet start --write-config ./node-configs
 iota-node --config-path ./node-configs/fullnode.yaml
 ```
 
-The fullnode is written as `fullnode.yaml` and each validator as `<host>-<port>.yaml`, for example `127.0.0.1-9200.yaml`. Nothing reads these files back: editing one does not change what `iota-localnet start` runs, so pass `--node-config-override` for that. They contain the nodes' key pairs, as `network.yaml` already does.
+The fullnode is written as `fullnode.yaml` and each validator as `validator-<index>.yaml`, for example `validator-0.yaml`. Nothing reads these files back: editing one does not change what `iota-localnet start` runs, so pass `--node-config-override` for that. They contain the nodes' key pairs, as `network.yaml` already does.
 
 A config directory created by an older version of `iota-localnet` is rejected, since its `network.yaml` holds node configs rather than the state they are derived from. Re-create it with `iota-localnet genesis --force`.
 

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -66,6 +66,14 @@ rm -rf "$IOTA_CONFIG_DIR"
 
 "$WORKING_DIR/iota-localnet-release" genesis --epoch-duration-ms 20000 --committee-size 4
 
+# `genesis` wrote the node config files itself until the release that made
+# `start --write-config` write them instead. Asking for them only when they are
+# missing covers both, and can be made unconditional once RELEASE_COMMIT is at
+# or past that release.
+if [ -z "$(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print -quit)" ]; then
+  "$WORKING_DIR/iota-localnet-release" start --write-config "$IOTA_CONFIG_DIR"
+fi
+
 LOG_DIR="$WORKING_DIR/logs"
 
 mkdir -p "$LOG_DIR"

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -66,11 +66,12 @@ rm -rf "$IOTA_CONFIG_DIR"
 
 "$WORKING_DIR/iota-localnet-release" genesis --epoch-duration-ms 20000 --committee-size 4
 
-# `genesis` wrote the node config files itself until the release that made
-# `start --write-config` write them instead. Asking for them only when they are
-# missing covers both, and can be made unconditional once RELEASE_COMMIT is at
-# or past that release.
-if [ -z "$(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print -quit)" ]; then
+# `genesis` wrote the node config files itself, named `<host>-<port>.yaml`,
+# until the release that made `start --write-config` write them instead, named
+# `validator-<index>.yaml`. Both names are matched here, so the check works
+# either side of that release.
+VALIDATOR_CONFIG_NAMES=(-name "127.0.0.1*.yaml" -o -name "validator-*.yaml")
+if [ -z "$(find "$IOTA_CONFIG_DIR" \( "${VALIDATOR_CONFIG_NAMES[@]}" \) -print -quit)" ]; then
   "$WORKING_DIR/iota-localnet-release" start --write-config "$IOTA_CONFIG_DIR"
 fi
 
@@ -82,7 +83,7 @@ mkdir -p "$LOG_DIR"
 CONFIGS=()
 while IFS= read -r -d '' file; do
   CONFIGS+=("$file")
-done < <(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print0)
+done < <(find "$IOTA_CONFIG_DIR" \( "${VALIDATOR_CONFIG_NAMES[@]}" \) -print0)
 
 export RUST_LOG=iota=debug,info
 

--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -71,6 +71,14 @@ rm -rf "$IOTA_CONFIG_DIR"
 
 "$WORKING_DIR/iota-localnet-release" genesis --epoch-duration-ms 600000 --committee-size 4
 
+# `genesis` wrote the node config files itself until the release that made
+# `start --write-config` write them instead. Asking for them only when they are
+# missing covers both, and can be made unconditional once RELEASE_COMMIT is at
+# or past that release.
+if [ -z "$(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print -quit)" ]; then
+  "$WORKING_DIR/iota-localnet-release" start --write-config "$IOTA_CONFIG_DIR"
+fi
+
 LOG_DIR="$WORKING_DIR/logs"
 METRICS_DIR="$WORKING_DIR/metrics"
 

--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -71,11 +71,12 @@ rm -rf "$IOTA_CONFIG_DIR"
 
 "$WORKING_DIR/iota-localnet-release" genesis --epoch-duration-ms 600000 --committee-size 4
 
-# `genesis` wrote the node config files itself until the release that made
-# `start --write-config` write them instead. Asking for them only when they are
-# missing covers both, and can be made unconditional once RELEASE_COMMIT is at
-# or past that release.
-if [ -z "$(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print -quit)" ]; then
+# `genesis` wrote the node config files itself, named `<host>-<port>.yaml`,
+# until the release that made `start --write-config` write them instead, named
+# `validator-<index>.yaml`. Both names are matched here, so the check works
+# either side of that release.
+VALIDATOR_CONFIG_NAMES=(-name "127.0.0.1*.yaml" -o -name "validator-*.yaml")
+if [ -z "$(find "$IOTA_CONFIG_DIR" \( "${VALIDATOR_CONFIG_NAMES[@]}" \) -print -quit)" ]; then
   "$WORKING_DIR/iota-localnet-release" start --write-config "$IOTA_CONFIG_DIR"
 fi
 
@@ -89,7 +90,7 @@ mkdir -p "$METRICS_DIR"
 CONFIGS=()
 while IFS= read -r -d '' file; do
   CONFIGS+=("$file")
-done < <(find "$IOTA_CONFIG_DIR" -name "127.0.0.1*.yaml" -print0)
+done < <(find "$IOTA_CONFIG_DIR" \( "${VALIDATOR_CONFIG_NAMES[@]}" \) -print0)
 
 export RUST_LOG=iota=debug,info
 


### PR DESCRIPTION
# Description of change

`network.yaml` held the complete validator configs, and `start` used them as they were. The fullnode was different. `start` built it again on each run, and read only four fields from `fullnode.yaml`. It compared two more fields, and ignored the remainder of the file without a message. This PR builds both node types in the same way.

- `network.yaml` now holds a `GenesisConfig`, the genesis account keys and a format `version`. The type is `PersistedNetworkConfig`. In persisted mode and in `--force-regenesis` mode, `start` uses the same steps: `GenesisConfig -> NodeConfig -> overrides -> validate -> launch`. `start` does not build the genesis blob again. The blob stays a file, and the derived configs point to it.
- `GenesisConfig` gets a `fullnode_config_info` field. Thus the identity, the database path and the addresses of the fullnode stay the same on each run. Before, they changed on each run, and this is why `start` read `db-path` from `fullnode.yaml`.
- `genesis` no longer writes `fullnode.yaml` or the per-validator files. There is one exception: with `--from-config` and state-sync fullnodes, it writes the validator files, because `dev-tools/iota-private-network/bootstrap.sh` reads the seed peers from them. Use `start --write-config <DIR>` to get the files. It writes the configs that the run uses, with the overrides and the indexer or GraphQL settings. You can start each file with `iota-node --config-path`. `--write-config` then stops, and starts no node. It is not permitted with `--force-regenesis` or with `--with-faucet`.
- `start` refuses a `network.yaml` with a `version` that this build cannot read. For an older version, or for no version, it tells you to make the directory again with `genesis --force`. For a newer version, it tells you to update `iota-localnet`, because `--force` deletes the blob, the keys and the databases of that network.
- Each derived config now has the default DoS protection `policy-config`. `start` sets it after the mode branch. Before, only the persisted mode set it, and `--force-regenesis` derived `policy-config: null`.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/12429. Related to #12403.

## How the change has been tested

The new tests cover the two version refusals, a config without validators or without the fullnode entry, two runs that derive the same configs and the same fullnode database path, and `--write-config`, which writes usable configs, shows the overrides and starts nothing. The `genesis_config_snapshot_matches` snapshot gets one more line. I also tested by hand: a second `start` that uses the same fullnode database, and `iota-node --config-path` with a written validator config and with the written `fullnode.yaml`.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

### Release Notes

- [x] CLI: `iota-localnet genesis` no longer writes node config files; `start --write-config <DIR>` writes runnable ones; a config directory from an older version is rejected with a re-genesis message.