### PR TITLE
feat(iota-core): unify tx input checks for execution and simulation

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -114,7 +114,7 @@ use iota_types::{
     },
     traffic_control::{PolicyConfig, RemoteFirewallConfig, TrafficControlReconfigParams},
     transaction::*,
-    transaction_executor::{InputCheckRelaxations, SimulateTransactionResult, VmChecks},
+    transaction_executor::{InputCheckRules, SimulateTransactionResult, VmChecks},
 };
 use itertools::Itertools;
 use move_binary_format::{CompiledModule, binary_config::BinaryConfig};
@@ -2259,10 +2259,10 @@ impl AuthorityState {
 
         // Checks enabled -> DRY-RUN, it means we are simulating a real TX
         // Checks disabled -> DEV-INSPECT, more relaxed Move VM checks
-        let relaxations = if checks.enabled() {
-            InputCheckRelaxations::EXECUTION
+        let input_checks = if checks.enabled() {
+            InputCheckRules::EXECUTION
         } else {
-            InputCheckRelaxations::SIMULATION
+            InputCheckRules::SIMULATION
         };
         let (gas_status, checked_input_objects) = iota_transaction_checks::check_transaction_input(
             protocol_config,
@@ -2273,7 +2273,7 @@ impl AuthorityState {
             &self.metrics.bytecode_verifier_metrics,
             &self.config.verifier_signing_config,
             authenticator_gas_budget,
-            relaxations,
+            input_checks,
         )?;
 
         // Create a new executor for the simulation
@@ -5715,7 +5715,7 @@ impl AuthorityState {
                 &self.metrics.bytecode_verifier_metrics,
                 &self.config.verifier_signing_config,
                 authenticator_gas_budget,
-                InputCheckRelaxations::EXECUTION,
+                InputCheckRules::EXECUTION,
             )?;
 
         Ok((

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -114,7 +114,7 @@ use iota_types::{
     },
     traffic_control::{PolicyConfig, RemoteFirewallConfig, TrafficControlReconfigParams},
     transaction::*,
-    transaction_executor::{SimulateTransactionResult, VmChecks},
+    transaction_executor::{InputCheckRelaxations, SimulateTransactionResult, VmChecks},
 };
 use itertools::Itertools;
 use move_binary_format::{CompiledModule, binary_config::BinaryConfig};
@@ -2259,44 +2259,22 @@ impl AuthorityState {
 
         // Checks enabled -> DRY-RUN, it means we are simulating a real TX
         // Checks disabled -> DEV-INSPECT, more relaxed Move VM checks
-        let (gas_status, checked_input_objects) = if checks.enabled() {
-            iota_transaction_checks::check_transaction_input(
-                protocol_config,
-                epoch_store.reference_gas_price(),
-                &transaction,
-                input_objects,
-                &receiving_objects,
-                &self.metrics.bytecode_verifier_metrics,
-                &self.config.verifier_signing_config,
-                authenticator_gas_budget,
-            )?
+        let relaxations = if checks.enabled() {
+            InputCheckRelaxations::EXECUTION
         } else {
-            // Execution smashes the gas coins and reserves the whole budget from them
-            // before running any command, treating the input checks as having verified
-            // that they are gas coins at all — so with those checks skipped here, this
-            // has to stand in for them. With the checks enabled,
-            // `check_transaction_input` covers it.
-            iota_types::gas::check_gas_coins_cover_budget_in_simulation(
-                &input_objects,
-                transaction.gas(),
-                transaction.gas_budget(),
-            )?;
-
-            let checked_input_objects = iota_transaction_checks::check_simulation_input(
-                protocol_config,
-                transaction.kind(),
-                input_objects,
-                receiving_objects,
-            )?;
-            let gas_status = IotaGasStatus::new(
-                transaction.gas_budget(),
-                transaction.gas_price(),
-                epoch_store.reference_gas_price(),
-                protocol_config,
-            )?;
-
-            (gas_status, checked_input_objects)
+            InputCheckRelaxations::SIMULATION
         };
+        let (gas_status, checked_input_objects) = iota_transaction_checks::check_transaction_input(
+            protocol_config,
+            epoch_store.reference_gas_price(),
+            &transaction,
+            input_objects,
+            &receiving_objects,
+            &self.metrics.bytecode_verifier_metrics,
+            &self.config.verifier_signing_config,
+            authenticator_gas_budget,
+            relaxations,
+        )?;
 
         // Create a new executor for the simulation
         let executor = iota_execution::executor(
@@ -5737,6 +5715,7 @@ impl AuthorityState {
                 &self.metrics.bytecode_verifier_metrics,
                 &self.config.verifier_signing_config,
                 authenticator_gas_budget,
+                InputCheckRelaxations::EXECUTION,
             )?;
 
         Ok((

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -1312,6 +1312,262 @@ async fn test_simulate_rejects_a_gas_payment_that_is_not_a_gas_coin() {
     }
 }
 
+/// Simulates `pt` under both [`VmChecks`], returning what each produced.
+///
+/// The input checks a simulation shares with a signing validator must reject
+/// the same transaction either way, so a test asserting one of them asserts it
+/// over this.
+fn simulate_under_both_checks(
+    fullnode: &Arc<AuthorityState>,
+    sender: Address,
+    gas: Vec<ObjectReference>,
+    pt: &ProgrammableTransaction,
+) -> Vec<(VmChecks, IotaResult<SimulateTransactionResult>)> {
+    [VmChecks::Enabled, VmChecks::Disabled]
+        .into_iter()
+        .map(|checks| {
+            let transaction = Transaction::V1(TransactionV1 {
+                kind: TransactionKind::new_programmable(pt.clone()),
+                sender,
+                gas_payment: GasPayment {
+                    objects: gas.clone(),
+                    owner: sender,
+                    price: 0,
+                    budget: 0,
+                },
+                expiration: TransactionExpiration::None,
+            });
+            (checks, fullnode.simulate_transaction(transaction, checks))
+        })
+        .collect()
+}
+
+/// A command that touches none of the object inputs, so a test can assert on
+/// what the input checks make of those inputs rather than on what running them
+/// would do. The two pure arguments are the last two inputs.
+fn create_object_command(package: ObjectId, first_pure_input: u16) -> Command {
+    Command::new_move_call(
+        package,
+        Identifier::from_static("object_basics"),
+        Identifier::from_static("create"),
+        vec![],
+        vec![
+            Argument::Input(first_pure_input),
+            Argument::Input(first_pure_input + 1),
+        ],
+    )
+}
+
+/// An `object_basics::Object` with the given owner, ready to insert as a
+/// genesis object.
+fn object_basics_object(package: ObjectId, owner: Owner) -> Object {
+    let object_id = ObjectId::random();
+    Object::new_move(
+        MoveStruct::new(
+            StructTag::new(
+                Address::from(package),
+                Identifier::from_static("object_basics"),
+                Identifier::from_static("Object"),
+                vec![],
+            )
+            .into(),
+            OBJECT_START_VERSION,
+            // A Move object's contents lead with its own id.
+            bcs::to_bytes(&(object_id, 7u64)).unwrap(),
+        )
+        .unwrap(),
+        owner,
+        TransactionDigest::GENESIS_MARKER,
+    )
+}
+
+/// Sets up a fullnode with `object_basics` published and a gas coin that covers
+/// any budget, plus whatever extra objects the caller needs on both nodes.
+async fn simulation_fixture(
+    sender: Address,
+    extra_objects: impl Fn(ObjectId) -> Vec<Object>,
+) -> (Arc<AuthorityState>, ObjectId, ObjectReference, Vec<Object>) {
+    let (validator, fullnode, object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![]).await;
+    let max_tx_gas = validator
+        .epoch_store_for_testing()
+        .protocol_config()
+        .max_tx_gas();
+    let gas_coin = Object::new_gas_with_balance_and_owner_for_testing(max_tx_gas * 4, sender);
+    let extra = extra_objects(object_basics.object_id);
+
+    for object in std::iter::once(gas_coin.clone()).chain(extra.iter().cloned()) {
+        validator.insert_genesis_object(object.clone());
+        fullnode.insert_genesis_object(object);
+    }
+
+    (
+        fullnode,
+        object_basics.object_id,
+        gas_coin.object_ref(),
+        extra,
+    )
+}
+
+/// A package named as an owned object is rejected by both check modes: the
+/// engine has no way to treat a package as a Move value.
+#[tokio::test]
+async fn test_simulate_rejects_a_package_used_as_an_object() {
+    let sender = Address::random();
+    let (fullnode, object_basics, gas, _) = simulation_fixture(sender, |_| vec![]).await;
+    let package = fullnode.get_object(&object_basics).unwrap();
+
+    let pt = ProgrammableTransaction {
+        inputs: vec![
+            CallArg::ImmutableOrOwned(package.object_ref()),
+            CallArg::Pure(bcs::to_bytes(&16_u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+        commands: vec![create_object_command(object_basics, 1)],
+    };
+
+    for (checks, result) in simulate_under_both_checks(&fullnode, sender, vec![gas], &pt) {
+        let Err(error) = result else {
+            panic!("{checks:?} should reject a package used as an object");
+        };
+        assert!(
+            matches!(
+                error,
+                IotaError::UserInput {
+                    error: UserInputError::MovePackageAsObject { object_id }
+                } if object_id == object_basics
+            ),
+            "unexpected error for {checks:?}: {error:?}"
+        );
+    }
+}
+
+/// A child object named as an owned input is rejected by both check modes: it
+/// has to be reached through its parent, not passed directly.
+#[tokio::test]
+async fn test_simulate_rejects_a_child_object_used_as_owned() {
+    let sender = Address::random();
+    let parent_id = ObjectId::random();
+    let (fullnode, object_basics, gas, extra) = simulation_fixture(sender, |package| {
+        vec![object_basics_object(package, Owner::Object(parent_id))]
+    })
+    .await;
+    let child = &extra[0];
+
+    let pt = ProgrammableTransaction {
+        inputs: vec![
+            CallArg::ImmutableOrOwned(child.object_ref()),
+            CallArg::Pure(bcs::to_bytes(&16_u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+        commands: vec![create_object_command(object_basics, 1)],
+    };
+
+    for (checks, result) in simulate_under_both_checks(&fullnode, sender, vec![gas], &pt) {
+        let Err(error) = result else {
+            panic!("{checks:?} should reject a child object used as an owned input");
+        };
+        assert!(
+            matches!(
+                error,
+                IotaError::UserInput {
+                    error: UserInputError::InvalidChildObjectArgument { child_id, parent_id: p }
+                } if child_id == child.id() && p == parent_id
+            ),
+            "unexpected error for {checks:?}: {error:?}"
+        );
+    }
+}
+
+/// `Clock` taken mutably is rejected by both check modes: only a system
+/// transaction may do that.
+#[tokio::test]
+async fn test_simulate_rejects_a_mutable_clock_parameter() {
+    let sender = Address::random();
+    let (fullnode, object_basics, gas, _) = simulation_fixture(sender, |_| vec![]).await;
+
+    let pt = ProgrammableTransaction {
+        inputs: vec![
+            CallArg::Shared(SharedObjectReference::new(
+                ObjectId::CLOCK,
+                Version::from(1),
+                true,
+            )),
+            CallArg::Pure(bcs::to_bytes(&16_u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+        commands: vec![create_object_command(object_basics, 1)],
+    };
+
+    for (checks, result) in simulate_under_both_checks(&fullnode, sender, vec![gas], &pt) {
+        let Err(error) = result else {
+            panic!("{checks:?} should reject Clock as a mutable parameter");
+        };
+        assert!(
+            matches!(
+                error,
+                IotaError::UserInput {
+                    error: UserInputError::ImmutableParameterExpected { object_id }
+                } if object_id == ObjectId::CLOCK
+            ),
+            "unexpected error for {checks:?}: {error:?}"
+        );
+    }
+}
+
+/// A mismatched input object digest is rejected by a dry run and accepted by a
+/// dev inspect.
+///
+/// The digest is an optimistic-concurrency token for submission, which a dev
+/// inspect does not do, and nothing in execution reads it — the object is
+/// loaded by id and version either way.
+#[tokio::test]
+async fn test_simulate_input_object_digest_is_checked_only_with_checks_enabled() {
+    let sender = Address::random();
+    let (fullnode, object_basics, gas, extra) = simulation_fixture(sender, |package| {
+        vec![object_basics_object(package, Owner::Address(sender))]
+    })
+    .await;
+    let owned = &extra[0];
+    let object_ref = owned.object_ref();
+    let wrong_digest = ObjectReference::new(
+        object_ref.object_id,
+        object_ref.version,
+        ObjectDigest::new([9; 32]),
+    );
+
+    let pt = ProgrammableTransaction {
+        inputs: vec![
+            CallArg::ImmutableOrOwned(wrong_digest),
+            CallArg::Pure(bcs::to_bytes(&16_u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+        commands: vec![create_object_command(object_basics, 1)],
+    };
+
+    for (checks, result) in simulate_under_both_checks(&fullnode, sender, vec![gas], &pt) {
+        match checks {
+            VmChecks::Enabled => {
+                let Err(error) = result else {
+                    panic!("a dry run should reject a mismatched input object digest");
+                };
+                assert!(
+                    matches!(
+                        error,
+                        IotaError::UserInput {
+                            error: UserInputError::InvalidObjectDigest { object_id, .. }
+                        } if object_id == owned.id()
+                    ),
+                    "unexpected error for {checks:?}: {error:?}"
+                );
+            }
+            VmChecks::Disabled => {
+                result.expect("a dev inspect should accept a mismatched input object digest");
+            }
+        }
+    }
+}
+
 // tests using a gas coin with version MAX - 1
 #[tokio::test]
 async fn test_dry_run_dev_inspect_max_gas_version() {

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -29,8 +29,9 @@ mod checked {
         transaction::{
             CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult,
             ObjectReadResultKind, ProgrammableTransactionExt, ReceivingObjectReadResult,
-            ReceivingObjects, TransactionAPI, TransactionKindExt,
+            ReceivingObjects, TransactionAPI,
         },
+        transaction_executor::InputCheckRelaxations,
     };
     use tracing::{error, instrument};
 
@@ -56,6 +57,7 @@ mod checked {
         transaction: &Transaction,
         authentication_gas_budget: u64,
         is_execute_transaction_to_effects: bool,
+        relaxations: InputCheckRelaxations,
     ) -> IotaResult<IotaGasStatus> {
         if transaction.is_system_tx() {
             Ok(IotaGasStatus::new_unmetered())
@@ -69,10 +71,22 @@ mod checked {
                 transaction.gas_budget(),
                 authentication_gas_budget,
                 is_execute_transaction_to_effects,
+                relaxations,
             )
         }
     }
 
+    /// Checks whether a transaction may run, for signing, for a certificate, or
+    /// for a simulation.
+    ///
+    /// `relaxations` names the checks a caller drops. A simulation with
+    /// [`VmChecks::Disabled`](iota_types::transaction_executor::VmChecks::Disabled)
+    /// passes [`InputCheckRelaxations::SIMULATION`]; everything bound for
+    /// execution passes [`InputCheckRelaxations::EXECUTION`]. A caller that
+    /// needs a check relaxed must name it in `InputCheckRelaxations`, with the
+    /// reason on the field, rather than validating its inputs somewhere else:
+    /// the point of routing every caller through here is that a check added
+    /// below applies to all of them until someone says otherwise.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
     pub fn check_transaction_input(
         protocol_config: &ProtocolConfig,
@@ -83,6 +97,7 @@ mod checked {
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
         authentication_gas_budget: u64,
+        relaxations: InputCheckRelaxations,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_status = check_transaction_input_inner(
             protocol_config,
@@ -92,8 +107,9 @@ mod checked {
             &[],
             authentication_gas_budget,
             false,
+            relaxations,
         )?;
-        check_receiving_objects(&input_objects, receiving_objects)?;
+        check_receiving_objects(&input_objects, receiving_objects, relaxations)?;
         // Runs verifier, which could be expensive.
         check_non_system_packages_to_be_published(
             transaction,
@@ -127,8 +143,13 @@ mod checked {
             &[gas_object_ref],
             0,
             true,
+            InputCheckRelaxations::EXECUTION,
         )?;
-        check_receiving_objects(&input_objects, &receiving_objects)?;
+        check_receiving_objects(
+            &input_objects,
+            &receiving_objects,
+            InputCheckRelaxations::EXECUTION,
+        )?;
         // Runs verifier, which could be expensive.
         check_non_system_packages_to_be_published(
             transaction,
@@ -161,53 +182,13 @@ mod checked {
             &[],
             0,
             true,
+            InputCheckRelaxations::EXECUTION,
         )?;
         // NB: We do not check receiving objects when executing. Only at signing
         // time do we check. NB: move verifier is only checked at
         // signing time, not at execution.
 
         Ok((gas_status, input_objects.into_checked()))
-    }
-
-    /// WARNING! Only for simulating a transaction with
-    /// [`VmChecks::Disabled`](iota_types::transaction_executor::VmChecks::Disabled).
-    /// This bypasses many of the normal object checks. A simulation with
-    /// `VmChecks::Enabled` goes through [`check_transaction_input`] instead,
-    /// the same as a transaction bound for execution.
-    #[instrument(level = "trace", skip_all)]
-    pub fn check_simulation_input(
-        config: &ProtocolConfig,
-        kind: &TransactionKind,
-        input_objects: InputObjects,
-        // TODO: check ReceivingObjects when simulating?
-        _receiving_objects: ReceivingObjects,
-    ) -> IotaResult<CheckedInputObjects> {
-        kind.validity_check(config)?;
-        if kind.is_system() {
-            return Err(UserInputError::Unsupported(format!(
-                "Transaction kind {kind} is not supported in a simulation"
-            ))
-            .into());
-        }
-        let mut used_objects: HashSet<Address> = HashSet::new();
-        for input_object in input_objects.iter() {
-            let Some(object) = input_object.as_object() else {
-                // object was deleted
-                continue;
-            };
-
-            if !object.is_immutable() {
-                fp_ensure!(
-                    used_objects.insert(object.id().into()),
-                    UserInputError::MutableObjectUsedMoreThanOnce {
-                        object_id: object.id()
-                    }
-                    .into()
-                );
-            }
-        }
-
-        Ok(input_objects.into_checked())
     }
 
     /// A common function to check the `MoveAuthenticator` inputs for signing.
@@ -278,6 +259,7 @@ mod checked {
             &[],
             authenticator_gas_budget,
             true,
+            InputCheckRelaxations::EXECUTION,
         )?;
 
         let per_authenticator_checked_input_objects = per_authenticator_input_objects
@@ -308,6 +290,7 @@ mod checked {
         gas_override: &[ObjectReference],
         authentication_gas_budget: u64,
         is_execute_transaction_to_effects: bool,
+        relaxations: InputCheckRelaxations,
     ) -> IotaResult<IotaGasStatus> {
         // Cheap validity checks that is ok to run multiple times during processing.
         let gas = if gas_override.is_empty() {
@@ -324,16 +307,32 @@ mod checked {
             transaction,
             authentication_gas_budget,
             is_execute_transaction_to_effects,
+            relaxations,
         )?;
-        check_objects(transaction, input_objects)?;
+        check_objects(transaction, input_objects, relaxations)?;
 
         Ok(gas_status)
     }
 
+    /// Checks the receiving references against the objects they name.
+    ///
+    /// Two separable things happen here. Whether each reference is current —
+    /// its version and digest match the loaded object — is an
+    /// optimistic-concurrency question, dropped per half by
+    /// [`InputCheckRelaxations::any_receiving_object_version`] and
+    /// [`InputCheckRelaxations::any_receiving_object_digest`].
+    /// What the object is, and that no reference duplicates another or collides
+    /// with an input object, is not relaxed by anything: the duplicate
+    /// rejection below is the only one there is, since `CallArg::Receiving`
+    /// is not part of `input_objects()` and so escapes its
+    /// `DuplicateObjectRefInput` dedup. Without it a duplicated receiving
+    /// ticket reaches the object runtime, which treats receiving the same
+    /// object twice as impossible.
     #[instrument(level = "trace", skip_all)]
     fn check_receiving_objects(
         input_objects: &InputObjects,
         receiving_objects: &ReceivingObjects,
+        relaxations: InputCheckRelaxations,
     ) -> Result<(), IotaError> {
         let mut objects_in_txn: HashSet<_> = input_objects
             .object_kinds()
@@ -359,19 +358,36 @@ mod checked {
                 continue;
             };
 
+            // A reference is fine if it names an address-owned object and matches
+            // it on both counts the caller still cares about, so the block below
+            // is for the ones that are not. Relax each equality here rather than
+            // reordering the block: which error a caller gets when a reference
+            // fails more than one test is observable.
+            //
+            // Keep the two conditions in step with the two `fp_ensure!`s inside.
+            // The trailing `match object.owner` has no gate of its own, and its
+            // `Owner::Address` arm is a `debug_assert!(false)` — dead only
+            // because every path that enters here with an address owner bails at
+            // whichever `fp_ensure!` let it in. Skipping a test while still
+            // admitting the references it would have rejected makes that arm
+            // reachable, which panics in a debug build.
             if !(object.owner.is_address()
-                && object.version() == object_ref.version
-                && object.digest() == object_ref.digest)
+                && (object.version() == object_ref.version
+                    || relaxations.any_receiving_object_version)
+                && (object.digest() == object_ref.digest
+                    || relaxations.any_receiving_object_digest))
             {
-                // Version mismatch
-                fp_ensure!(
-                    object.version() == object_ref.version,
-                    UserInputError::ObjectVersionUnavailableForConsumption {
-                        provided_obj_ref: *object_ref,
-                        current_version: object.version(),
-                    }
-                    .into()
-                );
+                if !relaxations.any_receiving_object_version {
+                    // Version mismatch
+                    fp_ensure!(
+                        object.version() == object_ref.version,
+                        UserInputError::ObjectVersionUnavailableForConsumption {
+                            provided_obj_ref: *object_ref,
+                            current_version: object.version(),
+                        }
+                        .into()
+                    );
+                }
 
                 // Tried to receive a package
                 fp_ensure!(
@@ -382,16 +398,18 @@ mod checked {
                     .into()
                 );
 
-                // Digest mismatch
-                let expected_digest = object.digest();
-                fp_ensure!(
-                    expected_digest == object_ref.digest,
-                    UserInputError::InvalidObjectDigest {
-                        object_id: object_ref.object_id,
-                        expected_digest
-                    }
-                    .into()
-                );
+                if !relaxations.any_receiving_object_digest {
+                    // Digest mismatch
+                    let expected_digest = object.digest();
+                    fp_ensure!(
+                        expected_digest == object_ref.digest,
+                        UserInputError::InvalidObjectDigest {
+                            object_id: object_ref.object_id,
+                            expected_digest
+                        }
+                        .into()
+                    );
+                }
 
                 match object.owner {
                     Owner::Address(_) => {
@@ -457,6 +475,7 @@ mod checked {
         transaction_gas_budget: u64,
         authentication_gas_budget: u64,
         is_execute_transaction_to_effects: bool,
+        relaxations: InputCheckRelaxations,
     ) -> IotaResult<IotaGasStatus> {
         let gas_budget_to_set = if authentication_gas_budget > 0 {
             // If there is an authentication gas budget, then we are checking if
@@ -509,14 +528,22 @@ mod checked {
             })?;
             gas_objects.push(obj);
         }
-        gas_status.check_gas_balance(&gas_objects, gas_budget_to_check)?;
+        gas_status.check_gas_balance(
+            &gas_objects,
+            gas_budget_to_check,
+            !relaxations.unbounded_gas_budget,
+        )?;
         Ok(gas_status)
     }
 
     /// Check all the objects used in the transaction against the database, and
     /// ensure that they are all the correct version and number.
     #[instrument(level = "trace", skip_all)]
-    fn check_objects(transaction: &Transaction, objects: &InputObjects) -> UserInputResult<()> {
+    fn check_objects(
+        transaction: &Transaction,
+        objects: &InputObjects,
+        relaxations: InputCheckRelaxations,
+    ) -> UserInputResult<()> {
         // We require that mutable objects cannot show up more than once.
         let mut used_objects: HashSet<Address> = HashSet::new();
         for object in objects.iter() {
@@ -555,6 +582,7 @@ mod checked {
                         input_object_kind,
                         object,
                         system_transaction,
+                        relaxations,
                     )?;
                 }
                 // We skip checking a deleted shared object because it no longer exists
@@ -574,6 +602,7 @@ mod checked {
         object_kind: InputObjectKind,
         object: &Object,
         system_transaction: bool,
+        relaxations: InputCheckRelaxations,
     ) -> UserInputResult {
         match object_kind {
             InputObjectKind::MovePackage(package_id) => {
@@ -607,30 +636,38 @@ mod checked {
                 );
 
                 // Check the digest matches - user could give a mismatched ObjectDigest
-                let expected_digest = object.digest();
-                fp_ensure!(
-                    expected_digest == object_ref.digest,
-                    UserInputError::InvalidObjectDigest {
-                        object_id: object_ref.object_id,
-                        expected_digest
-                    }
-                );
+                if !relaxations.any_object_digest {
+                    let expected_digest = object.digest();
+                    fp_ensure!(
+                        expected_digest == object_ref.digest,
+                        UserInputError::InvalidObjectDigest {
+                            object_id: object_ref.object_id,
+                            expected_digest
+                        }
+                    );
+                }
 
                 match object.owner {
                     Owner::Immutable => {
                         // Nothing else to check for Immutable.
                     }
                     Owner::Address(actual_owner) => {
-                        // Check the owner is correct.
-                        fp_ensure!(
-                            owner == &actual_owner,
-                            UserInputError::IncorrectUserSignature {
-                                error: format!(
-                                    "Object {} is owned by account address {}, but given owner/signer address is {}",
-                                    object_ref.object_id, actual_owner, owner
-                                ),
-                            }
-                        );
+                        // Check the owner is correct. Only this arm is relaxed: whether
+                        // the sender owns the object is a question of permission, which
+                        // a simulation may ask past. The arms below are not — those
+                        // objects cannot be owned inputs at all, and the engine treats
+                        // the checks here as having established that.
+                        if !relaxations.any_object_owner {
+                            fp_ensure!(
+                                owner == &actual_owner,
+                                UserInputError::IncorrectUserSignature {
+                                    error: format!(
+                                        "Object {} is owned by account address {}, but given owner/signer address is {}",
+                                        object_ref.object_id, actual_owner, owner
+                                    ),
+                                }
+                            );
+                        }
                     }
                     Owner::Object(owner) => {
                         return Err(UserInputError::InvalidChildObjectArgument {

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -31,7 +31,7 @@ mod checked {
             ObjectReadResultKind, ProgrammableTransactionExt, ReceivingObjectReadResult,
             ReceivingObjects, TransactionAPI,
         },
-        transaction_executor::InputCheckRelaxations,
+        transaction_executor::InputCheckRules,
     };
     use tracing::{error, instrument};
 
@@ -57,7 +57,7 @@ mod checked {
         transaction: &Transaction,
         authentication_gas_budget: u64,
         is_execute_transaction_to_effects: bool,
-        relaxations: InputCheckRelaxations,
+        input_checks: InputCheckRules,
     ) -> IotaResult<IotaGasStatus> {
         if transaction.is_system_tx() {
             Ok(IotaGasStatus::new_unmetered())
@@ -71,7 +71,7 @@ mod checked {
                 transaction.gas_budget(),
                 authentication_gas_budget,
                 is_execute_transaction_to_effects,
-                relaxations,
+                input_checks,
             )
         }
     }
@@ -79,11 +79,11 @@ mod checked {
     /// Checks whether a transaction may run, for signing, for a certificate, or
     /// for a simulation.
     ///
-    /// `relaxations` names the checks a caller drops. A simulation with
+    /// `input_checks` names the checks a caller drops. A simulation with
     /// [`VmChecks::Disabled`](iota_types::transaction_executor::VmChecks::Disabled)
-    /// passes [`InputCheckRelaxations::SIMULATION`]; everything bound for
-    /// execution passes [`InputCheckRelaxations::EXECUTION`]. A caller that
-    /// needs a check relaxed must name it in `InputCheckRelaxations`, with the
+    /// passes [`InputCheckRules::SIMULATION`]; everything bound for
+    /// execution passes [`InputCheckRules::EXECUTION`]. A caller that
+    /// needs a check relaxed must name it in `InputCheckRules`, with the
     /// reason on the field, rather than validating its inputs somewhere else:
     /// the point of routing every caller through here is that a check added
     /// below applies to all of them until someone says otherwise.
@@ -97,7 +97,7 @@ mod checked {
         metrics: &Arc<BytecodeVerifierMetrics>,
         verifier_signing_config: &VerifierSigningConfig,
         authentication_gas_budget: u64,
-        relaxations: InputCheckRelaxations,
+        input_checks: InputCheckRules,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_status = check_transaction_input_inner(
             protocol_config,
@@ -107,9 +107,9 @@ mod checked {
             &[],
             authentication_gas_budget,
             false,
-            relaxations,
+            input_checks,
         )?;
-        check_receiving_objects(&input_objects, receiving_objects, relaxations)?;
+        check_receiving_objects(&input_objects, receiving_objects, input_checks)?;
         // Runs verifier, which could be expensive.
         check_non_system_packages_to_be_published(
             transaction,
@@ -143,12 +143,12 @@ mod checked {
             &[gas_object_ref],
             0,
             true,
-            InputCheckRelaxations::EXECUTION,
+            InputCheckRules::EXECUTION,
         )?;
         check_receiving_objects(
             &input_objects,
             &receiving_objects,
-            InputCheckRelaxations::EXECUTION,
+            InputCheckRules::EXECUTION,
         )?;
         // Runs verifier, which could be expensive.
         check_non_system_packages_to_be_published(
@@ -182,7 +182,7 @@ mod checked {
             &[],
             0,
             true,
-            InputCheckRelaxations::EXECUTION,
+            InputCheckRules::EXECUTION,
         )?;
         // NB: We do not check receiving objects when executing. Only at signing
         // time do we check. NB: move verifier is only checked at
@@ -259,7 +259,7 @@ mod checked {
             &[],
             authenticator_gas_budget,
             true,
-            InputCheckRelaxations::EXECUTION,
+            InputCheckRules::EXECUTION,
         )?;
 
         let per_authenticator_checked_input_objects = per_authenticator_input_objects
@@ -290,7 +290,7 @@ mod checked {
         gas_override: &[ObjectReference],
         authentication_gas_budget: u64,
         is_execute_transaction_to_effects: bool,
-        relaxations: InputCheckRelaxations,
+        input_checks: InputCheckRules,
     ) -> IotaResult<IotaGasStatus> {
         // Cheap validity checks that is ok to run multiple times during processing.
         let gas = if gas_override.is_empty() {
@@ -307,9 +307,9 @@ mod checked {
             transaction,
             authentication_gas_budget,
             is_execute_transaction_to_effects,
-            relaxations,
+            input_checks,
         )?;
-        check_objects(transaction, input_objects, relaxations)?;
+        check_objects(transaction, input_objects, input_checks)?;
 
         Ok(gas_status)
     }
@@ -319,8 +319,8 @@ mod checked {
     /// Two separable things happen here. Whether each reference is current —
     /// its version and digest match the loaded object — is an
     /// optimistic-concurrency question, dropped per half by
-    /// [`InputCheckRelaxations::any_receiving_object_version`] and
-    /// [`InputCheckRelaxations::any_receiving_object_digest`].
+    /// [`InputCheckRules::any_receiving_object_version`] and
+    /// [`InputCheckRules::any_receiving_object_digest`].
     /// What the object is, and that no reference duplicates another or collides
     /// with an input object, is not relaxed by anything: the duplicate
     /// rejection below is the only one there is, since `CallArg::Receiving`
@@ -332,7 +332,7 @@ mod checked {
     fn check_receiving_objects(
         input_objects: &InputObjects,
         receiving_objects: &ReceivingObjects,
-        relaxations: InputCheckRelaxations,
+        input_checks: InputCheckRules,
     ) -> Result<(), IotaError> {
         let mut objects_in_txn: HashSet<_> = input_objects
             .object_kinds()
@@ -373,11 +373,11 @@ mod checked {
             // reachable, which panics in a debug build.
             if !(object.owner.is_address()
                 && (object.version() == object_ref.version
-                    || relaxations.any_receiving_object_version)
+                    || input_checks.any_receiving_object_version)
                 && (object.digest() == object_ref.digest
-                    || relaxations.any_receiving_object_digest))
+                    || input_checks.any_receiving_object_digest))
             {
-                if !relaxations.any_receiving_object_version {
+                if !input_checks.any_receiving_object_version {
                     // Version mismatch
                     fp_ensure!(
                         object.version() == object_ref.version,
@@ -398,7 +398,7 @@ mod checked {
                     .into()
                 );
 
-                if !relaxations.any_receiving_object_digest {
+                if !input_checks.any_receiving_object_digest {
                     // Digest mismatch
                     let expected_digest = object.digest();
                     fp_ensure!(
@@ -475,7 +475,7 @@ mod checked {
         transaction_gas_budget: u64,
         authentication_gas_budget: u64,
         is_execute_transaction_to_effects: bool,
-        relaxations: InputCheckRelaxations,
+        input_checks: InputCheckRules,
     ) -> IotaResult<IotaGasStatus> {
         let gas_budget_to_set = if authentication_gas_budget > 0 {
             // If there is an authentication gas budget, then we are checking if
@@ -531,7 +531,7 @@ mod checked {
         gas_status.check_gas_balance(
             &gas_objects,
             gas_budget_to_check,
-            !relaxations.unbounded_gas_budget,
+            !input_checks.unbounded_gas_budget,
         )?;
         Ok(gas_status)
     }
@@ -542,7 +542,7 @@ mod checked {
     fn check_objects(
         transaction: &Transaction,
         objects: &InputObjects,
-        relaxations: InputCheckRelaxations,
+        input_checks: InputCheckRules,
     ) -> UserInputResult<()> {
         // We require that mutable objects cannot show up more than once.
         let mut used_objects: HashSet<Address> = HashSet::new();
@@ -582,7 +582,7 @@ mod checked {
                         input_object_kind,
                         object,
                         system_transaction,
-                        relaxations,
+                        input_checks,
                     )?;
                 }
                 // We skip checking a deleted shared object because it no longer exists
@@ -602,7 +602,7 @@ mod checked {
         object_kind: InputObjectKind,
         object: &Object,
         system_transaction: bool,
-        relaxations: InputCheckRelaxations,
+        input_checks: InputCheckRules,
     ) -> UserInputResult {
         match object_kind {
             InputObjectKind::MovePackage(package_id) => {
@@ -636,7 +636,7 @@ mod checked {
                 );
 
                 // Check the digest matches - user could give a mismatched ObjectDigest
-                if !relaxations.any_object_digest {
+                if !input_checks.any_object_digest {
                     let expected_digest = object.digest();
                     fp_ensure!(
                         expected_digest == object_ref.digest,
@@ -657,7 +657,7 @@ mod checked {
                         // a simulation may ask past. The arms below are not — those
                         // objects cannot be owned inputs at all, and the engine treats
                         // the checks here as having established that.
-                        if !relaxations.any_object_owner {
+                        if !input_checks.any_object_owner {
                             fp_ensure!(
                                 owner == &actual_owner,
                                 UserInputError::IncorrectUserSignature {

--- a/crates/iota-types/src/gas.rs
+++ b/crates/iota-types/src/gas.rs
@@ -81,13 +81,18 @@ pub mod checked {
 
         // This is the only public API on IotaGasStatus, all other gas related
         // operations should go through `GasCharger`
+        //
+        // `bounded_budget` selects whether the budget itself must fall between the
+        // protocol minimum and maximum. The gas coins are required to be
+        // address-owned and to cover the budget either way.
         pub fn check_gas_balance(
             &self,
             gas_objs: &[&ObjectReadResult],
             gas_budget: u64,
+            bounded_budget: bool,
         ) -> UserInputResult {
             match self {
-                Self::V1(status) => status.check_gas_balance(gas_objs, gas_budget),
+                Self::V1(status) => status.check_gas_balance(gas_objs, gas_budget, bounded_budget),
             }
         }
 
@@ -215,46 +220,8 @@ pub mod checked {
             reported.budget = gas_used;
         }
     }
-
-    /// Checks that every object `gas` refers to is an address-owned gas coin
-    /// present in `input_objects`, and that their combined balance covers
-    /// `gas_budget`.
-    pub fn check_gas_coins_cover_budget_in_simulation(
-        input_objects: &InputObjects,
-        gas: &[ObjectReference],
-        gas_budget: u64,
-    ) -> UserInputResult {
-        let objects: HashMap<_, _> = input_objects
-            .iter()
-            .map(|object| (object.id(), object))
-            .collect();
-
-        let mut gas_balance = 0u128;
-        for gas_ref in gas {
-            let read = objects
-                .get(&gas_ref.object_id)
-                .ok_or(UserInputError::ObjectNotFound {
-                    object_id: gas_ref.object_id,
-                    version: Some(gas_ref.version),
-                })?;
-            // `as_object` returning `None` means the object was deleted, which makes
-            // it a shared one, and gas cannot be shared.
-            let object = read.as_object().ok_or(UserInputError::MissingGasPayment)?;
-            if !object.is_address_owned() {
-                return Err(UserInputError::GasObjectNotOwnedObject {
-                    owner: object.owner,
-                });
-            }
-            gas_balance += get_gas_balance(object)? as u128;
-        }
-
-        if gas_balance < gas_budget as u128 {
-            return Err(UserInputError::GasBalanceTooLow {
-                gas_balance,
-                needed_gas_amount: gas_budget as u128,
-            });
-        }
-
-        Ok(())
-    }
 }
+
+#[cfg(test)]
+#[path = "unit_tests/gas_tests.rs"]
+mod gas_tests;

--- a/crates/iota-types/src/gas_model/gas_v1.rs
+++ b/crates/iota-types/src/gas_model/gas_v1.rs
@@ -301,15 +301,24 @@ mod checked {
 
         // Check whether gas arguments are legit:
         // 1. Gas object has an address owner.
-        // 2. Gas budget is between min and max budget allowed
+        // 2. Gas budget is between min and max budget allowed, when `bounded_budget` is
+        //    set.
         // 3. Gas balance (all gas coins together) is bigger or equal to budget
         //
         // Keep the three checks together: it is only sound because step 1 has already
         // rejected every gas object that `as_object` returns `None` for.
+        //
+        // Step 3 sums the balances of `gas_objs` as given, so an object listed twice
+        // is counted twice and the balance it reports is too high. Nothing here
+        // rejects that; `check_transaction_input` rejects it afterwards, in
+        // `check_objects`, as `MutableObjectUsedMoreThanOnce`. So an inflated
+        // balance can pass this function but not the call it is part of. A caller
+        // reaching this directly has to reject duplicate gas references itself.
         pub(crate) fn check_gas_balance(
             &self,
             gas_objs: &[&ObjectReadResult],
             gas_budget: u64,
+            bounded_budget: bool,
         ) -> UserInputResult {
             // 1. All gas objects have an address owner
             for gas_object in gas_objs {
@@ -326,18 +335,20 @@ mod checked {
                 }
             }
 
-            // 2. Gas budget is between min and max budget allowed
-            if gas_budget > self.cost_table.max_gas_budget {
-                return Err(UserInputError::GasBudgetTooHigh {
-                    gas_budget,
-                    max_budget: self.cost_table.max_gas_budget,
-                });
-            }
-            if gas_budget < self.cost_table.min_transaction_cost {
-                return Err(UserInputError::GasBudgetTooLow {
-                    gas_budget,
-                    min_budget: self.cost_table.min_transaction_cost,
-                });
+            if bounded_budget {
+                // 2. Gas budget is between min and max budget allowed
+                if gas_budget > self.cost_table.max_gas_budget {
+                    return Err(UserInputError::GasBudgetTooHigh {
+                        gas_budget,
+                        max_budget: self.cost_table.max_gas_budget,
+                    });
+                }
+                if gas_budget < self.cost_table.min_transaction_cost {
+                    return Err(UserInputError::GasBudgetTooLow {
+                        gas_budget,
+                        min_budget: self.cost_table.min_transaction_cost,
+                    });
+                }
             }
 
             // 3. Gas balance (all gas coins together) is bigger or equal to budget

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -129,3 +129,80 @@ impl VmChecks {
         matches!(self, Self::Enabled)
     }
 }
+
+/// Which input checks a simulation drops relative to a transaction bound for
+/// execution.
+///
+/// Every field defaults to `false`, so a check added to the shared path applies
+/// to a simulation too until someone names it here and says why.
+#[derive(Default, Debug, Copy, Clone)]
+pub struct InputCheckRelaxations {
+    /// Skip the bounds on the gas budget itself, so a caller whose gas is not
+    /// settled runs out of gas rather than being rejected. The gas coins are
+    /// still required to be address-owned and to cover whatever budget is set.
+    pub unbounded_gas_budget: bool,
+    /// Skip the requirement that an address-owned input object be owned by the
+    /// sender, so a caller can ask what a transaction would do over objects it
+    /// does not own.
+    ///
+    /// This relaxes only whose object it is. A child object or a shared object
+    /// named as an owned input is still rejected: those are not questions of
+    /// permission but of what may be an owned input at all, and the engine
+    /// treats the input checks as having settled them — a child object reaching
+    /// it trips an invariant that names this checker.
+    ///
+    /// It also drops the check that the gas payment is owned by the
+    /// transaction's gas owner, since gas coins go through the same arm. The
+    /// weaker requirement that they be address-owned survives, in the gas
+    /// balance check.
+    pub any_object_owner: bool,
+    /// Skip the match between an input object's declared digest and the loaded
+    /// object. The digest is an optimistic-concurrency token for submission,
+    /// which a simulation does not do, and nothing in execution reads it: the
+    /// object is loaded by id and version, and every value is built from what
+    /// was loaded. An object that does not exist still fails in the loader.
+    pub any_object_digest: bool,
+    /// Skip the match between a receiving reference's declared version and the
+    /// version of the object it names, so a simulation can run over a reference
+    /// the caller has not refreshed.
+    ///
+    /// A receiving reference's version is not only an optimistic-concurrency
+    /// token, unlike the two above: execution resolves the receive at exactly
+    /// the declared version, so a stale one still fails at runtime with
+    /// `E_UNABLE_TO_RECEIVE_OBJECT`. This drops the up-front rejection, not the
+    /// outcome.
+    ///
+    /// Neither this nor [`Self::any_receiving_object_digest`] relaxes what the
+    /// object is, or the rejection of a reference that duplicates another or
+    /// collides with an input object — that last one is the only rejection
+    /// standing between a duplicated receiving ticket and an invariant
+    /// violation in the object runtime.
+    pub any_receiving_object_version: bool,
+    /// Skip the match between a receiving reference's declared digest and the
+    /// object it names, for the same reason as [`Self::any_object_digest`]: the
+    /// digest is an optimistic-concurrency token for submission, which a
+    /// simulation does not do.
+    ///
+    /// See [`Self::any_receiving_object_version`] for what stays checked.
+    pub any_receiving_object_digest: bool,
+}
+
+impl InputCheckRelaxations {
+    /// No relaxations: exactly what a validator applies.
+    pub const EXECUTION: Self = Self {
+        unbounded_gas_budget: false,
+        any_object_owner: false,
+        any_object_digest: false,
+        any_receiving_object_version: false,
+        any_receiving_object_digest: false,
+    };
+
+    /// What a simulation with [`VmChecks::Disabled`] drops.
+    pub const SIMULATION: Self = Self {
+        unbounded_gas_budget: true,
+        any_object_owner: true,
+        any_object_digest: true,
+        any_receiving_object_version: true,
+        any_receiving_object_digest: true,
+    };
+}

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -136,7 +136,7 @@ impl VmChecks {
 /// Every field defaults to `false`, so a check added to the shared path applies
 /// to a simulation too until someone names it here and says why.
 #[derive(Default, Debug, Copy, Clone)]
-pub struct InputCheckRelaxations {
+pub struct InputCheckRules {
     /// Skip the bounds on the gas budget itself, so a caller whose gas is not
     /// settled runs out of gas rather than being rejected. The gas coins are
     /// still required to be address-owned and to cover whatever budget is set.
@@ -187,7 +187,7 @@ pub struct InputCheckRelaxations {
     pub any_receiving_object_digest: bool,
 }
 
-impl InputCheckRelaxations {
+impl InputCheckRules {
     /// No relaxations: exactly what a validator applies.
     pub const EXECUTION: Self = Self {
         unbounded_gas_budget: false,

--- a/crates/iota-types/src/unit_tests/gas_tests.rs
+++ b/crates/iota-types/src/unit_tests/gas_tests.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_protocol_config::ProtocolConfig;
+use iota_sdk_types::Address;
+
+use crate::{
+    error::UserInputError,
+    gas::*,
+    object::Object,
+    transaction::{InputObjectKind, ObjectReadResult},
+};
+
+/// The same gas coins and an under-minimum budget are rejected when the
+/// budget is bounded and accepted when it is not, which is the whole of
+/// what a simulation relaxes about gas.
+#[test]
+fn check_gas_balance_bounds_the_budget_only_when_asked() {
+    let config = ProtocolConfig::get_for_max_version_UNSAFE();
+    let gas_price = config.max_gas_price();
+    let gas_object =
+        Object::new_gas_with_balance_and_owner_for_testing(1_000_000_000, Address::random());
+    let read = ObjectReadResult::new(
+        InputObjectKind::ImmOrOwnedMoveObject(gas_object.object_ref()),
+        gas_object.into(),
+    );
+    let gas_objs = [&read];
+
+    let status = IotaGasStatus::new(0, gas_price, gas_price, &config)
+        .expect("gas price equal to the reference price is in bounds");
+
+    assert!(matches!(
+        status.check_gas_balance(&gas_objs, 0, true),
+        Err(UserInputError::GasBudgetTooLow { .. })
+    ));
+    assert!(status.check_gas_balance(&gas_objs, 0, false).is_ok());
+}

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -37,7 +37,7 @@ use iota_types::{
         ReceivingObjectReadResult, ReceivingObjects, TransactionAPI,
         merge_authenticator_input_objects,
     },
-    transaction_executor::{InputCheckRelaxations, SimulateTransactionResult},
+    transaction_executor::{InputCheckRules, SimulateTransactionResult},
 };
 use move_trace_format::format::MoveTraceBuilder;
 
@@ -169,10 +169,10 @@ pub(super) fn prepare_transaction(
     // above resolves to `max_tx_gas` when the caller declares none, matching the
     // node's dev-inspect entry point, and drops the input checks a simulation
     // does not need. Every other mode runs what a validator runs.
-    let (relaxations, check_name) = if matches!(mode, ExecutionMode::DevInspect) {
-        (InputCheckRelaxations::SIMULATION, "simulation input check")
+    let (input_checks, check_name) = if matches!(mode, ExecutionMode::DevInspect) {
+        (InputCheckRules::SIMULATION, "simulation input check")
     } else {
-        (InputCheckRelaxations::EXECUTION, "transaction input check")
+        (InputCheckRules::EXECUTION, "transaction input check")
     };
     // Offline default: the verifier-signing limits may differ from those a
     // live validator enforces, so this check will not match a real chain.
@@ -196,7 +196,7 @@ pub(super) fn prepare_transaction(
         &env.bytecode_verifier_metrics,
         &verifier_signing_config,
         0,
-        relaxations,
+        input_checks,
     )
     .map_err(|e| ValidationError::new(check_name, e))?;
 

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -25,10 +25,7 @@ use iota_types::{
     auth_context::AuthContextData,
     effects::TransactionEffectsAPI,
     error::{IotaError, UserInputError},
-    gas::{
-        IotaGasStatus, IotaGasStatusAPI, check_gas_coins_cover_budget_in_simulation,
-        fill_in_unset_simulation_gas,
-    },
+    gas::{IotaGasStatus, IotaGasStatusAPI, fill_in_unset_simulation_gas},
     gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::InnerTemporaryStore,
     layout_resolver::LayoutResolver,
@@ -40,7 +37,7 @@ use iota_types::{
         ReceivingObjectReadResult, ReceivingObjects, TransactionAPI,
         merge_authenticator_input_objects,
     },
-    transaction_executor::SimulateTransactionResult,
+    transaction_executor::{InputCheckRelaxations, SimulateTransactionResult},
 };
 use move_trace_format::format::MoveTraceBuilder;
 
@@ -168,62 +165,40 @@ pub(super) fn prepare_transaction(
             .collect::<Vec<_>>()
     });
 
-    let (gas_status, checked_input_objects) = if matches!(mode, ExecutionMode::DevInspect) {
-        // Dev-inspect meters against the transaction's budget, which the fill-in
-        // above resolves to `max_tx_gas` when the caller declares none, matching
-        // the node's dev-inspect entry point.
-        //
-        // The engine smashes the gas coins and reserves the whole budget from them
-        // before running any command, treating the input checks as having verified
-        // that they are gas coins at all — so with those checks skipped here, this
-        // stands in for them, the same way the node's simulation does.
-        let gas_budget = transaction.gas_budget();
-        check_gas_coins_cover_budget_in_simulation(&input_objects, transaction.gas(), gas_budget)
-            .map_err(|e| ValidationError::new("gas balance check", e))?;
-
-        let checked_input_objects = iota_transaction_checks::check_simulation_input(
-            &env.protocol_config,
-            transaction.kind(),
-            input_objects,
-            receiving_objects,
-        )
-        .map_err(|e| ValidationError::new("simulation input check", e))?;
-
-        let gas_status = IotaGasStatus::new(
-            gas_budget,
-            transaction.gas_price(),
-            env.reference_gas_price,
-            &env.protocol_config,
-        )
-        .map_err(|e| ValidationError::new("gas status", e))?;
-        (gas_status, checked_input_objects)
+    // Dev-inspect meters against the transaction's budget, which the fill-in
+    // above resolves to `max_tx_gas` when the caller declares none, matching the
+    // node's dev-inspect entry point, and drops the input checks a simulation
+    // does not need. Every other mode runs what a validator runs.
+    let (relaxations, check_name) = if matches!(mode, ExecutionMode::DevInspect) {
+        (InputCheckRelaxations::SIMULATION, "simulation input check")
     } else {
-        // Offline default: the verifier-signing limits may differ from those a
-        // live validator enforces, so this check will not match a real chain.
-        let verifier_signing_config =
-            iota_config::verifier_signing_config::VerifierSigningConfig::default();
-        // Pass `0` for the authenticator gas budget: this crate runs the
-        // authenticator and body together to effects, which is the node's
-        // post-consensus path, where they share the full transaction budget
-        // (`max_auth_gas` caps only the separate pre-consensus signing check,
-        // which this crate does not model). A `0` budget makes
-        // `check_transaction_input` meter at the full transaction budget, as
-        // `check_certificate_input` does. (Move-authentication support is
-        // verified before preparation, so the precondition a non-zero budget
-        // would enforce is already covered.)
-        let (gas_status, checked_input_objects) = iota_transaction_checks::check_transaction_input(
-            &env.protocol_config,
-            env.reference_gas_price,
-            &transaction,
-            input_objects,
-            &receiving_objects,
-            &env.bytecode_verifier_metrics,
-            &verifier_signing_config,
-            0,
-        )
-        .map_err(|e| ValidationError::new("transaction input check", e))?;
-        (gas_status, checked_input_objects)
+        (InputCheckRelaxations::EXECUTION, "transaction input check")
     };
+    // Offline default: the verifier-signing limits may differ from those a
+    // live validator enforces, so this check will not match a real chain.
+    let verifier_signing_config =
+        iota_config::verifier_signing_config::VerifierSigningConfig::default();
+    // Pass `0` for the authenticator gas budget: this crate runs the
+    // authenticator and body together to effects, which is the node's
+    // post-consensus path, where they share the full transaction budget
+    // (`max_auth_gas` caps only the separate pre-consensus signing check,
+    // which this crate does not model). A `0` budget makes
+    // `check_transaction_input` meter at the full transaction budget, as
+    // `check_certificate_input` does. (Move-authentication support is
+    // verified before preparation, so the precondition a non-zero budget
+    // would enforce is already covered.)
+    let (gas_status, checked_input_objects) = iota_transaction_checks::check_transaction_input(
+        &env.protocol_config,
+        env.reference_gas_price,
+        &transaction,
+        input_objects,
+        &receiving_objects,
+        &env.bytecode_verifier_metrics,
+        &verifier_signing_config,
+        0,
+        relaxations,
+    )
+    .map_err(|e| ValidationError::new(check_name, e))?;
 
     if let Some(receiving) = coin_deny_receiving {
         // Regulated-coin deny-list check over the transaction's own inputs and

--- a/crates/iota-vm-sdk/tests/receiving_inputs.rs
+++ b/crates/iota-vm-sdk/tests/receiving_inputs.rs
@@ -12,7 +12,8 @@
 //! them, like the node. Self-contained — uses only the built-in framework.
 
 use iota_sdk_types::{
-    MoveStruct, ObjectId, ObjectReference, Owner, Transaction, TransactionDigest, Version,
+    MoveStruct, ObjectId, ObjectReference, Owner, ProgrammableTransaction, Transaction,
+    TransactionDigest, Version,
 };
 use iota_types::{
     error::{IotaError, UserInputError},
@@ -21,8 +22,8 @@ use iota_types::{
     transaction::{CallArg, TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TransactionAPI},
 };
 use iota_vm_sdk::{
-    Address, Chain, ChainContext, ExecuteOptions, InMemoryStore, LocalVm, ProtocolVersion, Store,
-    VmSdkError,
+    Address, Chain, ChainContext, ExecuteOptions, ExecutionResult, InMemoryStore, LocalVm,
+    ProtocolVersion, Store, VmSdkError,
 };
 
 const GAS_PRICE: u64 = 1000;
@@ -191,4 +192,149 @@ fn dev_inspect_skips_receiving_checks() {
         "the receiving input is unused, so the run must succeed, got {:?}",
         result.status
     );
+}
+
+/// Runs `tx` under both execution modes and returns what each produced.
+///
+/// Only whether a receiving reference is *current* is relaxed for a dev
+/// inspect. What the object is, and that no reference is named twice, is
+/// checked either way, so these assert over both modes.
+fn execute_under_both_modes(
+    vm: &mut LocalVm,
+    tx: Transaction,
+) -> Vec<(&'static str, Result<ExecutionResult, VmSdkError>)> {
+    vec![
+        ("dry run", vm.execute(tx.clone(), ExecuteOptions::dry_run())),
+        ("dev inspect", vm.execute(tx, ExecuteOptions::dev_inspect())),
+    ]
+}
+
+/// A transfer PTB with `extra` appended as declared-but-unused inputs.
+///
+/// [`ProgrammableTransactionBuilder`] deduplicates object inputs and refuses to
+/// name one object under two argument kinds, so a malformed set of references
+/// cannot be built through it. A client sends the transaction as bytes and is
+/// under no such constraint, which is what the input checks answer for.
+fn tx_with_extra_inputs(sender: Address, gas: &Object, extra: Vec<CallArg>) -> Transaction {
+    let mut b = ProgrammableTransactionBuilder::new();
+    b.transfer_iota(Address::from(ObjectId::random()), Some(1000));
+    let ProgrammableTransaction {
+        mut inputs,
+        commands,
+    } = b.finish();
+    inputs.extend(extra);
+
+    Transaction::new_programmable(
+        sender,
+        vec![gas.object_ref()],
+        ProgrammableTransaction { inputs, commands },
+        TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE * GAS_PRICE,
+        GAS_PRICE,
+    )
+}
+
+fn assert_user_input_error(
+    label: &str,
+    result: Result<ExecutionResult, VmSdkError>,
+    expected: impl Fn(&UserInputError) -> bool,
+) {
+    let Err(VmSdkError::Validation(validation)) = &result else {
+        panic!("{label} must reject the transaction, got {result:?}");
+    };
+    let IotaError::UserInput { error } = &validation.source else {
+        panic!("{label} must fail the input checks, got {validation:?}");
+    };
+    assert!(expected(error), "unexpected error for {label}: {error:?}");
+}
+
+/// The same object named by two receiving references is rejected under both
+/// modes.
+///
+/// `CallArg::Receiving` is not part of `input_objects()`, so it escapes that
+/// function's duplicate rejection; this check is the only one there is. Without
+/// it both tickets reach the object runtime, which treats receiving one object
+/// twice as impossible.
+#[test]
+fn both_modes_reject_a_duplicate_receiving_reference() {
+    let sender = Address::ZERO;
+    let (mut vm, gas, receivable_ref) = vm_with_receivable_coin(sender, ObjectId::random());
+
+    let tx = tx_with_extra_inputs(
+        sender,
+        &gas,
+        vec![
+            CallArg::Receiving(receivable_ref),
+            CallArg::Receiving(receivable_ref),
+        ],
+    );
+
+    for (label, result) in execute_under_both_modes(&mut vm, tx) {
+        assert_user_input_error(label, result, |error| {
+            matches!(error, UserInputError::DuplicateObjectRefInput)
+        });
+    }
+}
+
+/// An object named both as an owned input and as a receiving reference is
+/// rejected under both modes.
+#[test]
+fn both_modes_reject_a_receiving_reference_that_is_also_an_input() {
+    let sender = Address::ZERO;
+    let gas = Object::new_move(
+        MoveStruct::new_gas_coin(OBJECT_START_VERSION, ObjectId::random(), GAS_COIN_VALUE),
+        Owner::Address(sender),
+        TransactionDigest::ZERO,
+    );
+    // Owned by the sender, so the owned-input checks pass and the collision
+    // between the two references is what rejects the transaction.
+    let owned = Object::new_move(
+        MoveStruct::new_gas_coin(OBJECT_START_VERSION, ObjectId::random(), 1),
+        Owner::Address(sender),
+        TransactionDigest::ZERO,
+    );
+    let owned_ref = owned.object_ref();
+
+    let mut store = InMemoryStore::with_framework();
+    store.insert(gas.clone());
+    store.insert(owned);
+    let mut vm = LocalVm::new(chain_context(), store).expect("build LocalVm");
+
+    let tx = tx_with_extra_inputs(
+        sender,
+        &gas,
+        vec![
+            CallArg::ImmutableOrOwned(owned_ref),
+            CallArg::Receiving(owned_ref),
+        ],
+    );
+
+    for (label, result) in execute_under_both_modes(&mut vm, tx) {
+        assert_user_input_error(label, result, |error| {
+            matches!(error, UserInputError::DuplicateObjectRefInput)
+        });
+    }
+}
+
+/// A package named as a receiving reference is rejected under both modes: a
+/// package is not a value that can be received.
+#[test]
+fn both_modes_reject_receiving_a_package() {
+    let sender = Address::ZERO;
+    let (mut vm, gas, _) = vm_with_receivable_coin(sender, ObjectId::random());
+    let package = vm
+        .store()
+        .get_object(&ObjectId::FRAMEWORK, None)
+        .expect("store lookup")
+        .expect("framework package");
+
+    let tx = tx_with_receiving_input(sender, &gas, package.object_ref());
+
+    for (label, result) in execute_under_both_modes(&mut vm, tx) {
+        assert_user_input_error(label, result, |error| {
+            matches!(
+                error,
+                UserInputError::MovePackageAsObject { object_id } if *object_id == ObjectId::FRAMEWORK
+            )
+        });
+    }
 }

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -24,7 +24,7 @@ use iota_types::{
     },
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
     transaction::{ObjectReadResult, TransactionAPI, VerifiedTransaction},
-    transaction_executor::{InputCheckRelaxations, SimulateTransactionResult, VmChecks},
+    transaction_executor::{InputCheckRules, SimulateTransactionResult, VmChecks},
 };
 
 use crate::SimulatorStore;
@@ -141,7 +141,7 @@ impl EpochState {
             &self.bytecode_verifier_metrics,
             verifier_signing_config,
             authenticator_gas_budget,
-            InputCheckRelaxations::EXECUTION,
+            InputCheckRules::EXECUTION,
         )?;
 
         let transaction = transaction.data().transaction();
@@ -237,10 +237,10 @@ impl EpochState {
 
         // Checks enabled -> DRY-RUN (simulating a real TX)
         // Checks disabled -> DEV-INSPECT (more relaxed Move VM checks)
-        let relaxations = if checks.enabled() {
-            InputCheckRelaxations::EXECUTION
+        let input_checks = if checks.enabled() {
+            InputCheckRules::EXECUTION
         } else {
-            InputCheckRelaxations::SIMULATION
+            InputCheckRules::SIMULATION
         };
         let (gas_status, checked_input_objects) = iota_transaction_checks::check_transaction_input(
             &self.protocol_config,
@@ -251,7 +251,7 @@ impl EpochState {
             &self.bytecode_verifier_metrics,
             verifier_signing_config,
             authenticator_gas_budget,
-            relaxations,
+            input_checks,
         )?;
 
         // Execute the simulation

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -14,7 +14,7 @@ use iota_sdk_types::{Transaction, TransactionEffects};
 use iota_types::{
     committee::{Committee, EpochId},
     effects::TransactionEffectsAPI,
-    error::IotaResult,
+    error::{IotaError, IotaResult},
     gas::IotaGasStatus,
     gas_coin::mock_simulation_gas_coin,
     inner_temporary_store::InnerTemporaryStore,
@@ -24,7 +24,7 @@ use iota_types::{
     },
     metrics::{BytecodeVerifierMetrics, LimitsMetrics},
     transaction::{ObjectReadResult, TransactionAPI, VerifiedTransaction},
-    transaction_executor::{SimulateTransactionResult, VmChecks},
+    transaction_executor::{InputCheckRelaxations, SimulateTransactionResult, VmChecks},
 };
 
 use crate::SimulatorStore;
@@ -141,6 +141,7 @@ impl EpochState {
             &self.bytecode_verifier_metrics,
             verifier_signing_config,
             authenticator_gas_budget,
+            InputCheckRelaxations::EXECUTION,
         )?;
 
         let transaction = transaction.data().transaction();
@@ -178,6 +179,12 @@ impl EpochState {
         mut transaction: Transaction,
         checks: VmChecks,
     ) -> IotaResult<SimulateTransactionResult> {
+        if transaction.kind().is_system() {
+            return Err(IotaError::UnsupportedFeature {
+                error: "simulate does not support system transactions".to_string(),
+            });
+        }
+
         // Cheap validity checks for a transaction, including input size limits.
         transaction.validity_check_no_gas_check(&self.protocol_config)?;
 
@@ -230,44 +237,22 @@ impl EpochState {
 
         // Checks enabled -> DRY-RUN (simulating a real TX)
         // Checks disabled -> DEV-INSPECT (more relaxed Move VM checks)
-        let (gas_status, checked_input_objects) = if checks.enabled() {
-            iota_transaction_checks::check_transaction_input(
-                &self.protocol_config,
-                self.epoch_start_state.reference_gas_price(),
-                &transaction,
-                input_objects,
-                &receiving_objects,
-                &self.bytecode_verifier_metrics,
-                verifier_signing_config,
-                authenticator_gas_budget,
-            )?
+        let relaxations = if checks.enabled() {
+            InputCheckRelaxations::EXECUTION
         } else {
-            // Execution smashes the gas coins and reserves the whole budget from them
-            // before running any command, treating the input checks as having verified
-            // that they are gas coins at all — so with those checks skipped here, this
-            // has to stand in for them. With the checks enabled,
-            // `check_transaction_input` covers it.
-            iota_types::gas::check_gas_coins_cover_budget_in_simulation(
-                &input_objects,
-                transaction.gas(),
-                transaction.gas_budget(),
-            )?;
-
-            let checked_input_objects = iota_transaction_checks::check_simulation_input(
-                &self.protocol_config,
-                transaction.kind(),
-                input_objects,
-                receiving_objects,
-            )?;
-            let gas_status = IotaGasStatus::new(
-                transaction.gas_budget(),
-                transaction.gas_price(),
-                self.epoch_start_state.reference_gas_price(),
-                &self.protocol_config,
-            )?;
-
-            (gas_status, checked_input_objects)
+            InputCheckRelaxations::SIMULATION
         };
+        let (gas_status, checked_input_objects) = iota_transaction_checks::check_transaction_input(
+            &self.protocol_config,
+            self.epoch_start_state.reference_gas_price(),
+            &transaction,
+            input_objects,
+            &receiving_objects,
+            &self.bytecode_verifier_metrics,
+            verifier_signing_config,
+            authenticator_gas_budget,
+            relaxations,
+        )?;
 
         // Execute the simulation
         let (kind, signer, gas_data) = transaction.execution_parts();

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -1058,4 +1058,30 @@ mod tests {
         assert_eq!(&checkpoint.epoch_rolling_gas_cost_summary, gas_summary);
         assert_eq!(checkpoint.network_total_transactions, 2); // genesis + 1 txn
     }
+
+    /// A system transaction kind is rejected under both check modes.
+    ///
+    /// Simulating one would run it outside the sequencing that gives it
+    /// meaning, and the shared input checks treat a system transaction as
+    /// exempt from the gas and object rules rather than rejecting it, so the
+    /// entry point is where this belongs — as it is on the node and in the SDK.
+    #[test]
+    fn simulate_rejects_system_transactions() {
+        use iota_types::{error::IotaError, transaction_executor::VmChecks};
+
+        let sim = Simulacrum::new();
+        let (tx, _) = sim.transfer_txn(Address::random());
+        let mut transaction = tx.data().transaction().clone();
+        *transaction.kind_mut() = TransactionKind::EndOfEpoch(vec![]);
+
+        for checks in [VmChecks::Enabled, VmChecks::Disabled] {
+            let Err(error) = sim.simulate_transaction(transaction.clone(), checks) else {
+                panic!("{checks:?} must not simulate a system transaction");
+            };
+            assert!(
+                matches!(error, IotaError::UnsupportedFeature { .. }),
+                "unexpected error for {checks:?}: {error:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
# Description of change

Routes every caller that asks "may this transaction run?" through `check_transaction_input`, and names the checks a simulation drops instead of letting them go missing.

- Adds `InputCheckRelaxations` (`iota-types::transaction_executor`), a struct of named relaxations with `EXECUTION` and `SIMULATION` constants. Each field what it drops and why.
- Deletes `check_simulation_input` and `iota_types::gas::check_gas_coins_cover_budget_in_simulation`. The three
  simulation paths (`iota-core`, `simulacrum`, `iota-vm-sdk`) now call `check_transaction_input` with `InputCheckRelaxations::SIMULATION`.

**Why.** `check_simulation_input` was a second, hand-written answer to the same question — the transaction kind, no system transactions, no mutable object used twice, and nothing else. It was written as "the minimum needed to make dev
inspect run" rather than derived as "the real checks minus what dev inspect needs relaxed", so it silently omitted whatever its author did not think about, and nothing flagged the gap as the real path grew.

That cost four defects of one shape: a check missing from the simulation path, and downstream code asserting the check had happened.

| Reached                                                                | Result                                           | Found         |
| ---------------------------------------------------------------------- | ------------------------------------------------ | ------------- |
| `GasCharger::smash_gas` with a non-`Coin<IOTA>` gas payment            | `panic!` — process abort under `panic = 'abort'` | #12508 review |
| PTB context with gas that cannot cover the budget                      | `invariant_violation!`                           | #12508 review |
| `check_one_object` skipped for a child object named as an owned input  | `invariant_violation!` — panics in a debug build | here          |
| `ObjectRuntime::receive_object` with a duplicated `Receiving` argument | `VmInvariantViolation`                           | here          |

#12508 fixed the first two by adding a helper and calling it alongside. That fixes the instances, not the shape: the next check added to `check_transaction_input` would again not reach simulation, and nobody would be told. This removes the second path so there is nothing to keep in sync.

The rule the type encodes: **a relaxation may name a permission or a concurrency token, never a structural fact the engine relies on.** Both defects found here were structural checks relaxed by mistake.

## What a simulation still drops

Every relaxation is deliberate and matches existing behaviour — no simulation becomes more permissive than it is today.

- `unbounded_gas_budget` — the `[min, max]` bounds on the budget, so an unsettled or deliberately small budget runs and reports out-of-gas. Gas coins must still be address-owned and cover the budget.
- `any_object_owner` — whether the sender owns an address-owned input, so a caller can ask what a transaction would do over objects it does not own. A child or shared object named as an owned input is still rejected.
- `any_object_digest` — the declared digest of an input object. Nothing in execution reads it; the object is loaded by id and version.
- `any_receiving_object_version` / `any_receiving_object_digest` — the same, per half, for receiving references. The version half only moves where the failure surfaces: execution resolves the receive at the declared version, so a stale one still fails with `E_UNABLE_TO_RECEIVE_OBJECT`.

What is **not** relaxed, and now applies to dev inspect: the object is not a package, not shared or immutable, and no receiving reference duplicates another or collides with an input object. That last one is the only rejection there is — `CallArg::Receiving` is not part of `input_objects()` and escapes its `DuplicateObjectRefInput` dedup.

## What does not change

The signing, certificate, and execution paths are untouched — `EXECUTION` is expression-for-expression the previous behaviour, including the order in which competing errors are reported. No protocol change, no snapshot change.

## Links to any relevant issues

Follow-up to #12508.

Fixes #12770.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Evidence:

- 534 adapter and verifier transactional tests pass with **zero `.exp` diffs**, the regression signal that the execution path is unchanged.
- 1063 tests pass across `iota-types`, `iota-transaction-checks`, `iota-core`, `simulacrum`, `iota-vm-sdk`.
- The relaxations stay pinned by the tests that assert them: `test_dev_inspect_unowned_object`, `dev_inspect_skips_receiving_checks`, `dry_run_rejects_outdated_receiving_version`, `dev_inspect_meters_against_a_declared_budget`.

New tests, each asserting the same outcome under `VmChecks::Enabled` and `VmChecks::Disabled`:

- `iota-core` — a package used as an object, a child object used as owned, `Clock` taken mutably, and a mismatched input digest (rejected by a dry run, accepted by a dev inspect, so the relaxation is recorded in code).
- `iota-vm-sdk` — a duplicate `Receiving` reference, one that collides with an input object, and one naming a package. None of these had coverage.
- `simulacrum` — a system transaction kind is rejected by `simulate_transaction`.
- `iota-types` — `check_gas_balance` accepts an under-minimum budget with `bounded_budget: false` and rejects it with `true`.

The child-object test is what caught `any_object_owner` being specified too broadly, and the duplicate-`Receiving` test covers a path that had none.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): dev inspect now rejects malformed inputs up front — a package or child object used as an owned input, `Clock` taken mutably, and duplicate or malformed receiving references — instead of letting them reach the engine as an invariant violation.
- [ ] Indexer:
- [x] JSON-RPC: `iota_devInspectTransactionBlock` reports these as input errors rather than execution failures; a transaction that publishes a package now runs the signing-time bytecode verifier.
- [x] GraphQL: same change to `dryRun` with dev-inspect semantics.
- [ ] CLI:
- [ ] Rust SDK:
- [x] gRPC: same change to `SimulateTransaction` when `DisableVmChecks` is set.
