### PR TITLE
feat(starfish): select header peers by delivery latency

### DIFF
--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -11,6 +11,7 @@ use ahash::{AHashMap, AHashSet};
 use bytes::Bytes;
 use iota_metrics::monitored_mpsc::{self, Receiver, Sender};
 use parking_lot::RwLock;
+use rand::{Rng as _, SeedableRng, prelude::StdRng};
 use starfish_config::AuthorityIndex;
 use tokio::{
     sync::{Mutex, mpsc::error::TrySendError},
@@ -100,6 +101,7 @@ pub(crate) struct CordialKnowledge {
     /// Whether headers are currently requested from each peer. This ensures an
     /// empty set is sent once when the last request is removed.
     has_useful_headers_from_peer: Vec<bool>,
+    rng: StdRng,
 }
 
 /// High-level messages sent to the CordialKnowledge task.
@@ -301,6 +303,7 @@ impl CordialKnowledge {
                 missing_authors: vec![None; num_authorities],
                 latest_own_block_round: Round::MIN,
                 has_useful_headers_from_peer: vec![false; num_authorities],
+                rng: StdRng::from_entropy(),
             },
             connection_knowledges,
             cordial_knowledge_sender,
@@ -315,8 +318,9 @@ impl CordialKnowledge {
         context: Arc<Context>,
         dag_state: Arc<RwLock<DagState>>,
     ) -> (Self, Vec<Arc<RwLock<ConnectionKnowledge>>>) {
-        let (cordial_knowledge, connection_knowledges, _sender, _eviction_sender) =
+        let (mut cordial_knowledge, connection_knowledges, _sender, _eviction_sender) =
             Self::new(context, dag_state);
+        cordial_knowledge.rng = StdRng::seed_from_u64(0);
         (cordial_knowledge, connection_knowledges)
     }
 
@@ -615,8 +619,10 @@ impl CordialKnowledge {
             .set(missing_authors);
     }
 
-    /// Remove stale authors and useful peers. When bounded, select at most the
-    /// configured number of useful peers for each author.
+    /// Remove stale authors and useful peers. When bounded, retain selected
+    /// useful peers and fill free places. With ranking enabled, keep the
+    /// fastest measured useful peer selected and occasionally try another
+    /// useful peer.
     fn refresh_missing_authors_and_peers(&mut self) {
         let bounded = self.context.parameters.enable_bounded_header_advertisement;
         let latest_own_block_round = self.latest_own_block_round;
@@ -665,7 +671,78 @@ impl CordialKnowledge {
                 }
                 missing_author.selected_peers.insert(*peer);
             }
+            if self.context.parameters.enable_peer_responsiveness_ranking {
+                Self::select_fastest_useful_peer(&self.context, author, missing_author);
+                Self::explore_header_peer(&self.context, &mut self.rng, author, missing_author);
+            }
         }
+    }
+
+    fn select_fastest_useful_peer(
+        context: &Context,
+        author: AuthorityIndex,
+        missing_author: &mut MissingAuthor,
+    ) {
+        let useful_peers: Vec<_> = missing_author.useful_peers.keys().copied().collect();
+        let Some((fastest_peer, fastest_latency)) = context
+            .peer_responsiveness
+            .fastest_peer_for_header_delivery(author, &useful_peers)
+        else {
+            return;
+        };
+        if missing_author.selected_peers.contains(&fastest_peer) {
+            return;
+        }
+
+        if missing_author.selected_peers.len() == MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER {
+            let selected_peers: Vec<_> = missing_author.selected_peers.iter().copied().collect();
+            let Some((slowest_peer, slowest_latency)) = context
+                .peer_responsiveness
+                .slowest_peer_for_header_delivery(author, &selected_peers)
+            else {
+                return;
+            };
+            if slowest_latency.is_some_and(|latency| fastest_latency >= latency) {
+                return;
+            }
+            missing_author.selected_peers.remove(&slowest_peer);
+        }
+
+        missing_author.selected_peers.insert(fastest_peer);
+    }
+
+    fn explore_header_peer(
+        context: &Context,
+        rng: &mut StdRng,
+        author: AuthorityIndex,
+        missing_author: &mut MissingAuthor,
+    ) {
+        if missing_author.selected_peers.len() != MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER
+            || !context.peer_responsiveness.should_explore(rng)
+        {
+            return;
+        }
+
+        let candidates: Vec<_> = missing_author
+            .useful_peers
+            .keys()
+            .filter(|peer| !missing_author.selected_peers.contains(peer))
+            .copied()
+            .collect();
+        if candidates.is_empty() {
+            return;
+        }
+        let peer = candidates[rng.gen_range(0..candidates.len())];
+        let selected_peers: Vec<_> = missing_author.selected_peers.iter().copied().collect();
+        let Some((slowest_peer, _)) = context
+            .peer_responsiveness
+            .slowest_peer_for_header_delivery(author, &selected_peers)
+        else {
+            return;
+        };
+
+        missing_author.selected_peers.remove(&slowest_peer);
+        missing_author.selected_peers.insert(peer);
     }
 
     /// Prepare useful authors message for each connection knowledge.
@@ -1442,6 +1519,21 @@ mod tests {
         CordialKnowledge::new_for_test(context, dag_state)
     }
 
+    fn ranked_cordial_knowledge_for_test(
+        validators: usize,
+    ) -> (CordialKnowledge, Vec<Arc<RwLock<ConnectionKnowledge>>>) {
+        let (context, _key_pairs) = Context::new_for_test(validators);
+        let parameters = Parameters {
+            enable_bounded_header_advertisement: true,
+            enable_peer_responsiveness_ranking: true,
+            ..context.parameters.clone()
+        };
+        let context = Arc::new(context.with_parameters(parameters));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        CordialKnowledge::new_for_test(context, dag_state)
+    }
+
     fn selected_peers_gauge(cordial_knowledge: &CordialKnowledge, author: AuthorityIndex) -> i64 {
         cordial_knowledge
             .context
@@ -1829,6 +1921,143 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_full_selection_explores_another_peer() {
+        let (mut cordial_knowledge, _connection_knowledges) = ranked_cordial_knowledge_for_test(8);
+        let context = cordial_knowledge.context.clone();
+        let author = AuthorityIndex::new_for_test(7);
+        for (peer, latency_ms) in [(1, 10), (2, 20), (3, 30), (4, 40)] {
+            context
+                .peer_responsiveness
+                .record_streaming_header_deliveries(
+                    AuthorityIndex::new_for_test(peer),
+                    latency_ms,
+                    [(author, 1, 0)],
+                );
+            report_missing(&mut cordial_knowledge, peer, 7);
+        }
+        cordial_knowledge.latest_own_block_round = 10;
+        recompute(&mut cordial_knowledge);
+        let initial = selected_peers(&cordial_knowledge, author);
+        assert_eq!(initial, [1, 2, 3].map(AuthorityIndex::new_for_test));
+
+        let mut explored = false;
+        for round in 11..=200 {
+            cordial_knowledge.latest_own_block_round = round;
+            for peer in 1..=4 {
+                report_missing(&mut cordial_knowledge, peer, 7);
+            }
+            recompute(&mut cordial_knowledge);
+            let selected = selected_peers(&cordial_knowledge, author);
+            if selected != initial {
+                assert_eq!(selected.len(), MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER);
+                assert!(selected.contains(&AuthorityIndex::new_for_test(1)));
+                assert!(
+                    selected
+                        .iter()
+                        .all(|peer| [1, 2, 3, 4].contains(&(peer.value() as u8)))
+                );
+                explored = true;
+                break;
+            }
+        }
+        assert!(explored);
+    }
+
+    #[tokio::test]
+    async fn test_fastest_useful_peer_is_selected() {
+        let (mut cordial_knowledge, _connection_knowledges) = ranked_cordial_knowledge_for_test(8);
+        let context = cordial_knowledge.context.clone();
+        let author = AuthorityIndex::new_for_test(7);
+        let fastest_peer = AuthorityIndex::new_for_test(1);
+        for peer in 1..=6u8 {
+            let latency_ms = if peer == 1 { 10 } else { 1_000 };
+            context
+                .peer_responsiveness
+                .record_streaming_header_deliveries(
+                    AuthorityIndex::new_for_test(peer),
+                    latency_ms,
+                    [(author, 1, 0)],
+                );
+        }
+
+        cordial_knowledge.latest_own_block_round = 10;
+        for peer in 1..=6 {
+            report_missing(&mut cordial_knowledge, peer, 7);
+        }
+        recompute(&mut cordial_knowledge);
+
+        assert!(selected_peers(&cordial_knowledge, author).contains(&fastest_peer));
+    }
+
+    #[tokio::test]
+    async fn test_faster_useful_peer_replaces_slowest_selected_peer() {
+        let (mut cordial_knowledge, _connection_knowledges) = ranked_cordial_knowledge_for_test(8);
+        let context = cordial_knowledge.context.clone();
+        let author = AuthorityIndex::new_for_test(7);
+        for (peer, latency_ms) in [(1, 100), (2, 200), (3, 300)] {
+            context
+                .peer_responsiveness
+                .record_streaming_header_deliveries(
+                    AuthorityIndex::new_for_test(peer),
+                    latency_ms,
+                    [(author, 1, 0)],
+                );
+        }
+        cordial_knowledge.latest_own_block_round = 10;
+        for peer in 1..=3 {
+            report_missing(&mut cordial_knowledge, peer, 7);
+        }
+        recompute(&mut cordial_knowledge);
+        assert_eq!(
+            selected_peers(&cordial_knowledge, author),
+            [1, 2, 3].map(AuthorityIndex::new_for_test)
+        );
+
+        let faster_peer = AuthorityIndex::new_for_test(4);
+        context
+            .peer_responsiveness
+            .record_streaming_header_deliveries(faster_peer, 10, [(author, 1, 0)]);
+        cordial_knowledge.latest_own_block_round = 11;
+        report_missing(&mut cordial_knowledge, 4, 7);
+        recompute(&mut cordial_knowledge);
+
+        let selected = selected_peers(&cordial_knowledge, author);
+        assert!(selected.contains(&faster_peer));
+        assert!(!selected.contains(&AuthorityIndex::new_for_test(3)));
+    }
+
+    #[tokio::test]
+    async fn test_slower_useful_peer_does_not_replace_selected_peer() {
+        let (mut cordial_knowledge, _connection_knowledges) = ranked_cordial_knowledge_for_test(8);
+        let context = cordial_knowledge.context.clone();
+        let author = AuthorityIndex::new_for_test(7);
+        for (peer, latency_ms) in [(1, 10), (2, 20), (3, 30), (4, 100)] {
+            context
+                .peer_responsiveness
+                .record_streaming_header_deliveries(
+                    AuthorityIndex::new_for_test(peer),
+                    latency_ms,
+                    [(author, 1, 0)],
+                );
+        }
+        cordial_knowledge.latest_own_block_round = 10;
+        for peer in 1..=3 {
+            report_missing(&mut cordial_knowledge, peer, 7);
+        }
+        recompute(&mut cordial_knowledge);
+        let selected = selected_peers(&cordial_knowledge, author);
+
+        cordial_knowledge.latest_own_block_round = 51;
+        for peer in &selected {
+            report_missing(&mut cordial_knowledge, peer.value() as u8, 7);
+        }
+        report_missing(&mut cordial_knowledge, 4, 7);
+        recompute(&mut cordial_knowledge);
+
+        assert_eq!(selected_peers(&cordial_knowledge, author), selected);
     }
 
     /// Test that cordial knowledge correctly tracks blocks from a byzantine

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -345,7 +345,7 @@ impl PeerResponsiveness {
         // Exploration round: ignore ranking entirely. This is the floor that
         // keeps every peer reachable early and prevents any peer from
         // monopolizing the head of the list across rounds.
-        if rng.gen::<f64>() < EXPLORE_PROBABILITY {
+        if self.should_explore(rng) {
             candidates.shuffle(rng);
             return;
         }
@@ -397,6 +397,66 @@ impl PeerResponsiveness {
             .collect();
 
         Self::reorder_by_latency(candidates, &stats, rng);
+    }
+
+    /// Returns whether this selection should explore instead of using ranking.
+    pub(crate) fn should_explore<R: Rng>(&self, rng: &mut R) -> bool {
+        rng.gen::<f64>() < EXPLORE_PROBABILITY
+    }
+
+    /// Returns the uniquely fastest peer measured delivering `author`'s
+    /// headers.
+    pub(crate) fn fastest_peer_for_header_delivery(
+        &self,
+        author: AuthorityIndex,
+        candidates: &[AuthorityIndex],
+    ) -> Option<(AuthorityIndex, f64)> {
+        let latencies = self.header_delivery_latencies(author, candidates);
+        let fastest_latency = latencies.iter().flatten().copied().min_by(f64::total_cmp)?;
+        let mut fastest = candidates
+            .iter()
+            .copied()
+            .zip(latencies)
+            .filter(|(_, latency)| {
+                latency.is_some_and(|latency| latency.total_cmp(&fastest_latency).is_eq())
+            })
+            .map(|(peer, _)| peer);
+        let peer = fastest.next()?;
+        fastest.next().is_none().then_some((peer, fastest_latency))
+    }
+
+    /// Returns the slowest peer, treating an unmeasured peer as slower.
+    pub(crate) fn slowest_peer_for_header_delivery(
+        &self,
+        author: AuthorityIndex,
+        candidates: &[AuthorityIndex],
+    ) -> Option<(AuthorityIndex, Option<f64>)> {
+        candidates
+            .iter()
+            .copied()
+            .zip(self.header_delivery_latencies(author, candidates))
+            .max_by(|(left_peer, left_latency), (right_peer, right_latency)| {
+                left_latency
+                    .unwrap_or(f64::INFINITY)
+                    .total_cmp(&right_latency.unwrap_or(f64::INFINITY))
+                    .then_with(|| left_peer.cmp(right_peer))
+            })
+    }
+
+    fn header_delivery_latencies(
+        &self,
+        author: AuthorityIndex,
+        candidates: &[AuthorityIndex],
+    ) -> Vec<Option<f64>> {
+        let table = self.streaming_headers.lock();
+        candidates
+            .iter()
+            .map(|peer| {
+                table
+                    .get(peer.value())
+                    .and_then(|row| row.get(author.value()).copied().flatten())
+            })
+            .collect()
     }
 
     /// Writes the ranked order back into `candidates` from per-candidate
@@ -574,6 +634,44 @@ mod tests {
             *counts.entry(c[0]).or_insert(0) += 1;
         }
         counts
+    }
+
+    fn record_streaming_header_delivery(
+        pr: &PeerResponsiveness,
+        peer: AuthorityIndex,
+        author: AuthorityIndex,
+        latency_ms: u64,
+    ) {
+        pr.record_streaming_header_deliveries(peer, latency_ms, [(author, 1, 0)]);
+    }
+
+    #[test]
+    fn fastest_header_delivery_peer_is_reported() {
+        let pr = responsiveness(6);
+        let author = idx(5);
+        record_streaming_header_delivery(&pr, idx(1), author, 10);
+        for peer in [2u8, 3, 4] {
+            record_streaming_header_delivery(&pr, idx(peer), author, 1_000);
+        }
+        let candidates = vec![idx(1), idx(2), idx(3), idx(4)];
+        assert_eq!(
+            pr.fastest_peer_for_header_delivery(author, &candidates),
+            Some((idx(1), 10.0))
+        );
+    }
+
+    #[test]
+    fn unmeasured_selected_peer_is_replaced_first() {
+        let pr = responsiveness(5);
+        let author = idx(4);
+        record_streaming_header_delivery(&pr, idx(1), author, 10);
+        record_streaming_header_delivery(&pr, idx(2), author, 1_000);
+        let candidates = vec![idx(1), idx(2), idx(3)];
+
+        assert_eq!(
+            pr.slowest_peer_for_header_delivery(author, &candidates),
+            Some((idx(3), None))
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Description of change

Uses bundled-header delivery latency when choosing useful peers.

- Keeps the fastest measured useful peer selected.
- Occasionally replaces the slowest selected peer with another useful peer.
- Never selects a peer that has not recently supplied or referenced the author's headers.
- Does not change synchronization.

## Links to any relevant issues

Fixes #12774

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes