### PR TITLE
feat(consensus): charge peers that relay a second shard into one slot

### DIFF
--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -433,6 +433,13 @@ pub(crate) enum ConsensusError {
         size: usize,
         limit: usize,
     },
+
+    #[error("Peer {peer} relayed a second shard for slot (author {author}, round {round})")]
+    SecondShardForSlot {
+        peer: AuthorityIndex,
+        author: AuthorityIndex,
+        round: Round,
+    },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -223,8 +223,9 @@ impl MisbehaviorStore {
     ///   distributing a block they could have verified themselves.
     /// - Unprovable faults (bad/missing signature): charged to `peer` only — we
     ///   can't verify the author field, but we know who sent it to us.
-    /// - Bundle-part faults (corrupt framing, metadata, or shard): charged to
-    ///   `peer` only, under the dedicated bundle-part counter.
+    /// - Bundle-part faults (corrupt framing, metadata, or shard, or a shard
+    ///   the peer had no right to relay): charged to `peer` only, under the
+    ///   dedicated bundle-part counter.
     pub(crate) fn record_faulty_block(
         &self,
         peer: AuthorityIndex,
@@ -300,8 +301,9 @@ enum FaultType {
     /// (epoch / genesis / author-vs-peer mismatch) so its `author` field
     /// can't be trusted. Charged to the sending peer, not the claimed author.
     Unprovable,
-    /// Corrupt or invalid relayed bundle part (framing, metadata, or shard)
-    /// that isn't tied to a verified author. Charged to the sending peer.
+    /// Relayed bundle part (framing, metadata, or shard) that is corrupt,
+    /// invalid, or one the peer had no right to relay, and isn't tied to a
+    /// verified author. Charged to the sending peer.
     BundlePart,
     /// Not counted as misbehavior.
     Untracked,
@@ -328,15 +330,17 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::UnexpectedBlockHeaderForCommit { .. }
         | ConsensusError::TooManyFetchedHeadersReturned { .. } => FaultType::Unprovable,
 
-        // Corrupt or invalid relayed bundle parts (framing, additional-header
-        // round, and shard structure/proof). We know which peer relayed them
-        // but can't tie them to a verified author.
+        // Relayed bundle parts that are corrupt or invalid (framing,
+        // additional-header round, shard structure/proof) or that the peer had
+        // no right to relay (a second shard for one slot). We know which peer
+        // relayed them but can't tie them to a verified author.
         ConsensusError::MalformedShard(_)
         | ConsensusError::TooBigHeaderRoundInABundle { .. }
         | ConsensusError::TooBigShardRoundInABundle { .. }
         | ConsensusError::IncorrectShardProof { .. }
         | ConsensusError::UnrequestedHeaderOutOfWindow { .. }
-        | ConsensusError::SerializedShardTooLarge { .. } => FaultType::BundlePart,
+        | ConsensusError::SerializedShardTooLarge { .. }
+        | ConsensusError::SecondShardForSlot { .. } => FaultType::BundlePart,
 
         // Checks that run only after the author's signature is verified, so the
         // signed header itself proves the author produced a block that violates
@@ -1182,6 +1186,11 @@ mod tests {
                 peer: AuthorityIndex::new_for_test(0),
                 size: 100,
                 limit: 50,
+            },
+            ConsensusError::SecondShardForSlot {
+                peer: AuthorityIndex::new_for_test(0),
+                author: AuthorityIndex::new_for_test(1),
+                round: 10,
             },
         ];
         for e in cases {

--- a/crates/starfish/core/src/shard_reconstructor.rs
+++ b/crates/starfish/core/src/shard_reconstructor.rs
@@ -754,11 +754,9 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             return Ok(());
         }
 
-        // Relaying two shards for one slot is the peer's own fault;
-        // exceeding the accumulator limit is not, as others may have
-        // filled the slot.
-        // TODO: charge the peer for the former once every validator
-        // runs the per-slot header cap.
+        // Relaying two shards for one slot is the peer's own fault and is
+        // charged; exceeding the accumulator limit is not, as others may
+        // have filled the slot.
         let slot_start = TransactionRef {
             round: tx_ref.round,
             author: tx_ref.author,
@@ -779,10 +777,12 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
             }
         }
 
-        // One shard per (relaying peer, slot), across all accumulators:
-        // an honest peer holds exactly one shard per slot, so a peer
-        // whose index already appears in another accumulator of the
-        // slot has spent the contribution it was entitled to.
+        // One shard per (relaying peer, slot), across all accumulators: the
+        // per-slot header cap leaves an honest peer holding exactly one own
+        // shard per slot, so a peer whose index already appears in another
+        // accumulator of the slot has relayed a shard it could not have held
+        // honestly. The shard carries no relayer signature, so the evidence
+        // stays local.
         if peer_in_other_accumulator {
             self.context
                 .metrics
@@ -794,6 +794,21 @@ impl<C: CoreThreadDispatcher> ShardReconstructor<C> {
                 "Dropping shard for {tx_ref:?}: peer index {} already contributed a shard in this slot",
                 shard_msg.shard_index
             );
+            if let Some(peer) = self
+                .context
+                .committee
+                .to_authority_index(shard_msg.shard_index)
+            {
+                self.misbehavior_store.record_faulty_block(
+                    peer,
+                    peer,
+                    &ConsensusError::SecondShardForSlot {
+                        peer,
+                        author: tx_ref.author,
+                        round: tx_ref.round,
+                    },
+                );
+            }
             return Ok(());
         }
 
@@ -1886,9 +1901,10 @@ mod tests {
     }
 
     /// A peer gets one shard per (author, round) slot across all accumulators:
-    /// its shard for a second commitment in the slot is dropped whether that
-    /// would create a new accumulator or join one another peer created. The
-    /// first commitment still reconstructs from `info_length` distinct peers.
+    /// its shard for a second commitment in the slot is dropped and charged as
+    /// a bundle-part fault, whether that would create a new accumulator or
+    /// join one another peer created. The first commitment still reconstructs
+    /// from `info_length` distinct peers.
     #[tokio::test]
     async fn test_shard_admission_one_shard_per_peer_per_slot() {
         telemetry_subscribers::init_for_testing();
@@ -1992,6 +2008,17 @@ mod tests {
             first_commitment
         );
 
+        // Only peer 0 is charged, once per dropped shard; peer 1 relayed a
+        // single shard into the slot and stays clean.
+        let counts = h.dag_state.read().misbehavior_store().snapshot_totals();
+        assert_eq!(
+            counts[0].as_v2().invalid_bundle_parts,
+            2,
+            "each second shard relayed into the slot must be charged to peer 0"
+        );
+        assert_eq!(counts[0].as_v2().faulty_blocks_unprovable, 0);
+        assert_eq!(counts[1].as_v2().invalid_bundle_parts, 0);
+
         h.handle.stop().await.unwrap();
     }
 
@@ -2063,6 +2090,11 @@ mod tests {
                 .get(),
             0,
             "honest single-shard-per-peer traffic must never be dropped"
+        );
+        let counts = h.dag_state.read().misbehavior_store().snapshot_totals();
+        assert!(
+            counts.iter().all(|c| c.as_v2().invalid_bundle_parts == 0),
+            "honest single-shard-per-peer traffic must never be charged"
         );
 
         h.handle.stop().await.unwrap();


### PR DESCRIPTION
# Description of change

A peer that relays two shards for one `(author, round)` slot — one from each of two equivocating blocks — was dropped and counted but not charged, because a validator without the per-slot header cap would honestly hold and relay both. The cap ships in release 1.30 (protocol v33), so a binary with this change never shares a committee with a cap-less peer; the deferral is over and the relaying peer is now charged.

The fault is classified as a bundle-part fault: the relayer is known from the authenticated connection, but shards carry no relayer signature, so the evidence is local. The other rejection at the same site (slot already holds the maximum number of accumulators) stays uncharged — it is not attributable to the peer that trips it.

Detection is best-effort: it fires only while the first commitment's accumulator is still alive in the slot, so it can under-charge but never charges an honest single-shard-per-peer relayer.

## Links to any relevant issues

fixes iotaledger/iota-private#490

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
