### PR TITLE
feat(starfish): bound the peers asked to push one author's headers

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -182,6 +182,11 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_enable_peer_responsiveness_ranking")]
     pub enable_peer_responsiveness_ranking: bool,
 
+    /// Ask only a bounded number of peers that recently supplied a new header
+    /// or referenced a missing one to push more headers from that author.
+    #[serde(default = "Parameters::default_enable_bounded_header_advertisement")]
+    pub enable_bounded_header_advertisement: bool,
+
     /// Port for the DAG visualizer gRPC server (localhost only).
     /// When set, starts a debugging server for real-time DAG visualization.
     /// Only has an effect when the `dag-visualizer` feature is compiled in.
@@ -486,6 +491,10 @@ impl Parameters {
         true
     }
 
+    pub(crate) fn default_enable_bounded_header_advertisement() -> bool {
+        true
+    }
+
     pub(crate) fn default_solid_commit_lag_threshold() -> u32 {
         // The healthy gap is a few rounds at most; 500 rounds (a few minutes of
         // commits) is far above live jitter yet caps how long a solidification
@@ -539,6 +548,8 @@ impl Default for Parameters {
                 Parameters::default_enable_starfish_speed_adaptive_acknowledgments(),
             enable_peer_responsiveness_ranking:
                 Parameters::default_enable_peer_responsiveness_ranking(),
+            enable_bounded_header_advertisement:
+                Parameters::default_enable_bounded_header_advertisement(),
             dag_visualizer_port: None,
             solid_commit_lag_threshold: Parameters::default_solid_commit_lag_threshold(),
             shard_budget_per_authority: Parameters::default_shard_budget_per_authority(),

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -56,6 +56,7 @@ enable_block_stream_reset_on_fast_sync_exit: true
 enable_commit_sync_peer_selection_by_commit_votes: true
 enable_starfish_speed_adaptive_acknowledgments: true
 enable_peer_responsiveness_ranking: true
+enable_bounded_header_advertisement: true
 dag_visualizer_port: ~
 solid_commit_lag_threshold: 500
 shard_budget_per_authority: 1000

--- a/crates/starfish/core/src/context.rs
+++ b/crates/starfish/core/src/context.rs
@@ -117,6 +117,8 @@ impl Context {
                 // for the many tests that rely on stable peer order; tests that
                 // exercise ranking opt in explicitly.
                 enable_peer_responsiveness_ranking: false,
+                // Tests enable bounded peer selection explicitly when needed.
+                enable_bounded_header_advertisement: false,
                 ..Default::default()
             },
             ProtocolConfig::get_for_max_version_UNSAFE(),

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -25,6 +25,7 @@ use crate::{
     context::Context,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
+    header_synchronizer::MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER,
     network::{BlockBundle, SerializedBlockBundleParts},
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
 };
@@ -47,7 +48,7 @@ const EVICTION_CHECK_INTERVAL: usize = 10_000;
 pub type Ancestors = Arc<[BlockRef]>;
 
 /// Tracks one author for which recent peer block bundles contained an accepted
-/// header or referenced a missing ancestor. Those peers are asked to keep
+/// header or referenced a missing ancestor, and the peers asked to keep
 /// including the author's headers in block bundles.
 #[derive(Clone, Default)]
 struct MissingAuthor {
@@ -58,6 +59,8 @@ struct MissingAuthor {
     /// exposed one as a missing ancestor, and the latest local own-block round
     /// when that happened. Does not contain the author.
     useful_peers: BTreeMap<AuthorityIndex, Round>,
+    /// Useful peers selected to push this author's headers.
+    selected_peers: BTreeSet<AuthorityIndex>,
 }
 
 /// Manages the global cordial knowledge state.
@@ -116,11 +119,10 @@ pub enum CordialKnowledgeMessage {
     /// Update internal state about shards from which authorities are useful for
     /// the local node
     UsefulShardsFromPeers(BTreeMap<AuthorityIndex, Round>),
-    /// Authors for which the peer's block bundle contained an accepted header
-    /// or referenced a missing ancestor.
+    /// Useful header information from one peer's block bundle.
     UsefulHeadersFromPeer {
         peer: AuthorityIndex,
-        authors: BTreeSet<AuthorityIndex>,
+        useful_header_authors: BTreeSet<AuthorityIndex>,
     },
 }
 
@@ -231,6 +233,8 @@ impl CordialKnowledgeHandle {
             }
         }
 
+        // Report what this peer's bundle said about headers, so the task can
+        // pick who to ask for the missing authors.
         // Accepted headers remain useful input even when they arrive before the
         // block that references them and therefore prevent a missing ancestor.
         let useful_header_authors = additional_block_headers
@@ -241,7 +245,7 @@ impl CordialKnowledgeHandle {
         if !useful_header_authors.is_empty() {
             let cordial_knowledge_message = CordialKnowledgeMessage::UsefulHeadersFromPeer {
                 peer,
-                authors: useful_header_authors,
+                useful_header_authors,
             };
             if let Err(TrySendError::Closed(_)) =
                 cordial_knowledge_sender.try_send(cordial_knowledge_message)
@@ -278,10 +282,8 @@ impl CordialKnowledge {
 
         let mut connection_knowledges = Vec::with_capacity(num_authorities);
 
-        for peer_index in 0..num_authorities {
-            let peer = AuthorityIndex::from(peer_index as u8);
-            let connection_knowledge =
-                ConnectionKnowledge::new(context.clone(), peer, dag_state.clone());
+        for _ in 0..num_authorities {
+            let connection_knowledge = ConnectionKnowledge::new(context.clone(), dag_state.clone());
 
             let connection_knowledge = Arc::new(RwLock::new(connection_knowledge));
 
@@ -470,8 +472,11 @@ impl CordialKnowledge {
             CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
                 self.handle_useful_shards_from(useful_shards_from_peer)
             }
-            CordialKnowledgeMessage::UsefulHeadersFromPeer { peer, authors } => {
-                self.handle_useful_headers_from_peer(peer, authors);
+            CordialKnowledgeMessage::UsefulHeadersFromPeer {
+                peer,
+                useful_header_authors,
+            } => {
+                self.handle_useful_headers_from_peer(peer, useful_header_authors);
                 None
             }
         }
@@ -513,23 +518,24 @@ impl CordialKnowledge {
         }
     }
 
-    /// Records authors for which the peer's block bundle contained an accepted
-    /// header or referenced a missing ancestor.
+    /// Record useful header information from one peer's block bundle.
     fn handle_useful_headers_from_peer(
         &mut self,
         peer: AuthorityIndex,
-        authors: BTreeSet<AuthorityIndex>,
+        useful_header_authors: BTreeSet<AuthorityIndex>,
     ) {
         let own_index = self.context.own_index;
         let latest_own_block_round = self.latest_own_block_round;
-        for author in authors {
+        for author in useful_header_authors {
             if author == own_index {
                 continue;
             }
-            let state = self.missing_authors[author].get_or_insert_default();
-            state.last_useful_round = latest_own_block_round;
+            let missing_author = self.missing_authors[author].get_or_insert_default();
+            missing_author.last_useful_round = latest_own_block_round;
             if peer != author && peer != own_index {
-                state.useful_peers.insert(peer, latest_own_block_round);
+                missing_author
+                    .useful_peers
+                    .insert(peer, latest_own_block_round);
             }
         }
     }
@@ -540,33 +546,57 @@ impl CordialKnowledge {
         &mut self,
         vec_connection_knowledge_msgs_batch: &mut [Vec<ConnectionKnowledgeMessage>],
     ) {
-        let own_index = self.context.own_index;
-        let latest_own_block_round = self.latest_own_block_round;
-        let is_stale = |round: Round| {
-            latest_own_block_round.saturating_sub(round) > MAX_ROUND_GAP_FOR_USEFUL_PARTS
-        };
+        self.refresh_missing_authors_and_peers();
 
-        let mut missing_authors: i64 = 0;
+        let bounded = self.context.parameters.enable_bounded_header_advertisement;
+        let latest_own_block_round = self.latest_own_block_round;
+        let mut missing_authors = 0;
         let mut useful_headers_from_peer: Vec<BTreeMap<AuthorityIndex, Round>> =
             vec![BTreeMap::new(); self.context.committee.size()];
-        for (author_index, state) in self.missing_authors.iter_mut().enumerate() {
-            if state
-                .as_ref()
-                .is_some_and(|missing| is_stale(missing.last_useful_round))
-            {
-                *state = None;
-            }
-            let Some(missing) = state else { continue };
-            missing.useful_peers.retain(|_, round| !is_stale(*round));
+        for (author_index, missing_author) in self.missing_authors.iter().enumerate() {
+            let Some(missing_author) = missing_author else {
+                continue;
+            };
             missing_authors += 1;
+            let asked_count = if bounded {
+                missing_author.selected_peers.len()
+            } else {
+                missing_author.useful_peers.len()
+            };
+            let unselected_useful_count = if bounded {
+                missing_author
+                    .useful_peers
+                    .len()
+                    .saturating_sub(missing_author.selected_peers.len())
+            } else {
+                0
+            };
             let author = AuthorityIndex::from(author_index as u8);
-            for peer in missing.useful_peers.keys() {
-                useful_headers_from_peer[peer.value()].insert(author, latest_own_block_round);
+            self.context
+                .metrics
+                .node_metrics
+                .cordial_knowledge_selected_peers
+                .with_label_values(&[self.context.authority_hostname(author)])
+                .set(asked_count as i64);
+            self.context
+                .metrics
+                .node_metrics
+                .cordial_knowledge_unselected_useful_peers
+                .with_label_values(&[self.context.authority_hostname(author)])
+                .set(unselected_useful_count as i64);
+            // Bounding asks the selected subset; otherwise every useful peer is asked.
+            if bounded {
+                for peer in &missing_author.selected_peers {
+                    useful_headers_from_peer[peer.value()].insert(author, latest_own_block_round);
+                }
+            } else {
+                for peer in missing_author.useful_peers.keys() {
+                    useful_headers_from_peer[peer.value()].insert(author, latest_own_block_round);
+                }
             }
         }
-
         for (peer_index, authors) in useful_headers_from_peer.into_iter().enumerate() {
-            if peer_index == own_index.value() {
+            if peer_index == self.context.own_index.value() {
                 continue;
             }
             let non_empty = !authors.is_empty();
@@ -583,6 +613,59 @@ impl CordialKnowledge {
             .node_metrics
             .cordial_knowledge_missing_authors
             .set(missing_authors);
+    }
+
+    /// Remove stale authors and useful peers. When bounded, select at most the
+    /// configured number of useful peers for each author.
+    fn refresh_missing_authors_and_peers(&mut self) {
+        let bounded = self.context.parameters.enable_bounded_header_advertisement;
+        let latest_own_block_round = self.latest_own_block_round;
+        let committee_size = self.context.committee.size();
+        let is_stale = |round: Round| {
+            latest_own_block_round.saturating_sub(round) > MAX_ROUND_GAP_FOR_USEFUL_PARTS
+        };
+
+        for author_index in 0..committee_size {
+            let author = AuthorityIndex::from(author_index as u8);
+            let Some(missing_author) = self.missing_authors[author_index].as_mut() else {
+                continue;
+            };
+
+            if is_stale(missing_author.last_useful_round) {
+                self.missing_authors[author_index] = None;
+                self.context
+                    .metrics
+                    .node_metrics
+                    .cordial_knowledge_selected_peers
+                    .with_label_values(&[self.context.authority_hostname(author)])
+                    .set(0);
+                self.context
+                    .metrics
+                    .node_metrics
+                    .cordial_knowledge_unselected_useful_peers
+                    .with_label_values(&[self.context.authority_hostname(author)])
+                    .set(0);
+                continue;
+            }
+
+            missing_author
+                .useful_peers
+                .retain(|_, round| !is_stale(*round));
+            if !bounded {
+                continue;
+            }
+
+            missing_author
+                .selected_peers
+                .retain(|peer| missing_author.useful_peers.contains_key(peer));
+            for peer in missing_author.useful_peers.keys() {
+                if missing_author.selected_peers.len() == MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER
+                {
+                    break;
+                }
+                missing_author.selected_peers.insert(*peer);
+            }
+        }
     }
 
     /// Prepare useful authors message for each connection knowledge.
@@ -834,7 +917,6 @@ pub enum ConnectionKnowledgeMessage {
 /// Receives updates from the global cordial knowledge
 pub struct ConnectionKnowledge {
     context: Arc<Context>,
-    peer: AuthorityIndex,
     dag_state: Arc<RwLock<DagState>>,
     /// Keeps track of which headers are not known by the peer yet.
     headers_not_known: Vec<BTreeMap<Round, AHashSet<BlockRef>>>,
@@ -855,16 +937,11 @@ pub struct ConnectionKnowledge {
 }
 
 impl ConnectionKnowledge {
-    pub fn new(
-        context: Arc<Context>,
-        peer: AuthorityIndex,
-        dag_state: Arc<RwLock<DagState>>,
-    ) -> Self {
+    pub fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
         let num_authorities = context.committee.size();
 
         Self {
             dag_state,
-            peer,
             last_useful_headers_to_peer_round: vec![None; num_authorities],
             last_useful_shards_to_peer_round: vec![None; num_authorities],
             last_useful_headers_from_peer_round: vec![None; num_authorities],
@@ -1196,17 +1273,6 @@ impl ConnectionKnowledge {
             .collect::<BTreeSet<AuthorityIndex>>();
 
         // Report useful authors
-        let peer_hostname = self.context.authority_hostname(self.peer);
-        for author in &useful_headers_authors_from_peer {
-            let author_hostname = self.context.authority_hostname(*author);
-            self.context
-                .metrics
-                .node_metrics
-                .cordial_knowledge_useful_headers_authors
-                .with_label_values(&[peer_hostname, author_hostname])
-                .inc();
-        }
-
         for author in &useful_shards_authors_from_peer {
             let author_hostname = self.context.authority_hostname(*author);
             self.context
@@ -1310,6 +1376,7 @@ mod tests {
     use std::sync::Arc;
 
     use parking_lot::RwLock;
+    use starfish_config::Parameters;
     use tokio::time::sleep;
 
     use super::*;
@@ -1358,6 +1425,54 @@ mod tests {
             AuthorityIndex::new_for_test(peer),
             BTreeSet::from([AuthorityIndex::new_for_test(missing_author)]),
         );
+    }
+
+    /// A worker with bounded peer selection.
+    fn bounded_cordial_knowledge_for_test(
+        validators: usize,
+    ) -> (CordialKnowledge, Vec<Arc<RwLock<ConnectionKnowledge>>>) {
+        let (context, _key_pairs) = Context::new_for_test(validators);
+        let parameters = Parameters {
+            enable_bounded_header_advertisement: true,
+            ..context.parameters.clone()
+        };
+        let context = Arc::new(context.with_parameters(parameters));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        CordialKnowledge::new_for_test(context, dag_state)
+    }
+
+    fn selected_peers_gauge(cordial_knowledge: &CordialKnowledge, author: AuthorityIndex) -> i64 {
+        cordial_knowledge
+            .context
+            .metrics
+            .node_metrics
+            .cordial_knowledge_selected_peers
+            .with_label_values(&[cordial_knowledge.context.authority_hostname(author)])
+            .get()
+    }
+
+    fn unselected_useful_peers_gauge(
+        cordial_knowledge: &CordialKnowledge,
+        author: AuthorityIndex,
+    ) -> i64 {
+        cordial_knowledge
+            .context
+            .metrics
+            .node_metrics
+            .cordial_knowledge_unselected_useful_peers
+            .with_label_values(&[cordial_knowledge.context.authority_hostname(author)])
+            .get()
+    }
+
+    fn selected_peers(
+        cordial_knowledge: &CordialKnowledge,
+        author: AuthorityIndex,
+    ) -> Vec<AuthorityIndex> {
+        cordial_knowledge.missing_authors[author]
+            .as_ref()
+            .map(|missing_author| missing_author.selected_peers.iter().copied().collect())
+            .unwrap_or_default()
     }
 
     fn asks_nothing(connection_knowledge: &Arc<RwLock<ConnectionKnowledge>>) -> bool {
@@ -1473,8 +1588,8 @@ mod tests {
         report_missing(&mut cordial_knowledge, 3, own_index.value() as u8);
 
         assert!(cordial_knowledge.missing_authors[own_index].is_none());
-        let state = cordial_knowledge.missing_authors[author].as_ref().unwrap();
-        assert!(!state.useful_peers.contains_key(&author));
+        let missing_author = cordial_knowledge.missing_authors[author].as_ref().unwrap();
+        assert!(!missing_author.useful_peers.contains_key(&author));
         let batch = recompute(&mut cordial_knowledge);
         assert!(batch.iter().all(|msgs| msgs.is_empty()));
     }
@@ -1496,11 +1611,14 @@ mod tests {
                 .process_vec_messages(msgs);
         }
         assert!(!asks_nothing(&connection_knowledges[1]));
+        assert_eq!(selected_peers_gauge(&cordial_knowledge, author), 2);
 
         cordial_knowledge.latest_own_block_round = 10 + MAX_ROUND_GAP_FOR_USEFUL_PARTS + 1;
         let mut batch = recompute(&mut cordial_knowledge);
 
         assert!(cordial_knowledge.missing_authors[author].is_none());
+        assert_eq!(selected_peers_gauge(&cordial_knowledge, author), 0);
+        assert_eq!(unselected_useful_peers_gauge(&cordial_knowledge, author), 0);
         for index in [1, 2] {
             assert_eq!(asked_authors(&batch[index]), Some(BTreeSet::new()));
             let msgs = std::mem::take(&mut batch[index]);
@@ -1545,15 +1663,171 @@ mod tests {
 
         report_missing(&mut cordial_knowledge, 1, 4);
 
-        let state = cordial_knowledge.missing_authors[author].as_ref().unwrap();
-        assert_eq!(state.last_useful_round, 42);
-        assert_eq!(state.useful_peers[&AuthorityIndex::new_for_test(1)], 42);
+        let missing_author = cordial_knowledge.missing_authors[author].as_ref().unwrap();
+        assert_eq!(missing_author.last_useful_round, 42);
+        assert_eq!(
+            missing_author.useful_peers[&AuthorityIndex::new_for_test(1)],
+            42
+        );
         let batch = recompute(&mut cordial_knowledge);
         match &batch[1][..] {
             [ConnectionKnowledgeMessage::SetUsefulHeadersFromPeer(set)] => {
                 assert_eq!(set[&author], 42);
             }
             other => panic!("unexpected messages: {other:?}"),
+        }
+    }
+
+    /// At most MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER useful peers are asked
+    /// for one author.
+    #[tokio::test]
+    async fn test_at_most_three_peers_are_asked_for_one_author() {
+        let (mut cordial_knowledge, _connection_knowledges) =
+            bounded_cordial_knowledge_for_test(10);
+        cordial_knowledge.latest_own_block_round = 10;
+        let author = AuthorityIndex::new_for_test(9);
+
+        for peer in 1..9 {
+            report_missing(&mut cordial_knowledge, peer, 9);
+        }
+        let batch = recompute(&mut cordial_knowledge);
+
+        let missing_author = cordial_knowledge.missing_authors[author].as_ref().unwrap();
+        assert_eq!(
+            missing_author.selected_peers.len(),
+            MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER
+        );
+        assert!(
+            missing_author
+                .selected_peers
+                .iter()
+                .all(|peer| missing_author.useful_peers.contains_key(peer))
+        );
+        assert_eq!(
+            selected_peers_gauge(&cordial_knowledge, author),
+            MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER as i64
+        );
+        assert_eq!(unselected_useful_peers_gauge(&cordial_knowledge, author), 5);
+        let asked = batch
+            .iter()
+            .filter(|msgs| asked_authors(msgs).is_some_and(|set| set.contains(&author)))
+            .count();
+        assert_eq!(asked, MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER);
+    }
+
+    /// Without the bound every referencing peer is asked, as before.
+    #[tokio::test]
+    async fn test_every_referencing_peer_is_asked_when_unbounded() {
+        let (mut cordial_knowledge, _connection_knowledges) = cordial_knowledge_for_test(10);
+        cordial_knowledge.latest_own_block_round = 10;
+        let author = AuthorityIndex::new_for_test(9);
+
+        for peer in 1..9 {
+            report_missing(&mut cordial_knowledge, peer, 9);
+        }
+        let batch = recompute(&mut cordial_knowledge);
+
+        assert!(selected_peers(&cordial_knowledge, author).is_empty());
+        assert_eq!(selected_peers_gauge(&cordial_knowledge, author), 8);
+        assert_eq!(unselected_useful_peers_gauge(&cordial_knowledge, author), 0);
+        let asked = batch
+            .iter()
+            .filter(|msgs| asked_authors(msgs).is_some_and(|set| set.contains(&author)))
+            .count();
+        assert_eq!(asked, 8);
+    }
+
+    /// Only peers that supplied or referenced an author's headers are selected.
+    #[tokio::test]
+    async fn test_only_useful_peers_are_selected() {
+        let (mut cordial_knowledge, _connection_knowledges) =
+            bounded_cordial_knowledge_for_test(10);
+        cordial_knowledge.latest_own_block_round = 10;
+        let author = AuthorityIndex::new_for_test(9);
+
+        report_missing(&mut cordial_knowledge, 4, 9);
+        report_missing(&mut cordial_knowledge, 6, 9);
+        recompute(&mut cordial_knowledge);
+
+        assert_eq!(
+            selected_peers(&cordial_knowledge, author),
+            [4, 6].map(AuthorityIndex::new_for_test)
+        );
+        assert_eq!(unselected_useful_peers_gauge(&cordial_knowledge, author), 0);
+
+        let (mut cordial_knowledge, _connection_knowledges) =
+            bounded_cordial_knowledge_for_test(10);
+        cordial_knowledge.latest_own_block_round = 10;
+        for peer in [2, 4, 6, 8] {
+            report_missing(&mut cordial_knowledge, peer, 9);
+        }
+        recompute(&mut cordial_knowledge);
+
+        let chosen = selected_peers(&cordial_knowledge, author);
+        assert_eq!(chosen.len(), MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER);
+        assert!(
+            chosen
+                .iter()
+                .all(|peer| [2, 4, 6, 8].contains(&(peer.value() as u8)))
+        );
+        assert_eq!(unselected_useful_peers_gauge(&cordial_knowledge, author), 1);
+    }
+
+    /// A selected peer is removed when it is no longer useful.
+    #[tokio::test]
+    async fn test_selected_peer_is_replaced_after_usefulness_expires() {
+        let (mut cordial_knowledge, _connection_knowledges) = bounded_cordial_knowledge_for_test(6);
+        cordial_knowledge.latest_own_block_round = 10;
+        let author = AuthorityIndex::new_for_test(5);
+
+        report_missing(&mut cordial_knowledge, 1, 5);
+        report_missing(&mut cordial_knowledge, 2, 5);
+        report_missing(&mut cordial_knowledge, 3, 5);
+        recompute(&mut cordial_knowledge);
+        assert_eq!(
+            selected_peers(&cordial_knowledge, author),
+            [1, 2, 3].map(AuthorityIndex::new_for_test)
+        );
+
+        cordial_knowledge.latest_own_block_round = 30;
+        report_missing(&mut cordial_knowledge, 2, 5);
+        report_missing(&mut cordial_knowledge, 3, 5);
+        report_missing(&mut cordial_knowledge, 4, 5);
+        cordial_knowledge.latest_own_block_round = 10 + MAX_ROUND_GAP_FOR_USEFUL_PARTS + 1;
+        recompute(&mut cordial_knowledge);
+
+        assert_eq!(
+            selected_peers(&cordial_knowledge, author),
+            [2, 3, 4].map(AuthorityIndex::new_for_test)
+        );
+    }
+
+    /// Selected useful peers are not redrawn from one own block to the next.
+    #[tokio::test]
+    async fn test_a_healthy_choice_is_not_redrawn() {
+        let (mut cordial_knowledge, _connection_knowledges) = bounded_cordial_knowledge_for_test(8);
+        cordial_knowledge.latest_own_block_round = 10;
+        let author = AuthorityIndex::new_for_test(7);
+
+        for peer in 1..=4 {
+            report_missing(&mut cordial_knowledge, peer, 7);
+        }
+        recompute(&mut cordial_knowledge);
+        let chosen = selected_peers(&cordial_knowledge, author);
+
+        for round in 11..=20 {
+            cordial_knowledge.latest_own_block_round = round;
+            for peer in 1..=4 {
+                report_missing(&mut cordial_knowledge, peer, 7);
+            }
+            let batch = recompute(&mut cordial_knowledge);
+            assert_eq!(selected_peers(&cordial_knowledge, author), chosen);
+            for peer in &chosen {
+                assert_eq!(
+                    asked_authors(&batch[peer.value()]),
+                    Some(BTreeSet::from([author]))
+                );
+            }
         }
     }
 

--- a/crates/starfish/core/src/header_synchronizer.rs
+++ b/crates/starfish/core/src/header_synchronizer.rs
@@ -68,8 +68,9 @@ const FETCH_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(4_000);
 
 /// The maximum number of authorities from which we will try to periodically
 /// fetch block header at the same moment. The guard will protect that we will
-/// not ask from more than this number of authorities at the same time.
-const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER: usize = 3;
+/// not ask from more than this number of authorities at the same time. Cordial
+/// knowledge shares it to bound the peers asked to push one author's headers.
+pub(crate) const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER: usize = 3;
 
 /// The maximum number of authorities from which the live synchronizer will try
 /// to fetch block headers at the same moment. This is lower than the periodic

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -234,9 +234,10 @@ pub(crate) struct NodeMetrics {
     pub(crate) accepted_block_headers_round_gap: HistogramVec,
     pub(crate) core_skipped_headers: IntCounterVec,
     pub(crate) core_skipped_transactions: IntCounterVec,
-    pub(crate) cordial_knowledge_useful_headers_authors: IntCounterVec,
     pub(crate) cordial_knowledge_useful_shards_authors: IntCounterVec,
     pub(crate) cordial_knowledge_missing_authors: IntGauge,
+    pub(crate) cordial_knowledge_selected_peers: IntGaugeVec,
+    pub(crate) cordial_knowledge_unselected_useful_peers: IntGaugeVec,
     pub(crate) dag_state_recent_transactions: IntGauge,
     pub(crate) dag_state_recent_headers: IntGauge,
     pub(crate) dag_state_recent_shards: IntGauge,
@@ -770,13 +771,6 @@ impl NodeMetrics {
                 &["peer", "method"],
                 registry,
             ).unwrap(),
-            cordial_knowledge_useful_headers_authors: register_int_counter_vec_with_registry!(
-                "cordial_knowledge_useful_headers_authors",
-                "Useful authors for pushing headers to the local node",
-                &["peer", "author"],
-                registry;
-                MetricLevel::Warn,
-            ).unwrap(),
             cordial_knowledge_useful_shards_authors: register_int_counter_vec_with_registry!(
                 "cordial_knowledge_useful_shards_authors",
                 "Useful authors for pushing shards to the local node",
@@ -787,6 +781,20 @@ impl NodeMetrics {
             cordial_knowledge_missing_authors: register_int_gauge_with_registry!(
                 "cordial_knowledge_missing_authors",
                 "Authors whose blocks are currently missing and whose headers peers are asked to push",
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            cordial_knowledge_selected_peers: register_int_gauge_vec_with_registry!(
+                "cordial_knowledge_selected_peers",
+                "Peers currently selected to push this author's headers",
+                &["author"],
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            cordial_knowledge_unselected_useful_peers: register_int_gauge_vec_with_registry!(
+                "cordial_knowledge_unselected_useful_peers",
+                "Useful peers not selected to push this author's headers",
+                &["author"],
                 registry;
                 MetricLevel::Warn,
             ).unwrap(),

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -8658,321 +8658,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Number of  requests about useful authors from host to peers",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "cellOptions": {
-                  "type": "color-background"
-                },
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "transparent"
-                  },
-                  {
-                    "color": "light-yellow",
-                    "value": 0.02
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  },
-                  {
-                    "color": "red",
-                    "value": 2
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 24,
-            "x": 0,
-            "y": 334
-          },
-          "id": 225,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": [
-              {
-                "desc": false,
-                "displayName": "peer\\host"
-              }
-            ]
-          },
-          "pluginVersion": "10.1.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "disableTextWrap": false,
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum by(host, peer)(\n  rate(consensus_cordial_knowledge_useful_headers_authors[2m])\n)\n/\nignoring(peer) group_left()\nsum by(host)(\n  rate(consensus_accepted_block_headers{source=\"own\"}[2m])\n)",
-              "format": "table",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
-            }
-          ],
-          "title": "Average useful headers by host to peer",
-          "transformations": [
-            {
-              "id": "groupingToMatrix",
-              "options": {
-                "columnField": "host",
-                "rowField": "peer",
-                "valueField": "Value"
-              }
-            }
-          ],
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "description": "Number of requests about useful shard from hosts",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "cellOptions": {
-                  "type": "color-background"
-                },
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "transparent"
-                  },
-                  {
-                    "color": "light-yellow",
-                    "value": 0.02
-                  },
-                  {
-                    "color": "orange",
-                    "value": 2
-                  },
-                  {
-                    "color": "red",
-                    "value": 3
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 24,
-            "x": 0,
-            "y": 345
-          },
-          "id": 241,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": [
-              {
-                "desc": true,
-                "displayName": "Value"
-              }
-            ]
-          },
-          "pluginVersion": "10.1.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "disableTextWrap": false,
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum by(host)(\n  rate(consensus_cordial_knowledge_useful_shards_authors[2m])\n)\n/\nsum by(host)(\n  rate(consensus_accepted_block_headers{source=\"own\"}[2m])\n)\n/\nsum by (host) (consensus_subscribed_by == 1)",
-              "format": "table",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
-            }
-          ],
-          "title": "Average useful shards by host",
-          "transformations": [
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Time": true
-                },
-                "indexByName": {},
-                "renameByName": {}
-              }
-            },
-            {
-              "id": "groupingToMatrix",
-              "options": {
-                "columnField": "host",
-                "rowField": "peer",
-                "valueField": "Value"
-              }
-            }
-          ],
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "description": "How many times given author was reported as useful header",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 356
-          },
-          "id": 226,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "disableTextWrap": false,
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum by (author) (rate(consensus_cordial_knowledge_useful_headers_authors[2m]))",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
-            }
-          ],
-          "title": "Rate messages useful headers by author",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "description": "Number of peers with useful shards",
+          "description": "Rate at which validators request shards from each author.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -9030,7 +8716,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 356
+            "y": 334
           },
           "id": 218,
           "options": {
@@ -9058,13 +8744,313 @@
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "__auto",
+              "legendFormat": "{{author}}",
               "range": true,
               "refId": "A",
               "useBackend": false
             }
           ],
-          "title": "Rate messages useful shards by host",
+          "title": "Useful shard authors over time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Peer selections across validators for each author. A peer selected by several validators is counted once per validator.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 334
+          },
+          "id": 432,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by (author) (consensus_cordial_knowledge_selected_peers)",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{author}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Peers asked to push additional headers",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Useful peers that are not selected because the per-author limit has been reached.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 342
+          },
+          "id": 433,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by (author) (consensus_cordial_knowledge_unselected_useful_peers)",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{author}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Useful peers not selected to push headers",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Authors whose blocks are currently missing for each validator. One validator with many missing authors is falling behind.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 342
+          },
+          "id": 434,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "consensus_cordial_knowledge_missing_authors",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Missing authors per validator",
           "type": "timeseries"
         }
       ],
@@ -9077,7 +9063,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 365
+        "y": 354
       },
       "id": 107,
       "panels": [
@@ -9145,7 +9131,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 365
+            "y": 354
           },
           "id": 158,
           "options": {
@@ -9240,7 +9226,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 365
+            "y": 354
           },
           "id": 232,
           "options": {
@@ -9322,7 +9308,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 373
+            "y": 362
           },
           "id": 237,
           "options": {
@@ -9452,7 +9438,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 373
+            "y": 362
           },
           "id": 238,
           "options": {
@@ -9547,7 +9533,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 381
+            "y": 370
           },
           "id": 236,
           "options": {
@@ -9641,7 +9627,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 381
+            "y": 370
           },
           "id": 120,
           "options": {
@@ -9683,7 +9669,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 390
+        "y": 379
       },
       "id": 179,
       "panels": [
@@ -9748,7 +9734,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 390
+            "y": 379
           },
           "id": 183,
           "options": {
@@ -9842,7 +9828,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 390
+            "y": 379
           },
           "id": 184,
           "options": {
@@ -9940,7 +9926,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 398
+            "y": 387
           },
           "id": 180,
           "options": {
@@ -9998,7 +9984,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 406
+            "y": 395
           },
           "id": 254,
           "options": {
@@ -10121,7 +10107,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 406
+            "y": 395
           },
           "id": 255,
           "options": {
@@ -10219,7 +10205,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 398
+            "y": 387
           },
           "id": 181,
           "options": {
@@ -10312,7 +10298,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 414
+            "y": 403
           },
           "id": 211,
           "options": {
@@ -10410,7 +10396,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 414
+            "y": 403
           },
           "id": 185,
           "options": {
@@ -10487,7 +10473,7 @@
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 422
+            "y": 411
           },
           "id": 231,
           "options": {
@@ -10572,7 +10558,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 435
+        "y": 424
       },
       "id": 200,
       "panels": [
@@ -10638,7 +10624,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 435
+            "y": 424
           },
           "id": 201,
           "options": {
@@ -10732,7 +10718,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 435
+            "y": 424
           },
           "id": 202,
           "options": {
@@ -10826,7 +10812,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 443
+            "y": 432
           },
           "id": 203,
           "options": {
@@ -10920,7 +10906,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 443
+            "y": 432
           },
           "id": 204,
           "options": {
@@ -11018,7 +11004,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 451
+            "y": 440
           },
           "id": 205,
           "options": {
@@ -11116,7 +11102,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 451
+            "y": 440
           },
           "id": 206,
           "options": {
@@ -11214,7 +11200,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 459
+            "y": 448
           },
           "id": 300,
           "options": {
@@ -11260,7 +11246,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 460
+        "y": 449
       },
       "id": 169,
       "panels": [
@@ -11327,7 +11313,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 460
+            "y": 449
           },
           "id": 172,
           "options": {
@@ -11477,7 +11463,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 460
+            "y": 449
           },
           "id": 189,
           "options": {
@@ -11576,7 +11562,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 468
+            "y": 457
           },
           "id": 174,
           "options": {
@@ -11675,7 +11661,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 468
+            "y": 457
           },
           "id": 190,
           "options": {
@@ -11774,7 +11760,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 476
+            "y": 465
           },
           "id": 176,
           "options": {
@@ -11873,7 +11859,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 476
+            "y": 465
           },
           "id": 191,
           "options": {
@@ -11976,7 +11962,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 502
+            "y": 491
           },
           "id": 175,
           "options": {
@@ -12076,7 +12062,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 502
+            "y": 491
           },
           "id": 192,
           "options": {
@@ -12178,7 +12164,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 510
+            "y": 499
           },
           "id": 173,
           "options": {
@@ -12279,7 +12265,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 510
+            "y": 499
           },
           "id": 193,
           "options": {
@@ -12379,7 +12365,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 518
+            "y": 507
           },
           "id": 178,
           "options": {
@@ -12481,7 +12467,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 518
+            "y": 507
           },
           "id": 177,
           "options": {
@@ -12581,7 +12567,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 526
+            "y": 515
           },
           "id": 186,
           "options": {
@@ -12677,7 +12663,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 526
+            "y": 515
           },
           "id": 170,
           "options": {
@@ -12724,7 +12710,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 535
+        "y": 524
       },
       "id": 95,
       "panels": [
@@ -12790,7 +12776,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 535
+            "y": 524
           },
           "id": 138,
           "options": {
@@ -12889,7 +12875,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 535
+            "y": 524
           },
           "id": 171,
           "options": {
@@ -12988,7 +12974,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 543
+            "y": 532
           },
           "id": 140,
           "options": {
@@ -13087,7 +13073,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 543
+            "y": 532
           },
           "id": 160,
           "options": {
@@ -13191,7 +13177,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 551
+            "y": 540
           },
           "id": 118,
           "options": {
@@ -13286,7 +13272,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 551
+            "y": 540
           },
           "id": 161,
           "options": {
@@ -13387,7 +13373,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 559
+            "y": 548
           },
           "id": 139,
           "options": {
@@ -13488,7 +13474,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 559
+            "y": 548
           },
           "id": 106,
           "options": {
@@ -13589,7 +13575,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 567
+            "y": 556
           },
           "id": 163,
           "options": {
@@ -13690,7 +13676,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 567
+            "y": 556
           },
           "id": 162,
           "options": {
@@ -13791,7 +13777,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 575
+            "y": 564
           },
           "id": 105,
           "options": {
@@ -13892,7 +13878,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 575
+            "y": 564
           },
           "id": 141,
           "options": {
@@ -13954,7 +13940,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 583
+            "y": 572
           },
           "id": 229,
           "options": {
@@ -14079,7 +14065,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 583
+            "y": 572
           },
           "id": 230,
           "options": {
@@ -14127,7 +14113,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 592
+        "y": 581
       },
       "id": 228,
       "panels": [
@@ -14216,7 +14202,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 592
+            "y": 581
           },
           "id": 78,
           "options": {
@@ -14333,7 +14319,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 592
+            "y": 581
           },
           "id": 92,
           "options": {
@@ -14451,7 +14437,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 600
+            "y": 589
           },
           "id": 76,
           "options": {
@@ -14568,7 +14554,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 600
+            "y": 589
           },
           "id": 136,
           "options": {
@@ -14686,7 +14672,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 608
+            "y": 597
           },
           "id": 137,
           "options": {
@@ -14783,7 +14769,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 608
+            "y": 597
           },
           "id": 338,
           "options": {
@@ -14912,7 +14898,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 616
+            "y": 605
           },
           "id": 331,
           "options": {
@@ -15029,7 +15015,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 616
+            "y": 605
           },
           "id": 332,
           "options": {
@@ -15146,7 +15132,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 624
+            "y": 613
           },
           "id": 333,
           "options": {
@@ -15263,7 +15249,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 624
+            "y": 613
           },
           "id": 334,
           "options": {
@@ -15380,7 +15366,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 632
+            "y": 621
           },
           "id": 335,
           "options": {
@@ -15497,7 +15483,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 632
+            "y": 621
           },
           "id": 336,
           "options": {
@@ -15591,7 +15577,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 640
+            "y": 629
           },
           "id": 407,
           "options": {
@@ -15637,7 +15623,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 641
+        "y": 630
       },
       "id": 127,
       "panels": [
@@ -15704,7 +15690,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 642
+            "y": 631
           },
           "id": 128,
           "options": {
@@ -15799,7 +15785,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 642
+            "y": 631
           },
           "id": 412,
           "options": {
@@ -15895,7 +15881,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 650
+            "y": 639
           },
           "id": 129,
           "options": {
@@ -15991,7 +15977,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 650
+            "y": 639
           },
           "id": 413,
           "options": {
@@ -16087,7 +16073,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 658
+            "y": 647
           },
           "id": 130,
           "options": {
@@ -16183,7 +16169,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 658
+            "y": 647
           },
           "id": 414,
           "options": {
@@ -16280,7 +16266,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 666
+            "y": 655
           },
           "id": 133,
           "options": {
@@ -16377,7 +16363,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 666
+            "y": 655
           },
           "id": 415,
           "options": {
@@ -16473,7 +16459,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 674
+            "y": 663
           },
           "id": 131,
           "options": {
@@ -16569,7 +16555,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 674
+            "y": 663
           },
           "id": 416,
           "options": {
@@ -16665,7 +16651,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 682
+            "y": 671
           },
           "id": 134,
           "options": {
@@ -16761,7 +16747,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 682
+            "y": 671
           },
           "id": 417,
           "options": {
@@ -16857,7 +16843,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 690
+            "y": 679
           },
           "id": 330,
           "options": {
@@ -16902,7 +16888,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 674
+        "y": 663
       },
       "id": 67,
       "panels": [
@@ -16967,7 +16953,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 674
+            "y": 663
           },
           "id": 157,
           "options": {
@@ -17037,7 +17023,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 674
+            "y": 663
           },
           "id": 242,
           "options": {
@@ -17140,7 +17126,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 682
+            "y": 671
           },
           "id": 243,
           "options": {
@@ -17266,7 +17252,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 682
+            "y": 671
           },
           "id": 68,
           "options": {
@@ -17367,7 +17353,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 690
+            "y": 679
           },
           "id": 96,
           "options": {
@@ -17460,7 +17446,7 @@
             "h": 19,
             "w": 24,
             "x": 0,
-            "y": 697
+            "y": 686
           },
           "id": 74,
           "options": {
@@ -17506,7 +17492,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 717
+        "y": 706
       },
       "id": 7,
       "panels": [
@@ -17568,7 +17554,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 717
+            "y": 706
           },
           "id": 51,
           "options": {
@@ -17707,7 +17693,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 717
+            "y": 706
           },
           "id": 61,
           "options": {
@@ -17850,7 +17836,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 717
+            "y": 706
           },
           "id": 64,
           "options": {
@@ -17944,7 +17930,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 725
+            "y": 714
           },
           "id": 1,
           "options": {
@@ -18038,7 +18024,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 725
+            "y": 714
           },
           "id": 28,
           "options": {
@@ -18132,7 +18118,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 725
+            "y": 714
           },
           "id": 11,
           "options": {
@@ -18225,7 +18211,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 733
+            "y": 722
           },
           "id": 6,
           "options": {
@@ -18319,7 +18305,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 733
+            "y": 722
           },
           "id": 60,
           "options": {
@@ -18414,7 +18400,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 733
+            "y": 722
           },
           "id": 58,
           "options": {
@@ -18510,7 +18496,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 741
+            "y": 730
           },
           "id": 29,
           "options": {
@@ -18605,7 +18591,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 741
+            "y": 730
           },
           "id": 31,
           "options": {
@@ -18648,7 +18634,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 750
+        "y": 739
       },
       "id": 15,
       "panels": [
@@ -18715,7 +18701,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 750
+            "y": 739
           },
           "id": 18,
           "options": {
@@ -18811,7 +18797,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 750
+            "y": 739
           },
           "id": 13,
           "options": {
@@ -18912,7 +18898,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 750
+            "y": 739
           },
           "id": 16,
           "options": {
@@ -19013,7 +18999,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 758
+            "y": 747
           },
           "id": 19,
           "options": {
@@ -19109,7 +19095,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 758
+            "y": 747
           },
           "id": 14,
           "options": {
@@ -19210,7 +19196,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 758
+            "y": 747
           },
           "id": 17,
           "options": {
@@ -19311,7 +19297,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 766
+            "y": 755
           },
           "id": 42,
           "options": {
@@ -19407,7 +19393,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 766
+            "y": 755
           },
           "id": 59,
           "options": {
@@ -19503,7 +19489,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 766
+            "y": 755
           },
           "id": 50,
           "options": {
@@ -19545,7 +19531,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 775
+        "y": 764
       },
       "id": 44,
       "panels": [
@@ -19608,7 +19594,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 775
+            "y": 764
           },
           "id": 222,
           "options": {
@@ -19701,7 +19687,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 804
+            "y": 793
           },
           "id": 47,
           "options": {
@@ -19796,7 +19782,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 804
+            "y": 793
           },
           "id": 46,
           "options": {
@@ -19925,7 +19911,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 804
+            "y": 793
           },
           "id": 220,
           "options": {
@@ -20019,7 +20005,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 812
+            "y": 801
           },
           "id": 45,
           "options": {
@@ -20114,7 +20100,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 812
+            "y": 801
           },
           "id": 48,
           "options": {
@@ -20244,7 +20230,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 812
+            "y": 801
           },
           "id": 221,
           "options": {
@@ -20336,7 +20322,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 820
+            "y": 809
           },
           "id": 234,
           "options": {
@@ -20455,7 +20441,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 820
+            "y": 809
           },
           "id": 235,
           "options": {
@@ -20576,7 +20562,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 828
+            "y": 817
           },
           "id": 408,
           "options": {
@@ -20670,7 +20656,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 828
+            "y": 817
           },
           "id": 409,
           "options": {
@@ -20712,7 +20698,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 836
+        "y": 825
       },
       "id": 400,
       "panels": [
@@ -20775,7 +20761,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 837
+            "y": 826
           },
           "id": 401,
           "options": {
@@ -20853,7 +20839,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 837
+            "y": 826
           },
           "id": 402,
           "options": {
@@ -20973,7 +20959,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 845
+            "y": 834
           },
           "id": 403,
           "options": {
@@ -21063,7 +21049,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 845
+            "y": 834
           },
           "id": 404,
           "options": {
@@ -21153,7 +21139,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 853
+            "y": 842
           },
           "id": 405,
           "options": {
@@ -21243,7 +21229,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 853
+            "y": 842
           },
           "id": 406,
           "options": {
@@ -21333,7 +21319,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 861
+            "y": 850
           },
           "id": 421,
           "options": {
@@ -21423,7 +21409,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 861
+            "y": 850
           },
           "id": 422,
           "options": {
@@ -21514,7 +21500,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 869
+            "y": 858
           },
           "id": 423,
           "options": {
@@ -21604,7 +21590,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 869
+            "y": 858
           },
           "id": 424,
           "options": {
@@ -21656,7 +21642,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 854
+        "y": 843
       },
       "id": 420,
       "panels": [
@@ -21755,7 +21741,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 855
+            "y": 844
           },
           "id": 419,
           "options": {
@@ -21883,7 +21869,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 855
+            "y": 844
           },
           "id": 425,
           "options": {
@@ -22011,7 +21997,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 863
+            "y": 852
           },
           "id": 426,
           "options": {
@@ -22139,7 +22125,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 863
+            "y": 852
           },
           "id": 427,
           "options": {


### PR DESCRIPTION
# Description of change

Limits the peers asked to include one author’s headers in block bundles.

- Selects only peers that recently supplied or referenced the author’s headers.
- Asks at most 3 peers; fewer when fewer peers are useful.
- Adds selected and unselected-useful peer metrics.
- As a side effect, substantially reduces metric cardinality.
- Does not change the bundle format.

## Links to any relevant issues

Fixes #12680

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes