### PR TITLE
feat(graphql): do not expose u64 values as Int in the schema

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -1677,7 +1677,7 @@ type Lagged {
 	"""
 	Number of missed payloads since the previous emitted one.
 	"""
-	count: UInt53!
+	count: Int!
 }
 
 """
@@ -5163,7 +5163,7 @@ type ValidatorSet {
 	"""
 	Size of the stake pool mappings `Table`.
 	"""
-	stakingPoolMappingsSize: UInt53
+	stakingPoolMappingsSize: Int
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""
@@ -5171,7 +5171,7 @@ type ValidatorSet {
 	"""
 	Size of the inactive pools `Table`.
 	"""
-	inactivePoolsSize: UInt53
+	inactivePoolsSize: Int
 	"""
 	Object ID of the `Table` storing the validator candidates.
 	"""
@@ -5179,7 +5179,7 @@ type ValidatorSet {
 	"""
 	Size of the validator candidates `Table`.
 	"""
-	validatorCandidatesSize: UInt53
+	validatorCandidatesSize: Int
 	"""
 	The current set of active validators.
 	"""

--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -1677,7 +1677,7 @@ type Lagged {
 	"""
 	Number of missed payloads since the previous emitted one.
 	"""
-	count: Int!
+	count: UInt53!
 }
 
 """
@@ -2419,7 +2419,7 @@ type MovePackage implements IObject & IOwner {
 	Fetch another version of this package (the package that shares this
 	package's original ID, but has the specified `version`).
 	"""
-	packageAtVersion(version: Int!): MovePackage
+	packageAtVersion(version: UInt53!): MovePackage
 	"""
 	Fetch all versions of this package (packages that share this package's
 	original ID), optionally bounding the versions exclusively from
@@ -5163,7 +5163,7 @@ type ValidatorSet {
 	"""
 	Size of the stake pool mappings `Table`.
 	"""
-	stakingPoolMappingsSize: Int
+	stakingPoolMappingsSize: UInt53
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""
@@ -5171,7 +5171,7 @@ type ValidatorSet {
 	"""
 	Size of the inactive pools `Table`.
 	"""
-	inactivePoolsSize: Int
+	inactivePoolsSize: UInt53
 	"""
 	Object ID of the `Table` storing the validator candidates.
 	"""
@@ -5179,7 +5179,7 @@ type ValidatorSet {
 	"""
 	Size of the validator candidates `Table`.
 	"""
-	validatorCandidatesSize: Int
+	validatorCandidatesSize: UInt53
 	"""
 	The current set of active validators.
 	"""

--- a/crates/iota-graphql-rpc/src/config.rs
+++ b/crates/iota-graphql-rpc/src/config.rs
@@ -10,7 +10,7 @@ use iota_names::config::IotaNamesConfig;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::functional_group::FunctionalGroup;
+use crate::{functional_group::FunctionalGroup, types::int::try_into_int};
 
 pub(crate) const DEFAULT_PAGE_SIZE: u32 = 20;
 pub(crate) const MAX_PAGE_SIZE: u32 = 50;
@@ -299,14 +299,14 @@ impl ServiceConfig {
     }
 
     /// The maximum depth a GraphQL query can be to be accepted by this service.
-    pub async fn max_query_depth(&self) -> u32 {
-        self.limits.max_query_depth
+    pub async fn max_query_depth(&self) -> Result<i32> {
+        try_into_int(self.limits.max_query_depth).extend()
     }
 
     /// The maximum number of nodes (field names) the service will accept in a
     /// single query.
-    pub async fn max_query_nodes(&self) -> u32 {
-        self.limits.max_query_nodes
+    pub async fn max_query_nodes(&self) -> Result<i32> {
+        try_into_int(self.limits.max_query_nodes).extend()
     }
 
     /// The maximum number of output nodes in a GraphQL response.
@@ -321,25 +321,25 @@ impl ServiceConfig {
     /// connection with last: 20, the count at the second level would be 200
     /// nodes. This is then summed to the count of 10 nodes at the first
     /// level, for a total of 210 nodes.
-    pub async fn max_output_nodes(&self) -> u32 {
-        self.limits.max_output_nodes
+    pub async fn max_output_nodes(&self) -> Result<i32> {
+        try_into_int(self.limits.max_output_nodes).extend()
     }
 
     /// Maximum estimated cost of a database query used to serve a GraphQL
     /// request.  This is measured in the same units that the database uses
     /// in EXPLAIN queries.
-    async fn max_db_query_cost(&self) -> u32 {
-        self.limits.max_db_query_cost
+    async fn max_db_query_cost(&self) -> Result<i32> {
+        try_into_int(self.limits.max_db_query_cost).extend()
     }
 
     /// Default number of elements allowed on a single page of a connection.
-    async fn default_page_size(&self) -> u32 {
-        self.limits.default_page_size
+    async fn default_page_size(&self) -> Result<i32> {
+        try_into_int(self.limits.default_page_size).extend()
     }
 
     /// Maximum number of elements allowed on a single page of a connection.
-    async fn max_page_size(&self) -> u32 {
-        self.limits.max_page_size
+    async fn max_page_size(&self) -> Result<i32> {
+        try_into_int(self.limits.max_page_size).extend()
     }
 
     /// Maximum time in milliseconds spent waiting for a response from fullnode
@@ -348,14 +348,14 @@ impl ServiceConfig {
     /// idempotent, so a transaction that times out should be resubmitted
     /// until the network returns a definite response (success or failure, not
     /// timeout).
-    async fn mutation_timeout_ms(&self) -> u32 {
-        self.limits.mutation_timeout_ms
+    async fn mutation_timeout_ms(&self) -> Result<i32> {
+        try_into_int(self.limits.mutation_timeout_ms).extend()
     }
 
     /// Maximum time in milliseconds that will be spent to serve one query
     /// request.
-    async fn request_timeout_ms(&self) -> u32 {
-        self.limits.request_timeout_ms
+    async fn request_timeout_ms(&self) -> Result<i32> {
+        try_into_int(self.limits.request_timeout_ms).extend()
     }
 
     /// The maximum bytes allowed for transactions in queries.
@@ -367,51 +367,51 @@ impl ServiceConfig {
     /// By default, this is set to the value of the maximum transaction bytes
     /// (including the signatures) allowed by the protocol, plus the Base64
     /// overhead (roughly 1/3 of the original string).
-    async fn max_transaction_payload_size(&self) -> u32 {
-        self.limits.max_tx_payload_size
+    async fn max_transaction_payload_size(&self) -> Result<i32> {
+        try_into_int(self.limits.max_tx_payload_size).extend()
     }
 
     /// The maximum bytes allowed for the read part of GraphQL queries.
     ///
     /// In case of mutations or `dryRunTransactionBlocks` the `txBytes` and
     /// `signatures` are not included in this limit.
-    async fn max_query_payload_size(&self) -> u32 {
-        self.limits.max_query_payload_size
+    async fn max_query_payload_size(&self) -> Result<i32> {
+        try_into_int(self.limits.max_query_payload_size).extend()
     }
 
     /// Maximum nesting allowed in type arguments in Move Types resolved by this
     /// service.
-    async fn max_type_argument_depth(&self) -> u32 {
-        self.limits.max_type_argument_depth
+    async fn max_type_argument_depth(&self) -> Result<i32> {
+        try_into_int(self.limits.max_type_argument_depth).extend()
     }
 
     /// Maximum number of type arguments passed into a generic instantiation of
     /// a Move Type resolved by this service.
-    async fn max_type_argument_width(&self) -> u32 {
-        self.limits.max_type_argument_width
+    async fn max_type_argument_width(&self) -> Result<i32> {
+        try_into_int(self.limits.max_type_argument_width).extend()
     }
 
     /// Maximum number of structs that need to be processed when calculating the
     /// layout of a single Move Type.
-    async fn max_type_nodes(&self) -> u32 {
-        self.limits.max_type_nodes
+    async fn max_type_nodes(&self) -> Result<i32> {
+        try_into_int(self.limits.max_type_nodes).extend()
     }
 
     /// Maximum nesting allowed in struct fields when calculating the layout of
     /// a single Move Type.
-    async fn max_move_value_depth(&self) -> u32 {
-        self.limits.max_move_value_depth
+    async fn max_move_value_depth(&self) -> Result<i32> {
+        try_into_int(self.limits.max_move_value_depth).extend()
     }
 
     /// Maximum number of transaction ids that can be passed to a
     /// `TransactionBlockFilter`.
-    async fn max_transaction_ids(&self) -> u32 {
-        self.limits.max_transaction_ids
+    async fn max_transaction_ids(&self) -> Result<i32> {
+        try_into_int(self.limits.max_transaction_ids).extend()
     }
 
     /// Maximum number of candidates to scan when gathering a page of results.
-    async fn max_scan_limit(&self) -> u32 {
-        self.limits.max_scan_limit
+    async fn max_scan_limit(&self) -> Result<i32> {
+        try_into_int(self.limits.max_scan_limit).extend()
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/available_range.rs
+++ b/crates/iota-graphql-rpc/src/types/available_range.rs
@@ -22,15 +22,13 @@ pub(crate) struct AvailableRange {
 #[Object]
 impl AvailableRange {
     async fn first(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx, CheckpointId::by_seq_num(self.first), self.last)
-            .await
-            .extend()
+        let id = CheckpointId::by_seq_num(self.first).extend()?;
+        Checkpoint::query(ctx, id, self.last).await.extend()
     }
 
     async fn last(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx, CheckpointId::by_seq_num(self.last), self.last)
-            .await
-            .extend()
+        let id = CheckpointId::by_seq_num(self.last).extend()?;
+        Checkpoint::query(ctx, id, self.last).await.extend()
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/balance.rs
+++ b/crates/iota-graphql-rpc/src/types/balance.rs
@@ -205,7 +205,7 @@ impl TryFrom<StoredBalance> for Balance {
             .transpose()
             .map_err(|_| Error::Internal("Failed to read balance.".to_string()))?;
 
-        let coin_object_count = count.map(|c| UInt53::from(c as u64));
+        let coin_object_count = count.map(|c| UInt53::try_from(c as u64)).transpose()?;
 
         let coin_type = TypeTag::from_str(&coin_type)
             .map_err(|e| Error::Internal(format!("Failed to parse coin type: {e}")))?

--- a/crates/iota-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/iota-graphql-rpc/src/types/checkpoint.rs
@@ -125,8 +125,8 @@ impl Checkpoint {
     /// This checkpoint's position in the total order of finalized checkpoints,
     /// agreed upon by consensus.
     #[graphql(complexity = 0)]
-    async fn sequence_number(&self) -> UInt53 {
-        self.sequence_number_impl().into()
+    async fn sequence_number(&self) -> Result<UInt53> {
+        UInt53::try_from(self.sequence_number_impl()).extend()
     }
 
     /// The timestamp at which the checkpoint is agreed to have happened
@@ -156,8 +156,10 @@ impl Checkpoint {
     /// The total number of transaction blocks in the network by the end of this
     /// checkpoint.
     #[graphql(complexity = 0)]
-    async fn network_total_transactions(&self) -> Option<UInt53> {
-        Some(self.network_total_transactions_impl().into())
+    async fn network_total_transactions(&self) -> Result<Option<UInt53>> {
+        Ok(Some(
+            UInt53::try_from(self.network_total_transactions_impl()).extend()?,
+        ))
     }
 
     /// The computation cost, storage cost, storage rebate, and non-refundable
@@ -235,7 +237,7 @@ impl Checkpoint {
         let Some(filter) = filter
             .unwrap_or_default()
             .intersect(TransactionBlockFilter {
-                at_checkpoint: Some(UInt53::from(self.stored.sequence_number as u64)),
+                at_checkpoint: Some(UInt53::try_from(self.stored.sequence_number as u64).extend()?),
                 ..Default::default()
             })
         else {
@@ -249,11 +251,11 @@ impl Checkpoint {
 }
 
 impl CheckpointId {
-    pub(crate) fn by_seq_num(seq_num: u64) -> Self {
-        CheckpointId {
-            sequence_number: Some(seq_num.into()),
+    pub(crate) fn by_seq_num(seq_num: u64) -> Result<Self, Error> {
+        Ok(CheckpointId {
+            sequence_number: Some(seq_num.try_into()?),
             digest: None,
-        }
+        })
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -164,7 +164,7 @@ impl Coin {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt53 {
+    pub(crate) async fn version(&self) -> Result<UInt53> {
         ObjectImpl(&self.super_.super_).version().await
     }
 
@@ -185,7 +185,7 @@ impl Coin {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Result<Option<ObjectOwner>> {
         ObjectImpl(&self.super_.super_).owner(ctx).await
     }
 

--- a/crates/iota-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/iota-graphql-rpc/src/types/coin_metadata.rs
@@ -149,7 +149,7 @@ impl CoinMetadata {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt53 {
+    pub(crate) async fn version(&self) -> Result<UInt53> {
         ObjectImpl(&self.super_.super_).version().await
     }
 
@@ -170,7 +170,7 @@ impl CoinMetadata {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Result<Option<ObjectOwner>> {
         ObjectImpl(&self.super_.super_).owner(ctx).await
     }
 

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -55,8 +55,8 @@ struct EpochKey {
 impl Epoch {
     /// The epoch's id as a sequence number that starts at 0 and is incremented
     /// by one at every epoch change.
-    async fn epoch_id(&self) -> UInt53 {
-        UInt53::from(self.stored.epoch as u64)
+    async fn epoch_id(&self) -> Result<UInt53> {
+        UInt53::try_from(self.stored.epoch as u64).extend()
     }
 
     /// The minimum gas price that a quorum of validators are guaranteed to sign
@@ -79,7 +79,7 @@ impl Epoch {
             self.stored.total_stake as u64,
             self.checkpoint_viewed_at,
             self.stored.epoch as u64,
-        );
+        )?;
         Ok(Some(validator_set))
     }
 
@@ -106,18 +106,19 @@ impl Epoch {
             }
         };
 
-        Ok(Some(UInt53::from(
-            last - self.stored.first_checkpoint_id as u64 + 1,
-        )))
+        Ok(Some(
+            UInt53::try_from(last - self.stored.first_checkpoint_id as u64 + 1).extend()?,
+        ))
     }
 
     /// The total number of transaction blocks in this epoch.
     async fn total_transactions(&self) -> Result<Option<UInt53>> {
         // TODO: this currently returns None for the current epoch. Fix this.
-        Ok(self
-            .stored
+        self.stored
             .epoch_total_transactions()
-            .map(|v| UInt53::from(v as u64)))
+            .map(|v| UInt53::try_from(v as u64))
+            .transpose()
+            .extend()
     }
 
     /// The total amount of gas fees (in NANOS) that were paid in this epoch.
@@ -272,11 +273,15 @@ impl Epoch {
             .intersect(TransactionBlockFilter {
                 // If `first_checkpoint_id` is 0, we include the 0th checkpoint by leaving it None
                 after_checkpoint: (self.stored.first_checkpoint_id > 0)
-                    .then(|| UInt53::from(self.stored.first_checkpoint_id as u64 - 1)),
+                    .then(|| UInt53::try_from(self.stored.first_checkpoint_id as u64 - 1))
+                    .transpose()
+                    .extend()?,
                 before_checkpoint: self
                     .stored
                     .last_checkpoint_id
-                    .map(|id| UInt53::from(id as u64 + 1)),
+                    .map(|id| UInt53::try_from(id as u64 + 1))
+                    .transpose()
+                    .extend()?,
                 ..Default::default()
             })
         else {

--- a/crates/iota-graphql-rpc/src/types/gas.rs
+++ b/crates/iota-graphql-rpc/src/types/gas.rs
@@ -176,21 +176,23 @@ impl GasInput {
     /// which this `GasInput` was queried for. This is stored on `GasInput`
     /// so that when viewing that entity's state, it will be as if it was
     /// read at the same checkpoint.
-    pub(crate) fn from(s: &GasPayment, checkpoint_viewed_at: u64) -> Self {
-        Self {
+    pub(crate) fn try_from(s: &GasPayment, checkpoint_viewed_at: u64) -> Result<Self, Error> {
+        Ok(Self {
             owner: s.owner.into(),
             price: s.price,
             budget: s.budget,
             payment_obj_keys: s
                 .objects
                 .iter()
-                .map(|o| ObjectKey {
-                    object_id: o.object_id.into(),
-                    version: o.version.as_u64().into(),
+                .map(|o| {
+                    Ok(ObjectKey {
+                        object_id: o.object_id.into(),
+                        version: o.version.as_u64().try_into()?,
+                    })
                 })
-                .collect(),
+                .collect::<Result<_, Error>>()?,
             checkpoint_viewed_at,
-        }
+        })
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/int.rs
+++ b/crates/iota-graphql-rpc/src/types/int.rs
@@ -17,5 +17,5 @@ where
 {
     value
         .try_into()
-        .map_err(|_| Error::Internal(format!("value {value} does not fit in a GraphQL Int")))
+        .map_err(|_| Error::Internal(format!("Value {value} does not fit in a GraphQL Int")))
 }

--- a/crates/iota-graphql-rpc/src/types/int.rs
+++ b/crates/iota-graphql-rpc/src/types/int.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Display;
+
+use crate::error::Error;
+
+/// Convert an integer to `i32`, the value range of a GraphQL `Int`, returning
+/// an internal error if the value does not fit.
+///
+/// This should be preferred over returning wider rust int types like u32, i64,
+/// etc. as they are officially exposed in the GraphQL schema as i32 anyway, and
+/// may result in data being truncated on client side.
+pub(crate) fn try_into_int<T>(value: T) -> Result<i32, Error>
+where
+    T: TryInto<i32> + Display + Copy,
+{
+    value
+        .try_into()
+        .map_err(|_| Error::Internal(format!("value {value} does not fit in a GraphQL Int")))
+}

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -203,7 +203,7 @@ impl NameRegistration {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt53 {
+    pub(crate) async fn version(&self) -> Result<UInt53> {
         ObjectImpl(&self.super_.super_).version().await
     }
 
@@ -224,7 +224,7 @@ impl NameRegistration {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Result<Option<ObjectOwner>> {
         ObjectImpl(&self.super_.super_).owner(ctx).await
     }
 

--- a/crates/iota-graphql-rpc/src/types/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod epoch;
 pub(crate) mod event;
 pub(crate) mod execution_result;
 pub(crate) mod gas;
+pub(crate) mod int;
 pub(crate) mod intersect;
 pub(crate) mod iota_address;
 pub(crate) mod iota_names_registration;

--- a/crates/iota-graphql-rpc/src/types/move_module.rs
+++ b/crates/iota-graphql-rpc/src/types/move_module.rs
@@ -17,6 +17,7 @@ use crate::{
         base64::Base64,
         cursor::{JsonCursor, Page},
         datatype::MoveDatatype,
+        int::try_into_int,
         iota_address::IotaAddress,
         move_enum::MoveEnum,
         move_function::MoveFunction,
@@ -67,8 +68,8 @@ impl MoveModule {
     }
 
     /// Format version of this module's bytecode.
-    async fn file_format_version(&self) -> u32 {
-        self.parsed.bytecode().version
+    async fn file_format_version(&self) -> Result<i32> {
+        try_into_int(self.parsed.bytecode().version).extend()
     }
 
     /// Modules that this module considers friends (these modules can access

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -219,7 +219,7 @@ impl MoveObject {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt53 {
+    pub(crate) async fn version(&self) -> Result<UInt53> {
         ObjectImpl(&self.super_).version().await
     }
 
@@ -240,7 +240,7 @@ impl MoveObject {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Result<Option<ObjectOwner>> {
         ObjectImpl(&self.super_).owner(ctx).await
     }
 

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -310,7 +310,7 @@ impl MovePackage {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt53 {
+    pub(crate) async fn version(&self) -> Result<UInt53> {
         ObjectImpl(&self.super_).version().await
     }
 
@@ -332,7 +332,7 @@ impl MovePackage {
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
     /// Packages are always Immutable.
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Result<Option<ObjectOwner>> {
         ObjectImpl(&self.super_).owner(ctx).await
     }
 
@@ -419,12 +419,12 @@ impl MovePackage {
     async fn package_at_version(
         &self,
         ctx: &Context<'_>,
-        version: u64,
+        version: UInt53,
     ) -> Result<Option<MovePackage>> {
         MovePackage::query(
             ctx,
             self.super_.address,
-            MovePackage::by_version(version, self.checkpoint_viewed_at_impl()),
+            MovePackage::by_version(version.into(), self.checkpoint_viewed_at_impl()),
         )
         .await
         .extend()
@@ -557,19 +557,22 @@ impl MovePackage {
     }
 
     /// The transitive dependencies of this package.
-    async fn linkage(&self) -> Option<Vec<Linkage>> {
+    async fn linkage(&self) -> Result<Option<Vec<Linkage>>> {
         let linkage = self
             .native
             .linkage_table()
             .iter()
-            .map(|(&runtime_id, upgrade_info)| Linkage {
-                original_id: runtime_id.into(),
-                upgraded_id: upgrade_info.upgraded_id.into(),
-                version: upgrade_info.upgraded_version.as_u64().into(),
+            .map(|(&runtime_id, upgrade_info)| {
+                Ok(Linkage {
+                    original_id: runtime_id.into(),
+                    upgraded_id: upgrade_info.upgraded_id.into(),
+                    version: upgrade_info.upgraded_version.as_u64().try_into()?,
+                })
             })
-            .collect();
+            .collect::<Result<_, Error>>()
+            .extend()?;
 
-        Some(linkage)
+        Ok(Some(linkage))
     }
 
     /// The (previous) versions of this package that introduced its types.

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -455,7 +455,7 @@ impl Object {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt53 {
+    pub(crate) async fn version(&self) -> Result<UInt53> {
         ObjectImpl(self).version().await
     }
 
@@ -477,7 +477,7 @@ impl Object {
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
     /// Immutable and Shared Objects do not have owners.
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Result<Option<ObjectOwner>> {
         ObjectImpl(self).owner(ctx).await
     }
 
@@ -622,8 +622,8 @@ impl Object {
 }
 
 impl ObjectImpl<'_> {
-    pub(crate) async fn version(&self) -> UInt53 {
-        self.0.version_impl().into()
+    pub(crate) async fn version(&self) -> Result<UInt53> {
+        UInt53::try_from(self.0.version_impl()).extend()
     }
 
     pub(crate) async fn status(&self) -> ObjectStatus {
@@ -634,7 +634,7 @@ impl ObjectImpl<'_> {
         Some(self.0.native_impl().digest().to_base58())
     }
 
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Result<Option<ObjectOwner>> {
         use NativeOwner as O;
 
         let native = self.0.native_impl();
@@ -642,15 +642,15 @@ impl ObjectImpl<'_> {
         match native.owner {
             O::Address(address) => {
                 let address = IotaAddress::from(address);
-                Some(ObjectOwner::Address(AddressOwner {
+                Ok(Some(ObjectOwner::Address(AddressOwner {
                     owner: Some(Owner {
                         address,
                         checkpoint_viewed_at: self.0.checkpoint_viewed_at,
                         root_version: None,
                     }),
-                }))
+                })))
             }
-            O::Immutable => Some(ObjectOwner::Immutable(Immutable { dummy: None })),
+            O::Immutable => Ok(Some(ObjectOwner::Immutable(Immutable { dummy: None }))),
             O::Object(address) => {
                 let parent = Object::query(
                     ctx,
@@ -661,11 +661,12 @@ impl ObjectImpl<'_> {
                 .ok()
                 .flatten();
 
-                Some(ObjectOwner::Parent(Box::new(Parent { parent })))
+                Ok(Some(ObjectOwner::Parent(Box::new(Parent { parent }))))
             }
-            O::Shared(initial_shared_version) => Some(ObjectOwner::Shared(Shared {
-                initial_shared_version: initial_shared_version.as_u64().into(),
-            })),
+            O::Shared(initial_shared_version) => Ok(Some(ObjectOwner::Shared(Shared {
+                initial_shared_version: UInt53::try_from(initial_shared_version.as_u64())
+                    .extend()?,
+            }))),
             _ => unimplemented!("a new Owner enum variant was added and needs to be handled"),
         }
     }
@@ -1140,7 +1141,7 @@ impl ObjectFilter {
                 .filter_map(|(id, v)| {
                     Some(ObjectKey {
                         object_id: *id,
-                        version: (*v)?.into(),
+                        version: (*v)?,
                     })
                 })
                 .collect();
@@ -1159,7 +1160,7 @@ impl ObjectFilter {
     /// Extract the Object ID and Key filters into one combined map from Object
     /// IDs in this filter, to the versions they should have (or None if the
     /// filter mentions the ID but no version for it).
-    fn keys(&self) -> Option<BTreeMap<IotaAddress, Option<u64>>> {
+    fn keys(&self) -> Option<BTreeMap<IotaAddress, Option<UInt53>>> {
         if self.object_keys.is_none() && self.object_ids.is_none() {
             return None;
         }
@@ -1168,7 +1169,7 @@ impl ObjectFilter {
             self.object_keys
                 .iter()
                 .flatten()
-                .map(|key| (key.object_id, Some(key.version.into())))
+                .map(|key| (key.object_id, Some(key.version)))
                 // Chain ID filters after Key filters so if there is overlap, we overwrite the key
                 // filter with the ID filter.
                 .chain(self.object_ids.iter().flatten().map(|id| (*id, None))),

--- a/crates/iota-graphql-rpc/src/types/object_read.rs
+++ b/crates/iota-graphql-rpc/src/types/object_read.rs
@@ -24,8 +24,8 @@ impl ObjectRead {
     }
 
     /// Version of the object being read.
-    async fn version(&self) -> UInt53 {
-        self.version_impl().into()
+    async fn version(&self) -> Result<UInt53> {
+        UInt53::try_from(self.version_impl()).extend()
     }
 
     /// 32-byte hash that identifies the object's contents at this version,

--- a/crates/iota-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/iota-graphql-rpc/src/types/protocol_config.rs
@@ -44,8 +44,8 @@ impl ProtocolConfigs {
     /// The protocol is not required to change on every epoch boundary, so the
     /// protocol version tracks which change to the protocol these configs
     /// are from.
-    async fn protocol_version(&self) -> UInt53 {
-        self.version.into()
+    async fn protocol_version(&self) -> Result<UInt53> {
+        UInt53::try_from(self.version).extend()
     }
 
     /// List all available feature flags and their values.  Feature flags are a

--- a/crates/iota-graphql-rpc/src/types/stake.rs
+++ b/crates/iota-graphql-rpc/src/types/stake.rs
@@ -169,7 +169,7 @@ impl StakedIota {
             .await
     }
 
-    pub(crate) async fn version(&self) -> UInt53 {
+    pub(crate) async fn version(&self) -> Result<UInt53> {
         ObjectImpl(&self.super_.super_).version().await
     }
 
@@ -190,7 +190,7 @@ impl StakedIota {
     }
 
     /// The owner type of this object: Immutable, Shared, Parent, Address
-    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
+    pub(crate) async fn owner(&self, ctx: &Context<'_>) -> Result<Option<ObjectOwner>> {
         ObjectImpl(&self.super_.super_).owner(ctx).await
     }
 

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -22,9 +22,9 @@ use crate::{
     types::{
         digest::Digest,
         event::Event,
+        int::try_into_int,
         subscription::filter::{SubscriptionEventFilter, SubscriptionTransactionFilter},
         transaction_block::{TransactionBlock, TransactionBlockInner},
-        uint53::UInt53,
     },
 };
 
@@ -39,7 +39,7 @@ const BROKER_CHANNEL_SIZE: NonZeroUsize =
 #[derive(SimpleObject, Clone)]
 pub(crate) struct Lagged {
     /// Number of missed payloads since the previous emitted one.
-    count: UInt53,
+    count: i32,
 }
 
 /// Possible responses from a subscription.
@@ -179,8 +179,7 @@ impl GraphQLStream {
                     }
                     Err(IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(count))) => {
                         warn!("subscriber lagging by {count} messages");
-                        UInt53::try_from(count)
-                            .map(|count| SubscriptionItem::Lagged(Lagged { count }))
+                        try_into_int(count).map(|count| SubscriptionItem::Lagged(Lagged { count }))
                     }
                     Err(err) => Err(err.into()),
                 };
@@ -215,8 +214,7 @@ impl GraphQLStream {
                     }
                     Err(IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(count))) => {
                         warn!("subscriber lagging by {count} messages");
-                        UInt53::try_from(count)
-                            .map(|count| SubscriptionItem::Lagged(Lagged { count }))
+                        try_into_int(count).map(|count| SubscriptionItem::Lagged(Lagged { count }))
                     }
                     Err(err) => Err(err.into()),
                 };

--- a/crates/iota-graphql-rpc/src/types/subscription/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/subscription/mod.rs
@@ -24,6 +24,7 @@ use crate::{
         event::Event,
         subscription::filter::{SubscriptionEventFilter, SubscriptionTransactionFilter},
         transaction_block::{TransactionBlock, TransactionBlockInner},
+        uint53::UInt53,
     },
 };
 
@@ -38,7 +39,7 @@ const BROKER_CHANNEL_SIZE: NonZeroUsize =
 #[derive(SimpleObject, Clone)]
 pub(crate) struct Lagged {
     /// Number of missed payloads since the previous emitted one.
-    count: u64,
+    count: UInt53,
 }
 
 /// Possible responses from a subscription.
@@ -178,7 +179,8 @@ impl GraphQLStream {
                     }
                     Err(IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(count))) => {
                         warn!("subscriber lagging by {count} messages");
-                        Ok(SubscriptionItem::Lagged(Lagged { count }))
+                        UInt53::try_from(count)
+                            .map(|count| SubscriptionItem::Lagged(Lagged { count }))
                     }
                     Err(err) => Err(err.into()),
                 };
@@ -213,7 +215,8 @@ impl GraphQLStream {
                     }
                     Err(IndexerStreamingError::Lagged(BroadcastStreamRecvError::Lagged(count))) => {
                         warn!("subscriber lagging by {count} messages");
-                        Ok(SubscriptionItem::Lagged(Lagged { count }))
+                        UInt53::try_from(count)
+                            .map(|count| SubscriptionItem::Lagged(Lagged { count }))
                     }
                     Err(err) => Err(err.into()),
                 };

--- a/crates/iota-graphql-rpc/src/types/system_parameters.rs
+++ b/crates/iota-graphql-rpc/src/types/system_parameters.rs
@@ -13,10 +13,10 @@ pub(crate) struct SystemParameters {
     pub duration_ms: Option<BigInt>,
 
     /// The minimum number of active validators that the system supports.
-    pub min_validator_count: Option<u64>,
+    pub min_validator_count: Option<i32>,
 
     /// The maximum number of active validators that the system supports.
-    pub max_validator_count: Option<u64>,
+    pub max_validator_count: Option<i32>,
 
     /// Minimum stake needed to become a new validator.
     pub min_validator_joining_stake: Option<BigInt>,

--- a/crates/iota-graphql-rpc/src/types/system_state_summary.rs
+++ b/crates/iota-graphql-rpc/src/types/system_state_summary.rs
@@ -11,10 +11,13 @@ use iota_types::iota_system_state::iota_system_state_summary::{
 };
 
 use super::validator_set::ValidatorSet;
-use crate::types::{
-    address::Address, big_int::BigInt, gas::GasCostSummary, iota_address::IotaAddress,
-    safe_mode::SafeMode, storage_fund::StorageFund, system_parameters::SystemParameters,
-    uint53::UInt53, validator::Validator,
+use crate::{
+    error::Error,
+    types::{
+        address::Address, big_int::BigInt, gas::GasCostSummary, int::try_into_int,
+        iota_address::IotaAddress, safe_mode::SafeMode, storage_fund::StorageFund,
+        system_parameters::SystemParameters, uint53::UInt53, validator::Validator,
+    },
 };
 
 #[derive(Clone, Debug)]
@@ -89,29 +92,36 @@ impl NativeStateValidatorInfo {
         total_stake: u64,
         checkpoint_viewed_at: u64,
         requested_for_epoch: u64,
-    ) -> ValidatorSet {
+    ) -> Result<ValidatorSet, Error> {
         let active_validators = self.to_validators_mut(checkpoint_viewed_at, requested_for_epoch);
         let committee_members = self
             .committee_members
             .into_iter()
             .map(|i| active_validators[i as usize].clone())
             .collect();
+        let pending_removals = self
+            .pending_removals
+            .into_iter()
+            .map(try_into_int)
+            .collect::<Result<Vec<_>, _>>()?;
 
-        ValidatorSet {
+        Ok(ValidatorSet {
             total_stake: Some(BigInt::from(total_stake)),
             active_validators: Some(active_validators),
             committee_members: Some(committee_members),
-            pending_removals: Some(self.pending_removals),
+            pending_removals: Some(pending_removals),
             pending_active_validators_id: Some(self.pending_active_validators_id.into()),
-            pending_active_validators_size: Some(self.pending_active_validators_size),
+            pending_active_validators_size: Some(try_into_int(
+                self.pending_active_validators_size,
+            )?),
             staking_pool_mappings_id: Some(self.staking_pool_mappings_id.into()),
-            staking_pool_mappings_size: Some(self.staking_pool_mappings_size),
+            staking_pool_mappings_size: Some(self.staking_pool_mappings_size.try_into()?),
             inactive_pools_id: Some(self.inactive_pools_id.into()),
-            inactive_pools_size: Some(self.inactive_pools_size),
+            inactive_pools_size: Some(self.inactive_pools_size.try_into()?),
             validator_candidates_id: Some(self.validator_candidates_id.into()),
-            validator_candidates_size: Some(self.validator_candidates_size),
+            validator_candidates_size: Some(self.validator_candidates_size.try_into()?),
             checkpoint_viewed_at,
-        }
+        })
     }
 }
 
@@ -223,8 +233,10 @@ impl SystemStateSummary {
     /// `0x3::iota::IotaSystemState` object.  This version changes whenever
     /// the fields contained in the system state object (held in a dynamic
     /// field attached to `0x5`) change.
-    async fn system_state_version(&self) -> Option<UInt53> {
-        Some(self.native.system_state_version().into())
+    async fn system_state_version(&self) -> Result<Option<UInt53>> {
+        Ok(Some(
+            UInt53::try_from(self.native.system_state_version()).extend()?,
+        ))
     }
 
     /// The total IOTA supply.
@@ -238,13 +250,13 @@ impl SystemStateSummary {
     }
 
     /// Details of the system that are decided during genesis.
-    async fn system_parameters(&self) -> Option<SystemParameters> {
-        Some(SystemParameters {
+    async fn system_parameters(&self) -> Result<Option<SystemParameters>> {
+        Ok(Some(SystemParameters {
             duration_ms: Some(BigInt::from(self.native.epoch_duration_ms())),
             // TODO min validator count can be extracted, but it requires some JSON RPC changes,
             // so we decided to wait on it for now.
             min_validator_count: None,
-            max_validator_count: Some(self.native.max_validator_count()),
+            max_validator_count: Some(try_into_int(self.native.max_validator_count()).extend()?),
             min_validator_joining_stake: Some(BigInt::from(
                 self.native.min_validator_joining_stake(),
             )),
@@ -257,6 +269,6 @@ impl SystemStateSummary {
             validator_low_stake_grace_period: Some(BigInt::from(
                 self.native.validator_low_stake_grace_period(),
             )),
-        })
+        }))
     }
 }

--- a/crates/iota-graphql-rpc/src/types/system_state_summary.rs
+++ b/crates/iota-graphql-rpc/src/types/system_state_summary.rs
@@ -115,11 +115,11 @@ impl NativeStateValidatorInfo {
                 self.pending_active_validators_size,
             )?),
             staking_pool_mappings_id: Some(self.staking_pool_mappings_id.into()),
-            staking_pool_mappings_size: Some(self.staking_pool_mappings_size.try_into()?),
+            staking_pool_mappings_size: Some(try_into_int(self.staking_pool_mappings_size)?),
             inactive_pools_id: Some(self.inactive_pools_id.into()),
-            inactive_pools_size: Some(self.inactive_pools_size.try_into()?),
+            inactive_pools_size: Some(try_into_int(self.inactive_pools_size)?),
             validator_candidates_id: Some(self.validator_candidates_id.into()),
-            validator_candidates_size: Some(self.validator_candidates_size.try_into()?),
+            validator_candidates_size: Some(try_into_int(self.validator_candidates_size)?),
             checkpoint_viewed_at,
         })
     }

--- a/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block/mod.rs
@@ -214,7 +214,7 @@ impl TransactionBlock {
     /// If the owner of the gas object(s) is not the same as the sender, the
     /// transaction block is a sponsored transaction block.
     #[graphql(complexity = "child_complexity")]
-    async fn gas_input(&self, ctx: &Context<'_>) -> Option<GasInput> {
+    async fn gas_input(&self, ctx: &Context<'_>) -> Result<Option<GasInput>> {
         let checkpoint_viewed_at =
             if matches!(self.inner, TransactionBlockInner::Checkpointed { .. })
                 && self.is_available()
@@ -229,9 +229,8 @@ impl TransactionBlock {
                 checkpoint
             };
 
-        Some(GasInput::from(
-            self.native().gas_data(),
-            checkpoint_viewed_at,
+        Ok(Some(
+            GasInput::try_from(self.native().gas_data(), checkpoint_viewed_at).extend()?,
         ))
     }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_effects.rs
@@ -119,8 +119,8 @@ impl TransactionBlockEffects {
     /// created or modified by this transaction, immediately following this
     /// transaction.
     #[graphql(complexity = 0)]
-    async fn lamport_version(&self) -> UInt53 {
-        self.native().lamport_version().as_u64().into()
+    async fn lamport_version(&self) -> Result<UInt53> {
+        UInt53::try_from(self.native().lamport_version().as_u64()).extend()
     }
 
     /// The reason for a transaction failure, if it did fail.
@@ -239,15 +239,13 @@ impl TransactionBlockEffects {
         connection.has_next_page = consistent_page.has_next_page;
 
         for c in consistent_page.cursors {
-            let result = UnchangedSharedObject::try_from(input_shared_objects[c.ix], c.c);
-            match result {
-                Ok(unchanged_shared_object) => {
-                    connection
-                        .edges
-                        .push(Edge::new(c.encode_cursor(), unchanged_shared_object));
-                }
-                Err(_shared_object_changed) => continue, /* Only add unchanged shared objects to
-                                                          * the connection. */
+            // Only unchanged shared objects are added to the connection.
+            if let Some(unchanged_shared_object) =
+                UnchangedSharedObject::try_from(input_shared_objects[c.ix], c.c).extend()?
+            {
+                connection
+                    .edges
+                    .push(Edge::new(c.encode_cursor(), unchanged_shared_object));
             }
         }
 
@@ -443,7 +441,7 @@ impl TransactionBlockEffects {
 
         Checkpoint::query(
             ctx,
-            CheckpointId::by_seq_num(stored_tx.checkpoint_sequence_number as u64),
+            CheckpointId::by_seq_num(stored_tx.checkpoint_sequence_number as u64).extend()?,
             self.checkpoint_viewed_at,
         )
         .await

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -28,8 +28,8 @@ impl ConsensusCommitPrologueTransaction {
     }
 
     /// Consensus round of the commit.
-    async fn round(&self) -> UInt53 {
-        self.native.round.into()
+    async fn round(&self) -> Result<UInt53> {
+        UInt53::try_from(self.native.round).extend()
     }
 
     /// Unix timestamp from consensus.

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -225,8 +225,8 @@ impl ChangeEpochTransaction {
     }
 
     /// The protocol version in effect in the new epoch.
-    async fn protocol_version(&self) -> UInt53 {
-        self.native.protocol_version.into()
+    async fn protocol_version(&self) -> Result<UInt53> {
+        UInt53::try_from(self.native.protocol_version).extend()
     }
 
     /// The total amount of gas charged for storage during the previous epoch
@@ -329,8 +329,8 @@ impl ChangeEpochTransactionV2 {
     }
 
     /// The protocol version in effect in the new epoch.
-    async fn protocol_version(&self) -> UInt53 {
-        self.protocol_version.as_u64().into()
+    async fn protocol_version(&self) -> Result<UInt53> {
+        UInt53::try_from(self.protocol_version.as_u64()).extend()
     }
 
     /// The total amount of gas charged for storage during the previous epoch

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -237,7 +237,8 @@ impl ProgrammableTransactionBlock {
         connection.has_next_page = consistent_page.has_next_page;
 
         for c in consistent_page.cursors {
-            let input = TransactionInput::from(self.native.inputs[c.ix].clone(), c.c);
+            let input =
+                TransactionInput::try_from(self.native.inputs[c.ix].clone(), c.c).extend()?;
             connection.edges.push(Edge::new(c.encode_cursor(), input));
         }
 
@@ -326,11 +327,11 @@ impl MoveCallTransaction {
 }
 
 impl TransactionInput {
-    fn from(argument: NativeCallArg, checkpoint_viewed_at: u64) -> Self {
+    fn try_from(argument: NativeCallArg, checkpoint_viewed_at: u64) -> Result<Self, Error> {
         use NativeCallArg as N;
         use TransactionInput as I;
 
-        match argument {
+        Ok(match argument {
             N::Pure(bytes) => I::Pure(Pure {
                 bytes: Base64::from(bytes),
             }),
@@ -348,7 +349,7 @@ impl TransactionInput {
                 mutable,
             }) => I::SharedInput(SharedInput {
                 address: id.into(),
-                initial_shared_version: initial_shared_version.as_u64().into(),
+                initial_shared_version: initial_shared_version.as_u64().try_into()?,
                 mutable,
             }),
 
@@ -360,7 +361,7 @@ impl TransactionInput {
             }),
 
             _ => unimplemented!("a new CallArg enum variant was added and needs to be handled"),
-        }
+        })
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -25,8 +25,8 @@ impl RandomnessStateUpdateTransaction {
     }
 
     /// Randomness round of the update.
-    async fn randomness_round(&self) -> UInt53 {
-        self.native.randomness_round.value().into()
+    async fn randomness_round(&self) -> Result<UInt53> {
+        UInt53::try_from(self.native.randomness_round.value()).extend()
     }
 
     /// Updated random bytes, encoded as Base64.
@@ -35,10 +35,7 @@ impl RandomnessStateUpdateTransaction {
     }
 
     /// The initial version the randomness object was shared at.
-    async fn randomness_obj_initial_shared_version(&self) -> UInt53 {
-        self.native
-            .randomness_obj_initial_shared_version
-            .as_u64()
-            .into()
+    async fn randomness_obj_initial_shared_version(&self) -> Result<UInt53> {
+        UInt53::try_from(self.native.randomness_obj_initial_shared_version.as_u64()).extend()
     }
 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/transaction_deny_rules_update.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/transaction_deny_rules_update.rs
@@ -25,8 +25,8 @@ impl TransactionDenyRulesUpdateTransaction {
     }
 
     /// Consensus round of the update.
-    async fn round(&self) -> UInt53 {
-        self.native.round.into()
+    async fn round(&self) -> Result<UInt53> {
+        UInt53::try_from(self.native.round).extend()
     }
 
     /// Addresses added to the sender-or-sponsor deny list.
@@ -120,10 +120,7 @@ impl TransactionDenyRulesUpdateTransaction {
     }
 
     /// The initial version the deny rules object was shared at.
-    async fn deny_rules_obj_initial_shared_version(&self) -> UInt53 {
-        self.native
-            .deny_rules_obj_initial_shared_version
-            .as_u64()
-            .into()
+    async fn deny_rules_obj_initial_shared_version(&self) -> Result<UInt53> {
+        UInt53::try_from(self.native.deny_rules_obj_initial_shared_version.as_u64()).extend()
     }
 }

--- a/crates/iota-graphql-rpc/src/types/uint53.rs
+++ b/crates/iota-graphql-rpc/src/types/uint53.rs
@@ -30,13 +30,8 @@ impl ScalarType for UInt53 {
             return Err(InputValueError::custom("Expected an unsigned integer."));
         };
 
-        if n > MAX_UINT53 {
-            return Err(InputValueError::custom(
-                "Value exceeds the maximum of UInt53 (2^53 - 1).",
-            ));
-        }
-
-        Ok(UInt53(n))
+        Self::try_from(n)
+            .map_err(|_| InputValueError::custom("Value exceeds the maximum of UInt53 (2^53 - 1)."))
     }
 
     fn to_value(&self) -> Value {

--- a/crates/iota-graphql-rpc/src/types/uint53.rs
+++ b/crates/iota-graphql-rpc/src/types/uint53.rs
@@ -51,7 +51,7 @@ impl TryFrom<u64> for UInt53 {
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         if value > MAX_UINT53 {
             return Err(Error::Internal(format!(
-                "value {value} exceeds the maximum of UInt53 (2^53 - 1)"
+                "Value {value} exceeds the maximum of UInt53 (2^53 - 1)"
             )));
         }
         Ok(Self(value))

--- a/crates/iota-graphql-rpc/src/types/uint53.rs
+++ b/crates/iota-graphql-rpc/src/types/uint53.rs
@@ -8,6 +8,11 @@ use async_graphql::*;
 use iota_sdk_types::Version;
 use iota_types::iota_serde::BigInt;
 
+use crate::error::Error;
+
+/// The largest value that a `UInt53` can hold, 2^53 - 1.
+const MAX_UINT53: u64 = (1 << 53) - 1;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) struct UInt53(u64);
 
@@ -25,6 +30,12 @@ impl ScalarType for UInt53 {
             return Err(InputValueError::custom("Expected an unsigned integer."));
         };
 
+        if n > MAX_UINT53 {
+            return Err(InputValueError::custom(
+                "Value exceeds the maximum of UInt53 (2^53 - 1).",
+            ));
+        }
+
         Ok(UInt53(n))
     }
 
@@ -39,9 +50,22 @@ impl fmt::Display for UInt53 {
     }
 }
 
-impl From<u64> for UInt53 {
-    fn from(value: u64) -> Self {
-        Self(value)
+impl TryFrom<u64> for UInt53 {
+    type Error = Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        if value > MAX_UINT53 {
+            return Err(Error::Internal(format!(
+                "value {value} exceeds the maximum of UInt53 (2^53 - 1)"
+            )));
+        }
+        Ok(Self(value))
+    }
+}
+
+impl From<u32> for UInt53 {
+    fn from(value: u32) -> Self {
+        Self(value.into())
     }
 }
 
@@ -66,5 +90,27 @@ impl From<UInt53> for u64 {
 impl From<UInt53> for i64 {
     fn from(value: UInt53) -> Self {
         value.0 as i64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bounds() {
+        assert_eq!(
+            <UInt53 as ScalarType>::parse(Value::Number(MAX_UINT53.into())).unwrap(),
+            UInt53(MAX_UINT53)
+        );
+        assert!(<UInt53 as ScalarType>::parse(Value::Number((MAX_UINT53 + 1).into())).is_err());
+        assert!(<UInt53 as ScalarType>::parse(Value::Number((-1).into())).is_err());
+        assert!(<UInt53 as ScalarType>::parse(Value::String("1".to_string())).is_err());
+    }
+
+    #[test]
+    fn try_from_bounds() {
+        assert_eq!(UInt53::try_from(MAX_UINT53).unwrap(), UInt53(MAX_UINT53));
+        assert!(UInt53::try_from(MAX_UINT53 + 1).is_err());
     }
 }

--- a/crates/iota-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/iota-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -5,7 +5,10 @@
 use async_graphql::*;
 use iota_sdk_types::InputSharedObject;
 
-use crate::types::{iota_address::IotaAddress, object_read::ObjectRead, uint53::UInt53};
+use crate::{
+    error::Error,
+    types::{iota_address::IotaAddress, object_read::ObjectRead, uint53::UInt53},
+};
 
 /// Details pertaining to shared objects that are referenced by but not changed
 /// by a transaction. This information is considered part of the effects,
@@ -53,43 +56,42 @@ pub(crate) struct SharedObjectCancelled {
     version: UInt53,
 }
 
-/// Error for converting from an `InputSharedObject`.
-pub(crate) struct SharedObjectChanged;
-
 impl UnchangedSharedObject {
+    /// Returns `Ok(None)` if the input shared object was mutated by the
+    /// transaction, as only unchanged shared objects are represented here.
     pub fn try_from(
         input: InputSharedObject,
         checkpoint_viewed_at: u64,
-    ) -> Result<Self, SharedObjectChanged> {
+    ) -> Result<Option<Self>, Error> {
         use InputSharedObject as I;
         use UnchangedSharedObject as U;
 
-        match input {
-            I::Mutate(_) => Err(SharedObjectChanged),
+        Ok(match input {
+            I::Mutate(_) => None,
 
-            I::ReadOnly(oref) => Ok(U::Read(SharedObjectRead {
+            I::ReadOnly(oref) => Some(U::Read(SharedObjectRead {
                 read: ObjectRead {
                     native: oref,
                     checkpoint_viewed_at,
                 },
             })),
 
-            I::ReadDeleted(object) => Ok(U::Delete(SharedObjectDelete {
+            I::ReadDeleted(object) => Some(U::Delete(SharedObjectDelete {
                 address: object.object_id.into(),
-                version: object.version.as_u64().into(),
+                version: object.version.as_u64().try_into()?,
                 mutable: false,
             })),
 
-            I::MutateDeleted(object) => Ok(U::Delete(SharedObjectDelete {
+            I::MutateDeleted(object) => Some(U::Delete(SharedObjectDelete {
                 address: object.object_id.into(),
-                version: object.version.as_u64().into(),
+                version: object.version.as_u64().try_into()?,
                 mutable: true,
             })),
 
-            I::Canceled(object) => Ok(U::Cancelled(SharedObjectCancelled {
+            I::Canceled(object) => Some(U::Cancelled(SharedObjectCancelled {
                 address: object.object_id.into(),
-                version: object.version.as_u64().into(),
+                version: object.version.as_u64().try_into()?,
             })),
-        }
+        })
     }
 }

--- a/crates/iota-graphql-rpc/src/types/validator.rs
+++ b/crates/iota-graphql-rpc/src/types/validator.rs
@@ -429,9 +429,9 @@ impl Validator {
             .iter()
             .map(|(_, exchange_rate)| exchange_rate);
 
-        let avg_apy = Some(mean_apy_from_exchange_rates(rates));
+        let apy_basis_points = mean_apy_from_exchange_rates(rates) * 10000.0;
 
-        Ok(avg_apy.map(|x| (x * 10000.0) as i32))
+        Ok(Some(try_into_int(apy_basis_points as i64)?))
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/validator.rs
+++ b/crates/iota-graphql-rpc/src/types/validator.rs
@@ -32,6 +32,7 @@ use crate::{
         big_int::BigInt,
         cursor::{JsonCursor, Page},
         epoch::Epoch,
+        int::try_into_int,
         iota_address::IotaAddress,
         move_object::MoveObject,
         object::Object,
@@ -247,15 +248,19 @@ impl Validator {
     }
 
     /// Number of exchange rates in the table.
-    async fn exchange_rates_size(&self) -> Option<UInt53> {
-        Some(self.validator_summary.exchange_rates_size.into())
+    async fn exchange_rates_size(&self) -> Result<Option<UInt53>> {
+        Ok(Some(
+            UInt53::try_from(self.validator_summary.exchange_rates_size).extend()?,
+        ))
     }
 
     /// The epoch at which this pool became active.
-    async fn staking_pool_activation_epoch(&self) -> Option<UInt53> {
+    async fn staking_pool_activation_epoch(&self) -> Result<Option<UInt53>> {
         self.validator_summary
             .staking_pool_activation_epoch
-            .map(UInt53::from)
+            .map(UInt53::try_from)
+            .transpose()
+            .extend()
     }
 
     /// The total number of IOTA tokens in this pool.
@@ -299,8 +304,10 @@ impl Validator {
 
     /// The voting power of this validator in basis points (e.g., 100 = 1%
     /// voting power).
-    async fn voting_power(&self) -> Option<u64> {
-        Some(self.validator_summary.voting_power)
+    async fn voting_power(&self) -> Result<Option<i32>> {
+        Ok(Some(
+            try_into_int(self.validator_summary.voting_power).extend()?,
+        ))
     }
 
     // TODO async fn stake_units(&self) -> Option<u64>{}
@@ -311,15 +318,17 @@ impl Validator {
     }
 
     /// The fee set by the validator for providing staking services.
-    async fn commission_rate(&self) -> Option<u64> {
-        Some(self.validator_summary.commission_rate)
+    async fn commission_rate(&self) -> Result<Option<i32>> {
+        Ok(Some(
+            try_into_int(self.validator_summary.commission_rate).extend()?,
+        ))
     }
 
     /// The effective fee charged by the validator for staking services.
     ///
     /// This is evaluated according to [IIP8](https://github.com/iotaledger/IIPs/blob/main/iips/IIP-0008/IIP-0008.md)
     /// for epochs with protocol version >= 20.
-    async fn effective_commission_rate(&self, ctx: &Context<'_>) -> Result<Option<u64>> {
+    async fn effective_commission_rate(&self, ctx: &Context<'_>) -> Result<Option<i32>> {
         let summary = &self.validator_summary;
         let epoch = Epoch::query(
             ctx,
@@ -331,10 +340,12 @@ impl Validator {
         if let Some(epoch) = epoch {
             if epoch.protocol_version() < PROTOCOL_VERSION_IIP8 {
                 // Pre IIP8
-                return Ok(Some(summary.commission_rate));
+                return Ok(Some(try_into_int(summary.commission_rate).extend()?));
             }
         }
-        Ok(Some(summary.commission_rate.max(summary.voting_power)))
+        Ok(Some(
+            try_into_int(summary.commission_rate.max(summary.voting_power)).extend()?,
+        ))
     }
 
     /// The total number of IOTA tokens in this pool plus
@@ -349,14 +360,16 @@ impl Validator {
     }
 
     /// The proposed next epoch fee for the validator's staking services.
-    async fn next_epoch_commission_rate(&self) -> Option<u64> {
-        Some(self.validator_summary.next_epoch_commission_rate)
+    async fn next_epoch_commission_rate(&self) -> Result<Option<i32>> {
+        Ok(Some(
+            try_into_int(self.validator_summary.next_epoch_commission_rate).extend()?,
+        ))
     }
 
     /// The number of epochs for which this validator has been below the
     /// low stake threshold.
-    async fn at_risk(&self) -> Option<UInt53> {
-        self.at_risk.map(UInt53::from)
+    async fn at_risk(&self) -> Result<Option<UInt53>> {
+        self.at_risk.map(UInt53::try_from).transpose().extend()
     }
 
     /// The addresses of other validators this validator has reported.
@@ -399,7 +412,7 @@ impl Validator {
 
     /// The APY of this validator in basis points. To get the APY in
     /// percentage, divide by 100.
-    async fn apy(&self, ctx: &Context<'_>) -> Result<Option<u64>, Error> {
+    async fn apy(&self, ctx: &Context<'_>) -> Result<Option<i32>, Error> {
         let DataLoader(loader) = ctx.data_unchecked();
         let exchange_rates = loader
             .load_one(self.requested_for_epoch)
@@ -418,7 +431,7 @@ impl Validator {
 
         let avg_apy = Some(mean_apy_from_exchange_rates(rates));
 
-        Ok(avg_apy.map(|x| (x * 10000.0) as u64))
+        Ok(avg_apy.map(|x| (x * 10000.0) as i32))
     }
 }
 

--- a/crates/iota-graphql-rpc/src/types/validator_set.rs
+++ b/crates/iota-graphql-rpc/src/types/validator_set.rs
@@ -13,7 +13,6 @@ use crate::{
         big_int::BigInt,
         cursor::{JsonCursor, Page},
         iota_address::IotaAddress,
-        uint53::UInt53,
         validator::Validator,
     },
 };
@@ -50,19 +49,19 @@ pub(crate) struct ValidatorSet {
     pub staking_pool_mappings_id: Option<IotaAddress>,
 
     /// Size of the stake pool mappings `Table`.
-    pub staking_pool_mappings_size: Option<UInt53>,
+    pub staking_pool_mappings_size: Option<i32>,
 
     /// Object ID of the `Table` storing the inactive staking pools.
     pub inactive_pools_id: Option<IotaAddress>,
 
     /// Size of the inactive pools `Table`.
-    pub inactive_pools_size: Option<UInt53>,
+    pub inactive_pools_size: Option<i32>,
 
     /// Object ID of the `Table` storing the validator candidates.
     pub validator_candidates_id: Option<IotaAddress>,
 
     /// Size of the validator candidates `Table`.
-    pub validator_candidates_size: Option<UInt53>,
+    pub validator_candidates_size: Option<i32>,
 
     #[graphql(skip)]
     pub checkpoint_viewed_at: u64,

--- a/crates/iota-graphql-rpc/src/types/validator_set.rs
+++ b/crates/iota-graphql-rpc/src/types/validator_set.rs
@@ -13,6 +13,7 @@ use crate::{
         big_int::BigInt,
         cursor::{JsonCursor, Page},
         iota_address::IotaAddress,
+        uint53::UInt53,
         validator::Validator,
     },
 };
@@ -31,7 +32,7 @@ pub(crate) struct ValidatorSet {
 
     /// Validators that are pending removal from the active validator set,
     /// expressed as indices in to `activeValidators`.
-    pub pending_removals: Option<Vec<u64>>,
+    pub pending_removals: Option<Vec<i32>>,
 
     // TODO: instead of returning the id and size of the table, potentially return the table
     // itself, paginated.
@@ -40,7 +41,7 @@ pub(crate) struct ValidatorSet {
     pub pending_active_validators_id: Option<IotaAddress>,
 
     /// Size of the pending active validators table.
-    pub pending_active_validators_size: Option<u64>,
+    pub pending_active_validators_size: Option<i32>,
 
     /// Object ID of the `Table` storing the mapping from staking pool ids to
     /// the addresses of the corresponding validators. This is needed
@@ -49,19 +50,19 @@ pub(crate) struct ValidatorSet {
     pub staking_pool_mappings_id: Option<IotaAddress>,
 
     /// Size of the stake pool mappings `Table`.
-    pub staking_pool_mappings_size: Option<u64>,
+    pub staking_pool_mappings_size: Option<UInt53>,
 
     /// Object ID of the `Table` storing the inactive staking pools.
     pub inactive_pools_id: Option<IotaAddress>,
 
     /// Size of the inactive pools `Table`.
-    pub inactive_pools_size: Option<u64>,
+    pub inactive_pools_size: Option<UInt53>,
 
     /// Object ID of the `Table` storing the validator candidates.
     pub validator_candidates_id: Option<IotaAddress>,
 
     /// Size of the validator candidates `Table`.
-    pub validator_candidates_size: Option<u64>,
+    pub validator_candidates_size: Option<UInt53>,
 
     #[graphql(skip)]
     pub checkpoint_viewed_at: u64,

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1681,7 +1681,7 @@ type Lagged {
 	"""
 	Number of missed payloads since the previous emitted one.
 	"""
-	count: UInt53!
+	count: Int!
 }
 
 """
@@ -5167,7 +5167,7 @@ type ValidatorSet {
 	"""
 	Size of the stake pool mappings `Table`.
 	"""
-	stakingPoolMappingsSize: UInt53
+	stakingPoolMappingsSize: Int
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""
@@ -5175,7 +5175,7 @@ type ValidatorSet {
 	"""
 	Size of the inactive pools `Table`.
 	"""
-	inactivePoolsSize: UInt53
+	inactivePoolsSize: Int
 	"""
 	Object ID of the `Table` storing the validator candidates.
 	"""
@@ -5183,7 +5183,7 @@ type ValidatorSet {
 	"""
 	Size of the validator candidates `Table`.
 	"""
-	validatorCandidatesSize: UInt53
+	validatorCandidatesSize: Int
 	"""
 	The current set of active validators.
 	"""

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1681,7 +1681,7 @@ type Lagged {
 	"""
 	Number of missed payloads since the previous emitted one.
 	"""
-	count: Int!
+	count: UInt53!
 }
 
 """
@@ -2423,7 +2423,7 @@ type MovePackage implements IObject & IOwner {
 	Fetch another version of this package (the package that shares this
 	package's original ID, but has the specified `version`).
 	"""
-	packageAtVersion(version: Int!): MovePackage
+	packageAtVersion(version: UInt53!): MovePackage
 	"""
 	Fetch all versions of this package (packages that share this package's
 	original ID), optionally bounding the versions exclusively from
@@ -5167,7 +5167,7 @@ type ValidatorSet {
 	"""
 	Size of the stake pool mappings `Table`.
 	"""
-	stakingPoolMappingsSize: Int
+	stakingPoolMappingsSize: UInt53
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""
@@ -5175,7 +5175,7 @@ type ValidatorSet {
 	"""
 	Size of the inactive pools `Table`.
 	"""
-	inactivePoolsSize: Int
+	inactivePoolsSize: UInt53
 	"""
 	Object ID of the `Table` storing the validator candidates.
 	"""
@@ -5183,7 +5183,7 @@ type ValidatorSet {
 	"""
 	Size of the validator candidates `Table`.
 	"""
-	validatorCandidatesSize: Int
+	validatorCandidatesSize: UInt53
 	"""
 	The current set of active validators.
 	"""


### PR DESCRIPTION
# Description of change

The GraphQL schema exposed several `u64`-backed fields as `Int`, which the GraphQL spec defines as signed 32-bit. Values above 2^31 - 1 would not match the declared type.

- Fields exposed as `Int` in the schema now use `i32` on the Rust side, so values are validated to fit in an `Int` instead of being sent under the wrong type.
- Fields exposed as `UInt53` are validated to fit in `UInt53` (2^53 - 1), both when parsing client input and when constructing the value from a `u64`.
- The `packageAtVersion(version:)` argument changed its schema type from `Int` to `UInt53`, so all three ways of selecting a package by its version (`package(version:)`, `packageVersions(filter:)` and `packageAtVersion(version:)`) accept the same range. JSON responses are unchanged, since `UInt53` is also serialized as a plain number.

## Links to any relevant issues

fixes #9292

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: the `packageAtVersion(version:)` argument now uses `UInt53`. Schema only change, data format on the wire is unchanged.

#### Breaking Changes Rollout

Affected Crates:

- iota-graphql-rpc

Required User Actions:

- Queries that pass the `packageAtVersion` argument through a GraphQL variable declared as `Int!` must declare it as `UInt53!`. Inline literals and JSON responses are unchanged.

