### PR TITLE
fix(iota-core,iota-e2e-tests): fix nightly simtest failures from state leaking across simulator iterations

### DIFF
--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1614,7 +1614,10 @@ async fn failed_deny_rule_update_execution_is_reported() {
 async fn failed_deny_rule_update_execution_asserts_on_derived_effects() {
     use std::{
         collections::BTreeSet,
-        sync::atomic::{AtomicUsize, Ordering},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
     };
 
     use iota_common::register_debug_fatal_handler;
@@ -1624,9 +1627,12 @@ async fn failed_deny_rule_update_execution_asserts_on_derived_effects() {
         transaction::VerifiedTransaction,
     };
 
-    static ASSERTED: AtomicUsize = AtomicUsize::new(0);
-    register_debug_fatal_handler!("TransactionDenyRulesUpdate failed execution", || {
-        ASSERTED.fetch_add(1, Ordering::SeqCst);
+    let asserted = Arc::new(AtomicUsize::new(0));
+    register_debug_fatal_handler!("TransactionDenyRulesUpdate failed execution", {
+        let asserted = asserted.clone();
+        move || {
+            asserted.fetch_add(1, Ordering::SeqCst);
+        }
     });
 
     let update = VerifiedExecutableTransaction::new_system(
@@ -1671,7 +1677,7 @@ async fn failed_deny_rule_update_execution_asserts_on_derived_effects() {
         None,
         &store,
     );
-    assert_eq!(ASSERTED.load(Ordering::SeqCst), 0);
+    assert_eq!(asserted.load(Ordering::SeqCst), 0);
     assert_eq!(store.metrics.deny_rule_update_execution_failures.get(), 0);
 
     authority_state.report_failed_deny_rule_update_execution(
@@ -1683,6 +1689,6 @@ async fn failed_deny_rule_update_execution_asserts_on_derived_effects() {
         None,
         &store,
     );
-    assert_eq!(ASSERTED.load(Ordering::SeqCst), 1);
+    assert_eq!(asserted.load(Ordering::SeqCst), 1);
     assert_eq!(store.metrics.deny_rule_update_execution_failures.get(), 1);
 }

--- a/crates/iota-e2e-tests/tests/pcool_transaction_flow_tests.rs
+++ b/crates/iota-e2e-tests/tests/pcool_transaction_flow_tests.rs
@@ -44,9 +44,9 @@ use std::str::FromStr;
 
 use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
-use iota_sdk_types::{ObjectId, TypeTag};
+use iota_sdk_types::{ObjectId, StructTag, TypeTag};
 use iota_test_transaction_builder::TestTransactionBuilder;
-use iota_types::{base_types::dbg_addr, transaction::CallArg};
+use iota_types::{base_types::dbg_addr, coin::CoinMetadata, transaction::CallArg};
 use test_cluster::{TestCluster, TestClusterBuilder};
 
 /// Applies a thread-local protocol-config override that enables the P-COOL
@@ -265,17 +265,22 @@ async fn run_immutable_object_read_twice(test_cluster: &TestCluster) {
     let sender = test_cluster.get_address_0();
     let rgp = test_cluster.get_reference_gas_price().await;
 
+    // Resolved from the genesis objects rather than through `coin_read_api`:
+    // the RPC's package-object lookup sits behind a process-global cache
+    // (keyed only by package id and struct tag), which under MSIM_TEST_NUM > 1
+    // serves the object id from a previous iteration's genesis.
     let metadata_id = test_cluster
-        .wallet
-        .get_client()
-        .await
-        .unwrap()
-        .coin_read_api()
-        .get_coin_metadata("0x2::iota::IOTA".to_string())
-        .await
-        .unwrap()
-        .and_then(|metadata| metadata.id)
-        .expect("the IOTA coin metadata object exists at genesis");
+        .get_genesis()
+        .objects()
+        .iter()
+        .find(|object| {
+            object.data.as_opt_struct().is_some_and(|move_struct| {
+                CoinMetadata::is_coin_metadata_with_coin_type(move_struct.struct_tag())
+                    .is_some_and(StructTag::is_gas)
+            })
+        })
+        .expect("the IOTA coin metadata object exists at genesis")
+        .id();
     let metadata_ref = test_cluster.get_latest_object_ref(&metadata_id).await;
 
     // Sequential, not concurrent: the point is that the first read leaves no


### PR DESCRIPTION
# Description of change

The [nightly simtest run](https://github.com/iotaledger/iota/actions/runs/32904498428) fails three tests. The nightly runs every test with `MSIM_TEST_NUM=2` iterations in one process (PR CI runs a single iteration, so the tests passed on merge), and process-global state leaks from the first iteration into the second. Both fixes are test-only.

- `failed_deny_rule_update_execution_asserts_on_derived_effects`: the test counted intercepted `debug_fatal!` calls in a `static AtomicUsize`, which keeps its count from the previous iteration. The handler closure now owns a per-run `Arc<AtomicUsize>` instead, so each iteration starts from a fresh counter.
- `test_pcool_immutable_object_read_twice_{transaction_manager,execution_scheduler}`: the tests resolved the `CoinMetadata` object id via `coin_read_api`, whose package-object lookup sits behind a process-global cache keyed only by package id and struct tag (`find_package_object_id` in `crates/iota-json-rpc/src/coin_api.rs`). The second iteration has a different genesis, but the cache serves the first iteration's object id and the RPC returns no metadata. The tests now resolve the id from the genesis objects directly. The cache itself is left as is: in a real node process one process is one network, so it only misbehaves under multi-iteration simtests.

Reproduce the failures with the nightly's parameters: `MSIM_TEST_SEED=1787695583 MSIM_TEST_NUM=2 cargo simtest ...` (the seed printed by the nightly, `4532946497001723490`, is the derived second-iteration seed and does not reproduce on its own).

## Links to any relevant issues

None.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

All three tests reproduce the nightly failure locally with `MSIM_TEST_SEED=1787695583 MSIM_TEST_NUM=2` before the fix and pass with the same parameters after it.