### PR TITLE
upstream(move): Port upstream shared abstract interpreter in the compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9353,6 +9353,7 @@ dependencies = [
  "dunce",
  "hex",
  "lsp-types",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9565,6 +9565,7 @@ dependencies = [
  "dunce",
  "hex",
  "lsp-types",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2018,6 +2018,7 @@ dependencies = [
  "dunce",
  "hex",
  "lsp-types",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2040,6 +2040,7 @@ dependencies = [
  "dunce",
  "hex",
  "lsp-types",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",

--- a/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
@@ -6,11 +6,32 @@ use std::collections::BTreeMap;
 
 use crate::control_flow_graph::ControlFlowGraph;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum JoinResult {
     Changed,
     Unchanged,
 }
+
+#[derive(Debug, Clone)]
+pub enum BlockPostCondition<State> {
+    /// Unprocessed block
+    Unprocessed,
+    /// Block has been processed
+    Processed(State),
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockInvariant<State> {
+    /// Precondition of the block
+    pub pre: State,
+    /// Postcondition of the block
+    pub post: BlockPostCondition<State>,
+}
+
+pub type InvariantMap<A> = BTreeMap<
+    <A as AbstractInterpreter>::BlockId,
+    BlockInvariant<<A as AbstractInterpreter>::State>,
+>;
 
 pub trait AbstractInterpreter {
     type Error;
@@ -20,19 +41,13 @@ pub trait AbstractInterpreter {
     type InstructionIndex: Copy + Ord;
     type Instruction;
 
-    fn start(&mut self) -> Result<(), Self::Error>;
+    /// Joining two states together, this along with `execute` drives the
+    /// analysis.
     fn join(
         &mut self,
         pre: &mut Self::State,
         post: &Self::State,
     ) -> Result<JoinResult, Self::Error>;
-    fn visit_block_execution(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
-    fn visit_successor(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
-    fn visit_back_edge(
-        &mut self,
-        from: Self::BlockId,
-        to: Self::BlockId,
-    ) -> Result<(), Self::Error>;
 
     /// Execute local@instr found at index local@index in the current basic
     /// block from pre-state local@pre.
@@ -47,11 +62,54 @@ pub trait AbstractInterpreter {
     /// state before a join).
     fn execute(
         &mut self,
-        state: &mut Self::State,
+        block_id: Self::BlockId,
         bounds: (Self::InstructionIndex, Self::InstructionIndex),
+        state: &mut Self::State,
         offset: Self::InstructionIndex,
         instr: &Self::Instruction,
     ) -> Result<(), Self::Error>;
+
+    /// A visitor for starting the analysis. This is called before any blocks
+    /// are processed.
+    fn start(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// A visitor intended for bookkeeping. They should _not_ be used to modify
+    /// the state in any way related to the analysis.
+    fn visit_block_pre_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        _invariant: &mut BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// A visitor intended for bookkeeping. They should _not_ be used to modify
+    /// the state in any way related to the analysis.
+    fn visit_block_post_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        _invariant: &mut BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// A visitor intended for bookkeeping. They should _not_ be used to modify
+    /// the state in any way related to the analysis.
+    fn visit_successor(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// A visitor intended for bookkeeping. They should _not_ be used to modify
+    /// the state in any way related to the analysis.
+    fn visit_back_edge(
+        &mut self,
+        _from: Self::BlockId,
+        _to: Self::BlockId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 /// Analyze procedure local@function_context starting from pre-state
@@ -61,7 +119,7 @@ pub fn analyze_function<A, CFG>(
     cfg: &CFG,
     code: &<CFG as ControlFlowGraph>::Instructions,
     initial_state: A::State,
-) -> Result<(), A::Error>
+) -> Result<InvariantMap<A>, A::Error>
 where
     A: AbstractInterpreter,
     CFG: ControlFlowGraph<
@@ -74,31 +132,34 @@ where
     let mut inv_map = BTreeMap::new();
     let entry_block_id = cfg.entry_block_id();
     let mut next_block = Some(entry_block_id);
-    inv_map.insert(entry_block_id, initial_state);
+    inv_map.insert(
+        entry_block_id,
+        BlockInvariant {
+            pre: initial_state.clone(),
+            post: BlockPostCondition::Unprocessed,
+        },
+    );
 
     while let Some(block_id) = next_block {
-        let block_invariant = match inv_map.get_mut(&block_id) {
-            Some(invariant) => invariant,
-            None => {
-                // This can only happen when all predecessors have errors,
-                // so skip the block and move on to the next one
-                next_block = cfg.next_block(block_id);
-                continue;
-            }
-        };
+        let block_invariant = inv_map.entry(block_id).or_insert_with(|| BlockInvariant {
+            pre: initial_state.clone(),
+            post: BlockPostCondition::Unprocessed,
+        });
 
-        let pre_state = &block_invariant;
-        // Note: this will stop analysis after the first error occurs, to avoid the risk
-        // of subsequent crashes
+        interpreter.visit_block_pre_execution(block_id, block_invariant)?;
+        let pre_state = &block_invariant.pre;
         let post_state = execute_block(interpreter, cfg, code, block_id, pre_state)?;
+        block_invariant.post = BlockPostCondition::Processed(post_state.clone());
+        interpreter.visit_block_post_execution(block_id, block_invariant)?;
 
         let mut next_block_candidate = cfg.next_block(block_id);
         // propagate postcondition of this block to successor blocks
-        for &successor_block_id in cfg.successors(block_id) {
+        for successor_block_id in cfg.successors(block_id) {
             interpreter.visit_successor(successor_block_id)?;
             match inv_map.get_mut(&successor_block_id) {
                 Some(next_block_invariant) => {
-                    let join_result = interpreter.join(next_block_invariant, &post_state)?;
+                    let join_result =
+                        interpreter.join(&mut next_block_invariant.pre, &post_state)?;
                     match join_result {
                         JoinResult::Unchanged => {
                             // Pre is the same after join. Reanalyzing this
@@ -106,6 +167,7 @@ where
                             // the same post
                         }
                         JoinResult::Changed => {
+                            next_block_invariant.post = BlockPostCondition::Unprocessed;
                             // If the cur->successor is a back edge, jump back to the beginning
                             // of the loop, instead of the normal next block
                             if cfg.is_back_edge(block_id, successor_block_id) {
@@ -119,13 +181,19 @@ where
                 None => {
                     // Haven't visited the next block yet. Use the post of the current block as
                     // its pre
-                    inv_map.insert(successor_block_id, post_state.clone());
+                    inv_map.insert(
+                        successor_block_id,
+                        BlockInvariant {
+                            pre: post_state.clone(),
+                            post: BlockPostCondition::Unprocessed,
+                        },
+                    );
                 }
             }
         }
         next_block = next_block_candidate;
     }
-    Ok(())
+    Ok(inv_map)
 }
 
 fn execute_block<A, CFG>(
@@ -143,11 +211,10 @@ where
             Instruction = A::Instruction,
         >,
 {
-    interpreter.visit_block_execution(block_id)?;
     let mut state_acc = pre_state.clone();
     let bounds = (cfg.block_start(block_id), cfg.block_end(block_id));
     for (offset, instr) in cfg.instructions(code, block_id) {
-        interpreter.execute(&mut state_acc, bounds, offset, instr)?
+        interpreter.execute(block_id, bounds, &mut state_acc, offset, instr)?
     }
     Ok(state_acc)
 }

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -20,22 +20,22 @@ pub trait ControlFlowGraph {
     fn block_end(&self, block_id: Self::BlockId) -> Self::InstructionIndex;
 
     /// Successors of the block ID in the bytecode vector
-    fn successors(&self, block_id: Self::BlockId) -> &[Self::BlockId];
+    fn successors(&self, block_id: Self::BlockId) -> impl Iterator<Item = Self::BlockId>;
 
     /// Return the next block in traversal order
     fn next_block(&self, block_id: Self::BlockId) -> Option<Self::BlockId>;
 
     /// Iterator over the indexes of instructions in this block
     fn instructions<'a>(
-        &self,
+        &'a self,
         function_code: &'a Self::Instructions,
         block_id: Self::BlockId,
-    ) -> impl IntoIterator<Item = (Self::InstructionIndex, &'a Self::Instruction)>
+    ) -> impl Iterator<Item = (Self::InstructionIndex, &'a Self::Instruction)>
     where
         Self::Instruction: 'a;
 
     /// Return an iterator over the blocks of the CFG
-    fn blocks(&self) -> Vec<Self::BlockId>;
+    fn blocks(&self) -> impl Iterator<Item = Self::BlockId>;
 
     /// Return the number of blocks (vertices) in the control flow graph
     fn num_blocks(&self) -> usize;
@@ -50,9 +50,6 @@ pub trait ControlFlowGraph {
     /// Checks if the edge from cur->next is a back edge
     /// returns false if the edge is not in the cfg
     fn is_back_edge(&self, cur: Self::BlockId, next: Self::BlockId) -> bool;
-
-    /// Return the number of back edges in the cfg
-    fn num_back_edges(&self) -> usize;
 }
 
 /// Used for the VM control flow graph
@@ -77,6 +74,7 @@ pub trait Instruction: Sized {
     fn is_branch(&self) -> bool;
 }
 
+#[derive(Debug, Clone)]
 struct BasicBlock<InstructionIndex> {
     exit: InstructionIndex,
     successors: Vec<InstructionIndex>,
@@ -85,6 +83,7 @@ struct BasicBlock<InstructionIndex> {
 /// The control flow graph that we build from the bytecode.
 /// Assumes a list of bytecode isntructions that satisfy the invariants
 /// specified in the VM's file format.
+#[derive(Debug, Clone)]
 pub struct VMControlFlowGraph<I: Instruction> {
     /// The basic blocks
     blocks: BTreeMap<I::Index, BasicBlock<I::Index>>,
@@ -297,15 +296,14 @@ impl<I: Instruction> VMControlFlowGraph<I> {
         let mut seen = BTreeSet::new();
 
         ret.push(block_id);
-        seen.insert(&block_id);
+        seen.insert(block_id);
 
         while index < ret.len() {
             let block_id = ret[index];
             index += 1;
-            let successors = self.successors(block_id);
-            for block_id in successors.iter() {
+            for block_id in self.successors(block_id) {
                 if !seen.contains(&block_id) {
-                    ret.push(*block_id);
+                    ret.push(block_id);
                     seen.insert(block_id);
                 }
             }
@@ -316,6 +314,12 @@ impl<I: Instruction> VMControlFlowGraph<I> {
 
     pub fn reachable_from(&self, block_id: I::Index) -> Vec<I::Index> {
         self.traverse_by(block_id)
+    }
+
+    pub fn num_back_edges(&self) -> usize {
+        self.loop_heads
+            .iter()
+            .fold(0, |acc, (_, edges)| acc + edges.len())
     }
 }
 
@@ -341,8 +345,8 @@ impl<I: Instruction> ControlFlowGraph for VMControlFlowGraph<I> {
         self.blocks[&block_id].exit
     }
 
-    fn successors(&self, block_id: Self::BlockId) -> &[Self::BlockId] {
-        &self.blocks[&block_id].successors
+    fn successors(&self, block_id: Self::BlockId) -> impl Iterator<Item = Self::BlockId> {
+        self.blocks[&block_id].successors.iter().copied()
     }
 
     fn next_block(&self, block_id: Self::BlockId) -> Option<I::Index> {
@@ -354,7 +358,7 @@ impl<I: Instruction> ControlFlowGraph for VMControlFlowGraph<I> {
         &self,
         function_code: &'a [I],
         block_id: Self::BlockId,
-    ) -> impl IntoIterator<Item = (Self::BlockId, &'a I)>
+    ) -> impl Iterator<Item = (Self::BlockId, &'a I)>
     where
         I: 'a,
     {
@@ -363,8 +367,8 @@ impl<I: Instruction> ControlFlowGraph for VMControlFlowGraph<I> {
         (start..=end).map(|pc| (I::usize_as_index(pc), &function_code[pc]))
     }
 
-    fn blocks(&self) -> Vec<Self::BlockId> {
-        self.blocks.keys().cloned().collect()
+    fn blocks(&self) -> impl Iterator<Item = Self::BlockId> {
+        self.blocks.keys().copied()
     }
 
     fn num_blocks(&self) -> usize {
@@ -383,11 +387,5 @@ impl<I: Instruction> ControlFlowGraph for VMControlFlowGraph<I> {
         self.loop_heads
             .get(&next)
             .is_some_and(|back_edges| back_edges.contains(&cur))
-    }
-
-    fn num_back_edges(&self) -> usize {
-        self.loop_heads
-            .iter()
-            .fold(0, |acc, (_, edges)| acc + edges.len())
     }
 }

--- a/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
@@ -60,12 +60,13 @@ pub fn analyze_function<TF: TransferFunctions, M: Meter + ?Sized>(
         meter,
         transfer_functions,
     };
-    absint::analyze_function(
+    let _states = absint::analyze_function(
         &mut interpreter,
         &function_context.cfg,
         &function_context.code.code,
         initial_state,
-    )
+    )?;
+    Ok(())
 }
 
 /// A `FunctionContext` holds all the information needed by the verifier for
@@ -165,8 +166,20 @@ impl<M: Meter + ?Sized, TF: TransferFunctions> absint::AbstractInterpreter
         pre.join(post, self.meter)
     }
 
-    fn visit_block_execution(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+    fn visit_block_pre_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        _invariant: &mut absint::BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error> {
         self.meter.add(Scope::Function, EXECUTE_BLOCK_BASE_COST)
+    }
+
+    fn visit_block_post_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        _invariant: &mut absint::BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     fn visit_successor(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
@@ -183,10 +196,11 @@ impl<M: Meter + ?Sized, TF: TransferFunctions> absint::AbstractInterpreter
 
     fn execute(
         &mut self,
+        _block_id: Self::BlockId,
+        bounds: (CodeOffset, CodeOffset),
         state: &mut Self::State,
-        bounds: (Self::InstructionIndex, Self::InstructionIndex),
-        offset: Self::InstructionIndex,
-        instr: &Self::Instruction,
+        offset: CodeOffset,
+        instr: &Bytecode,
     ) -> Result<(), Self::Error> {
         self.transfer_functions
             .execute(state, instr, offset, bounds, self.meter)

--- a/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -135,7 +135,7 @@ pub fn verify_function<'env>(
     )?;
 
     if let Some(limit) = verifier_config.max_basic_blocks {
-        if function_context.cfg().blocks().len() > limit {
+        if function_context.cfg().blocks().count() > limit {
             return Err(
                 PartialVMError::new(StatusCode::TOO_MANY_BASIC_BLOCKS).at_code_offset(index, 0)
             );

--- a/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -103,10 +103,9 @@ impl LoopSummary {
 
         let mut stack: Vec<Frontier> = cfg
             .successors(root_block)
-            .iter()
             .map(|succ| Visit {
                 from_node: root_node,
-                to_block: *succ,
+                to_block: succ,
             })
             .collect();
 
@@ -149,9 +148,9 @@ impl LoopSummary {
                             parent: from_node,
                         });
 
-                        stack.extend(cfg.successors(to_block).iter().map(|succ| Visit {
+                        stack.extend(cfg.successors(to_block).map(|succ| Visit {
                             from_node: to_node,
-                            to_block: *succ,
+                            to_block: succ,
                         }));
                     }
                 },

--- a/external-crates/move/crates/move-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-compiler/Cargo.toml
@@ -27,6 +27,7 @@ stacker.workspace = true
 vfs.workspace = true
 
 # internal dependencies
+move-abstract-interpreter.workspace = true
 move-binary-format.workspace = true
 move-borrow-graph.workspace = true
 move-bytecode-source-map.workspace = true

--- a/external-crates/move/crates/move-compiler/src/cfgir/absint.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/absint.rs
@@ -3,7 +3,10 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, rc::Rc};
+
+pub use absint::JoinResult;
+use move_abstract_interpreter::absint;
 
 use super::cfg::CFG;
 use crate::{diagnostics::Diagnostics, hlir::ast::*};
@@ -12,50 +15,6 @@ use crate::{diagnostics::Diagnostics, hlir::ast::*};
 /// require a more complex trait with widening and a partial order.
 pub trait AbstractDomain: Clone + Sized {
     fn join(&mut self, other: &Self) -> JoinResult;
-}
-
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum JoinResult {
-    Unchanged,
-    Changed,
-}
-
-#[derive(Clone)]
-enum BlockPostcondition {
-    /// Unprocessed block
-    Unprocessed,
-    /// Analyzing block was successful
-    Success,
-    /// Analyzing block ended in an error
-    Error(Diagnostics),
-}
-
-#[derive(Clone)]
-struct BlockInvariant<State> {
-    /// Precondition of the block
-    pre: State,
-    /// Postcondition of the block---just success/error for now
-    post: BlockPostcondition,
-}
-
-/// A map from block id's to the pre/post of each block after a fixed point is
-/// reached.
-type InvariantMap<State> = BTreeMap<Label, BlockInvariant<State>>;
-
-fn collect_states_and_diagnostics<State>(
-    map: InvariantMap<State>,
-) -> (BTreeMap<Label, State>, Diagnostics) {
-    let mut diags = Diagnostics::new();
-    let final_states = map
-        .into_iter()
-        .map(|(lbl, BlockInvariant { pre, post })| {
-            if let BlockPostcondition::Error(ds) = post {
-                diags.extend(ds)
-            }
-            (lbl, pre)
-        })
-        .collect();
-    (final_states, diags)
 }
 
 /// Take a pre-state + instruction and mutate it to produce a post-state
@@ -83,89 +42,169 @@ pub trait TransferFunctions {
     ) -> Diagnostics;
 }
 
-pub trait AbstractInterpreter: TransferFunctions {
-    /// Analyze procedure local@function_context starting from pre-state
-    /// local@initial_state.
-    fn analyze_function(
-        &mut self,
-        cfg: &dyn CFG,
-        initial_state: Self::State,
-    ) -> (BTreeMap<Label, Self::State>, Diagnostics) {
-        let mut inv_map: InvariantMap<Self::State> = InvariantMap::new();
-        let start = cfg.start_block();
-        let mut next_block = Some(start);
-
-        while let Some(block_label) = next_block {
-            let block_invariant = inv_map
-                .entry(block_label)
-                .or_insert_with(|| BlockInvariant {
-                    pre: initial_state.clone(),
-                    post: BlockPostcondition::Unprocessed,
-                });
-
-            let (post_state, errors) = self.execute_block(cfg, &block_invariant.pre, block_label);
-            block_invariant.post = if errors.is_empty() {
-                BlockPostcondition::Success
-            } else {
-                BlockPostcondition::Error(errors)
-            };
-
-            // propagate postcondition of this block to successor blocks
-            let mut next_block_candidate = cfg.next_block(block_label);
-            for next_block_id in cfg.successors(block_label) {
-                match inv_map.get_mut(next_block_id) {
-                    Some(next_block_invariant) => {
-                        let join_result = {
-                            let old_pre = &mut next_block_invariant.pre;
-                            old_pre.join(&post_state)
-                        };
-                        match join_result {
-                            JoinResult::Unchanged => {
-                                // Pre is the same after join. Reanalyzing this
-                                // block would produce
-                                // the same post
-                            }
-                            JoinResult::Changed => {
-                                // Pre has changed, the post condition is now unknown for the block
-                                next_block_invariant.post = BlockPostcondition::Unprocessed;
-                                // If the cur->successor is a back edge, jump back to the beginning
-                                // of the loop, instead of the normal next block
-                                if cfg.is_back_edge(block_label, *next_block_id) {
-                                    next_block_candidate = Some(*next_block_id);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    None => {
-                        // Haven't visited the next block yet. Use the post of the current block as
-                        // its pre
-                        inv_map.insert(
-                            *next_block_id,
-                            BlockInvariant {
-                                pre: post_state.clone(),
-                                post: BlockPostcondition::Success,
-                            },
-                        );
-                    }
+pub fn analyze_function<C: CFG, TF: TransferFunctions>(
+    transfer_functions: &mut TF,
+    cfg: &C,
+    initial_state: TF::State,
+) -> (BTreeMap<Label, TF::State>, Diagnostics) {
+    fn collect_states_and_diagnostics<State>(
+        map: BTreeMap<Label, absint::BlockInvariant<(State, Option<Rc<Diagnostics>>)>>,
+    ) -> (BTreeMap<Label, State>, Diagnostics) {
+        let mut diags = Diagnostics::new();
+        let final_states = map
+            .into_iter()
+            .map(|(lbl, inv)| {
+                let absint::BlockInvariant {
+                    pre: (pre, _pre_diags),
+                    post,
+                } = inv;
+                debug_assert!(_pre_diags.is_none());
+                // can be None for empty blocks
+                if let absint::BlockPostCondition::Processed((_, Some(rc_diags))) = post {
+                    diags.extend(Rc::into_inner(rc_diags).unwrap());
                 }
-            }
-            next_block = next_block_candidate;
-        }
-        collect_states_and_diagnostics(inv_map)
+                (lbl, pre)
+            })
+            .collect();
+        (final_states, diags)
     }
 
-    fn execute_block(
+    let mut interpreter = AbstractInterpreter { transfer_functions };
+    let inv_map = absint::analyze_function(
+        &mut interpreter,
+        &CFGWrapper(cfg),
+        &(),
+        (initial_state, None),
+    )
+    .unwrap();
+    collect_states_and_diagnostics(inv_map)
+}
+
+struct AbstractInterpreter<'a, TF: TransferFunctions> {
+    pub transfer_functions: &'a mut TF,
+}
+
+impl<TF: TransferFunctions> absint::AbstractInterpreter for AbstractInterpreter<'_, TF> {
+    type Error = ();
+    type BlockId = Label;
+
+    type State = (<TF as TransferFunctions>::State, Option<Rc<Diagnostics>>);
+
+    type InstructionIndex = usize;
+    type Instruction = Command;
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn join(
         &mut self,
-        cfg: &dyn CFG,
-        pre_state: &Self::State,
-        block_lbl: Label,
-    ) -> (Self::State, Diagnostics) {
-        let mut state = pre_state.clone();
-        let mut diags = Diagnostics::new();
-        for (idx, cmd) in cfg.commands(block_lbl) {
-            diags.extend(self.execute(&mut state, block_lbl, idx, cmd));
+        (pre, _): &mut (TF::State, Option<Rc<Diagnostics>>),
+        (post, _): &(TF::State, Option<Rc<Diagnostics>>),
+    ) -> Result<JoinResult, Self::Error> {
+        Ok(pre.join(post))
+    }
+
+    fn visit_block_pre_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        invariant: &mut absint::BlockInvariant<(TF::State, Option<Rc<Diagnostics>>)>,
+    ) -> Result<(), Self::Error> {
+        // each block needs its own unique Diagnostics, so set to None to be then
+        // initialized in the `execute`
+        invariant.pre.1 = None;
+        Ok(())
+    }
+
+    fn visit_block_post_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        _invariant: &mut absint::BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn visit_successor(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn visit_back_edge(
+        &mut self,
+        _from: Self::BlockId,
+        _to: Self::BlockId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn execute(
+        &mut self,
+        lbl: Self::BlockId,
+        (start, _stop): (Self::InstructionIndex, Self::InstructionIndex),
+        (state, diags): &mut (TF::State, Option<Rc<Diagnostics>>),
+        idx: Self::InstructionIndex,
+        command: &Self::Instruction,
+    ) -> Result<(), Self::Error> {
+        if idx == start {
+            *diags = Some(Rc::new(Diagnostics::new()));
         }
-        (state, diags)
+        let diags: &mut Diagnostics = Rc::get_mut(diags.as_mut().expect("Set as some"))
+            .expect("unique ownership while iterating through block");
+        diags.extend(self.transfer_functions.execute(state, lbl, idx, command));
+        Ok(())
+    }
+}
+
+struct CFGWrapper<'a, T: CFG>(&'a T);
+impl<T: CFG> move_abstract_interpreter::control_flow_graph::ControlFlowGraph for CFGWrapper<'_, T> {
+    type BlockId = Label;
+    type InstructionIndex = usize;
+    type Instruction = Command;
+    type Instructions = ();
+
+    fn block_start(&self, label: Self::BlockId) -> Self::InstructionIndex {
+        self.0.block_start(label)
+    }
+
+    fn block_end(&self, label: Self::BlockId) -> Self::InstructionIndex {
+        self.0.block_end(label)
+    }
+
+    fn successors(&self, label: Self::BlockId) -> impl Iterator<Item = Self::BlockId> {
+        self.0.successors(label).iter().copied()
+    }
+
+    fn next_block(&self, label: Self::BlockId) -> Option<Self::BlockId> {
+        self.0.next_block(label)
+    }
+
+    fn instructions<'a>(
+        &'a self,
+        _: &'a (),
+        block_id: Self::BlockId,
+    ) -> impl Iterator<Item = (Self::InstructionIndex, &'a Self::Instruction)>
+    where
+        Self::Instruction: 'a,
+    {
+        self.0.commands(block_id)
+    }
+
+    fn blocks(&self) -> impl Iterator<Item = Self::BlockId> {
+        self.0.block_labels()
+    }
+
+    fn num_blocks(&self) -> usize {
+        self.0.num_blocks()
+    }
+
+    fn entry_block_id(&self) -> Self::BlockId {
+        self.0.start_block()
+    }
+
+    fn is_loop_head(&self, label: Self::BlockId) -> bool {
+        self.0.is_loop_head(label)
+    }
+
+    fn is_back_edge(&self, cur: Self::BlockId, next: Self::BlockId) -> bool {
+        self.0.is_back_edge(cur, next)
     }
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
@@ -89,8 +89,6 @@ impl TransferFunctions for BorrowSafety {
     }
 }
 
-impl AbstractInterpreter for BorrowSafety {}
-
 pub fn verify(
     context: &super::CFGContext,
     cfg: &super::cfg::MutForwardCFG,
@@ -105,7 +103,7 @@ pub fn verify(
     let mut initial_state = BorrowState::initial(locals, safety.mutably_used.clone(), has_errors);
     initial_state.bind_arguments(&signature.parameters);
     initial_state.canonicalize_locals(&safety.local_numbers);
-    let (final_state, ds) = safety.analyze_function(cfg, initial_state);
+    let (final_state, ds) = analyze_function(&mut safety, cfg, initial_state);
     context.add_diags(ds);
     unused_mut_borrows(context, safety.mutably_used);
     final_state

--- a/external-crates/move/crates/move-compiler/src/cfgir/cfg.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/cfg.rs
@@ -28,7 +28,11 @@ pub trait CFG {
     fn successors(&self, label: Label) -> &BTreeSet<Label>;
 
     fn predecessors(&self, label: Label) -> &BTreeSet<Label>;
-    fn commands<'a>(&'a self, label: Label) -> Box<dyn Iterator<Item = (usize, &'a Command)> + 'a>;
+    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &Command)>;
+    fn block_start(&self, label: Label) -> usize;
+    fn block_end(&self, label: Label) -> usize;
+    fn num_commands(&self, label: Label) -> usize;
+    fn block_labels(&self) -> impl Iterator<Item = Label>;
     fn num_blocks(&self) -> usize;
     fn start_block(&self) -> Label;
 
@@ -242,8 +246,24 @@ impl<T: Deref<Target = BasicBlocks>> CFG for ForwardCFG<T> {
         self.predecessor_map.get(&label).unwrap()
     }
 
-    fn commands<'s>(&'s self, label: Label) -> Box<dyn Iterator<Item = (usize, &'s Command)> + 's> {
-        Box::new(self.block(label).iter().enumerate())
+    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &Command)> {
+        self.block(label).iter().enumerate()
+    }
+
+    fn block_start(&self, _label: Label) -> usize {
+        0
+    }
+
+    fn block_end(&self, label: Label) -> usize {
+        self.block(label).len().saturating_sub(1)
+    }
+
+    fn num_commands(&self, label: Label) -> usize {
+        self.block(label).len()
+    }
+
+    fn block_labels(&self) -> impl Iterator<Item = Label> {
+        self.blocks.keys().copied()
     }
 
     fn num_blocks(&self) -> usize {
@@ -629,8 +649,24 @@ impl<Blocks: Deref<Target = BasicBlocks>> CFG for ReverseCFG<'_, Blocks> {
         self.predecessor_map.get(&label).unwrap()
     }
 
-    fn commands<'s>(&'s self, label: Label) -> Box<dyn Iterator<Item = (usize, &'s Command)> + 's> {
-        Box::new(self.block(label).iter().enumerate().rev())
+    fn commands(&self, label: Label) -> impl Iterator<Item = (usize, &Command)> {
+        self.block(label).iter().enumerate().rev()
+    }
+
+    fn block_start(&self, label: Label) -> usize {
+        self.block(label).len().saturating_sub(1)
+    }
+
+    fn block_end(&self, _label: Label) -> usize {
+        0
+    }
+
+    fn num_commands(&self, label: Label) -> usize {
+        self.block(label).len()
+    }
+
+    fn block_labels(&self) -> impl Iterator<Item = Label> {
+        self.blocks().map(|(lbl, _)| *lbl)
     }
 
     fn num_blocks(&self) -> usize {

--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -66,8 +66,6 @@ impl TransferFunctions for Liveness {
     }
 }
 
-impl AbstractInterpreter for Liveness {}
-
 //**************************************************************************************************
 // Analysis
 //**************************************************************************************************
@@ -79,7 +77,7 @@ fn analyze(
     let reverse = &mut ReverseCFG::new(cfg, infinite_loop_starts);
     let initial_state = LivenessState::initial();
     let mut liveness = Liveness::new(reverse);
-    let (final_invariants, errors) = liveness.analyze_function(reverse, initial_state);
+    let (final_invariants, errors) = analyze_function(&mut liveness, reverse, initial_state);
     assert!(errors.is_empty());
     (final_invariants, liveness.states)
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -174,8 +174,6 @@ impl TransferFunctions for LocalsSafety<'_> {
     }
 }
 
-impl AbstractInterpreter for LocalsSafety<'_> {}
-
 pub fn verify(
     context: &super::CFGContext,
     cfg: &super::cfg::MutForwardCFG,
@@ -185,7 +183,7 @@ pub fn verify(
     } = context;
     let initial_state = LocalStates::initial(&signature.parameters, locals);
     let mut locals_safety = LocalsSafety::new(context, locals, signature);
-    let (final_state, ds) = locals_safety.analyze_function(cfg, initial_state);
+    let (final_state, ds) = analyze_function(&mut locals_safety, cfg, initial_state);
     unused_let_muts(context, locals, locals_safety.unused_mut);
     context.add_diags(ds);
     final_state

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -11,7 +11,7 @@ use move_proc_macros::growing_stack;
 use crate::{
     cfgir::{
         CFGContext,
-        absint::{AbstractDomain, AbstractInterpreter, JoinResult, TransferFunctions},
+        absint::{AbstractDomain, JoinResult, TransferFunctions, analyze_function},
         ast as G,
         cfg::ImmForwardCFG,
     },
@@ -530,7 +530,7 @@ pub trait SimpleAbsIntConstructor: Sized {
         let Some(mut ai) = Self::new(context, cfg, &mut init_state) else {
             return Diagnostics::new();
         };
-        let (final_state, ds) = ai.analyze_function(cfg, init_state);
+        let (final_state, ds) = analyze_function(&mut ai, cfg, init_state);
         ai.finish(final_state, ds)
     }
 }
@@ -808,7 +808,6 @@ impl<V: SimpleAbsInt> TransferFunctions for V {
         self.finish_command(context, pre)
     }
 }
-impl<V: SimpleAbsInt> AbstractInterpreter for V {}
 
 impl<V: AbstractInterpreterVisitor + 'static> From<V> for AbsIntVisitorObj {
     fn from(value: V) -> Self {

--- a/external-crates/move/crates/move-coverage/src/lcov.rs
+++ b/external-crates/move/crates/move-coverage/src/lcov.rs
@@ -355,7 +355,7 @@ impl FileRecordKeeper {
                     let loc = f_source_map.get_code_location(block_end).unwrap();
                     let line_no = file_mapping.start_position(&loc).line_offset() + 1;
                     block_id += 1;
-                    for &o in cfg.successors(cfg_block_id) {
+                    for o in cfg.successors(cfg_block_id) {
                         self.branches
                             .entry((index as u16, block_end))
                             .or_insert_with(|| BranchInfo::new(line_no, block_id - 1))

--- a/external-crates/move/crates/move-coverage/src/summary.rs
+++ b/external-crates/move/crates/move-coverage/src/summary.rs
@@ -203,7 +203,7 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
                     // get function entry and return points
                     let fn_entry = fn_cfg.block_start(fn_cfg.entry_block_id());
                     let mut fn_returns: BTreeSet<CodeOffset> = BTreeSet::new();
-                    for block_id in fn_cfg.blocks().into_iter() {
+                    for block_id in fn_cfg.blocks() {
                         for i in fn_cfg.block_start(block_id)..=fn_cfg.block_end(block_id) {
                             if let Bytecode::Ret = &code_unit.code[i as usize] {
                                 fn_returns.insert(i);
@@ -216,15 +216,14 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
 
                     let block_to_node: BTreeMap<_, _> = fn_cfg
                         .blocks()
-                        .into_iter()
                         .map(|block_id| (block_id, fn_dgraph.add_node(block_id)))
                         .collect();
 
-                    for block_id in fn_cfg.blocks().into_iter() {
-                        for succ_block_id in fn_cfg.successors(block_id).iter() {
+                    for block_id in fn_cfg.blocks() {
+                        for succ_block_id in fn_cfg.successors(block_id) {
                             fn_dgraph.add_edge(
                                 *block_to_node.get(&block_id).unwrap(),
-                                *block_to_node.get(succ_block_id).unwrap(),
+                                *block_to_node.get(&succ_block_id).unwrap(),
                                 (),
                             );
                         }

--- a/external-crates/move/crates/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/crates/move-disassembler/src/disassembler.rs
@@ -876,7 +876,6 @@ impl Disassembler<'_> {
         let cfg_opt = if self.options.print_basic_blocks {
             let cfg: BTreeMap<_, _> = VMControlFlowGraph::new(&code.code, &code.jump_tables)
                 .blocks()
-                .into_iter()
                 .enumerate()
                 .map(|(block_number, pc_start)| (pc_start, block_number))
                 .collect();

--- a/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
@@ -20,7 +20,7 @@ fn cfg_compile_script_ret() {
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
     cfg.display();
-    assert_eq!(cfg.blocks().len(), 1);
+    assert_eq!(cfg.blocks().count(), 1);
     assert_eq!(cfg.num_blocks(), 1);
     assert_eq!(cfg.reachable_from(0).len(), 1);
 }
@@ -41,7 +41,7 @@ fn cfg_compile_script_let() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 1);
+    assert_eq!(cfg.blocks().count(), 1);
     assert_eq!(cfg.num_blocks(), 1);
     assert_eq!(cfg.reachable_from(0).len(), 1);
 }
@@ -65,7 +65,7 @@ fn cfg_compile_if() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
 }
@@ -92,7 +92,7 @@ fn cfg_compile_if_else() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
 }
@@ -115,7 +115,7 @@ fn cfg_compile_if_else_with_else_return() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
 }
@@ -146,7 +146,7 @@ fn cfg_compile_nested_if() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 7);
+    assert_eq!(cfg.blocks().count(), 7);
     assert_eq!(cfg.num_blocks(), 7);
     assert_eq!(cfg.reachable_from(8).len(), 3);
 }
@@ -169,7 +169,7 @@ fn cfg_compile_if_else_with_if_return() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
     assert_eq!(cfg.reachable_from(4).len(), 2);
@@ -192,7 +192,7 @@ fn cfg_compile_if_else_with_two_returns() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 3);
     assert_eq!(cfg.reachable_from(4).len(), 1);
@@ -219,7 +219,7 @@ fn cfg_compile_if_else_with_else_abort() {
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
     cfg.display();
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
 }
@@ -243,7 +243,7 @@ fn cfg_compile_if_else_with_if_abort() {
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
     cfg.display();
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
     assert_eq!(cfg.reachable_from(4).len(), 2);
@@ -267,7 +267,7 @@ fn cfg_compile_if_else_with_two_aborts() {
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
     cfg.display();
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 3);
     assert_eq!(cfg.reachable_from(4).len(), 1);
@@ -297,7 +297,7 @@ fn cfg_compile_variant_switch_simple() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 3);
+    assert_eq!(cfg.blocks().count(), 3);
     assert_eq!(cfg.num_blocks(), 3);
     assert_eq!(cfg.reachable_from(0).len(), 3);
 }
@@ -327,7 +327,7 @@ fn cfg_compile_variant_switch_simple_unconditional_jump() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 3);
 }
@@ -363,7 +363,7 @@ fn cfg_compile_variant_switch() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 6);
+    assert_eq!(cfg.blocks().count(), 6);
     assert_eq!(cfg.num_blocks(), 6);
     assert_eq!(cfg.reachable_from(0).len(), 6);
 }
@@ -399,7 +399,7 @@ fn cfg_compile_variant_switch_with_two_aborts() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 6);
+    assert_eq!(cfg.blocks().count(), 6);
     assert_eq!(cfg.num_blocks(), 6);
     assert_eq!(cfg.reachable_from(0).len(), 5);
 }
@@ -441,7 +441,7 @@ fn cfg_compile_variant_switch_with_return() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 7);
+    assert_eq!(cfg.blocks().count(), 7);
     assert_eq!(cfg.num_blocks(), 7);
     assert_eq!(cfg.reachable_from(0).len(), 5);
 }


### PR DESCRIPTION
# Description of change

Replaces the compiler's own copy of the abstract interpreter fixpoint loop with the shared one in `move-abstract-interpreter`, so the compiler and the bytecode verifier now drive their analyses through the same code.

- `cfgir::absint` loses its `AbstractInterpreter` trait and its private `BlockInvariant`/`BlockPostcondition`/`InvariantMap`; the fixpoint loop becomes a free `analyze_function` that wraps the shared interpreter, and `JoinResult` is re-exported from `move-abstract-interpreter`.
- Per-block diagnostics are threaded through the shared `State` as `Option<Rc<Diagnostics>>`, which is what the new `visit_block_pre_execution` / `visit_block_post_execution` visitors exist for.
- `ControlFlowGraph::successors` and `blocks` return iterators instead of `&[BlockId]` and `Vec<BlockId>`; `num_back_edges` moves off the trait onto `VMControlFlowGraph`.
- The `cfgir::CFG` trait gains `block_start`, `block_end`, `num_commands` and `block_labels`, and `commands` returns an iterator instead of a boxed one.

## Behaviour

No observable change. Upstream did change one thing beyond the mechanical refactor: `analyze_function` used to skip a block with no recorded invariant and now seeds it with the function's initial state. The branch is unreachable for the bytecode verifier, because every analysis it drives is forward over VMControlFlowGraph. It is reachable for the compiler's liveness analysis, which runs over a ReverseCFG - but the compiler already seeded those blocks before this change, so its behavior is unaffected.

Worth a look anyway, because the same loop drives the bytecode verifier, which is not versioned here (no cuts under `external-crates/move/move-execution/`).

## Upstream commits

| Commit | Upstream PR | Description |
|--------|-------------|-------------|
| `a38e14501a7ebf1d2e56ae90bfa1afd94763319f` | #22322 | [move-abstract-interpreter] Use shared abstract interpreter in the compiler |

### Downstream adaptations

| File | Adaptation | Reason |
|------|-----------|--------|
| `move-abstract-interpreter/src/{absint,control_flow_graph}.rs`, `move-bytecode-verifier/src/absint.rs`, `move-compiler/src/cfgir/absint.rs` | 10 hunks re-placed by hand | Context drift only: downstream rustfmt wraps doc comments at a narrower width and groups imports `StdExternalCrate`, so the patch context did not match |
| `move-compiler/src/cfgir/absint.rs` | `use` order is std / external / crate instead of upstream's flat alphabetical order | `cargo +nightly fmt` output; same three imports |
| `move-compiler/Cargo.toml` | `move-abstract-interpreter.workspace = true` placed at the top of the existing `# internal dependencies` block | Downstream splits dependencies into `# external` / `# internal` groups |
| `Cargo.lock`, `external-crates/move/Cargo.lock` | Regenerated with cargo instead of applying the patch hunks | Generated artifacts; both came out as the same single added line as upstream |

## Links to any relevant issues

Fixes #10846

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have checked that new and existing unit tests pass locally with my changes

Rebased onto develop (the base changed from `vm-lang/upstream/mainnet-1.50.1-1.52.3`): the commit replayed with no conflicts, and the `lcov.rs` hunk above is the only addition.

Ran locally:

- `cargo check --workspace --all-targets` on `external-crates/move`: clean.
- `cargo check -p iota-move -p iota-move-build -p iota-framework --all-targets` in the root workspace: clean.
- `cargo test -p move-compiler -p move-ir-compiler -p move-disassembler`: 1899 + 17 + 3 passed, 0 failed. The 1899 are `move_check_testsuite`, which is the surface that would move if the diagnostics rework changed ordering or dropped diagnostics — no expected-output file needed updating.
- `cargo test -p bytecode-verifier-tests -p move-bytecode-verifier -p move-compiler-transactional-tests -p bytecode-verifier-transactional-tests -p move-analyzer`: 677 passed, 0 failed.
- `cargo +nightly fmt`, `cargo machete`, `cargo ci-license`, and clippy on the touched crates plus the root consumers: clean.
- Verified hunk-by-hunk against the upstream patch: the file sets match exactly (18 on both sides), and for 16 of the 18 the added and removed code is character-identical after normalising whitespace. The two that differ do so only in formatting: `move-abstract-interpreter/src/absint.rs` wraps doc comments narrower (3789 characters on both sides once the wrapping is joined), and `cfgir/absint.rs` does the same and orders two `use` lines std-before-external per downstream rustfmt (7199 characters on both sides with those lines set aside). Neither side touches copyright headers.

One thing worth a reviewer's attention: clippy flags `very complex type used` on the `collect_states_and_diagnostics` parameter in `cfgir/absint.rs`, which is upstream's own signature, left as written. `external-crates/move` is a separate workspace whose crates are path dependencies, so `cargo ci-clippy` does not lint it.


