### PR TITLE
chore: update SDK rev after signing_digest returns SigningDigest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7593,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7625,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7633,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,9 +401,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "25907f345ed0deb33a56fe40677d1d128209ffea" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "25907f345ed0deb33a56fe40677d1d128209ffea" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -443,10 +443,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "25907f345ed0deb33a56fe40677d1d128209ffea", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "25907f345ed0deb33a56fe40677d1d128209ffea", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "25907f345ed0deb33a56fe40677d1d128209ffea", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "25907f345ed0deb33a56fe40677d1d128209ffea", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -199,9 +199,9 @@ fn get_registry() -> Result<Registry> {
     )
     .signing_digest();
 
-    let sig1: SimpleSignature = kp1.sign(&*digest);
-    let sig2: SimpleSignature = kp2.sign(&*digest);
-    let sig3: SimpleSignature = kp3.sign(&*digest);
+    let sig1: SimpleSignature = kp1.sign(&digest);
+    let sig2: SimpleSignature = kp2.sign(&digest);
+    let sig3: SimpleSignature = kp3.sign(&digest);
 
     let multi_sig = MultisigAggregatedSignature::new(
         vec![

--- a/crates/iota-keys/src/keystore.rs
+++ b/crates/iota-keys/src/keystore.rs
@@ -377,7 +377,7 @@ impl AccountKeystore for FileBasedKeystore {
 
         let intent_msg = &IntentMessage::new(intent, msg);
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(keypair.sign(intent_msg.signing_digest().inner())),
+            StoredKey::KeyPair(keypair) => Ok(keypair.sign(&intent_msg.signing_digest())),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_secure is not supported for account type",
             )),
@@ -770,7 +770,7 @@ impl AccountKeystore for InMemKeystore {
 
         let intent_msg = &IntentMessage::new(intent, msg);
         match stored_key {
-            StoredKey::KeyPair(keypair) => Ok(keypair.sign(intent_msg.signing_digest().inner())),
+            StoredKey::KeyPair(keypair) => Ok(keypair.sign(&intent_msg.signing_digest())),
             StoredKey::Account(_) => Err(signature::Error::from_source(
                 "sign_secure is not supported for account type",
             )),

--- a/crates/iota-types/src/multisig.rs
+++ b/crates/iota-types/src/multisig.rs
@@ -36,7 +36,7 @@ impl AuthenticatorTrait for MultisigAggregatedSignature {
             .with_additional_multisig_checks(verify_params.additional_multisig_checks);
 
         verifier
-            .verify(&*digest, self)
+            .verify(&digest, self)
             .map_err(|e| IotaError::InvalidSignature {
                 error: format!("Invalid multisig: {e}"),
             })

--- a/crates/iota-types/src/passkey_authenticator.rs
+++ b/crates/iota-types/src/passkey_authenticator.rs
@@ -33,7 +33,7 @@ impl AuthenticatorTrait for PasskeyAuthenticator {
 
         PasskeyVerifier::new()
             .with_address(author)
-            .verify(&*digest, self)
+            .verify(&digest, self)
             .map_err(|e| IotaError::InvalidSignature {
                 error: format!("Invalid passkey authentication: {e}"),
             })

--- a/crates/iota-types/src/signature.rs
+++ b/crates/iota-types/src/signature.rs
@@ -81,7 +81,7 @@ impl AuthenticatorTrait for SimpleSignature {
         }
 
         SimpleVerifier
-            .verify(value.signing_digest().inner(), self)
+            .verify(&value.signing_digest(), self)
             .map_err(|e| IotaError::InvalidSignature {
                 error: format!("Fail to verify user sig {e}"),
             })

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2360,7 +2360,7 @@ impl TransactionEnvelope {
         signer: &impl iota_sdk_crypto::Signer<SimpleSignature>,
     ) -> SimpleSignature {
         let digest = IntentMessage::new(intent, tx).signing_digest();
-        signer.sign(digest.inner())
+        signer.sign(&digest)
     }
 
     pub fn from_user_sig_data(tx: Transaction, signatures: Vec<UserSignature>) -> Self {

--- a/crates/iota-types/src/unit_tests/base_types_tests.rs
+++ b/crates/iota-types/src/unit_tests/base_types_tests.rs
@@ -56,7 +56,7 @@ fn test_signatures() {
     let bar = IntentMessage::new(Intent::iota_transaction(), Bar("hello".into()));
 
     let aux = VerifyParams::default();
-    let s: SimpleSignature = sec1.sign(foo.signing_digest().inner());
+    let s: SimpleSignature = sec1.sign(&foo.signing_digest());
     assert!(s.verify_claims(&foo, addr1, &aux).is_ok());
     assert!(s.verify_claims(&foo, addr2, &aux).is_err());
     assert!(s.verify_claims(&foox, addr1, &aux).is_err());
@@ -80,11 +80,8 @@ fn test_signatures() {
 fn test_signatures_serde() {
     let sec1 = AccountKeyPair::random();
     let foo = Foo("hello".into());
-    let s: SimpleSignature = sec1.sign(
-        IntentMessage::new(Intent::iota_transaction(), foo)
-            .signing_digest()
-            .inner(),
-    );
+    let s: SimpleSignature =
+        sec1.sign(&IntentMessage::new(Intent::iota_transaction(), foo).signing_digest());
 
     let serialized = bcs::to_bytes(&s).unwrap();
     println!("{serialized:?}");

--- a/crates/iota-types/src/unit_tests/messages_tests.rs
+++ b/crates/iota-types/src/unit_tests/messages_tests.rs
@@ -717,7 +717,7 @@ fn signature_from_signer(
     signer: &impl Signer<SimpleSignature>,
 ) -> SimpleSignature {
     let digest = IntentMessage::new(intent, tx).signing_digest();
-    signer.sign(digest.inner())
+    signer.sign(&digest)
 }
 
 #[test]

--- a/crates/iota-types/src/unit_tests/multisig_tests.rs
+++ b/crates/iota-types/src/unit_tests/multisig_tests.rs
@@ -35,7 +35,7 @@ fn verify_rejects_signature_pubkey_scheme_mismatch() {
     );
 
     // Sign with the Secp256k1 key even though the committee member is Ed25519.
-    let secp_sig: Secp256k1Signature = kp2.sign(&*intent_msg.signing_digest());
+    let secp_sig: Secp256k1Signature = kp2.sign(&intent_msg.signing_digest());
     let multisig = MultisigAggregatedSignature::new_unchecked(
         vec![MultisigMemberSignature::Secp256k1(secp_sig)],
         0b1,

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=df5feb3a920da979393fbc954dbaaa87ad5f17fd#df5feb3a920da979393fbc954dbaaa87ad5f17fd"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=25907f345ed0deb33a56fe40677d1d128209ffea#25907f345ed0deb33a56fe40677d1d128209ffea"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "25907f345ed0deb33a56fe40677d1d128209ffea" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "df5feb3a920da979393fbc954dbaaa87ad5f17fd" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "25907f345ed0deb33a56fe40677d1d128209ffea" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
# Description of change

Bump the `iota-rust-sdk` rev to `25907f3` and adapt to the change in
[iotaledger/iota-rust-sdk#1360](https://github.com/iotaledger/iota-rust-sdk/pull/1360),
which makes `IntentMessage::signing_digest()` return `SigningDigest` (`[u8; 32]`)
instead of `Digest`.

- Drop the now-unneeded `.inner()` calls and `&*` derefs at the `sign()` /
  `verify()` call sites in `iota-types`, `iota-keys` and `iota-core`.
- Update the rev in `Cargo.toml`, `Cargo.lock`, and the two standalone example
  manifests (`docs/examples/rust`, `examples/tic-tac-toe/cli`).

No behaviour change.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---