### PR TITLE
feat(iota-localnet): check ports before launching

### DIFF
--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -99,7 +99,8 @@ pub struct IndexerFeatureArgs {
     /// and value: `--with-graphql=6124` or `--with-graphql=0.0.0.0`, or
     /// `--with-graphql=0.0.0.0:9125` Note that GraphQL requires a running
     /// indexer, which will be enabled by default if the `--with-indexer`
-    /// flag is not set.
+    /// flag is not set. GraphQL serves its metrics on the next port, 9126 by
+    /// default.
     #[arg(
             long,
             default_missing_value = "0.0.0.0:9125",
@@ -541,6 +542,27 @@ async fn start(
                 .map_err(|_| anyhow!("Invalid graphql host and port"))
         })
         .transpose()?;
+    // The GraphQL service binds a Prometheus listener beside its main port.
+    // Its own default is the fullnode metrics port, so the address is pinned
+    // here, where the port check also reads it.
+    #[cfg(feature = "indexer")]
+    let graphql_metrics_address = graphql_address
+        .map(|_| -> Result<SocketAddr, anyhow::Error> {
+            let address = parse_host_port_with_default_host(
+                graphql_metrics_address.unwrap_or_default(),
+                &Ipv4Addr::LOCALHOST.to_string(),
+                DEFAULT_GRAPHQL_METRICS_PORT,
+            )
+            .map_err(|_| anyhow!("Invalid graphql metrics host and port"))?;
+            // The service rebuilds the address as `host:port`, which an IPv6
+            // host needs brackets to survive.
+            ensure!(
+                address.is_ipv4(),
+                "graphql metrics configuration requires an IPv4 address"
+            );
+            Ok(address)
+        })
+        .transpose()?;
 
     if epoch_duration_ms.is_some() && genesis_blob_exists(config_dir.clone()) && !force_regenesis {
         bail!(
@@ -744,6 +766,13 @@ async fn start(
                 graphql_address,
             ));
         }
+        if let Some(graphql_metrics_address) = graphql_metrics_address {
+            addresses.push(BoundAddress::service(
+                "GraphQL metrics",
+                "--graphql-metrics-address",
+                graphql_metrics_address,
+            ));
+        }
     }
     check_ports_are_free(&addresses)?;
 
@@ -847,21 +876,8 @@ async fn start(
     #[cfg(feature = "indexer")]
     if let Some(graphql_address) = graphql_address {
         tracing::info!("Starting the GraphQL service at {graphql_address}");
-        // The metrics address the service picks by default collides with the
-        // fullnode metrics endpoint, which binds `FULLNODE_PORT_BASE` before
-        // this runs.
-        let graphql_metrics_address = parse_host_port_with_default_host(
-            graphql_metrics_address.unwrap_or_default(),
-            &Ipv4Addr::LOCALHOST.to_string(),
-            DEFAULT_GRAPHQL_METRICS_PORT,
-        )
-        .map_err(|_| anyhow!("Invalid graphql metrics host and port"))?;
-        // The service rebuilds the address as `host:port`, which an IPv6 host
-        // needs brackets to survive.
-        ensure!(
-            graphql_metrics_address.is_ipv4(),
-            "graphql metrics configuration requires an IPv4 address"
-        );
+        let graphql_metrics_address =
+            graphql_metrics_address.expect("resolved with the GraphQL address");
         tracing::info!("Serving the GraphQL metrics at {graphql_metrics_address}");
         let graphql_connection_config = ConnectionConfig {
             port: graphql_address.port(),
@@ -1460,6 +1476,12 @@ fn log_applied_overrides_for_node<'a>(
     );
 }
 
+/// The addresses `--with-graphql` binds: the GraphQL server itself, and the
+/// Prometheus listener beside it.
+
+/// The GraphQL service settings of a local network: the address the flag
+/// gave it, the indexer database at `db_url`, and its Prometheus listener.
+
 /// Parse the input string into a SocketAddr, with a default port if none is
 /// provided.
 pub fn parse_host_port(
@@ -1509,6 +1531,23 @@ mod tests {
         // `all:` reaches the validators, so it stays allowed either way.
         let all_scoped: NodeConfigOverride = "all:enable-index-processing=false".parse().unwrap();
         check_fullnode_override_scopes(std::slice::from_ref(&all_scoped), false).unwrap();
+    }
+
+    /// The GraphQL service binds a Prometheus listener beside its main port.
+    /// The port check reads the same address the service is given, so the run
+    /// cannot check one address and bind another.
+    #[cfg(feature = "indexer")]
+    #[test]
+    fn the_graphql_metrics_address_defaults_beside_the_fullnode_metrics_port() {
+        let localhost = Ipv4Addr::LOCALHOST.to_string();
+        let address = parse_host_port_with_default_host(
+            String::new(),
+            &localhost,
+            DEFAULT_GRAPHQL_METRICS_PORT,
+        )
+        .unwrap();
+        assert_eq!(address, SocketAddr::from(([127, 0, 0, 1], 9126)));
+        assert_ne!(address.port(), FULLNODE_PORT_BASE);
     }
 
     #[test]

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -523,24 +523,20 @@ async fn start(
     // starts. An unparsable one then fails before genesis, and the port check
     // knows every address this run binds.
     let faucet_address = with_faucet
-        .map(|input| {
-            parse_host_port(input, DEFAULT_FAUCET_PORT)
-                .map_err(|_| anyhow!("Invalid faucet host and port"))
-        })
+        .map(|input| service_address(input, DEFAULT_FAUCET_PORT, "faucet"))
         .transpose()?;
+    // The faucet builds its config from an `Ipv4Addr`.
+    ensure!(
+        faucet_address.is_none_or(|address| address.is_ipv4()),
+        "Invalid faucet host and port: the faucet needs an IPv4 address"
+    );
     #[cfg(feature = "indexer")]
     let indexer_address = with_indexer
-        .map(|input| {
-            parse_host_port(input, DEFAULT_INDEXER_PORT)
-                .map_err(|_| anyhow!("Invalid indexer host and port"))
-        })
+        .map(|input| service_address(input, DEFAULT_INDEXER_PORT, "indexer"))
         .transpose()?;
     #[cfg(feature = "indexer")]
     let graphql_address = with_graphql
-        .map(|input| {
-            parse_host_port(input, DEFAULT_GRAPHQL_PORT)
-                .map_err(|_| anyhow!("Invalid graphql host and port"))
-        })
+        .map(|input| service_address(input, DEFAULT_GRAPHQL_PORT, "graphql"))
         .transpose()?;
     // The GraphQL service binds a Prometheus listener beside its main port.
     // Its own default is the fullnode metrics port, so the address is pinned
@@ -881,9 +877,11 @@ async fn start(
         tracing::info!("Serving the GraphQL metrics at {graphql_metrics_address}");
         let graphql_connection_config = ConnectionConfig {
             port: graphql_address.port(),
-            host: graphql_address.ip().to_string(),
+            // The server joins host and port with `format!`, so an IPv6 host
+            // needs its brackets.
+            host: graphql_host(graphql_address),
             db_url: pg_address,
-            prom_host: graphql_metrics_address.ip().to_string(),
+            prom_host: graphql_host(graphql_metrics_address),
             prom_port: graphql_metrics_address.port(),
             ..Default::default()
         };
@@ -908,6 +906,7 @@ async fn start(
 
         let host_ip = match faucet_address {
             SocketAddr::V4(addr) => *addr.ip(),
+            // Rejected where the address is parsed, before genesis.
             _ => bail!("faucet configuration requires an IPv4 address"),
         };
 
@@ -1134,8 +1133,7 @@ async fn genesis(
     let admin_interface_address_with_port = admin_interface_address
         .map(|input| {
             let default_port = iota_config::node::default_admin_interface_address().port();
-            parse_host_port(input, default_port)
-                .map_err(|_| anyhow!("Invalid admin interface host and port"))
+            service_address(input, default_port, "admin interface")
         })
         .transpose()?;
 
@@ -1409,8 +1407,7 @@ fn write_node_config(config: &NodeConfig, path: &Path) -> Result<(), anyhow::Err
 /// replaces the whole section. The fields that value does not mention come
 /// out at their default.
 fn with_grpc_overrides(input: String) -> Result<[NodeConfigOverride; 2], anyhow::Error> {
-    let grpc_address = parse_host_port(input, DEFAULT_GRPC_PORT)
-        .map_err(|_| anyhow!("Invalid gRPC host and port"))?;
+    let grpc_address = service_address(input, DEFAULT_GRPC_PORT, "gRPC")?;
     Ok([
         "fullnode:enable-grpc-api=true".parse()?,
         // Quoted: an IPv6 address like `[::1]:50051` is YAML structure
@@ -1476,11 +1473,25 @@ fn log_applied_overrides_for_node<'a>(
     );
 }
 
-/// The addresses `--with-graphql` binds: the GraphQL server itself, and the
-/// Prometheus listener beside it.
+/// The host half of `address` in the form the GraphQL server accepts: it
+/// joins host and port with `format!("{host}:{port}")`, so an IPv6 host
+/// needs its brackets.
+#[cfg(feature = "indexer")]
+fn graphql_host(address: SocketAddr) -> String {
+    match address.ip() {
+        IpAddr::V6(ip) => format!("[{ip}]"),
+        ip => ip.to_string(),
+    }
+}
 
-/// The GraphQL service settings of a local network: the address the flag
-/// gave it, the indexer database at `db_url`, and its Prometheus listener.
+/// Parse a service address, with `default_port` when the input has none.
+fn service_address(
+    input: String,
+    default_port: u16,
+    service: &str,
+) -> Result<SocketAddr, anyhow::Error> {
+    parse_host_port(input, default_port).map_err(|_| anyhow!("Invalid {service} host and port"))
+}
 
 /// Parse the input string into a SocketAddr, with a default port if none is
 /// provided.

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -53,6 +53,8 @@ use rand::rngs::OsRng;
 use tempfile::tempdir;
 use tracing::info;
 
+use crate::ports::{BoundAddress, addresses_bound_at_launch, check_ports_are_free};
+
 const CONCURRENCY_LIMIT: usize = 30;
 const DEFAULT_COMMITTEE_SIZE: usize = 1;
 const DEFAULT_EPOCH_DURATION_MS: u64 = 60_000;
@@ -516,6 +518,30 @@ async fn start(
         );
     }
 
+    // The service addresses are resolved here rather than where each service
+    // starts, so that an unparsable one fails before genesis and so that the
+    // port check knows every address this run binds.
+    let faucet_address = with_faucet
+        .map(|input| {
+            parse_host_port(input, DEFAULT_FAUCET_PORT)
+                .map_err(|_| anyhow!("Invalid faucet host and port"))
+        })
+        .transpose()?;
+    #[cfg(feature = "indexer")]
+    let indexer_address = with_indexer
+        .map(|input| {
+            parse_host_port(input, DEFAULT_INDEXER_PORT)
+                .map_err(|_| anyhow!("Invalid indexer host and port"))
+        })
+        .transpose()?;
+    #[cfg(feature = "indexer")]
+    let graphql_address = with_graphql
+        .map(|input| {
+            parse_host_port(input, DEFAULT_GRAPHQL_PORT)
+                .map_err(|_| anyhow!("Invalid graphql host and port"))
+        })
+        .transpose()?;
+
     if epoch_duration_ms.is_some() && genesis_blob_exists(config_dir.clone()) && !force_regenesis {
         bail!(
             "epoch duration can only be set when passing the `--force-regenesis` flag, or when \
@@ -641,7 +667,7 @@ async fn start(
     // the indexer and GraphQL services communicate with the fullnode via gRPC, we
     // must enable it by default.
     #[cfg(feature = "indexer")]
-    if with_indexer.is_some() || with_graphql.is_some() {
+    if indexer_address.is_some() || graphql_address.is_some() {
         // The gRPC API config is given rather than left out. The builder
         // would otherwise put the API on a free port, which differs on every
         // run. A `--node-config-override` still wins over it.
@@ -657,7 +683,7 @@ async fn start(
     // The directory is owned here until the network launches, so that
     // `--write-config`, which starts nothing, leaves none behind.
     #[cfg(feature = "indexer")]
-    let data_ingestion_tempdir = if with_indexer.is_some() && data_ingestion_dir.is_none() {
+    let data_ingestion_tempdir = if indexer_address.is_some() && data_ingestion_dir.is_none() {
         let tempdir = tempdir()?;
         data_ingestion_dir = Some(tempdir.path().to_path_buf());
         Some(tempdir)
@@ -693,6 +719,33 @@ async fn start(
     if let Some(directory) = write_config {
         return write_node_configs(&swarm, &directory);
     }
+
+    let mut addresses = addresses_bound_at_launch(&swarm);
+    if let Some(faucet_address) = faucet_address {
+        addresses.push(BoundAddress::service(
+            "faucet",
+            "--with-faucet",
+            faucet_address,
+        ));
+    }
+    #[cfg(feature = "indexer")]
+    {
+        if let Some(indexer_address) = indexer_address {
+            addresses.push(BoundAddress::service(
+                "indexer",
+                "--with-indexer",
+                indexer_address,
+            ));
+        }
+        if let Some(graphql_address) = graphql_address {
+            addresses.push(BoundAddress::service(
+                "GraphQL",
+                "--with-graphql",
+                graphql_address,
+            ));
+        }
+    }
+    check_ports_are_free(&addresses)?;
 
     // The fullnode writes to the data ingestion directory for as long as it
     // runs, so it outlives this function from here on.
@@ -751,9 +804,7 @@ async fn start(
     };
 
     #[cfg(feature = "indexer")]
-    if let Some(input) = with_indexer {
-        let indexer_address = parse_host_port(input, DEFAULT_INDEXER_PORT)
-            .map_err(|_| anyhow!("Invalid indexer host and port"))?;
+    if let Some(indexer_address) = indexer_address {
         tracing::info!("Starting the indexer service at {indexer_address}");
         // Start in writer mode
         start_test_indexer(
@@ -794,9 +845,7 @@ async fn start(
     }
 
     #[cfg(feature = "indexer")]
-    if let Some(input) = with_graphql {
-        let graphql_address = parse_host_port(input, DEFAULT_GRAPHQL_PORT)
-            .map_err(|_| anyhow!("Invalid graphql host and port"))?;
+    if let Some(graphql_address) = graphql_address {
         tracing::info!("Starting the GraphQL service at {graphql_address}");
         // The metrics address the service picks by default collides with the
         // fullnode metrics endpoint, which binds `FULLNODE_PORT_BASE` before
@@ -832,9 +881,7 @@ async fn start(
         info!("GraphQL started");
     }
 
-    if let Some(input) = with_faucet {
-        let faucet_address = parse_host_port(input, DEFAULT_FAUCET_PORT)
-            .map_err(|_| anyhow!("Invalid faucet host and port"))?;
+    if let Some(faucet_address) = faucet_address {
         tracing::info!("Starting the faucet service at {faucet_address}");
         let faucet_config_dir = if force_regenesis {
             // tempdir is used so the faucet file is cleaned up afterwards

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -531,34 +531,35 @@ async fn start(
         "Invalid faucet host and port: the faucet needs an IPv4 address"
     );
     #[cfg(feature = "indexer")]
-    let indexer_address = with_indexer
-        .map(|input| service_address(input, DEFAULT_INDEXER_PORT, "indexer"))
-        .transpose()?;
-    #[cfg(feature = "indexer")]
-    let graphql_address = with_graphql
-        .map(|input| service_address(input, DEFAULT_GRAPHQL_PORT, "graphql"))
-        .transpose()?;
-    // The GraphQL service binds a Prometheus listener beside its main port.
-    // Its own default is the fullnode metrics port, so the address is pinned
-    // here, where the port check also reads it.
-    #[cfg(feature = "indexer")]
-    let graphql_metrics_address = graphql_address
-        .map(|_| -> Result<SocketAddr, anyhow::Error> {
-            let address = parse_host_port_with_default_host(
-                graphql_metrics_address.unwrap_or_default(),
-                &Ipv4Addr::LOCALHOST.to_string(),
-                DEFAULT_GRAPHQL_METRICS_PORT,
-            )
-            .map_err(|_| anyhow!("Invalid graphql metrics host and port"))?;
-            // The service rebuilds the address as `host:port`, which an IPv6
-            // host needs brackets to survive.
-            ensure!(
-                address.is_ipv4(),
-                "graphql metrics configuration requires an IPv4 address"
-            );
-            Ok(address)
-        })
-        .transpose()?;
+    let (indexer_address, graphql_address, graphql_metrics_address) = {
+        let indexer_address = with_indexer
+            .map(|input| service_address(input, DEFAULT_INDEXER_PORT, "indexer"))
+            .transpose()?;
+        let graphql_address = with_graphql
+            .map(|input| service_address(input, DEFAULT_GRAPHQL_PORT, "graphql"))
+            .transpose()?;
+        // The GraphQL service binds a Prometheus listener beside its main
+        // port. Its own default is the fullnode metrics port, so the address
+        // is pinned here, where the port check also reads it.
+        let graphql_metrics_address = graphql_address
+            .map(|_| -> Result<SocketAddr, anyhow::Error> {
+                let address = parse_host_port_with_default_host(
+                    graphql_metrics_address.unwrap_or_default(),
+                    &Ipv4Addr::LOCALHOST.to_string(),
+                    DEFAULT_GRAPHQL_METRICS_PORT,
+                )
+                .map_err(|_| anyhow!("Invalid graphql metrics host and port"))?;
+                // The service rebuilds the address as `host:port`, which an
+                // IPv6 host needs brackets to survive.
+                ensure!(
+                    address.is_ipv4(),
+                    "graphql metrics configuration requires an IPv4 address"
+                );
+                Ok(address)
+            })
+            .transpose()?;
+        (indexer_address, graphql_address, graphql_metrics_address)
+    };
 
     if epoch_duration_ms.is_some() && genesis_blob_exists(config_dir.clone()) && !force_regenesis {
         bail!(

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -519,8 +519,8 @@ async fn start(
     }
 
     // The service addresses are resolved here rather than where each service
-    // starts, so that an unparsable one fails before genesis and so that the
-    // port check knows every address this run binds.
+    // starts. An unparsable one then fails before genesis, and the port check
+    // knows every address this run binds.
     let faucet_address = with_faucet
         .map(|input| {
             parse_host_port(input, DEFAULT_FAUCET_PORT)

--- a/crates/iota-localnet/src/lib.rs
+++ b/crates/iota-localnet/src/lib.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod commands;
+mod ports;

--- a/crates/iota-localnet/src/ports.rs
+++ b/crates/iota-localnet/src/ports.rs
@@ -47,9 +47,8 @@ impl BoundAddress {
         }
     }
 
-    /// An address whose port a validator's peers read from the committee
-    /// metadata in `genesis.blob`, so that moving it at start time would only
-    /// leave the validator unreachable.
+    /// An address a new genesis moves and an override cannot; `advice` says
+    /// which committee field pins it.
     fn fixed_by_genesis(
         scope: &str,
         field: &str,
@@ -288,25 +287,6 @@ mod tests {
     }
 
     #[test]
-    fn a_clash_names_the_node_the_field_and_the_override_that_moves_it() {
-        let directory = tempfile::tempdir().unwrap();
-        let (_listener, port) = occupy_tcp_port();
-        let (mut config, primary_address) = validator_config(directory.path(), 29200);
-        config.metrics_address = (Ipv4Addr::LOCALHOST, port).into();
-
-        let addresses = validator_addresses("validator-0", &config, primary_address);
-        let err = check_ports_are_free(&addresses).unwrap_err().to_string();
-
-        assert_eq!(
-            err,
-            format!(
-                "port {port} (validator-0 metrics-address) is already in use\n  override it with \
-                 --node-config-override validator-0:metrics-address=127.0.0.1:<port>"
-            )
-        );
-    }
-
-    #[test]
     fn a_committee_address_is_reported_as_one_only_a_new_genesis_moves() {
         let directory = tempfile::tempdir().unwrap();
         let (_socket, port) = occupy_udp_port();
@@ -367,20 +347,6 @@ mod tests {
             err,
             format!("port {port} (faucet) is already in use\n  move it with --with-faucet=<port>")
         );
-    }
-
-    #[test]
-    fn a_network_whose_ports_are_free_passes() {
-        let directory = tempfile::tempdir().unwrap();
-        let (config, primary_address) = validator_config(directory.path(), 29230);
-        let mut addresses = validator_addresses("validator-0", &config, primary_address);
-        let mut fullnode_config = fullnode_config(directory.path());
-        fullnode_config.json_rpc_address = (Ipv4Addr::LOCALHOST, 29184).into();
-        fullnode_config.metrics_address = (Ipv4Addr::LOCALHOST, 29185).into();
-        fullnode_config.p2p_config.listen_address = (Ipv4Addr::LOCALHOST, 29186).into();
-        addresses.extend(fullnode_addresses(&fullnode_config));
-
-        check_ports_are_free(&addresses).unwrap();
     }
 
     /// Only a port something else holds is a clash. A bind that fails for

--- a/crates/iota-localnet/src/ports.rs
+++ b/crates/iota-localnet/src/ports.rs
@@ -50,7 +50,7 @@ impl BoundAddress {
         }
     }
 
-    /// An address a new genesis moves and an override cannot; `advice` says
+    /// An address a new genesis moves and an override cannot. `advice` says
     /// which committee field pins it.
     fn fixed_by_genesis(
         scope: &str,
@@ -79,9 +79,9 @@ impl BoundAddress {
         }
     }
 
-    /// Whether something already holds the address. Any other reason a bind
-    /// fails, such as an address this host does not have, is not a port clash
-    /// and is left to the node to report.
+    /// Whether something already holds the address. A bind can fail for other
+    /// reasons, such as an address this host does not have. Those are not port
+    /// clashes, and the node reports them itself.
     fn is_in_use(&self) -> bool {
         let bound = match self.transport {
             Transport::Tcp => TcpListener::bind(self.address).map(drop),
@@ -90,8 +90,8 @@ impl BoundAddress {
         matches!(bound, Err(err) if err.kind() == io::ErrorKind::AddrInUse)
     }
 
-    /// Whether both addresses want the same socket, so that whichever binds
-    /// first takes it from the other. A wildcard address covers every IP of
+    /// Whether both addresses want the same socket. Whichever binds first
+    /// then takes it from the other. A wildcard address covers every IP of
     /// the host, so it clashes with any address on its port.
     fn clashes_with(&self, other: &Self) -> bool {
         self.transport == other.transport
@@ -103,21 +103,23 @@ impl BoundAddress {
 }
 
 /// Fail if two of `addresses` want one socket, or if something else already
-/// holds one of them, naming every clash and what to do about it.
+/// holds one of them. The error names every clash and what to do about it.
 ///
-/// This runs just before the network launches and reserves nothing: each port
-/// is free again the moment it has been probed, so one that passes here can
-/// still be taken by the time a node binds it. It turns the common case — a
-/// second local network, another program on a fixed port, or one port given
-/// to two things of this run — into a message naming the node and the field,
-/// instead of a bind failure from inside a node.
+/// This runs just before the network launches and reserves nothing. Each port
+/// is free again the moment the check probes it. A port that passes here can
+/// therefore still be taken by the time a node binds it.
+///
+/// The check turns the common case into a message that names the node and the
+/// field, instead of a bind failure from inside a node. That case is a second
+/// local network, another program on a fixed port, or one port given to two
+/// things of this run.
 pub fn check_ports_are_free(addresses: &[BoundAddress]) -> Result<(), anyhow::Error> {
     let mut clashes = Vec::new();
 
     for (index, address) in addresses.iter().enumerate() {
-        // Only the first later address on the port is reported, so that a port
-        // several of them want reads as a chain of pairs rather than as every
-        // combination of them.
+        // Only the first later address on the port is reported. A port that
+        // several of them want then reads as a chain of pairs, rather than as
+        // every combination of them.
         let Some(other) = addresses[index + 1..]
             .iter()
             .find(|other| address.clashes_with(other))
@@ -294,10 +296,10 @@ mod tests {
     /// primary address its committee entry carries, both derived from one
     /// genesis entry as `start` derives them.
     ///
-    /// A test that probes these addresses passes a `port_base` away from the
-    /// real one, so that a local network running beside the test does not read
-    /// as a clash, and its own, so that two tests binding at the same moment
-    /// do not read as one.
+    /// A test that probes these addresses passes a `port_base` of its own,
+    /// away from the real one. A local network beside the test then does not
+    /// read as a clash. Two tests that bind at the same moment do not read as
+    /// one either.
     fn validator_config(directory: &Path, port_base: u16) -> (NodeConfig, Option<SocketAddr>) {
         let validator = ValidatorGenesisConfigBuilder::new()
             .with_ip("127.0.0.1".to_owned())
@@ -394,7 +396,7 @@ mod tests {
     }
 
     /// Two addresses of one run on one port never both bind, however free the
-    /// port is, so the check has to compare the run's own addresses too.
+    /// port is. The check therefore compares the run's own addresses too.
     #[test]
     fn a_port_this_run_binds_twice_is_reported() {
         // TEST-NET-1, which is not assigned to an interface, so that nothing
@@ -422,8 +424,8 @@ mod tests {
     }
 
     /// Only a port something else holds is a clash. A bind that fails for
-    /// another reason must not be reported, or every address this host does
-    /// not have would look occupied.
+    /// another reason must not be reported. Every address this host does not
+    /// have would otherwise look occupied.
     #[test]
     fn an_address_this_host_does_not_have_is_not_a_clash() {
         // TEST-NET-1, which is not assigned to an interface.

--- a/crates/iota-localnet/src/ports.rs
+++ b/crates/iota-localnet/src/ports.rs
@@ -95,6 +95,12 @@ impl BoundAddress {
     /// the host in its own address family. The IPv6 wildcard `[::]` also
     /// covers the IPv4 space on the default dual-stack setting, so it
     /// clashes across the families.
+    ///
+    /// Linux enforces this rule and refuses the second bind. macOS does not:
+    /// a listener sets `SO_REUSEADDR` there, so a wildcard address and a
+    /// specific address can hold one port together. A run that mixes the two
+    /// is therefore reported here, but would start on macOS. The rule stays
+    /// strict, because that run fails on Linux and in CI.
     fn clashes_with(&self, other: &Self) -> bool {
         if self.transport != other.transport || self.address.port() != other.address.port() {
             return false;

--- a/crates/iota-localnet/src/ports.rs
+++ b/crates/iota-localnet/src/ports.rs
@@ -117,11 +117,6 @@ impl BoundAddress {
 /// This runs just before the network launches and reserves nothing. Each port
 /// is free again the moment the check probes it. A port that passes here can
 /// therefore still be taken by the time a node binds it.
-///
-/// The check turns the common case into a message that names the node and the
-/// field, instead of a bind failure from inside a node. That case is a second
-/// local network, another program on a fixed port, or one port given to two
-/// things of this run.
 pub fn check_ports_are_free(addresses: &[BoundAddress]) -> Result<(), anyhow::Error> {
     let mut clashes = Vec::new();
 
@@ -430,6 +425,32 @@ mod tests {
         assert!(v6_wildcard.clashes_with(&v4));
         assert!(v6_wildcard.clashes_with(&v4_wildcard));
         assert!(v6_wildcard.clashes_with(&v6));
+    }
+
+    /// Every override the clash advice suggests must stay a valid override,
+    /// or the report sends the user to a command the parser rejects.
+    #[test]
+    fn every_suggested_override_parses() {
+        let directory = tempfile::tempdir().unwrap();
+        let (validator_config, primary_address) = validator_config(directory.path(), 29260);
+        let mut addresses = validator_addresses("validator-0", &validator_config, primary_address);
+        addresses.extend(fullnode_addresses(&fullnode_config(directory.path())));
+
+        let mut parsed = 0;
+        for address in &addresses {
+            let Some(suggested) = address
+                .advice
+                .strip_prefix("override it with --node-config-override ")
+            else {
+                assert!(address.fixed_by_genesis, "{}", address.bound_by);
+                continue;
+            };
+            suggested
+                .parse::<iota_swarm_config::node_config_override::NodeConfigOverride>()
+                .unwrap_or_else(|err| panic!("{}: {err:#}", address.bound_by));
+            parsed += 1;
+        }
+        assert!(parsed > 0);
     }
 
     /// Two addresses of one run on one port never both bind, however free the

--- a/crates/iota-localnet/src/ports.rs
+++ b/crates/iota-localnet/src/ports.rs
@@ -3,7 +3,7 @@
 
 use std::{
     io,
-    net::{SocketAddr, TcpListener, UdpSocket},
+    net::{IpAddr, Ipv6Addr, SocketAddr, TcpListener, UdpSocket},
 };
 
 use anyhow::bail;
@@ -92,10 +92,19 @@ impl BoundAddress {
 
     /// Whether both addresses want the same socket. Whichever binds first
     /// then takes it from the other. A wildcard address covers every IP of
-    /// the host, so it clashes with any address on its port.
+    /// the host in its own address family. The IPv6 wildcard `[::]` also
+    /// covers the IPv4 space on the default dual-stack setting, so it
+    /// clashes across the families.
     fn clashes_with(&self, other: &Self) -> bool {
-        self.transport == other.transport
-            && self.address.port() == other.address.port()
+        if self.transport != other.transport || self.address.port() != other.address.port() {
+            return false;
+        }
+        if self.address.ip() == IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+            || other.address.ip() == IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+        {
+            return true;
+        }
+        self.address.is_ipv4() == other.address.is_ipv4()
             && (self.address.ip() == other.address.ip()
                 || self.address.ip().is_unspecified()
                 || other.address.ip().is_unspecified())
@@ -221,12 +230,17 @@ fn validator_addresses(
         "its port is the validator's `p2p-address` in the committee metadata of `genesis.blob`, \
          so only a new genesis can move it",
     ));
-    addresses.push(BoundAddress::overridable(
-        scope,
-        "metrics-address",
-        config.metrics_address,
-        Transport::Tcp,
-    ));
+    // Under the simulator no Prometheus server starts, so nothing binds
+    // this address. It is the only validator address kept on 127.0.0.1
+    // there, so probing it would read an unrelated process as a clash.
+    if !cfg!(msim) {
+        addresses.push(BoundAddress::overridable(
+            scope,
+            "metrics-address",
+            config.metrics_address,
+            Transport::Tcp,
+        ));
+    }
     if let Some(primary_address) = primary_address {
         // Consensus serves this over TCP, even though the committee writes it
         // as a UDP multiaddr.
@@ -358,10 +372,10 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let (_metrics_listener, metrics_port) = occupy_tcp_port();
         let (_json_rpc_listener, json_rpc_port) = occupy_tcp_port();
-        let (mut validator_config, primary_address) = validator_config(directory.path(), 29220);
-        validator_config.metrics_address = (Ipv4Addr::LOCALHOST, metrics_port).into();
+        let (validator_config, primary_address) = validator_config(directory.path(), 29220);
         let mut fullnode_config = fullnode_config(directory.path());
         fullnode_config.json_rpc_address = (Ipv4Addr::LOCALHOST, json_rpc_port).into();
+        fullnode_config.metrics_address = (Ipv4Addr::LOCALHOST, metrics_port).into();
 
         let mut addresses = validator_addresses("validator-0", &validator_config, primary_address);
         addresses.extend(fullnode_addresses(&fullnode_config));
@@ -370,10 +384,10 @@ mod tests {
         assert_eq!(
             err,
             format!(
-                "port {metrics_port} (validator-0 metrics-address) is already in use\n  override \
-                 it with --node-config-override validator-0:metrics-address=127.0.0.1:<port>\n\
-                 port {json_rpc_port} (fullnode json-rpc-address) is already in use\n  override \
-                 it with --node-config-override fullnode:json-rpc-address=127.0.0.1:<port>"
+                "port {json_rpc_port} (fullnode json-rpc-address) is already in use\n  override \
+                 it with --node-config-override fullnode:json-rpc-address=127.0.0.1:<port>\n\
+                 port {metrics_port} (fullnode metrics-address) is already in use\n  override \
+                 it with --node-config-override fullnode:metrics-address=127.0.0.1:<port>"
             )
         );
     }
@@ -393,6 +407,29 @@ mod tests {
             err,
             format!("port {port} (faucet) is already in use\n  move it with --with-faucet=<port>")
         );
+    }
+
+    /// An IPv4 wildcard covers only its own family: `0.0.0.0` and `[::1]`
+    /// on one port bind side by side. The IPv6 wildcard covers both
+    /// families on the default dual-stack setting.
+    #[test]
+    fn a_wildcard_clashes_only_within_the_families_it_covers() {
+        let v4_wildcard =
+            BoundAddress::service("faucet", "--with-faucet", "0.0.0.0:9123".parse().unwrap());
+        let v6_wildcard =
+            BoundAddress::service("faucet", "--with-faucet", "[::]:9123".parse().unwrap());
+        let v6 = BoundAddress::service("indexer", "--with-indexer", "[::1]:9123".parse().unwrap());
+        let v4 = BoundAddress::service(
+            "indexer",
+            "--with-indexer",
+            "127.0.0.1:9123".parse().unwrap(),
+        );
+
+        assert!(!v4_wildcard.clashes_with(&v6));
+        assert!(v4_wildcard.clashes_with(&v4));
+        assert!(v6_wildcard.clashes_with(&v4));
+        assert!(v6_wildcard.clashes_with(&v4_wildcard));
+        assert!(v6_wildcard.clashes_with(&v6));
     }
 
     /// Two addresses of one run on one port never both bind, however free the
@@ -447,24 +484,30 @@ mod tests {
 
         let addresses = validator_addresses("validator-0", &config, primary_address);
 
+        // Under the simulator no Prometheus server starts, so the
+        // metrics-address is not listed there.
+        let mut expected_bound_by = vec![
+            "validator-0 network-address",
+            "validator-0 p2p-config.listen-address",
+        ];
+        let mut expected_ports = vec![9200, 9201];
+        if !cfg!(msim) {
+            expected_bound_by.push("validator-0 metrics-address");
+            expected_ports.push(9202);
+        }
+        expected_bound_by.push("validator-0 primary-address");
+        expected_ports.push(9203);
+
         let bound_by: Vec<&str> = addresses
             .iter()
             .map(|address| address.bound_by.as_str())
             .collect();
-        assert_eq!(
-            bound_by,
-            [
-                "validator-0 network-address",
-                "validator-0 p2p-config.listen-address",
-                "validator-0 metrics-address",
-                "validator-0 primary-address",
-            ]
-        );
+        assert_eq!(bound_by, expected_bound_by);
         let ports: Vec<u16> = addresses
             .iter()
             .map(|address| address.address.port())
             .collect();
-        assert_eq!(ports, [9200, 9201, 9202, 9203]);
+        assert_eq!(ports, expected_ports);
     }
 
     /// The gRPC API is off unless a run asks for it, and an address nothing

--- a/crates/iota-localnet/src/ports.rs
+++ b/crates/iota-localnet/src/ports.rs
@@ -1,0 +1,452 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    io,
+    net::{SocketAddr, TcpListener, UdpSocket},
+};
+
+use anyhow::bail;
+use iota_config::NodeConfig;
+use iota_swarm::memory::{Node, Swarm};
+
+/// The transport an address is bound with.
+#[derive(Clone, Copy, Debug)]
+enum Transport {
+    Tcp,
+    Udp,
+}
+
+const COMMITTEE_ADDRESS_ADVICE: &str =
+    "it is fixed by the committee metadata in `genesis.blob`, so only a new genesis can move it";
+
+/// An address a local network binds when it launches, named as the user sees
+/// it and paired with the way to move it.
+#[derive(Debug)]
+pub struct BoundAddress {
+    /// What binds the address, e.g. `validator-0 metrics-address`.
+    bound_by: String,
+    address: SocketAddr,
+    transport: Transport,
+    /// What to do about the address when its port is taken.
+    advice: String,
+}
+
+impl BoundAddress {
+    /// An address a node config field holds, which `--node-config-override`
+    /// can move.
+    fn overridable(scope: &str, field: &str, address: SocketAddr, transport: Transport) -> Self {
+        Self {
+            bound_by: format!("{scope} {field}"),
+            address,
+            transport,
+            advice: format!(
+                "override it with --node-config-override {scope}:{field}={ip}:<port>",
+                ip = address.ip()
+            ),
+        }
+    }
+
+    /// An address whose port a validator's peers read from the committee
+    /// metadata in `genesis.blob`, so that moving it at start time would only
+    /// leave the validator unreachable.
+    fn fixed_by_genesis(
+        scope: &str,
+        field: &str,
+        address: SocketAddr,
+        transport: Transport,
+        advice: &str,
+    ) -> Self {
+        Self {
+            bound_by: format!("{scope} {field}"),
+            address,
+            transport,
+            advice: advice.to_owned(),
+        }
+    }
+
+    /// An address a service listens on, which `flag` moves.
+    pub fn service(name: &str, flag: &str, address: SocketAddr) -> Self {
+        Self {
+            bound_by: name.to_owned(),
+            address,
+            transport: Transport::Tcp,
+            advice: format!("move it with {flag}=<port>"),
+        }
+    }
+
+    /// Whether something already holds the address. Any other reason a bind
+    /// fails, such as an address this host does not have, is not a port clash
+    /// and is left to the node to report.
+    fn is_in_use(&self) -> bool {
+        let bound = match self.transport {
+            Transport::Tcp => TcpListener::bind(self.address).map(drop),
+            Transport::Udp => UdpSocket::bind(self.address).map(drop),
+        };
+        matches!(bound, Err(err) if err.kind() == io::ErrorKind::AddrInUse)
+    }
+}
+
+/// Fail if any of `addresses` is already taken, naming every one that is and
+/// what to do about it.
+///
+/// This runs just before the network launches and reserves nothing: each port
+/// is free again the moment it has been probed, so one that passes here can
+/// still be taken by the time a node binds it. It turns the common case — a
+/// second local network, or another program on a fixed port — into a message
+/// naming the node and the field, instead of a bind failure from inside a
+/// node.
+pub fn check_ports_are_free(addresses: &[BoundAddress]) -> Result<(), anyhow::Error> {
+    let taken: Vec<String> = addresses
+        .iter()
+        .filter(|address| address.is_in_use())
+        .map(|address| {
+            format!(
+                "port {port} ({bound_by}) is already in use\n  {advice}",
+                port = address.address.port(),
+                bound_by = address.bound_by,
+                advice = address.advice
+            )
+        })
+        .collect();
+
+    if taken.is_empty() {
+        return Ok(());
+    }
+    bail!(taken.join("\n"))
+}
+
+/// The addresses the nodes of `swarm` bind when the network launches.
+///
+/// A node binds fewer addresses than its config names: `iota-localnet` runs
+/// the nodes in-process, which starts no admin interface, and a validator
+/// serves neither the JSON-RPC nor the gRPC API.
+pub fn addresses_bound_at_launch(swarm: &Swarm) -> Vec<BoundAddress> {
+    let mut addresses = Vec::new();
+
+    let committee = swarm.config().committee_with_network();
+    for (index, config) in swarm.config().validator_configs().iter().enumerate() {
+        // A validator's consensus address has no node config field of its
+        // own: it reads its own, like its peers', from the committee.
+        let primary_address = committee
+            .validators()
+            .get(&config.authority_public_key())
+            .and_then(|(_, metadata)| metadata.primary_address.udp_multiaddr_to_listen_address());
+        addresses.extend(validator_addresses(
+            &format!("validator-{index}"),
+            config,
+            primary_address,
+        ));
+    }
+
+    // The swarm keeps its nodes in a map, so sort them to report the same
+    // order on every run.
+    let mut fullnodes: Vec<&Node> = swarm.fullnodes().collect();
+    fullnodes.sort_by_key(|fullnode| fullnode.name());
+    for fullnode in fullnodes {
+        addresses.extend(fullnode_addresses(&fullnode.config()));
+    }
+
+    addresses
+}
+
+/// The addresses a validator binds.
+fn validator_addresses(
+    scope: &str,
+    config: &NodeConfig,
+    primary_address: Option<SocketAddr>,
+) -> Vec<BoundAddress> {
+    let mut addresses = Vec::new();
+
+    if let Ok(network_address) = config.network_address.to_socket_addr() {
+        addresses.push(BoundAddress::fixed_by_genesis(
+            scope,
+            "network-address",
+            network_address,
+            Transport::Tcp,
+            COMMITTEE_ADDRESS_ADVICE,
+        ));
+    }
+    // The listen address itself is overridable, but its port is not.
+    addresses.push(BoundAddress::fixed_by_genesis(
+        scope,
+        "p2p-config.listen-address",
+        config.p2p_config.listen_address,
+        Transport::Udp,
+        "its port is the validator's `p2p-address` in the committee metadata of `genesis.blob`, \
+         so only a new genesis can move it",
+    ));
+    addresses.push(BoundAddress::overridable(
+        scope,
+        "metrics-address",
+        config.metrics_address,
+        Transport::Tcp,
+    ));
+    if let Some(primary_address) = primary_address {
+        // Consensus serves this over TCP, even though the committee writes it
+        // as a UDP multiaddr.
+        addresses.push(BoundAddress::fixed_by_genesis(
+            scope,
+            "primary-address",
+            primary_address,
+            Transport::Tcp,
+            COMMITTEE_ADDRESS_ADVICE,
+        ));
+    }
+
+    addresses
+}
+
+/// The addresses a fullnode binds.
+fn fullnode_addresses(config: &NodeConfig) -> Vec<BoundAddress> {
+    let mut addresses = vec![
+        BoundAddress::overridable(
+            "fullnode",
+            "json-rpc-address",
+            config.json_rpc_address,
+            Transport::Tcp,
+        ),
+        BoundAddress::overridable(
+            "fullnode",
+            "metrics-address",
+            config.metrics_address,
+            Transport::Tcp,
+        ),
+        BoundAddress::overridable(
+            "fullnode",
+            "p2p-config.listen-address",
+            config.p2p_config.listen_address,
+            Transport::Udp,
+        ),
+    ];
+
+    if config.enable_grpc_api {
+        if let Some(grpc_api_config) = &config.grpc_api_config {
+            addresses.push(BoundAddress::overridable(
+                "fullnode",
+                "grpc-api-config.address",
+                grpc_api_config.address,
+                Transport::Tcp,
+            ));
+        }
+    }
+
+    addresses
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::Ipv4Addr, path::Path};
+
+    use iota_config::node::Genesis;
+    use iota_swarm_config::{
+        genesis_config::ValidatorGenesisConfigBuilder,
+        node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder},
+    };
+    use rand::rngs::OsRng;
+
+    use super::*;
+
+    /// A validator on the localnet port layout: its node config, and the
+    /// primary address its committee entry carries, both derived from one
+    /// genesis entry as `start` derives them.
+    ///
+    /// A test that probes these addresses passes a `port_base` away from the
+    /// real one, so that a local network running beside the test does not read
+    /// as a clash, and its own, so that two tests binding at the same moment
+    /// do not read as one.
+    fn validator_config(directory: &Path, port_base: u16) -> (NodeConfig, Option<SocketAddr>) {
+        let validator = ValidatorGenesisConfigBuilder::new()
+            .with_ip("127.0.0.1".to_owned())
+            .with_deterministic_ports(port_base)
+            .build(&mut OsRng);
+        let primary_address = validator.primary_address.udp_multiaddr_to_listen_address();
+        let config = ValidatorConfigBuilder::new()
+            .with_config_directory(directory.to_path_buf())
+            .build_without_genesis(validator);
+        (config, primary_address)
+    }
+
+    fn fullnode_config(directory: &Path) -> NodeConfig {
+        FullnodeConfigBuilder::new()
+            .with_config_directory(directory.to_path_buf())
+            .build_from_parts(&mut OsRng, &[], Genesis::new_empty())
+    }
+
+    /// Hold a TCP port for as long as the returned listener lives.
+    fn occupy_tcp_port() -> (TcpListener, u16) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        (listener, port)
+    }
+
+    /// Hold a UDP port for as long as the returned socket lives.
+    fn occupy_udp_port() -> (UdpSocket, u16) {
+        let socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = socket.local_addr().unwrap().port();
+        (socket, port)
+    }
+
+    #[test]
+    fn a_clash_names_the_node_the_field_and_the_override_that_moves_it() {
+        let directory = tempfile::tempdir().unwrap();
+        let (_listener, port) = occupy_tcp_port();
+        let (mut config, primary_address) = validator_config(directory.path(), 29200);
+        config.metrics_address = (Ipv4Addr::LOCALHOST, port).into();
+
+        let addresses = validator_addresses("validator-0", &config, primary_address);
+        let err = check_ports_are_free(&addresses).unwrap_err().to_string();
+
+        assert_eq!(
+            err,
+            format!(
+                "port {port} (validator-0 metrics-address) is already in use\n  override it with \
+                 --node-config-override validator-0:metrics-address=127.0.0.1:<port>"
+            )
+        );
+    }
+
+    #[test]
+    fn a_committee_address_is_reported_as_one_only_a_new_genesis_moves() {
+        let directory = tempfile::tempdir().unwrap();
+        let (_socket, port) = occupy_udp_port();
+        let (mut config, primary_address) = validator_config(directory.path(), 29210);
+        config.p2p_config.listen_address = (Ipv4Addr::LOCALHOST, port).into();
+
+        let addresses = validator_addresses("validator-0", &config, primary_address);
+        let err = check_ports_are_free(&addresses).unwrap_err().to_string();
+
+        assert_eq!(
+            err,
+            format!(
+                "port {port} (validator-0 p2p-config.listen-address) is already in use\n  its \
+                 port is the validator's `p2p-address` in the committee metadata of \
+                 `genesis.blob`, so only a new genesis can move it"
+            )
+        );
+        assert!(!err.contains("--node-config-override"), "{err}");
+    }
+
+    #[test]
+    fn every_clash_is_reported_not_only_the_first() {
+        let directory = tempfile::tempdir().unwrap();
+        let (_metrics_listener, metrics_port) = occupy_tcp_port();
+        let (_json_rpc_listener, json_rpc_port) = occupy_tcp_port();
+        let (mut validator_config, primary_address) = validator_config(directory.path(), 29220);
+        validator_config.metrics_address = (Ipv4Addr::LOCALHOST, metrics_port).into();
+        let mut fullnode_config = fullnode_config(directory.path());
+        fullnode_config.json_rpc_address = (Ipv4Addr::LOCALHOST, json_rpc_port).into();
+
+        let mut addresses = validator_addresses("validator-0", &validator_config, primary_address);
+        addresses.extend(fullnode_addresses(&fullnode_config));
+        let err = check_ports_are_free(&addresses).unwrap_err().to_string();
+
+        assert_eq!(
+            err,
+            format!(
+                "port {metrics_port} (validator-0 metrics-address) is already in use\n  override \
+                 it with --node-config-override validator-0:metrics-address=127.0.0.1:<port>\n\
+                 port {json_rpc_port} (fullnode json-rpc-address) is already in use\n  override \
+                 it with --node-config-override fullnode:json-rpc-address=127.0.0.1:<port>"
+            )
+        );
+    }
+
+    #[test]
+    fn a_service_clash_names_the_flag_that_moves_it() {
+        let (_listener, port) = occupy_tcp_port();
+        let addresses = [BoundAddress::service(
+            "faucet",
+            "--with-faucet",
+            (Ipv4Addr::LOCALHOST, port).into(),
+        )];
+
+        let err = check_ports_are_free(&addresses).unwrap_err().to_string();
+
+        assert_eq!(
+            err,
+            format!("port {port} (faucet) is already in use\n  move it with --with-faucet=<port>")
+        );
+    }
+
+    #[test]
+    fn a_network_whose_ports_are_free_passes() {
+        let directory = tempfile::tempdir().unwrap();
+        let (config, primary_address) = validator_config(directory.path(), 29230);
+        let mut addresses = validator_addresses("validator-0", &config, primary_address);
+        let mut fullnode_config = fullnode_config(directory.path());
+        fullnode_config.json_rpc_address = (Ipv4Addr::LOCALHOST, 29184).into();
+        fullnode_config.metrics_address = (Ipv4Addr::LOCALHOST, 29185).into();
+        fullnode_config.p2p_config.listen_address = (Ipv4Addr::LOCALHOST, 29186).into();
+        addresses.extend(fullnode_addresses(&fullnode_config));
+
+        check_ports_are_free(&addresses).unwrap();
+    }
+
+    /// Only a port something else holds is a clash. A bind that fails for
+    /// another reason must not be reported, or every address this host does
+    /// not have would look occupied.
+    #[test]
+    fn an_address_this_host_does_not_have_is_not_a_clash() {
+        // TEST-NET-1, which is not assigned to an interface.
+        let addresses = [BoundAddress::service(
+            "faucet",
+            "--with-faucet",
+            "192.0.2.1:9123".parse().unwrap(),
+        )];
+
+        check_ports_are_free(&addresses).unwrap();
+    }
+
+    /// A validator serves no JSON-RPC, and nothing starts its admin interface
+    /// in-process, so neither address is checked.
+    #[test]
+    fn a_validator_binds_neither_its_json_rpc_nor_its_admin_interface() {
+        let directory = tempfile::tempdir().unwrap();
+        let (config, primary_address) = validator_config(directory.path(), 9200);
+
+        let addresses = validator_addresses("validator-0", &config, primary_address);
+
+        let bound_by: Vec<&str> = addresses
+            .iter()
+            .map(|address| address.bound_by.as_str())
+            .collect();
+        assert_eq!(
+            bound_by,
+            [
+                "validator-0 network-address",
+                "validator-0 p2p-config.listen-address",
+                "validator-0 metrics-address",
+                "validator-0 primary-address",
+            ]
+        );
+        let ports: Vec<u16> = addresses
+            .iter()
+            .map(|address| address.address.port())
+            .collect();
+        assert_eq!(ports, [9200, 9201, 9202, 9203]);
+    }
+
+    /// The gRPC API is off unless a run asks for it, and an address nothing
+    /// binds must not be reported as taken.
+    #[test]
+    fn a_fullnode_binds_its_grpc_api_address_only_when_the_api_is_on() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut config = fullnode_config(directory.path());
+
+        config.enable_grpc_api = false;
+        assert!(
+            !fullnode_addresses(&config)
+                .iter()
+                .any(|address| address.bound_by.contains("grpc-api-config.address"))
+        );
+
+        config.enable_grpc_api = true;
+        config.grpc_api_config = Some(Default::default());
+        assert!(
+            fullnode_addresses(&config)
+                .iter()
+                .any(|address| address.bound_by.contains("grpc-api-config.address"))
+        );
+    }
+}

--- a/crates/iota-localnet/src/ports.rs
+++ b/crates/iota-localnet/src/ports.rs
@@ -11,7 +11,7 @@ use iota_config::NodeConfig;
 use iota_swarm::memory::{Node, Swarm};
 
 /// The transport an address is bound with.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Transport {
     Tcp,
     Udp,
@@ -28,6 +28,8 @@ pub struct BoundAddress {
     bound_by: String,
     address: SocketAddr,
     transport: Transport,
+    /// Whether only a new genesis moves the address.
+    fixed_by_genesis: bool,
     /// What to do about the address when its port is taken.
     advice: String,
 }
@@ -40,6 +42,7 @@ impl BoundAddress {
             bound_by: format!("{scope} {field}"),
             address,
             transport,
+            fixed_by_genesis: false,
             advice: format!(
                 "override it with --node-config-override {scope}:{field}={ip}:<port>",
                 ip = address.ip()
@@ -60,6 +63,7 @@ impl BoundAddress {
             bound_by: format!("{scope} {field}"),
             address,
             transport,
+            fixed_by_genesis: true,
             advice: advice.to_owned(),
         }
     }
@@ -70,6 +74,7 @@ impl BoundAddress {
             bound_by: name.to_owned(),
             address,
             transport: Transport::Tcp,
+            fixed_by_genesis: false,
             advice: format!("move it with {flag}=<port>"),
         }
     }
@@ -84,35 +89,74 @@ impl BoundAddress {
         };
         matches!(bound, Err(err) if err.kind() == io::ErrorKind::AddrInUse)
     }
+
+    /// Whether both addresses want the same socket, so that whichever binds
+    /// first takes it from the other. A wildcard address covers every IP of
+    /// the host, so it clashes with any address on its port.
+    fn clashes_with(&self, other: &Self) -> bool {
+        self.transport == other.transport
+            && self.address.port() == other.address.port()
+            && (self.address.ip() == other.address.ip()
+                || self.address.ip().is_unspecified()
+                || other.address.ip().is_unspecified())
+    }
 }
 
-/// Fail if any of `addresses` is already taken, naming every one that is and
-/// what to do about it.
+/// Fail if two of `addresses` want one socket, or if something else already
+/// holds one of them, naming every clash and what to do about it.
 ///
 /// This runs just before the network launches and reserves nothing: each port
 /// is free again the moment it has been probed, so one that passes here can
 /// still be taken by the time a node binds it. It turns the common case — a
-/// second local network, or another program on a fixed port — into a message
-/// naming the node and the field, instead of a bind failure from inside a
-/// node.
+/// second local network, another program on a fixed port, or one port given
+/// to two things of this run — into a message naming the node and the field,
+/// instead of a bind failure from inside a node.
 pub fn check_ports_are_free(addresses: &[BoundAddress]) -> Result<(), anyhow::Error> {
-    let taken: Vec<String> = addresses
-        .iter()
-        .filter(|address| address.is_in_use())
-        .map(|address| {
-            format!(
-                "port {port} ({bound_by}) is already in use\n  {advice}",
-                port = address.address.port(),
-                bound_by = address.bound_by,
-                advice = address.advice
-            )
-        })
-        .collect();
+    let mut clashes = Vec::new();
 
-    if taken.is_empty() {
+    for (index, address) in addresses.iter().enumerate() {
+        // Only the first later address on the port is reported, so that a port
+        // several of them want reads as a chain of pairs rather than as every
+        // combination of them.
+        let Some(other) = addresses[index + 1..]
+            .iter()
+            .find(|other| address.clashes_with(other))
+        else {
+            continue;
+        };
+        // Only a new genesis moves a genesis-fixed address, so advise on the
+        // other one wherever there is a choice.
+        let advice = if other.fixed_by_genesis && !address.fixed_by_genesis {
+            &address.advice
+        } else {
+            &other.advice
+        };
+        clashes.push(format!(
+            "port {port} is bound twice by this run ({bound_by}, {other_bound_by})\n  {advice}",
+            port = address.address.port(),
+            bound_by = address.bound_by,
+            other_bound_by = other.bound_by,
+        ));
+    }
+
+    clashes.extend(
+        addresses
+            .iter()
+            .filter(|address| address.is_in_use())
+            .map(|address| {
+                format!(
+                    "port {port} ({bound_by}) is already in use\n  {advice}",
+                    port = address.address.port(),
+                    bound_by = address.bound_by,
+                    advice = address.advice
+                )
+            }),
+    );
+
+    if clashes.is_empty() {
         return Ok(());
     }
-    bail!(taken.join("\n"))
+    bail!(clashes.join("\n"))
 }
 
 /// The addresses the nodes of `swarm` bind when the network launches.
@@ -346,6 +390,34 @@ mod tests {
         assert_eq!(
             err,
             format!("port {port} (faucet) is already in use\n  move it with --with-faucet=<port>")
+        );
+    }
+
+    /// Two addresses of one run on one port never both bind, however free the
+    /// port is, so the check has to compare the run's own addresses too.
+    #[test]
+    fn a_port_this_run_binds_twice_is_reported() {
+        // TEST-NET-1, which is not assigned to an interface, so that nothing
+        // but the comparison between these addresses can report them.
+        let address: SocketAddr = "192.0.2.1:9123".parse().unwrap();
+        let addresses = [
+            BoundAddress::overridable("fullnode", "json-rpc-address", address, Transport::Tcp),
+            BoundAddress::service("faucet", "--with-faucet", address),
+            // The same port over the other transport is another socket.
+            BoundAddress::overridable(
+                "fullnode",
+                "p2p-config.listen-address",
+                address,
+                Transport::Udp,
+            ),
+        ];
+
+        let err = check_ports_are_free(&addresses).unwrap_err().to_string();
+
+        assert_eq!(
+            err,
+            "port 9123 is bound twice by this run (fullnode json-rpc-address, faucet)\n  move it \
+             with --with-faucet=<port>"
         );
     }
 

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -89,8 +89,17 @@ Each validator owns a block of ten ports starting at `9200 + 10 * i`: validator 
 | `9205 + 10 * i` to `9209 + 10 * i` | Reserved. |
 
 The default committee of 1 therefore owns `9200`-`9209`, and `--committee-size 4` owns `9200`-`9239`.
-A node fails to start if one of its ports is already taken, for instance by a second local network.
 The admin interface addresses can be changed with `iota-localnet genesis --admin-interface-address`.
+
+`start` checks every port it is about to bind before it launches anything, so a port already taken — by a second local network, say — is reported up front:
+
+```
+port 9202 (validator-0 metrics-address) is already in use
+  override it with --node-config-override validator-0:metrics-address=127.0.0.1:<port>
+```
+
+For the addresses that [Node config overrides](#node-config-overrides) rejects, the report names a new genesis instead of suggesting an override.
+The admin interface ports are not checked: a local network runs its nodes in-process, which starts no admin interface.
 
 ### Node config overrides
 

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -98,7 +98,7 @@ port 9202 (validator-0 metrics-address) is already in use
   override it with --node-config-override validator-0:metrics-address=127.0.0.1:<port>
 ```
 
-For the addresses that [Node config overrides](#node-config-overrides) rejects, the report names a new genesis instead of suggesting an override.
+For a validator's `network-address`, `primary-address` and the port of its `p2p-config.listen-address`, the report names a new genesis instead of suggesting an override.
 The admin interface ports are not checked: a local network runs its nodes in-process, which starts no admin interface.
 
 ### Node config overrides

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -98,6 +98,7 @@ port 9202 (validator-0 metrics-address) is already in use
   override it with --node-config-override validator-0:metrics-address=127.0.0.1:<port>
 ```
 
+A port the run itself would bind twice — a `--with-faucet` port that is also the fullnode's JSON-RPC port, say — is reported the same way.
 For a validator's `network-address`, `primary-address` and the port of its `p2p-config.listen-address`, the report names a new genesis instead of suggesting an override.
 The admin interface ports are not checked: a local network runs its nodes in-process, which starts no admin interface.
 


### PR DESCRIPTION
# Description of change

Today a busy port causes a bind failure in a node. You get a panic in a task, or `Failed to bind to /ip4/127.0.0.1/tcp/9200/http`. Neither message tells you which node has the problem, or which setting to change. `start` now examines the addresses that the run will bind, and reports all of them before it starts a node:

```
port 9202 (validator-0 metrics-address) is already in use
  override it with --node-config-override validator-0:metrics-address=127.0.0.1:<port>
```

- New file `crates/iota-localnet/src/ports.rs`. `addresses_bound_at_launch` collects the addresses from the derived configs, after the overrides. Thus the check shows what the run binds, not the default ports. `check_ports_are_free` tests each address, and reports all the clashes, not only the first one.
- For each node type the check tests only the addresses that the node binds in the process. The doc comment gives the addresses that it does not test: `admin-interface-address`, which only `iota-node`'s `main.rs` serves, and a validator's `json-rpc-address` and gRPC API, which `build_http_server` and `build_grpc_server` refuse.
- The check also reports a port that the run itself binds two times, and gives both users of the port. Two addresses clash when the transport and the port are the same, and the IP is the same or one address is a wildcard that includes the other. Only `AddrInUse` is a clash.
- For a committee address the message tells you that only a new genesis can move it. An override would leave the validator unreachable. For all other addresses the message gives the override that moves the port. A test sends each of these messages through the parser, thus the advice always gives a command that the parser accepts.
- The GraphQL service binds a Prometheus listener beside its main port. #12779 moved that listener to `127.0.0.1:9126` and added `--graphql-metrics-address`. The address is now resolved with the other service addresses, before genesis, so the check reads the same value the service is given. The check does not run for `--write-config`, which binds nothing.

The check is a diagnostic, not a reservation. It holds no port. Thus a port that is free during the check can become busy before the node binds it. The doc comment gives this limit.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/12429.

## How the change has been tested

I tested by hand: with a listener on 9202 the run stops with the message above and exits 1, and the override in the message starts the network.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Change checklist

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

### Release Notes

- [x] CLI: `iota-localnet start` reports a port clash before launching, naming the node, the config field and the override that moves it. `--with-graphql` now serves its metrics on the port after the GraphQL port (9126 by default) instead of on the fullnode's metrics port.