### PR TITLE
fix(iota-localnet): move the GraphQL metrics port off 9184

### DIFF
--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -58,6 +58,11 @@ const DEFAULT_GRPC_PORT: u16 = 50051;
 const DEFAULT_GRAPHQL_PORT: u16 = 9125;
 #[cfg(feature = "indexer")]
 const DEFAULT_INDEXER_PORT: u16 = 9124;
+/// Metrics port a local network gives the GraphQL service, overriding the
+/// `9184` the service picks by default, which the fullnode metrics endpoint
+/// already holds.
+#[cfg(feature = "indexer")]
+const GRAPHQL_METRICS_PORT: u16 = 9126;
 /// Port base of the fullnode layout, see
 /// [`FullnodeConfigBuilder::with_deterministic_ports`].
 const FULLNODE_PORT_BASE: u16 = 9184;
@@ -722,6 +727,10 @@ async fn start(
             port: graphql_address.port(),
             host: graphql_address.ip().to_string(),
             db_url: pg_address,
+            // The default metrics port collides with the fullnode metrics
+            // endpoint, which binds `FULLNODE_PORT_BASE` before this runs.
+            prom_host: Ipv4Addr::LOCALHOST.to_string(),
+            prom_port: GRAPHQL_METRICS_PORT,
             ..Default::default()
         };
         start_graphql_server_with_fn_rpc(
@@ -1156,5 +1165,32 @@ pub fn parse_host_port(
         format!("{default_host}:{input}").parse::<SocketAddr>()
     } else {
         format!("{default_host}:{default_port_if_missing}").parse::<SocketAddr>()
+    }
+}
+
+#[cfg(all(test, feature = "indexer"))]
+mod tests {
+    use super::*;
+
+    /// Every service port of a local network is fixed, so a collision is a
+    /// startup failure rather than a test flake. The fullnode metrics
+    /// endpoint and the GraphQL metrics endpoint shared `9184` once.
+    #[test]
+    fn service_ports_do_not_collide() {
+        let mut ports = vec![
+            DEFAULT_FAUCET_PORT,
+            DEFAULT_GRPC_PORT,
+            DEFAULT_GRAPHQL_PORT,
+            DEFAULT_INDEXER_PORT,
+            GRAPHQL_METRICS_PORT,
+            9000, // fullnode JSON-RPC, see `fullnode_rpc_port`
+        ];
+        // The fullnode owns `FULLNODE_PORT_BASE` and the two ports above it,
+        // each validator the ten ports above its own base.
+        ports.extend((0..3).map(|offset| FULLNODE_PORT_BASE + offset));
+        ports.extend((0..10 * DEFAULT_COMMITTEE_SIZE as u16).map(|o| VALIDATOR_PORT_BASE + o));
+
+        let unique = ports.iter().collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(unique.len(), ports.len(), "two services share a port");
     }
 }

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -56,13 +56,13 @@ const DEFAULT_FAUCET_PORT: u16 = 9123;
 const DEFAULT_GRPC_PORT: u16 = 50051;
 #[cfg(feature = "indexer")]
 const DEFAULT_GRAPHQL_PORT: u16 = 9125;
-#[cfg(feature = "indexer")]
-const DEFAULT_INDEXER_PORT: u16 = 9124;
 /// Metrics port a local network gives the GraphQL service, overriding the
 /// `9184` the service picks by default, which the fullnode metrics endpoint
-/// already holds.
+/// already holds. Metrics endpoints stay on `127.0.0.1`, as the node ones do.
 #[cfg(feature = "indexer")]
-const GRAPHQL_METRICS_PORT: u16 = 9126;
+const DEFAULT_GRAPHQL_METRICS_PORT: u16 = 9126;
+#[cfg(feature = "indexer")]
+const DEFAULT_INDEXER_PORT: u16 = 9124;
 /// Port base of the fullnode layout, see
 /// [`FullnodeConfigBuilder::with_deterministic_ports`].
 const FULLNODE_PORT_BASE: u16 = 9184;
@@ -101,6 +101,13 @@ pub struct IndexerFeatureArgs {
             value_name = "GRAPHQL_HOST_PORT"
         )]
     with_graphql: Option<String>,
+    /// Bind the GraphQL metrics endpoint to this host and port instead of
+    /// 127.0.0.1:9126. This flag accepts a port, a host, or both (e.g.,
+    /// `--graphql-metrics-address=9127`, `--graphql-metrics-address=0.0.0.0`,
+    /// or `--graphql-metrics-address=0.0.0.0:9127`). It has no effect without
+    /// `--with-graphql`.
+    #[arg(long, value_name = "GRAPHQL_METRICS_HOST_PORT")]
+    graphql_metrics_address: Option<String>,
     /// Port for the Indexer Postgres DB. Default port is 5432.
     #[arg(long, default_value = "5432")]
     pg_port: u16,
@@ -131,6 +138,7 @@ impl IndexerFeatureArgs {
         Self {
             with_indexer: None,
             with_graphql: None,
+            graphql_metrics_address: None,
             pg_port: 5432,
             pg_host: "localhost".to_string(),
             pg_db_name: "iota_indexer".to_string(),
@@ -410,6 +418,7 @@ async fn start(
     let IndexerFeatureArgs {
         mut with_indexer,
         with_graphql,
+        graphql_metrics_address,
         pg_port,
         pg_host,
         pg_db_name,
@@ -723,14 +732,22 @@ async fn start(
         let graphql_address = parse_host_port(input, DEFAULT_GRAPHQL_PORT)
             .map_err(|_| anyhow!("Invalid graphql host and port"))?;
         tracing::info!("Starting the GraphQL service at {graphql_address}");
+        // The metrics address the service picks by default collides with the
+        // fullnode metrics endpoint, which binds `FULLNODE_PORT_BASE` before
+        // this runs.
+        let graphql_metrics_address = parse_host_port_with_default_host(
+            graphql_metrics_address.unwrap_or_default(),
+            &Ipv4Addr::LOCALHOST.to_string(),
+            DEFAULT_GRAPHQL_METRICS_PORT,
+        )
+        .map_err(|_| anyhow!("Invalid graphql metrics host and port"))?;
+        tracing::info!("Serving the GraphQL metrics at {graphql_metrics_address}");
         let graphql_connection_config = ConnectionConfig {
             port: graphql_address.port(),
             host: graphql_address.ip().to_string(),
             db_url: pg_address,
-            // The default metrics port collides with the fullnode metrics
-            // endpoint, which binds `FULLNODE_PORT_BASE` before this runs.
-            prom_host: Ipv4Addr::LOCALHOST.to_string(),
-            prom_port: GRAPHQL_METRICS_PORT,
+            prom_host: graphql_metrics_address.ip().to_string(),
+            prom_port: graphql_metrics_address.port(),
             ..Default::default()
         };
         start_graphql_server_with_fn_rpc(
@@ -1152,7 +1169,16 @@ pub fn parse_host_port(
     input: String,
     default_port_if_missing: u16,
 ) -> Result<SocketAddr, AddrParseError> {
-    let default_host = "0.0.0.0";
+    parse_host_port_with_default_host(input, "0.0.0.0", default_port_if_missing)
+}
+
+/// Same as [`parse_host_port`], for an endpoint whose host defaults to
+/// something other than `0.0.0.0`.
+pub fn parse_host_port_with_default_host(
+    input: String,
+    default_host: &str,
+    default_port_if_missing: u16,
+) -> Result<SocketAddr, AddrParseError> {
     let mut input = input;
     if input.contains("localhost") {
         input = input.replace("localhost", "127.0.0.1");
@@ -1182,7 +1208,7 @@ mod tests {
             DEFAULT_GRPC_PORT,
             DEFAULT_GRAPHQL_PORT,
             DEFAULT_INDEXER_PORT,
-            GRAPHQL_METRICS_PORT,
+            DEFAULT_GRAPHQL_METRICS_PORT,
             9000, // fullnode JSON-RPC, see `fullnode_rpc_port`
         ];
         // The fullnode owns `FULLNODE_PORT_BASE` and the two ports above it,

--- a/crates/iota-localnet/src/commands.rs
+++ b/crates/iota-localnet/src/commands.rs
@@ -741,6 +741,12 @@ async fn start(
             DEFAULT_GRAPHQL_METRICS_PORT,
         )
         .map_err(|_| anyhow!("Invalid graphql metrics host and port"))?;
+        // The service rebuilds the address as `host:port`, which an IPv6 host
+        // needs brackets to survive.
+        ensure!(
+            graphql_metrics_address.is_ipv4(),
+            "graphql metrics configuration requires an IPv4 address"
+        );
         tracing::info!("Serving the GraphQL metrics at {graphql_metrics_address}");
         let graphql_connection_config = ConnectionConfig {
             port: graphql_address.port(),
@@ -1218,5 +1224,29 @@ mod tests {
 
         let unique = ports.iter().collect::<std::collections::BTreeSet<_>>();
         assert_eq!(unique.len(), ports.len(), "two services share a port");
+    }
+
+    /// An endpoint that keeps its host on localhost must stay there when only
+    /// a port is given, and when nothing is given at all.
+    #[test]
+    fn a_metrics_address_defaults_to_localhost() {
+        let localhost = Ipv4Addr::LOCALHOST.to_string();
+        let parse = |input: &str| {
+            parse_host_port_with_default_host(
+                input.to_string(),
+                &localhost,
+                DEFAULT_GRAPHQL_METRICS_PORT,
+            )
+            .unwrap()
+        };
+
+        assert_eq!(parse(""), SocketAddr::from(([127, 0, 0, 1], 9126)));
+        assert_eq!(parse("9127"), SocketAddr::from(([127, 0, 0, 1], 9127)));
+        assert_eq!(parse("localhost"), SocketAddr::from(([127, 0, 0, 1], 9126)));
+        assert_eq!(parse("0.0.0.0"), SocketAddr::from(([0, 0, 0, 0], 9126)));
+        assert_eq!(
+            parse("0.0.0.0:9127"),
+            SocketAddr::from(([0, 0, 0, 0], 9127))
+        );
     }
 }

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -69,6 +69,7 @@ The metrics, admin interface, p2p, network and primary addresses are on `127.0.0
 | `9123` | Faucet (`--with-faucet`). |
 | `9124` | Indexer (`--with-indexer`). |
 | `9125` | GraphQL (`--with-graphql`). |
+| `9126` | GraphQL metrics (`--with-graphql`). |
 | `9184` | Fullnode metrics. |
 | `9185` | Fullnode admin interface. |
 | `9186` | Fullnode p2p (UDP). |

--- a/docs/content/developer/references/cli/localnet.mdx
+++ b/docs/content/developer/references/cli/localnet.mdx
@@ -69,7 +69,7 @@ The metrics, admin interface, p2p, network and primary addresses are on `127.0.0
 | `9123` | Faucet (`--with-faucet`). |
 | `9124` | Indexer (`--with-indexer`). |
 | `9125` | GraphQL (`--with-graphql`). |
-| `9126` | GraphQL metrics (`--with-graphql`). |
+| `9126` | GraphQL metrics (change it with `--graphql-metrics-address`). |
 | `9184` | Fullnode metrics. |
 | `9185` | Fullnode admin interface. |
 | `9186` | Fullnode p2p (UDP). |
@@ -98,6 +98,7 @@ When built with the `indexer` feature, additional options are available:
 |--------|-------------|
 | `--with-indexer[=HOST:PORT]` | Start an indexer (default: `0.0.0.0:9124`). Requires Postgres. |
 | `--with-graphql[=HOST:PORT]` | Start a GraphQL server (default: `0.0.0.0:9125`). Automatically enables indexer. |
+| `--graphql-metrics-address <HOST:PORT>` | Bind the GraphQL metrics endpoint elsewhere (default: `127.0.0.1:9126`). |
 | `--pg-port <PORT>` | Postgres port (default: `5432`). |
 | `--pg-host <HOST>` | Postgres hostname (default: `localhost`). |
 | `--pg-db-name <NAME>` | Postgres database name (default: `iota_indexer`). |


### PR DESCRIPTION
# Description of change

A local network started with `--with-graphql` aborts: the fullnode binds `127.0.0.1:9184` for metrics, the GraphQL server then binds `0.0.0.0:9184` for its own Prometheus endpoint, and the `unwrap` in `iota_metrics::start_prometheus_server` turns the `EADDRINUSE` into a process abort. This is a regression from #12667, which pinned the fullnode metrics port to `9184`; before that the fullnode took a random free port, so the collision with the GraphQL default was hidden rather than absent.

- `iota-localnet`: `start` now sets `prom_host`/`prom_port` on the GraphQL `ConnectionConfig` to `127.0.0.1:9126` instead of inheriting the `0.0.0.0:9184` default from `ConnectionConfig::default()`.
  - `9184` stays the fullnode metrics port. It is the metrics port everywhere else in the repo (`default_metrics_address`, the ssfn configs, the indexer, the source-validation service), so the GraphQL endpoint is the one that moves.
  - The GraphQL metrics endpoint moves to `127.0.0.1`, matching the other metrics endpoints of the layout.
- `iota-localnet`: a new `--graphql-metrics-address[=HOST:PORT]` flag overrides that address, accepting a port, a host or both, as the sibling service flags do. `parse_host_port` grows a `parse_host_port_with_default_host` variant so a port-only value keeps the `127.0.0.1` default rather than falling back to `0.0.0.0`.
- `iota-localnet`: `start` rejects a non-IPv4 metrics address, since the service rebuilds it as `host:port` without brackets and would fail to parse its own configuration.
- `iota-localnet`: unit tests assert that no two ports of the fixed layout collide — the service ports, the three fullnode ports and the validator block — and that a port-only `--graphql-metrics-address` keeps the `127.0.0.1` host.
- Docs: the localnet port table lists `9126`, and the indexer option table lists the new flag.

## Links to any relevant issues

None.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] CLI: For `iota-localnet start --with-graphql`, The GraphQL Prometheus endpoint moves from `0.0.0.0:9184`, which the fullnode metrics endpoint holds, to `127.0.0.1:9126`.