### PR TITLE
fix(iota-network): stop a checkpoint summary sync another writer has passed

### DIFF
--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -92,9 +92,8 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 .as_secs_f64(),
         );
 
-        let highest_verified_checkpoint = checkpoint_store
-            .get_highest_verified_checkpoint()?
-            .map(|x| x.sequence_number());
+        let highest_verified_checkpoint =
+            checkpoint_store.get_highest_verified_checkpoint_seq_number()?;
 
         if Some(checkpoint_seq) > highest_verified_checkpoint {
             debug!(

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -403,8 +403,12 @@ impl CheckpointStore {
         self.tables.checkpoint_content.multi_get(contents_digest)
     }
 
-    /// The row `watermark` holds — the sequence number and digest of the
-    /// checkpoint it names — and `None` when it has never been written.
+    /// The row `watermark` holds — a sequence number and a digest — and `None`
+    /// when it has never been written.
+    ///
+    /// Only the verified, synced and executed rows name a checkpoint. The
+    /// pruner writes a random digest for `HighestPruned`, since nothing reads
+    /// it, so that row's sequence number is the only part worth having.
     fn get_watermark(
         &self,
         watermark: CheckpointWatermark,
@@ -679,8 +683,9 @@ impl CheckpointStore {
     }
 
     /// Marks a consecutive run of checkpoints as synced: writes the watermark
-    /// once, for the last checkpoint, but notifies waiters of every
-    /// checkpoint in the run.
+    /// once, for the last checkpoint, and notifies the waiters that write
+    /// releases. Does nothing when another writer has already carried the
+    /// watermark past the run.
     pub fn multi_update_highest_synced_checkpoint(
         &self,
         checkpoints: &[VerifiedCheckpoint],
@@ -806,17 +811,13 @@ impl CheckpointStore {
         )
     }
 
-    /// Sets highest executed checkpoint to any value.
-    ///
-    /// WARNING: This method is very subtle and can corrupt the database if used
-    /// incorrectly. It should only be used in one-off cases or tests after
-    /// fully understanding the risk.
     /// Sets the verified watermark to `checkpoint` whether or not that moves
     /// it forwards.
     ///
-    /// Only for tooling that deliberately rewinds it. Every path the node
-    /// takes goes through [`Self::update_highest_verified_checkpoint`], which
-    /// only ever advances it.
+    /// Only for tooling that deliberately rewinds it. The node writes this row
+    /// through [`Self::update_highest_verified_checkpoint`], which declines to
+    /// move it backwards — though it reads and writes without a lock, so two
+    /// writers racing can still leave it behind where one of them saw it.
     pub fn set_highest_verified_checkpoint_subtle(
         &self,
         checkpoint: &VerifiedCheckpoint,
@@ -830,10 +831,9 @@ impl CheckpointStore {
     /// Sets the synced watermark to `checkpoint` whether or not that moves it
     /// forwards.
     ///
-    /// Only for tooling that deliberately rewinds it. Every path the node
-    /// takes goes through
-    /// [`Self::multi_update_highest_synced_checkpoint`], which only ever
-    /// advances it.
+    /// Only for tooling that deliberately rewinds it. The node writes this row
+    /// through [`Self::multi_update_highest_synced_checkpoint`], which
+    /// declines to move it backwards.
     pub fn set_highest_synced_checkpoint_subtle(
         &self,
         checkpoint: &VerifiedCheckpoint,
@@ -844,6 +844,11 @@ impl CheckpointStore {
         )
     }
 
+    /// Sets highest executed checkpoint to any value.
+    ///
+    /// WARNING: This method is very subtle and can corrupt the database if used
+    /// incorrectly. It should only be used in one-off cases or tests after
+    /// fully understanding the risk.
     pub fn set_highest_executed_checkpoint_subtle(
         &self,
         checkpoint: &VerifiedCheckpoint,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -816,8 +816,7 @@ impl CheckpointStore {
     ///
     /// Only for tooling that deliberately rewinds it. The node writes this row
     /// through [`Self::update_highest_verified_checkpoint`], which declines to
-    /// move it backwards — though it reads and writes without a lock, so two
-    /// writers racing can still leave it behind where one of them saw it.
+    /// move it backwards, under a lock its callers share.
     pub fn set_highest_verified_checkpoint_subtle(
         &self,
         checkpoint: &VerifiedCheckpoint,
@@ -832,8 +831,8 @@ impl CheckpointStore {
     /// forwards.
     ///
     /// Only for tooling that deliberately rewinds it. The node writes this row
-    /// through [`Self::multi_update_highest_synced_checkpoint`], which
-    /// declines to move it backwards.
+    /// through [`Self::multi_update_highest_synced_checkpoint`], which declines
+    /// to move it backwards, under a lock its callers share.
     pub fn set_highest_synced_checkpoint_subtle(
         &self,
         checkpoint: &VerifiedCheckpoint,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -403,96 +403,81 @@ impl CheckpointStore {
         self.tables.checkpoint_content.multi_get(contents_digest)
     }
 
+    /// The row `watermark` holds — the sequence number and digest of the
+    /// checkpoint it names — and `None` when it has never been written.
+    fn get_watermark(
+        &self,
+        watermark: CheckpointWatermark,
+    ) -> Result<Option<(CheckpointSequenceNumber, CheckpointDigest)>, TypedStoreError> {
+        self.tables.watermarks.get(&watermark)
+    }
+
+    /// The checkpoint `watermark` names.
+    ///
+    /// Resolved by digest, so it costs a lookup the row itself does not, and
+    /// answers `None` for a checkpoint the store no longer holds. A caller
+    /// that only compares positions wants [`Self::get_watermark_seq_number`].
+    fn get_watermark_checkpoint(
+        &self,
+        watermark: CheckpointWatermark,
+    ) -> Result<Option<VerifiedCheckpoint>, TypedStoreError> {
+        let Some((_sequence_number, digest)) = self.get_watermark(watermark)? else {
+            return Ok(None);
+        };
+        self.get_checkpoint_by_digest(&digest)
+    }
+
+    /// The sequence number of the checkpoint `watermark` names, read from the
+    /// row rather than from the checkpoint.
+    fn get_watermark_seq_number(
+        &self,
+        watermark: CheckpointWatermark,
+    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
+        Ok(self
+            .get_watermark(watermark)?
+            .map(|(sequence_number, _digest)| sequence_number))
+    }
+
     pub fn get_highest_verified_checkpoint(
         &self,
     ) -> Result<Option<VerifiedCheckpoint>, TypedStoreError> {
-        let highest_verified = if let Some(highest_verified) = self
-            .tables
-            .watermarks
-            .get(&CheckpointWatermark::HighestVerified)?
-        {
-            highest_verified
-        } else {
-            return Ok(None);
-        };
-        self.get_checkpoint_by_digest(&highest_verified.1)
-    }
-
-    pub fn get_highest_synced_checkpoint(
-        &self,
-    ) -> Result<Option<VerifiedCheckpoint>, TypedStoreError> {
-        let highest_synced = if let Some(highest_synced) = self
-            .tables
-            .watermarks
-            .get(&CheckpointWatermark::HighestSynced)?
-        {
-            highest_synced
-        } else {
-            return Ok(None);
-        };
-        self.get_checkpoint_by_digest(&highest_synced.1)
+        self.get_watermark_checkpoint(CheckpointWatermark::HighestVerified)
     }
 
     pub fn get_highest_verified_checkpoint_seq_number(
         &self,
     ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
-        Ok(self
-            .tables
-            .watermarks
-            .get(&CheckpointWatermark::HighestVerified)?
-            .map(|(sequence_number, _digest)| sequence_number))
+        self.get_watermark_seq_number(CheckpointWatermark::HighestVerified)
+    }
+
+    pub fn get_highest_synced_checkpoint(
+        &self,
+    ) -> Result<Option<VerifiedCheckpoint>, TypedStoreError> {
+        self.get_watermark_checkpoint(CheckpointWatermark::HighestSynced)
     }
 
     pub fn get_highest_synced_checkpoint_seq_number(
         &self,
     ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
-        if let Some(highest_synced) = self
-            .tables
-            .watermarks
-            .get(&CheckpointWatermark::HighestSynced)?
-        {
-            Ok(Some(highest_synced.0))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub fn get_highest_executed_checkpoint_seq_number(
-        &self,
-    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
-        if let Some(highest_executed) = self
-            .tables
-            .watermarks
-            .get(&CheckpointWatermark::HighestExecuted)?
-        {
-            Ok(Some(highest_executed.0))
-        } else {
-            Ok(None)
-        }
+        self.get_watermark_seq_number(CheckpointWatermark::HighestSynced)
     }
 
     pub fn get_highest_executed_checkpoint(
         &self,
     ) -> Result<Option<VerifiedCheckpoint>, TypedStoreError> {
-        let highest_executed = if let Some(highest_executed) = self
-            .tables
-            .watermarks
-            .get(&CheckpointWatermark::HighestExecuted)?
-        {
-            highest_executed
-        } else {
-            return Ok(None);
-        };
-        self.get_checkpoint_by_digest(&highest_executed.1)
+        self.get_watermark_checkpoint(CheckpointWatermark::HighestExecuted)
+    }
+
+    pub fn get_highest_executed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
+        self.get_watermark_seq_number(CheckpointWatermark::HighestExecuted)
     }
 
     pub fn get_highest_pruned_checkpoint_seq_number(
         &self,
     ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
-        self.tables
-            .watermarks
-            .get(&CheckpointWatermark::HighestPruned)
-            .map(|watermark| watermark.map(|w| w.0))
+        self.get_watermark_seq_number(CheckpointWatermark::HighestPruned)
     }
 
     pub fn get_checkpoint_contents(
@@ -672,11 +657,7 @@ impl CheckpointStore {
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), TypedStoreError> {
-        if Some(checkpoint.sequence_number())
-            > self
-                .get_highest_verified_checkpoint()?
-                .map(|x| x.sequence_number())
-        {
+        if Some(checkpoint.sequence_number()) > self.get_highest_verified_checkpoint_seq_number()? {
             debug!(
                 checkpoint_seq = checkpoint.sequence_number(),
                 "Updating highest verified checkpoint",
@@ -2898,10 +2879,8 @@ impl CheckpointServiceNotify for CheckpointService {
         let sequence = info.summary.sequence_number;
         let signer = info.summary.auth_sig().authority.concise();
 
-        if let Some(highest_verified_checkpoint) = self
-            .tables
-            .get_highest_verified_checkpoint()?
-            .map(|x| x.sequence_number())
+        if let Some(highest_verified_checkpoint) =
+            self.tables.get_highest_verified_checkpoint_seq_number()?
         {
             if sequence <= highest_verified_checkpoint {
                 trace!(

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -688,17 +688,28 @@ impl CheckpointStore {
         let Some(last) = checkpoints.last() else {
             return Ok(());
         };
-        debug!(
-            checkpoint_seq = last.sequence_number(),
-            "Updating highest synced checkpoint",
-        );
-        self.tables.watermarks.insert(
-            &CheckpointWatermark::HighestSynced,
-            &(last.sequence_number(), *last.digest()),
-        )?;
-        for checkpoint in checkpoints {
-            self.synced_checkpoint_notify_read
-                .notify(&checkpoint.sequence_number(), checkpoint);
+
+        // Only ever forwards, like the other two: another writer advances this
+        // as well, and moving it back offers contents that may not be there.
+        let previous = self.get_highest_synced_checkpoint_seq_number()?;
+        if previous.is_none_or(|previous_seq_number| previous_seq_number < last.sequence_number()) {
+            debug!(
+                checkpoint_seq = last.sequence_number(),
+                "Updating highest synced checkpoint",
+            );
+            self.tables.watermarks.insert(
+                &CheckpointWatermark::HighestSynced,
+                &(last.sequence_number(), *last.digest()),
+            )?;
+
+            // A reader parks only below the watermark, so only what this
+            // write has just passed can have anyone waiting on it.
+            for checkpoint in checkpoints.iter().filter(|c| {
+                previous.is_none_or(|previous_seq_number| previous_seq_number < c.sequence_number())
+            }) {
+                self.synced_checkpoint_notify_read
+                    .notify(&checkpoint.sequence_number(), checkpoint);
+            }
         }
         Ok(())
     }
@@ -800,6 +811,39 @@ impl CheckpointStore {
     /// WARNING: This method is very subtle and can corrupt the database if used
     /// incorrectly. It should only be used in one-off cases or tests after
     /// fully understanding the risk.
+    /// Sets the verified watermark to `checkpoint` whether or not that moves
+    /// it forwards.
+    ///
+    /// Only for tooling that deliberately rewinds it. Every path the node
+    /// takes goes through [`Self::update_highest_verified_checkpoint`], which
+    /// only ever advances it.
+    pub fn set_highest_verified_checkpoint_subtle(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<(), TypedStoreError> {
+        self.tables.watermarks.insert(
+            &CheckpointWatermark::HighestVerified,
+            &(checkpoint.sequence_number(), *checkpoint.digest()),
+        )
+    }
+
+    /// Sets the synced watermark to `checkpoint` whether or not that moves it
+    /// forwards.
+    ///
+    /// Only for tooling that deliberately rewinds it. Every path the node
+    /// takes goes through
+    /// [`Self::multi_update_highest_synced_checkpoint`], which only ever
+    /// advances it.
+    pub fn set_highest_synced_checkpoint_subtle(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<(), TypedStoreError> {
+        self.tables.watermarks.insert(
+            &CheckpointWatermark::HighestSynced,
+            &(checkpoint.sequence_number(), *checkpoint.digest()),
+        )
+    }
+
     pub fn set_highest_executed_checkpoint_subtle(
         &self,
         checkpoint: &VerifiedCheckpoint,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -433,6 +433,16 @@ impl CheckpointStore {
         self.get_checkpoint_by_digest(&highest_synced.1)
     }
 
+    pub fn get_highest_verified_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
+        Ok(self
+            .tables
+            .watermarks
+            .get(&CheckpointWatermark::HighestVerified)?
+            .map(|(sequence_number, _digest)| sequence_number))
+    }
+
     pub fn get_highest_synced_checkpoint_seq_number(
         &self,
     ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -138,6 +138,15 @@ impl ReadStore for RocksDbStore {
             .map_err(Into::into)
     }
 
+    fn try_get_highest_synced_checkpoint_seq_number(
+        &self,
+    ) -> Result<CheckpointSequenceNumber, StorageError> {
+        Ok(self
+            .checkpoint_store
+            .get_highest_synced_checkpoint_seq_number()?
+            .expect("storage should have been initialized with genesis checkpoint"))
+    }
+
     fn try_get_lowest_available_checkpoint(
         &self,
     ) -> Result<CheckpointSequenceNumber, StorageError> {
@@ -323,13 +332,6 @@ impl WriteStore for RocksDbStore {
             .map_err(Into::into)
     }
 
-    fn try_update_highest_synced_checkpoint(
-        &self,
-        checkpoint: &VerifiedCheckpoint,
-    ) -> Result<(), iota_types::storage::error::Error> {
-        self.update_highest_synced_checkpoints(std::slice::from_ref(checkpoint))
-    }
-
     fn try_update_highest_verified_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
@@ -343,6 +345,13 @@ impl WriteStore for RocksDbStore {
             .map_err(iota_types::storage::error::Error::custom)?;
         *locked = Some(checkpoint.sequence_number);
         Ok(())
+    }
+
+    fn try_update_highest_synced_checkpoint(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<(), iota_types::storage::error::Error> {
+        self.update_highest_synced_checkpoints(std::slice::from_ref(checkpoint))
     }
 
     fn try_insert_checkpoint_contents(

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -39,7 +39,10 @@ pub struct RocksDbStore {
 
     committee_store: Arc<CommitteeStore>,
     checkpoint_store: Arc<CheckpointStore>,
-    // in memory checkpoint watermark sequence numbers
+    // Lower bounds on the watermark rows, not mirrors of them: a row already
+    // ahead leaves its cache behind, which costs a repeated call and nothing
+    // else. Held so that the read and the write of a row happen under one
+    // lock.
     highest_verified_checkpoint: Arc<Mutex<Option<u64>>>,
     highest_synced_checkpoint: Arc<Mutex<Option<u64>>>,
 }
@@ -85,7 +88,7 @@ impl RocksDbStore {
         self.checkpoint_store
             .multi_update_highest_synced_checkpoint(checkpoints)
             .map_err(iota_types::storage::error::Error::custom)?;
-        *locked = Some(last.sequence_number);
+        *locked = locked.max(Some(last.sequence_number));
         Ok(())
     }
 }
@@ -328,8 +331,13 @@ impl WriteStore for RocksDbStore {
         }
 
         self.checkpoint_store
-            .insert_verified_checkpoint(checkpoint)
-            .map_err(Into::into)
+            .insert_certified_checkpoint(checkpoint)
+            .map_err(iota_types::storage::error::Error::custom)?;
+        // Not `insert_verified_checkpoint`, which would write the watermark
+        // straight to the store: taking the same lock the archive path takes
+        // is what stops two writers leaving the row behind where one of them
+        // had already seen it.
+        self.try_update_highest_verified_checkpoint(checkpoint)
     }
 
     fn try_update_highest_verified_checkpoint(
@@ -343,7 +351,7 @@ impl WriteStore for RocksDbStore {
         self.checkpoint_store
             .update_highest_verified_checkpoint(checkpoint)
             .map_err(iota_types::storage::error::Error::custom)?;
-        *locked = Some(checkpoint.sequence_number);
+        *locked = locked.max(Some(checkpoint.sequence_number));
         Ok(())
     }
 

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -119,6 +119,15 @@ impl ReadStore for RocksDbStore {
             .map_err(Into::into)
     }
 
+    fn try_get_highest_verified_checkpoint_seq_number(
+        &self,
+    ) -> Result<CheckpointSequenceNumber, StorageError> {
+        Ok(self
+            .checkpoint_store
+            .get_highest_verified_checkpoint_seq_number()?
+            .expect("storage should have been initialized with genesis checkpoint"))
+    }
+
     fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint, StorageError> {
         self.checkpoint_store
             .get_highest_synced_checkpoint()

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -489,10 +489,22 @@ impl ReadStore for GrpcReadStore {
         self.rocks.try_get_highest_verified_checkpoint()
     }
 
+    fn try_get_highest_verified_checkpoint_seq_number(
+        &self,
+    ) -> iota_types::storage::error::Result<CheckpointSequenceNumber> {
+        self.rocks.try_get_highest_verified_checkpoint_seq_number()
+    }
+
     fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         self.rocks.try_get_highest_synced_checkpoint()
+    }
+
+    fn try_get_highest_synced_checkpoint_seq_number(
+        &self,
+    ) -> iota_types::storage::error::Result<CheckpointSequenceNumber> {
+        self.rocks.try_get_highest_synced_checkpoint_seq_number()
     }
 
     fn try_get_lowest_available_checkpoint(

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1339,7 +1339,7 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
         .iter()
         .map(|(_p, state_sync_info)| state_sync_info.lowest)
         .min();
-    let highest_synced = store.get_highest_synced_checkpoint().sequence_number;
+    let highest_synced = store.get_highest_synced_checkpoint_seq_number();
     // Only sync from checkpoint archive when there is at least one checkpoint in
     // the gap [highest_synced+1, lowest_peer). If highest_synced+1 ==
     // lowest_peer the archive range is empty and there is nothing to do.
@@ -1418,9 +1418,7 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             }
         };
         let run_result = run_future.await;
-        let highest_synced_now = store_for_log
-            .get_highest_synced_checkpoint()
-            .sequence_number;
+        let highest_synced_now = store_for_log.get_highest_synced_checkpoint_seq_number();
         match run_result {
             Ok(_) => info!(
                 "State sync from checkpoint archive finished. Highest synced checkpoint = \
@@ -1804,12 +1802,12 @@ where
     loop {
         tokio::select! {
              _now = interval.tick() => {
-                let highest_verified_checkpoint = store.try_get_highest_verified_checkpoint()
-                    .expect("store operation should not fail");
-                metrics.set_highest_verified_checkpoint(highest_verified_checkpoint.sequence_number);
-                let highest_synced_checkpoint = store.try_get_highest_synced_checkpoint()
-                    .expect("store operation should not fail");
-                metrics.set_highest_synced_checkpoint(highest_synced_checkpoint.sequence_number);
+                metrics.set_highest_verified_checkpoint(
+                    store.get_highest_verified_checkpoint_seq_number(),
+                );
+                metrics.set_highest_synced_checkpoint(
+                    store.get_highest_synced_checkpoint_seq_number(),
+                );
              },
             _ = &mut recv => break,
         }

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1173,18 +1173,14 @@ where
 
     let mut last_cleaned = current.sequence_number();
     while let Some((maybe_checkpoint, next, maybe_peer_id)) = request_stream.next().await {
-        // This task fixed its range when it started, and it is not the only
-        // writer of the verified watermark: the checkpoint-archive reducer
-        // advances it too, over a range that can overlap this one. Stop once
-        // it has passed us rather than fetch, verify and write summaries the
-        // store already holds. Whatever is left is picked up by the next task,
-        // which starts from wherever the watermark has since reached.
+        // Don't redo work: the archive sync advances the same watermark, and
+        // may already have passed the range this task fixed when it started.
         let highest_verified = store
-            .try_get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint_seq_number()
             .expect("store operation should not fail");
-        if highest_verified.sequence_number() > current.sequence_number() {
+        if highest_verified > current.sequence_number() {
             debug!(
-                highest_verified = highest_verified.sequence_number(),
+                highest_verified,
                 walked_to = current.sequence_number(),
                 "stopping a checkpoint summary sync another writer has passed",
             );

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -913,25 +913,24 @@ where
     ) {
         let highest_verified_checkpoint = self
             .store
-            .try_get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint_seq_number()
             .expect("store operation should not fail");
         let highest_synced_checkpoint = self
             .store
-            .try_get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint_seq_number()
             .expect("store operation should not fail");
 
-        if highest_verified_checkpoint.sequence_number()
-            > highest_synced_checkpoint.sequence_number()
+        if highest_verified_checkpoint > highest_synced_checkpoint
             // Skip if we aren't connected to any peers that can help
             && self
                 .peer_heights
                 .read()
                 .unwrap()
                 .highest_known_checkpoint_sequence_number()
-                > Some(highest_synced_checkpoint.sequence_number())
+                > Some(highest_synced_checkpoint)
         {
             let _ = target_sequence_channel.send_if_modified(|num| {
-                let new_num = highest_verified_checkpoint.sequence_number();
+                let new_num = highest_verified_checkpoint;
                 if *num == new_num {
                     return false;
                 }
@@ -1665,9 +1664,8 @@ where
     // retrying failed content syncs at the front of the queue, blocking
     // the watermark from advancing past them.
     if store
-        .try_get_highest_synced_checkpoint()
+        .try_get_highest_synced_checkpoint_seq_number()
         .expect("store operation should not fail")
-        .sequence_number()
         >= checkpoint.sequence_number()
     {
         debug!("checkpoint was already created via consensus output");

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1173,6 +1173,23 @@ where
 
     let mut last_cleaned = current.sequence_number();
     while let Some((maybe_checkpoint, next, maybe_peer_id)) = request_stream.next().await {
+        // This task fixed its range when it started, and it is not the only
+        // writer of the verified watermark: the checkpoint-archive reducer
+        // advances it too, over a range that can overlap this one. Stop once
+        // it has passed us rather than fetch, verify and write summaries the
+        // store already holds. Whatever is left is picked up by the next task,
+        // which starts from wherever the watermark has since reached.
+        let highest_verified = store
+            .try_get_highest_verified_checkpoint()
+            .expect("store operation should not fail");
+        if highest_verified.sequence_number() > current.sequence_number() {
+            debug!(
+                highest_verified = highest_verified.sequence_number(),
+                walked_to = current.sequence_number(),
+                "stopping a checkpoint summary sync another writer has passed",
+            );
+            return Ok(());
+        }
         assert_eq!(
             current
                 .sequence_number()

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1183,6 +1183,12 @@ where
                 walked_to = current.sequence_number(),
                 "stopping a checkpoint summary sync another writer has passed",
             );
+            // Everything up to there is another task's business now, and this
+            // is the last chance to drop what this one accumulated.
+            peer_heights
+                .write()
+                .unwrap()
+                .cleanup_old_checkpoints(highest_verified);
             return Ok(());
         }
         assert_eq!(

--- a/crates/iota-network/src/state_sync/server.rs
+++ b/crates/iota-network/src/state_sync/server.rs
@@ -86,9 +86,8 @@ where
 
         let highest_verified_checkpoint = self
             .store
-            .try_get_highest_verified_checkpoint()
-            .map_err(|e| Status::internal(e.to_string()))?
-            .sequence_number();
+            .try_get_highest_verified_checkpoint_seq_number()
+            .map_err(|e| Status::internal(e.to_string()))?;
 
         // If this checkpoint is higher than our highest verified checkpoint notify the
         // event loop to potentially sync it

--- a/crates/iota-tool/src/db_tool/mod.rs
+++ b/crates/iota-tool/src/db_tool/mod.rs
@@ -415,7 +415,7 @@ pub fn set_checkpoint_watermark(
         else {
             bail!("Checkpoint {highest_verified} not found");
         };
-        checkpoint_db.update_highest_verified_checkpoint(&checkpoint)?;
+        checkpoint_db.set_highest_verified_checkpoint_subtle(&checkpoint)?;
     }
     if let Some(highest_synced) = options.highest_synced {
         let Some(checkpoint) = checkpoint_db.get_checkpoint_by_sequence_number(highest_synced)?
@@ -434,7 +434,7 @@ pub fn set_checkpoint_watermark(
                  Setting highest_synced without contents would cause the executor to panic."
             );
         }
-        checkpoint_db.update_highest_synced_checkpoint(&checkpoint)?;
+        checkpoint_db.set_highest_synced_checkpoint_subtle(&checkpoint)?;
     }
     Ok(())
 }

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -619,8 +619,7 @@ pub(crate) async fn backfill_checkpoint_summaries(
         &RocksDbStore::new(cache_traits, committee_store, checkpoint_store.clone());
 
     let highest_synced = checkpoint_store
-        .get_highest_synced_checkpoint()?
-        .map(|c| c.sequence_number)
+        .get_highest_synced_checkpoint_seq_number()?
         .ok_or_else(|| {
             anyhow!("checkpoint store at {node_db_path:?} is empty; restore the node first")
         })?;

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -100,6 +100,18 @@ pub trait ReadStore: ObjectStore {
             .expect("storage access failed")
     }
 
+    /// The sequence number of the highest verified checkpoint, without the
+    /// checkpoint itself.
+    ///
+    /// Cheaper than [`Self::try_get_highest_verified_checkpoint`] for a caller
+    /// that only compares positions, and it cannot fail to find a checkpoint
+    /// the watermark names.
+    fn try_get_highest_verified_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        Ok(self
+            .try_get_highest_verified_checkpoint()?
+            .sequence_number())
+    }
+
     /// Get the highest synced checkpoint. This is the highest checkpoint that
     /// has been synced from state-synce. The checkpoint header, contents,
     /// transactions, and effects of this checkpoint are guaranteed to be
@@ -476,6 +488,10 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
         (*self).try_get_highest_verified_checkpoint()
     }
 
+    fn try_get_highest_verified_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        (*self).try_get_highest_verified_checkpoint_seq_number()
+    }
+
     fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         (*self).try_get_highest_synced_checkpoint()
     }
@@ -595,6 +611,10 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
         (**self).try_get_highest_verified_checkpoint()
     }
 
+    fn try_get_highest_verified_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        (**self).try_get_highest_verified_checkpoint_seq_number()
+    }
+
     fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         (**self).try_get_highest_synced_checkpoint()
     }
@@ -712,6 +732,10 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
 
     fn try_get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         (**self).try_get_highest_verified_checkpoint()
+    }
+
+    fn try_get_highest_verified_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        (**self).try_get_highest_verified_checkpoint_seq_number()
     }
 
     fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -103,13 +103,21 @@ pub trait ReadStore: ObjectStore {
     /// The sequence number of the highest verified checkpoint, without the
     /// checkpoint itself.
     ///
-    /// Cheaper than [`Self::try_get_highest_verified_checkpoint`] for a caller
-    /// that only compares positions, and it cannot fail to find a checkpoint
-    /// the watermark names.
+    /// For a caller that only compares positions. An implementation holding
+    /// the watermark should override this to read it directly, which is a
+    /// lookup cheaper and cannot fail to find a checkpoint the watermark
+    /// names; the default resolves the checkpoint and so does neither.
     fn try_get_highest_verified_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
         Ok(self
             .try_get_highest_verified_checkpoint()?
             .sequence_number())
+    }
+
+    /// Non-fallible version of
+    /// `try_get_highest_verified_checkpoint_seq_number`.
+    fn get_highest_verified_checkpoint_seq_number(&self) -> CheckpointSequenceNumber {
+        self.try_get_highest_verified_checkpoint_seq_number()
+            .expect("storage access failed")
     }
 
     /// Get the highest synced checkpoint. This is the highest checkpoint that
@@ -129,6 +137,12 @@ pub trait ReadStore: ObjectStore {
     /// [`Self::try_get_highest_verified_checkpoint_seq_number`].
     fn try_get_highest_synced_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
         Ok(self.try_get_highest_synced_checkpoint()?.sequence_number())
+    }
+
+    /// Non-fallible version of `try_get_highest_synced_checkpoint_seq_number`.
+    fn get_highest_synced_checkpoint_seq_number(&self) -> CheckpointSequenceNumber {
+        self.try_get_highest_synced_checkpoint_seq_number()
+            .expect("storage access failed")
     }
 
     /// Lowest available checkpoint for which transaction and checkpoint data

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -124,6 +124,13 @@ pub trait ReadStore: ObjectStore {
             .expect("storage access failed")
     }
 
+    /// The sequence number of the highest synced checkpoint, without the
+    /// checkpoint itself. See
+    /// [`Self::try_get_highest_verified_checkpoint_seq_number`].
+    fn try_get_highest_synced_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        Ok(self.try_get_highest_synced_checkpoint()?.sequence_number())
+    }
+
     /// Lowest available checkpoint for which transaction and checkpoint data
     /// can be requested.
     ///
@@ -496,6 +503,10 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
         (*self).try_get_highest_synced_checkpoint()
     }
 
+    fn try_get_highest_synced_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        (*self).try_get_highest_synced_checkpoint_seq_number()
+    }
+
     fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
         (*self).try_get_lowest_available_checkpoint()
     }
@@ -619,6 +630,10 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
         (**self).try_get_highest_synced_checkpoint()
     }
 
+    fn try_get_highest_synced_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        (**self).try_get_highest_synced_checkpoint_seq_number()
+    }
+
     fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
         (**self).try_get_lowest_available_checkpoint()
     }
@@ -740,6 +755,10 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
 
     fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         (**self).try_get_highest_synced_checkpoint()
+    }
+
+    fn try_get_highest_synced_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        (**self).try_get_highest_synced_checkpoint_seq_number()
     }
 
     fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -172,18 +172,18 @@ impl WriteStore for SharedInMemoryStore {
         Ok(())
     }
 
-    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        self.inner_mut()
-            .update_highest_synced_checkpoint(checkpoint);
-        Ok(())
-    }
-
     fn try_update_highest_verified_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<()> {
         self.inner_mut()
             .update_highest_verified_checkpoint(checkpoint);
+        Ok(())
+    }
+
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        self.inner_mut()
+            .update_highest_synced_checkpoint(checkpoint);
         Ok(())
     }
 
@@ -399,18 +399,6 @@ impl InMemoryStore {
         Ok(())
     }
 
-    pub fn update_highest_synced_checkpoint(&mut self, checkpoint: &VerifiedCheckpoint) {
-        if !self.checkpoints.contains_key(checkpoint.digest()) {
-            panic!("store should already contain checkpoint");
-        }
-        if let Some(highest_synced_checkpoint) = self.highest_synced_checkpoint {
-            if highest_synced_checkpoint.0 >= checkpoint.sequence_number {
-                return;
-            }
-        }
-        self.highest_synced_checkpoint = Some((checkpoint.sequence_number(), *checkpoint.digest()));
-    }
-
     pub fn update_highest_verified_checkpoint(&mut self, checkpoint: &VerifiedCheckpoint) {
         if !self.checkpoints.contains_key(checkpoint.digest()) {
             panic!("store should already contain checkpoint");
@@ -422,6 +410,18 @@ impl InMemoryStore {
         }
         self.highest_verified_checkpoint =
             Some((checkpoint.sequence_number(), *checkpoint.digest()));
+    }
+
+    pub fn update_highest_synced_checkpoint(&mut self, checkpoint: &VerifiedCheckpoint) {
+        if !self.checkpoints.contains_key(checkpoint.digest()) {
+            panic!("store should already contain checkpoint");
+        }
+        if let Some(highest_synced_checkpoint) = self.highest_synced_checkpoint {
+            if highest_synced_checkpoint.0 >= checkpoint.sequence_number {
+                return;
+            }
+        }
+        self.highest_synced_checkpoint = Some((checkpoint.sequence_number(), *checkpoint.digest()));
     }
 
     pub fn checkpoints(&self) -> &HashMap<CheckpointDigest, VerifiedCheckpoint> {
@@ -600,16 +600,16 @@ impl WriteStore for SingleCheckpointSharedInMemoryStore {
         Ok(())
     }
 
-    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        self.0.try_update_highest_synced_checkpoint(checkpoint)?;
-        Ok(())
-    }
-
     fn try_update_highest_verified_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<()> {
         self.0.try_update_highest_verified_checkpoint(checkpoint)?;
+        Ok(())
+    }
+
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        self.0.try_update_highest_synced_checkpoint(checkpoint)?;
         Ok(())
     }
 

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -73,6 +73,20 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
+    fn try_get_highest_verified_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        self.inner()
+            .get_highest_verified_checkpoint_seq_number()
+            .expect("storage should have been initialized with genesis checkpoint")
+            .pipe(Ok)
+    }
+
+    fn try_get_highest_synced_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        self.inner()
+            .get_highest_synced_checkpoint_seq_number()
+            .expect("storage should have been initialized with genesis checkpoint")
+            .pipe(Ok)
+    }
+
     fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
         Ok(self.inner().get_lowest_available_checkpoint())
     }
@@ -308,6 +322,16 @@ impl InMemoryStore {
             .and_then(|(_, digest)| self.get_checkpoint_by_digest(digest))
     }
 
+    pub fn get_highest_verified_checkpoint_seq_number(&self) -> Option<CheckpointSequenceNumber> {
+        self.highest_verified_checkpoint
+            .map(|(sequence_number, _digest)| sequence_number)
+    }
+
+    pub fn get_highest_synced_checkpoint_seq_number(&self) -> Option<CheckpointSequenceNumber> {
+        self.highest_synced_checkpoint
+            .map(|(sequence_number, _digest)| sequence_number)
+    }
+
     pub fn get_lowest_available_checkpoint(&self) -> CheckpointSequenceNumber {
         self.lowest_checkpoint_number
     }
@@ -527,6 +551,14 @@ impl ReadStore for SingleCheckpointSharedInMemoryStore {
 
     fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         self.0.try_get_highest_synced_checkpoint()
+    }
+
+    fn try_get_highest_verified_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        self.0.try_get_highest_verified_checkpoint_seq_number()
+    }
+
+    fn try_get_highest_synced_checkpoint_seq_number(&self) -> Result<CheckpointSequenceNumber> {
+        self.0.try_get_highest_synced_checkpoint_seq_number()
     }
 
     fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {

--- a/crates/iota-types/src/storage/write_store.rs
+++ b/crates/iota-types/src/storage/write_store.rs
@@ -22,20 +22,20 @@ pub trait WriteStore: ReadStore {
             .expect("storage access failed")
     }
 
-    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()>;
-
-    /// Non-fallible version of `try_update_highest_synced_checkpoint`.
-    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
-        self.try_update_highest_synced_checkpoint(checkpoint)
-            .expect("storage access failed")
-    }
-
     fn try_update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint)
     -> Result<()>;
 
     /// Non-fallible version of `try_update_highest_verified_checkpoint`.
     fn update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
         self.try_update_highest_verified_checkpoint(checkpoint)
+            .expect("storage access failed")
+    }
+
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()>;
+
+    /// Non-fallible version of `try_update_highest_synced_checkpoint`.
+    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
+        self.try_update_highest_synced_checkpoint(checkpoint)
             .expect("storage access failed")
     }
 
@@ -114,15 +114,15 @@ impl<T: WriteStore + ?Sized> WriteStore for &T {
         (*self).try_insert_checkpoint(checkpoint)
     }
 
-    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (*self).try_update_highest_synced_checkpoint(checkpoint)
-    }
-
     fn try_update_highest_verified_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<()> {
         (*self).try_update_highest_verified_checkpoint(checkpoint)
+    }
+
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (*self).try_update_highest_synced_checkpoint(checkpoint)
     }
 
     fn try_insert_checkpoint_contents(
@@ -163,15 +163,15 @@ impl<T: WriteStore + ?Sized> WriteStore for Box<T> {
         (**self).try_insert_checkpoint(checkpoint)
     }
 
-    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (**self).try_update_highest_synced_checkpoint(checkpoint)
-    }
-
     fn try_update_highest_verified_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<()> {
         (**self).try_update_highest_verified_checkpoint(checkpoint)
+    }
+
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (**self).try_update_highest_synced_checkpoint(checkpoint)
     }
 
     fn try_insert_checkpoint_contents(
@@ -212,15 +212,15 @@ impl<T: WriteStore + ?Sized> WriteStore for Arc<T> {
         (**self).try_insert_checkpoint(checkpoint)
     }
 
-    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (**self).try_update_highest_synced_checkpoint(checkpoint)
-    }
-
     fn try_update_highest_verified_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<()> {
         (**self).try_update_highest_verified_checkpoint(checkpoint)
+    }
+
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (**self).try_update_highest_synced_checkpoint(checkpoint)
     }
 
     fn try_insert_checkpoint_contents(


### PR DESCRIPTION
# Description of change

Two writers advance the checkpoint watermarks — state sync's summary walk and `StateSyncReducer::commit`, the checkpoint-archive path — and nothing accounted for that. Found while diagnosing a fullnode sync crash on #12762.

- **A summary sync stops once another writer has passed it.** `sync_to_checkpoint` fixes its range when the task starts, so when the archive reducer covers the same ground it goes on re-fetching, re-verifying and re-writing summaries the store already holds. It now stops as soon as the watermark passes the point it has walked to. Nothing is skipped: the next task starts from wherever the watermark has since reached. The check cannot fire spuriously — `try_insert_checkpoint` sets the watermark to the checkpoint the loop has just taken, so the two are equal at the top of every iteration and only a third party moving it further trips it.
- **The synced watermark only ever advances.** It was the one written unconditionally, so a run another writer had already overtaken dragged it backwards, costing a stalled executor and a re-sync of ground already covered. A warm process was covered by the in-memory guard in `RocksDbStore::update_highest_synced_checkpoints`; that starts empty, so the first write after a restart was not. It now guards at the row, as the verified and executed watermarks do.
- **A watermark's sequence number is read from its row.** The seven getters had four shapes between them and no order. They now sit in the order the enum declares — verified, synced, executed, pruned — over one internal that reads the row and two that take it apart, so the resolving and sequence-only forms cannot drift. Every layer that carries these follows that order. Callers that only compare positions take the sequence-only form; the rest genuinely want the checkpoint and keep it.

**The last of those is a fix, not just tidying.** The monotonic guard in `update_highest_verified_checkpoint` resolved the current watermark by digest, which answers `None` if that checkpoint is not readable — and `Some(seq) > None` holds for every checkpoint, so the guard would stop being monotonic exactly when it was needed. No pruning reaches that far today, so it is not a live bug; it becomes one once the checkpoint history moves into per-epoch buckets. Reading the row cannot fail that way.

- **The verified watermark's writers are serialised.** The archive path took a lock around reading and writing the row; the summary path went straight to the store and took nothing, so two writers could interleave and leave the row behind where one had already seen it. A guard cannot close that on its own, since it only ever sees the value it read. Both paths now take the same lock, which the clone shares, and the guard on the row covers the first write after a restart while that lock's cache is still empty.

Setting a watermark backwards on purpose keeps working: `db-tool set-checkpoint-watermark` takes deliberate setters, named after `set_highest_executed_checkpoint_subtle`, which `rewind-checkpoint-execution` has always used. That also fixes `--highest-verified`, which silently did nothing before, the guard there having been in place all along.

## Links to any relevant issues

Found while diagnosing a fullnode sync crash on #12762, which carries its own guard so it does not depend on this landing.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo ci-clippy` clean, `cargo nextest run -p iota-network -p iota-core --lib -p iota-types -p iota-tool` 1072 passed, and `cargo simtest -p iota-e2e-tests` 312 passed.

No test drives the stopping check's positive path. Making it fire deterministically needs the watermark advanced between `current` being read and the first loop iteration, which means either a live two-writer race or a `WriteStore` test double, and that trait is wide enough that the double is a piece of work in itself. What the suite does cover is this change's actual regression risk — the check firing when it should not, or the new guard stalling a sync — and `test_state_sync_using_checkpoint_archive` exercises exactly the archive-and-peer combination.

The getter reordering is pure movement: sorted non-blank lines are identical to the previous revision in the files a script touched, and the per-file count of watermark functions is unchanged.

### Release Notes

- [x] Nodes (Validators and Full nodes): a syncing node no longer re-downloads and re-verifies checkpoint summaries the checkpoint-archive sync has already stored, so catching up does less redundant work and asks less of its peers.
- [x] CLI: `iota-tool db-tool set-checkpoint-watermark --highest-verified` now lowers the watermark as documented; it previously accepted the value and left it unchanged.


