### PR TITLE
feat(indexer): remove `objects_snapshot`

### DIFF
--- a/crates/iota-indexer/migrations/pg/2026-08-27-100000_drop_objects_snapshot/down.sql
+++ b/crates/iota-indexer/migrations/pg/2026-08-27-100000_drop_objects_snapshot/down.sql
@@ -1,0 +1,31 @@
+-- Recreate the objects_snapshot table in the state it had just before this
+-- migration
+
+CREATE TABLE objects_snapshot (
+    object_id                   bytea         PRIMARY KEY,
+    object_version              bigint        NOT NULL,
+    object_status               smallint      NOT NULL,
+    object_digest               bytea,
+    checkpoint_sequence_number  bigint        NOT NULL,
+    owner_type                  smallint,
+    owner_id                    bytea,
+    object_type                 text,
+    object_type_package         bytea,
+    object_type_module          text,
+    object_type_name            text,
+    serialized_object           bytea,
+    coin_type                   text,
+    coin_balance                bigint,
+    df_kind                     smallint
+);
+CREATE INDEX objects_snapshot_checkpoint_sequence_number ON objects_snapshot (checkpoint_sequence_number);
+CREATE INDEX objects_snapshot_owner ON objects_snapshot (owner_type, owner_id, object_id) WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL;
+CREATE INDEX objects_snapshot_coin_owner ON objects_snapshot (owner_id, coin_type, object_id) WHERE coin_type IS NOT NULL AND owner_type = 1;
+CREATE INDEX objects_snapshot_coin_only ON objects_snapshot (coin_type, object_id) WHERE coin_type IS NOT NULL;
+CREATE INDEX objects_snapshot_type_id ON objects_snapshot (object_type_package, object_type_module, object_type_name, object_type, object_id);
+CREATE INDEX objects_snapshot_id_type ON objects_snapshot (object_id, object_type_package, object_type_module, object_type_name, object_type);
+CREATE INDEX objects_snapshot_owner_package_module_name_full_type ON objects_snapshot (owner_id, object_type_package, object_type_module, object_type_name, object_type);
+
+CREATE STATISTICS IF NOT EXISTS objects_snapshot_type_stats (dependencies, mcv)
+ON object_type_package, object_type_module, object_type_name, object_type
+FROM objects_snapshot;

--- a/crates/iota-indexer/migrations/pg/2026-08-27-100000_drop_objects_snapshot/up.sql
+++ b/crates/iota-indexer/migrations/pg/2026-08-27-100000_drop_objects_snapshot/up.sql
@@ -1,0 +1,5 @@
+DELETE FROM watermarks WHERE entity = 'objects_snapshot';
+
+-- CASCADE drops the indexes and extended statistics defined on the table
+-- (objects_snapshot_type_stats).
+DROP TABLE IF EXISTS objects_snapshot CASCADE;

--- a/crates/iota-indexer/schema.md
+++ b/crates/iota-indexer/schema.md
@@ -77,18 +77,6 @@ The Indexer pulls checkpoint data from the full node and populates the tables sh
 | objects_package_module_name_full_type       | object_type_package, object_type_module, object_type_name, object_type           |                                                           |
 | objects_owner_package_module_name_full_type | owner_id, object_type_package, object_type_module, object_type_name, object_type |                                                           |
 
-### Table `objects_snapshot`
-
-| Index name                                           | Keys                                                                              | Condition                                                 |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| objects_snapshot_checkpoint_sequence_number          | checkpoint_sequence_number                                                        |                                                           |
-| objects_snapshot_owner                               | owner_type, owner_id, object_id                                                   | WHERE owner_type BETWEEN 1 AND 2 AND owner_id IS NOT NULL |
-| objects_snapshot_coin_owner                          | owner_id, coin_type, object_id                                                    | WHERE coin_type IS NOT NULL AND owner_type = 1            |
-| objects_snapshot_coin_only                           | coin_type, object_id                                                              | WHERE coin_type IS NOT NULL                               |
-| objects_snapshot_type_id                             | object_type_package, object_type_module, object_type_name, object_type, object_id |                                                           |
-| objects_snapshot_id_type                             | object_id, object_type_package, object_type_module, object_type_name, object_type |                                                           |
-| objects_snapshot_owner_package_module_name_full_type | owner_id, object_type_package, object_type_module, object_type_name, object_type  |                                                           |
-
 ### Table `transactions`
 
 | Index name                              | Keys                       | Condition                  |

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -281,26 +281,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    objects_snapshot (object_id) {
-        object_id -> Bytea,
-        object_version -> Int8,
-        object_status -> Int2,
-        object_digest -> Nullable<Bytea>,
-        checkpoint_sequence_number -> Int8,
-        owner_type -> Nullable<Int2>,
-        owner_id -> Nullable<Bytea>,
-        object_type -> Nullable<Text>,
-        object_type_package -> Nullable<Bytea>,
-        object_type_module -> Nullable<Text>,
-        object_type_name -> Nullable<Text>,
-        serialized_object -> Nullable<Bytea>,
-        coin_type -> Nullable<Text>,
-        coin_balance -> Nullable<Int8>,
-        df_kind -> Nullable<Int2>,
-    }
-}
-
-diesel::table! {
     objects_version (object_id, object_version) {
         object_id -> Bytea,
         object_version -> Int8,
@@ -497,7 +477,6 @@ macro_rules! for_all_tables {
             move_calls,
             objects,
             objects_backward_history,
-            objects_snapshot,
             objects_version,
             optimistic_transactions,
             packages,


### PR DESCRIPTION
# Description of change

Drop the `objects_snapshot` table. Nothing reads or writes it any more - consistent views are served by `checkpointed_objects` and `objects_backward_history`. 

## Links to any relevant issues

fixes #12787

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
