### PR TITLE
feat(consensus): drop and charge out-of-order blocks on a subscription stream

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -865,22 +865,27 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 }
             };
             self.misbehavior_store.record_faulty_block(peer, peer, &e);
-            let reason = if equivocation {
-                "equivocation"
-            } else if block_ref.round == previous.round {
-                "repeat"
+            if equivocation {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .dropped_slot_cap_headers_total
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        DataSource::BlockStreaming.as_str(),
+                    ])
+                    .inc();
             } else {
-                "regression"
-            };
-            self.context
-                .metrics
-                .node_metrics
-                .dropped_out_of_order_streamed_blocks_total
-                .with_label_values(&[peer_hostname.as_str(), reason])
-                .inc();
+                self.context
+                    .metrics
+                    .node_metrics
+                    .dropped_out_of_order_streamed_blocks_total
+                    .with_label_values(&[peer_hostname.as_str()])
+                    .inc();
+            }
             warn!(
                 "Peer {peer} streamed block {block_ref} at or below its round {} already held: \
-                 dropping it ({reason})",
+                 dropping it ({e})",
                 previous.round
             );
             return Err(e);
@@ -2309,9 +2314,9 @@ mod tests {
     }
 
     /// Over one subscription stream the peer's primary block round must
-    /// strictly increase. A repeated or regressing block is dropped before its
-    /// payload reaches the reconstructor or the core and is charged to the
-    /// peer; a same-round block with another digest is charged as
+    /// strictly increase. A block at or below the highest round seen is dropped
+    /// before its payload reaches the reconstructor or the core and is charged
+    /// to the peer; a same-round block with another digest is charged as
     /// equivocation; a gap in rounds is fine.
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_enforces_stream_round_order() {
@@ -2361,8 +2366,8 @@ mod tests {
         );
         while fixture.tx_message_receiver.try_recv().is_ok() {}
 
-        // A repeat, a regression, and a second digest for a round already
-        // streamed.
+        // The same block again, a lower round, and a second digest for a round
+        // already streamed.
         for block in [&block_4, &block_3, &block_4_other] {
             fixture
                 .authority_service
@@ -2410,28 +2415,39 @@ mod tests {
         let counts = totals[peer.value()].as_v2();
         assert_eq!(
             counts.faulty_blocks_unprovable, 2,
-            "the repeat and the regression are charged to the peer"
+            "the repeated block and the lower round are charged to the peer"
         );
         assert_eq!(
             counts.faulty_blocks_provable, 1,
             "a second digest for a streamed round is equivocation"
         );
-        for reason in ["repeat", "regression", "equivocation"] {
-            assert_eq!(
-                context
-                    .metrics
-                    .node_metrics
-                    .dropped_out_of_order_streamed_blocks_total
-                    .with_label_values(&[context.authority_hostname(peer), reason])
-                    .get(),
-                1,
-                "one dropped block counted as {reason}"
-            );
-        }
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_out_of_order_streamed_blocks_total
+                .with_label_values(&[context.authority_hostname(peer)])
+                .get(),
+            2,
+            "the repeated block and the lower round are counted as round violations"
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_slot_cap_headers_total
+                .with_label_values(&[
+                    context.authority_hostname(peer),
+                    DataSource::BlockStreaming.as_str(),
+                ])
+                .get(),
+            1,
+            "the second digest is counted as an equivocation drop"
+        );
     }
 
     /// A block below the stream position whose slot already holds an accepted
-    /// header is charged as equivocation, not as a regression.
+    /// header is charged as equivocation, not merely for the round.
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_accepted_slot_beats_stream_order() {
         let (context, _keys) = Context::new_for_test(4);
@@ -2481,23 +2497,33 @@ mod tests {
         let counts = totals[peer.value()].as_v2();
         assert_eq!(counts.faulty_blocks_provable, 1);
         assert_eq!(counts.faulty_blocks_unprovable, 0);
-        for (reason, expected) in [("equivocation", 1), ("regression", 0)] {
-            assert_eq!(
-                context
-                    .metrics
-                    .node_metrics
-                    .dropped_out_of_order_streamed_blocks_total
-                    .with_label_values(&[context.authority_hostname(peer), reason])
-                    .get(),
-                expected
-            );
-        }
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_slot_cap_headers_total
+                .with_label_values(&[
+                    context.authority_hostname(peer),
+                    DataSource::BlockStreaming.as_str(),
+                ])
+                .get(),
+            1
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_out_of_order_streamed_blocks_total
+                .with_label_values(&[context.authority_hostname(peer)])
+                .get(),
+            0
+        );
     }
 
     /// A subscription asks for blocks above `last_received`, so a fresh stream
     /// starting at or below that round is a violation from its first block.
-    /// Without a digest for that round the same-round block can only be
-    /// charged as a repeat; with one, another digest is equivocation.
+    /// Without a digest for that round a same-round block can only be charged
+    /// for the round; with one, another digest is equivocation.
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_stream_must_start_above_requested_round() {
         let (context, _keys) = Context::new_for_test(4);

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -835,12 +835,81 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let block_ref = verified_block.reference();
         let transaction_ref = verified_block.transaction_ref();
         let gen_transaction_ref = GenericTransactionRef::from(transaction_ref);
-        // 1b. Track the highest primary block round seen on this connection; the
-        // order check against it runs in step 5c, after the slot check.
+        // 1b. The stream carries the peer's own blocks in proposal order, so the
+        // round must strictly increase over one connection, starting above the
+        // round the subscription asked for. A same-round block with another
+        // digest is the peer's equivocation.
         let previous = *last_streamed_block;
-        if block_ref.round > previous.round {
-            *last_streamed_block = StreamPosition::from(block_ref);
+        if block_ref.round <= previous.round {
+            let equivocation = block_ref.round == previous.round
+                && previous
+                    .digest
+                    .is_some_and(|digest| digest != block_ref.digest);
+            let e = if equivocation {
+                ConsensusError::BlockHeaderEquivocation {
+                    authority: peer,
+                    round: block_ref.round,
+                }
+            } else {
+                ConsensusError::StreamedBlockRoundNotIncreasing {
+                    peer,
+                    round: block_ref.round,
+                    last_round: previous.round,
+                }
+            };
+            self.misbehavior_store.record_faulty_block(peer, peer, &e);
+            let reason = if equivocation {
+                "equivocation"
+            } else if block_ref.round == previous.round {
+                "repeat"
+            } else {
+                "regression"
+            };
+            self.context
+                .metrics
+                .node_metrics
+                .dropped_out_of_order_streamed_blocks_total
+                .with_label_values(&[peer_hostname.as_str(), reason])
+                .inc();
+            warn!(
+                "Peer {peer} streamed block {block_ref} at or below its round {} already held: \
+                 dropping it ({reason})",
+                previous.round
+            );
+            return Err(e);
         }
+        *last_streamed_block = StreamPosition::from(block_ref);
+
+        // 1c. Two signed headers from the author's own stream for one slot are
+        // provable equivocation, so drop the block before its shards and payload
+        // are processed, and charge the author. A same-slot header still only
+        // suspended is caught by the equivalent cap in the block manager.
+        if self
+            .dag_state
+            .read()
+            .contains_other_block_header_at_slot(&block_ref)
+        {
+            let e = ConsensusError::BlockHeaderEquivocation {
+                authority: peer,
+                round: block_ref.round,
+            };
+            self.misbehavior_store.record_faulty_block(peer, peer, &e);
+            self.context
+                .metrics
+                .node_metrics
+                .dropped_slot_cap_headers_total
+                .with_label_values(&[
+                    self.context.authority_hostname(peer),
+                    DataSource::BlockStreaming.as_str(),
+                ])
+                .inc();
+            warn!(
+                "Peer {peer} equivocated: dropping streamed block {block_ref}, its slot already \
+                 holds a header with a different digest"
+            );
+            return Err(e);
+        }
+
         // 2. Record timestamp drift metric (NEW mode - no waiting or rejection)
         let now = self.context.clock.timestamp_utc_ms();
         let block_timestamp_ms = verified_block.timestamp_ms();
@@ -913,94 +982,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             );
         }
 
-        // 5b. Two signed headers from the author's own stream for one slot are
-        // provable equivocation, so drop the block before its shards and payload
-        // are processed, and charge the author. A same-slot header still only
-        // suspended is caught by the equivalent cap in the block manager.
-        let primary_block_equivocates = !primary_block_far_future
-            && self
-                .dag_state
-                .read()
-                .contains_other_block_header_at_slot(&block_ref);
-        if primary_block_equivocates {
-            let e = ConsensusError::BlockHeaderEquivocation {
-                authority: peer,
-                round: block_ref.round,
-            };
-            self.misbehavior_store.record_faulty_block(peer, peer, &e);
-            self.context
-                .metrics
-                .node_metrics
-                .dropped_slot_cap_headers_total
-                .with_label_values(&[
-                    self.context.authority_hostname(peer),
-                    DataSource::BlockStreaming.as_str(),
-                ])
-                .inc();
-            warn!(
-                "Peer {peer} equivocated: dropping streamed block {block_ref}, its slot already \
-                 holds a header with a different digest"
-            );
-        }
-        // 5c. The stream carries the peer's own blocks in proposal order, so the
-        // round must strictly increase over one connection, starting above the
-        // round the subscription asked for. A repeated or regressing block is
-        // dropped and charged to the peer; a same-round block with another
-        // digest is the peer's equivocation, charged here unless the slot check
-        // above already charged it.
-        let primary_block_out_of_order = if block_ref.round <= previous.round {
-            let equivocation = block_ref.round == previous.round
-                && previous
-                    .digest
-                    .is_some_and(|digest| digest != block_ref.digest);
-            if !primary_block_equivocates {
-                let e = if equivocation {
-                    ConsensusError::BlockHeaderEquivocation {
-                        authority: peer,
-                        round: block_ref.round,
-                    }
-                } else {
-                    ConsensusError::StreamedBlockRoundNotIncreasing {
-                        peer,
-                        round: block_ref.round,
-                        last_round: previous.round,
-                    }
-                };
-                self.misbehavior_store.record_faulty_block(peer, peer, &e);
-            }
-            let reason = if equivocation {
-                "equivocation"
-            } else if block_ref.round == previous.round {
-                "repeat"
-            } else {
-                "regression"
-            };
-            self.context
-                .metrics
-                .node_metrics
-                .dropped_out_of_order_streamed_blocks_total
-                .with_label_values(&[peer_hostname.as_str(), reason])
-                .inc();
-            warn!(
-                "Peer {peer} streamed block {block_ref} at or below its round {} already held: \
-                 dropping it ({reason})",
-                previous.round
-            );
-            true
-        } else {
-            false
-        };
-        // The block is not accepted for any of these reasons, so the steps below
-        // skip it.
-        let primary_block_dropped =
-            primary_block_far_future || primary_block_equivocates || primary_block_out_of_order;
-
         // 6. Collect shards from a bundle and check their proofs. Skipped for a
         // dropped primary block so its shards never reach the reconstructor. The
         // bundled headers still go through: they are signed by their authors and
         // already verified, while a shard's proof is checked only against the
         // commitment carried inside the shard itself.
-        let verified_shards = if primary_block_dropped {
+        let verified_shards = if primary_block_far_future {
             Vec::new()
         } else {
             let serialized_shards =
@@ -1061,7 +1048,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // 9. Prepare transaction messages for shard reconstructor and send them.
         // Skipped for a dropped primary block (no shards were collected).
-        if !primary_block_dropped {
+        if !primary_block_far_future {
             let transaction_messages = TransactionMessage::create_transaction_messages(
                 &verified_blocks[0],
                 &verified_shards,
@@ -1096,7 +1083,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // 11. Add the block to dag, add its missing ancestors to the set. A
         // block dropped above is not forwarded to the core.
-        if !primary_block_dropped {
+        if !primary_block_far_future {
             let (missing_block_ancestors, missing_block_committed_transactions) = self
                 .core_dispatcher
                 .add_blocks(verified_blocks, DataSource::BlockStreaming)
@@ -1123,7 +1110,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // 12. Add our shard from the received block and its proof to the dag_state
         // only if it contains transactions and the block was not dropped.
-        if let Some(shard_for_core) = shard_for_core.filter(|_| !primary_block_dropped) {
+        if let Some(shard_for_core) = shard_for_core.filter(|_| !primary_block_far_future) {
             let serialized_shard_for_core: Bytes = bcs::to_bytes(&shard_for_core)
                 .map_err(ConsensusError::SerializationFailure)?
                 .into();
@@ -2341,15 +2328,18 @@ mod tests {
             .accept_block_header(accepted, DataSource::BlockBundleStream);
 
         let bundle = SerializedBlockBundle::try_from(input_block).unwrap();
-        authority_service
+        let result = authority_service
             .handle_subscribed_block_bundle(
                 peer,
                 bundle,
                 &mut encoder,
                 &mut StreamPosition::default(),
             )
-            .await
-            .unwrap();
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConsensusError::BlockHeaderEquivocation { .. })
+        ));
 
         assert!(
             tx_message_receiver.try_recv().is_err(),
@@ -2521,7 +2511,7 @@ mod tests {
                     &mut last_streamed_block,
                 )
                 .await
-                .unwrap();
+                .unwrap_err();
             assert!(
                 fixture.tx_message_receiver.try_recv().is_err(),
                 "a dropped block must not feed the shard reconstructor"
@@ -2578,8 +2568,8 @@ mod tests {
         }
     }
 
-    /// A same-round block the slot check already charged as equivocation is
-    /// not charged again by the stream order check.
+    /// A same-round block for a slot whose header is both accepted and the
+    /// stream position is charged once, as equivocation.
     #[tokio::test(flavor = "current_thread")]
     async fn test_handle_subscribed_block_bundle_stream_round_order_charges_equivocation_once() {
         let (context, _keys) = Context::new_for_test(4);
@@ -2606,7 +2596,7 @@ mod tests {
         );
 
         let mut last_streamed_block = StreamPosition::from(accepted.reference());
-        fixture
+        let result = fixture
             .authority_service
             .handle_subscribed_block_bundle(
                 peer,
@@ -2614,8 +2604,11 @@ mod tests {
                 &mut encoder,
                 &mut last_streamed_block,
             )
-            .await
-            .unwrap();
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConsensusError::BlockHeaderEquivocation { .. })
+        ));
 
         assert!(fixture.core_dispatcher.get_blocks().is_empty());
         let totals = fixture.misbehavior_store.snapshot_totals();
@@ -2664,7 +2657,7 @@ mod tests {
             round: 4,
             digest: None,
         };
-        for block in [&block_3, &block_4_other, &block_5] {
+        for block in [&block_3, &block_4_other] {
             fixture
                 .authority_service
                 .handle_subscribed_block_bundle(
@@ -2674,8 +2667,18 @@ mod tests {
                     &mut last_streamed_block,
                 )
                 .await
-                .unwrap();
+                .unwrap_err();
         }
+        fixture
+            .authority_service
+            .handle_subscribed_block_bundle(
+                peer,
+                SerializedBlockBundle::try_from(block_5.clone()).unwrap(),
+                &mut encoder,
+                &mut last_streamed_block,
+            )
+            .await
+            .unwrap();
         assert_eq!(fixture.core_dispatcher.get_blocks(), vec![block_5.clone()]);
         let totals = fixture.misbehavior_store.snapshot_totals();
         let counts = totals[peer.value()].as_v2();
@@ -2684,7 +2687,7 @@ mod tests {
 
         // Requested blocks above round 4 while holding block 4 itself.
         let mut last_streamed_block = StreamPosition::from(block_4.reference());
-        fixture
+        let result = fixture
             .authority_service
             .handle_subscribed_block_bundle(
                 peer,
@@ -2692,8 +2695,11 @@ mod tests {
                 &mut encoder,
                 &mut last_streamed_block,
             )
-            .await
-            .unwrap();
+            .await;
+        assert!(matches!(
+            result,
+            Err(ConsensusError::BlockHeaderEquivocation { .. })
+        ));
         let totals = fixture.misbehavior_store.snapshot_totals();
         let counts = totals[peer.value()].as_v2();
         assert_eq!(counts.faulty_blocks_provable, 1);

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -795,6 +795,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
         encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
+        last_streamed_block: &mut Option<BlockRef>,
     ) -> ConsensusResult<()> {
         fail_point_async!("consensus-rpc-response");
         let _s = self
@@ -834,6 +835,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let block_ref = verified_block.reference();
         let transaction_ref = verified_block.transaction_ref();
         let gen_transaction_ref = GenericTransactionRef::from(transaction_ref);
+        // 1b. Track the highest primary block round seen on this connection; the
+        // order check against it runs in step 5c, after the slot check.
+        let previous_streamed_block = *last_streamed_block;
+        if previous_streamed_block.is_none_or(|last| block_ref.round > last.round) {
+            *last_streamed_block = Some(block_ref);
+        }
         // 2. Record timestamp drift metric (NEW mode - no waiting or rejection)
         let now = self.context.clock.timestamp_utc_ms();
         let block_timestamp_ms = verified_block.timestamp_ms();
@@ -935,8 +942,54 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                  holds a header with a different digest"
             );
         }
-        // The block is not accepted for either reason, so the steps below skip it.
-        let primary_block_dropped = primary_block_far_future || primary_block_equivocates;
+        // 5c. The stream carries the peer's own blocks in proposal order, so the
+        // round must strictly increase over one connection. A repeated or
+        // regressing block is dropped and charged to the peer; a same-round
+        // block with another digest is the peer's equivocation, charged here
+        // unless the slot check above already charged it.
+        let primary_block_out_of_order = match previous_streamed_block {
+            Some(last) if block_ref.round <= last.round => {
+                let equivocation = block_ref.round == last.round && block_ref.digest != last.digest;
+                if !primary_block_equivocates {
+                    let e = if equivocation {
+                        ConsensusError::BlockHeaderEquivocation {
+                            authority: peer,
+                            round: block_ref.round,
+                        }
+                    } else {
+                        ConsensusError::StreamedBlockRoundNotIncreasing {
+                            peer,
+                            round: block_ref.round,
+                            last_round: last.round,
+                        }
+                    };
+                    self.misbehavior_store.record_faulty_block(peer, peer, &e);
+                }
+                let reason = if equivocation {
+                    "equivocation"
+                } else if block_ref.round == last.round {
+                    "repeat"
+                } else {
+                    "regression"
+                };
+                self.context
+                    .metrics
+                    .node_metrics
+                    .dropped_out_of_order_streamed_blocks_total
+                    .with_label_values(&[peer_hostname.as_str(), reason])
+                    .inc();
+                warn!(
+                    "Peer {peer} streamed block {block_ref} after its block {last}: dropping it \
+                     ({reason})"
+                );
+                true
+            }
+            _ => false,
+        };
+        // The block is not accepted for any of these reasons, so the steps below
+        // skip it.
+        let primary_block_dropped =
+            primary_block_far_future || primary_block_equivocates || primary_block_out_of_order;
 
         // 6. Collect shards from a bundle and check their proofs. Skipped for a
         // dropped primary block so its shards never reach the reconstructor. The
@@ -1935,7 +1988,7 @@ mod tests {
         core::{Core, CoreSignals, ReasonToCreateBlock},
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::{DagState, DataSource},
-        encoder::create_encoder,
+        encoder::{ShardEncoder, create_encoder},
         error::{ConsensusError, ConsensusResult},
         header_synchronizer::HeaderSynchronizer,
         leader_schedule::LeaderSchedule,
@@ -1945,6 +1998,7 @@ mod tests {
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
             SerializedTransactionsV2, TransactionFetchMode,
         },
+        shard_reconstructor::TransactionMessage,
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
         transaction::TransactionConsumer,
@@ -2091,6 +2145,7 @@ mod tests {
                 context.committee.to_authority_index(1).unwrap(),
                 serialized_block_bundle.clone(),
                 &mut encoder,
+                &mut None,
             )
             .await;
 
@@ -2107,6 +2162,7 @@ mod tests {
                     context.committee.to_authority_index(0).unwrap(),
                     serialized_block_bundle,
                     &mut encoder,
+                    &mut None,
                 )
                 .await
                 .unwrap();
@@ -2180,6 +2236,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 bundle,
                 &mut encoder,
+                &mut None,
             )
             .await
             .unwrap();
@@ -2281,7 +2338,7 @@ mod tests {
 
         let bundle = SerializedBlockBundle::try_from(input_block).unwrap();
         authority_service
-            .handle_subscribed_block_bundle(peer, bundle, &mut encoder)
+            .handle_subscribed_block_bundle(peer, bundle, &mut encoder, &mut None)
             .await
             .unwrap();
 
@@ -2310,6 +2367,254 @@ mod tests {
         assert_eq!(
             counts.faulty_blocks_provable, 1,
             "two signed headers for one slot are provable equivocation"
+        );
+    }
+
+    /// Service wired to a mock core, for tests that drive
+    /// `handle_subscribed_block_bundle` directly.
+    struct StreamFixture {
+        authority_service: Arc<AuthorityService<MockCoreThreadDispatcher>>,
+        misbehavior_store: Arc<MisbehaviorStore>,
+        core_dispatcher: Arc<MockCoreThreadDispatcher>,
+        dag_state: Arc<RwLock<DagState>>,
+        tx_message_receiver: mpsc::Receiver<Vec<TransactionMessage>>,
+    }
+
+    fn stream_fixture(context: Arc<Context>) -> StreamFixture {
+        let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
+        let (tx_message_sender, tx_message_receiver) = mpsc::channel(100);
+        let network_client = Arc::new(FakeNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
+        let transactions_synchronizer = TransactionsSynchronizer::start(
+            network_client.clone(),
+            context.clone(),
+            core_dispatcher.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+        );
+        let header_synchronizer = HeaderSynchronizer::start(
+            network_client,
+            context.clone(),
+            core_dispatcher.clone(),
+            commit_vote_monitor.clone(),
+            transactions_synchronizer.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            false,
+            None,
+            Arc::new(MisbehaviorStore::new(&context)),
+        );
+        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
+        let authority_service = Arc::new(AuthorityService::new(
+            context,
+            block_verifier,
+            commit_vote_monitor,
+            header_synchronizer,
+            transactions_synchronizer,
+            core_dispatcher.clone(),
+            rx_block_broadcast,
+            dag_state.clone(),
+            store,
+            misbehavior_store.clone(),
+            tx_message_sender,
+            cordial_knowledge,
+        ));
+        StreamFixture {
+            authority_service,
+            misbehavior_store,
+            core_dispatcher,
+            dag_state,
+            tx_message_receiver,
+        }
+    }
+
+    /// A block of authority 0 at `round`; `ancestors` only varies the digest.
+    fn own_block(
+        context: &Arc<Context>,
+        encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
+        round: Round,
+        ancestors: Vec<BlockRef>,
+    ) -> VerifiedBlock {
+        VerifiedBlock::new_for_test(
+            TestBlockHeader::new_with_commitment(round, 0, context, encoder)
+                .set_ancestors(ancestors)
+                .build(),
+        )
+    }
+
+    /// Over one subscription stream the peer's primary block round must
+    /// strictly increase. A repeated or regressing block is dropped before its
+    /// payload reaches the reconstructor or the core and is charged to the
+    /// peer; a same-round block with another digest is charged as
+    /// equivocation; a gap in rounds is fine.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_subscribed_block_bundle_enforces_stream_round_order() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let mut fixture = stream_fixture(context.clone());
+        let mut encoder = create_encoder(&context);
+        let peer = context.committee.to_authority_index(0).unwrap();
+
+        let block_2 = own_block(&context, &mut encoder, 2, vec![]);
+        let block_4 = own_block(&context, &mut encoder, 4, vec![]);
+        let block_3 = own_block(&context, &mut encoder, 3, vec![]);
+        let block_4_other = own_block(
+            &context,
+            &mut encoder,
+            4,
+            vec![BlockRef::new(
+                GENESIS_ROUND,
+                AuthorityIndex::new_for_test(1),
+                BlockHeaderDigest::MIN,
+            )],
+        );
+        let block_5 = own_block(&context, &mut encoder, 5, vec![]);
+        assert_ne!(block_4.reference(), block_4_other.reference());
+
+        let mut last_streamed_block = None;
+        for block in [&block_2, &block_4] {
+            fixture
+                .authority_service
+                .handle_subscribed_block_bundle(
+                    peer,
+                    SerializedBlockBundle::try_from(block.clone()).unwrap(),
+                    &mut encoder,
+                    &mut last_streamed_block,
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            fixture.core_dispatcher.get_blocks(),
+            vec![block_2.clone(), block_4.clone()],
+            "increasing rounds, with a gap, are accepted"
+        );
+        assert_eq!(last_streamed_block, Some(block_4.reference()));
+        while fixture.tx_message_receiver.try_recv().is_ok() {}
+
+        // A repeat, a regression, and a second digest for a round already
+        // streamed.
+        for block in [&block_4, &block_3, &block_4_other] {
+            fixture
+                .authority_service
+                .handle_subscribed_block_bundle(
+                    peer,
+                    SerializedBlockBundle::try_from(block.clone()).unwrap(),
+                    &mut encoder,
+                    &mut last_streamed_block,
+                )
+                .await
+                .unwrap();
+            assert!(
+                fixture.tx_message_receiver.try_recv().is_err(),
+                "a dropped block must not feed the shard reconstructor"
+            );
+        }
+        assert_eq!(
+            fixture.core_dispatcher.get_blocks().len(),
+            2,
+            "dropped blocks are not forwarded to the core"
+        );
+        assert_eq!(
+            last_streamed_block,
+            Some(block_4.reference()),
+            "dropped blocks do not move the stream position"
+        );
+
+        fixture
+            .authority_service
+            .handle_subscribed_block_bundle(
+                peer,
+                SerializedBlockBundle::try_from(block_5.clone()).unwrap(),
+                &mut encoder,
+                &mut last_streamed_block,
+            )
+            .await
+            .unwrap();
+        assert_eq!(fixture.core_dispatcher.get_blocks().len(), 3);
+        assert_eq!(last_streamed_block, Some(block_5.reference()));
+
+        let totals = fixture.misbehavior_store.snapshot_totals();
+        let counts = totals[peer.value()].as_v2();
+        assert_eq!(
+            counts.faulty_blocks_unprovable, 2,
+            "the repeat and the regression are charged to the peer"
+        );
+        assert_eq!(
+            counts.faulty_blocks_provable, 1,
+            "a second digest for a streamed round is equivocation"
+        );
+        for reason in ["repeat", "regression", "equivocation"] {
+            assert_eq!(
+                context
+                    .metrics
+                    .node_metrics
+                    .dropped_out_of_order_streamed_blocks_total
+                    .with_label_values(&[context.authority_hostname(peer), reason])
+                    .get(),
+                1,
+                "one dropped block counted as {reason}"
+            );
+        }
+    }
+
+    /// A same-round block the slot check already charged as equivocation is
+    /// not charged again by the stream order check.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_subscribed_block_bundle_stream_round_order_charges_equivocation_once() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let fixture = stream_fixture(context.clone());
+        let mut encoder = create_encoder(&context);
+        let peer = context.committee.to_authority_index(0).unwrap();
+
+        let accepted = own_block(
+            &context,
+            &mut encoder,
+            1,
+            vec![BlockRef::new(
+                GENESIS_ROUND,
+                AuthorityIndex::new_for_test(1),
+                BlockHeaderDigest::MIN,
+            )],
+        );
+        let input_block = own_block(&context, &mut encoder, 1, vec![]);
+        assert_ne!(accepted.reference(), input_block.reference());
+        fixture.dag_state.write().accept_block_header(
+            accepted.verified_block_header.clone(),
+            DataSource::BlockBundleStream,
+        );
+
+        let mut last_streamed_block = Some(accepted.reference());
+        fixture
+            .authority_service
+            .handle_subscribed_block_bundle(
+                peer,
+                SerializedBlockBundle::try_from(input_block).unwrap(),
+                &mut encoder,
+                &mut last_streamed_block,
+            )
+            .await
+            .unwrap();
+
+        assert!(fixture.core_dispatcher.get_blocks().is_empty());
+        let totals = fixture.misbehavior_store.snapshot_totals();
+        let counts = totals[peer.value()].as_v2();
+        assert_eq!(counts.faulty_blocks_provable, 1);
+        assert_eq!(counts.faulty_blocks_unprovable, 0);
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_out_of_order_streamed_blocks_total
+                .with_label_values(&[context.authority_hostname(peer), "equivocation"])
+                .get(),
+            1
         );
     }
 
@@ -2395,7 +2700,7 @@ mod tests {
         let bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
 
         let result = authority_service
-            .handle_subscribed_block_bundle(peer, bundle.clone(), &mut encoder)
+            .handle_subscribed_block_bundle(peer, bundle.clone(), &mut encoder, &mut None)
             .await;
         assert!(
             matches!(result, Err(ConsensusError::BlockRejected { .. })),
@@ -2431,7 +2736,7 @@ mod tests {
         });
 
         authority_service
-            .handle_subscribed_block_bundle(peer, bundle, &mut encoder)
+            .handle_subscribed_block_bundle(peer, bundle, &mut encoder, &mut None)
             .await
             .unwrap();
         assert_eq!(core_dispatcher.get_blocks(), vec![input_block]);
@@ -2524,7 +2829,7 @@ mod tests {
         let bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
 
         authority_service
-            .handle_subscribed_block_bundle(peer, bundle, &mut encoder)
+            .handle_subscribed_block_bundle(peer, bundle, &mut encoder, &mut None)
             .await
             .unwrap();
         assert_eq!(core_dispatcher.get_blocks(), vec![input_block]);
@@ -2613,6 +2918,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 serialized_block_bundle,
                 &mut encoder,
+                &mut None,
             )
             .await;
 
@@ -2645,6 +2951,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 malformed_bundle,
                 &mut encoder,
+                &mut None,
             )
             .await;
         assert!(matches!(
@@ -2747,6 +3054,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 serialized_block_bundle_with_big_round,
                 &mut encoder,
+                &mut None,
             )
             .await;
 
@@ -2790,6 +3098,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 serialized_block_bundle,
                 &mut encoder,
+                &mut None,
             )
             .await;
 
@@ -2834,6 +3143,7 @@ mod tests {
                     context.committee.to_authority_index(0).unwrap(),
                     serialized_block_bundle,
                     &mut encoder,
+                    &mut None,
                 )
                 .await
                 .unwrap();
@@ -2921,6 +3231,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 serialized_block_bundle,
                 &mut encoder,
+                &mut None,
             )
             .await;
 
@@ -3241,6 +3552,7 @@ mod tests {
             all_headers.push(dag_builder.block_headers(round..=round));
             all_transactions.push(dag_builder.transactions(round..=round));
         }
+        let mut last_streamed_blocks = vec![None; validators];
         for round in 1..=rounds {
             core_dispatcher
                 .add_block_headers(
@@ -3282,6 +3594,7 @@ mod tests {
                         context.committee.to_authority_index(peer).unwrap(),
                         serialized_block_bundle,
                         &mut encoder,
+                        &mut last_streamed_blocks[peer],
                     )
                     .await
                     .expect("bundle is expected to be processed successfully");
@@ -3457,6 +3770,7 @@ mod tests {
                     ],
                 ),
                 &mut encoder,
+                &mut None,
             )
             .await
             .expect("bundle is expected to be processed successfully");
@@ -3490,6 +3804,7 @@ mod tests {
                 peer_2,
                 send_bundle(2, vec![newest_of_author_3.clone()]),
                 &mut encoder,
+                &mut None,
             )
             .await
             .expect("bundle is expected to be processed successfully");
@@ -3612,6 +3927,7 @@ mod tests {
             all_headers.push(dag_builder.block_headers(round..=round));
             all_transactions.push(dag_builder.transactions(round..=round));
         }
+        let mut last_streamed_blocks = vec![None; validators];
         for round in 1..=rounds {
             core_dispatcher
                 .add_block_headers(
@@ -3645,6 +3961,7 @@ mod tests {
                         context.committee.to_authority_index(peer).unwrap(),
                         serialized_block_bundle,
                         &mut encoder,
+                        &mut last_streamed_blocks[peer],
                     )
                     .await
                     .expect("bundle is expected to be processed successfully");

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -835,46 +835,23 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let block_ref = verified_block.reference();
         let transaction_ref = verified_block.transaction_ref();
         let gen_transaction_ref = GenericTransactionRef::from(transaction_ref);
-        // 1b. Two signed headers from the author's own stream for one slot are
-        // provable equivocation, so drop the block before its shards and payload
-        // are processed, and charge the author. Runs before the order check so
-        // the stronger charge wins whenever the slot is already accepted.
-        if self
-            .dag_state
-            .read()
-            .contains_other_block_header_at_slot(&block_ref)
-        {
-            let e = ConsensusError::BlockHeaderEquivocation {
-                authority: peer,
-                round: block_ref.round,
-            };
-            self.misbehavior_store.record_faulty_block(peer, peer, &e);
-            self.context
-                .metrics
-                .node_metrics
-                .dropped_slot_cap_headers_total
-                .with_label_values(&[
-                    self.context.authority_hostname(peer),
-                    DataSource::BlockStreaming.as_str(),
-                ])
-                .inc();
-            warn!(
-                "Peer {peer} equivocated: dropping streamed block {block_ref}, its slot already \
-                 holds a header with a different digest"
-            );
-            return Err(e);
-        }
-
-        // 1c. The stream carries the peer's own blocks in proposal order, so the
+        // 1b. The stream carries the peer's own blocks in proposal order, so the
         // round must strictly increase over one connection, starting above the
         // round the subscription asked for. A same-round block with another
-        // digest is the peer's equivocation.
+        // digest is the peer's equivocation, as is a lower-round block whose
+        // slot already holds another accepted header. DagState is read only
+        // for that last case, never for a block in order.
         let previous = *last_streamed_block;
         if block_ref.round <= previous.round {
-            let equivocation = block_ref.round == previous.round
-                && previous
+            let equivocation = if block_ref.round == previous.round {
+                previous
                     .digest
-                    .is_some_and(|digest| digest != block_ref.digest);
+                    .is_some_and(|digest| digest != block_ref.digest)
+            } else {
+                self.dag_state
+                    .read()
+                    .contains_other_block_header_at_slot(&block_ref)
+            };
             let e = if equivocation {
                 ConsensusError::BlockHeaderEquivocation {
                     authority: peer,
@@ -2254,121 +2231,6 @@ mod tests {
         );
     }
 
-    /// A second streamed block for a slot we already accepted a header for is
-    /// provable equivocation by its author: the block is dropped before shard
-    /// extraction, its payload and own shard never reach the core, and the
-    /// author is charged.
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribed_block_bundle_drops_slot_equivocation() {
-        let (context, _keys) = Context::new_for_test(4);
-        let context = Arc::new(context);
-        let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
-        let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
-        let (tx_message_sender, mut tx_message_receiver) = mpsc::channel(100);
-        let network_client = Arc::new(FakeNetworkClient::default());
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
-        let cordial_knowledge = CordialKnowledge::start(context.clone(), dag_state.clone());
-        let transactions_synchronizer = TransactionsSynchronizer::start(
-            network_client.clone(),
-            context.clone(),
-            core_dispatcher.clone(),
-            dag_state.clone(),
-            block_verifier.clone(),
-        );
-        let header_synchronizer = HeaderSynchronizer::start(
-            network_client.clone(),
-            context.clone(),
-            core_dispatcher.clone(),
-            commit_vote_monitor.clone(),
-            transactions_synchronizer.clone(),
-            block_verifier.clone(),
-            dag_state.clone(),
-            false,
-            None,
-            Arc::new(MisbehaviorStore::new(&context)),
-        );
-        let misbehavior_store = Arc::new(MisbehaviorStore::new(&context));
-        let authority_service = Arc::new(AuthorityService::new(
-            context.clone(),
-            block_verifier,
-            commit_vote_monitor,
-            header_synchronizer,
-            transactions_synchronizer,
-            core_dispatcher.clone(),
-            rx_block_broadcast,
-            dag_state.clone(),
-            store,
-            misbehavior_store.clone(),
-            tx_message_sender,
-            cordial_knowledge,
-        ));
-        let mut encoder = create_encoder(&context);
-
-        // Authority 0 already has an accepted header at round 1; the streamed
-        // block below is a different header for the same slot.
-        let peer = context.committee.to_authority_index(0).unwrap();
-        let accepted = VerifiedBlockHeader::new_for_test(
-            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder)
-                .set_ancestors(vec![BlockRef::new(
-                    GENESIS_ROUND,
-                    AuthorityIndex::new_for_test(1),
-                    BlockHeaderDigest::MIN,
-                )])
-                .build(),
-        );
-        let input_block = VerifiedBlock::new_for_test(
-            TestBlockHeader::new_with_commitment(1, 0, &context, &mut encoder).build(),
-        );
-        assert_ne!(accepted.reference(), input_block.reference());
-        dag_state
-            .write()
-            .accept_block_header(accepted, DataSource::BlockBundleStream);
-
-        let bundle = SerializedBlockBundle::try_from(input_block).unwrap();
-        let result = authority_service
-            .handle_subscribed_block_bundle(
-                peer,
-                bundle,
-                &mut encoder,
-                &mut StreamPosition::default(),
-            )
-            .await;
-        assert!(matches!(
-            result,
-            Err(ConsensusError::BlockHeaderEquivocation { .. })
-        ));
-
-        assert!(
-            tx_message_receiver.try_recv().is_err(),
-            "an equivocating bundle must not feed the shard reconstructor"
-        );
-        assert!(
-            core_dispatcher.get_blocks().is_empty(),
-            "the equivocating block must not be forwarded to the core"
-        );
-        assert_eq!(
-            context
-                .metrics
-                .node_metrics
-                .dropped_slot_cap_headers_total
-                .with_label_values(&[
-                    context.authority_hostname(peer),
-                    DataSource::BlockStreaming.as_str(),
-                ])
-                .get(),
-            1,
-        );
-        let totals = misbehavior_store.snapshot_totals();
-        let counts = totals[peer.value()].as_v2();
-        assert_eq!(
-            counts.faulty_blocks_provable, 1,
-            "two signed headers for one slot are provable equivocation"
-        );
-    }
-
     /// Service wired to a mock core, for tests that drive
     /// `handle_subscribed_block_bundle` directly.
     struct StreamFixture {
@@ -2619,27 +2481,17 @@ mod tests {
         let counts = totals[peer.value()].as_v2();
         assert_eq!(counts.faulty_blocks_provable, 1);
         assert_eq!(counts.faulty_blocks_unprovable, 0);
-        assert_eq!(
-            context
-                .metrics
-                .node_metrics
-                .dropped_slot_cap_headers_total
-                .with_label_values(&[
-                    context.authority_hostname(peer),
-                    DataSource::BlockStreaming.as_str(),
-                ])
-                .get(),
-            1
-        );
-        assert_eq!(
-            context
-                .metrics
-                .node_metrics
-                .dropped_out_of_order_streamed_blocks_total
-                .with_label_values(&[context.authority_hostname(peer), "regression"])
-                .get(),
-            0
-        );
+        for (reason, expected) in [("equivocation", 1), ("regression", 0)] {
+            assert_eq!(
+                context
+                    .metrics
+                    .node_metrics
+                    .dropped_out_of_order_streamed_blocks_total
+                    .with_label_values(&[context.authority_hostname(peer), reason])
+                    .get(),
+                expected
+            );
+        }
     }
 
     /// A subscription asks for blocks above `last_received`, so a fresh stream

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -43,7 +43,7 @@ use crate::{
     network::{
         BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockBundle,
         SerializedBlockBundleParts, SerializedHeaderAndTransactions, SerializedTransactionsV2,
-        TransactionFetchMode,
+        StreamPosition, TransactionFetchMode,
     },
     shard_reconstructor::TransactionMessage,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -795,7 +795,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
         encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
-        last_streamed_block: &mut Option<BlockRef>,
+        last_streamed_block: &mut StreamPosition,
     ) -> ConsensusResult<()> {
         fail_point_async!("consensus-rpc-response");
         let _s = self
@@ -837,9 +837,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let gen_transaction_ref = GenericTransactionRef::from(transaction_ref);
         // 1b. Track the highest primary block round seen on this connection; the
         // order check against it runs in step 5c, after the slot check.
-        let previous_streamed_block = *last_streamed_block;
-        if previous_streamed_block.is_none_or(|last| block_ref.round > last.round) {
-            *last_streamed_block = Some(block_ref);
+        let previous = *last_streamed_block;
+        if block_ref.round > previous.round {
+            *last_streamed_block = StreamPosition::from(block_ref);
         }
         // 2. Record timestamp drift metric (NEW mode - no waiting or rejection)
         let now = self.context.clock.timestamp_utc_ms();
@@ -943,48 +943,52 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             );
         }
         // 5c. The stream carries the peer's own blocks in proposal order, so the
-        // round must strictly increase over one connection. A repeated or
-        // regressing block is dropped and charged to the peer; a same-round
-        // block with another digest is the peer's equivocation, charged here
-        // unless the slot check above already charged it.
-        let primary_block_out_of_order = match previous_streamed_block {
-            Some(last) if block_ref.round <= last.round => {
-                let equivocation = block_ref.round == last.round && block_ref.digest != last.digest;
-                if !primary_block_equivocates {
-                    let e = if equivocation {
-                        ConsensusError::BlockHeaderEquivocation {
-                            authority: peer,
-                            round: block_ref.round,
-                        }
-                    } else {
-                        ConsensusError::StreamedBlockRoundNotIncreasing {
-                            peer,
-                            round: block_ref.round,
-                            last_round: last.round,
-                        }
-                    };
-                    self.misbehavior_store.record_faulty_block(peer, peer, &e);
-                }
-                let reason = if equivocation {
-                    "equivocation"
-                } else if block_ref.round == last.round {
-                    "repeat"
+        // round must strictly increase over one connection, starting above the
+        // round the subscription asked for. A repeated or regressing block is
+        // dropped and charged to the peer; a same-round block with another
+        // digest is the peer's equivocation, charged here unless the slot check
+        // above already charged it.
+        let primary_block_out_of_order = if block_ref.round <= previous.round {
+            let equivocation = block_ref.round == previous.round
+                && previous
+                    .digest
+                    .is_some_and(|digest| digest != block_ref.digest);
+            if !primary_block_equivocates {
+                let e = if equivocation {
+                    ConsensusError::BlockHeaderEquivocation {
+                        authority: peer,
+                        round: block_ref.round,
+                    }
                 } else {
-                    "regression"
+                    ConsensusError::StreamedBlockRoundNotIncreasing {
+                        peer,
+                        round: block_ref.round,
+                        last_round: previous.round,
+                    }
                 };
-                self.context
-                    .metrics
-                    .node_metrics
-                    .dropped_out_of_order_streamed_blocks_total
-                    .with_label_values(&[peer_hostname.as_str(), reason])
-                    .inc();
-                warn!(
-                    "Peer {peer} streamed block {block_ref} after its block {last}: dropping it \
-                     ({reason})"
-                );
-                true
+                self.misbehavior_store.record_faulty_block(peer, peer, &e);
             }
-            _ => false,
+            let reason = if equivocation {
+                "equivocation"
+            } else if block_ref.round == previous.round {
+                "repeat"
+            } else {
+                "regression"
+            };
+            self.context
+                .metrics
+                .node_metrics
+                .dropped_out_of_order_streamed_blocks_total
+                .with_label_values(&[peer_hostname.as_str(), reason])
+                .inc();
+            warn!(
+                "Peer {peer} streamed block {block_ref} at or below its round {} already held: \
+                 dropping it ({reason})",
+                previous.round
+            );
+            true
+        } else {
+            false
         };
         // The block is not accepted for any of these reasons, so the steps below
         // skip it.
@@ -1996,7 +2000,7 @@ mod tests {
         network::{
             BlockBundle, BlockBundleStream, NetworkClient, NetworkService, SerializedBlock,
             SerializedBlockBundle, SerializedBlockBundleParts, SerializedHeaderAndTransactions,
-            SerializedTransactionsV2, TransactionFetchMode,
+            SerializedTransactionsV2, StreamPosition, TransactionFetchMode,
         },
         shard_reconstructor::TransactionMessage,
         storage::{Store, WriteBatch, mem_store::MemStore},
@@ -2145,7 +2149,7 @@ mod tests {
                 context.committee.to_authority_index(1).unwrap(),
                 serialized_block_bundle.clone(),
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await;
 
@@ -2162,7 +2166,7 @@ mod tests {
                     context.committee.to_authority_index(0).unwrap(),
                     serialized_block_bundle,
                     &mut encoder,
-                    &mut None,
+                    &mut StreamPosition::default(),
                 )
                 .await
                 .unwrap();
@@ -2236,7 +2240,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 bundle,
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await
             .unwrap();
@@ -2338,7 +2342,12 @@ mod tests {
 
         let bundle = SerializedBlockBundle::try_from(input_block).unwrap();
         authority_service
-            .handle_subscribed_block_bundle(peer, bundle, &mut encoder, &mut None)
+            .handle_subscribed_block_bundle(
+                peer,
+                bundle,
+                &mut encoder,
+                &mut StreamPosition::default(),
+            )
             .await
             .unwrap();
 
@@ -2476,7 +2485,7 @@ mod tests {
         let block_5 = own_block(&context, &mut encoder, 5, vec![]);
         assert_ne!(block_4.reference(), block_4_other.reference());
 
-        let mut last_streamed_block = None;
+        let mut last_streamed_block = StreamPosition::default();
         for block in [&block_2, &block_4] {
             fixture
                 .authority_service
@@ -2494,7 +2503,10 @@ mod tests {
             vec![block_2.clone(), block_4.clone()],
             "increasing rounds, with a gap, are accepted"
         );
-        assert_eq!(last_streamed_block, Some(block_4.reference()));
+        assert_eq!(
+            last_streamed_block,
+            StreamPosition::from(block_4.reference())
+        );
         while fixture.tx_message_receiver.try_recv().is_ok() {}
 
         // A repeat, a regression, and a second digest for a round already
@@ -2522,7 +2534,7 @@ mod tests {
         );
         assert_eq!(
             last_streamed_block,
-            Some(block_4.reference()),
+            StreamPosition::from(block_4.reference()),
             "dropped blocks do not move the stream position"
         );
 
@@ -2537,7 +2549,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fixture.core_dispatcher.get_blocks().len(), 3);
-        assert_eq!(last_streamed_block, Some(block_5.reference()));
+        assert_eq!(
+            last_streamed_block,
+            StreamPosition::from(block_5.reference())
+        );
 
         let totals = fixture.misbehavior_store.snapshot_totals();
         let counts = totals[peer.value()].as_v2();
@@ -2590,7 +2605,7 @@ mod tests {
             DataSource::BlockBundleStream,
         );
 
-        let mut last_streamed_block = Some(accepted.reference());
+        let mut last_streamed_block = StreamPosition::from(accepted.reference());
         fixture
             .authority_service
             .handle_subscribed_block_bundle(
@@ -2616,6 +2631,73 @@ mod tests {
                 .get(),
             1
         );
+    }
+
+    /// A subscription asks for blocks above `last_received`, so a fresh stream
+    /// starting at or below that round is a violation from its first block.
+    /// Without a digest for that round the same-round block can only be
+    /// charged as a repeat; with one, another digest is equivocation.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_subscribed_block_bundle_stream_must_start_above_requested_round() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let fixture = stream_fixture(context.clone());
+        let mut encoder = create_encoder(&context);
+        let peer = context.committee.to_authority_index(0).unwrap();
+
+        let block_3 = own_block(&context, &mut encoder, 3, vec![]);
+        let block_4 = own_block(&context, &mut encoder, 4, vec![]);
+        let block_4_other = own_block(
+            &context,
+            &mut encoder,
+            4,
+            vec![BlockRef::new(
+                GENESIS_ROUND,
+                AuthorityIndex::new_for_test(1),
+                BlockHeaderDigest::MIN,
+            )],
+        );
+        let block_5 = own_block(&context, &mut encoder, 5, vec![]);
+
+        // Requested blocks above round 4 without holding a block at round 4.
+        let mut last_streamed_block = StreamPosition {
+            round: 4,
+            digest: None,
+        };
+        for block in [&block_3, &block_4_other, &block_5] {
+            fixture
+                .authority_service
+                .handle_subscribed_block_bundle(
+                    peer,
+                    SerializedBlockBundle::try_from(block.clone()).unwrap(),
+                    &mut encoder,
+                    &mut last_streamed_block,
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(fixture.core_dispatcher.get_blocks(), vec![block_5.clone()]);
+        let totals = fixture.misbehavior_store.snapshot_totals();
+        let counts = totals[peer.value()].as_v2();
+        assert_eq!(counts.faulty_blocks_unprovable, 2);
+        assert_eq!(counts.faulty_blocks_provable, 0);
+
+        // Requested blocks above round 4 while holding block 4 itself.
+        let mut last_streamed_block = StreamPosition::from(block_4.reference());
+        fixture
+            .authority_service
+            .handle_subscribed_block_bundle(
+                peer,
+                SerializedBlockBundle::try_from(block_4_other).unwrap(),
+                &mut encoder,
+                &mut last_streamed_block,
+            )
+            .await
+            .unwrap();
+        let totals = fixture.misbehavior_store.snapshot_totals();
+        let counts = totals[peer.value()].as_v2();
+        assert_eq!(counts.faulty_blocks_provable, 1);
+        assert_eq!(counts.faulty_blocks_unprovable, 2);
     }
 
     /// A bundle is rejected while local commits run further ahead of the last
@@ -2700,7 +2782,12 @@ mod tests {
         let bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
 
         let result = authority_service
-            .handle_subscribed_block_bundle(peer, bundle.clone(), &mut encoder, &mut None)
+            .handle_subscribed_block_bundle(
+                peer,
+                bundle.clone(),
+                &mut encoder,
+                &mut StreamPosition::default(),
+            )
             .await;
         assert!(
             matches!(result, Err(ConsensusError::BlockRejected { .. })),
@@ -2736,7 +2823,12 @@ mod tests {
         });
 
         authority_service
-            .handle_subscribed_block_bundle(peer, bundle, &mut encoder, &mut None)
+            .handle_subscribed_block_bundle(
+                peer,
+                bundle,
+                &mut encoder,
+                &mut StreamPosition::default(),
+            )
             .await
             .unwrap();
         assert_eq!(core_dispatcher.get_blocks(), vec![input_block]);
@@ -2829,7 +2921,12 @@ mod tests {
         let bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
 
         authority_service
-            .handle_subscribed_block_bundle(peer, bundle, &mut encoder, &mut None)
+            .handle_subscribed_block_bundle(
+                peer,
+                bundle,
+                &mut encoder,
+                &mut StreamPosition::default(),
+            )
             .await
             .unwrap();
         assert_eq!(core_dispatcher.get_blocks(), vec![input_block]);
@@ -2918,7 +3015,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 serialized_block_bundle,
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await;
 
@@ -2951,7 +3048,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 malformed_bundle,
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await;
         assert!(matches!(
@@ -3054,7 +3151,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 serialized_block_bundle_with_big_round,
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await;
 
@@ -3098,7 +3195,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 serialized_block_bundle,
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await;
 
@@ -3143,7 +3240,7 @@ mod tests {
                     context.committee.to_authority_index(0).unwrap(),
                     serialized_block_bundle,
                     &mut encoder,
-                    &mut None,
+                    &mut StreamPosition::default(),
                 )
                 .await
                 .unwrap();
@@ -3231,7 +3328,7 @@ mod tests {
                 context.committee.to_authority_index(0).unwrap(),
                 serialized_block_bundle,
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await;
 
@@ -3552,7 +3649,7 @@ mod tests {
             all_headers.push(dag_builder.block_headers(round..=round));
             all_transactions.push(dag_builder.transactions(round..=round));
         }
-        let mut last_streamed_blocks = vec![None; validators];
+        let mut last_streamed_blocks = vec![StreamPosition::default(); validators];
         for round in 1..=rounds {
             core_dispatcher
                 .add_block_headers(
@@ -3770,7 +3867,7 @@ mod tests {
                     ],
                 ),
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await
             .expect("bundle is expected to be processed successfully");
@@ -3804,7 +3901,7 @@ mod tests {
                 peer_2,
                 send_bundle(2, vec![newest_of_author_3.clone()]),
                 &mut encoder,
-                &mut None,
+                &mut StreamPosition::default(),
             )
             .await
             .expect("bundle is expected to be processed successfully");
@@ -3927,7 +4024,7 @@ mod tests {
             all_headers.push(dag_builder.block_headers(round..=round));
             all_transactions.push(dag_builder.transactions(round..=round));
         }
-        let mut last_streamed_blocks = vec![None; validators];
+        let mut last_streamed_blocks = vec![StreamPosition::default(); validators];
         for round in 1..=rounds {
             core_dispatcher
                 .add_block_headers(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -835,7 +835,37 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let block_ref = verified_block.reference();
         let transaction_ref = verified_block.transaction_ref();
         let gen_transaction_ref = GenericTransactionRef::from(transaction_ref);
-        // 1b. The stream carries the peer's own blocks in proposal order, so the
+        // 1b. Two signed headers from the author's own stream for one slot are
+        // provable equivocation, so drop the block before its shards and payload
+        // are processed, and charge the author. Runs before the order check so
+        // the stronger charge wins whenever the slot is already accepted.
+        if self
+            .dag_state
+            .read()
+            .contains_other_block_header_at_slot(&block_ref)
+        {
+            let e = ConsensusError::BlockHeaderEquivocation {
+                authority: peer,
+                round: block_ref.round,
+            };
+            self.misbehavior_store.record_faulty_block(peer, peer, &e);
+            self.context
+                .metrics
+                .node_metrics
+                .dropped_slot_cap_headers_total
+                .with_label_values(&[
+                    self.context.authority_hostname(peer),
+                    DataSource::BlockStreaming.as_str(),
+                ])
+                .inc();
+            warn!(
+                "Peer {peer} equivocated: dropping streamed block {block_ref}, its slot already \
+                 holds a header with a different digest"
+            );
+            return Err(e);
+        }
+
+        // 1c. The stream carries the peer's own blocks in proposal order, so the
         // round must strictly increase over one connection, starting above the
         // round the subscription asked for. A same-round block with another
         // digest is the peer's equivocation.
@@ -879,36 +909,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             return Err(e);
         }
         *last_streamed_block = StreamPosition::from(block_ref);
-
-        // 1c. Two signed headers from the author's own stream for one slot are
-        // provable equivocation, so drop the block before its shards and payload
-        // are processed, and charge the author. A same-slot header still only
-        // suspended is caught by the equivalent cap in the block manager.
-        if self
-            .dag_state
-            .read()
-            .contains_other_block_header_at_slot(&block_ref)
-        {
-            let e = ConsensusError::BlockHeaderEquivocation {
-                authority: peer,
-                round: block_ref.round,
-            };
-            self.misbehavior_store.record_faulty_block(peer, peer, &e);
-            self.context
-                .metrics
-                .node_metrics
-                .dropped_slot_cap_headers_total
-                .with_label_values(&[
-                    self.context.authority_hostname(peer),
-                    DataSource::BlockStreaming.as_str(),
-                ])
-                .inc();
-            warn!(
-                "Peer {peer} equivocated: dropping streamed block {block_ref}, its slot already \
-                 holds a header with a different digest"
-            );
-            return Err(e);
-        }
 
         // 2. Record timestamp drift metric (NEW mode - no waiting or rejection)
         let now = self.context.clock.timestamp_utc_ms();
@@ -2568,10 +2568,10 @@ mod tests {
         }
     }
 
-    /// A same-round block for a slot whose header is both accepted and the
-    /// stream position is charged once, as equivocation.
+    /// A block below the stream position whose slot already holds an accepted
+    /// header is charged as equivocation, not as a regression.
     #[tokio::test(flavor = "current_thread")]
-    async fn test_handle_subscribed_block_bundle_stream_round_order_charges_equivocation_once() {
+    async fn test_handle_subscribed_block_bundle_accepted_slot_beats_stream_order() {
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let fixture = stream_fixture(context.clone());
@@ -2595,7 +2595,11 @@ mod tests {
             DataSource::BlockBundleStream,
         );
 
-        let mut last_streamed_block = StreamPosition::from(accepted.reference());
+        // The stream has already moved on to round 2.
+        let mut last_streamed_block = StreamPosition {
+            round: 2,
+            digest: None,
+        };
         let result = fixture
             .authority_service
             .handle_subscribed_block_bundle(
@@ -2619,10 +2623,22 @@ mod tests {
             context
                 .metrics
                 .node_metrics
-                .dropped_out_of_order_streamed_blocks_total
-                .with_label_values(&[context.authority_hostname(peer), "equivocation"])
+                .dropped_slot_cap_headers_total
+                .with_label_values(&[
+                    context.authority_hostname(peer),
+                    DataSource::BlockStreaming.as_str(),
+                ])
                 .get(),
             1
+        );
+        assert_eq!(
+            context
+                .metrics
+                .node_metrics
+                .dropped_out_of_order_streamed_blocks_total
+                .with_label_values(&[context.authority_hostname(peer), "regression"])
+                .get(),
+            0
         );
     }
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -440,6 +440,15 @@ pub(crate) enum ConsensusError {
         author: AuthorityIndex,
         round: Round,
     },
+
+    #[error(
+        "Peer {peer} streamed its block for round {round} after its block for round {last_round}"
+    )]
+    StreamedBlockRoundNotIncreasing {
+        peer: AuthorityIndex,
+        round: Round,
+        last_round: Round,
+    },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -367,6 +367,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) dropped_slot_cap_headers_total: IntCounterVec,
     pub(crate) synchronizer_fetch_window_violations: IntCounterVec,
     pub(crate) shard_reconstructor_dropped_shards: IntCounterVec,
+    pub(crate) dropped_out_of_order_streamed_blocks_total: IntCounterVec,
 }
 
 impl NodeMetrics {
@@ -1503,6 +1504,13 @@ impl NodeMetrics {
                 "shard_reconstructor_dropped_shards",
                 "Number of shards dropped by the reconstructor's admission rules, by reason: the relaying peer already contributed a shard in the slot, the slot already holds the maximum number of accumulators, the slot is already resolved, or the peer's retained-shard budget evicted its oldest shard",
                 &["reason"],
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            dropped_out_of_order_streamed_blocks_total: register_int_counter_vec_with_registry!(
+                "dropped_out_of_order_streamed_blocks_total",
+                "Number of streamed primary blocks dropped because their round did not increase over the subscription stream, by peer and reason (repeat, regression, equivocation)",
+                &["peer", "reason"],
                 registry;
                 MetricLevel::Warn,
             ).unwrap(),

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -1509,8 +1509,8 @@ impl NodeMetrics {
             ).unwrap(),
             dropped_out_of_order_streamed_blocks_total: register_int_counter_vec_with_registry!(
                 "dropped_out_of_order_streamed_blocks_total",
-                "Number of streamed primary blocks dropped because their round did not increase over the subscription stream, by peer and reason (repeat, regression, equivocation)",
-                &["peer", "reason"],
+                "Number of streamed primary blocks dropped because their round did not increase over the subscription stream, by peer",
+                &["peer"],
                 registry;
                 MetricLevel::Warn,
             ).unwrap(),

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -317,7 +317,7 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
     match error {
         // Pre-signature / parsing errors — the header's author field can't
         // be trusted, so charge the sender, not the claimed author. A streamed
-        // block that repeats or regresses the peer's own round is charged the
+        // block that repeats or lowers the peer's own round is charged the
         // same way: the signed header proves authorship, not the send order.
         ConsensusError::WrongEpoch { .. }
         | ConsensusError::UnexpectedGenesisHeader

--- a/crates/starfish/core/src/misbehavior_store.rs
+++ b/crates/starfish/core/src/misbehavior_store.rs
@@ -296,10 +296,12 @@ enum FaultType {
     /// Block has a valid author signature but violates protocol rules.
     /// The signed block header itself is proof of misbehavior.
     Provable,
-    /// Can't prove authorship — either because the signature is bad or
-    /// missing, or because the header is rejected by a pre-signature check
-    /// (epoch / genesis / author-vs-peer mismatch) so its `author` field
-    /// can't be trusted. Charged to the sending peer, not the claimed author.
+    /// Can't prove the fault from the signed data — either because the
+    /// signature is bad or missing, or because the header is rejected by a
+    /// pre-signature check (epoch / genesis / author-vs-peer mismatch) so its
+    /// `author` field can't be trusted, or because the fault is in how the
+    /// peer sent the block (stream order) rather than in the block itself.
+    /// Charged to the sending peer, not the claimed author.
     Unprovable,
     /// Relayed bundle part (framing, metadata, or shard) that is corrupt,
     /// invalid, or one the peer had no right to relay, and isn't tied to a
@@ -314,7 +316,9 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
     // fault type here rather than silently falling through to `Untracked`.
     match error {
         // Pre-signature / parsing errors — the header's author field can't
-        // be trusted, so charge the sender, not the claimed author.
+        // be trusted, so charge the sender, not the claimed author. A streamed
+        // block that repeats or regresses the peer's own round is charged the
+        // same way: the signed header proves authorship, not the send order.
         ConsensusError::WrongEpoch { .. }
         | ConsensusError::UnexpectedGenesisHeader
         | ConsensusError::UnexpectedAuthority(..)
@@ -328,7 +332,8 @@ fn classify_block_error(error: &ConsensusError) -> FaultType {
         | ConsensusError::SerializedTransactionsTooLarge { .. }
         | ConsensusError::TransactionCommitmentFailure { .. }
         | ConsensusError::UnexpectedBlockHeaderForCommit { .. }
-        | ConsensusError::TooManyFetchedHeadersReturned { .. } => FaultType::Unprovable,
+        | ConsensusError::TooManyFetchedHeadersReturned { .. }
+        | ConsensusError::StreamedBlockRoundNotIncreasing { .. } => FaultType::Unprovable,
 
         // Relayed bundle parts that are corrupt or invalid (framing,
         // additional-header round, shard structure/proof) or that the peer had
@@ -1149,6 +1154,11 @@ mod tests {
                 peer: AuthorityIndex::new_for_test(0),
                 requested: 2,
                 received: 3,
+            },
+            ConsensusError::StreamedBlockRoundNotIncreasing {
+                peer: AuthorityIndex::new_for_test(0),
+                round: 4,
+                last_round: 5,
             },
         ];
         for e in cases {

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -33,7 +33,7 @@ use starfish_config::{AuthorityIndex, Committee};
 use crate::{
     Round, VerifiedBlockHeader,
     authority_set::AuthoritySet,
-    block_header::{BlockRef, VerifiedBlock},
+    block_header::{BlockHeaderDigest, BlockRef, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
 };
@@ -155,20 +155,38 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
     ) -> ConsensusResult<Vec<Bytes>>;
 }
 
+/// Where a block subscription stream stands: the highest round of the peer's
+/// own blocks the receiver holds, and that block's digest when it is known.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct StreamPosition {
+    pub(crate) round: Round,
+    pub(crate) digest: Option<BlockHeaderDigest>,
+}
+
+impl From<BlockRef> for StreamPosition {
+    fn from(block_ref: BlockRef) -> Self {
+        Self {
+            round: block_ref.round,
+            digest: Some(block_ref.digest),
+        }
+    }
+}
+
 /// Network service for handling requests from peers.
 #[async_trait]
 pub(crate) trait NetworkService: Send + Sync + 'static {
     /// Handles the block and headers sent from the peer via subscription
     /// stream. Peer value can be trusted to be a valid authority index. But
     /// serialized_block must be verified before its contents are trusted.
-    /// `last_streamed_block` is the highest-round primary block received so
-    /// far on this connection; the caller keeps it per connection.
+    /// `last_streamed_block` is the highest round of the peer's own blocks the
+    /// receiver holds, from the subscription request or from this connection;
+    /// the caller keeps it per connection.
     async fn handle_subscribed_block_bundle(
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
         encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
-        last_streamed_block: &mut Option<BlockRef>,
+        last_streamed_block: &mut StreamPosition,
     ) -> ConsensusResult<()>;
 
     /// Handles the subscription request from the peer.

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -161,11 +161,14 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     /// Handles the block and headers sent from the peer via subscription
     /// stream. Peer value can be trusted to be a valid authority index. But
     /// serialized_block must be verified before its contents are trusted.
+    /// `last_streamed_block` is the highest-round primary block received so
+    /// far on this connection; the caller keeps it per connection.
     async fn handle_subscribed_block_bundle(
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
         encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
+        last_streamed_block: &mut Option<BlockRef>,
     ) -> ConsensusResult<()>;
 
     /// Handles the subscription request from the peer.

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -77,6 +77,7 @@ impl NetworkService for Mutex<TestService> {
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
         _encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
+        _last_streamed_block: &mut Option<BlockRef>,
     ) -> ConsensusResult<()> {
         let release = {
             let mut state = self.lock();

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -18,7 +18,7 @@ use crate::{
     commit_syncer::CommitSyncType,
     encoder::ShardEncoder,
     error::ConsensusResult,
-    network::{BlockBundleStream, NetworkService, SerializedBlockBundle},
+    network::{BlockBundleStream, NetworkService, SerializedBlockBundle, StreamPosition},
     transaction_ref::TransactionRef,
 };
 
@@ -77,7 +77,7 @@ impl NetworkService for Mutex<TestService> {
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
         _encoder: &mut Box<dyn ShardEncoder + Send + Sync>,
-        _last_streamed_block: &mut Option<BlockRef>,
+        _last_streamed_block: &mut StreamPosition,
     ) -> ConsensusResult<()> {
         let release = {
             let mut state = self.lock();

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -265,6 +265,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                 .with_label_values(&[peer_hostname])
                 .set(1);
 
+            let mut last_streamed_block = None;
             'stream: loop {
                 // Observe a reset only between bundles: wrapping the handler
                 // below in this select would cancel it mid-bundle.
@@ -288,7 +289,12 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             .with_label_values(&[peer_hostname])
                             .inc();
                         let result = authority_service
-                            .handle_subscribed_block_bundle(peer, block, &mut encoder)
+                            .handle_subscribed_block_bundle(
+                                peer,
+                                block,
+                                &mut encoder,
+                                &mut last_streamed_block,
+                            )
                             .await;
                         if let Err(e) = result {
                             match e {

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -21,7 +21,7 @@ use crate::{
     dag_state::DagState,
     encoder::create_encoder,
     error::ConsensusError,
-    network::{NetworkClient, NetworkService},
+    network::{NetworkClient, NetworkService, StreamPosition},
 };
 
 /// Returns whether the reset channel closed; otherwise records the reset and
@@ -198,7 +198,21 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             }
             retries += 1;
 
-            let last_received = dag_state.read().resume_round_for_authority(peer);
+            let (last_received, mut last_streamed_block) = {
+                let dag_state = dag_state.read();
+                let last_received = dag_state.resume_round_for_authority(peer);
+                let last_header = dag_state
+                    .get_last_block_header_for_authority(peer)
+                    .reference();
+                let digest = (last_header.round == last_received).then_some(last_header.digest);
+                (
+                    last_received,
+                    StreamPosition {
+                        round: last_received,
+                        digest,
+                    },
+                )
+            };
             // Wrap subscribe_block_bundles in a timeout and increment metric on timeout
             let subscribe_future =
                 network_client.subscribe_block_bundles(peer, last_received, MAX_RETRY_INTERVAL);
@@ -265,7 +279,6 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                 .with_label_values(&[peer_hostname])
                 .set(1);
 
-            let mut last_streamed_block = None;
             'stream: loop {
                 // Observe a reset only between bundles: wrapping the handler
                 // below in this select would cancel it mid-bundle.


### PR DESCRIPTION
# Description of change

A block subscription stream carries the sending peer's own blocks in proposal order, and since #12767 an honest sender never repeats a round on one connection. The receiver now holds it to that: each connection tracks the highest round of the peer's blocks it holds, starting from the round the subscription asked to resume from, and a block at or below it is dropped before shard extraction, the reconstructor and the core, and charged to the peer. A repeat or a regression is an unprovable fault (the signed header proves authorship, not the order it was sent in); a same-round block with another digest is charged as equivocation, and so is a lower-round block whose slot already holds another accepted header. The stream stays open: closing it is evadable by reconnecting and would only replay the backlog.

The check runs right after signature verification and rejects the bundle outright, so a block in order costs one round comparison and no DagState access; DagState is read only to classify a lower-round violation. The stream-level slot check added in #12539 is removed with it: an in-order block for a slot that already holds another header is caught by the block manager's slot cap at `add_blocks`, as before #12539, so its shards reach the reconstructor first. Only the far-future drop keeps the path of dropping the primary block while still processing the bundle's relayed headers, since a far-future block is not misbehavior.


## Links to any relevant issues

Step 2 of the plan in iotaledger/iota-private#492. Closes iotaledger/iota-private#492.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
