### PR TITLE
fix(data-ingestion): stop redundant and cancelled downloads in the historical checkpoint reader

### DIFF
--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -43,6 +43,7 @@ prometheus-filtered.workspace = true
 [dev-dependencies]
 # external dependencies
 rand.workspace = true
+tokio = { workspace = true, features = ["io-util", "net"] }
 
 # internal dependencies
 iota-common.workspace = true

--- a/crates/iota-data-ingestion-core/src/history/manifest.rs
+++ b/crates/iota-data-ingestion-core/src/history/manifest.rs
@@ -196,11 +196,11 @@ pub async fn verify_historical_checkpoints_with_checksums(
         manifest.next_checkpoint_seq_num()
     );
 
-    let file_metadata = reader.verify_and_get_manifest_files(manifest)?;
+    let file_metadata = reader.manifest_files().await;
 
     // Account for both summary and content files
     let num_files = file_metadata.len() * 2;
-    reader.verify_file_consistency(file_metadata).await?;
+    reader.verify_file_consistency(&file_metadata).await?;
     info!("all {num_files} files are valid");
     Ok(())
 }

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -27,7 +27,7 @@ use crate::{
     history::{
         CHECKPOINT_FILE_MAGIC,
         epoch_boundaries::{EpochBoundaries, read_epoch_boundaries},
-        manifest::{FileMetadata, Manifest, read_manifest},
+        manifest::{FileMetadata, Manifest, read_manifest, read_manifest_from_bytes},
     },
 };
 
@@ -203,6 +203,11 @@ impl HistoricalReader {
     /// data from the remote store, decodes the raw data, and streams the
     /// deserialized values.
     ///
+    /// The file is fetched with a single request, so the caller is
+    /// responsible for retrying. The request is bounded by the store
+    /// client's connect and stall timeouts rather than by a total duration,
+    /// since a transfer takes as long as the file is large.
+    ///
     /// # Errors
     ///
     /// Returns an error in the following cases:
@@ -213,7 +218,7 @@ impl HistoricalReader {
         &self,
         file_path: Path,
     ) -> Result<impl Iterator<Item = CheckpointData>> {
-        let raw_data_batch = get(&self.remote_object_store, &file_path).await?;
+        let raw_data_batch = self.remote_object_store.get_bytes(&file_path).await?;
         make_blob_iterator(raw_data_batch)
     }
 
@@ -249,6 +254,21 @@ impl HistoricalReader {
     /// Syncs the Manifest from remote store.
     pub async fn sync_manifest_once(&self) -> Result<()> {
         Self::sync_manifest(self.remote_object_store.clone(), self.manifest.clone()).await?;
+        Ok(())
+    }
+
+    /// Syncs the Manifest from remote store with a single request.
+    ///
+    /// Unlike [`Self::sync_manifest_once`], a failed request is reported to
+    /// the caller instead of being retried, so a caller that already runs a
+    /// retry loop does not end up nesting two backoff schedules.
+    pub async fn sync_manifest_no_retry(&self) -> Result<()> {
+        let bytes = self
+            .remote_object_store
+            .get_bytes(&Manifest::file_path())
+            .await?;
+        let new_manifest = read_manifest_from_bytes(bytes.to_vec())?;
+        *self.manifest.lock().await = new_manifest;
         Ok(())
     }
 

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -19,7 +19,7 @@ use tokio::sync::{
     Mutex,
     oneshot::{self, Sender},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     IngestionError,
@@ -39,8 +39,69 @@ pub struct HistoricalReader {
     /// reader and hence terminate the manifest sync
     /// process.
     sender: Arc<Sender<()>>,
-    manifest: Arc<Mutex<Manifest>>,
+    manifest: Arc<Mutex<ManifestState>>,
     remote_object_store: Arc<dyn ObjectStoreGetExt>,
+}
+
+/// The manifest as of the last sync, together with the file list derived from
+/// it.
+///
+/// Deriving the list means sorting and verifying every entry, which for a
+/// long-lived chain is hundreds of thousands of them. Doing it once per sync
+/// keeps that cost off every read.
+struct ManifestState {
+    manifest: Manifest,
+    files: Arc<[FileMetadata]>,
+}
+
+impl ManifestState {
+    /// The state before the first sync, holding no checkpoint data.
+    fn unsynced() -> Self {
+        Self {
+            manifest: Manifest::new(0),
+            files: Arc::from([]),
+        }
+    }
+
+    /// Verifies `manifest` and derives its file list, sorted by starting
+    /// sequence number.
+    ///
+    /// # Errors
+    ///
+    /// Fails unless the files cover every checkpoint from sequence number 0
+    /// up to the latest available one, with no missing checkpoint.
+    fn new(manifest: Manifest) -> Result<Self> {
+        let mut files = manifest.to_files();
+        if files.is_empty() {
+            return Err(IngestionError::HistoryRead(
+                "unexpected empty remote store of historical data".to_string(),
+            ));
+        }
+
+        files.sort_by_key(|f| f.checkpoint_seq_range.start);
+
+        let start = files[0].checkpoint_seq_range.start;
+        if start != 0 {
+            return Err(IngestionError::HistoryRead(format!(
+                "historical data starts at checkpoint {start} instead of 0"
+            )));
+        }
+
+        if let Some(gap) = files
+            .windows(2)
+            .find(|w| w[1].checkpoint_seq_range.start != w[0].checkpoint_seq_range.end)
+        {
+            return Err(IngestionError::HistoryRead(format!(
+                "historical data is missing checkpoints {} to {}",
+                gap[0].checkpoint_seq_range.end, gap[1].checkpoint_seq_range.start
+            )));
+        }
+
+        Ok(Self {
+            manifest,
+            files: files.into(),
+        })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -57,7 +118,7 @@ impl HistoricalReader {
             config.remote_store_config.make().map(Arc::new)?
         };
         let (sender, recv) = oneshot::channel();
-        let manifest = Arc::new(Mutex::new(Manifest::new(0)));
+        let manifest = Arc::new(Mutex::new(ManifestState::unsynced()));
         // Start a background tokio task to keep local manifest in sync with remote
         Self::spawn_manifest_sync_task(remote_object_store.clone(), manifest.clone(), recv);
         Ok(Self {
@@ -68,36 +129,17 @@ impl HistoricalReader {
         })
     }
 
-    /// This function verifies the manifest and returns the file metadata
-    /// sorted by the starting sequence number.
+    /// Returns the files of the archive, sorted by starting sequence number,
+    /// as verified when the manifest was last synced.
     ///
-    /// More specifically it verifies that the files in the remote store
-    /// cover the entire range of checkpoints from sequence number 0
-    /// until the latest available checkpoint with no missing checkpoint.
-    pub fn verify_and_get_manifest_files(&self, manifest: Manifest) -> Result<Vec<FileMetadata>> {
-        let mut files = manifest.to_files();
-        if files.is_empty() {
-            return Err(IngestionError::HistoryRead(
-                "unexpected empty remote store of historical data".to_string(),
-            ));
-        }
-
-        files.sort_by_key(|f| f.checkpoint_seq_range.start);
-
-        assert!(
-            files
-                .windows(2)
-                .all(|w| w[1].checkpoint_seq_range.start == w[0].checkpoint_seq_range.end)
-        );
-
-        assert_eq!(files.first().map(|f| f.checkpoint_seq_range.start), Some(0));
-
-        Ok(files)
+    /// The list is empty until the first successful sync.
+    pub async fn manifest_files(&self) -> Arc<[FileMetadata]> {
+        self.manifest.lock().await.files.clone()
     }
 
     /// This function downloads checkpoint data files and ensures their
     /// computed checksum matches the one in manifest.
-    pub async fn verify_file_consistency(&self, files: Vec<FileMetadata>) -> Result<()> {
+    pub async fn verify_file_consistency(&self, files: &[FileMetadata]) -> Result<()> {
         let remote_object_store = self.remote_object_store.clone();
         futures::stream::iter(files.iter())
             .map(|metadata| {
@@ -227,6 +269,7 @@ impl HistoricalReader {
         self.manifest
             .lock()
             .await
+            .manifest
             .next_checkpoint_seq_num()
             .checked_sub(1)
             .ok_or_else(|| {
@@ -268,22 +311,23 @@ impl HistoricalReader {
             .get_bytes(&Manifest::file_path())
             .await?;
         let new_manifest = read_manifest_from_bytes(bytes.to_vec())?;
-        *self.manifest.lock().await = new_manifest;
+        *self.manifest.lock().await = ManifestState::new(new_manifest)?;
         Ok(())
     }
 
     pub async fn get_manifest(&self) -> Manifest {
-        self.manifest.lock().await.clone()
+        self.manifest.lock().await.manifest.clone()
     }
 
     /// Copies Manifest from remote store to the given Manifest.
     async fn sync_manifest(
         remote_store: Arc<dyn ObjectStoreGetExt>,
-        manifest: Arc<Mutex<Manifest>>,
+        manifest: Arc<Mutex<ManifestState>>,
     ) -> Result<()> {
         let new_manifest = read_manifest(remote_store.clone()).await?;
+        let new_state = ManifestState::new(new_manifest)?;
         let mut locked = manifest.lock().await;
-        *locked = new_manifest;
+        *locked = new_state;
         Ok(())
     }
 
@@ -301,12 +345,16 @@ impl HistoricalReader {
         &self,
         checkpoint_range: Range<CheckpointSequenceNumber>,
     ) -> Result<impl Iterator<Item = FileMetadata>> {
-        let manifest = self.get_manifest().await;
+        let (next_checkpoint_seq_num, files) = {
+            let state = self.manifest.lock().await;
+            (
+                state.manifest.next_checkpoint_seq_num(),
+                state.files.clone(),
+            )
+        };
 
-        let latest_available_checkpoint = manifest
-            .next_checkpoint_seq_num()
-            .checked_sub(1)
-            .ok_or_else(|| {
+        let latest_available_checkpoint =
+            next_checkpoint_seq_num.checked_sub(1).ok_or_else(|| {
                 IngestionError::HistoryRead("no checkpoint data in the remote store".into())
             })?;
 
@@ -316,13 +364,11 @@ impl HistoricalReader {
             )));
         }
 
-        let files = self.verify_and_get_manifest_files(manifest)?;
-
         let start_index = match files
             .binary_search_by_key(&checkpoint_range.start, |s| s.checkpoint_seq_range.start)
         {
             Ok(index) => index,
-            Err(index) => index - 1,
+            Err(index) => index.saturating_sub(1),
         };
 
         let end_index = match files
@@ -332,17 +378,12 @@ impl HistoricalReader {
             Err(index) => index,
         };
 
-        Ok(files
-            .into_iter()
-            .enumerate()
-            .filter_map(move |(index, metadata)| {
-                (index >= start_index && index < end_index).then_some(metadata)
-            }))
+        Ok((start_index..end_index).map(move |index| files[index].clone()))
     }
 
     fn spawn_manifest_sync_task(
         remote_store: Arc<dyn ObjectStoreGetExt>,
-        manifest: Arc<Mutex<Manifest>>,
+        manifest: Arc<Mutex<ManifestState>>,
         mut recv: oneshot::Receiver<()>,
     ) {
         tokio::task::spawn(async move {
@@ -350,13 +391,16 @@ impl HistoricalReader {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        Self::sync_manifest(remote_store.clone(), manifest.clone()).await?;
+                        // A failed sync leaves the previous manifest in place; giving
+                        // up here would leave it stale for the reader's whole lifetime.
+                        if let Err(err) = Self::sync_manifest(remote_store.clone(), manifest.clone()).await {
+                            warn!("failed to sync the manifest from the remote store: {err}");
+                        }
                     }
                     _ = &mut recv => break,
                 }
             }
             info!("terminating the manifest sync loop");
-            Ok::<(), IngestionError>(())
         });
     }
 }
@@ -381,4 +425,61 @@ pub fn make_blob_iterator_for_range(
 ) -> Result<impl Iterator<Item = CheckpointData>> {
     Ok(make_blob_iterator(blob)?
         .filter(move |data| range.contains(&data.checkpoint_summary.sequence_number)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(checkpoint_seq_range: Range<CheckpointSequenceNumber>) -> FileMetadata {
+        FileMetadata {
+            checkpoint_seq_range,
+            sha3_digest: [0; 32],
+        }
+    }
+
+    fn manifest(files: impl IntoIterator<Item = FileMetadata>) -> Manifest {
+        let mut manifest = Manifest::new(0);
+        for file in files {
+            let next_checkpoint_seq_num = file.checkpoint_seq_range.end;
+            manifest.update(next_checkpoint_seq_num, file);
+        }
+        manifest
+    }
+
+    #[test]
+    fn manifest_state_sorts_the_files() {
+        let state = ManifestState::new(manifest([file(10..20), file(0..10)])).unwrap();
+
+        let starts: Vec<_> = state
+            .files
+            .iter()
+            .map(|f| f.checkpoint_seq_range.start)
+            .collect();
+        assert_eq!(starts, vec![0, 10]);
+    }
+
+    #[test]
+    fn manifest_state_rejects_an_empty_manifest() {
+        assert!(matches!(
+            ManifestState::new(manifest([])),
+            Err(IngestionError::HistoryRead(_))
+        ));
+    }
+
+    #[test]
+    fn manifest_state_rejects_files_not_starting_at_genesis() {
+        assert!(matches!(
+            ManifestState::new(manifest([file(1..10)])),
+            Err(IngestionError::HistoryRead(_))
+        ));
+    }
+
+    #[test]
+    fn manifest_state_rejects_a_gap_between_files() {
+        assert!(matches!(
+            ManifestState::new(manifest([file(0..10), file(11..20)])),
+            Err(IngestionError::HistoryRead(_))
+        ));
+    }
 }

--- a/crates/iota-data-ingestion-core/src/reader/common.rs
+++ b/crates/iota-data-ingestion-core/src/reader/common.rs
@@ -17,7 +17,11 @@ pub struct ReaderOptions {
     ///
     /// Default: 100ms.
     pub tick_interval_ms: u64,
-    /// Network request timeout, it applies to remote store operations.
+    /// Network request timeout, it applies to live remote store operations.
+    ///
+    /// Reads from the historical store are bulk transfers whose duration
+    /// scales with the file size, so they are bounded by the store client's
+    /// connect and stall timeouts instead.
     ///
     /// Default: 5 seconds.
     pub timeout_secs: u64,

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -256,22 +256,16 @@ impl CheckpointReaderActor {
             }
         }
 
-        let manifest = historical_reader.get_manifest().await;
-
-        let files = historical_reader.verify_and_get_manifest_files(manifest)?;
+        let files = historical_reader.manifest_files().await;
 
         let start_index = match files.binary_search_by_key(&self.current_checkpoint_number, |s| {
             s.checkpoint_seq_range.start
         }) {
             Ok(index) => index,
-            Err(index) => index - 1,
+            Err(index) => index.saturating_sub(1),
         };
 
-        for metadata in files
-            .into_iter()
-            .enumerate()
-            .filter_map(|(index, metadata)| (index >= start_index).then_some(metadata))
-        {
+        for metadata in files.iter().skip(start_index) {
             // Checkpoints from a file the channel has no room for would be
             // thrown away again, so stop before spending the request.
             if self.exceeds_capacity(self.current_checkpoint_number) {

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -272,6 +272,12 @@ impl CheckpointReaderActor {
             .enumerate()
             .filter_map(|(index, metadata)| (index >= start_index).then_some(metadata))
         {
+            // Checkpoints from a file the channel has no room for would be
+            // thrown away again, so stop before spending the request.
+            if self.exceeds_capacity(self.current_checkpoint_number) {
+                return Err(IngestionError::MaxCheckpointsCapacityReached);
+            }
+
             let checkpoints = historical_reader
                 .iter_for_file(metadata.file_path())
                 .await?

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -245,14 +245,7 @@ impl CheckpointReaderActor {
         // If the requested checkpoint is beyond what's currently available in our
         // cached manifest, we need to refresh it to check for newer checkpoints.
         if self.current_checkpoint_number > historical_reader.latest_available_checkpoint().await? {
-            timeout(
-                Duration::from_secs(self.reader_options.timeout_secs),
-                historical_reader.sync_manifest_once(),
-            )
-            .await
-            .map_err(|_| {
-                IngestionError::HistoryRead("reading manifest exceeded the timeout".into())
-            })??;
+            historical_reader.sync_manifest_no_retry().await?;
 
             // Verify the requested checkpoint is now available after the manifest refresh.
             // If it's still not available, the checkpoint hasn't been published yet.
@@ -279,19 +272,11 @@ impl CheckpointReaderActor {
             .enumerate()
             .filter_map(|(index, metadata)| (index >= start_index).then_some(metadata))
         {
-            let checkpoints = timeout(
-                Duration::from_secs(self.reader_options.timeout_secs),
-                historical_reader.iter_for_file(metadata.file_path()),
-            )
-            .await
-            .map_err(|_| {
-                IngestionError::HistoryRead(format!(
-                    "reading checkpoint {} exceeded the timeout",
-                    metadata.file_path()
-                ))
-            })??
-            .filter(|c| c.checkpoint_summary.sequence_number >= self.current_checkpoint_number)
-            .collect::<Vec<CheckpointData>>();
+            let checkpoints = historical_reader
+                .iter_for_file(metadata.file_path())
+                .await?
+                .filter(|c| c.checkpoint_summary.sequence_number >= self.current_checkpoint_number)
+                .collect::<Vec<CheckpointData>>();
 
             for checkpoint in checkpoints {
                 let size = bcs::serialized_size(&checkpoint)?;

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -3,15 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    collections::HashMap,
     path::PathBuf,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use iota_protocol_config::ProtocolConfig;
 use iota_sdk_types::{
     Address, ObjectDigest, ObjectId, ObjectReference, RandomnessStateUpdate, Transaction,
@@ -19,7 +21,10 @@ use iota_sdk_types::{
     checkpoint::{CheckpointContents, CheckpointSummary},
     gas::GasCostSummary,
 };
-use iota_storage::blob::{Blob, BlobEncoding};
+use iota_storage::{
+    FileCompression, StorageFormat,
+    blob::{Blob, BlobEncoding},
+};
 use iota_types::{
     committee::EpochId,
     crypto::KeypairTraits,
@@ -35,13 +40,22 @@ use iota_types::{
 use prometheus_filtered::Registry;
 use rand::{SeedableRng, prelude::StdRng};
 use tempfile::NamedTempFile;
-use tokio::time::timeout;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    time::timeout,
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, IngestionError, IngestionLimit,
     IngestionResult, ProgressStore, ReaderOptions, Reducer, ShutdownAction, Worker, WorkerPool,
-    progress_store::ExecutorProgress, reader::v2::CheckpointReaderConfig,
+    history::{
+        CHECKPOINT_FILE_MAGIC,
+        manifest::{Manifest, create_file_metadata_from_bytes, finalize_manifest},
+    },
+    progress_store::ExecutorProgress,
+    reader::v2::{CheckpointReaderConfig, RemoteUrl},
 };
 
 async fn add_worker_pool<W: Worker + 'static>(
@@ -744,6 +758,19 @@ fn mock_checkpoint_data_bytes_with_opt(
     epoch: EpochId,
     transactions: Vec<CheckpointTransaction>,
 ) -> Vec<u8> {
+    Blob::encode(
+        &mock_checkpoint_data(seq_number, epoch, transactions),
+        BlobEncoding::Bcs,
+    )
+    .unwrap()
+    .to_bytes()
+}
+
+fn mock_checkpoint_data(
+    seq_number: CheckpointSequenceNumber,
+    epoch: EpochId,
+    transactions: Vec<CheckpointTransaction>,
+) -> CheckpointData {
     let mut rng = StdRng::from_seed(RNG_SEED);
     let (keys, committee) = make_committee_key(&mut rng);
     let contents = CheckpointContents::new_with_digests_only_for_tests(vec![]);
@@ -768,13 +795,185 @@ fn mock_checkpoint_data_bytes_with_opt(
         })
         .collect();
 
-    let checkpoint_data = CheckpointData {
+    CheckpointData {
         checkpoint_summary: CertifiedCheckpointSummary::new(summary, sign_infos, &committee)
             .unwrap(),
         checkpoint_contents: contents,
         transactions,
-    };
-    Blob::encode(&checkpoint_data, BlobEncoding::Bcs)
+    }
+}
+
+/// Serves a fixed set of files over HTTP and counts the requests received for
+/// each of them.
+///
+/// Returns the base URL of the server and the request counter.
+async fn spawn_counting_file_server(
+    files: HashMap<String, Vec<u8>>,
+    token: CancellationToken,
+) -> (String, Arc<Mutex<HashMap<String, usize>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let requests = Arc::new(Mutex::new(HashMap::new()));
+    let files = Arc::new(files);
+
+    tokio::spawn({
+        let requests = requests.clone();
+        async move {
+            loop {
+                let socket = tokio::select! {
+                    _ = token.cancelled() => break,
+                    accepted = listener.accept() => match accepted {
+                        Ok((socket, _)) => socket,
+                        Err(_) => break,
+                    },
+                };
+                tokio::spawn(serve_connection(socket, files.clone(), requests.clone()));
+            }
+        }
+    });
+
+    (url, requests)
+}
+
+/// Answers every request on `socket` until the peer closes the connection.
+async fn serve_connection(
+    mut socket: TcpStream,
+    files: Arc<HashMap<String, Vec<u8>>>,
+    requests: Arc<Mutex<HashMap<String, usize>>>,
+) {
+    let mut pending = Vec::new();
+    let mut chunk = [0u8; 1024];
+    loop {
+        // Requests are all GETs, so the head is the whole request.
+        let head_len = loop {
+            if let Some(offset) = pending.windows(4).position(|window| window == b"\r\n\r\n") {
+                break offset + 4;
+            }
+            match socket.read(&mut chunk).await {
+                Ok(0) | Err(_) => return,
+                Ok(read) => pending.extend_from_slice(&chunk[..read]),
+            }
+        };
+        let head = String::from_utf8_lossy(&pending[..head_len]).into_owned();
+        pending.drain(..head_len);
+
+        let path = head
+            .split_whitespace()
+            .nth(1)
+            .unwrap_or_default()
+            .trim_start_matches('/')
+            .to_owned();
+        *requests.lock().unwrap().entry(path.clone()).or_default() += 1;
+
+        let response = match files.get(&path) {
+            Some(body) => {
+                let mut response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nETag: \"{path}\"\r\nLast-Modified: \
+                     Wed, 21 Oct 2015 07:28:00 +0000\r\n\r\n",
+                    body.len()
+                )
+                .into_bytes();
+                response.extend_from_slice(body);
+                response
+            }
+            None => b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n".to_vec(),
+        };
+        if socket.write_all(&response).await.is_err() {
+            return;
+        }
+    }
+}
+
+/// Builds a historical store holding `checkpoint_count` checkpoints in a
+/// single file, as the file name to contents map a file server expects.
+fn mock_historical_store(checkpoint_count: CheckpointSequenceNumber) -> HashMap<String, Vec<u8>> {
+    let mut file = Vec::new();
+    file.extend_from_slice(&CHECKPOINT_FILE_MAGIC.to_be_bytes());
+    file.push(StorageFormat::Blob as u8);
+    file.push(FileCompression::None as u8);
+    for sequence_number in 0..checkpoint_count {
+        Blob::encode(
+            &mock_checkpoint_data(sequence_number, 0, vec![]),
+            BlobEncoding::Bcs,
+        )
         .unwrap()
-        .to_bytes()
+        .write(&mut file)
+        .unwrap();
+    }
+
+    let file_metadata =
+        create_file_metadata_from_bytes(Bytes::from(file.clone()), 0..checkpoint_count).unwrap();
+    let mut manifest = Manifest::new(0);
+    manifest.update(checkpoint_count, file_metadata);
+    let manifest_bytes = finalize_manifest(manifest).unwrap();
+
+    HashMap::from([
+        ("0.chk".to_owned(), file),
+        ("MANIFEST".to_owned(), manifest_bytes.to_vec()),
+    ])
+}
+
+/// A worker that never finishes processing a checkpoint, so that the executor
+/// makes no progress and the reader's capacity is never released.
+#[derive(Clone)]
+struct StalledWorker(CancellationToken);
+
+#[async_trait]
+impl Worker for StalledWorker {
+    type Message = ();
+    type Error = IngestionError;
+
+    async fn process_checkpoint(
+        &self,
+        _checkpoint: Arc<CheckpointData>,
+    ) -> Result<Self::Message, Self::Error> {
+        self.0.cancelled().await;
+        Ok(())
+    }
+}
+
+/// Once the reader has as many checkpoints in progress as it is allowed to
+/// hold, it must stop fetching from the historical store instead of
+/// downloading files it can only throw away again.
+#[tokio::test]
+async fn historical_read_stops_fetching_at_capacity() {
+    let files = mock_historical_store(4);
+    let server_token = CancellationToken::new();
+    let (url, requests) = spawn_counting_file_server(files, server_token.clone()).await;
+
+    let bundle = create_executor_bundle().await;
+    let mut executor = bundle.executor;
+    add_worker_pool(&mut executor, StalledWorker(bundle.token.clone()), 1)
+        .await
+        .unwrap();
+
+    let executor_fut = executor.run_with_config(CheckpointReaderConfig {
+        reader_options: ReaderOptions {
+            tick_interval_ms: 10,
+            batch_size: 1,
+            // Room for a single checkpoint, so the reader is at capacity as
+            // soon as it has handed over the first one.
+            data_limit: 1,
+            ..Default::default()
+        },
+        ingestion_path: None,
+        remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
+            historical_url: url,
+            live_url: None,
+        }),
+    });
+    let executor_handle = tokio::spawn(executor_fut);
+
+    // Long enough for a reader that keeps fetching to tick many times over.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    bundle.token.cancel();
+    let _ = executor_handle.await;
+    server_token.cancel();
+
+    let checkpoint_file_requests = requests.lock().unwrap().get("0.chk").copied().unwrap_or(0);
+    assert_eq!(
+        checkpoint_file_requests, 1,
+        "the reader downloaded the same checkpoint file {checkpoint_file_requests} times while \
+         being at capacity"
+    );
 }


### PR DESCRIPTION
# Description of change

## What we hit

During a node sync, the reader's handling turned one unreadable archive object into a permanent, unrecoverable stall. The fullnode sat at the same checkpoint for hours, emitting an ERROR with a full cause chain on every retry attempt while hammering the archive endpoint. The failed download had an external cause outside this repo, but nothing in the reader recovered from it, gave up on it, or made it diagnosable.

Tracing that surfaced three defects in the historical reader, fixed here. Two of them also waste bandwidth on every healthy backfill, not just when something is broken.

## Downloads were cancelled mid-transfer, with retries nested three deep

`relay_from_historical` wrapped `iter_for_file` in `timeout(reader_options.timeout_secs)` — 5s by default. That call already contains a `backoff::ExponentialBackoff::default()` retry with a 15-minute budget inside `object_store::util::get`, itself inside the reader's own 60s backoff loop. So the inner backoff could never complete a schedule, and every in-flight GET was aborted at 5s.

On any link that cannot pull a ~1 MB archive file within 5s, the reader can never pass that file, at any error rate.

Archive reads are now a single request each, bounded by the store client's connect (15s) and stall (60s) timeouts, with the reader's backoff as the only retry layer — the shape the live path already uses (`create_remote_store_client` sets `max_retries: 0`).

## Files were downloaded before the capacity check, then discarded

`send_remote_checkpoint_with_capacity_check` rejects a checkpoint only after its file has been fetched. Once the reader's window is full — the steady state during a from-genesis backfill, since execution is far slower than download — every 100ms tick re-downloaded the same file and threw it away. That is megabytes per second of wasted egress per node against the archive endpoint, indefinitely. The check now runs before the request.

## The manifest was re-verified on every read

`get_manifest()` cloned the `Manifest` and `verify_and_get_manifest_files()` cloned and sorted the file list again on every tick — 223,518 entries on testnet today, so roughly 21 MB cloned and sorted ten times a second. The verified, sorted list is now derived once per manifest sync and shared as `Arc<[FileMetadata]>`.

The archive keeps growing while the node reads it, so to be explicit about freshness:

- Both refresh triggers are unchanged: the 60s background sync, and the on-demand refresh in `relay_from_historical` when the requested checkpoint is past `latest_available_checkpoint()`.
- Both writes replace the whole `ManifestState`, which recomputes the file list, so the cached list cannot drift from the manifest it came from.
- Nothing gets staler. `verify_and_get_manifest_files` already ran against a `Manifest` that only changed at sync time, so the derived list was only ever as fresh as the last sync. Verification moved from read time to sync time; the input did not change.
- `latest_available_checkpoint()` and `manifest_files()` are separate lock acquisitions, so a sync can land between them. That is harmless: the manifest is append-only and verified contiguous from checkpoint 0, so a newer list shares a prefix with the old one and `start_index` stays valid.

Two related fixes in the same commit:

- The `assert!`s checking manifest continuity are now `HistoryRead` errors; a malformed remote manifest should not panic a node. Rejecting it at sync time also keeps the last good manifest in place instead of failing the read. The "starts at checkpoint 0" check now runs after sorting, which it did not before.
- The 60s background sync no longer terminates on a single failed fetch. Previously one transient failure killed the task, leaving the manifest to refresh only via the tip-triggered path for the rest of that reader's lifetime.

## Links to any relevant issues

None.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes


- `historical_read_stops_fetching_at_capacity` serves an archive over a request-counting HTTP server and stalls the worker so the reader stays at capacity: 67 downloads of the same file before the fix, 1 after.
- Unit tests for manifest verification: empty manifest, files not starting at genesis, gap between files, unsorted input.
- `cargo nextest run -p iota-data-ingestion-core` (30 tests) and `state_sync::tests::test_state_sync_using_checkpoint_archive` pass; clippy clean over `iota-data-ingestion-core`, `iota-network`, `iota-tool`, `iota-light-client`.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Fixed checkpoint-archive backfill stalling permanently on a slow or failing download, and repeatedly re-downloading archive files it had no room for.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
