### PR TITLE
fix(consensus): count equivocations per slot, not per header arrival

### DIFF
--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -521,6 +521,8 @@ pub struct MisbehaviorObservationsV1 {
     pub faulty_blocks_provable: Vec<u64>,
     pub faulty_blocks_unprovable: Vec<u64>,
     pub missing_proposals: Vec<u64>,
+    /// Per-authority count of rounds in which the authority signed more than
+    /// one block header, however many extra headers each round held.
     pub equivocations: Vec<u64>,
 }
 
@@ -553,6 +555,8 @@ pub struct MisbehaviorObservationsV2 {
     pub faulty_blocks_provable: Vec<u64>,
     pub faulty_blocks_unprovable: Vec<u64>,
     pub missing_proposals: Vec<u64>,
+    /// Per-authority count of rounds in which the authority signed more than
+    /// one block header, however many extra headers each round held.
     pub equivocations: Vec<u64>,
     pub invalid_bundle_parts: Vec<u64>,
 }

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -520,6 +520,8 @@ pub struct MisbehaviorObservationsV1 {
     pub faulty_blocks_provable: Vec<u64>,
     pub faulty_blocks_unprovable: Vec<u64>,
     pub missing_proposals: Vec<u64>,
+    /// Per-authority count of rounds in which the authority signed more than
+    /// one block header, however many extra headers each round held.
     pub equivocations: Vec<u64>,
 }
 
@@ -552,6 +554,8 @@ pub struct MisbehaviorObservationsV2 {
     pub faulty_blocks_provable: Vec<u64>,
     pub faulty_blocks_unprovable: Vec<u64>,
     pub missing_proposals: Vec<u64>,
+    /// Per-authority count of rounds in which the authority signed more than
+    /// one block header, however many extra headers each round held.
     pub equivocations: Vec<u64>,
     pub invalid_bundle_parts: Vec<u64>,
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -874,8 +874,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // 5b. Two signed headers from the author's own stream for one slot are
-        // provable equivocation, so drop the block before its shards and payload
-        // are processed, and charge the author. A same-slot header still only
+        // equivocation, so drop the block before its shards and payload are
+        // processed, and flag the slot. A same-slot header still only
         // suspended is caught by the equivalent cap in the block manager.
         let primary_block_equivocates = !primary_block_far_future
             && self
@@ -883,11 +883,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .read()
                 .contains_other_block_header_at_slot(&block_ref);
         if primary_block_equivocates {
-            let e = ConsensusError::BlockHeaderEquivocation {
-                authority: peer,
-                round: block_ref.round,
-            };
-            self.misbehavior_store.record_faulty_block(peer, peer, &e);
+            self.misbehavior_store
+                .record_equivocating_slot(peer, block_ref.round);
             self.context
                 .metrics
                 .node_metrics
@@ -2141,9 +2138,9 @@ mod tests {
     }
 
     /// A second streamed block for a slot we already accepted a header for is
-    /// provable equivocation by its author: the block is dropped before shard
+    /// equivocation by its author: the block is dropped before shard
     /// extraction, its payload and own shard never reach the core, and the
-    /// author is charged.
+    /// slot is flagged.
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_drops_slot_equivocation() {
         let (context, _keys) = Context::new_for_test(4);
@@ -2239,11 +2236,16 @@ mod tests {
                 .get(),
             1,
         );
+        assert_eq!(
+            misbehavior_store.equivocating_rounds(peer),
+            vec![1],
+            "two signed headers for one slot flag the slot as equivocating"
+        );
         let totals = misbehavior_store.snapshot_totals();
         let counts = totals[peer.value()].as_v2();
         assert_eq!(
-            counts.faulty_blocks_provable, 1,
-            "two signed headers for one slot are provable equivocation"
+            counts.faulty_blocks_provable, 0,
+            "an equivocation is not charged as a block fault"
         );
     }
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -864,8 +864,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     last_round: previous.round,
                 }
             };
-            self.misbehavior_store.record_faulty_block(peer, peer, &e);
             if equivocation {
+                self.misbehavior_store
+                    .record_equivocating_slot(peer, block_ref.round);
                 self.context
                     .metrics
                     .node_metrics
@@ -876,6 +877,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     ])
                     .inc();
             } else {
+                self.misbehavior_store.record_faulty_block(peer, peer, &e);
                 self.context
                     .metrics
                     .node_metrics
@@ -2418,8 +2420,13 @@ mod tests {
             "the repeated block and the lower round are charged to the peer"
         );
         assert_eq!(
-            counts.faulty_blocks_provable, 1,
-            "a second digest for a streamed round is equivocation"
+            counts.faulty_blocks_provable, 0,
+            "an equivocation is flagged per slot, not charged as a block fault"
+        );
+        assert_eq!(
+            fixture.misbehavior_store.equivocating_rounds(peer),
+            vec![4],
+            "a second digest for a streamed round flags that slot"
         );
         assert_eq!(
             context
@@ -2493,9 +2500,10 @@ mod tests {
         ));
 
         assert!(fixture.core_dispatcher.get_blocks().is_empty());
+        assert_eq!(fixture.misbehavior_store.equivocating_rounds(peer), vec![1]);
         let totals = fixture.misbehavior_store.snapshot_totals();
         let counts = totals[peer.value()].as_v2();
-        assert_eq!(counts.faulty_blocks_provable, 1);
+        assert_eq!(counts.faulty_blocks_provable, 0);
         assert_eq!(counts.faulty_blocks_unprovable, 0);
         assert_eq!(
             context
@@ -2594,9 +2602,10 @@ mod tests {
             result,
             Err(ConsensusError::BlockHeaderEquivocation { .. })
         ));
+        assert_eq!(fixture.misbehavior_store.equivocating_rounds(peer), vec![4]);
         let totals = fixture.misbehavior_store.snapshot_totals();
         let counts = totals[peer.value()].as_v2();
-        assert_eq!(counts.faulty_blocks_provable, 1);
+        assert_eq!(counts.faulty_blocks_provable, 0);
         assert_eq!(counts.faulty_blocks_unprovable, 2);
     }
 

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -30,7 +30,6 @@ use crate::{
     block_manager::block_suspender::BlockSuspender,
     context::Context,
     dag_state::{DagState, DataSource},
-    error::ConsensusError,
 };
 
 /// Combine headers accepted via the regular path with headers unsuspended by
@@ -605,7 +604,7 @@ impl BlockManager {
     /// peer-controlled sources are filtered, the rest pass through unchanged.
     ///
     /// A drop means two headers of one slot passed signature verification, so
-    /// the author is charged a provable fault.
+    /// the slot is flagged as an equivocation by its author.
     fn drop_over_slot_cap<T>(
         &self,
         items: Vec<T>,
@@ -648,17 +647,7 @@ impl BlockManager {
                             source.as_str(),
                         ])
                         .inc();
-                    // No relaying peer is known at this level; passing the
-                    // author as the peer leaves the author's provable fault as
-                    // the only charge.
-                    misbehavior_store.record_faulty_block(
-                        block_ref.author,
-                        block_ref.author,
-                        &ConsensusError::BlockHeaderEquivocation {
-                            authority: block_ref.author,
-                            round: block_ref.round,
-                        },
-                    );
+                    misbehavior_store.record_equivocating_slot(block_ref.author, block_ref.round);
                 }
                 admit
             })
@@ -1799,18 +1788,26 @@ mod tests {
         );
         assert_eq!(slot_cap_drops(DataSource::BlockBundleStream), 1);
         assert_eq!(
+            misbehavior_store.equivocating_rounds(AuthorityIndex::new_for_test(1)),
+            vec![50],
+            "two verified headers for one slot flag the slot as equivocating"
+        );
+        assert_eq!(
             faults(1),
-            (1, 0),
-            "two verified headers for one slot are the author's provable fault, \
-             and no relaying peer is charged for it"
+            (0, 0),
+            "an equivocation is not charged as a block fault"
         );
 
-        // A repeat of the suspended header is neither a drop nor a fault.
+        // A repeat of the suspended header is neither a drop nor an
+        // equivocation.
         let (accepted, _) =
             block_manager.try_accept_block_headers(vec![first], DataSource::BlockStreaming);
         assert!(accepted.is_empty());
         assert_eq!(slot_cap_drops(DataSource::BlockStreaming), 0);
-        assert_eq!(faults(1), (1, 0));
+        assert_eq!(
+            misbehavior_store.equivocating_rounds(AuthorityIndex::new_for_test(1)),
+            vec![50]
+        );
 
         // Same-batch case at a fresh slot: two different digests in one call,
         // only the first survives.
@@ -1832,8 +1829,17 @@ mod tests {
                 .contains(&batch_second.reference())
         );
         assert_eq!(slot_cap_drops(DataSource::BlockBundleStream), 2);
-        assert_eq!(faults(1), (2, 0));
-        assert_eq!(faults(0), (0, 0), "only the equivocating author is charged");
+        assert_eq!(
+            misbehavior_store.equivocating_rounds(AuthorityIndex::new_for_test(1)),
+            vec![50, 60]
+        );
+        assert_eq!(faults(1), (0, 0));
+        assert!(
+            misbehavior_store
+                .equivocating_rounds(AuthorityIndex::new_for_test(0))
+                .is_empty(),
+            "only the equivocating author is flagged"
+        );
     }
 
     /// A header the cap dropped is still accepted when it arrives from an

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -412,12 +412,6 @@ pub(crate) enum ConsensusError {
         starfish_speed: bool,
     },
 
-    #[error("Authority {authority} equivocated: signed a second block header for round {round}")]
-    BlockHeaderEquivocation {
-        authority: AuthorityIndex,
-        round: Round,
-    },
-
     #[error(
         "Fetch response from {peer} contains unrequested header (author {author}, round {round}) outside the request's gap-fill window"
     )]

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -1405,7 +1405,7 @@ impl NodeMetrics {
             ).unwrap(),
             equivocations_by_authority: register_int_gauge_vec_with_registry!(
                 "equivocations_by_authority",
-                "Equivocations per authority (source: persisted or in_memory)",
+                "Rounds with more than one signed header per authority (source: persisted or in_memory)",
                 &["authority", "source"],
                 registry;
                 MetricLevel::Warn,

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -1428,7 +1428,7 @@ impl NodeMetrics {
             ).unwrap(),
             equivocations_by_authority: register_int_gauge_vec_with_registry!(
                 "equivocations_by_authority",
-                "Equivocations per authority (source: persisted or in_memory)",
+                "Rounds with more than one signed header per authority (source: persisted or in_memory)",
                 &["authority", "source"],
                 registry;
                 MetricLevel::Warn,

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use iota_common::debug_fatal;
 use prometheus_filtered::IntGauge;
 use serde::{Deserialize, Serialize};
 use starfish_config::{AuthorityIndex, Committee};
@@ -58,13 +59,15 @@ impl MisbehaviorStore {
     /// Records that `author` signed more than one header for `round`: a second
     /// verified header for an occupied slot was dropped at ingest. Idempotent —
     /// repeated arrivals and further distinct headers for the same slot
-    /// collapse into one equivocation. `author` comes from a verified header,
-    /// so it is within the committee.
+    /// collapse into one equivocation. Callers pass the author of a verified
+    /// header, so an author outside the committee is a verification bug and is
+    /// reported rather than recorded.
     pub(crate) fn record_equivocating_slot(&self, author: AuthorityIndex, round: Round) {
-        self.equivocating_rounds[author.value()]
-            .lock()
-            .unwrap()
-            .insert(round);
+        let Some(rounds) = self.equivocating_rounds.get(author.value()) else {
+            debug_fatal!("equivocating author {author} is outside the committee");
+            return;
+        };
+        rounds.lock().unwrap().insert(round);
     }
 
     /// Restores persisted counts from storage and computes in-memory counts

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -150,10 +150,14 @@ impl MisbehaviorStore {
         threshold_clock_round: Round,
         context: &Arc<Context>,
     ) -> Option<MisbehaviorCounts> {
-        if threshold_clock_round == 0 || authority_index.value() >= context.committee.size() {
+        if threshold_clock_round == 0 {
             return None;
         }
         let idx = authority_index.value();
+        if idx >= context.committee.size() {
+            debug_fatal!("authority {authority_index} is outside the committee");
+            return None;
+        }
 
         // Move buffered faulty block counts to persisted.
         let had_faulty = self.flush_faulty_block_buffer(idx);
@@ -273,6 +277,7 @@ impl MisbehaviorStore {
         let peer_idx = peer.value();
         let author_idx = author.value();
         if peer_idx >= committee_size {
+            debug_fatal!("peer {peer} is outside the committee");
             return;
         }
         match classify_block_error(error) {
@@ -313,12 +318,20 @@ impl MisbehaviorStore {
         relayers: impl IntoIterator<Item = AuthorityIndex>,
     ) {
         let committee_size = self.in_memory.authorities.len();
-        if authored && author.value() < committee_size {
-            self.in_memory.record_block_fault_provable(author.value());
+        if authored {
+            if author.value() < committee_size {
+                self.in_memory.record_block_fault_provable(author.value());
+            } else {
+                debug_fatal!("author {author} of a verified header is outside the committee");
+            }
         }
         for peer in relayers {
             let idx = peer.value();
-            if idx >= committee_size || (authored && peer == author) {
+            if idx >= committee_size {
+                debug_fatal!("relaying peer {peer} is outside the committee");
+                continue;
+            }
+            if authored && peer == author {
                 continue;
             }
             self.in_memory.record_block_fault_unprovable(idx);
@@ -946,12 +959,6 @@ mod tests {
             result,
             Some(MisbehaviorCounts::new_v2_for_test(0, 0, 3, 0, 0))
         );
-
-        // Out-of-bounds authority → None
-        let oob = AuthorityIndex::new_for_test(4);
-        let result =
-            store.update_misbehavior_counts_on_eviction(oob, &recent_refs, 2, 1, 3, &context);
-        assert!(result.is_none());
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -27,6 +27,11 @@ use crate::{
 pub(crate) struct MisbehaviorStore {
     in_memory: CommitteeMisbehaviorCounts,
     persisted: CommitteeMisbehaviorCounts,
+    /// Per-authority rounds in which a second verified header for an occupied
+    /// slot was dropped at ingest. Counted into the in-memory equivocations on
+    /// each flush and folded into the persisted count when the round is
+    /// evicted.
+    equivocating_rounds: Vec<Mutex<BTreeSet<Round>>>,
 }
 
 impl MisbehaviorStore {
@@ -35,6 +40,9 @@ impl MisbehaviorStore {
         Self {
             in_memory: CommitteeMisbehaviorCounts::new(&context.committee, metrics, "in_memory"),
             persisted: CommitteeMisbehaviorCounts::new(&context.committee, metrics, "persisted"),
+            equivocating_rounds: (0..context.committee.size())
+                .map(|_| Mutex::new(BTreeSet::new()))
+                .collect(),
         }
     }
 
@@ -42,6 +50,21 @@ impl MisbehaviorStore {
     pub(crate) fn reset(&self) {
         self.in_memory.reset();
         self.persisted.reset();
+        for rounds in &self.equivocating_rounds {
+            rounds.lock().unwrap().clear();
+        }
+    }
+
+    /// Records that `author` signed more than one header for `round`: a second
+    /// verified header for an occupied slot was dropped at ingest. Idempotent —
+    /// repeated arrivals and further distinct headers for the same slot
+    /// collapse into one equivocation. `author` comes from a verified header,
+    /// so it is within the committee.
+    pub(crate) fn record_equivocating_slot(&self, author: AuthorityIndex, round: Round) {
+        self.equivocating_rounds[author.value()]
+            .lock()
+            .unwrap()
+            .insert(round);
     }
 
     /// Restores persisted counts from storage and computes in-memory counts
@@ -97,8 +120,11 @@ impl MisbehaviorStore {
                     .iter()
                     .map(|r| r.round)
                     .collect();
+                // Equivocation flags are volatile: after a restart only the
+                // cache surplus is visible until new drops are recorded.
                 let (eq, missing) = calculate_misbehavior_counts_for_range(
                     cached_rounds,
+                    &BTreeSet::new(),
                     eviction_round + 1,
                     threshold_clock_round.saturating_sub(1),
                 );
@@ -129,6 +155,8 @@ impl MisbehaviorStore {
         // Move buffered faulty block counts to persisted.
         let had_faulty = self.flush_faulty_block_buffer(idx);
 
+        let mut equivocating_rounds = self.equivocating_rounds[idx].lock().unwrap();
+
         // Recompute in-memory window from blocks still in cache.
         let in_memory_block_rounds: Vec<Round> = recent_refs
             .iter()
@@ -137,6 +165,7 @@ impl MisbehaviorStore {
             .collect();
         let (in_memory_eq, in_memory_missing) = calculate_misbehavior_counts_for_range(
             in_memory_block_rounds,
+            &equivocating_rounds,
             eviction_round + 1,
             threshold_clock_round.saturating_sub(1),
         );
@@ -153,11 +182,15 @@ impl MisbehaviorStore {
                 .collect();
             let (evicted_eq, evicted_missing) = calculate_misbehavior_counts_for_range(
                 evicted_block_rounds,
+                &equivocating_rounds,
                 last_eviction_round + 1,
                 eviction_round,
             );
             self.persisted
                 .add_dag_faults(idx, evicted_missing, evicted_eq);
+            // Evicted rounds are folded into persisted above; drop their flags.
+            let live_rounds = equivocating_rounds.split_off(&(eviction_round + 1));
+            *equivocating_rounds = live_rounds;
         }
 
         if eviction_advanced || had_faulty {
@@ -358,8 +391,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::TransactionTooLarge { .. }
         | ConsensusError::TooManyTransactions { .. }
         | ConsensusError::TooManyTransactionBytes { .. }
-        | ConsensusError::InvalidTransaction(_)
-        | ConsensusError::BlockHeaderEquivocation { .. } => FaultType::Provable,
+        | ConsensusError::InvalidTransaction(_) => FaultType::Provable,
 
         // Not attributable as misbehavior from a signed block alone: subjective
         // rejections, commit-chain and commit-sync inconsistencies, fetch-shape
@@ -577,22 +609,33 @@ impl CommitteeMisbehaviorCounts {
     }
 }
 
-/// Given block rounds for one authority in [start, end], returns
-/// (equivocations, missing_proposals).
+/// Given one authority's cached block rounds in [start, end] and the rounds
+/// flagged as equivocating at ingest, returns (equivocations,
+/// missing_proposals). An equivocation is a round with more than one signed
+/// header observed: more than one cached header, or a flag recorded when a
+/// second header for the slot was dropped. A flagged round with no cached
+/// header still counts as missing — none of its headers was accepted.
 fn calculate_misbehavior_counts_for_range(
     mut block_rounds: Vec<Round>,
+    flagged_rounds: &BTreeSet<Round>,
     start: Round,
     end: Round,
 ) -> (u64, u64) {
+    if start > end {
+        return (0, 0);
+    }
     block_rounds.retain(|&round| round >= start && round <= end);
     block_rounds.sort();
-    let number_of_blocks = block_rounds.len();
+    let mut equivocating_rounds: BTreeSet<Round> = block_rounds
+        .windows(2)
+        .filter_map(|pair| (pair[0] == pair[1]).then_some(pair[0]))
+        .collect();
+    equivocating_rounds.extend(flagged_rounds.range(start..=end).copied());
     block_rounds.dedup();
     let unique_block_rounds = block_rounds.len();
-    let number_of_equivocations = number_of_blocks.saturating_sub(unique_block_rounds) as u64;
     let number_of_missing_blocks =
         (end + 1).saturating_sub(start + unique_block_rounds as u32) as u64;
-    (number_of_equivocations, number_of_missing_blocks)
+    (equivocating_rounds.len() as u64, number_of_missing_blocks)
 }
 
 /// Versioned envelope for persisted scoring metrics. New versions are added as
@@ -614,6 +657,8 @@ pub struct MisbehaviorCountsV1 {
     pub faulty_blocks_provable: u64,
     pub faulty_blocks_unprovable: u64,
     pub missing_proposals: u64,
+    /// Rounds in which the authority signed more than one block header,
+    /// however many extra headers each round held.
     pub equivocations: u64,
 }
 
@@ -624,6 +669,8 @@ pub struct MisbehaviorCountsV2 {
     pub faulty_blocks_provable: u64,
     pub faulty_blocks_unprovable: u64,
     pub missing_proposals: u64,
+    /// Rounds in which the authority signed more than one block header,
+    /// however many extra headers each round held.
     pub equivocations: u64,
     pub invalid_bundle_parts: u64,
 }
@@ -666,6 +713,15 @@ impl MisbehaviorStore {
 
     pub(crate) fn in_memory_faulty_blocks_unprovable(&self) -> Vec<u64> {
         self.in_memory.collect(|c| c.faulty_blocks_unprovable)
+    }
+
+    pub(crate) fn equivocating_rounds(&self, author: AuthorityIndex) -> Vec<Round> {
+        self.equivocating_rounds[author.value()]
+            .lock()
+            .unwrap()
+            .iter()
+            .copied()
+            .collect()
     }
 }
 
@@ -721,7 +777,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_header::BlockRef,
+        block_header::{BlockHeaderDigest, BlockRef},
         context::Context,
         dag_state::{DagState, DataSource},
         error::ConsensusError,
@@ -731,77 +787,116 @@ mod tests {
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_basic() {
+        let no_flags = BTreeSet::new();
+
         // No blocks in range → all missing, no equivocations
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], 1, 5);
+        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], &no_flags, 1, 5);
         assert_eq!(eq, 0);
         assert_eq!(missing, 5);
 
         // All rounds present, no equivocations
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 3, 4, 5], 1, 5);
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 3, 4, 5], &no_flags, 1, 5);
         assert_eq!(eq, 0);
         assert_eq!(missing, 0);
 
-        // One equivocation (duplicate round 3)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 3, 3, 4, 5], 1, 5);
+        // One equivocating round (duplicate round 3)
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 3, 3, 4, 5], &no_flags, 1, 5);
         assert_eq!(eq, 1);
         assert_eq!(missing, 0);
 
-        // One missing (round 3) + one equivocation (round 2)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 2, 4, 5], 1, 5);
+        // One missing (round 3) + one equivocating round (round 2)
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 2, 4, 5], &no_flags, 1, 5);
         assert_eq!(eq, 1);
         assert_eq!(missing, 1);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_filters_out_of_range() {
-        // Rounds outside [2, 4] are filtered
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 3, 4, 5], 2, 4);
+        // Rounds outside [2, 4] are filtered, in the cached rounds and in the
+        // flags alike
+        let flags = BTreeSet::from([1, 5]);
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 3, 4, 5], &flags, 2, 4);
         assert_eq!(eq, 0);
         assert_eq!(missing, 0);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_empty_range() {
-        // start > end → no missing, no equivocations (saturating_sub handles it)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], 5, 3);
+        // start > end → no missing, no equivocations
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![], &BTreeSet::from([4]), 5, 3);
         assert_eq!(eq, 0);
         assert_eq!(missing, 0);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_unsorted_input() {
-        // Unsorted with one equivocation (round 3 appears twice) and one missing (round
-        // 5)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![4, 1, 3, 2, 3], 1, 5);
+        // Unsorted with one equivocating round (round 3 appears twice) and one
+        // missing (round 5)
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![4, 1, 3, 2, 3], &BTreeSet::new(), 1, 5);
         assert_eq!(eq, 1);
         assert_eq!(missing, 1);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_multiple_equivocations() {
-        // Round 2 appears 3 times (2 equivocations), round 4 appears twice (1
-        // equivocation)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 2, 2, 3, 4, 4], 1, 4);
-        assert_eq!(eq, 3);
+        // Round 2 appears 3 times and round 4 twice — two equivocating rounds,
+        // however many extra headers each holds
+        let (eq, missing) = calculate_misbehavior_counts_for_range(
+            vec![1, 2, 2, 2, 3, 4, 4],
+            &BTreeSet::new(),
+            1,
+            4,
+        );
+        assert_eq!(eq, 2);
         assert_eq!(missing, 0);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_single_round() {
+        let no_flags = BTreeSet::new();
+
         // Single-round range with block present
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![5], 5, 5);
+        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![5], &no_flags, 5, 5);
         assert_eq!(eq, 0);
         assert_eq!(missing, 0);
 
         // Single-round range with no block
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], 5, 5);
+        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], &no_flags, 5, 5);
         assert_eq!(eq, 0);
         assert_eq!(missing, 1);
 
         // Single-round range with equivocation
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![5, 5], 5, 5);
+        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![5, 5], &no_flags, 5, 5);
         assert_eq!(eq, 1);
         assert_eq!(missing, 0);
+    }
+
+    #[test]
+    fn test_calculate_misbehavior_counts_for_range_flagged_rounds() {
+        // A flag alone marks the round as equivocating
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 3], &BTreeSet::from([2]), 1, 3);
+        assert_eq!(eq, 1);
+        assert_eq!(missing, 0);
+
+        // A flag and a cached surplus on the same round count once
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 2, 3], &BTreeSet::from([2]), 1, 3);
+        assert_eq!(eq, 1);
+        assert_eq!(missing, 0);
+
+        // A flagged round with no cached header counts as both equivocating
+        // and missing: two headers were signed, none was accepted
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 3], &BTreeSet::from([2]), 1, 3);
+        assert_eq!(eq, 1);
+        assert_eq!(missing, 1);
     }
 
     #[tokio::test]
@@ -854,6 +949,54 @@ mod tests {
         let result =
             store.update_misbehavior_counts_on_eviction(oob, &recent_refs, 2, 1, 3, &context);
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_equivocating_slot_flags() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let store = MisbehaviorStore::new(&context);
+        let author = AuthorityIndex::new_for_test(1);
+        let idx = author.value();
+
+        // One cached header per round 1..=9.
+        let recent_refs: BTreeSet<BlockRef> = (1..=9)
+            .map(|round| BlockRef::new(round, author, BlockHeaderDigest::MIN))
+            .collect();
+
+        // Repeated arrivals and a further distinct header collapse per slot.
+        store.record_equivocating_slot(author, 5);
+        store.record_equivocating_slot(author, 5);
+        store.record_equivocating_slot(author, 7);
+
+        // No eviction advance: the flags show up in the in-memory window and
+        // no block fault is charged.
+        let result =
+            store.update_misbehavior_counts_on_eviction(author, &recent_refs, 0, 0, 10, &context);
+        assert!(result.is_none());
+        assert_eq!(store.in_memory_equivocations()[idx], 2);
+        assert_eq!(store.in_memory_faulty_blocks_provable()[idx], 0);
+
+        // Eviction advances to round 6: the flag at round 5 folds into
+        // persisted and is pruned; round 7 stays in the in-memory window.
+        let result =
+            store.update_misbehavior_counts_on_eviction(author, &recent_refs, 6, 0, 10, &context);
+        assert!(result.is_some());
+        assert_eq!(store.persisted_equivocations()[idx], 1);
+        assert_eq!(store.in_memory_equivocations()[idx], 1);
+        assert_eq!(store.equivocating_rounds(author), vec![7]);
+
+        // The next advance folds the remaining flag; nothing is counted twice.
+        let result =
+            store.update_misbehavior_counts_on_eviction(author, &recent_refs, 9, 6, 10, &context);
+        assert!(result.is_some());
+        assert_eq!(store.persisted_equivocations()[idx], 2);
+        assert_eq!(store.in_memory_equivocations()[idx], 0);
+        assert!(store.equivocating_rounds(author).is_empty());
+
+        // Reset clears the flags.
+        store.record_equivocating_slot(author, 12);
+        store.reset();
+        assert!(store.equivocating_rounds(author).is_empty());
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -150,10 +150,14 @@ impl MisbehaviorStore {
         threshold_clock_round: Round,
         context: &Arc<Context>,
     ) -> Option<MisbehaviorCounts> {
-        if threshold_clock_round == 0 || authority_index.value() >= context.committee.size() {
+        if threshold_clock_round == 0 {
             return None;
         }
         let idx = authority_index.value();
+        if idx >= context.committee.size() {
+            debug_fatal!("authority {authority_index} is outside the committee");
+            return None;
+        }
 
         // Move buffered faulty block counts to persisted.
         let had_faulty = self.flush_faulty_block_buffer(idx);
@@ -274,6 +278,7 @@ impl MisbehaviorStore {
         let peer_idx = peer.value();
         let author_idx = author.value();
         if peer_idx >= committee_size {
+            debug_fatal!("peer {peer} is outside the committee");
             return;
         }
         match classify_block_error(error) {
@@ -314,12 +319,20 @@ impl MisbehaviorStore {
         relayers: impl IntoIterator<Item = AuthorityIndex>,
     ) {
         let committee_size = self.in_memory.authorities.len();
-        if authored && author.value() < committee_size {
-            self.in_memory.record_block_fault_provable(author.value());
+        if authored {
+            if author.value() < committee_size {
+                self.in_memory.record_block_fault_provable(author.value());
+            } else {
+                debug_fatal!("author {author} of a verified header is outside the committee");
+            }
         }
         for peer in relayers {
             let idx = peer.value();
-            if idx >= committee_size || (authored && peer == author) {
+            if idx >= committee_size {
+                debug_fatal!("relaying peer {peer} is outside the committee");
+                continue;
+            }
+            if authored && peer == author {
                 continue;
             }
             self.in_memory.record_block_fault_unprovable(idx);
@@ -959,12 +972,6 @@ mod tests {
             result,
             Some(MisbehaviorCounts::new_v2_for_test(0, 0, 3, 0, 0))
         );
-
-        // Out-of-bounds authority → None
-        let oob = AuthorityIndex::new_for_test(4);
-        let result =
-            store.update_misbehavior_counts_on_eviction(oob, &recent_refs, 2, 1, 3, &context);
-        assert!(result.is_none());
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -27,6 +27,11 @@ use crate::{
 pub(crate) struct MisbehaviorStore {
     in_memory: CommitteeMisbehaviorCounts,
     persisted: CommitteeMisbehaviorCounts,
+    /// Per-authority rounds in which a second verified header for an occupied
+    /// slot was dropped at ingest. Counted into the in-memory equivocations on
+    /// each flush and folded into the persisted count when the round is
+    /// evicted.
+    equivocating_rounds: Vec<Mutex<BTreeSet<Round>>>,
 }
 
 impl MisbehaviorStore {
@@ -35,6 +40,9 @@ impl MisbehaviorStore {
         Self {
             in_memory: CommitteeMisbehaviorCounts::new(&context.committee, metrics, "in_memory"),
             persisted: CommitteeMisbehaviorCounts::new(&context.committee, metrics, "persisted"),
+            equivocating_rounds: (0..context.committee.size())
+                .map(|_| Mutex::new(BTreeSet::new()))
+                .collect(),
         }
     }
 
@@ -42,6 +50,21 @@ impl MisbehaviorStore {
     pub(crate) fn reset(&self) {
         self.in_memory.reset();
         self.persisted.reset();
+        for rounds in &self.equivocating_rounds {
+            rounds.lock().unwrap().clear();
+        }
+    }
+
+    /// Records that `author` signed more than one header for `round`: a second
+    /// verified header for an occupied slot was dropped at ingest. Idempotent —
+    /// repeated arrivals and further distinct headers for the same slot
+    /// collapse into one equivocation. `author` comes from a verified header,
+    /// so it is within the committee.
+    pub(crate) fn record_equivocating_slot(&self, author: AuthorityIndex, round: Round) {
+        self.equivocating_rounds[author.value()]
+            .lock()
+            .unwrap()
+            .insert(round);
     }
 
     /// Restores persisted counts from storage and computes in-memory counts
@@ -97,8 +120,11 @@ impl MisbehaviorStore {
                     .iter()
                     .map(|r| r.round)
                     .collect();
+                // Flags are not persisted, so only rounds with more than one
+                // cached header count after a restart.
                 let (eq, missing) = calculate_misbehavior_counts_for_range(
                     cached_rounds,
+                    &BTreeSet::new(),
                     eviction_round + 1,
                     threshold_clock_round.saturating_sub(1),
                 );
@@ -129,6 +155,8 @@ impl MisbehaviorStore {
         // Move buffered faulty block counts to persisted.
         let had_faulty = self.flush_faulty_block_buffer(idx);
 
+        let mut equivocating_rounds = self.equivocating_rounds[idx].lock().unwrap();
+
         // Recompute in-memory window from blocks still in cache.
         let in_memory_block_rounds: Vec<Round> = recent_refs
             .iter()
@@ -137,6 +165,7 @@ impl MisbehaviorStore {
             .collect();
         let (in_memory_eq, in_memory_missing) = calculate_misbehavior_counts_for_range(
             in_memory_block_rounds,
+            &equivocating_rounds,
             eviction_round + 1,
             threshold_clock_round.saturating_sub(1),
         );
@@ -153,11 +182,15 @@ impl MisbehaviorStore {
                 .collect();
             let (evicted_eq, evicted_missing) = calculate_misbehavior_counts_for_range(
                 evicted_block_rounds,
+                &equivocating_rounds,
                 last_eviction_round + 1,
                 eviction_round,
             );
             self.persisted
                 .add_dag_faults(idx, evicted_missing, evicted_eq);
+            // Evicted rounds are folded into persisted above; drop their flags.
+            let live_rounds = equivocating_rounds.split_off(&(eviction_round + 1));
+            *equivocating_rounds = live_rounds;
         }
 
         if eviction_advanced || had_faulty {
@@ -367,8 +400,11 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::TransactionTooLarge { .. }
         | ConsensusError::TooManyTransactions { .. }
         | ConsensusError::TooManyTransactionBytes { .. }
-        | ConsensusError::InvalidTransaction(_)
-        | ConsensusError::BlockHeaderEquivocation { .. } => FaultType::Provable,
+        | ConsensusError::InvalidTransaction(_) => FaultType::Provable,
+
+        // Equivocation is counted once per slot when the header is dropped, so
+        // the error that rejects the delivery carrying it is not charged again.
+        ConsensusError::BlockHeaderEquivocation { .. }
 
         // Not attributable as misbehavior from a signed block alone: subjective
         // rejections, commit-chain and commit-sync inconsistencies, fetch-shape
@@ -376,7 +412,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         // transport, request-shape checks, local lifecycle signals, and version
         // mismatches that may stem from a benign upgrade misconfiguration rather
         // than a faulty peer.
-        ConsensusError::MalformedCommit(_)
+        | ConsensusError::MalformedCommit(_)
         | ConsensusError::UnexpectedGenesisRequested { .. }
         | ConsensusError::NotEnoughHeadersFetched { .. }
         | ConsensusError::UnexpectedLastOwnHeader { .. }
@@ -586,22 +622,33 @@ impl CommitteeMisbehaviorCounts {
     }
 }
 
-/// Given block rounds for one authority in [start, end], returns
-/// (equivocations, missing_proposals).
+/// Given one authority's cached block rounds in [start, end] and the rounds
+/// flagged as equivocating at ingest, returns (equivocations,
+/// missing_proposals). An equivocation is a round with more than one signed
+/// header observed: more than one cached header, or a flag recorded when a
+/// second header for the slot was dropped. A flagged round with no cached
+/// header still counts as missing — none of its headers was accepted.
 fn calculate_misbehavior_counts_for_range(
     mut block_rounds: Vec<Round>,
+    flagged_rounds: &BTreeSet<Round>,
     start: Round,
     end: Round,
 ) -> (u64, u64) {
+    if start > end {
+        return (0, 0);
+    }
     block_rounds.retain(|&round| round >= start && round <= end);
     block_rounds.sort();
-    let number_of_blocks = block_rounds.len();
+    let mut equivocating_rounds: BTreeSet<Round> = block_rounds
+        .windows(2)
+        .filter_map(|pair| (pair[0] == pair[1]).then_some(pair[0]))
+        .collect();
+    equivocating_rounds.extend(flagged_rounds.range(start..=end).copied());
     block_rounds.dedup();
     let unique_block_rounds = block_rounds.len();
-    let number_of_equivocations = number_of_blocks.saturating_sub(unique_block_rounds) as u64;
     let number_of_missing_blocks =
         (end + 1).saturating_sub(start + unique_block_rounds as u32) as u64;
-    (number_of_equivocations, number_of_missing_blocks)
+    (equivocating_rounds.len() as u64, number_of_missing_blocks)
 }
 
 /// Versioned envelope for persisted scoring metrics. New versions are added as
@@ -623,6 +670,8 @@ pub struct MisbehaviorCountsV1 {
     pub faulty_blocks_provable: u64,
     pub faulty_blocks_unprovable: u64,
     pub missing_proposals: u64,
+    /// Rounds in which the authority signed more than one block header,
+    /// however many extra headers each round held.
     pub equivocations: u64,
 }
 
@@ -633,6 +682,8 @@ pub struct MisbehaviorCountsV2 {
     pub faulty_blocks_provable: u64,
     pub faulty_blocks_unprovable: u64,
     pub missing_proposals: u64,
+    /// Rounds in which the authority signed more than one block header,
+    /// however many extra headers each round held.
     pub equivocations: u64,
     pub invalid_bundle_parts: u64,
 }
@@ -675,6 +726,15 @@ impl MisbehaviorStore {
 
     pub(crate) fn in_memory_faulty_blocks_unprovable(&self) -> Vec<u64> {
         self.in_memory.collect(|c| c.faulty_blocks_unprovable)
+    }
+
+    pub(crate) fn equivocating_rounds(&self, author: AuthorityIndex) -> Vec<Round> {
+        self.equivocating_rounds[author.value()]
+            .lock()
+            .unwrap()
+            .iter()
+            .copied()
+            .collect()
     }
 }
 
@@ -730,7 +790,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_header::BlockRef,
+        block_header::{BlockHeaderDigest, BlockRef},
         context::Context,
         dag_state::{DagState, DataSource},
         error::ConsensusError,
@@ -740,77 +800,116 @@ mod tests {
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_basic() {
+        let no_flags = BTreeSet::new();
+
         // No blocks in range → all missing, no equivocations
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], 1, 5);
+        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], &no_flags, 1, 5);
         assert_eq!(eq, 0);
         assert_eq!(missing, 5);
 
         // All rounds present, no equivocations
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 3, 4, 5], 1, 5);
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 3, 4, 5], &no_flags, 1, 5);
         assert_eq!(eq, 0);
         assert_eq!(missing, 0);
 
-        // One equivocation (duplicate round 3)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 3, 3, 4, 5], 1, 5);
+        // One equivocating round (duplicate round 3)
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 3, 3, 4, 5], &no_flags, 1, 5);
         assert_eq!(eq, 1);
         assert_eq!(missing, 0);
 
-        // One missing (round 3) + one equivocation (round 2)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 2, 4, 5], 1, 5);
+        // One missing (round 3) + one equivocating round (round 2)
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 2, 4, 5], &no_flags, 1, 5);
         assert_eq!(eq, 1);
         assert_eq!(missing, 1);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_filters_out_of_range() {
-        // Rounds outside [2, 4] are filtered
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 3, 4, 5], 2, 4);
+        // Rounds outside [2, 4] are filtered, in the cached rounds and in the
+        // flags alike
+        let flags = BTreeSet::from([1, 5]);
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 3, 4, 5], &flags, 2, 4);
         assert_eq!(eq, 0);
         assert_eq!(missing, 0);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_empty_range() {
-        // start > end → no missing, no equivocations (saturating_sub handles it)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], 5, 3);
+        // start > end → no missing, no equivocations
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![], &BTreeSet::from([4]), 5, 3);
         assert_eq!(eq, 0);
         assert_eq!(missing, 0);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_unsorted_input() {
-        // Unsorted with one equivocation (round 3 appears twice) and one missing (round
-        // 5)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![4, 1, 3, 2, 3], 1, 5);
+        // Unsorted with one equivocating round (round 3 appears twice) and one
+        // missing (round 5)
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![4, 1, 3, 2, 3], &BTreeSet::new(), 1, 5);
         assert_eq!(eq, 1);
         assert_eq!(missing, 1);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_multiple_equivocations() {
-        // Round 2 appears 3 times (2 equivocations), round 4 appears twice (1
-        // equivocation)
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![1, 2, 2, 2, 3, 4, 4], 1, 4);
-        assert_eq!(eq, 3);
+        // Round 2 appears 3 times and round 4 twice — two equivocating rounds,
+        // however many extra headers each holds
+        let (eq, missing) = calculate_misbehavior_counts_for_range(
+            vec![1, 2, 2, 2, 3, 4, 4],
+            &BTreeSet::new(),
+            1,
+            4,
+        );
+        assert_eq!(eq, 2);
         assert_eq!(missing, 0);
     }
 
     #[test]
     fn test_calculate_misbehavior_counts_for_range_single_round() {
+        let no_flags = BTreeSet::new();
+
         // Single-round range with block present
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![5], 5, 5);
+        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![5], &no_flags, 5, 5);
         assert_eq!(eq, 0);
         assert_eq!(missing, 0);
 
         // Single-round range with no block
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], 5, 5);
+        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![], &no_flags, 5, 5);
         assert_eq!(eq, 0);
         assert_eq!(missing, 1);
 
         // Single-round range with equivocation
-        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![5, 5], 5, 5);
+        let (eq, missing) = calculate_misbehavior_counts_for_range(vec![5, 5], &no_flags, 5, 5);
         assert_eq!(eq, 1);
         assert_eq!(missing, 0);
+    }
+
+    #[test]
+    fn test_calculate_misbehavior_counts_for_range_flagged_rounds() {
+        // A flag alone marks the round as equivocating
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 3], &BTreeSet::from([2]), 1, 3);
+        assert_eq!(eq, 1);
+        assert_eq!(missing, 0);
+
+        // A flag and a cached surplus on the same round count once
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 2, 2, 3], &BTreeSet::from([2]), 1, 3);
+        assert_eq!(eq, 1);
+        assert_eq!(missing, 0);
+
+        // A flagged round with no cached header counts as both equivocating
+        // and missing: two headers were signed, none was accepted
+        let (eq, missing) =
+            calculate_misbehavior_counts_for_range(vec![1, 3], &BTreeSet::from([2]), 1, 3);
+        assert_eq!(eq, 1);
+        assert_eq!(missing, 1);
     }
 
     #[tokio::test]
@@ -863,6 +962,54 @@ mod tests {
         let result =
             store.update_misbehavior_counts_on_eviction(oob, &recent_refs, 2, 1, 3, &context);
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_equivocating_slot_flags() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let store = MisbehaviorStore::new(&context);
+        let author = AuthorityIndex::new_for_test(1);
+        let idx = author.value();
+
+        // One cached header per round 1..=9.
+        let recent_refs: BTreeSet<BlockRef> = (1..=9)
+            .map(|round| BlockRef::new(round, author, BlockHeaderDigest::MIN))
+            .collect();
+
+        // Repeated arrivals and a further distinct header collapse per slot.
+        store.record_equivocating_slot(author, 5);
+        store.record_equivocating_slot(author, 5);
+        store.record_equivocating_slot(author, 7);
+
+        // No eviction advance: the flags show up in the in-memory window and
+        // no block fault is charged.
+        let result =
+            store.update_misbehavior_counts_on_eviction(author, &recent_refs, 0, 0, 10, &context);
+        assert!(result.is_none());
+        assert_eq!(store.in_memory_equivocations()[idx], 2);
+        assert_eq!(store.in_memory_faulty_blocks_provable()[idx], 0);
+
+        // Eviction advances to round 6: the flag at round 5 folds into
+        // persisted and is pruned; round 7 stays in the in-memory window.
+        let result =
+            store.update_misbehavior_counts_on_eviction(author, &recent_refs, 6, 0, 10, &context);
+        assert!(result.is_some());
+        assert_eq!(store.persisted_equivocations()[idx], 1);
+        assert_eq!(store.in_memory_equivocations()[idx], 1);
+        assert_eq!(store.equivocating_rounds(author), vec![7]);
+
+        // The next advance folds the remaining flag; nothing is counted twice.
+        let result =
+            store.update_misbehavior_counts_on_eviction(author, &recent_refs, 9, 6, 10, &context);
+        assert!(result.is_some());
+        assert_eq!(store.persisted_equivocations()[idx], 2);
+        assert_eq!(store.in_memory_equivocations()[idx], 0);
+        assert!(store.equivocating_rounds(author).is_empty());
+
+        // Reset clears the flags.
+        store.record_equivocating_slot(author, 12);
+        store.reset();
+        assert!(store.equivocating_rounds(author).is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description of change

The one-header-per-slot admission cap drops a second header before it reaches the cache, so the cache-surplus-based `equivocations` count reads zero while an author actively equivocates, and each dropped arrival is instead charged as a provable block fault — a Minor scorer metric, counted once per arrival so honest reporters disagree. Equivocations are the scorer's Major metric (any occurrence zeroes the score), so the score collapse never fired.

Count equivocations per slot instead: a flag per `(author, round)` is set when a second verified header for an occupied slot is dropped, unioned at eviction with slots still holding a cache surplus (headers admitted via cap-exempt paths). Repeated arrivals and further distinct headers for a flagged slot collapse into one, so reporters converge on a fact about the author. The per-arrival block-fault charge is removed along with the now-unused `BlockHeaderEquivocation` error variant.

No wire or scorer change: the report keeps its shape, only the meaning of the `equivocations` numbers changes, and scoring reads only their existence.

The misbehavior store's entry points receive authority indices whose bounds are guaranteed elsewhere (the network layer for peers and relayers, signature verification for authors, the committee iteration for the flush). An index outside the committee is therefore a bug; the store now reports it with `debug_fatal!` (panic in debug and tests, error-level log in production) and skips the record, instead of either indexing raw or returning silently.

## Links to any relevant issues

fixes iotaledger/iota-private#487

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
