### PR TITLE
feat(indexer): make the CALLED_FROM_BLOCKING_POOL usage consistent

### DIFF
--- a/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/object_changes_unwrapped.rs
@@ -14,7 +14,7 @@ use crate::{
     IndexerMetrics, Registry, backfill::ingestion::IngestionBackfill, db::ConnectionPool,
     errors::IndexerError, ingestion::primary::prepare::PrimaryWorker,
     models::transactions::StoredTransaction, schema::transactions,
-    transactional_blocking_with_retry,
+    store::diesel_macro::spawn_blocking_task, transactional_blocking_with_retry,
 };
 
 const PG_DB_COMMIT_SLEEP_DURATION: Duration = Duration::from_secs(3600);
@@ -93,19 +93,25 @@ impl IngestionBackfill for ObjectChangesUnwrappedBackfill {
 
         // The UPDATE only affects rows that exist in the database. Update for
         // non-existing rows is silently skipped.
-        transactional_blocking_with_retry!(
-            &pool,
-            |conn| {
-                for (tx_seq, obj_changes) in tx_sequence_numbers.iter().zip(object_changes.iter()) {
-                    diesel::update(transactions::table)
-                        .filter(transactions::tx_sequence_number.eq(tx_seq))
-                        .set(transactions::object_changes.eq(obj_changes))
-                        .execute(conn)?;
-                }
+        spawn_blocking_task(move || {
+            transactional_blocking_with_retry!(
+                &pool,
+                |conn| {
+                    for (tx_seq, obj_changes) in
+                        tx_sequence_numbers.iter().zip(object_changes.iter())
+                    {
+                        diesel::update(transactions::table)
+                            .filter(transactions::tx_sequence_number.eq(tx_seq))
+                            .set(transactions::object_changes.eq(obj_changes))
+                            .execute(conn)?;
+                    }
 
-                Ok::<(), IndexerError>(())
-            },
-            PG_DB_COMMIT_SLEEP_DURATION
-        )
+                    Ok::<(), IndexerError>(())
+                },
+                PG_DB_COMMIT_SLEEP_DURATION
+            )
+        })
+        .await
+        .map_err(IndexerError::from)?
     }
 }

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -77,7 +77,11 @@ impl Indexer {
         // not yet in the db. Otherwise, we would do the persisting in
         // `commit_checkpoint` while the first cp is being indexed.
         if let Some(chain_id) = IndexerStore::get_chain_identifier(&store).await? {
-            store.persist_protocol_configs_and_feature_flags(chain_id)?;
+            store
+                .execute_in_blocking_worker(move |this| {
+                    this.persist_protocol_configs_and_feature_flags(chain_id)
+                })
+                .await?;
         }
 
         // Restore metric from the DB so it doesn't stay as 0 until next epoch change.

--- a/crates/iota-indexer/src/ingestion/primary/persist.rs
+++ b/crates/iota-indexer/src/ingestion/primary/persist.rs
@@ -257,9 +257,15 @@ impl PrimaryWriter {
                 .await
                 .expect("failed to get chain identifier")
                 .expect("chain identifier should have been indexed at this point");
-            let _ = self
+            if let Err(e) = self
                 .state
-                .persist_protocol_configs_and_feature_flags(chain_id);
+                .execute_in_blocking_worker(move |this| {
+                    this.persist_protocol_configs_and_feature_flags(chain_id)
+                })
+                .await
+            {
+                error!("failed to persist protocol configs and feature flags: {e}");
+            }
         }
 
         self.state

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -33,7 +33,7 @@ use crate::{
         transactions::{OptimisticTransaction, StoredTransaction},
     },
     read::{IndexerReader, InputObjectsStatus},
-    store::{IndexerStore, PgIndexerStore},
+    store::{IndexerStore, PgIndexerStore, diesel_macro::spawn_blocking_task},
     transactional_blocking_with_retry_with_conditional_abort,
     types::{IndexedDeletedObject, IndexedObject, IndexerResult, grpc_conversion},
 };
@@ -368,7 +368,7 @@ impl OptimisticTransactionExecutor {
         full_tx_data: &CheckpointTransaction,
     ) -> Result<Option<OptimisticTransaction>, IndexerError> {
         let db_write_timer = self.metrics.optimistic_tx_db_write_time.start_timer();
-        match tokio::task::spawn_blocking({
+        match spawn_blocking_task({
             let this: OptimisticTransactionExecutor = self.clone();
             let full_tx_data = full_tx_data.clone();
             move || this.index_transaction(&full_tx_data)

--- a/crates/iota-indexer/src/processors/address_metrics_processor.rs
+++ b/crates/iota-indexer/src/processors/address_metrics_processor.rs
@@ -5,7 +5,11 @@
 use tap::tap::TapFallible;
 use tracing::{error, info};
 
-use crate::{metrics::IndexerMetrics, store::IndexerAnalyticalStore, types::IndexerResult};
+use crate::{
+    metrics::IndexerMetrics,
+    store::{IndexerAnalyticalStore, diesel_macro::spawn_blocking_task},
+    types::IndexerResult,
+};
 
 const ADDRESS_PROCESSOR_BATCH_SIZE: usize = 80000;
 const PARALLELISM: usize = 10;
@@ -63,7 +67,7 @@ where
                 .step_by(step_size)
             {
                 let address_store = self.store.clone();
-                persist_tasks.push(tokio::task::spawn_blocking(move || {
+                persist_tasks.push(spawn_blocking_task(move || {
                     address_store.persist_addresses_in_tx_range(
                         chunk_start_tx_seq,
                         chunk_start_tx_seq + step_size as i64,

--- a/crates/iota-indexer/src/processors/move_call_metrics_processor.rs
+++ b/crates/iota-indexer/src/processors/move_call_metrics_processor.rs
@@ -5,7 +5,11 @@
 use tap::tap::TapFallible;
 use tracing::{error, info};
 
-use crate::{metrics::IndexerMetrics, store::IndexerAnalyticalStore, types::IndexerResult};
+use crate::{
+    metrics::IndexerMetrics,
+    store::{IndexerAnalyticalStore, diesel_macro::spawn_blocking_task},
+    types::IndexerResult,
+};
 
 const MOVE_CALL_PROCESSOR_BATCH_SIZE: usize = 80000;
 const PARALLELISM: usize = 10;
@@ -62,7 +66,7 @@ where
                 .step_by(step_size)
             {
                 let move_call_store = self.store.clone();
-                persist_tasks.push(tokio::task::spawn_blocking(move || {
+                persist_tasks.push(spawn_blocking_task(move || {
                     move_call_store.persist_move_calls_in_tx_range(
                         chunk_start_tx_seq,
                         chunk_start_tx_seq + step_size as i64,

--- a/crates/iota-indexer/src/processors/network_metrics_processor.rs
+++ b/crates/iota-indexer/src/processors/network_metrics_processor.rs
@@ -6,7 +6,9 @@ use tap::tap::TapFallible;
 use tracing::{error, info};
 
 use crate::{
-    errors::IndexerError, metrics::IndexerMetrics, store::IndexerAnalyticalStore,
+    errors::IndexerError,
+    metrics::IndexerMetrics,
+    store::{IndexerAnalyticalStore, diesel_macro::spawn_blocking_task},
     types::IndexerResult,
 };
 
@@ -111,7 +113,7 @@ where
                     (chunk_start_cp + step_size as i64).min(last_processed_cp_seq + batch_size + 1);
 
                 let store = self.store.clone();
-                persist_tasks.push(tokio::task::spawn_blocking(move || {
+                persist_tasks.push(spawn_blocking_task(move || {
                     store.persist_tx_count_metrics(chunk_start_cp, chunk_end_cp)
                 }));
             }

--- a/crates/iota-indexer/src/pruning/pruner.rs
+++ b/crates/iota-indexer/src/pruning/pruner.rs
@@ -16,7 +16,10 @@ use crate::{
     metrics::IndexerMetrics,
     models::watermarks::StoredWatermark,
     spawn_monitored_task,
-    store::{IndexerStore, PgIndexerStore, pg_partition_manager::PgPartitionManager},
+    store::{
+        IndexerStore, PgIndexerStore, diesel_macro::spawn_blocking_task,
+        pg_partition_manager::PgPartitionManager,
+    },
     types::IndexerResult,
 };
 
@@ -377,8 +380,13 @@ impl<'a> TablePruner<'a> {
         match self.table.pruning_strategy() {
             PruningStrategy::ByEpochPartition => {
                 for epoch in start..=end {
-                    self.partition_manager
-                        .drop_table_partition(self.table.as_ref().to_string(), epoch)?;
+                    let partition_manager = self.partition_manager.clone();
+                    let table = self.table.as_ref().to_string();
+                    spawn_blocking_task(move || {
+                        partition_manager.drop_table_partition(table, epoch)
+                    })
+                    .await
+                    .map_err(IndexerError::from)??;
                     info!(
                         "dropped epoch {epoch} partition for table {}",
                         self.table.as_ref()
@@ -495,7 +503,7 @@ impl Pruner {
         metrics: IndexerMetrics,
     ) -> Result<Self, IndexerError> {
         let blocking_cp = PrimaryWorker::pg_blocking_cp(store.clone()).unwrap();
-        let partition_manager = PgPartitionManager::new(blocking_cp)?;
+        let partition_manager = PgPartitionManager::new(blocking_cp);
         let retention_policies = retention_config.retention_policies();
 
         Ok(Self {

--- a/crates/iota-indexer/src/read.rs
+++ b/crates/iota-indexer/src/read.rs
@@ -90,10 +90,7 @@ use crate::{
         objects, objects_version, optimistic_transactions, packages, pruner_cp_watermark,
         transactions, tx_global_order,
     },
-    store::{
-        diesel_macro::{mark_in_blocking_pool, *},
-        package_resolver::IndexerStorePackageResolver,
-    },
+    store::{diesel_macro::*, package_resolver::IndexerStorePackageResolver},
     types::{IndexerResult, OwnerType},
 };
 
@@ -281,14 +278,9 @@ impl IndexerReader {
         E: Send + 'static,
     {
         let this = self.clone();
-        let current_span = tracing::Span::current();
-        tokio::task::spawn_blocking(move || {
-            mark_in_blocking_pool();
-            let _guard = current_span.enter();
-            f(this)
-        })
-        .await
-        .expect("propagate any panics")
+        spawn_blocking_task(move || f(this))
+            .await
+            .expect("propagate any panics")
     }
 
     pub fn get_pool(&self) -> ConnectionPool {
@@ -333,7 +325,7 @@ impl IndexerReader {
     ) -> Result<Option<StoredObject>, IndexerError> {
         let object_id = object_id.as_bytes();
 
-        let stored_object = run_query!(&self.pool, |conn| {
+        let stored_object = read_only_blocking!(&self.pool, |conn| {
             if let Some(version) = version {
                 objects::dsl::objects
                     .filter(objects::dsl::object_id.eq(object_id))
@@ -388,7 +380,7 @@ impl IndexerReader {
 
     fn get_object_raw(&self, object_id: ObjectId) -> Result<Option<StoredObject>, IndexerError> {
         let id = object_id.as_bytes();
-        let stored_object = run_query!(&self.pool, |conn| {
+        let stored_object = read_only_blocking!(&self.pool, |conn| {
             objects::dsl::objects
                 .filter(objects::dsl::object_id.eq(id))
                 .first::<StoredObject>(conn)
@@ -558,7 +550,7 @@ impl IndexerReader {
         &self,
         epoch: Option<EpochId>,
     ) -> Result<Option<StoredEpochInfo>, IndexerError> {
-        let stored_epoch = run_query!(&self.pool, |conn| {
+        let stored_epoch = read_only_blocking!(&self.pool, |conn| {
             if let Some(epoch) = epoch {
                 epochs::dsl::epochs
                     .filter(epochs::epoch.eq(epoch as i64))
@@ -576,7 +568,7 @@ impl IndexerReader {
     }
 
     pub fn get_latest_epoch_info_from_db(&self) -> Result<StoredEpochInfo, IndexerError> {
-        let stored_epoch = run_query!(&self.pool, |conn| {
+        let stored_epoch = read_only_blocking!(&self.pool, |conn| {
             epochs::dsl::epochs
                 .order_by(epochs::epoch.desc())
                 .first::<StoredEpochInfo>(conn)
@@ -606,7 +598,7 @@ impl IndexerReader {
         limit: usize,
         descending_order: bool,
     ) -> Result<Vec<StoredEpochInfo>, IndexerError> {
-        run_query!(&self.pool, |conn| {
+        read_only_blocking!(&self.pool, |conn| {
             let mut boxed_query = epochs::table.into_boxed();
             if let Some(cursor) = cursor {
                 if descending_order {
@@ -671,7 +663,7 @@ impl IndexerReader {
     }
 
     pub fn get_chain_identifier(&self) -> Result<ChainIdentifier, IndexerError> {
-        let stored_chain_identifier = run_query!(&self.pool, |conn| {
+        let stored_chain_identifier = read_only_blocking!(&self.pool, |conn| {
             chain_identifier::dsl::chain_identifier
                 .first::<StoredChainIdentifier>(conn)
                 .optional()
@@ -693,7 +685,7 @@ impl IndexerReader {
     }
 
     pub fn get_latest_checkpoint_from_db(&self) -> Result<StoredCheckpoint, IndexerError> {
-        let stored_checkpoint = run_query!(&self.pool, |conn| {
+        let stored_checkpoint = read_only_blocking!(&self.pool, |conn| {
             checkpoints::dsl::checkpoints
                 .order_by(checkpoints::sequence_number.desc())
                 .first::<StoredCheckpoint>(conn)
@@ -1057,7 +1049,7 @@ impl IndexerReader {
             .filter(txdsl::tx_sequence_number.le(max_seq))
             .order(txdsl::tx_sequence_number.asc())
             .into_boxed();
-        run_query!(&self.pool, |conn| query.load::<StoredTransaction>(conn))
+        read_only_blocking!(&self.pool, |conn| query.load::<StoredTransaction>(conn))
     }
 
     pub async fn get_owned_objects_in_blocking_task(
@@ -1078,7 +1070,7 @@ impl IndexerReader {
         cursor: Option<ObjectId>,
         limit: usize,
     ) -> Result<Vec<StoredObject>, IndexerError> {
-        run_query!(&self.pool, |conn| {
+        read_only_blocking!(&self.pool, |conn| {
             let mut query = objects::dsl::objects
                 .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16))
                 .filter(objects::dsl::owner_id.eq(address.as_bytes()))
@@ -1152,7 +1144,7 @@ impl IndexerReader {
     fn get_singleton_object(&self, struct_tag: StructTag) -> Result<Option<Object>, IndexerError> {
         let object_type = struct_tag.to_canonical_string(/* with_prefix */ true);
 
-        run_query!(&self.pool, |conn| {
+        read_only_blocking!(&self.pool, |conn| {
             let object = match objects::dsl::objects
                 .filter(objects::object_type_package.eq(struct_tag.address().as_bytes().to_vec()))
                 .filter(objects::object_type_module.eq(struct_tag.module().to_string()))
@@ -1183,7 +1175,7 @@ impl IndexerReader {
         object_ids: Vec<ObjectId>,
     ) -> Result<Vec<StoredObject>, IndexerError> {
         let object_ids = object_ids.iter().map(|id| id.as_bytes()).collect_vec();
-        run_query!(&self.pool, |conn| {
+        read_only_blocking!(&self.pool, |conn| {
             objects::dsl::objects
                 .filter(objects::object_id.eq_any(object_ids))
                 .load::<StoredObject>(conn)
@@ -1251,7 +1243,7 @@ impl IndexerReader {
             result: Option<bool>,
         }
 
-        run_query!(&self.pool, |conn| {
+        read_only_blocking!(&self.pool, |conn| {
             diesel::sql_query(query)
                 .get_result::<TriState>(conn)
                 .map(|r| match r.result {
@@ -1962,7 +1954,7 @@ impl IndexerReader {
     ) -> IndexerResult<bool> {
         self.spawn_blocking(move |this| {
             let digest_bytes = digest.bytes().to_vec();
-            let global_order_entry = run_query!(&this.pool, |conn| {
+            let global_order_entry = read_only_blocking!(&this.pool, |conn| {
                 tx_global_order::table
                     .filter(tx_global_order::tx_digest.eq(digest_bytes))
                     .select((
@@ -1978,7 +1970,7 @@ impl IndexerReader {
                 Some((opt_seq, _)) if opt_seq > 0 => Ok(true),
                 // Checkpoint tx: check if the latest indexed checkpoint covers this tx.
                 Some((_, Some(tx_seq))) => {
-                    let max_indexed_tx = run_query!(&this.pool, |conn| {
+                    let max_indexed_tx = read_only_blocking!(&this.pool, |conn| {
                         checkpoints::table
                             .order(checkpoints::sequence_number.desc())
                             .select(checkpoints::max_tx_sequence_number)
@@ -2355,7 +2347,7 @@ impl IndexerReader {
         cursor: Option<ObjectId>,
         limit: usize,
     ) -> Result<Vec<StoredObject>, IndexerError> {
-        let objects: Vec<StoredObject> = run_query!(&self.pool, |conn| {
+        let objects: Vec<StoredObject> = read_only_blocking!(&self.pool, |conn| {
             let mut query = objects::dsl::objects
                 .filter(objects::dsl::owner_type.eq(OwnerType::Object as i16))
                 .filter(objects::dsl::owner_id.eq(parent_object_id.as_bytes()))
@@ -2484,7 +2476,7 @@ impl IndexerReader {
         &self,
         object_type: String,
     ) -> Result<Option<VecMap<String, String>>, IndexerError> {
-        let stored_display = run_query!(&self.pool, |conn| {
+        let stored_display = read_only_blocking!(&self.pool, |conn| {
             display::table
                 .filter(display::object_type.eq(object_type))
                 .first::<StoredDisplay>(conn)
@@ -2532,7 +2524,8 @@ impl IndexerReader {
             .order(objects::dsl::object_id.asc())
             .limit(limit as i64);
 
-        let stored_objects = run_query!(&self.pool, |conn| query.load::<StoredObject>(conn))?;
+        let stored_objects =
+            read_only_blocking!(&self.pool, |conn| query.load::<StoredObject>(conn))?;
 
         stored_objects
             .into_iter()
@@ -2580,7 +2573,7 @@ impl IndexerReader {
         );
 
         tracing::debug!("get coin balances query: {query}");
-        let coin_balances = run_query!(&self.pool, |conn| diesel::sql_query(query)
+        let coin_balances = read_only_blocking!(&self.pool, |conn| diesel::sql_query(query)
             .load::<CoinBalance>(conn))?;
         coin_balances
             .into_iter()
@@ -2589,21 +2582,21 @@ impl IndexerReader {
     }
 
     pub fn get_latest_network_metrics(&self) -> IndexerResult<NetworkMetrics> {
-        let mut metrics = run_query!(&self.pool, |conn| {
+        let mut metrics = read_only_blocking!(&self.pool, |conn| {
             diesel::sql_query("SELECT * FROM network_metrics;")
                 .get_result::<StoredNetworkMetrics>(conn)
         })?;
         if metrics.total_addresses == -1 {
             // this implies that the estimate is not available in the db
             // so we fallback to the more expensive count query
-            metrics.total_addresses = run_query!(&self.pool, |conn| {
+            metrics.total_addresses = read_only_blocking!(&self.pool, |conn| {
                 addresses::dsl::addresses.count().get_result::<i64>(conn)
             })?;
         }
         if metrics.total_packages == -1 {
             // this implies that the estimate is not available in the db
             // so we fallback to the more expensive count query
-            metrics.total_packages = run_query!(&self.pool, |conn| {
+            metrics.total_packages = read_only_blocking!(&self.pool, |conn| {
                 packages::dsl::packages.count().get_result::<i64>(conn)
             })?;
         }
@@ -2651,7 +2644,7 @@ impl IndexerReader {
             LIMIT 10
         ";
 
-        let queried_metrics = run_query!(&self.pool, |conn| sql_query(query)
+        let queried_metrics = read_only_blocking!(&self.pool, |conn| sql_query(query)
             .bind::<BigInt, _>(day_value)
             .load::<QueriedMoveCallMetrics>(conn))?;
 
@@ -2667,7 +2660,7 @@ impl IndexerReader {
     }
 
     pub fn get_latest_address_metrics(&self) -> IndexerResult<AddressMetrics> {
-        let stored_address_metrics = run_query!(&self.pool, |conn| {
+        let stored_address_metrics = read_only_blocking!(&self.pool, |conn| {
             address_metrics::table
                 .order(address_metrics::dsl::checkpoint.desc())
                 .first::<StoredAddressMetrics>(conn)
@@ -2679,7 +2672,7 @@ impl IndexerReader {
         &self,
         checkpoint_seq: u64,
     ) -> IndexerResult<AddressMetrics> {
-        let stored_address_metrics = run_query!(&self.pool, |conn| {
+        let stored_address_metrics = read_only_blocking!(&self.pool, |conn| {
             address_metrics::table
                 .filter(address_metrics::dsl::checkpoint.eq(checkpoint_seq as i64))
                 .first::<StoredAddressMetrics>(conn)
@@ -2706,7 +2699,7 @@ impl IndexerReader {
               WHERE row_num = 1 ORDER BY epoch {}",
             if is_descending { "DESC" } else { "ASC" },
         );
-        let epoch_address_metrics = run_query!(&self.pool, |conn| {
+        let epoch_address_metrics = read_only_blocking!(&self.pool, |conn| {
             diesel::sql_query(epoch_address_metrics_query).load::<StoredAddressMetrics>(conn)
         })?;
 
@@ -2876,7 +2869,7 @@ impl IndexerReader {
     /// number of unique addresses that have delegated stake in the current
     /// epoch. Includes both staked and timelocked staked IOTA.
     pub fn get_participation_metrics(&self) -> IndexerResult<ParticipationMetrics> {
-        run_query!(&self.pool, |conn| {
+        read_only_blocking!(&self.pool, |conn| {
             diesel::sql_query("SELECT * FROM participation_metrics")
                 .get_result::<StoredParticipationMetrics>(conn)
         })

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -21,18 +21,42 @@ pub mod diesel_macro {
 
     /// Marks the current thread as being in a blocking pool.
     ///
-    /// Call this at the start of any `spawn_blocking` closure that will perform
-    /// blocking DB operations.
+    /// Prefer [`spawn_blocking_task`], which spawns the closure and marks the
+    /// thread in one step.
     pub fn mark_in_blocking_pool() {
         CALLED_FROM_BLOCKING_POOL.with(|in_blocking_pool| *in_blocking_pool.borrow_mut() = true);
     }
 
+    /// Spawns a closure on the blocking thread pool and marks the thread as
+    /// being in a blocking pool, so the closure can run blocking DB
+    /// operations. The current tracing span is propagated into the closure.
+    pub fn spawn_blocking_task<F, R>(f: F) -> tokio::task::JoinHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let current_span = tracing::Span::current();
+        tokio::task::spawn_blocking(move || {
+            mark_in_blocking_pool();
+            let _guard = current_span.enter();
+            f()
+        })
+    }
+
+    /// Runs a read-only, repeatable-read SQL transaction, blocking the
+    /// calling thread until it completes.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called on an async runtime thread; run it on a blocking
+    /// thread instead, e.g. via `spawn_blocking_task`.
     #[macro_export]
     macro_rules! read_only_repeatable_blocking {
         ($pool:expr, $query:expr) => {{
             use downcast::Any;
             use $crate::db::{PoolConnection, get_pool_connection};
 
+            $crate::blocking_call_is_ok_or_panic!();
             let mut pool_conn = get_pool_connection($pool)?;
             pool_conn
                 .as_any_mut()
@@ -42,19 +66,24 @@ pub mod diesel_macro {
                 .read_only()
                 .repeatable_read()
                 .run($query)
-                .map_err(|e| IndexerError::PostgresRead(e.to_string()))
+                .map_err(|e| $crate::errors::IndexerError::PostgresRead(e.to_string()))
         }};
     }
 
-    /// Runs a blocking SQL query.
+    /// Runs a read-only SQL transaction, blocking the calling thread until it
+    /// completes.
     ///
-    /// In an async context, it must be wrapped in an spawn blocking task.
+    /// # Panics
+    ///
+    /// Panics when called on an async runtime thread; run it on a blocking
+    /// thread instead, e.g. via `spawn_blocking_task`.
     #[macro_export]
     macro_rules! read_only_blocking {
         ($pool:expr, $query:expr) => {{
             use downcast::Any;
             use $crate::db::{PoolConnection, get_pool_connection};
 
+            $crate::blocking_call_is_ok_or_panic!();
             let mut pool_conn = get_pool_connection($pool)?;
             pool_conn
                 .as_any_mut()
@@ -63,13 +92,17 @@ pub mod diesel_macro {
                 .build_transaction()
                 .read_only()
                 .run($query)
-                .map_err(|e| IndexerError::PostgresRead(e.to_string()))
+                .map_err(|e| $crate::errors::IndexerError::PostgresRead(e.to_string()))
         }};
     }
 
-    /// Runs a blocking SQL query.
+    /// Runs a read-write SQL transaction, blocking the calling thread until
+    /// it completes. Failures are retried with exponential backoff.
     ///
-    /// In an async context, it must be wrapped in an spawn blocking task.
+    /// # Panics
+    ///
+    /// Panics when called on an async runtime thread; run it on a blocking
+    /// thread instead, e.g. via `spawn_blocking_task`.
     #[macro_export]
     macro_rules! transactional_blocking_with_retry {
         ($pool:expr, $query:expr, $max_elapsed:expr) => {{
@@ -77,6 +110,7 @@ pub mod diesel_macro {
                 db::{PoolConnection, get_pool_connection},
                 errors::IndexerError,
             };
+            $crate::blocking_call_is_ok_or_panic!();
             let mut backoff = backoff::ExponentialBackoff::default();
             backoff.max_elapsed_time = Some($max_elapsed);
             let result = match backoff::retry(backoff, || {
@@ -109,9 +143,14 @@ pub mod diesel_macro {
         }};
     }
 
-    /// Runs a blocking SQL query.
+    /// Runs a read-write SQL transaction, blocking the calling thread until
+    /// it completes. Failures are retried with exponential backoff, except
+    /// for errors matching the abort condition, which stop the retries.
     ///
-    /// In an async context, it must be wrapped in an spawn blocking task.
+    /// # Panics
+    ///
+    /// Panics when called on an async runtime thread; run it on a blocking
+    /// thread instead, e.g. via `spawn_blocking_task`.
     #[macro_export]
     macro_rules! transactional_blocking_with_retry_with_conditional_abort {
         ($pool:expr, $query:expr, $abort_condition:expr, $max_elapsed:expr) => {{
@@ -119,6 +158,7 @@ pub mod diesel_macro {
                 db::{PoolConnection, get_pool_connection},
                 errors::IndexerError,
             };
+            $crate::blocking_call_is_ok_or_panic!();
             let mut backoff = backoff::ExponentialBackoff::default();
             backoff.max_elapsed_time = Some($max_elapsed);
             let result = match backoff::retry(backoff, || {
@@ -155,41 +195,16 @@ pub mod diesel_macro {
         }};
     }
 
-    /// Runs an async SQL query wrapped in a spawn blocking task.
+    /// Runs a read-only SQL transaction on a spawned blocking thread and
+    /// awaits its result. Safe to call from async code.
     #[macro_export]
     macro_rules! spawn_read_only_blocking {
         ($pool:expr, $query:expr, $repeatable_read:expr) => {{
-            use downcast::Any;
-            use $crate::{
-                db::{PoolConnection, get_pool_connection},
-                errors::IndexerError,
-                store::diesel_macro::mark_in_blocking_pool,
-            };
-            let current_span = tracing::Span::current();
-            tokio::task::spawn_blocking(move || {
-                mark_in_blocking_pool();
-                let _guard = current_span.enter();
-                let mut pool_conn = get_pool_connection($pool).unwrap();
-
+            $crate::store::diesel_macro::spawn_blocking_task(move || {
                 if $repeatable_read {
-                    pool_conn
-                        .as_any_mut()
-                        .downcast_mut::<PoolConnection>()
-                        .unwrap()
-                        .build_transaction()
-                        .read_only()
-                        .repeatable_read()
-                        .run($query)
-                        .map_err(|e| IndexerError::PostgresRead(e.to_string()))
+                    $crate::read_only_repeatable_blocking!($pool, $query)
                 } else {
-                    pool_conn
-                        .as_any_mut()
-                        .downcast_mut::<PoolConnection>()
-                        .unwrap()
-                        .build_transaction()
-                        .read_only()
-                        .run($query)
-                        .map_err(|e| IndexerError::PostgresRead(e.to_string()))
+                    $crate::read_only_blocking!($pool, $query)
                 }
             })
             .await
@@ -241,35 +256,16 @@ pub mod diesel_macro {
         }};
     }
 
-    /// Runs a blocking SQL query.
+    /// Runs a read-only SQL transaction, blocking the calling thread until it
+    /// completes. Failures are retried with exponential backoff.
     ///
-    /// In an async context, it must be wrapped in an spawn blocking task.
-    #[macro_export]
-    macro_rules! run_query {
-        ($pool:expr, $query:expr) => {{
-            blocking_call_is_ok_or_panic!();
-            read_only_blocking!($pool, $query)
-        }};
-    }
-
-    /// Runs a blocking SQL query.
+    /// # Panics
     ///
-    /// In an async context, it must be wrapped in an spawn blocking task.
-    #[macro_export]
-    macro_rules! run_query_repeatable {
-        ($pool:expr, $query:expr) => {{
-            blocking_call_is_ok_or_panic!();
-            read_only_repeatable_blocking!($pool, $query)
-        }};
-    }
-
-    /// Runs a blocking SQL query.
-    ///
-    /// In an async context, it must be wrapped in an spawn blocking task.
+    /// Panics when called on an async runtime thread; run it on a blocking
+    /// thread instead, e.g. via `spawn_blocking_task`.
     #[macro_export]
     macro_rules! run_query_with_retry {
         ($pool:expr, $query:expr, $max_elapsed:expr) => {{
-            blocking_call_is_ok_or_panic!();
             let mut backoff = backoff::ExponentialBackoff::default();
             backoff.max_elapsed_time = Some($max_elapsed);
             let result = match backoff::retry(backoff, || {
@@ -290,12 +286,15 @@ pub mod diesel_macro {
         }};
     }
 
-    /// Runs an async SQL query wrapped in a spawn blocking task.
+    /// Runs a read-only SQL transaction on a spawned blocking thread and
+    /// awaits its result. Safe to call from async code.
     #[macro_export]
     macro_rules! run_query_async {
         ($pool:expr, $query:expr) => {{ spawn_read_only_blocking!($pool, $query, false) }};
     }
 
+    /// Runs a read-only, repeatable-read SQL transaction on a spawned
+    /// blocking thread and awaits its result. Safe to call from async code.
     #[macro_export]
     macro_rules! run_query_repeatable_async {
         ($pool:expr, $query:expr) => {{ spawn_read_only_blocking!($pool, $query, true) }};
@@ -307,8 +306,10 @@ pub mod diesel_macro {
     ///
     /// Or:
     /// - If we are inside a tokio runtime context, ensure that the call went
-    ///   through `IndexerReader::spawn_blocking` which properly moves the
-    ///   blocking call to a blocking thread pool.
+    ///   through a spawned blocking task that called `mark_in_blocking_pool`,
+    ///   such as `store::diesel_macro::spawn_blocking_task`,
+    ///   `IndexerReader::spawn_blocking` or
+    ///   `PgIndexerStore::execute_in_blocking_worker`.
     #[macro_export]
     macro_rules! blocking_call_is_ok_or_panic {
         () => {{
@@ -318,8 +319,10 @@ pub mod diesel_macro {
             {
                 panic!(
                     "you are calling a blocking DB operation directly on an async thread. \
-                        Please use IndexerReader::spawn_blocking instead to move the \
-                        operation to a blocking thread"
+                        Please move the operation to a blocking thread, e.g. with \
+                        store::diesel_macro::spawn_blocking_task, \
+                        IndexerReader::spawn_blocking or \
+                        PgIndexerStore::execute_in_blocking_worker"
                 );
             }
         }};
@@ -412,10 +415,45 @@ pub mod diesel_macro {
     pub use blocking_call_is_ok_or_panic;
     pub use read_only_blocking;
     pub use read_only_repeatable_blocking;
-    pub use run_query;
     pub use run_query_async;
-    pub use run_query_repeatable;
     pub use run_query_repeatable_async;
     pub use spawn_read_only_blocking;
     pub use transactional_blocking_with_retry;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::diesel_macro::{
+        blocking_call_is_ok_or_panic, mark_in_blocking_pool, spawn_blocking_task,
+    };
+
+    #[test]
+    fn blocking_call_is_allowed_outside_a_runtime() {
+        blocking_call_is_ok_or_panic!();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "calling a blocking DB operation directly on an async thread")]
+    async fn blocking_call_panics_on_an_async_thread() {
+        blocking_call_is_ok_or_panic!();
+    }
+
+    #[tokio::test]
+    async fn blocking_call_is_allowed_on_a_marked_blocking_thread() {
+        tokio::task::spawn_blocking(|| {
+            mark_in_blocking_pool();
+            blocking_call_is_ok_or_panic!();
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn blocking_call_is_allowed_in_spawn_blocking_task() {
+        spawn_blocking_task(|| {
+            blocking_call_is_ok_or_panic!();
+        })
+        .await
+        .unwrap();
+    }
 }

--- a/crates/iota-indexer/src/store/package_resolver.rs
+++ b/crates/iota-indexer/src/store/package_resolver.rs
@@ -112,6 +112,6 @@ impl IndexerStorePackageResolver {
         id: Address,
     ) -> Result<Package, IndexerError> {
         let this = self.clone();
-        tokio::task::spawn_blocking(move || this.get_package_from_db(id)).await?
+        spawn_blocking_task(move || this.get_package_from_db(id)).await?
     }
 }

--- a/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
@@ -36,7 +36,9 @@ use crate::{
         active_addresses, address_metrics, addresses, checkpoints, epoch_peak_tps,
         move_call_metrics, move_calls, transactions, tx_count_metrics,
     },
-    store::diesel_macro::{read_only_blocking, transactional_blocking_with_retry},
+    store::diesel_macro::{
+        read_only_blocking, spawn_blocking_task, transactional_blocking_with_retry,
+    },
     types::IndexerResult,
 };
 
@@ -51,30 +53,48 @@ impl PgIndexerAnalyticalStore {
     pub fn new(blocking_cp: ConnectionPool) -> Self {
         Self { blocking_cp }
     }
+
+    async fn execute_in_blocking_worker<F, R>(&self, f: F) -> Result<R, IndexerError>
+    where
+        F: FnOnce(Self) -> Result<R, IndexerError> + Send + 'static,
+        R: Send + 'static,
+    {
+        let this = self.clone();
+        spawn_blocking_task(move || f(this))
+            .await
+            .map_err(Into::into)
+            .and_then(std::convert::identity)
+    }
 }
 
 #[async_trait]
 impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
     async fn get_latest_stored_checkpoint(&self) -> IndexerResult<Option<StoredCheckpoint>> {
-        let latest_cp = read_only_blocking!(&self.blocking_cp, |conn| {
-            checkpoints::dsl::checkpoints
-                .order(checkpoints::sequence_number.desc())
-                .first::<StoredCheckpoint>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let latest_cp = read_only_blocking!(&this.blocking_cp, |conn| {
+                checkpoints::dsl::checkpoints
+                    .order(checkpoints::sequence_number.desc())
+                    .first::<StoredCheckpoint>(conn)
+                    .optional()
+            })
+            .context("failed reading latest checkpoint from PostgresDB")?;
+            Ok(latest_cp)
         })
-        .context("failed reading latest checkpoint from PostgresDB")?;
-        Ok(latest_cp)
+        .await
     }
 
     async fn get_latest_stored_transaction(&self) -> IndexerResult<Option<StoredTransaction>> {
-        let latest_tx = read_only_blocking!(&self.blocking_cp, |conn| {
-            transactions::dsl::transactions
-                .order(transactions::tx_sequence_number.desc())
-                .first::<StoredTransaction>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let latest_tx = read_only_blocking!(&this.blocking_cp, |conn| {
+                transactions::dsl::transactions
+                    .order(transactions::tx_sequence_number.desc())
+                    .first::<StoredTransaction>(conn)
+                    .optional()
+            })
+            .context("failed reading latest transaction from PostgresDB")?;
+            Ok(latest_tx)
         })
-        .context("failed reading latest transaction from PostgresDB")?;
-        Ok(latest_tx)
+        .await
     }
 
     async fn get_checkpoints_in_range(
@@ -82,15 +102,18 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredCheckpoint>> {
-        let cps = read_only_blocking!(&self.blocking_cp, |conn| {
-            checkpoints::dsl::checkpoints
-                .filter(checkpoints::sequence_number.ge(start_checkpoint))
-                .filter(checkpoints::sequence_number.lt(end_checkpoint))
-                .order(checkpoints::sequence_number.asc())
-                .load::<StoredCheckpoint>(conn)
+        self.execute_in_blocking_worker(move |this| {
+            let cps = read_only_blocking!(&this.blocking_cp, |conn| {
+                checkpoints::dsl::checkpoints
+                    .filter(checkpoints::sequence_number.ge(start_checkpoint))
+                    .filter(checkpoints::sequence_number.lt(end_checkpoint))
+                    .order(checkpoints::sequence_number.asc())
+                    .load::<StoredCheckpoint>(conn)
+            })
+            .context("failed reading checkpoints from PostgresDB")?;
+            Ok(cps)
         })
-        .context("failed reading checkpoints from PostgresDB")?;
-        Ok(cps)
+        .await
     }
 
     async fn get_tx_timestamps_in_checkpoint_range(
@@ -98,19 +121,22 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredTransactionTimestamp>> {
-        let tx_timestamps = read_only_blocking!(&self.blocking_cp, |conn| {
-            transactions::dsl::transactions
-                .filter(transactions::dsl::checkpoint_sequence_number.ge(start_checkpoint))
-                .filter(transactions::dsl::checkpoint_sequence_number.lt(end_checkpoint))
-                .order(transactions::dsl::tx_sequence_number.asc())
-                .select((
-                    transactions::dsl::tx_sequence_number,
-                    transactions::dsl::timestamp_ms,
-                ))
-                .load::<StoredTransactionTimestamp>(conn)
+        self.execute_in_blocking_worker(move |this| {
+            let tx_timestamps = read_only_blocking!(&this.blocking_cp, |conn| {
+                transactions::dsl::transactions
+                    .filter(transactions::dsl::checkpoint_sequence_number.ge(start_checkpoint))
+                    .filter(transactions::dsl::checkpoint_sequence_number.lt(end_checkpoint))
+                    .order(transactions::dsl::tx_sequence_number.asc())
+                    .select((
+                        transactions::dsl::tx_sequence_number,
+                        transactions::dsl::timestamp_ms,
+                    ))
+                    .load::<StoredTransactionTimestamp>(conn)
+            })
+            .context("failed reading transaction timestamps from PostgresDB")?;
+            Ok(tx_timestamps)
         })
-        .context("failed reading transaction timestamps from PostgresDB")?;
-        Ok(tx_timestamps)
+        .await
     }
 
     async fn get_tx_checkpoints_in_checkpoint_range(
@@ -118,19 +144,22 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredTransactionCheckpoint>> {
-        let tx_checkpoints = read_only_blocking!(&self.blocking_cp, |conn| {
-            transactions::dsl::transactions
-                .filter(transactions::dsl::checkpoint_sequence_number.ge(start_checkpoint))
-                .filter(transactions::dsl::checkpoint_sequence_number.lt(end_checkpoint))
-                .order(transactions::dsl::tx_sequence_number.asc())
-                .select((
-                    transactions::dsl::tx_sequence_number,
-                    transactions::dsl::checkpoint_sequence_number,
-                ))
-                .load::<StoredTransactionCheckpoint>(conn)
+        self.execute_in_blocking_worker(move |this| {
+            let tx_checkpoints = read_only_blocking!(&this.blocking_cp, |conn| {
+                transactions::dsl::transactions
+                    .filter(transactions::dsl::checkpoint_sequence_number.ge(start_checkpoint))
+                    .filter(transactions::dsl::checkpoint_sequence_number.lt(end_checkpoint))
+                    .order(transactions::dsl::tx_sequence_number.asc())
+                    .select((
+                        transactions::dsl::tx_sequence_number,
+                        transactions::dsl::checkpoint_sequence_number,
+                    ))
+                    .load::<StoredTransactionCheckpoint>(conn)
+            })
+            .context("failed reading transaction checkpoints from PostgresDB")?;
+            Ok(tx_checkpoints)
         })
-        .context("failed reading transaction checkpoints from PostgresDB")?;
-        Ok(tx_checkpoints)
+        .await
     }
 
     async fn get_tx_success_cmd_counts_in_checkpoint_range(
@@ -138,64 +167,80 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
         start_checkpoint: i64,
         end_checkpoint: i64,
     ) -> IndexerResult<Vec<StoredTransactionSuccessCommandCount>> {
-        let tx_success_cmd_counts = read_only_blocking!(&self.blocking_cp, |conn| {
-            transactions::dsl::transactions
-                .filter(transactions::dsl::checkpoint_sequence_number.ge(start_checkpoint))
-                .filter(transactions::dsl::checkpoint_sequence_number.lt(end_checkpoint))
-                .order(transactions::dsl::tx_sequence_number.asc())
-                .select((
-                    transactions::dsl::tx_sequence_number,
-                    transactions::dsl::checkpoint_sequence_number,
-                    transactions::dsl::success_command_count,
-                    transactions::dsl::timestamp_ms,
-                ))
-                .load::<StoredTransactionSuccessCommandCount>(conn)
+        self.execute_in_blocking_worker(move |this| {
+            let tx_success_cmd_counts = read_only_blocking!(&this.blocking_cp, |conn| {
+                transactions::dsl::transactions
+                    .filter(transactions::dsl::checkpoint_sequence_number.ge(start_checkpoint))
+                    .filter(transactions::dsl::checkpoint_sequence_number.lt(end_checkpoint))
+                    .order(transactions::dsl::tx_sequence_number.asc())
+                    .select((
+                        transactions::dsl::tx_sequence_number,
+                        transactions::dsl::checkpoint_sequence_number,
+                        transactions::dsl::success_command_count,
+                        transactions::dsl::timestamp_ms,
+                    ))
+                    .load::<StoredTransactionSuccessCommandCount>(conn)
+            })
+            .context("failed reading transaction success command counts from PostgresDB")?;
+            Ok(tx_success_cmd_counts)
         })
-        .context("failed reading transaction success command counts from PostgresDB")?;
-        Ok(tx_success_cmd_counts)
+        .await
     }
+
     async fn get_tx(&self, tx_sequence_number: i64) -> IndexerResult<Option<StoredTransaction>> {
-        let tx = read_only_blocking!(&self.blocking_cp, |conn| {
-            transactions::dsl::transactions
-                .filter(transactions::dsl::tx_sequence_number.eq(tx_sequence_number))
-                .first::<StoredTransaction>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let tx = read_only_blocking!(&this.blocking_cp, |conn| {
+                transactions::dsl::transactions
+                    .filter(transactions::dsl::tx_sequence_number.eq(tx_sequence_number))
+                    .first::<StoredTransaction>(conn)
+                    .optional()
+            })
+            .context("failed reading transaction from PostgresDB")?;
+            Ok(tx)
         })
-        .context("failed reading transaction from PostgresDB")?;
-        Ok(tx)
+        .await
     }
 
     async fn get_cp(&self, sequence_number: i64) -> IndexerResult<Option<StoredCheckpoint>> {
-        let cp = read_only_blocking!(&self.blocking_cp, |conn| {
-            checkpoints::dsl::checkpoints
-                .filter(checkpoints::dsl::sequence_number.eq(sequence_number))
-                .first::<StoredCheckpoint>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let cp = read_only_blocking!(&this.blocking_cp, |conn| {
+                checkpoints::dsl::checkpoints
+                    .filter(checkpoints::dsl::sequence_number.eq(sequence_number))
+                    .first::<StoredCheckpoint>(conn)
+                    .optional()
+            })
+            .context("failed reading checkpoint from PostgresDB")?;
+            Ok(cp)
         })
-        .context("failed reading checkpoint from PostgresDB")?;
-        Ok(cp)
+        .await
     }
 
     async fn get_latest_tx_count_metrics(&self) -> IndexerResult<Option<StoredTxCountMetrics>> {
-        let latest_tx_count = read_only_blocking!(&self.blocking_cp, |conn| {
-            tx_count_metrics::dsl::tx_count_metrics
-                .order(tx_count_metrics::dsl::checkpoint_sequence_number.desc())
-                .first::<StoredTxCountMetrics>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let latest_tx_count = read_only_blocking!(&this.blocking_cp, |conn| {
+                tx_count_metrics::dsl::tx_count_metrics
+                    .order(tx_count_metrics::dsl::checkpoint_sequence_number.desc())
+                    .first::<StoredTxCountMetrics>(conn)
+                    .optional()
+            })
+            .context("failed reading latest tx count metrics from PostgresDB")?;
+            Ok(latest_tx_count)
         })
-        .context("failed reading latest tx count metrics from PostgresDB")?;
-        Ok(latest_tx_count)
+        .await
     }
 
     async fn get_latest_epoch_peak_tps(&self) -> IndexerResult<Option<StoredEpochPeakTps>> {
-        let latest_network_metrics = read_only_blocking!(&self.blocking_cp, |conn| {
-            epoch_peak_tps::dsl::epoch_peak_tps
-                .order(epoch_peak_tps::dsl::epoch.desc())
-                .first::<StoredEpochPeakTps>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let latest_network_metrics = read_only_blocking!(&this.blocking_cp, |conn| {
+                epoch_peak_tps::dsl::epoch_peak_tps
+                    .order(epoch_peak_tps::dsl::epoch.desc())
+                    .first::<StoredEpochPeakTps>(conn)
+                    .optional()
+            })
+            .context("failed reading latest epoch peak TPS from PostgresDB")?;
+            Ok(latest_network_metrics)
         })
-        .context("failed reading latest epoch peak TPS from PostgresDB")?;
-        Ok(latest_network_metrics)
+        .await
     }
 
     /// Persists the transaction count metrics for the given checkpoint range.
@@ -229,50 +274,56 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
     }
 
     async fn persist_epoch_peak_tps(&self, epoch: i64) -> IndexerResult<()> {
-        let epoch_peak_tps_query = construct_peak_tps_query(epoch, 1);
-        let peak_tps_30d_query = construct_peak_tps_query(epoch, 30);
-        let epoch_tps: Tps =
-            read_only_blocking!(&self.blocking_cp, |conn| diesel::RunQueryDsl::get_result(
-                diesel::sql_query(epoch_peak_tps_query),
-                conn
-            ))
-            .context("failed reading epoch peak TPS from PostgresDB")?;
-        let tps_30d: Tps =
-            read_only_blocking!(&self.blocking_cp, |conn| diesel::RunQueryDsl::get_result(
-                diesel::sql_query(peak_tps_30d_query),
-                conn
-            ))
-            .context("failed reading 30d peak TPS from PostgresDB")?;
+        self.execute_in_blocking_worker(move |this| {
+            let epoch_peak_tps_query = construct_peak_tps_query(epoch, 1);
+            let peak_tps_30d_query = construct_peak_tps_query(epoch, 30);
+            let epoch_tps: Tps =
+                read_only_blocking!(&this.blocking_cp, |conn| diesel::RunQueryDsl::get_result(
+                    diesel::sql_query(epoch_peak_tps_query),
+                    conn
+                ))
+                .context("failed reading epoch peak TPS from PostgresDB")?;
+            let tps_30d: Tps =
+                read_only_blocking!(&this.blocking_cp, |conn| diesel::RunQueryDsl::get_result(
+                    diesel::sql_query(peak_tps_30d_query),
+                    conn
+                ))
+                .context("failed reading 30d peak TPS from PostgresDB")?;
 
-        let epoch_peak_tps = StoredEpochPeakTps {
-            epoch,
-            peak_tps: epoch_tps.peak_tps,
-            peak_tps_30d: tps_30d.peak_tps,
-        };
-        transactional_blocking_with_retry!(
-            &self.blocking_cp,
-            |conn| {
-                diesel::insert_into(epoch_peak_tps::table)
-                    .values(epoch_peak_tps.clone())
-                    .on_conflict_do_nothing()
-                    .execute(conn)
-            },
-            Duration::from_secs(10)
-        )
-        .context("failed persisting epoch peak TPS to PostgresDB.")?;
-        Ok(())
+            let epoch_peak_tps = StoredEpochPeakTps {
+                epoch,
+                peak_tps: epoch_tps.peak_tps,
+                peak_tps_30d: tps_30d.peak_tps,
+            };
+            transactional_blocking_with_retry!(
+                &this.blocking_cp,
+                |conn| {
+                    diesel::insert_into(epoch_peak_tps::table)
+                        .values(epoch_peak_tps.clone())
+                        .on_conflict_do_nothing()
+                        .execute(conn)
+                },
+                Duration::from_secs(10)
+            )
+            .context("failed persisting epoch peak TPS to PostgresDB.")?;
+            Ok(())
+        })
+        .await
     }
 
     async fn get_address_metrics_last_processed_tx_seq(&self) -> IndexerResult<Option<TxSeq>> {
-        let last_processed_tx_seq = read_only_blocking!(&self.blocking_cp, |conn| {
-            active_addresses::dsl::active_addresses
-                .order(active_addresses::dsl::last_appearance_tx.desc())
-                .select((active_addresses::dsl::last_appearance_tx,))
-                .first::<TxSeq>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let last_processed_tx_seq = read_only_blocking!(&this.blocking_cp, |conn| {
+                active_addresses::dsl::active_addresses
+                    .order(active_addresses::dsl::last_appearance_tx.desc())
+                    .select((active_addresses::dsl::last_appearance_tx,))
+                    .first::<TxSeq>(conn)
+                    .optional()
+            })
+            .context("failed to read address metrics last processed tx sequence.")?;
+            Ok(last_processed_tx_seq)
         })
-        .context("failed to read address metrics last processed tx sequence.")?;
-        Ok(last_processed_tx_seq)
+        .await
     }
 
     /// Calls the stored procedure `persist_address_analytics`.
@@ -314,70 +365,79 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
                 .pop();
         }
         let checkpoint = checkpoint_opt.unwrap();
-        let cp_timestamp_ms = checkpoint.timestamp_ms;
-        let addr_count = read_only_blocking!(&self.blocking_cp, |conn| {
-            addresses::dsl::addresses
-                .filter(addresses::first_appearance_time.le(cp_timestamp_ms))
-                .count()
-                .get_result::<i64>(conn)
-        })?;
-        let active_addr_count = read_only_blocking!(&self.blocking_cp, |conn| {
-            active_addresses::dsl::active_addresses
-                .filter(active_addresses::first_appearance_time.le(cp_timestamp_ms))
-                .count()
-                .get_result::<i64>(conn)
-        })?;
-        let time_one_day_ago = cp_timestamp_ms - 1000 * 60 * 60 * 24;
-        let daily_active_addresses = read_only_blocking!(&self.blocking_cp, |conn| {
-            active_addresses::dsl::active_addresses
-                .filter(active_addresses::first_appearance_time.le(cp_timestamp_ms))
-                .filter(active_addresses::last_appearance_time.gt(time_one_day_ago))
-                .select(count(active_addresses::address))
-                .first(conn)
-        })?;
-        let address_metrics_to_commit = StoredAddressMetrics {
-            checkpoint: checkpoint.sequence_number,
-            epoch: checkpoint.epoch,
-            timestamp_ms: checkpoint.timestamp_ms,
-            cumulative_addresses: addr_count,
-            cumulative_active_addresses: active_addr_count,
-            daily_active_addresses,
-        };
-        transactional_blocking_with_retry!(
-            &self.blocking_cp,
-            |conn| {
-                diesel::insert_into(address_metrics::table)
-                    .values(address_metrics_to_commit.clone())
-                    .on_conflict_do_nothing()
-                    .execute(conn)
-            },
-            Duration::from_secs(60)
-        )
-        .context("failed persisting address metrics to PostgresDB")?;
-        Ok(())
+        self.execute_in_blocking_worker(move |this| {
+            let cp_timestamp_ms = checkpoint.timestamp_ms;
+            let addr_count = read_only_blocking!(&this.blocking_cp, |conn| {
+                addresses::dsl::addresses
+                    .filter(addresses::first_appearance_time.le(cp_timestamp_ms))
+                    .count()
+                    .get_result::<i64>(conn)
+            })?;
+            let active_addr_count = read_only_blocking!(&this.blocking_cp, |conn| {
+                active_addresses::dsl::active_addresses
+                    .filter(active_addresses::first_appearance_time.le(cp_timestamp_ms))
+                    .count()
+                    .get_result::<i64>(conn)
+            })?;
+            let time_one_day_ago = cp_timestamp_ms - 1000 * 60 * 60 * 24;
+            let daily_active_addresses = read_only_blocking!(&this.blocking_cp, |conn| {
+                active_addresses::dsl::active_addresses
+                    .filter(active_addresses::first_appearance_time.le(cp_timestamp_ms))
+                    .filter(active_addresses::last_appearance_time.gt(time_one_day_ago))
+                    .select(count(active_addresses::address))
+                    .first(conn)
+            })?;
+            let address_metrics_to_commit = StoredAddressMetrics {
+                checkpoint: checkpoint.sequence_number,
+                epoch: checkpoint.epoch,
+                timestamp_ms: checkpoint.timestamp_ms,
+                cumulative_addresses: addr_count,
+                cumulative_active_addresses: active_addr_count,
+                daily_active_addresses,
+            };
+            transactional_blocking_with_retry!(
+                &this.blocking_cp,
+                |conn| {
+                    diesel::insert_into(address_metrics::table)
+                        .values(address_metrics_to_commit.clone())
+                        .on_conflict_do_nothing()
+                        .execute(conn)
+                },
+                Duration::from_secs(60)
+            )
+            .context("failed persisting address metrics to PostgresDB")?;
+            Ok(())
+        })
+        .await
     }
 
     async fn get_latest_move_call_tx_seq(&self) -> IndexerResult<Option<TxSeq>> {
-        let last_processed_tx_seq = read_only_blocking!(&self.blocking_cp, |conn| {
-            move_calls::dsl::move_calls
-                .order(move_calls::dsl::transaction_sequence_number.desc())
-                .select((move_calls::dsl::transaction_sequence_number,))
-                .first::<TxSeq>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let last_processed_tx_seq = read_only_blocking!(&this.blocking_cp, |conn| {
+                move_calls::dsl::move_calls
+                    .order(move_calls::dsl::transaction_sequence_number.desc())
+                    .select((move_calls::dsl::transaction_sequence_number,))
+                    .first::<TxSeq>(conn)
+                    .optional()
+            })
+            .unwrap_or_default();
+            Ok(last_processed_tx_seq)
         })
-        .unwrap_or_default();
-        Ok(last_processed_tx_seq)
+        .await
     }
 
     async fn get_latest_move_call_metrics(&self) -> IndexerResult<Option<StoredMoveCallMetrics>> {
-        let latest_move_call_metrics = read_only_blocking!(&self.blocking_cp, |conn| {
-            move_call_metrics::dsl::move_call_metrics
-                .order(move_call_metrics::epoch.desc())
-                .first::<QueriedMoveCallMetrics>(conn)
-                .optional()
+        self.execute_in_blocking_worker(move |this| {
+            let latest_move_call_metrics = read_only_blocking!(&this.blocking_cp, |conn| {
+                move_call_metrics::dsl::move_call_metrics
+                    .order(move_call_metrics::epoch.desc())
+                    .first::<QueriedMoveCallMetrics>(conn)
+                    .optional()
+            })
+            .unwrap_or_default();
+            Ok(latest_move_call_metrics.map(|m| m.into()))
         })
-        .unwrap_or_default();
-        Ok(latest_move_call_metrics.map(|m| m.into()))
+        .await
     }
 
     fn persist_move_calls_in_tx_range(
@@ -405,19 +465,19 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
 
         let mut calculate_tasks = vec![];
         let blocking_cp_3d = self.blocking_cp.clone();
-        calculate_tasks.push(tokio::task::spawn_blocking(move || {
+        calculate_tasks.push(spawn_blocking_task(move || {
             read_only_blocking!(&blocking_cp_3d, |conn| {
                 diesel::sql_query(move_call_query_3d).get_results::<QueriedMoveMetrics>(conn)
             })
         }));
         let blocking_cp_7d = self.blocking_cp.clone();
-        calculate_tasks.push(tokio::task::spawn_blocking(move || {
+        calculate_tasks.push(spawn_blocking_task(move || {
             read_only_blocking!(&blocking_cp_7d, |conn| {
                 diesel::sql_query(move_call_query_7d).get_results::<QueriedMoveMetrics>(conn)
             })
         }));
         let blocking_cp_30d = self.blocking_cp.clone();
-        calculate_tasks.push(tokio::task::spawn_blocking(move || {
+        calculate_tasks.push(spawn_blocking_task(move || {
             read_only_blocking!(&blocking_cp_30d, |conn| {
                 diesel::sql_query(move_call_query_30d).get_results::<QueriedMoveMetrics>(conn)
             })
@@ -464,18 +524,21 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
             })
             .collect();
 
-        transactional_blocking_with_retry!(
-            &self.blocking_cp,
-            |conn| {
-                diesel::insert_into(move_call_metrics::table)
-                    .values(move_call_metrics.clone())
-                    .on_conflict_do_nothing()
-                    .execute(conn)
-            },
-            Duration::from_secs(60)
-        )
-        .context("failed persisting move call metrics to PostgresDB")?;
-        Ok(())
+        self.execute_in_blocking_worker(move |this| {
+            transactional_blocking_with_retry!(
+                &this.blocking_cp,
+                |conn| {
+                    diesel::insert_into(move_call_metrics::table)
+                        .values(move_call_metrics.clone())
+                        .on_conflict_do_nothing()
+                        .execute(conn)
+                },
+                Duration::from_secs(60)
+            )
+            .context("failed persisting move call metrics to PostgresDB")?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -23,7 +23,6 @@ use tracing::info;
 
 use super::pg_partition_manager::{EpochPartitionData, PgPartitionManager};
 use crate::{
-    blocking_call_is_ok_or_panic,
     db::ConnectionPool,
     errors::{Context, IndexerError},
     ingestion::{
@@ -56,7 +55,7 @@ use crate::{
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
     persist_chunk_into_table_in_existing_connection,
     pruning::pruner::PrunableTable,
-    read_only_blocking, run_query, run_query_with_retry,
+    read_only_blocking, run_query_with_retry,
     schema::{
         chain_identifier, checkpointed_objects, checkpoints, display, epochs, event_emit_module,
         event_emit_package, event_senders, event_struct_instantiation, event_struct_module,
@@ -66,7 +65,7 @@ use crate::{
         tx_calls_pkg, tx_changed_objects, tx_global_order, tx_input_objects, tx_kinds,
         tx_recipients, tx_senders, tx_wrapped_or_deleted_objects, watermarks,
     },
-    store::{IndexerStore, diesel_macro::mark_in_blocking_pool},
+    store::{IndexerStore, diesel_macro},
     transactional_blocking_with_retry,
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEvent, IndexedObject,
@@ -150,8 +149,7 @@ impl PgIndexerStore {
             .unwrap_or_else(|_e| PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE.to_string())
             .parse::<usize>()
             .unwrap();
-        let partition_manager = PgPartitionManager::new(blocking_cp.clone())
-            .expect("failed to initialize partition manager");
+        let partition_manager = PgPartitionManager::new(blocking_cp.clone());
         let config = PgIndexerStoreConfig {
             parallel_chunk_size,
             parallel_objects_chunk_size,
@@ -1560,7 +1558,7 @@ impl PgIndexerStore {
         epochs: &[u64],
     ) -> Result<HashMap<u64, (u64, u64)>, IndexerError> {
         let pool = &self.blocking_cp;
-        let results: Vec<(i64, i64, i64)> = run_query!(pool, move |conn| {
+        let results: Vec<(i64, i64, i64)> = read_only_blocking!(pool, move |conn| {
             epochs::table
                 .filter(epochs::epoch.eq_any(epochs.iter().map(|&e| e as i64)))
                 .select((
@@ -1717,15 +1715,10 @@ impl PgIndexerStore {
         R: Send + 'static,
     {
         let this = self.clone();
-        let current_span = tracing::Span::current();
-        tokio::task::spawn_blocking(move || {
-            mark_in_blocking_pool();
-            let _guard = current_span.enter();
-            f(this)
-        })
-        .await
-        .map_err(Into::into)
-        .and_then(std::convert::identity)
+        diesel_macro::spawn_blocking_task(move || f(this))
+            .await
+            .map_err(Into::into)
+            .and_then(std::convert::identity)
     }
 
     pub(crate) fn spawn_blocking_task<F, R>(
@@ -1737,11 +1730,8 @@ impl PgIndexerStore {
         R: Send + 'static,
     {
         let this = self.clone();
-        let current_span = tracing::Span::current();
         let guard = self.metrics.tokio_blocking_task_wait_latency.start_timer();
-        tokio::task::spawn_blocking(move || {
-            mark_in_blocking_pool();
-            let _guard = current_span.enter();
+        diesel_macro::spawn_blocking_task(move || {
             let _elapsed = guard.stop_and_record();
             f(this)
         })

--- a/crates/iota-indexer/src/store/pg_partition_manager.rs
+++ b/crates/iota-indexer/src/store/pg_partition_manager.rs
@@ -96,22 +96,15 @@ impl EpochPartitionData {
 }
 
 impl PgPartitionManager {
-    pub fn new(cp: ConnectionPool) -> Result<Self, IndexerError> {
+    pub fn new(cp: ConnectionPool) -> Self {
         let mut partition_strategies = HashMap::new();
         partition_strategies.insert("events", PgPartitionStrategy::TxSequenceNumber);
         partition_strategies.insert("transactions", PgPartitionStrategy::TxSequenceNumber);
         partition_strategies.insert("objects_version", PgPartitionStrategy::ObjectId);
-        let manager = Self {
+        Self {
             cp,
             partition_strategies,
-        };
-        let tables = manager.get_table_partitions()?;
-        info!(
-            "Found {} tables with partitions : [{:?}]",
-            tables.len(),
-            tables
-        );
-        Ok(manager)
+        }
     }
 
     pub fn get_table_partitions(&self) -> Result<BTreeMap<String, (u64, u64)>, IndexerError> {

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -154,7 +154,13 @@ pub async fn start_test_indexer_impl(
         crate::db::reset_database(&mut store.blocking_cp().get().unwrap()).unwrap();
     }
     if let Some(db_init_hook) = db_init_hook {
-        db_init_hook(&store);
+        store
+            .execute_in_blocking_worker(move |this| {
+                db_init_hook(&this);
+                Ok(())
+            })
+            .await
+            .expect("failed to run the DB init hook");
     }
 
     let registry = prometheus_filtered::Registry::default();

--- a/crates/iota-indexer/tests/common/backward_history.rs
+++ b/crates/iota-indexer/tests/common/backward_history.rs
@@ -5,54 +5,75 @@
 
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper};
 use iota_indexer::{
-    errors::IndexerError, models::objects::StoredBackwardHistoryObject,
-    schema::objects_backward_history, store::PgIndexerStore,
+    errors::IndexerError,
+    models::objects::StoredBackwardHistoryObject,
+    read_only_blocking,
+    schema::objects_backward_history,
+    store::{PgIndexerStore, diesel_macro::spawn_blocking_task},
 };
 
 /// Looks up a backward history entry by object_id and superseded_at_checkpoint.
-pub fn find_backward_entry(
+pub async fn find_backward_entry(
     store: &PgIndexerStore,
     object_id: &[u8],
     checkpoint: i64,
 ) -> Result<Option<StoredBackwardHistoryObject>, IndexerError> {
-    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
-        objects_backward_history::table
-            .filter(objects_backward_history::object_id.eq(object_id))
-            .filter(objects_backward_history::superseded_at_checkpoint.eq(checkpoint))
-            .select(StoredBackwardHistoryObject::as_select())
-            .first::<StoredBackwardHistoryObject>(conn)
-            .optional()
+    let blocking_cp = store.blocking_cp();
+    let object_id = object_id.to_vec();
+    spawn_blocking_task(move || {
+        read_only_blocking!(&blocking_cp, |conn| {
+            objects_backward_history::table
+                .filter(objects_backward_history::object_id.eq(object_id))
+                .filter(objects_backward_history::superseded_at_checkpoint.eq(checkpoint))
+                .select(StoredBackwardHistoryObject::as_select())
+                .first::<StoredBackwardHistoryObject>(conn)
+                .optional()
+        })
     })
+    .await
+    .expect("failed to join Tokio blocking task")
 }
 
 /// Looks up all backward history entries for an object_id at a given
 /// checkpoint, ordered by object_version.
-pub fn find_all_entries_at_checkpoint(
+pub async fn find_all_entries_at_checkpoint(
     store: &PgIndexerStore,
     object_id: &[u8],
     checkpoint: i64,
 ) -> Result<Vec<StoredBackwardHistoryObject>, IndexerError> {
-    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
-        objects_backward_history::table
-            .filter(objects_backward_history::object_id.eq(object_id))
-            .filter(objects_backward_history::superseded_at_checkpoint.eq(checkpoint))
-            .order(objects_backward_history::object_version.asc())
-            .select(StoredBackwardHistoryObject::as_select())
-            .load::<StoredBackwardHistoryObject>(conn)
+    let blocking_cp = store.blocking_cp();
+    let object_id = object_id.to_vec();
+    spawn_blocking_task(move || {
+        read_only_blocking!(&blocking_cp, |conn| {
+            objects_backward_history::table
+                .filter(objects_backward_history::object_id.eq(object_id))
+                .filter(objects_backward_history::superseded_at_checkpoint.eq(checkpoint))
+                .order(objects_backward_history::object_version.asc())
+                .select(StoredBackwardHistoryObject::as_select())
+                .load::<StoredBackwardHistoryObject>(conn)
+        })
     })
+    .await
+    .expect("failed to join Tokio blocking task")
 }
 
 /// Looks up all backward history entries for an object_id, ordered by
 /// superseded_at_checkpoint.
-pub fn find_all_entries_for_object(
+pub async fn find_all_entries_for_object(
     store: &PgIndexerStore,
     object_id: &[u8],
 ) -> Result<Vec<StoredBackwardHistoryObject>, IndexerError> {
-    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
-        objects_backward_history::table
-            .filter(objects_backward_history::object_id.eq(object_id))
-            .order(objects_backward_history::superseded_at_checkpoint.asc())
-            .select(StoredBackwardHistoryObject::as_select())
-            .load::<StoredBackwardHistoryObject>(conn)
+    let blocking_cp = store.blocking_cp();
+    let object_id = object_id.to_vec();
+    spawn_blocking_task(move || {
+        read_only_blocking!(&blocking_cp, |conn| {
+            objects_backward_history::table
+                .filter(objects_backward_history::object_id.eq(object_id))
+                .order(objects_backward_history::superseded_at_checkpoint.asc())
+                .select(StoredBackwardHistoryObject::as_select())
+                .load::<StoredBackwardHistoryObject>(conn)
+        })
     })
+    .await
+    .expect("failed to join Tokio blocking task")
 }

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -28,7 +28,7 @@ use iota_indexer::{
     models::checkpoints::StoredCheckpoint,
     read_only_blocking,
     schema::{checkpoints, optimistic_transactions},
-    store::{PgIndexerStore, indexer_store::IndexerStore},
+    store::{PgIndexerStore, diesel_macro::spawn_blocking_task, indexer_store::IndexerStore},
     test_utils::{DBInitHook, IndexerTypeConfig, create_pg_store, db_url, start_test_indexer},
 };
 use iota_json_rpc_api::{
@@ -217,7 +217,7 @@ pub async fn indexer_wait_for_epoch(pg_store: &PgIndexerStore, expected_epoch: u
     tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             let blocking_cp = pg_store.blocking_cp();
-            let result = tokio::task::spawn_blocking(move || {
+            let result = spawn_blocking_task(move || {
                 read_only_blocking!(&blocking_cp, |conn| {
                     checkpoints::table
                         .order(checkpoints::sequence_number.desc())
@@ -297,7 +297,7 @@ pub async fn node_wait_for_object(cluster: &TestCluster, object_id: ObjectId, ve
 
 pub async fn get_optimistic_transactions_count(pg_store: &PgIndexerStore) -> u64 {
     let blocking_cp = pg_store.blocking_cp();
-    tokio::task::spawn_blocking(move || {
+    spawn_blocking_task(move || {
         read_only_blocking!(&blocking_cp, |conn| {
             optimistic_transactions::table
                 .count()

--- a/crates/iota-indexer/tests/common/object_versions.rs
+++ b/crates/iota-indexer/tests/common/object_versions.rs
@@ -5,23 +5,31 @@
 
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
 use iota_indexer::{
-    errors::IndexerError, models::obj_indices::StoredObjectVersion, schema::objects_version,
-    store::PgIndexerStore,
+    errors::IndexerError,
+    models::obj_indices::StoredObjectVersion,
+    read_only_blocking,
+    schema::objects_version,
+    store::{PgIndexerStore, diesel_macro::spawn_blocking_task},
 };
 
 /// Looks up all object-version entries for a checkpoint, ordered by
 /// (object_id, object_version).
-pub fn find_object_versions_at_checkpoint(
+pub async fn find_object_versions_at_checkpoint(
     store: &PgIndexerStore,
     checkpoint: i64,
 ) -> Result<Vec<StoredObjectVersion>, IndexerError> {
-    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
-        objects_version::table
-            .filter(objects_version::cp_sequence_number.eq(checkpoint))
-            .order((
-                objects_version::object_id.asc(),
-                objects_version::object_version.asc(),
-            ))
-            .load::<StoredObjectVersion>(conn)
+    let blocking_cp = store.blocking_cp();
+    spawn_blocking_task(move || {
+        read_only_blocking!(&blocking_cp, |conn| {
+            objects_version::table
+                .filter(objects_version::cp_sequence_number.eq(checkpoint))
+                .order((
+                    objects_version::object_id.asc(),
+                    objects_version::object_version.asc(),
+                ))
+                .load::<StoredObjectVersion>(conn)
+        })
     })
+    .await
+    .expect("failed to join Tokio blocking task")
 }

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -25,7 +25,7 @@ mod ingestion_tests {
             transactions::{StoredTransaction, TxGlobalOrder},
         },
         schema::{checkpointed_objects, checkpoints, objects, transactions, tx_global_order},
-        store::{PgIndexerStore, indexer_store::IndexerStore},
+        store::{PgIndexerStore, diesel_macro::spawn_blocking_task, indexer_store::IndexerStore},
         transactional_blocking_with_retry,
         types::{EventIndex, ObjectStatus, TxIndex},
     };
@@ -51,12 +51,17 @@ mod ingestion_tests {
 
     macro_rules! read_only_blocking {
         ($pool:expr, $query:expr) => {{
-            let mut pg_pool_conn = get_pool_connection($pool)?;
-            pg_pool_conn
-                .build_transaction()
-                .read_only()
-                .run($query)
-                .map_err(|e| IndexerError::PostgresRead(e.to_string()))
+            let pool = $pool.clone();
+            spawn_blocking_task(move || {
+                let mut pg_pool_conn = get_pool_connection(&pool)?;
+                pg_pool_conn
+                    .build_transaction()
+                    .read_only()
+                    .run($query)
+                    .map_err(|e| IndexerError::PostgresRead(e.to_string()))
+            })
+            .await
+            .expect("failed to join Tokio blocking task")
         }};
     }
 
@@ -110,7 +115,7 @@ mod ingestion_tests {
 
         indexer_wait_for_checkpoint(&pg_store, 1).await;
 
-        let digest = effects.transaction_digest();
+        let digest = *effects.transaction_digest();
 
         // Read the transaction from the database directly.
         let db_txn: StoredTransaction = read_only_blocking!(&pg_store.blocking_cp(), |conn| {
@@ -215,7 +220,7 @@ mod ingestion_tests {
 
         indexer_wait_for_checkpoint(&pg_store, 1).await;
 
-        let digest = effects.transaction_digest();
+        let digest = *effects.transaction_digest();
 
         let stored_global_order = read_only_blocking!(&pg_store.blocking_cp(), |conn| {
             tx_global_order::table
@@ -697,7 +702,8 @@ mod ingestion_tests {
         // Both created coins should have NOT_YET_CREATED entries, with
         // object_version = lamport - 1 (the version assigned by the create tx,
         // minus one).
-        let entry = find_backward_entry(&pg_store, created_coin_1.as_bytes(), 1)?
+        let entry = find_backward_entry(&pg_store, created_coin_1.as_bytes(), 1)
+            .await?
             .expect("created coin 1 must have a backward history entry at cp 1");
         assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         assert_eq!(
@@ -707,7 +713,8 @@ mod ingestion_tests {
         assert!(entry.serialized_object.is_none());
         assert!(entry.object_digest.is_none());
 
-        let entry = find_backward_entry(&pg_store, created_coin_2.as_bytes(), 1)?
+        let entry = find_backward_entry(&pg_store, created_coin_2.as_bytes(), 1)
+            .await?
             .expect("created coin 2 must have a backward history entry at cp 1");
         assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         assert_eq!(
@@ -717,7 +724,8 @@ mod ingestion_tests {
 
         // The gas object was mutated twice in checkpoint 1 — there should be
         // two ACTIVE entries with different previous versions.
-        let gas_entries = find_all_entries_at_checkpoint(&pg_store, gas_object_id.as_bytes(), 1)?;
+        let gas_entries =
+            find_all_entries_at_checkpoint(&pg_store, gas_object_id.as_bytes(), 1).await?;
         assert_eq!(
             gas_entries.len(),
             2,
@@ -741,7 +749,8 @@ mod ingestion_tests {
 
         // === checkpoint 2 assertions (single transaction) ===
 
-        let entry = find_backward_entry(&pg_store, created_coin_3.as_bytes(), 2)?
+        let entry = find_backward_entry(&pg_store, created_coin_3.as_bytes(), 2)
+            .await?
             .expect("created coin 3 must have a backward history entry at cp 2");
         assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         assert_eq!(
@@ -749,7 +758,8 @@ mod ingestion_tests {
             created_coin_3_version.as_u64() as i64 - 1
         );
 
-        let entry = find_backward_entry(&pg_store, gas_object_id.as_bytes(), 2)?
+        let entry = find_backward_entry(&pg_store, gas_object_id.as_bytes(), 2)
+            .await?
             .expect("gas object must have a backward history entry at cp 2");
         assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert_eq!(entry.object_version, gas_version_before_tx3.as_u64() as i64);
@@ -835,7 +845,7 @@ mod ingestion_tests {
         ];
         cp1_expected.sort();
         assert_eq!(
-            find_object_versions_at_checkpoint(&pg_store, 1)?,
+            find_object_versions_at_checkpoint(&pg_store, 1).await?,
             cp1_expected
         );
 
@@ -846,7 +856,7 @@ mod ingestion_tests {
         ];
         cp2_expected.sort();
         assert_eq!(
-            find_object_versions_at_checkpoint(&pg_store, 2)?,
+            find_object_versions_at_checkpoint(&pg_store, 2).await?,
             cp2_expected
         );
 
@@ -1092,7 +1102,7 @@ mod ingestion_tests {
             };
 
         // cp3: warrior created (output) + sword wrapped (removed)
-        let cp3 = find_object_versions_at_checkpoint(&pg_store, 3)?;
+        let cp3 = find_object_versions_at_checkpoint(&pg_store, 3).await?;
         assert_present(
             &cp3,
             warrior_v0.object_id,
@@ -1107,7 +1117,7 @@ mod ingestion_tests {
         );
 
         // cp4: sword unwrapped (output)
-        let cp4 = find_object_versions_at_checkpoint(&pg_store, 4)?;
+        let cp4 = find_object_versions_at_checkpoint(&pg_store, 4).await?;
         assert_present(
             &cp4,
             sword_v0.object_id,
@@ -1116,7 +1126,7 @@ mod ingestion_tests {
         );
 
         // cp5: sword re-wrapped (removed)
-        let cp5 = find_object_versions_at_checkpoint(&pg_store, 5)?;
+        let cp5 = find_object_versions_at_checkpoint(&pg_store, 5).await?;
         assert_present(
             &cp5,
             sword_v0.object_id,
@@ -1125,7 +1135,7 @@ mod ingestion_tests {
         );
 
         // cp6: warrior deleted + sword unwrapped_then_deleted (both removed)
-        let cp6 = find_object_versions_at_checkpoint(&pg_store, 6)?;
+        let cp6 = find_object_versions_at_checkpoint(&pg_store, 6).await?;
         assert_present(
             &cp6,
             warrior_v0.object_id,

--- a/crates/iota-indexer/tests/rpc-tests/backward_history.rs
+++ b/crates/iota-indexer/tests/rpc-tests/backward_history.rs
@@ -174,7 +174,8 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         let (item_id, item_create_version) = first_created(&resp);
         let create_cp = resp.checkpoint.unwrap() as i64;
 
-        let entry = find_backward_entry(store, item_id.as_bytes(), create_cp)?
+        let entry = find_backward_entry(store, item_id.as_bytes(), create_cp)
+            .await?
             .expect("item should have backward history at create checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         // NotYetCreated rows carry lamport - 1 so MIN(object_version) stays
@@ -202,7 +203,8 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         .await;
         let mutate_cp = resp.checkpoint.unwrap() as i64;
 
-        let entry = find_backward_entry(store, item_id.as_bytes(), mutate_cp)?
+        let entry = find_backward_entry(store, item_id.as_bytes(), mutate_cp)
+            .await?
             .expect("item should have backward history at mutate checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(
@@ -231,13 +233,15 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         let (box_id, box_create_version) = first_created(&resp);
 
         // Item was wrapped → ACTIVE backward entry with previous data.
-        let entry = find_backward_entry(store, item_id.as_bytes(), wrap_cp)?
+        let entry = find_backward_entry(store, item_id.as_bytes(), wrap_cp)
+            .await?
             .expect("item should have backward history at wrap checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(entry.serialized_object.is_some());
 
         // Box was created → NOT_YET_CREATED.
-        let entry = find_backward_entry(store, box_id.as_bytes(), wrap_cp)?
+        let entry = find_backward_entry(store, box_id.as_bytes(), wrap_cp)
+            .await?
             .expect("box should have backward history at wrap checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::NotYetCreated as i16);
         assert_eq!(entry.object_version, box_create_version.as_u64() as i64 - 1);
@@ -261,7 +265,8 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
 
         // Item was unwrapped → WRAPPED_OR_DELETED (no data available).
         // Version should be lamport - 1 (the output version minus one).
-        let entry = find_backward_entry(store, item_id.as_bytes(), unwrap_cp)?
+        let entry = find_backward_entry(store, item_id.as_bytes(), unwrap_cp)
+            .await?
             .expect("item should have backward history at unwrap checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::WrappedOrDeleted as i16);
         assert_eq!(
@@ -273,7 +278,8 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         assert!(entry.object_digest.is_none());
 
         // Box was deleted → ACTIVE backward entry with data.
-        let entry = find_backward_entry(store, box_id.as_bytes(), unwrap_cp)?
+        let entry = find_backward_entry(store, box_id.as_bytes(), unwrap_cp)
+            .await?
             .expect("box should have backward history at unwrap checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(entry.serialized_object.is_some());
@@ -295,7 +301,8 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         let delete_cp = resp.checkpoint.unwrap() as i64;
 
         // Item was deleted → ACTIVE backward entry with previous data.
-        let entry = find_backward_entry(store, item_id.as_bytes(), delete_cp)?
+        let entry = find_backward_entry(store, item_id.as_bytes(), delete_cp)
+            .await?
             .expect("item should have backward history at delete checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(entry.serialized_object.is_some());
@@ -347,14 +354,16 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         let unwrap_delete_cp = resp.checkpoint.unwrap() as i64;
 
         // Box was deleted → ACTIVE backward entry.
-        let entry = find_backward_entry(store, box2_id.as_bytes(), unwrap_delete_cp)?
+        let entry = find_backward_entry(store, box2_id.as_bytes(), unwrap_delete_cp)
+            .await?
             .expect("box2 should have backward history at unwrap_and_delete checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::Active as i16);
         assert!(entry.serialized_object.is_some());
 
         // Item inside was unwrapped-then-deleted → WRAPPED_OR_DELETED.
         let item2_utd_version = unwrapped_then_deleted_version(&resp, item2_id);
-        let entry = find_backward_entry(store, item2_id.as_bytes(), unwrap_delete_cp)?
+        let entry = find_backward_entry(store, item2_id.as_bytes(), unwrap_delete_cp)
+            .await?
             .expect("item2 should have backward history at unwrap_and_delete checkpoint");
         assert_eq!(entry.object_status, ObjectStatus::WrappedOrDeleted as i16);
         assert_eq!(
@@ -368,7 +377,7 @@ fn backward_history_all_lifecycle_events() -> Result<(), anyhow::Error> {
         // ================================================================
         // Verify full history chain for the first item.
         // ================================================================
-        let all_entries = find_all_entries_for_object(store, item_id.as_bytes())?;
+        let all_entries = find_all_entries_for_object(store, item_id.as_bytes()).await?;
         assert_eq!(
             all_entries.len(),
             5,

--- a/crates/iota-indexer/tests/rpc-tests/checkpointed_objects.rs
+++ b/crates/iota-indexer/tests/rpc-tests/checkpointed_objects.rs
@@ -8,8 +8,12 @@ use std::str::FromStr;
 
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper};
 use iota_indexer::{
-    errors::IndexerError, models::objects::StoredCheckpointedObject, schema::checkpointed_objects,
-    store::PgIndexerStore, types::ObjectStatus,
+    errors::IndexerError,
+    models::objects::StoredCheckpointedObject,
+    read_only_blocking,
+    schema::checkpointed_objects,
+    store::{PgIndexerStore, diesel_macro::spawn_blocking_task},
+    types::ObjectStatus,
 };
 use iota_json::call_args;
 use iota_sdk_crypto::simple::SimpleKeypair;
@@ -23,17 +27,23 @@ use crate::{
     },
 };
 
-fn find_checkpointed_object(
+async fn find_checkpointed_object(
     store: &PgIndexerStore,
     object_id: &[u8],
 ) -> Result<Option<StoredCheckpointedObject>, IndexerError> {
-    iota_indexer::read_only_blocking!(&store.blocking_cp(), |conn| {
-        checkpointed_objects::table
-            .filter(checkpointed_objects::object_id.eq(object_id))
-            .select(StoredCheckpointedObject::as_select())
-            .first::<StoredCheckpointedObject>(conn)
-            .optional()
+    let blocking_cp = store.blocking_cp();
+    let object_id = object_id.to_vec();
+    spawn_blocking_task(move || {
+        read_only_blocking!(&blocking_cp, |conn| {
+            checkpointed_objects::table
+                .filter(checkpointed_objects::object_id.eq(object_id))
+                .select(StoredCheckpointedObject::as_select())
+                .first::<StoredCheckpointedObject>(conn)
+                .optional()
+        })
     })
+    .await
+    .expect("failed to join Tokio blocking task")
 }
 
 #[test]
@@ -77,7 +87,8 @@ fn checkpointed_objects_wrap_delete_unwrap_lifecycle() -> Result<(), anyhow::Err
         .await;
         let (item_id, _) = first_created(&resp);
 
-        let entry = find_checkpointed_object(store, item_id.as_bytes())?
+        let entry = find_checkpointed_object(store, item_id.as_bytes())
+            .await?
             .expect("item should exist in checkpointed_objects after creation");
         assert_eq!(
             entry.object_status,
@@ -102,7 +113,8 @@ fn checkpointed_objects_wrap_delete_unwrap_lifecycle() -> Result<(), anyhow::Err
         .await;
         let (box_id, _) = first_created(&resp);
 
-        let entry = find_checkpointed_object(store, item_id.as_bytes())?
+        let entry = find_checkpointed_object(store, item_id.as_bytes())
+            .await?
             .expect("wrapped item should still exist in checkpointed_objects as tombstone");
         assert_eq!(
             entry.object_status,
@@ -114,7 +126,8 @@ fn checkpointed_objects_wrap_delete_unwrap_lifecycle() -> Result<(), anyhow::Err
         assert!(entry.serialized_object.is_none());
 
         // Box should be Active.
-        let entry = find_checkpointed_object(store, box_id.as_bytes())?
+        let entry = find_checkpointed_object(store, box_id.as_bytes())
+            .await?
             .expect("box should exist in checkpointed_objects");
         assert_eq!(
             entry.object_status,
@@ -135,7 +148,8 @@ fn checkpointed_objects_wrap_delete_unwrap_lifecycle() -> Result<(), anyhow::Err
         )
         .await;
 
-        let entry = find_checkpointed_object(store, item_id.as_bytes())?
+        let entry = find_checkpointed_object(store, item_id.as_bytes())
+            .await?
             .expect("unwrapped item should exist in checkpointed_objects");
         assert_eq!(
             entry.object_status,
@@ -147,7 +161,8 @@ fn checkpointed_objects_wrap_delete_unwrap_lifecycle() -> Result<(), anyhow::Err
         assert!(entry.serialized_object.is_some());
 
         // Box should be WrappedOrDeleted (it was consumed by unwrap).
-        let entry = find_checkpointed_object(store, box_id.as_bytes())?
+        let entry = find_checkpointed_object(store, box_id.as_bytes())
+            .await?
             .expect("deleted box should still exist as tombstone");
         assert_eq!(
             entry.object_status,
@@ -168,7 +183,8 @@ fn checkpointed_objects_wrap_delete_unwrap_lifecycle() -> Result<(), anyhow::Err
         )
         .await;
 
-        let entry = find_checkpointed_object(store, item_id.as_bytes())?
+        let entry = find_checkpointed_object(store, item_id.as_bytes())
+            .await?
             .expect("deleted item should still exist as tombstone");
         assert_eq!(
             entry.object_status,

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -10,8 +10,12 @@ use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl};
 use fastcrypto::encoding::Base64;
 use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
 use iota_indexer::{
-    config::RetentionConfig, errors::IndexerError, read_only_blocking, schema::objects,
-    store::indexer_store::IndexerStore, types::IndexerResult,
+    config::RetentionConfig,
+    errors::IndexerError,
+    read_only_blocking,
+    schema::objects,
+    store::{diesel_macro::spawn_blocking_task, indexer_store::IndexerStore},
+    types::IndexerResult,
 };
 use iota_json::{call_arg, call_args, type_args};
 use iota_json_rpc_api::{
@@ -623,8 +627,9 @@ fn optimistic_objects_are_finalized() {
             .await
             .unwrap()
             .unwrap() as i64;
-        let non_finalized_count: i64 = (|| -> Result<_, IndexerError> {
-            read_only_blocking!(&store.blocking_cp(), |conn| {
+        let blocking_cp = store.blocking_cp();
+        let non_finalized_count: i64 = spawn_blocking_task(move || {
+            read_only_blocking!(&blocking_cp, |conn| {
                 objects::table
                     .filter(objects::object_id.eq_any(&changed_object_ids))
                     .filter(
@@ -635,7 +640,9 @@ fn optimistic_objects_are_finalized() {
                     .count()
                     .get_result::<i64>(conn)
             })
-        })()
+        })
+        .await
+        .expect("failed to join Tokio blocking task")
         .unwrap();
 
         assert_eq!(


### PR DESCRIPTION
# Description of change

Makes the `CALLED_FROM_BLOCKING_POOL` flag usage consistent in `iota-indexer`:

- Add `spawn_blocking_task` function : spawns a closure on the blocking thread pool and marks the thread with `mark_in_blocking_pool`. The existing wrappers (`IndexerReader::spawn_blocking`, `PgIndexerStore::execute_in_blocking_worker` / `spawn_blocking_task`, `spawn_read_only_blocking!`) now use it, so the flag is set in a single place.
- All blocking DB query macros now check `blocking_call_is_ok_or_panic!`
- Blocking DB calls that ran directly on async threads now properly spawn new blocking task:
  - the ingestion backfill
  - the analytical store methods (via a new `execute_in_blocking_worker` helper)
  - the pruner partition drops
  - persisting protocol configs
  - test helpers. 
- `PgPartitionManager::new` no longer queries the existing partitions (was a blocking call, needed only for printing a log).
- Removed `run_query!` (an exact alias of `read_only_blocking!`) and `run_query_repeatable!` (no callers)
- `spawn_read_only_blocking!` now reuses the macros to handle both repeatable and non repeatable case.
- Macro docs are now more clear on which method should be called in which context.

## Links to any relevant issues

fixes #9549

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
