### PR TITLE
fix(starfish): reset block streams after fast sync

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -147,7 +147,9 @@ pub struct Parameters {
 
     /// Reconnect block streams after fast commit sync reinitializes consensus,
     /// discarding bundles buffered against the previous state. Enabled by
-    /// default; operators can disable it locally.
+    /// default; operators can disable it locally. Has no effect unless
+    /// `enable_fast_commit_syncer` is also enabled, since only fast sync
+    /// signals the reset.
     #[serde(default = "Parameters::default_enable_block_stream_reset_on_fast_sync_exit")]
     pub enable_block_stream_reset_on_fast_sync_exit: bool,
 

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -145,6 +145,12 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_enable_fast_commit_syncer")]
     pub enable_fast_commit_syncer: bool,
 
+    /// Reconnect block streams after fast commit sync reinitializes consensus,
+    /// discarding bundles buffered against the previous state. Enabled by
+    /// default; operators can disable it locally.
+    #[serde(default = "Parameters::default_enable_block_stream_reset_on_fast_sync_exit")]
+    pub enable_block_stream_reset_on_fast_sync_exit: bool,
+
     /// Ask commit-sync peers that have voted for the end of the requested
     /// range before those that have not, since a vote means the peer has
     /// solidified every commit in the range. Peers without an observed vote
@@ -461,6 +467,10 @@ impl Parameters {
         true
     }
 
+    pub(crate) fn default_enable_block_stream_reset_on_fast_sync_exit() -> bool {
+        true
+    }
+
     pub(crate) fn default_enable_commit_sync_peer_selection_by_commit_votes() -> bool {
         // Enabled by default. Ordering only, so it cannot diverge consensus.
         true
@@ -519,6 +529,8 @@ impl Default for Parameters {
             fast_commit_sync_batch_size: Parameters::default_fast_commit_sync_batch_size(),
             commit_sync_gap_threshold: Parameters::default_commit_sync_gap_threshold(),
             enable_fast_commit_syncer: Parameters::default_enable_fast_commit_syncer(),
+            enable_block_stream_reset_on_fast_sync_exit:
+                Parameters::default_enable_block_stream_reset_on_fast_sync_exit(),
             enable_commit_sync_peer_selection_by_commit_votes:
                 Parameters::default_enable_commit_sync_peer_selection_by_commit_votes(),
             enable_starfish_speed_adaptive_acknowledgments:

--- a/crates/starfish/config/tests/parameters_test.rs
+++ b/crates/starfish/config/tests/parameters_test.rs
@@ -19,6 +19,7 @@ tonic:
   admission:
     max_header_fetches_per_peer: 5
     max_subscriptions_per_peer: 0
+enable_block_stream_reset_on_fast_sync_exit: false
 "#,
     )
     .unwrap();
@@ -29,6 +30,7 @@ tonic:
     assert_eq!(parameters.tonic.admission.max_header_fetches_per_peer, 5);
     // A cap set to `0` disables admission for that group.
     assert_eq!(parameters.tonic.admission.max_subscriptions_per_peer, 0);
+    assert!(!parameters.enable_block_stream_reset_on_fast_sync_exit);
     // Unspecified fields keep their defaults, per field rather than per block.
     assert_eq!(
         parameters.tonic.admission.max_transaction_fetches_per_peer,

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -52,6 +52,7 @@ tonic:
 fast_commit_sync_batch_size: 400
 commit_sync_gap_threshold: 1000
 enable_fast_commit_syncer: true
+enable_block_stream_reset_on_fast_sync_exit: true
 enable_commit_sync_peer_selection_by_commit_votes: true
 enable_starfish_speed_adaptive_acknowledgments: true
 enable_peer_responsiveness_ranking: true

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -263,7 +263,7 @@ impl ConsensusAuthority {
             .parameters
             .enable_fast_commit_syncer
             .then(|| Arc::new(AtomicBool::new(fast_sync_ongoing)));
-        let (block_stream_reset_sender, _) = tokio::sync::watch::channel(0_u64);
+        let (block_stream_reset_sender, _) = tokio::sync::watch::channel(());
 
         let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -263,6 +263,7 @@ impl ConsensusAuthority {
             .parameters
             .enable_fast_commit_syncer
             .then(|| Arc::new(AtomicBool::new(fast_sync_ongoing)));
+        let (block_stream_reset_sender, _) = tokio::sync::watch::channel(0_u64);
 
         let header_synchronizer = HeaderSynchronizer::start(
             network_client.clone(),
@@ -308,6 +309,7 @@ impl ConsensusAuthority {
                 header_synchronizer.clone(),
                 misbehavior_store.clone(),
                 flag.clone(),
+                block_stream_reset_sender.clone(),
             )
             .start()
         });
@@ -332,6 +334,7 @@ impl ConsensusAuthority {
             network_client,
             network_service.clone(),
             dag_state.clone(),
+            block_stream_reset_sender,
         );
         for (peer, _) in context.committee.authorities() {
             if peer != context.own_index {

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -20,7 +20,7 @@ use rand::{SeedableRng as _, rngs::StdRng, thread_rng};
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
-    sync::oneshot,
+    sync::{oneshot, watch},
     task::JoinSet,
     time::{Instant, MissedTickBehavior},
 };
@@ -141,6 +141,8 @@ pub(crate) struct FastCommitSyncer<C: NetworkClient> {
     // Shared components wrapper.
     inner: Arc<Inner<C>>,
 
+    block_stream_reset_sender: watch::Sender<u64>,
+
     // States only used by the scheduler.
 
     // Inflight requests to fetch commits from different authorities.
@@ -179,6 +181,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         header_synchronizer: Arc<HeaderSynchronizerHandle>,
         misbehavior_store: Arc<MisbehaviorStore>,
         fast_sync_active: Arc<AtomicBool>,
+        block_stream_reset_sender: watch::Sender<u64>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -200,6 +203,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         );
         FastCommitSyncer {
             inner,
+            block_stream_reset_sender,
             inflight_fetches: JoinSet::new(),
             pending_fetches: BTreeSet::new(),
             fetched_ranges: BTreeMap::new(),
@@ -285,6 +289,20 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                             self.inner
                                 .header_synchronizer
                                 .clear_verified_headers_cache();
+                            if self
+                                .inner
+                                .context
+                                .parameters
+                                .enable_block_stream_reset_on_fast_sync_exit
+                            {
+                                self.block_stream_reset_sender.send_modify(|generation| {
+                                    *generation = generation.wrapping_add(1);
+                                });
+                                info!(
+                                    "[{}] Signaled block stream reset",
+                                    self.inner.sync_type.as_str()
+                                );
+                            }
                             info!(
                                 "[{}] Components reinitialized, fast sync complete",
                                 self.inner.sync_type.as_str()
@@ -1155,6 +1173,7 @@ mod tests {
                 None,
                 misbehavior_store.clone(),
             );
+            let (block_stream_reset_sender, _) = tokio::sync::watch::channel(0_u64);
             FastCommitSyncer::new(
                 context,
                 core_thread_dispatcher,
@@ -1166,6 +1185,7 @@ mod tests {
                 header_synchronizer,
                 misbehavior_store,
                 Arc::new(AtomicBool::new(false)),
+                block_stream_reset_sender,
             )
             .inner
         }

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -141,7 +141,7 @@ pub(crate) struct FastCommitSyncer<C: NetworkClient> {
     // Shared components wrapper.
     inner: Arc<Inner<C>>,
 
-    block_stream_reset_sender: watch::Sender<u64>,
+    block_stream_reset_sender: watch::Sender<()>,
 
     // States only used by the scheduler.
 
@@ -181,7 +181,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         header_synchronizer: Arc<HeaderSynchronizerHandle>,
         misbehavior_store: Arc<MisbehaviorStore>,
         fast_sync_active: Arc<AtomicBool>,
-        block_stream_reset_sender: watch::Sender<u64>,
+        block_stream_reset_sender: watch::Sender<()>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -273,9 +273,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 );
 
                 match Self::fetch_headers_for_reinitialization(self.inner.clone()).await {
-                    Ok(headers) => {
-                        self.reinitialize_components(headers).await;
-                    }
+                    Ok(headers) => self.reinitialize_components(headers).await,
                     Err(e) => {
                         warn!(
                             "[{}] Failed to fetch headers for cached rounds: {}",
@@ -340,9 +338,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
             .parameters
             .enable_block_stream_reset_on_fast_sync_exit
         {
-            self.block_stream_reset_sender.send_modify(|generation| {
-                *generation = generation.wrapping_add(1);
-            });
+            self.block_stream_reset_sender.send_replace(());
             info!(
                 "[{}] Signaled block stream reset",
                 self.inner.sync_type.as_str()
@@ -1155,7 +1151,7 @@ mod tests {
             network_client: Arc<FakeNetworkClient>,
         ) -> Arc<Inner<FakeNetworkClient>> {
             let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
-            let (block_stream_reset_sender, _) = tokio::sync::watch::channel(0_u64);
+            let (block_stream_reset_sender, _) = tokio::sync::watch::channel(());
             make_syncer(
                 context,
                 network_client,
@@ -1169,7 +1165,7 @@ mod tests {
             context: Arc<Context>,
             network_client: Arc<FakeNetworkClient>,
             core_thread_dispatcher: Arc<D>,
-            block_stream_reset_sender: tokio::sync::watch::Sender<u64>,
+            block_stream_reset_sender: tokio::sync::watch::Sender<()>,
         ) -> FastCommitSyncer<FakeNetworkClient> {
             let block_verifier = Arc::new(NoopBlockVerifier {});
             let store: Arc<dyn Store> = Arc::new(MemStore::new());
@@ -1559,9 +1555,11 @@ mod tests {
 
     #[tokio::test]
     async fn block_stream_reset_requires_successful_reinitialization_and_enabled_flag() {
-        for (enabled, should_fail, expected_generation) in
-            [(true, false, 1), (false, false, 0), (true, true, 0)]
-        {
+        for (enabled, should_fail, expect_reset) in [
+            (true, false, true),
+            (false, false, false),
+            (true, true, false),
+        ] {
             let (mut context, _) = Context::new_for_test(4);
             context
                 .protocol_config
@@ -1574,7 +1572,7 @@ mod tests {
             let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
             core_thread_dispatcher.set_reinitialize_components_should_fail(should_fail);
             let (block_stream_reset_sender, block_stream_reset_receiver) =
-                tokio::sync::watch::channel(0_u64);
+                tokio::sync::watch::channel(());
             let syncer = fetch_once::make_syncer(
                 context,
                 network_client,
@@ -1586,8 +1584,8 @@ mod tests {
 
             assert_eq!(core_thread_dispatcher.reinitialize_components_calls(), 1);
             assert_eq!(
-                *block_stream_reset_receiver.borrow(),
-                expected_generation,
+                block_stream_reset_receiver.has_changed().unwrap(),
+                expect_reset,
                 "enabled={enabled}, should_fail={should_fail}"
             );
             syncer.inner.header_synchronizer.stop().await.unwrap();

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -274,40 +274,7 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
 
                 match Self::fetch_headers_for_reinitialization(self.inner.clone()).await {
                     Ok(headers) => {
-                        if let Err(e) = self
-                            .inner
-                            .core_thread_dispatcher
-                            .reinitialize_components(headers)
-                            .await
-                        {
-                            warn!(
-                                "[{}] Failed to reinitialize components: {}",
-                                self.inner.sync_type.as_str(),
-                                e
-                            );
-                        } else {
-                            self.inner
-                                .header_synchronizer
-                                .clear_verified_headers_cache();
-                            if self
-                                .inner
-                                .context
-                                .parameters
-                                .enable_block_stream_reset_on_fast_sync_exit
-                            {
-                                self.block_stream_reset_sender.send_modify(|generation| {
-                                    *generation = generation.wrapping_add(1);
-                                });
-                                info!(
-                                    "[{}] Signaled block stream reset",
-                                    self.inner.sync_type.as_str()
-                                );
-                            }
-                            info!(
-                                "[{}] Components reinitialized, fast sync complete",
-                                self.inner.sync_type.as_str()
-                            );
-                        }
+                        self.reinitialize_components(headers).await;
                     }
                     Err(e) => {
                         warn!(
@@ -343,6 +310,44 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 flag.store(active, Ordering::Relaxed);
             }
         }
+    }
+
+    async fn reinitialize_components(&self, headers: Vec<VerifiedBlockHeader>) {
+        if let Err(e) = self
+            .inner
+            .core_thread_dispatcher
+            .reinitialize_components(headers)
+            .await
+        {
+            warn!(
+                "[{}] Failed to reinitialize components: {}",
+                self.inner.sync_type.as_str(),
+                e
+            );
+            return;
+        }
+
+        self.inner
+            .header_synchronizer
+            .clear_verified_headers_cache();
+        if self
+            .inner
+            .context
+            .parameters
+            .enable_block_stream_reset_on_fast_sync_exit
+        {
+            self.block_stream_reset_sender.send_modify(|generation| {
+                *generation = generation.wrapping_add(1);
+            });
+            info!(
+                "[{}] Signaled block stream reset",
+                self.inner.sync_type.as_str()
+            );
+        }
+        info!(
+            "[{}] Components reinitialized, fast sync complete",
+            self.inner.sync_type.as_str()
+        );
     }
 
     fn try_schedule_once(&mut self) {
@@ -1106,7 +1111,8 @@ mod tests {
 
     use crate::{
         authority_node::tests::make_authority_with_params, commit::CommittedSubDag,
-        commit_consumer::CommitConsumerMonitor,
+        commit_consumer::CommitConsumerMonitor, commit_syncer::tests::FakeNetworkClient,
+        context::Context, core_thread::tests::MockCoreThreadDispatcher,
     };
 
     mod fetch_once {
@@ -1132,7 +1138,7 @@ mod tests {
             },
             commit_vote_monitor::CommitVoteMonitor,
             context::Context,
-            core_thread::tests::MockCoreThreadDispatcher,
+            core_thread::{CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
             dag_state::DagState,
             encoder::create_encoder,
             error::ConsensusError,
@@ -1148,8 +1154,24 @@ mod tests {
             context: Arc<Context>,
             network_client: Arc<FakeNetworkClient>,
         ) -> Arc<Inner<FakeNetworkClient>> {
-            let block_verifier = Arc::new(NoopBlockVerifier {});
             let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+            let (block_stream_reset_sender, _) = tokio::sync::watch::channel(0_u64);
+            make_syncer(
+                context,
+                network_client,
+                core_thread_dispatcher,
+                block_stream_reset_sender,
+            )
+            .inner
+        }
+
+        pub(crate) fn make_syncer<D: CoreThreadDispatcher>(
+            context: Arc<Context>,
+            network_client: Arc<FakeNetworkClient>,
+            core_thread_dispatcher: Arc<D>,
+            block_stream_reset_sender: tokio::sync::watch::Sender<u64>,
+        ) -> FastCommitSyncer<FakeNetworkClient> {
+            let block_verifier = Arc::new(NoopBlockVerifier {});
             let store: Arc<dyn Store> = Arc::new(MemStore::new());
             let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
             let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
@@ -1173,7 +1195,6 @@ mod tests {
                 None,
                 misbehavior_store.clone(),
             );
-            let (block_stream_reset_sender, _) = tokio::sync::watch::channel(0_u64);
             FastCommitSyncer::new(
                 context,
                 core_thread_dispatcher,
@@ -1187,7 +1208,6 @@ mod tests {
                 Arc::new(AtomicBool::new(false)),
                 block_stream_reset_sender,
             )
-            .inner
         }
 
         /// A complete `fetch_commits_and_transactions` response for commit
@@ -1534,6 +1554,43 @@ mod tests {
                 "unexpected error: {err:?}"
             );
             assert_unprovable_faults(&inner, vec![0; 4]);
+        }
+    }
+
+    #[tokio::test]
+    async fn block_stream_reset_requires_successful_reinitialization_and_enabled_flag() {
+        for (enabled, should_fail, expected_generation) in
+            [(true, false, 1), (false, false, 0), (true, true, 0)]
+        {
+            let (mut context, _) = Context::new_for_test(4);
+            context
+                .protocol_config
+                .set_consensus_fast_commit_sync_for_testing(true);
+            context
+                .parameters
+                .enable_block_stream_reset_on_fast_sync_exit = enabled;
+            let context = Arc::new(context);
+            let network_client = Arc::new(FakeNetworkClient::default());
+            let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+            core_thread_dispatcher.set_reinitialize_components_should_fail(should_fail);
+            let (block_stream_reset_sender, block_stream_reset_receiver) =
+                tokio::sync::watch::channel(0_u64);
+            let syncer = fetch_once::make_syncer(
+                context,
+                network_client,
+                core_thread_dispatcher.clone(),
+                block_stream_reset_sender,
+            );
+
+            syncer.reinitialize_components(Vec::new()).await;
+
+            assert_eq!(core_thread_dispatcher.reinitialize_components_calls(), 1);
+            assert_eq!(
+                *block_stream_reset_receiver.borrow(),
+                expected_generation,
+                "enabled={enabled}, should_fail={should_fail}"
+            );
+            syncer.inner.header_synchronizer.stop().await.unwrap();
         }
     }
 

--- a/crates/starfish/core/src/commit_syncer/fast.rs
+++ b/crates/starfish/core/src/commit_syncer/fast.rs
@@ -330,6 +330,10 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
         self.inner
             .header_synchronizer
             .clear_verified_headers_cache();
+        info!(
+            "[{}] Components reinitialized, fast sync complete",
+            self.inner.sync_type.as_str()
+        );
         if self
             .inner
             .context
@@ -344,10 +348,6 @@ impl<C: NetworkClient> FastCommitSyncer<C> {
                 self.inner.sync_type.as_str()
             );
         }
-        info!(
-            "[{}] Components reinitialized, fast sync complete",
-            self.inner.sync_type.as_str()
-        );
     }
 
     fn try_schedule_once(&mut self) {

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -575,10 +575,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::{
-        sync::atomic::{AtomicBool, Ordering},
-        time::Duration,
-    };
+    use std::time::Duration;
 
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::{Mutex, RwLock};
@@ -608,8 +605,8 @@ pub(crate) mod tests {
         last_known_proposed_round: Mutex<Vec<Round>>,
         new_block_calls: Arc<Mutex<Vec<(Round, ReasonToCreateBlock, Instant)>>>,
         quorum_subscribers_exists: Mutex<bool>,
-        reinitialize_components_calls: Mutex<Vec<Vec<VerifiedBlockHeader>>>,
-        reinitialize_components_should_fail: AtomicBool,
+        reinitialize_components_calls: Mutex<usize>,
+        reinitialize_components_should_fail: Mutex<bool>,
     }
 
     impl MockCoreThreadDispatcher {
@@ -652,12 +649,11 @@ pub(crate) mod tests {
         }
 
         pub(crate) fn set_reinitialize_components_should_fail(&self, should_fail: bool) {
-            self.reinitialize_components_should_fail
-                .store(should_fail, Ordering::Relaxed);
+            *self.reinitialize_components_should_fail.lock() = should_fail;
         }
 
         pub(crate) fn reinitialize_components_calls(&self) -> usize {
-            self.reinitialize_components_calls.lock().len()
+            *self.reinitialize_components_calls.lock()
         }
     }
 
@@ -739,15 +735,10 @@ pub(crate) mod tests {
 
         async fn reinitialize_components(
             &self,
-            block_headers: Vec<VerifiedBlockHeader>,
+            _block_headers: Vec<VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
-            self.reinitialize_components_calls
-                .lock()
-                .push(block_headers);
-            if self
-                .reinitialize_components_should_fail
-                .load(Ordering::Relaxed)
-            {
+            *self.reinitialize_components_calls.lock() += 1;
+            if *self.reinitialize_components_should_fail.lock() {
                 Err(CoreError::Shutdown("test failure".to_owned()))
             } else {
                 Ok(())

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -575,7 +575,10 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::time::Duration;
+    use std::{
+        sync::atomic::{AtomicBool, Ordering},
+        time::Duration,
+    };
 
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use parking_lot::{Mutex, RwLock};
@@ -605,6 +608,8 @@ pub(crate) mod tests {
         last_known_proposed_round: Mutex<Vec<Round>>,
         new_block_calls: Arc<Mutex<Vec<(Round, ReasonToCreateBlock, Instant)>>>,
         quorum_subscribers_exists: Mutex<bool>,
+        reinitialize_components_calls: Mutex<Vec<Vec<VerifiedBlockHeader>>>,
+        reinitialize_components_should_fail: AtomicBool,
     }
 
     impl MockCoreThreadDispatcher {
@@ -644,6 +649,15 @@ pub(crate) mod tests {
             let mut binding = self.new_block_calls.lock();
             let all_calls = binding.drain(0..);
             all_calls.into_iter().collect()
+        }
+
+        pub(crate) fn set_reinitialize_components_should_fail(&self, should_fail: bool) {
+            self.reinitialize_components_should_fail
+                .store(should_fail, Ordering::Relaxed);
+        }
+
+        pub(crate) fn reinitialize_components_calls(&self) -> usize {
+            self.reinitialize_components_calls.lock().len()
         }
     }
 
@@ -725,9 +739,19 @@ pub(crate) mod tests {
 
         async fn reinitialize_components(
             &self,
-            _block_headers: Vec<VerifiedBlockHeader>,
+            block_headers: Vec<VerifiedBlockHeader>,
         ) -> Result<(), CoreError> {
-            unimplemented!()
+            self.reinitialize_components_calls
+                .lock()
+                .push(block_headers);
+            if self
+                .reinitialize_components_should_fail
+                .load(Ordering::Relaxed)
+            {
+                Err(CoreError::Shutdown("test failure".to_owned()))
+            } else {
+                Ok(())
+            }
         }
 
         async fn new_block(

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2533,6 +2533,17 @@ impl DagState {
         self.gc_round(last_commit_round)
     }
 
+    /// The round to resume a peer's block stream from. Never below the GC
+    /// round, since blocks at or below it can no longer be sequenced and would
+    /// be dropped on arrival.
+    pub(crate) fn resume_round_for_authority(&self, authority: AuthorityIndex) -> Round {
+        self.recent_headers_refs_by_authority[authority]
+            .last()
+            .map(|block_ref| block_ref.round)
+            .unwrap_or(GENESIS_ROUND)
+            .max(self.gc_round_for_last_commit())
+    }
+
     /// Return the garbage collection round with respect a given round.
     pub(crate) fn gc_round(&self, round: Round) -> Round {
         round.saturating_sub(self.context.protocol_config.gc_depth() * 2)

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -326,6 +326,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) dropped_far_future_headers_total: IntCounterVec,
     pub(crate) threshold_clock_round: IntGauge,
     pub(crate) subscriber_connection_attempts: IntCounterVec,
+    pub(crate) block_stream_resets: IntCounterVec,
     pub(crate) subscribed_to: IntGaugeVec,
     pub(crate) subscribed_by: IntGaugeVec,
     pub(crate) commit_sync_inflight_fetches: IntGaugeVec,
@@ -1197,6 +1198,12 @@ impl NodeMetrics {
                 "subscriber_connection_attempts",
                 "The number of connection attempts per peer",
                 &["authority", "status"],
+                registry,
+            ).unwrap(),
+            block_stream_resets: register_int_counter_vec_with_registry!(
+                "block_stream_resets",
+                "The number of block stream subscriptions reset after fast sync, per peer",
+                &["authority"],
                 registry,
             ).unwrap(),
             subscribed_to: register_int_gauge_vec_with_registry!(

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -2,11 +2,14 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream;
 use parking_lot::Mutex;
 use starfish_config::AuthorityIndex;
+use tokio::sync::Notify;
 
 use crate::{
     Round,
@@ -25,6 +28,8 @@ pub(crate) struct TestService {
     pub(crate) handle_fetch_block_headers: Vec<(AuthorityIndex, Vec<BlockRef>)>,
     pub(crate) handle_fetch_commits: Vec<(AuthorityIndex, CommitRange)>,
     pub(crate) own_block_bundles: Vec<SerializedBlockBundle>,
+    pub(crate) block_bundle_handler_started: Option<Arc<Notify>>,
+    pub(crate) block_bundle_handler_release: Option<Arc<Notify>>,
 }
 
 impl TestService {
@@ -35,6 +40,8 @@ impl TestService {
             handle_subscribed_block_bundle_requests: Vec::new(),
             handle_fetch_block_headers: Vec::new(),
             handle_fetch_commits: Vec::new(),
+            block_bundle_handler_started: None,
+            block_bundle_handler_release: None,
         }
     }
 
@@ -52,10 +59,19 @@ impl NetworkService for Mutex<TestService> {
         serialized_block_bundle: SerializedBlockBundle,
         _encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> ConsensusResult<()> {
-        let mut state = self.lock();
-        state
-            .handle_subscribed_block_bundle
-            .push((peer, serialized_block_bundle));
+        let block_bundle_handler_release = {
+            let mut state = self.lock();
+            state
+                .handle_subscribed_block_bundle
+                .push((peer, serialized_block_bundle));
+            if let Some(started) = &state.block_bundle_handler_started {
+                started.notify_one();
+            }
+            state.block_bundle_handler_release.clone()
+        };
+        if let Some(release) = block_bundle_handler_release {
+            release.notified().await;
+        }
         Ok(())
     }
 

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -22,17 +22,37 @@ use crate::{
     transaction_ref::TransactionRef,
 };
 
+/// Parks the bundle handler so a test can act while one bundle is in flight.
+#[derive(Clone)]
+pub(crate) struct BundleHandlerGate {
+    pub(crate) started: Arc<Notify>,
+    pub(crate) release: Arc<Notify>,
+}
+
 pub(crate) struct TestService {
     pub(crate) handle_subscribed_block_bundle: Vec<(AuthorityIndex, SerializedBlockBundle)>,
     pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,
     pub(crate) handle_fetch_block_headers: Vec<(AuthorityIndex, Vec<BlockRef>)>,
     pub(crate) handle_fetch_commits: Vec<(AuthorityIndex, CommitRange)>,
     pub(crate) own_block_bundles: Vec<SerializedBlockBundle>,
-    pub(crate) block_bundle_handler_started: Option<Arc<Notify>>,
-    pub(crate) block_bundle_handler_release: Option<Arc<Notify>>,
+    pub(crate) block_bundle_handler_gate: Option<BundleHandlerGate>,
 }
 
 impl TestService {
+    /// A service whose bundle handler parks until the returned gate releases
+    /// it.
+    pub(crate) fn with_bundle_handler_gate() -> (Self, BundleHandlerGate) {
+        let gate = BundleHandlerGate {
+            started: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+        };
+        let service = Self {
+            block_bundle_handler_gate: Some(gate.clone()),
+            ..Self::new()
+        };
+        (service, gate)
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             own_block_bundles: Vec::new(),
@@ -40,8 +60,7 @@ impl TestService {
             handle_subscribed_block_bundle_requests: Vec::new(),
             handle_fetch_block_headers: Vec::new(),
             handle_fetch_commits: Vec::new(),
-            block_bundle_handler_started: None,
-            block_bundle_handler_release: None,
+            block_bundle_handler_gate: None,
         }
     }
 
@@ -59,17 +78,17 @@ impl NetworkService for Mutex<TestService> {
         serialized_block_bundle: SerializedBlockBundle,
         _encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
     ) -> ConsensusResult<()> {
-        let block_bundle_handler_release = {
+        let release = {
             let mut state = self.lock();
             state
                 .handle_subscribed_block_bundle
                 .push((peer, serialized_block_bundle));
-            if let Some(started) = &state.block_bundle_handler_started {
-                started.notify_one();
-            }
-            state.block_bundle_handler_release.clone()
+            state.block_bundle_handler_gate.as_ref().map(|gate| {
+                gate.started.notify_one();
+                gate.release.clone()
+            })
         };
-        if let Some(release) = block_bundle_handler_release {
+        if let Some(release) = release {
             release.notified().await;
         }
         Ok(())

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -9,13 +9,13 @@ use iota_metrics::spawn_monitored_task;
 use parking_lot::{Mutex, RwLock};
 use starfish_config::AuthorityIndex;
 use tokio::{
+    sync::watch,
     task::JoinHandle,
     time::{sleep, timeout},
 };
 use tracing::{debug, error, info};
 
 use crate::{
-    Round,
     block_header::BlockHeaderAPI as _,
     context::Context,
     dag_state::DagState,
@@ -34,6 +34,7 @@ pub(crate) struct Subscriber<C: NetworkClient, S: NetworkService> {
     network_client: Arc<C>,
     authority_service: Arc<S>,
     dag_state: Arc<RwLock<DagState>>,
+    block_stream_reset_sender: watch::Sender<u64>,
     subscriptions: Arc<Mutex<Box<[Option<JoinHandle<()>>]>>>,
 }
 
@@ -43,6 +44,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         network_client: Arc<C>,
         authority_service: Arc<S>,
         dag_state: Arc<RwLock<DagState>>,
+        block_stream_reset_sender: watch::Sender<u64>,
     ) -> Self {
         // Drop label combos left over from previous epochs whose hostnames
         // are no longer in the current committee — otherwise IntGaugeVec
@@ -56,6 +58,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             network_client,
             authority_service,
             dag_state,
+            block_stream_reset_sender,
             subscriptions: Arc::new(Mutex::new(subscriptions.into_boxed_slice())),
         }
     }
@@ -68,10 +71,8 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let authority_service = self.authority_service.clone();
-        let last_received = {
-            let dag_state = self.dag_state.read();
-            dag_state.get_last_block_header_for_authority(peer).round()
-        };
+        let dag_state = self.dag_state.clone();
+        let block_stream_reset_receiver = self.block_stream_reset_sender.subscribe();
 
         let mut subscriptions = self.subscriptions.lock();
         self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);
@@ -79,8 +80,9 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             context,
             network_client,
             authority_service,
+            dag_state,
             peer,
-            last_received,
+            block_stream_reset_receiver,
         )));
     }
 
@@ -119,8 +121,9 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         context: Arc<Context>,
         network_client: Arc<C>,
         authority_service: Arc<S>,
+        dag_state: Arc<RwLock<DagState>>,
         peer: AuthorityIndex,
-        last_received: Round,
+        mut block_stream_reset_receiver: watch::Receiver<u64>,
     ) {
         const IMMEDIATE_RETRIES: i64 = 3;
         // When not immediately retrying, limit retry delay between 100ms and 10s.
@@ -148,7 +151,17 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                     peer_hostname,
                     delay.as_secs_f32(),
                 );
-                sleep(delay).await;
+                tokio::select! {
+                    biased;
+                    reset = block_stream_reset_receiver.changed() => {
+                        if reset.is_err() {
+                            return;
+                        }
+                        retries = 0;
+                        continue 'subscription;
+                    }
+                    _ = sleep(delay) => {}
+                }
                 // Update delay for the next retry.
                 delay = delay
                     .mul_f32(RETRY_INTERVAL_MULTIPLIER)
@@ -162,10 +175,24 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             }
             retries += 1;
 
+            let last_received = dag_state
+                .read()
+                .get_last_block_header_for_authority(peer)
+                .round();
             // Wrap subscribe_block_bundles in a timeout and increment metric on timeout
             let subscribe_future =
                 network_client.subscribe_block_bundles(peer, last_received, MAX_RETRY_INTERVAL);
-            let subscribe_result = timeout(MAX_RETRY_INTERVAL * 5, subscribe_future).await;
+            let subscribe_result = tokio::select! {
+                biased;
+                reset = block_stream_reset_receiver.changed() => {
+                    if reset.is_err() {
+                        return;
+                    }
+                    retries = 0;
+                    continue 'subscription;
+                }
+                result = timeout(MAX_RETRY_INTERVAL * 5, subscribe_future) => result,
+            };
             let mut block_bundles = match subscribe_result {
                 Ok(inner_result) => match inner_result {
                     Ok(blocks) => {
@@ -219,7 +246,19 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                 .set(1);
 
             'stream: loop {
-                match block_bundles.next().await {
+                let next_block = tokio::select! {
+                    biased;
+                    reset = block_stream_reset_receiver.changed() => {
+                        if reset.is_err() {
+                            return;
+                        }
+                        debug!("Resetting block stream subscription to peer {peer} {peer_hostname}");
+                        retries = 0;
+                        continue 'subscription;
+                    }
+                    block = block_bundles.next() => block,
+                };
+                match next_block {
                     Some(block) => {
                         context
                             .metrics
@@ -271,19 +310,31 @@ mod test {
 
     use super::*;
     use crate::{
-        block_header::BlockRef,
+        Round,
+        block_header::{BlockRef, TestBlockHeader, VerifiedBlockHeader},
         commit::CommitRange,
+        dag_state::DataSource,
         error::ConsensusResult,
         network::{BlockBundleStream, SerializedBlockBundle, test_network::TestService},
         storage::mem_store::MemStore,
         transaction_ref::TransactionRef,
     };
 
-    struct SubscriberTestClient {}
+    struct SubscriberTestClient {
+        last_received_rounds: Mutex<Vec<Round>>,
+        pending_stream: bool,
+    }
 
     impl SubscriberTestClient {
-        fn new() -> Self {
-            Self {}
+        fn new(pending_stream: bool) -> Self {
+            Self {
+                last_received_rounds: Mutex::new(Vec::new()),
+                pending_stream,
+            }
+        }
+
+        fn last_received_rounds(&self) -> Vec<Round> {
+            self.last_received_rounds.lock().clone()
         }
     }
 
@@ -292,18 +343,23 @@ mod test {
         async fn subscribe_block_bundles(
             &self,
             _peer: AuthorityIndex,
-            _last_received: Round,
+            last_received: Round,
             _timeout: Duration,
         ) -> ConsensusResult<BlockBundleStream> {
-            let block_stream = stream::unfold((), |_| async {
-                sleep(Duration::from_millis(1)).await;
-                let block = SerializedBlockBundle {
-                    serialized_block_bundle: Bytes::from(vec![1u8; 8]),
-                };
-                Some((block, ()))
-            })
-            .take(10);
-            Ok(Box::pin(block_stream))
+            self.last_received_rounds.lock().push(last_received);
+            if self.pending_stream {
+                Ok(Box::pin(stream::pending()))
+            } else {
+                let block_stream = stream::unfold((), |_| async {
+                    sleep(Duration::from_millis(1)).await;
+                    let block = SerializedBlockBundle {
+                        serialized_block_bundle: Bytes::from(vec![1u8; 8]),
+                    };
+                    Some((block, ()))
+                })
+                .take(10);
+                Ok(Box::pin(block_stream))
+            }
         }
 
         async fn fetch_transactions(
@@ -353,24 +409,47 @@ mod test {
         }
     }
 
+    async fn wait_for_subscription_attempts(
+        network_client: &SubscriberTestClient,
+        expected: usize,
+    ) {
+        for _ in 0..100 {
+            if network_client.last_received_rounds().len() >= expected {
+                return;
+            }
+            sleep(Duration::from_millis(1)).await;
+        }
+        panic!("subscriber did not make {expected} subscription attempts");
+    }
+
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn subscriber_retries() {
         telemetry_subscribers::init_for_testing();
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let authority_service = Arc::new(Mutex::new(TestService::new()));
-        let network_client = Arc::new(SubscriberTestClient::new());
+        let network_client = Arc::new(SubscriberTestClient::new(false));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (block_stream_reset_sender, _) = watch::channel(0_u64);
         let subscriber = Subscriber::new(
             context.clone(),
-            network_client,
+            network_client.clone(),
             authority_service.clone(),
-            dag_state,
+            dag_state.clone(),
+            block_stream_reset_sender,
         );
 
         let peer = context.committee.to_authority_index(2).unwrap();
         subscriber.subscribe(peer);
+        wait_for_subscription_attempts(&network_client, 1).await;
+
+        let header =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(7, peer.value() as u8).build());
+        dag_state
+            .write()
+            .accept_block_headers(vec![header], DataSource::BlockBundleStream);
+        wait_for_subscription_attempts(&network_client, 2).await;
 
         // Wait for enough block bundles received.
         for _ in 0..10 {
@@ -394,5 +473,50 @@ mod test {
                 }
             );
         }
+        assert!(
+            network_client
+                .last_received_rounds()
+                .iter()
+                .skip(1)
+                .all(|round| *round == 7)
+        );
+        drop(service);
+        subscriber.stop();
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn subscriber_resets_stream_with_latest_cursor() {
+        telemetry_subscribers::init_for_testing();
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let authority_service = Arc::new(Mutex::new(TestService::new()));
+        let network_client = Arc::new(SubscriberTestClient::new(true));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (block_stream_reset_sender, _) = watch::channel(0_u64);
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client.clone(),
+            authority_service,
+            dag_state.clone(),
+            block_stream_reset_sender.clone(),
+        );
+
+        let peer = context.committee.to_authority_index(2).unwrap();
+        subscriber.subscribe(peer);
+        wait_for_subscription_attempts(&network_client, 1).await;
+
+        let header =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(11, peer.value() as u8).build());
+        dag_state
+            .write()
+            .accept_block_headers(vec![header], DataSource::BlockBundleStream);
+        block_stream_reset_sender.send_modify(|generation| {
+            *generation += 1;
+        });
+
+        wait_for_subscription_attempts(&network_client, 2).await;
+        assert_eq!(network_client.last_received_rounds(), vec![0, 11]);
+        subscriber.stop();
     }
 }

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -7,6 +7,7 @@ use std::{sync::Arc, time::Duration};
 use futures::StreamExt;
 use iota_metrics::spawn_monitored_task;
 use parking_lot::{Mutex, RwLock};
+use prometheus_filtered::IntCounter;
 use starfish_config::AuthorityIndex;
 use tokio::{
     sync::watch,
@@ -16,13 +17,30 @@ use tokio::{
 use tracing::{debug, error, info};
 
 use crate::{
-    block_header::BlockHeaderAPI as _,
     context::Context,
     dag_state::DagState,
     encoder::create_encoder,
     error::ConsensusError,
     network::{NetworkClient, NetworkService},
 };
+
+/// Returns whether the reset channel closed; otherwise records the reset and
+/// clears the retry count.
+fn observe_reset(
+    changed: Result<(), watch::error::RecvError>,
+    resets: &IntCounter,
+    retries: &mut i64,
+    peer: AuthorityIndex,
+    peer_hostname: &str,
+) -> bool {
+    if changed.is_err() {
+        return true;
+    }
+    debug!("Resetting block stream subscription to peer {peer} {peer_hostname}");
+    resets.inc();
+    *retries = 0;
+    false
+}
 
 /// Subscriber manages the block stream subscriptions to other peers, taking
 /// care of retrying when subscription streams break. Blocks returned from the
@@ -34,7 +52,7 @@ pub(crate) struct Subscriber<C: NetworkClient, S: NetworkService> {
     network_client: Arc<C>,
     authority_service: Arc<S>,
     dag_state: Arc<RwLock<DagState>>,
-    block_stream_reset_sender: watch::Sender<u64>,
+    block_stream_reset_sender: watch::Sender<()>,
     subscriptions: Arc<Mutex<Box<[Option<JoinHandle<()>>]>>>,
 }
 
@@ -44,7 +62,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         network_client: Arc<C>,
         authority_service: Arc<S>,
         dag_state: Arc<RwLock<DagState>>,
-        block_stream_reset_sender: watch::Sender<u64>,
+        block_stream_reset_sender: watch::Sender<()>,
     ) -> Self {
         // Drop label combos left over from previous epochs whose hostnames
         // are no longer in the current committee — otherwise IntGaugeVec
@@ -123,7 +141,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         authority_service: Arc<S>,
         dag_state: Arc<RwLock<DagState>>,
         peer: AuthorityIndex,
-        mut block_stream_reset_receiver: watch::Receiver<u64>,
+        mut block_stream_reset_receiver: watch::Receiver<()>,
     ) {
         const IMMEDIATE_RETRIES: i64 = 3;
         // When not immediately retrying, limit retry delay between 100ms and 10s.
@@ -159,11 +177,10 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                 tokio::select! {
                     biased;
                     reset = block_stream_reset_receiver.changed() => {
-                        if reset.is_err() {
-                            return;
-                        }
-                        block_stream_resets.inc();
-                        retries = 0;
+                            if observe_reset(reset, &block_stream_resets, &mut retries, peer, peer_hostname)
+                            {
+                                return;
+                            }
                         continue 'subscription;
                     }
                     _ = sleep(delay) => {}
@@ -181,26 +198,17 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             }
             retries += 1;
 
-            // Blocks at or below the GC round can no longer be sequenced, so
-            // never ask a peer to resend from further back than that.
-            let last_received = {
-                let dag_state = dag_state.read();
-                dag_state
-                    .get_last_block_header_for_authority(peer)
-                    .round()
-                    .max(dag_state.gc_round_for_last_commit())
-            };
+            let last_received = dag_state.read().resume_round_for_authority(peer);
             // Wrap subscribe_block_bundles in a timeout and increment metric on timeout
             let subscribe_future =
                 network_client.subscribe_block_bundles(peer, last_received, MAX_RETRY_INTERVAL);
             let subscribe_result = tokio::select! {
                 biased;
                 reset = block_stream_reset_receiver.changed() => {
-                    if reset.is_err() {
-                        return;
-                    }
-                    block_stream_resets.inc();
-                    retries = 0;
+                        if observe_reset(reset, &block_stream_resets, &mut retries, peer, peer_hostname)
+                        {
+                            return;
+                        }
                     continue 'subscription;
                 }
                 result = timeout(MAX_RETRY_INTERVAL * 5, subscribe_future) => result,
@@ -263,12 +271,10 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                 let next_block = tokio::select! {
                     biased;
                     reset = block_stream_reset_receiver.changed() => {
-                        if reset.is_err() {
-                            return;
-                        }
-                        debug!("Resetting block stream subscription to peer {peer} {peer_hostname}");
-                        block_stream_resets.inc();
-                        retries = 0;
+                            if observe_reset(reset, &block_stream_resets, &mut retries, peer, peer_hostname)
+                            {
+                                return;
+                            }
                         continue 'subscription;
                     }
                     block = block_bundles.next() => block,
@@ -335,22 +341,23 @@ mod test {
         transaction_ref::TransactionRef,
     };
 
-    /// How the fake peer feeds bundles once a subscription succeeds.
+    /// How the fake peer answers subscriptions.
     enum StreamMode {
         /// Ten bundles, one per millisecond.
         Paced,
         /// Never yields, so the subscriber stays parked on the stream.
         Pending,
-        /// Ten bundles at once on the first subscription, then a stream that
-        /// never yields, so a reconnect cannot add to the handled count.
+        /// Ten bundles at once on the first subscription, then never yields, so
+        /// a reconnect cannot add to the handled count.
         BufferedOnce,
+        /// Fails the first `n` subscribe calls, then never yields.
+        FailThenPending(usize),
     }
 
     struct SubscriberTestClient {
         last_received_rounds: Mutex<Vec<Round>>,
         subscription_attempts_sender: watch::Sender<usize>,
         stream_mode: StreamMode,
-        initial_failures: usize,
     }
 
     impl SubscriberTestClient {
@@ -360,13 +367,7 @@ mod test {
                 last_received_rounds: Mutex::new(Vec::new()),
                 subscription_attempts_sender,
                 stream_mode,
-                initial_failures: 0,
             }
-        }
-
-        fn with_initial_failures(mut self, initial_failures: usize) -> Self {
-            self.initial_failures = initial_failures;
-            self
         }
 
         fn last_received_rounds(&self) -> Vec<Round> {
@@ -394,13 +395,13 @@ mod test {
                 last_received_rounds.len()
             };
             self.subscription_attempts_sender.send_replace(attempts);
-            if attempts <= self.initial_failures {
-                return Err(ConsensusError::NetworkRequest(
-                    "injected failure".to_owned(),
-                ));
-            }
             match self.stream_mode {
-                StreamMode::Pending => Ok(Box::pin(stream::pending())),
+                StreamMode::FailThenPending(failures) if attempts <= failures => Err(
+                    ConsensusError::NetworkRequest("injected failure".to_owned()),
+                ),
+                StreamMode::Pending | StreamMode::FailThenPending(_) => {
+                    Ok(Box::pin(stream::pending()))
+                }
                 StreamMode::Paced => {
                     let block_stream = stream::unfold((), |_| async {
                         sleep(Duration::from_millis(1)).await;
@@ -409,14 +410,10 @@ mod test {
                     .take(10);
                     Ok(Box::pin(block_stream))
                 }
-                StreamMode::BufferedOnce => {
-                    if attempts > self.initial_failures + 1 {
-                        return Ok(Box::pin(stream::pending()));
-                    }
-                    Ok(Box::pin(stream::iter(
-                        std::iter::repeat_with(test_bundle).take(10),
-                    )))
-                }
+                StreamMode::BufferedOnce if attempts == 1 => Ok(Box::pin(stream::iter(
+                    std::iter::repeat_with(test_bundle).take(10),
+                ))),
+                StreamMode::BufferedOnce => Ok(Box::pin(stream::pending())),
             }
         }
 
@@ -472,51 +469,79 @@ mod test {
         expected: usize,
     ) {
         let mut attempts = network_client.subscription_attempts_sender.subscribe();
-        timeout(Duration::from_secs(5), async {
-            loop {
-                if *attempts.borrow() >= expected {
-                    return;
-                }
-                attempts.changed().await.unwrap();
-            }
-        })
+        timeout(
+            Duration::from_secs(5),
+            attempts.wait_for(|attempts| *attempts >= expected),
+        )
         .await
-        .unwrap_or_else(|_| panic!("subscriber did not make {expected} subscription attempts"));
+        .unwrap_or_else(|_| panic!("subscriber did not make {expected} subscription attempts"))
+        .expect("the sender outlives the test");
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn subscriber_retries() {
+    struct Fixture {
+        context: Arc<Context>,
+        network_client: Arc<SubscriberTestClient>,
+        authority_service: Arc<Mutex<TestService>>,
+        dag_state: Arc<RwLock<DagState>>,
+        reset_sender: watch::Sender<()>,
+        subscriber: Subscriber<SubscriberTestClient, Mutex<TestService>>,
+        peer: AuthorityIndex,
+    }
+
+    /// Wires a subscriber against `service` and `mode`, stopping short of
+    /// subscribing so a test can seed `dag_state` first.
+    fn fixture(context: Arc<Context>, service: TestService, mode: StreamMode) -> Fixture {
         telemetry_subscribers::init_for_testing();
-        let (context, _keys) = Context::new_for_test(4);
-        let context = Arc::new(context);
-        let authority_service = Arc::new(Mutex::new(TestService::new()));
-        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::Paced));
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let (block_stream_reset_sender, _) = watch::channel(0_u64);
+        let network_client = Arc::new(SubscriberTestClient::new(mode));
+        let authority_service = Arc::new(Mutex::new(service));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let (reset_sender, _) = watch::channel(());
         let subscriber = Subscriber::new(
             context.clone(),
             network_client.clone(),
             authority_service.clone(),
             dag_state.clone(),
-            block_stream_reset_sender,
+            reset_sender.clone(),
         );
-
         let peer = context.committee.to_authority_index(2).unwrap();
-        subscriber.subscribe(peer);
-        wait_for_subscription_attempts(&network_client, 1).await;
+        Fixture {
+            context,
+            network_client,
+            authority_service,
+            dag_state,
+            reset_sender,
+            subscriber,
+            peer,
+        }
+    }
 
-        let header =
-            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(7, peer.value() as u8).build());
-        dag_state
+    fn test_context(committee_size: usize) -> Arc<Context> {
+        let (context, _keys) = Context::new_for_test(committee_size);
+        Arc::new(context)
+    }
+
+    fn header_for(peer: AuthorityIndex, round: Round) -> VerifiedBlockHeader {
+        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, peer.value() as u8).build())
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn subscriber_retries() {
+        let f = fixture(test_context(4), TestService::new(), StreamMode::Paced);
+        f.subscriber.subscribe(f.peer);
+        wait_for_subscription_attempts(&f.network_client, 1).await;
+
+        f.dag_state
             .write()
-            .accept_block_headers(vec![header], DataSource::BlockBundleStream);
-        wait_for_subscription_attempts(&network_client, 2).await;
+            .accept_block_headers(vec![header_for(f.peer, 7)], DataSource::BlockBundleStream);
+        wait_for_subscription_attempts(&f.network_client, 2).await;
 
         // Wait for enough block bundles received.
         for _ in 0..10 {
             sleep(Duration::from_secs(1)).await;
-            let service = authority_service.lock();
+            let service = f.authority_service.lock();
             if service.handle_subscribed_block_bundle.len() >= 100 {
                 break;
             }
@@ -524,193 +549,108 @@ mod test {
 
         // Even if the stream ends after 10 blocks, the subscriber should retry and get
         // enough blocks eventually.
-        let service = authority_service.lock();
+        let service = f.authority_service.lock();
         assert!(service.handle_subscribed_block_bundle.len() >= 100);
         for (p, block) in service.handle_subscribed_block_bundle.iter() {
-            assert_eq!(*p, peer);
-            assert_eq!(
-                *block,
-                SerializedBlockBundle {
-                    serialized_block_bundle: Bytes::from(vec![1u8; 8]),
-                }
-            );
+            assert_eq!(*p, f.peer);
+            assert_eq!(*block, test_bundle());
         }
-        let rounds = network_client.last_received_rounds();
+        let rounds = f.network_client.last_received_rounds();
         assert!(
             rounds.len() > 1 && rounds[1..].iter().all(|round| *round == 7),
             "reconnects should resume from the peer's latest header: {rounds:?}"
         );
         drop(service);
-        subscriber.stop();
+        f.subscriber.stop();
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn subscriber_resets_stream_with_latest_cursor() {
-        telemetry_subscribers::init_for_testing();
-        let (context, _keys) = Context::new_for_test(4);
-        let context = Arc::new(context);
-        let authority_service = Arc::new(Mutex::new(TestService::new()));
-        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::Pending));
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let (block_stream_reset_sender, _) = watch::channel(0_u64);
-        let subscriber = Subscriber::new(
-            context.clone(),
-            network_client.clone(),
-            authority_service,
-            dag_state.clone(),
-            block_stream_reset_sender.clone(),
-        );
+        let f = fixture(test_context(4), TestService::new(), StreamMode::Pending);
+        f.subscriber.subscribe(f.peer);
+        wait_for_subscription_attempts(&f.network_client, 1).await;
 
-        let peer = context.committee.to_authority_index(2).unwrap();
-        subscriber.subscribe(peer);
-        wait_for_subscription_attempts(&network_client, 1).await;
-
-        let header =
-            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(11, peer.value() as u8).build());
-        dag_state
+        f.dag_state
             .write()
-            .accept_block_headers(vec![header], DataSource::BlockBundleStream);
-        block_stream_reset_sender.send_modify(|generation| {
-            *generation += 1;
-        });
+            .accept_block_headers(vec![header_for(f.peer, 11)], DataSource::BlockBundleStream);
+        f.reset_sender.send_replace(());
 
-        wait_for_subscription_attempts(&network_client, 2).await;
-        assert_eq!(network_client.last_received_rounds(), vec![0, 11]);
-        subscriber.stop();
+        wait_for_subscription_attempts(&f.network_client, 2).await;
+        assert_eq!(f.network_client.last_received_rounds(), vec![0, 11]);
+        f.subscriber.stop();
     }
 
+    /// A reset observed mid-bundle must not cancel the handler that is running.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn subscriber_finishes_bundle_handler_before_reset() {
-        telemetry_subscribers::init_for_testing();
-        let (context, _keys) = Context::new_for_test(4);
-        let context = Arc::new(context);
-        let handler_started = Arc::new(tokio::sync::Notify::new());
-        let handler_release = Arc::new(tokio::sync::Notify::new());
-        let mut service = TestService::new();
-        service.block_bundle_handler_started = Some(handler_started.clone());
-        service.block_bundle_handler_release = Some(handler_release.clone());
-        let authority_service = Arc::new(Mutex::new(service));
-        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::Paced));
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let (block_stream_reset_sender, _) = watch::channel(0_u64);
-        let subscriber = Subscriber::new(
-            context.clone(),
-            network_client.clone(),
-            authority_service,
-            dag_state,
-            block_stream_reset_sender.clone(),
+        let (service, gate) = TestService::with_bundle_handler_gate();
+        let f = fixture(test_context(4), service, StreamMode::Paced);
+        f.subscriber.subscribe(f.peer);
+        gate.started.notified().await;
+
+        f.reset_sender.send_replace(());
+        sleep(Duration::from_secs(1)).await;
+        assert_eq!(
+            f.network_client.last_received_rounds().len(),
+            1,
+            "a reset must not reconnect while the bundle handler is still running"
         );
 
-        let peer = context.committee.to_authority_index(2).unwrap();
-        subscriber.subscribe(peer);
-        handler_started.notified().await;
-
-        block_stream_reset_sender.send_modify(|generation| {
-            *generation += 1;
-        });
-        assert!(
-            timeout(
-                Duration::from_secs(1),
-                wait_for_subscription_attempts(&network_client, 2)
-            )
-            .await
-            .is_err()
-        );
-
-        handler_release.notify_one();
-        wait_for_subscription_attempts(&network_client, 2).await;
-        subscriber.stop();
+        gate.release.notify_one();
+        wait_for_subscription_attempts(&f.network_client, 2).await;
+        f.subscriber.stop();
     }
 
     /// A reset while the subscriber is waiting out a retry backoff reconnects
     /// straight away instead of sitting out the rest of the delay.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn subscriber_reset_short_circuits_retry_backoff() {
-        telemetry_subscribers::init_for_testing();
-        let (context, _keys) = Context::new_for_test(4);
-        let context = Arc::new(context);
-        let authority_service = Arc::new(Mutex::new(TestService::new()));
         // Four failed attempts put the next one into the delayed-retry branch.
-        let network_client =
-            Arc::new(SubscriberTestClient::new(StreamMode::Pending).with_initial_failures(4));
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let (block_stream_reset_sender, _) = watch::channel(0_u64);
-        let subscriber = Subscriber::new(
-            context.clone(),
-            network_client.clone(),
-            authority_service,
-            dag_state,
-            block_stream_reset_sender.clone(),
+        let f = fixture(
+            test_context(4),
+            TestService::new(),
+            StreamMode::FailThenPending(4),
         );
-
-        let peer = context.committee.to_authority_index(2).unwrap();
-        subscriber.subscribe(peer);
-        wait_for_subscription_attempts(&network_client, 4).await;
+        f.subscriber.subscribe(f.peer);
+        wait_for_subscription_attempts(&f.network_client, 4).await;
         // Let the subscriber reach the backoff sleep before resetting it.
         sleep(Duration::from_millis(1)).await;
 
         let before_reset = tokio::time::Instant::now();
-        block_stream_reset_sender.send_modify(|generation| {
-            *generation += 1;
-        });
-        wait_for_subscription_attempts(&network_client, 5).await;
+        f.reset_sender.send_replace(());
+        wait_for_subscription_attempts(&f.network_client, 5).await;
 
         let waited = before_reset.elapsed();
         assert!(
             waited < Duration::from_millis(50),
             "reset should not wait out the backoff, waited {waited:?}"
         );
-        subscriber.stop();
+        f.subscriber.stop();
     }
 
     /// Bundles already buffered on the stream are dropped by a reset rather
     /// than handled against the reinitialized state.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn subscriber_discards_buffered_bundles_on_reset() {
-        telemetry_subscribers::init_for_testing();
-        let (context, _keys) = Context::new_for_test(4);
-        let context = Arc::new(context);
-        let handler_started = Arc::new(tokio::sync::Notify::new());
-        let handler_release = Arc::new(tokio::sync::Notify::new());
-        let mut service = TestService::new();
-        service.block_bundle_handler_started = Some(handler_started.clone());
-        service.block_bundle_handler_release = Some(handler_release.clone());
-        let authority_service = Arc::new(Mutex::new(service));
-        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::BufferedOnce));
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let (block_stream_reset_sender, _) = watch::channel(0_u64);
-        let subscriber = Subscriber::new(
-            context.clone(),
-            network_client.clone(),
-            authority_service.clone(),
-            dag_state,
-            block_stream_reset_sender.clone(),
-        );
-
-        let peer = context.committee.to_authority_index(2).unwrap();
-        subscriber.subscribe(peer);
+        let (service, gate) = TestService::with_bundle_handler_gate();
+        let f = fixture(test_context(4), service, StreamMode::BufferedOnce);
+        f.subscriber.subscribe(f.peer);
         // The first bundle is in the handler, the other nine sit buffered.
-        handler_started.notified().await;
+        gate.started.notified().await;
 
-        block_stream_reset_sender.send_modify(|generation| {
-            *generation += 1;
-        });
-        handler_release.notify_one();
-        wait_for_subscription_attempts(&network_client, 2).await;
+        f.reset_sender.send_replace(());
+        gate.release.notify_one();
+        wait_for_subscription_attempts(&f.network_client, 2).await;
 
         assert_eq!(
-            authority_service
+            f.authority_service
                 .lock()
                 .handle_subscribed_block_bundle
                 .len(),
             1,
             "buffered bundles should be discarded by the reset"
         );
-        subscriber.stop();
+        f.subscriber.stop();
     }
 
     /// The subscription cursor never drops below the GC round: blocks at or
@@ -718,50 +658,31 @@ mod test {
     /// Above the GC round the peer's own latest header still wins.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn subscriber_does_not_resume_below_gc_round() {
-        telemetry_subscribers::init_for_testing();
         let (mut context, _keys) = Context::new_for_test(4);
         context.protocol_config.set_gc_depth_for_testing(5);
-        let context = Arc::new(context);
-        let authority_service = Arc::new(Mutex::new(TestService::new()));
-        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::Pending));
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let f = fixture(Arc::new(context), TestService::new(), StreamMode::Pending);
         // A commit led at round 30 with gc_depth 5 puts the GC round at 20.
-        dag_state
+        f.dag_state
             .write()
             .set_last_commit(TrustedCommit::new_for_test(
-                &context,
+                &f.context,
                 1,
                 CommitDigest::MIN,
-                context.clock.timestamp_utc_ms(),
+                f.context.clock.timestamp_utc_ms(),
                 BlockRef::new(30, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
                 vec![],
                 vec![],
             ));
-        let (block_stream_reset_sender, _) = watch::channel(0_u64);
-        let subscriber = Subscriber::new(
-            context.clone(),
-            network_client.clone(),
-            authority_service,
-            dag_state.clone(),
-            block_stream_reset_sender.clone(),
-        );
+        f.subscriber.subscribe(f.peer);
+        wait_for_subscription_attempts(&f.network_client, 1).await;
 
-        let peer = context.committee.to_authority_index(2).unwrap();
-        subscriber.subscribe(peer);
-        wait_for_subscription_attempts(&network_client, 1).await;
-
-        let header =
-            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(25, peer.value() as u8).build());
-        dag_state
+        f.dag_state
             .write()
-            .accept_block_headers(vec![header], DataSource::BlockBundleStream);
-        block_stream_reset_sender.send_modify(|generation| {
-            *generation += 1;
-        });
-        wait_for_subscription_attempts(&network_client, 2).await;
+            .accept_block_headers(vec![header_for(f.peer, 25)], DataSource::BlockBundleStream);
+        f.reset_sender.send_replace(());
+        wait_for_subscription_attempts(&f.network_client, 2).await;
 
-        assert_eq!(network_client.last_received_rounds(), vec![20, 25]);
-        subscriber.stop();
+        assert_eq!(f.network_client.last_received_rounds(), vec![20, 25]);
+        f.subscriber.stop();
     }
 }

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -322,13 +322,16 @@ mod test {
 
     struct SubscriberTestClient {
         last_received_rounds: Mutex<Vec<Round>>,
+        subscription_attempts_sender: watch::Sender<usize>,
         pending_stream: bool,
     }
 
     impl SubscriberTestClient {
         fn new(pending_stream: bool) -> Self {
+            let (subscription_attempts_sender, _) = watch::channel(0);
             Self {
                 last_received_rounds: Mutex::new(Vec::new()),
+                subscription_attempts_sender,
                 pending_stream,
             }
         }
@@ -346,7 +349,12 @@ mod test {
             last_received: Round,
             _timeout: Duration,
         ) -> ConsensusResult<BlockBundleStream> {
-            self.last_received_rounds.lock().push(last_received);
+            let attempts = {
+                let mut last_received_rounds = self.last_received_rounds.lock();
+                last_received_rounds.push(last_received);
+                last_received_rounds.len()
+            };
+            self.subscription_attempts_sender.send_replace(attempts);
             if self.pending_stream {
                 Ok(Box::pin(stream::pending()))
             } else {
@@ -413,13 +421,17 @@ mod test {
         network_client: &SubscriberTestClient,
         expected: usize,
     ) {
-        for _ in 0..100 {
-            if network_client.last_received_rounds().len() >= expected {
-                return;
+        let mut attempts = network_client.subscription_attempts_sender.subscribe();
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if *attempts.borrow() >= expected {
+                    return;
+                }
+                attempts.changed().await.unwrap();
             }
-            sleep(Duration::from_millis(1)).await;
-        }
-        panic!("subscriber did not make {expected} subscription attempts");
+        })
+        .await
+        .unwrap_or_else(|_| panic!("subscriber did not make {expected} subscription attempts"));
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -517,6 +529,50 @@ mod test {
 
         wait_for_subscription_attempts(&network_client, 2).await;
         assert_eq!(network_client.last_received_rounds(), vec![0, 11]);
+        subscriber.stop();
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn subscriber_finishes_bundle_handler_before_reset() {
+        telemetry_subscribers::init_for_testing();
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let handler_started = Arc::new(tokio::sync::Notify::new());
+        let handler_release = Arc::new(tokio::sync::Notify::new());
+        let mut service = TestService::new();
+        service.block_bundle_handler_started = Some(handler_started.clone());
+        service.block_bundle_handler_release = Some(handler_release.clone());
+        let authority_service = Arc::new(Mutex::new(service));
+        let network_client = Arc::new(SubscriberTestClient::new(false));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (block_stream_reset_sender, _) = watch::channel(0_u64);
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client.clone(),
+            authority_service,
+            dag_state,
+            block_stream_reset_sender.clone(),
+        );
+
+        let peer = context.committee.to_authority_index(2).unwrap();
+        subscriber.subscribe(peer);
+        handler_started.notified().await;
+
+        block_stream_reset_sender.send_modify(|generation| {
+            *generation += 1;
+        });
+        assert!(
+            timeout(
+                Duration::from_secs(1),
+                wait_for_subscription_attempts(&network_client, 2)
+            )
+            .await
+            .is_err()
+        );
+
+        handler_release.notify_one();
+        wait_for_subscription_attempts(&network_client, 2).await;
         subscriber.stop();
     }
 }

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -133,6 +133,11 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let peer_hostname = &context.committee.authority(peer).hostname;
         let mut retries: i64 = 0;
         let mut delay = INITIAL_RETRY_INTERVAL;
+        let block_stream_resets = context
+            .metrics
+            .node_metrics
+            .block_stream_resets
+            .with_label_values(&[peer_hostname]);
 
         let mut encoder = create_encoder(&context);
 
@@ -157,6 +162,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                         if reset.is_err() {
                             return;
                         }
+                        block_stream_resets.inc();
                         retries = 0;
                         continue 'subscription;
                     }
@@ -175,10 +181,15 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             }
             retries += 1;
 
-            let last_received = dag_state
-                .read()
-                .get_last_block_header_for_authority(peer)
-                .round();
+            // Blocks at or below the GC round can no longer be sequenced, so
+            // never ask a peer to resend from further back than that.
+            let last_received = {
+                let dag_state = dag_state.read();
+                dag_state
+                    .get_last_block_header_for_authority(peer)
+                    .round()
+                    .max(dag_state.gc_round_for_last_commit())
+            };
             // Wrap subscribe_block_bundles in a timeout and increment metric on timeout
             let subscribe_future =
                 network_client.subscribe_block_bundles(peer, last_received, MAX_RETRY_INTERVAL);
@@ -188,6 +199,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                     if reset.is_err() {
                         return;
                     }
+                    block_stream_resets.inc();
                     retries = 0;
                     continue 'subscription;
                 }
@@ -246,6 +258,8 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                 .set(1);
 
             'stream: loop {
+                // Observe a reset only between bundles: wrapping the handler
+                // below in this select would cancel it mid-bundle.
                 let next_block = tokio::select! {
                     biased;
                     reset = block_stream_reset_receiver.changed() => {
@@ -253,6 +267,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             return;
                         }
                         debug!("Resetting block stream subscription to peer {peer} {peer_hostname}");
+                        block_stream_resets.inc();
                         retries = 0;
                         continue 'subscription;
                     }
@@ -311,33 +326,57 @@ mod test {
     use super::*;
     use crate::{
         Round,
-        block_header::{BlockRef, TestBlockHeader, VerifiedBlockHeader},
-        commit::CommitRange,
+        block_header::{BlockHeaderDigest, BlockRef, TestBlockHeader, VerifiedBlockHeader},
+        commit::{CommitDigest, CommitRange, TrustedCommit},
         dag_state::DataSource,
-        error::ConsensusResult,
+        error::{ConsensusError, ConsensusResult},
         network::{BlockBundleStream, SerializedBlockBundle, test_network::TestService},
         storage::mem_store::MemStore,
         transaction_ref::TransactionRef,
     };
 
+    /// How the fake peer feeds bundles once a subscription succeeds.
+    enum StreamMode {
+        /// Ten bundles, one per millisecond.
+        Paced,
+        /// Never yields, so the subscriber stays parked on the stream.
+        Pending,
+        /// Ten bundles at once on the first subscription, then a stream that
+        /// never yields, so a reconnect cannot add to the handled count.
+        BufferedOnce,
+    }
+
     struct SubscriberTestClient {
         last_received_rounds: Mutex<Vec<Round>>,
         subscription_attempts_sender: watch::Sender<usize>,
-        pending_stream: bool,
+        stream_mode: StreamMode,
+        initial_failures: usize,
     }
 
     impl SubscriberTestClient {
-        fn new(pending_stream: bool) -> Self {
+        fn new(stream_mode: StreamMode) -> Self {
             let (subscription_attempts_sender, _) = watch::channel(0);
             Self {
                 last_received_rounds: Mutex::new(Vec::new()),
                 subscription_attempts_sender,
-                pending_stream,
+                stream_mode,
+                initial_failures: 0,
             }
+        }
+
+        fn with_initial_failures(mut self, initial_failures: usize) -> Self {
+            self.initial_failures = initial_failures;
+            self
         }
 
         fn last_received_rounds(&self) -> Vec<Round> {
             self.last_received_rounds.lock().clone()
+        }
+    }
+
+    fn test_bundle() -> SerializedBlockBundle {
+        SerializedBlockBundle {
+            serialized_block_bundle: Bytes::from(vec![1u8; 8]),
         }
     }
 
@@ -355,18 +394,29 @@ mod test {
                 last_received_rounds.len()
             };
             self.subscription_attempts_sender.send_replace(attempts);
-            if self.pending_stream {
-                Ok(Box::pin(stream::pending()))
-            } else {
-                let block_stream = stream::unfold((), |_| async {
-                    sleep(Duration::from_millis(1)).await;
-                    let block = SerializedBlockBundle {
-                        serialized_block_bundle: Bytes::from(vec![1u8; 8]),
-                    };
-                    Some((block, ()))
-                })
-                .take(10);
-                Ok(Box::pin(block_stream))
+            if attempts <= self.initial_failures {
+                return Err(ConsensusError::NetworkRequest(
+                    "injected failure".to_owned(),
+                ));
+            }
+            match self.stream_mode {
+                StreamMode::Pending => Ok(Box::pin(stream::pending())),
+                StreamMode::Paced => {
+                    let block_stream = stream::unfold((), |_| async {
+                        sleep(Duration::from_millis(1)).await;
+                        Some((test_bundle(), ()))
+                    })
+                    .take(10);
+                    Ok(Box::pin(block_stream))
+                }
+                StreamMode::BufferedOnce => {
+                    if attempts > self.initial_failures + 1 {
+                        return Ok(Box::pin(stream::pending()));
+                    }
+                    Ok(Box::pin(stream::iter(
+                        std::iter::repeat_with(test_bundle).take(10),
+                    )))
+                }
             }
         }
 
@@ -440,7 +490,7 @@ mod test {
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let authority_service = Arc::new(Mutex::new(TestService::new()));
-        let network_client = Arc::new(SubscriberTestClient::new(false));
+        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::Paced));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let (block_stream_reset_sender, _) = watch::channel(0_u64);
@@ -485,12 +535,10 @@ mod test {
                 }
             );
         }
+        let rounds = network_client.last_received_rounds();
         assert!(
-            network_client
-                .last_received_rounds()
-                .iter()
-                .skip(1)
-                .all(|round| *round == 7)
+            rounds.len() > 1 && rounds[1..].iter().all(|round| *round == 7),
+            "reconnects should resume from the peer's latest header: {rounds:?}"
         );
         drop(service);
         subscriber.stop();
@@ -502,7 +550,7 @@ mod test {
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let authority_service = Arc::new(Mutex::new(TestService::new()));
-        let network_client = Arc::new(SubscriberTestClient::new(true));
+        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::Pending));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let (block_stream_reset_sender, _) = watch::channel(0_u64);
@@ -543,7 +591,7 @@ mod test {
         service.block_bundle_handler_started = Some(handler_started.clone());
         service.block_bundle_handler_release = Some(handler_release.clone());
         let authority_service = Arc::new(Mutex::new(service));
-        let network_client = Arc::new(SubscriberTestClient::new(false));
+        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::Paced));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let (block_stream_reset_sender, _) = watch::channel(0_u64);
@@ -573,6 +621,147 @@ mod test {
 
         handler_release.notify_one();
         wait_for_subscription_attempts(&network_client, 2).await;
+        subscriber.stop();
+    }
+
+    /// A reset while the subscriber is waiting out a retry backoff reconnects
+    /// straight away instead of sitting out the rest of the delay.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn subscriber_reset_short_circuits_retry_backoff() {
+        telemetry_subscribers::init_for_testing();
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let authority_service = Arc::new(Mutex::new(TestService::new()));
+        // Four failed attempts put the next one into the delayed-retry branch.
+        let network_client =
+            Arc::new(SubscriberTestClient::new(StreamMode::Pending).with_initial_failures(4));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (block_stream_reset_sender, _) = watch::channel(0_u64);
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client.clone(),
+            authority_service,
+            dag_state,
+            block_stream_reset_sender.clone(),
+        );
+
+        let peer = context.committee.to_authority_index(2).unwrap();
+        subscriber.subscribe(peer);
+        wait_for_subscription_attempts(&network_client, 4).await;
+        // Let the subscriber reach the backoff sleep before resetting it.
+        sleep(Duration::from_millis(1)).await;
+
+        let before_reset = tokio::time::Instant::now();
+        block_stream_reset_sender.send_modify(|generation| {
+            *generation += 1;
+        });
+        wait_for_subscription_attempts(&network_client, 5).await;
+
+        let waited = before_reset.elapsed();
+        assert!(
+            waited < Duration::from_millis(50),
+            "reset should not wait out the backoff, waited {waited:?}"
+        );
+        subscriber.stop();
+    }
+
+    /// Bundles already buffered on the stream are dropped by a reset rather
+    /// than handled against the reinitialized state.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn subscriber_discards_buffered_bundles_on_reset() {
+        telemetry_subscribers::init_for_testing();
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let handler_started = Arc::new(tokio::sync::Notify::new());
+        let handler_release = Arc::new(tokio::sync::Notify::new());
+        let mut service = TestService::new();
+        service.block_bundle_handler_started = Some(handler_started.clone());
+        service.block_bundle_handler_release = Some(handler_release.clone());
+        let authority_service = Arc::new(Mutex::new(service));
+        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::BufferedOnce));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (block_stream_reset_sender, _) = watch::channel(0_u64);
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client.clone(),
+            authority_service.clone(),
+            dag_state,
+            block_stream_reset_sender.clone(),
+        );
+
+        let peer = context.committee.to_authority_index(2).unwrap();
+        subscriber.subscribe(peer);
+        // The first bundle is in the handler, the other nine sit buffered.
+        handler_started.notified().await;
+
+        block_stream_reset_sender.send_modify(|generation| {
+            *generation += 1;
+        });
+        handler_release.notify_one();
+        wait_for_subscription_attempts(&network_client, 2).await;
+
+        assert_eq!(
+            authority_service
+                .lock()
+                .handle_subscribed_block_bundle
+                .len(),
+            1,
+            "buffered bundles should be discarded by the reset"
+        );
+        subscriber.stop();
+    }
+
+    /// The subscription cursor never drops below the GC round: blocks at or
+    /// below it can no longer be sequenced, so replaying them is wasted work.
+    /// Above the GC round the peer's own latest header still wins.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn subscriber_does_not_resume_below_gc_round() {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, _keys) = Context::new_for_test(4);
+        context.protocol_config.set_gc_depth_for_testing(5);
+        let context = Arc::new(context);
+        let authority_service = Arc::new(Mutex::new(TestService::new()));
+        let network_client = Arc::new(SubscriberTestClient::new(StreamMode::Pending));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        // A commit led at round 30 with gc_depth 5 puts the GC round at 20.
+        dag_state
+            .write()
+            .set_last_commit(TrustedCommit::new_for_test(
+                &context,
+                1,
+                CommitDigest::MIN,
+                context.clock.timestamp_utc_ms(),
+                BlockRef::new(30, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+                vec![],
+                vec![],
+            ));
+        let (block_stream_reset_sender, _) = watch::channel(0_u64);
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client.clone(),
+            authority_service,
+            dag_state.clone(),
+            block_stream_reset_sender.clone(),
+        );
+
+        let peer = context.committee.to_authority_index(2).unwrap();
+        subscriber.subscribe(peer);
+        wait_for_subscription_attempts(&network_client, 1).await;
+
+        let header =
+            VerifiedBlockHeader::new_for_test(TestBlockHeader::new(25, peer.value() as u8).build());
+        dag_state
+            .write()
+            .accept_block_headers(vec![header], DataSource::BlockBundleStream);
+        block_stream_reset_sender.send_modify(|generation| {
+            *generation += 1;
+        });
+        wait_for_subscription_attempts(&network_client, 2).await;
+
+        assert_eq!(network_client.last_received_rounds(), vec![20, 25]);
         subscriber.stop();
     }
 }


### PR DESCRIPTION
# Description of change

- Reset block-stream subscriptions after successful fast-sync reinitialization so buffered bundles are discarded.
- Reconnect from the latest per-peer round in `DagState`, never below the GC round, including normal subscription retries.
- Finish the current bundle handler before observing a reset.
- Add a default-on local flag to disable the reset.
- Count block stream resets per peer in `block_stream_resets`.

This helps in three different situations:
 - Buffered bundles with very old data will not refill the Core queue immediately after recovery.
 - Blocks that were skipped previously will be resent from the proper point
 - A peer whose latest known header is below the GC round is no longer asked to replay blocks that can never be sequenced.

## Links to any relevant issues

Fixes #12760

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

