### PR TITLE
feat(starfish): select shard peers by block-stream latency

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -187,6 +187,12 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_enable_bounded_header_advertisement")]
     pub enable_bounded_header_advertisement: bool,
 
+    /// Ask only the fastest peers that together provide enough shards and
+    /// stake for reconstruction. Enabled by default; disabling it asks every
+    /// peer.
+    #[serde(default = "Parameters::default_enable_shard_peer_selection")]
+    pub enable_shard_peer_selection: bool,
+
     /// Port for the DAG visualizer gRPC server (localhost only).
     /// When set, starts a debugging server for real-time DAG visualization.
     /// Only has an effect when the `dag-visualizer` feature is compiled in.
@@ -495,6 +501,10 @@ impl Parameters {
         true
     }
 
+    pub(crate) fn default_enable_shard_peer_selection() -> bool {
+        true
+    }
+
     pub(crate) fn default_solid_commit_lag_threshold() -> u32 {
         // The healthy gap is a few rounds at most; 500 rounds (a few minutes of
         // commits) is far above live jitter yet caps how long a solidification
@@ -550,6 +560,7 @@ impl Default for Parameters {
                 Parameters::default_enable_peer_responsiveness_ranking(),
             enable_bounded_header_advertisement:
                 Parameters::default_enable_bounded_header_advertisement(),
+            enable_shard_peer_selection: Parameters::default_enable_shard_peer_selection(),
             dag_visualizer_port: None,
             solid_commit_lag_threshold: Parameters::default_solid_commit_lag_threshold(),
             shard_budget_per_authority: Parameters::default_shard_budget_per_authority(),

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -57,6 +57,7 @@ enable_commit_sync_peer_selection_by_commit_votes: true
 enable_starfish_speed_adaptive_acknowledgments: true
 enable_peer_responsiveness_ranking: true
 enable_bounded_header_advertisement: true
+enable_shard_peer_selection: true
 dag_visualizer_port: ~
 solid_commit_lag_threshold: 500
 shard_budget_per_authority: 1000

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -924,7 +924,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .observe(latency_to_process_stream.as_secs_f64());
         self.context
             .peer_responsiveness
-            .record_streaming_block_delivery(peer, latency_to_process_stream);
+            .record_streaming_block_delivery(peer, now, block_timestamp_ms);
 
         // 3. Create block headers from bytes from a bundle
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -922,6 +922,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .latency_to_process_stream_by_peer
             .with_label_values(&[peer_hostname.as_str()])
             .observe(latency_to_process_stream.as_secs_f64());
+        self.context
+            .peer_responsiveness
+            .record_streaming_block_delivery(peer, latency_to_process_stream);
 
         // 3. Create block headers from bytes from a bundle
 
@@ -4151,13 +4154,18 @@ mod tests {
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
             ]),
-            useful_shards_from_peer: vec![None, Some(GENESIS_ROUND), None, Some(GENESIS_ROUND)],
         };
         {
             let mut connection_knowledge = connection_knowledge.write();
             connection_knowledge.process_one_message(msg);
             connection_knowledge.process_one_message(
                 ConnectionKnowledgeMessage::SetUsefulHeadersFromPeer(BTreeMap::from([
+                    (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
+                    (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+                ])),
+            );
+            connection_knowledge.process_one_message(
+                ConnectionKnowledgeMessage::SetUsefulShardsFromPeer(BTreeMap::from([
                     (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
                     (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
                 ])),

--- a/crates/starfish/core/src/context.rs
+++ b/crates/starfish/core/src/context.rs
@@ -41,8 +41,9 @@ pub(crate) struct Context {
     pub metrics: Arc<Metrics>,
     /// Access to local clock
     pub clock: Arc<Clock>,
-    /// Tracks per-peer responsiveness and ranks candidates for synchronizer
-    /// peer selection. Shared per epoch.
+    /// Tracks per-peer responsiveness to select peers for the transactions
+    /// synchronizer, the commit syncer, the header synchronizer, and header
+    /// and shard pushes. Shared per epoch.
     pub peer_responsiveness: Arc<PeerResponsiveness>,
     /// Commitment over an empty transaction list for this committee.
     pub(crate) empty_transactions_commitment: TransactionsCommitment,
@@ -119,6 +120,8 @@ impl Context {
                 enable_peer_responsiveness_ranking: false,
                 // Tests enable bounded peer selection explicitly when needed.
                 enable_bounded_header_advertisement: false,
+                // Preserve ask-every-peer behavior in tests without stream samples.
+                enable_shard_peer_selection: false,
                 ..Default::default()
             },
             ProtocolConfig::get_for_max_version_UNSAFE(),

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -28,6 +28,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     header_synchronizer::MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER,
     network::{BlockBundle, SerializedBlockBundleParts},
+    peer_responsiveness::ShardPeerSelection,
     transaction_ref::{GenericTransactionRef, GenericTransactionRefAPI as _},
 };
 
@@ -74,11 +75,9 @@ pub(crate) struct CordialKnowledge {
     cordial_knowledge_receiver: Receiver<CordialKnowledgeMessage>,
     /// Receives eviction rounds from DagState (latest-only).
     eviction_rounds_receiver: tokio::sync::watch::Receiver<Vec<Round>>,
-    /// Keeps track of the last round for which each peer's shards were
-    /// considered useful to us. This is a global knowledge and is shared with
-    /// all connection tasks. Initialized to None for all authorities and
-    /// updated over time once AuthorityService reports useful shards from
-    /// peers.
+    /// Latest round per author whose shards are useful to fetch from peers:
+    /// we know of the block header but lack its payload. Global input from
+    /// which each peer's shard requests are selected.
     last_useful_shards_from_peer_round: Vec<Option<Round>>,
     /// Keeps track of the most recent DAG cordial
     /// knowledge (who knows which blocks) for each authority. This is a helper
@@ -102,6 +101,8 @@ pub(crate) struct CordialKnowledge {
     /// empty set is sent once when the last request is removed.
     has_useful_headers_from_peer: Vec<bool>,
     rng: StdRng,
+    /// Shard authors currently requested from each peer.
+    requested_shard_authors: Vec<BTreeMap<AuthorityIndex, Round>>,
 }
 
 /// High-level messages sent to the CordialKnowledge task.
@@ -185,15 +186,18 @@ impl CordialKnowledgeHandle {
         block_round: Round,
     ) -> ConsensusResult<()> {
         let cordial_knowledge_sender = &self.cordial_knowledge_sender;
-        // Extract authorities this peer has useful shards from
+        // Accepted headers arrive before their full blocks and missing ancestors
+        // lack header and payload alike, so both authors' shards are useful.
         let mut useful_shard_authors: BTreeMap<AuthorityIndex, Round> = BTreeMap::new();
-        // Since headers showed up in the filter before the corresponding full blocks
-        // we consider all authors of additional headers as useful shard authors too.
-        for header in additional_block_headers {
-            let author = header.author();
-            let round = header.round();
-
-            // Insert or update if newer round
+        let useful_shard_refs = additional_block_headers
+            .iter()
+            .map(|header| (header.author(), header.round()))
+            .chain(
+                missing_ancestors
+                    .iter()
+                    .map(|block_ref| (block_ref.author, block_ref.round)),
+            );
+        for (author, round) in useful_shard_refs {
             useful_shard_authors
                 .entry(author)
                 .and_modify(|was_round| *was_round = (*was_round).max(round))
@@ -218,7 +222,6 @@ impl CordialKnowledgeHandle {
         let connection_knowledge_message = ConnectionKnowledgeMessage::UsefulAuthors {
             useful_headers_to_peer,
             useful_shards_to_peer,
-            useful_shards_from_peer: vec![None; self.connection_knowledges.len()],
         };
         {
             let mut connection_knowledge_guard = self.connection_knowledges[peer].write();
@@ -304,6 +307,7 @@ impl CordialKnowledge {
                 latest_own_block_round: Round::MIN,
                 has_useful_headers_from_peer: vec![false; num_authorities],
                 rng: StdRng::from_entropy(),
+                requested_shard_authors: vec![BTreeMap::new(); num_authorities],
             },
             connection_knowledges,
             cordial_knowledge_sender,
@@ -399,6 +403,9 @@ impl CordialKnowledge {
                         self.append_useful_headers_from_peer_msgs(
                             &mut vec_connection_knowledge_msgs_batch,
                         );
+                        self.append_useful_shards_from_peer_msgs(
+                            &mut vec_connection_knowledge_msgs_batch,
+                        );
                     }
 
                     if processed_since_eviction >= EVICTION_CHECK_INTERVAL {
@@ -474,7 +481,8 @@ impl CordialKnowledge {
                 self.prepare_new_shard_msgs(gen_tx_ref)
             }
             CordialKnowledgeMessage::UsefulShardsFromPeers(useful_shards_from_peer) => {
-                self.handle_useful_shards_from(useful_shards_from_peer)
+                self.handle_useful_shards_from(useful_shards_from_peer);
+                None
             }
             CordialKnowledgeMessage::UsefulHeadersFromPeer {
                 peer,
@@ -506,20 +514,15 @@ impl CordialKnowledge {
         changed
     }
 
-    /// Update global knowledge about shards from which authors will be useful
-    /// for us
+    /// Record from which round each author's shards are useful to us.
     fn handle_useful_shards_from(
         &mut self,
         useful_shards_from_peer: BTreeMap<AuthorityIndex, Round>,
-    ) -> Option<Vec<Vec<ConnectionKnowledgeMessage>>> {
-        if Self::update_authority_rounds_if_greater(
+    ) {
+        Self::update_authority_rounds_if_greater(
             &mut self.last_useful_shards_from_peer_round,
             useful_shards_from_peer,
-        ) {
-            self.prepare_useful_shards_from_peers_msgs()
-        } else {
-            None
-        }
+        );
     }
 
     /// Record useful header information from one peer's block bundle.
@@ -745,25 +748,76 @@ impl CordialKnowledge {
         missing_author.selected_peers.insert(peer);
     }
 
-    /// Prepare useful authors message for each connection knowledge.
-    fn prepare_useful_shards_from_peers_msgs(
+    /// Refresh which authors each peer is asked to push shards of: only the
+    /// fastest peers that together provide enough shards and stake for
+    /// reconstruction, or every peer when selection is disabled.
+    fn append_useful_shards_from_peer_msgs(
         &mut self,
-    ) -> Option<Vec<Vec<ConnectionKnowledgeMessage>>> {
-        let mut vec_msgs: Vec<Vec<ConnectionKnowledgeMessage>> =
-            Vec::with_capacity(self.cordial_knowledge.len());
-        for index in 0..self.cordial_knowledge.len() {
-            if index == self.context.own_index.value() {
-                vec_msgs.push(vec![]);
+        vec_connection_knowledge_msgs_batch: &mut [Vec<ConnectionKnowledgeMessage>],
+    ) {
+        let own_index = self.context.own_index;
+        let latest_own_block_round = self.latest_own_block_round;
+        let selection_enabled = self.context.parameters.enable_shard_peer_selection;
+        let mut next_requested_shard_authors = vec![BTreeMap::new(); self.context.committee.size()];
+        let mut latest_selection = None;
+
+        for author_index in 0..self.last_useful_shards_from_peer_round.len() {
+            let author = AuthorityIndex::from(author_index as u8);
+            let Some(round) = self.last_useful_shards_from_peer_round[author_index] else {
+                continue;
+            };
+            if round.saturating_add(MAX_ROUND_GAP_FOR_USEFUL_PARTS) < latest_own_block_round {
                 continue;
             }
-            let msg = ConnectionKnowledgeMessage::UsefulAuthors {
-                useful_shards_from_peer: self.last_useful_shards_from_peer_round.clone(),
-                useful_headers_to_peer: BTreeMap::new(),
-                useful_shards_to_peer: BTreeMap::new(),
+
+            if !selection_enabled {
+                for (peer_index, authors) in next_requested_shard_authors.iter_mut().enumerate() {
+                    if peer_index != own_index.value() {
+                        authors.insert(author, round);
+                    }
+                }
+                continue;
+            }
+
+            let Some(selection) = self.context.peer_responsiveness.select_shard_peers(
+                &self.context.committee,
+                own_index,
+                author,
+            ) else {
+                continue;
             };
-            vec_msgs.push(vec![msg]);
+            for peer in &selection.peers {
+                next_requested_shard_authors[*peer].insert(author, round);
+            }
+            latest_selection = Some(selection);
         }
-        Some(vec_msgs)
+
+        if selection_enabled {
+            self.set_shard_selection_metrics(latest_selection.as_ref());
+        }
+
+        for (peer_index, authors) in next_requested_shard_authors.into_iter().enumerate() {
+            if peer_index == own_index.value()
+                || authors == self.requested_shard_authors[peer_index]
+            {
+                continue;
+            }
+            vec_connection_knowledge_msgs_batch[peer_index].push(
+                ConnectionKnowledgeMessage::SetUsefulShardsFromPeer(authors.clone()),
+            );
+            self.requested_shard_authors[peer_index] = authors;
+        }
+    }
+
+    /// Report the latest shard peer selection, or zeros while none is active.
+    fn set_shard_selection_metrics(&self, selection: Option<&ShardPeerSelection>) {
+        let metrics = &self.context.metrics.node_metrics;
+        metrics
+            .cordial_knowledge_selected_shard_peers
+            .set(selection.map_or(0, |selection| selection.peers.len() as i64));
+        metrics
+            .cordial_knowledge_shard_selection_latency_ms
+            .set(selection.map_or(0.0, |selection| selection.required_latency_ms));
     }
 
     /// Called when a new own shard (created locally) is added to dag state.
@@ -980,11 +1034,13 @@ pub enum ConnectionKnowledgeMessage {
     /// Replace the authors this peer is asked to push headers of. The cordial
     /// knowledge task is their only source.
     SetUsefulHeadersFromPeer(BTreeMap<AuthorityIndex, Round>),
-    /// Update useful info about which authorities are useful to/from the peer.
+    /// Replace the authors this peer is asked to push shards of. The cordial
+    /// knowledge task is their only source.
+    SetUsefulShardsFromPeer(BTreeMap<AuthorityIndex, Round>),
+    /// Update which authorities' headers and shards are useful to the peer.
     UsefulAuthors {
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
-        useful_shards_from_peer: Vec<Option<Round>>,
     },
     /// Global eviction (prune below round)
     EvictBelow(Vec<Round>),
@@ -1005,8 +1061,7 @@ pub struct ConnectionKnowledge {
     /// Last rounds for (potentially) useful headers that can be sent to this
     /// peer
     last_useful_headers_to_peer_round: Vec<Option<Round>>,
-    /// Last rounds for potentially useful shards that could be received from
-    /// this peer
+    /// Latest useful shard round for each author requested from this peer.
     last_useful_shards_from_peer_round: Vec<Option<Round>>,
     /// Last rounds for (potentially) useful headers that could be received from
     /// this peer
@@ -1170,16 +1225,14 @@ impl ConnectionKnowledge {
             ConnectionKnowledgeMessage::SetUsefulHeadersFromPeer(authorities_with_round) => {
                 self.set_useful_headers_from(authorities_with_round);
             }
+            ConnectionKnowledgeMessage::SetUsefulShardsFromPeer(authorities_with_round) => {
+                self.set_useful_shards_from(authorities_with_round);
+            }
             ConnectionKnowledgeMessage::UsefulAuthors {
                 useful_headers_to_peer,
                 useful_shards_to_peer,
-                useful_shards_from_peer,
             } => {
-                self.handle_useful_authors(
-                    useful_headers_to_peer,
-                    useful_shards_to_peer,
-                    useful_shards_from_peer,
-                );
+                self.handle_useful_authors(useful_headers_to_peer, useful_shards_to_peer);
             }
         }
     }
@@ -1190,25 +1243,9 @@ impl ConnectionKnowledge {
         &mut self,
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
-        useful_shards_from_peer: Vec<Option<Round>>,
     ) {
-        // Update local state
         self.handle_useful_headers_to(useful_headers_to_peer);
         self.handle_useful_shards_to(useful_shards_to_peer);
-        self.handle_useful_shards_from(useful_shards_from_peer);
-    }
-
-    /// Update last useful shards from peer rounds
-    fn handle_useful_shards_from(&mut self, useful_shards_from_peer_round: Vec<Option<Round>>) {
-        for (index, opt_round) in useful_shards_from_peer_round.into_iter().enumerate() {
-            if let Some(new_round) = opt_round {
-                if let Some(old_round) = &mut self.last_useful_shards_from_peer_round[index] {
-                    *old_round = max(*old_round, new_round);
-                } else {
-                    self.last_useful_shards_from_peer_round[index] = Some(new_round);
-                }
-            }
-        }
     }
 
     /// Replace the rounds of useful headers from peer, so an author the peer is
@@ -1217,6 +1254,15 @@ impl ConnectionKnowledge {
         self.last_useful_headers_from_peer_round.fill(None);
         for (authority, round) in authorities_with_round {
             self.last_useful_headers_from_peer_round[authority] = Some(round);
+        }
+    }
+
+    /// Replace the rounds of useful shards from peer, so an author the peer is
+    /// no longer asked for stops at once instead of ageing out.
+    fn set_useful_shards_from(&mut self, authorities_with_round: BTreeMap<AuthorityIndex, Round>) {
+        self.last_useful_shards_from_peer_round.fill(None);
+        for (authority, round) in authorities_with_round {
+            self.last_useful_shards_from_peer_round[authority] = Some(round);
         }
     }
 
@@ -1349,17 +1395,6 @@ impl ConnectionKnowledge {
             .map(|(authority_index, _opt_round)| AuthorityIndex::from(authority_index as u8))
             .collect::<BTreeSet<AuthorityIndex>>();
 
-        // Report useful authors
-        for author in &useful_shards_authors_from_peer {
-            let author_hostname = self.context.authority_hostname(*author);
-            self.context
-                .metrics
-                .node_metrics
-                .cordial_knowledge_useful_shards_authors
-                .with_label_values(&[author_hostname])
-                .inc();
-        }
-
         BlockBundle {
             verified_block: block,
             verified_headers: useful_headers_to_peer,
@@ -1450,7 +1485,7 @@ impl ConnectionKnowledge {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use parking_lot::RwLock;
     use starfish_config::Parameters;
@@ -1477,6 +1512,18 @@ mod tests {
         CordialKnowledge::new_for_test(context, dag_state)
     }
 
+    /// A worker with shard peer selection.
+    fn shard_selection_cordial_knowledge_for_test(
+        validators: usize,
+    ) -> (CordialKnowledge, Vec<Arc<RwLock<ConnectionKnowledge>>>) {
+        let (mut context, _key_pairs) = Context::new_for_test(validators);
+        context.parameters.enable_shard_peer_selection = true;
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        CordialKnowledge::new_for_test(context, dag_state)
+    }
+
     /// Runs one recompute and returns the per-connection messages it prepared.
     fn recompute(cordial_knowledge: &mut CordialKnowledge) -> Vec<Vec<ConnectionKnowledgeMessage>> {
         let mut batch: Vec<Vec<ConnectionKnowledgeMessage>> =
@@ -1487,11 +1534,36 @@ mod tests {
         batch
     }
 
+    /// Refreshes the shard requests once and returns the per-connection
+    /// messages it prepared.
+    fn refresh_shard_requests(
+        cordial_knowledge: &mut CordialKnowledge,
+    ) -> Vec<Vec<ConnectionKnowledgeMessage>> {
+        let mut batch: Vec<Vec<ConnectionKnowledgeMessage>> =
+            (0..cordial_knowledge.context.committee.size())
+                .map(|_| Vec::new())
+                .collect();
+        cordial_knowledge.append_useful_shards_from_peer_msgs(&mut batch);
+        batch
+    }
+
     /// The authors a message tells one connection to ask its peer for.
     fn asked_authors(msgs: &[ConnectionKnowledgeMessage]) -> Option<BTreeSet<AuthorityIndex>> {
         msgs.iter().find_map(|msg| match msg {
             ConnectionKnowledgeMessage::SetUsefulHeadersFromPeer(set) => {
                 Some(set.keys().copied().collect())
+            }
+            _ => None,
+        })
+    }
+
+    /// The shard authors a message tells one connection to ask its peer for.
+    fn asked_shard_authors(
+        msgs: &[ConnectionKnowledgeMessage],
+    ) -> Option<BTreeSet<AuthorityIndex>> {
+        msgs.iter().find_map(|msg| match msg {
+            ConnectionKnowledgeMessage::SetUsefulShardsFromPeer(authors) => {
+                Some(authors.keys().copied().collect())
             }
             _ => None,
         })
@@ -1573,6 +1645,111 @@ mod tests {
             .last_useful_headers_from_peer_round
             .iter()
             .all(|round| round.is_none())
+    }
+
+    #[test]
+    fn test_shards_are_requested_from_fastest_sufficient_peers() {
+        let (mut cordial_knowledge, _connection_knowledges) =
+            shard_selection_cordial_knowledge_for_test(7);
+        let author = AuthorityIndex::new_for_test(6);
+        cordial_knowledge.latest_own_block_round = 10;
+        for peer in 1..=5u8 {
+            cordial_knowledge
+                .context
+                .peer_responsiveness
+                .record_streaming_block_delivery(
+                    AuthorityIndex::new_for_test(peer),
+                    Duration::from_millis(peer as u64 * 10),
+                );
+        }
+        cordial_knowledge.handle_useful_shards_from(BTreeMap::from([(author, 10)]));
+
+        let batch = refresh_shard_requests(&mut cordial_knowledge);
+
+        for msgs in &batch[1..=3] {
+            assert_eq!(asked_shard_authors(msgs), Some(BTreeSet::from([author])));
+        }
+        assert!(batch[4].is_empty());
+        assert!(batch[5].is_empty());
+        let metrics = &cordial_knowledge.context.metrics.node_metrics;
+        assert_eq!(metrics.cordial_knowledge_selected_shard_peers.get(), 3);
+        assert_eq!(
+            metrics.cordial_knowledge_shard_selection_latency_ms.get(),
+            30.0
+        );
+    }
+
+    #[test]
+    fn test_shard_requests_wait_for_enough_latency_samples() {
+        let (mut cordial_knowledge, _connection_knowledges) =
+            shard_selection_cordial_knowledge_for_test(7);
+        let author = AuthorityIndex::new_for_test(6);
+        cordial_knowledge.latest_own_block_round = 10;
+        for peer in 1..=2u8 {
+            cordial_knowledge
+                .context
+                .peer_responsiveness
+                .record_streaming_block_delivery(
+                    AuthorityIndex::new_for_test(peer),
+                    Duration::from_millis(peer as u64 * 10),
+                );
+        }
+        cordial_knowledge.handle_useful_shards_from(BTreeMap::from([(author, 10)]));
+
+        let batch = refresh_shard_requests(&mut cordial_knowledge);
+
+        assert!(batch.iter().all(Vec::is_empty));
+        let metrics = &cordial_knowledge.context.metrics.node_metrics;
+        assert_eq!(metrics.cordial_knowledge_selected_shard_peers.get(), 0);
+    }
+
+    #[test]
+    fn test_disabling_shard_peer_selection_asks_every_peer() {
+        let (mut cordial_knowledge, _connection_knowledges) = cordial_knowledge_for_test(7);
+        let author = AuthorityIndex::new_for_test(6);
+        cordial_knowledge.latest_own_block_round = 10;
+        cordial_knowledge.handle_useful_shards_from(BTreeMap::from([(author, 10)]));
+
+        let batch = refresh_shard_requests(&mut cordial_knowledge);
+
+        for msgs in &batch[1..=6] {
+            assert_eq!(asked_shard_authors(msgs), Some(BTreeSet::from([author])));
+        }
+    }
+
+    #[test]
+    fn test_expired_shard_requests_are_cleared() {
+        let (mut cordial_knowledge, _connection_knowledges) =
+            shard_selection_cordial_knowledge_for_test(7);
+        let author = AuthorityIndex::new_for_test(6);
+        cordial_knowledge.latest_own_block_round = 10;
+        for peer in 1..=5u8 {
+            cordial_knowledge
+                .context
+                .peer_responsiveness
+                .record_streaming_block_delivery(
+                    AuthorityIndex::new_for_test(peer),
+                    Duration::from_millis(peer as u64 * 10),
+                );
+        }
+        cordial_knowledge.handle_useful_shards_from(BTreeMap::from([(author, 10)]));
+        refresh_shard_requests(&mut cordial_knowledge);
+
+        cordial_knowledge.latest_own_block_round = 10 + MAX_ROUND_GAP_FOR_USEFUL_PARTS + 1;
+        let batch = refresh_shard_requests(&mut cordial_knowledge);
+
+        for msgs in &batch[1..=3] {
+            assert_eq!(asked_shard_authors(msgs), Some(BTreeSet::new()));
+        }
+        assert_eq!(
+            cordial_knowledge
+                .context
+                .metrics
+                .node_metrics
+                .cordial_knowledge_selected_shard_peers
+                .get(),
+            0
+        );
     }
 
     /// Peers that referenced a missing block of an author are asked to push its
@@ -1663,6 +1840,63 @@ mod tests {
         cordial_knowledge.latest_own_block_round = 10 + MAX_ROUND_GAP_FOR_USEFUL_PARTS + 1;
         let batch = recompute(&mut cordial_knowledge);
         assert_eq!(asked_authors(&batch[peer]), Some(BTreeSet::from([author])));
+    }
+
+    /// A missing ancestor lacks header and payload alike, so its author's
+    /// shards are requested along with its headers.
+    #[tokio::test]
+    async fn test_missing_ancestor_author_shards_are_requested() {
+        let peer = AuthorityIndex::new_for_test(1);
+        let author = AuthorityIndex::new_for_test(3);
+        let (context, _key_pairs) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (
+            mut cordial_knowledge,
+            connection_knowledges,
+            cordial_knowledge_sender,
+            _eviction_rounds_sender,
+        ) = CordialKnowledge::new(context, dag_state);
+        let handle = CordialKnowledgeHandle {
+            cordial_knowledge_sender,
+            connection_knowledges,
+            cordial_knowledge_handle: Mutex::new(None),
+        };
+        cordial_knowledge.latest_own_block_round = 10;
+
+        let missing = VerifiedBlockHeader::new_for_test(
+            TestBlockHeader::new(10, author.value() as u8).build(),
+        )
+        .reference();
+        handle
+            .report_useful_authors(
+                peer,
+                &SerializedBlockBundleParts {
+                    serialized_block: Bytes::new(),
+                    serialized_headers: vec![],
+                    serialized_shards: vec![],
+                    useful_headers_authors_bitmask: AuthoritySet::default(),
+                    useful_shards_authors_bitmask: AuthoritySet::default(),
+                },
+                &[],
+                &BTreeSet::from([missing]),
+                7,
+            )
+            .unwrap();
+        while let Ok(message) = cordial_knowledge.cordial_knowledge_receiver.try_recv() {
+            let _ = cordial_knowledge.process_message(message);
+        }
+
+        assert_eq!(
+            cordial_knowledge.last_useful_shards_from_peer_round[author],
+            Some(10)
+        );
+        let batch = refresh_shard_requests(&mut cordial_knowledge);
+        assert_eq!(
+            asked_shard_authors(&batch[peer]),
+            Some(BTreeSet::from([author]))
+        );
     }
 
     /// An author cannot push its own headers, and the local node is never a
@@ -2140,13 +2374,18 @@ mod tests {
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
             ]),
-            useful_shards_from_peer: vec![None, Some(GENESIS_ROUND), None, Some(GENESIS_ROUND)],
         };
         {
             let mut connection_knowledge = connection_knowledge.write();
             connection_knowledge.process_one_message(msg);
             connection_knowledge.process_one_message(
                 ConnectionKnowledgeMessage::SetUsefulHeadersFromPeer(BTreeMap::from([
+                    (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
+                    (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+                ])),
+            );
+            connection_knowledge.process_one_message(
+                ConnectionKnowledgeMessage::SetUsefulShardsFromPeer(BTreeMap::from([
                     (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
                     (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
                 ])),
@@ -2276,7 +2515,6 @@ mod tests {
             ConnectionKnowledgeMessage::UsefulAuthors {
                 useful_headers_to_peer: BTreeMap::from([(equivocating_index, GENESIS_ROUND)]),
                 useful_shards_to_peer: BTreeMap::new(),
-                useful_shards_from_peer: vec![None; validators],
             },
         );
 
@@ -2356,13 +2594,18 @@ mod tests {
                 (AuthorityIndex::new_for_test(2), GENESIS_ROUND),
                 (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
             ]),
-            useful_shards_from_peer: vec![None, Some(GENESIS_ROUND), None, Some(GENESIS_ROUND)],
         };
         {
             let mut connection_knowledge = connection_knowledge.write();
             connection_knowledge.process_one_message(msg);
             connection_knowledge.process_one_message(
                 ConnectionKnowledgeMessage::SetUsefulHeadersFromPeer(BTreeMap::from([
+                    (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
+                    (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
+                ])),
+            );
+            connection_knowledge.process_one_message(
+                ConnectionKnowledgeMessage::SetUsefulShardsFromPeer(BTreeMap::from([
                     (AuthorityIndex::new_for_test(1), GENESIS_ROUND),
                     (AuthorityIndex::new_for_test(3), GENESIS_ROUND),
                 ])),

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1647,8 +1647,8 @@ mod tests {
             .all(|round| round.is_none())
     }
 
-    #[test]
-    fn test_shards_are_requested_from_fastest_sufficient_peers() {
+    #[tokio::test]
+    async fn test_shards_are_requested_from_fastest_sufficient_peers() {
         let (mut cordial_knowledge, _connection_knowledges) =
             shard_selection_cordial_knowledge_for_test(7);
         let author = AuthorityIndex::new_for_test(6);
@@ -1680,8 +1680,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_shard_requests_wait_for_enough_latency_samples() {
+    #[tokio::test]
+    async fn test_shard_requests_wait_for_enough_latency_samples() {
         let (mut cordial_knowledge, _connection_knowledges) =
             shard_selection_cordial_knowledge_for_test(7);
         let author = AuthorityIndex::new_for_test(6);
@@ -1705,8 +1705,8 @@ mod tests {
         assert_eq!(metrics.cordial_knowledge_selected_shard_peers.get(), 0);
     }
 
-    #[test]
-    fn test_disabling_shard_peer_selection_asks_every_peer() {
+    #[tokio::test]
+    async fn test_disabling_shard_peer_selection_asks_every_peer() {
         let (mut cordial_knowledge, _connection_knowledges) = cordial_knowledge_for_test(7);
         let author = AuthorityIndex::new_for_test(6);
         cordial_knowledge.latest_own_block_round = 10;
@@ -1719,8 +1719,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_expired_shard_requests_are_cleared() {
+    #[tokio::test]
+    async fn test_expired_shard_requests_are_cleared() {
         let (mut cordial_knowledge, _connection_knowledges) =
             shard_selection_cordial_knowledge_for_test(7);
         let author = AuthorityIndex::new_for_test(6);

--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -1485,7 +1485,7 @@ impl ConnectionKnowledge {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::sync::Arc;
 
     use parking_lot::RwLock;
     use starfish_config::Parameters;
@@ -1659,7 +1659,8 @@ mod tests {
                 .peer_responsiveness
                 .record_streaming_block_delivery(
                     AuthorityIndex::new_for_test(peer),
-                    Duration::from_millis(peer as u64 * 10),
+                    peer as u64 * 10,
+                    0,
                 );
         }
         cordial_knowledge.handle_useful_shards_from(BTreeMap::from([(author, 10)]));
@@ -1691,7 +1692,8 @@ mod tests {
                 .peer_responsiveness
                 .record_streaming_block_delivery(
                     AuthorityIndex::new_for_test(peer),
-                    Duration::from_millis(peer as u64 * 10),
+                    peer as u64 * 10,
+                    0,
                 );
         }
         cordial_knowledge.handle_useful_shards_from(BTreeMap::from([(author, 10)]));
@@ -1729,7 +1731,8 @@ mod tests {
                 .peer_responsiveness
                 .record_streaming_block_delivery(
                     AuthorityIndex::new_for_test(peer),
-                    Duration::from_millis(peer as u64 * 10),
+                    peer as u64 * 10,
+                    0,
                 );
         }
         cordial_knowledge.handle_useful_shards_from(BTreeMap::from([(author, 10)]));

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -5,9 +5,9 @@
 use std::{sync::Arc, time::Instant};
 
 use prometheus_filtered::{
-    Counter, CounterVec, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
-    IntGaugeVec, MetricLevel, Registry, register_counter_vec_with_registry,
-    register_counter_with_registry, register_gauge_vec_with_registry,
+    Counter, CounterVec, Gauge, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec,
+    IntGauge, IntGaugeVec, MetricLevel, Registry, register_counter_vec_with_registry,
+    register_counter_with_registry, register_gauge_vec_with_registry, register_gauge_with_registry,
     register_histogram_vec_with_registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
@@ -234,10 +234,11 @@ pub(crate) struct NodeMetrics {
     pub(crate) accepted_block_headers_round_gap: HistogramVec,
     pub(crate) core_skipped_headers: IntCounterVec,
     pub(crate) core_skipped_transactions: IntCounterVec,
-    pub(crate) cordial_knowledge_useful_shards_authors: IntCounterVec,
     pub(crate) cordial_knowledge_missing_authors: IntGauge,
     pub(crate) cordial_knowledge_selected_peers: IntGaugeVec,
     pub(crate) cordial_knowledge_unselected_useful_peers: IntGaugeVec,
+    pub(crate) cordial_knowledge_selected_shard_peers: IntGauge,
+    pub(crate) cordial_knowledge_shard_selection_latency_ms: Gauge,
     pub(crate) dag_state_recent_transactions: IntGauge,
     pub(crate) dag_state_recent_headers: IntGauge,
     pub(crate) dag_state_recent_shards: IntGauge,
@@ -786,13 +787,6 @@ impl NodeMetrics {
                 registry;
                 MetricLevel::Warn,
             ).unwrap(),
-            cordial_knowledge_useful_shards_authors: register_int_counter_vec_with_registry!(
-                "cordial_knowledge_useful_shards_authors",
-                "Useful authors for pushing shards to the local node",
-                &["author"],
-                registry;
-                MetricLevel::Warn,
-            ).unwrap(),
             cordial_knowledge_missing_authors: register_int_gauge_with_registry!(
                 "cordial_knowledge_missing_authors",
                 "Authors whose blocks are currently missing and whose headers peers are asked to push",
@@ -810,6 +804,18 @@ impl NodeMetrics {
                 "cordial_knowledge_unselected_useful_peers",
                 "Useful peers not selected to push this author's headers",
                 &["author"],
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            cordial_knowledge_selected_shard_peers: register_int_gauge_with_registry!(
+                "cordial_knowledge_selected_shard_peers",
+                "Peers selected to push one author's shards in the latest shard peer selection, zero while none is active",
+                registry;
+                MetricLevel::Warn,
+            ).unwrap(),
+            cordial_knowledge_shard_selection_latency_ms: register_gauge_with_registry!(
+                "cordial_knowledge_shard_selection_latency_ms",
+                "Block-stream latency (ms) of the slowest peer in the latest shard peer selection",
                 registry;
                 MetricLevel::Warn,
             ).unwrap(),

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -38,8 +38,9 @@
 //! keeps being sampled and a failed peer re-enters the ranked draw as soon as
 //! a fetch succeeds again.
 //!
-//! The block-bundle streaming path is tracked separately, per (peer, author)
-//! pair; see [`PeerResponsiveness::record_streaming_header_deliveries`].
+//! Block-bundle streaming also tracks primary block-stream latency per peer,
+//! used for shard peer selection, and header delivery latency per
+//! (peer, author) pair, used for header peer selection.
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -173,14 +174,24 @@ struct Tracks {
     per_kind: HashMap<DataSource, Vec<PeerStat>>,
 }
 
-/// Tracks per-peer responsiveness and ranks candidates for synchronizer peer
-/// selection. Shared per epoch.
+/// Tracks per-peer responsiveness to select peers for the transactions
+/// synchronizer, the commit syncer, the header synchronizer, and header and
+/// shard pushes. Shared per epoch.
 pub(crate) struct PeerResponsiveness {
     metrics: Arc<Metrics>,
     committee_size: usize,
     inner: Mutex<Tracks>,
+    /// Smoothed primary block-stream latency, indexed by peer.
+    streaming_blocks: Mutex<Vec<Option<f64>>>,
     /// Smoothed streaming-delivery latency, indexed `[peer][author]`.
     streaming_headers: Mutex<Vec<Vec<Option<f64>>>>,
+}
+
+/// The peers selected to push one author's shards.
+pub(crate) struct ShardPeerSelection {
+    pub(crate) peers: Vec<AuthorityIndex>,
+    /// Block-stream latency of the slowest selected peer.
+    pub(crate) required_latency_ms: f64,
 }
 
 impl PeerResponsiveness {
@@ -195,7 +206,79 @@ impl PeerResponsiveness {
                     .map(|source| (source, vec![PeerStat::default(); size]))
                     .collect(),
             }),
+            streaming_blocks: Mutex::new(vec![None; size]),
             streaming_headers: Mutex::new(vec![vec![None; size]; size]),
+        })
+    }
+
+    /// Records the latency of a primary block received on `peer`'s stream. The
+    /// latency is measured from the block's own timestamp, so the peer's clock
+    /// offset is part of the sample and, unlike the per-author header latency,
+    /// does not cancel across peers.
+    pub(crate) fn record_streaming_block_delivery(&self, peer: AuthorityIndex, latency: Duration) {
+        let sample = (latency.as_secs_f64() * 1_000.0).max(MIN_LATENCY_MS);
+        let mut streaming_blocks = self.streaming_blocks.lock();
+        let Some(previous) = streaming_blocks.get_mut(peer.value()) else {
+            return;
+        };
+        *previous = Some(blend_latency_ms(*previous, sample, ALPHA_SUCCESS));
+    }
+
+    /// Clears the block-stream latency when the stream to `peer` ends or
+    /// restarts.
+    pub(crate) fn clear_streaming_block_delivery(&self, peer: AuthorityIndex) {
+        let mut streaming_blocks = self.streaming_blocks.lock();
+        let Some(latency) = streaming_blocks.get_mut(peer.value()) else {
+            return;
+        };
+        *latency = None;
+    }
+
+    /// Returns the fastest measured peers that provide enough shards and stake
+    /// for reconstruction. The local node and `author` are excluded. Returns
+    /// `None` while too few peers have a measured latency to meet both
+    /// thresholds.
+    pub(crate) fn select_shard_peers(
+        &self,
+        committee: &Committee,
+        own_index: AuthorityIndex,
+        author: AuthorityIndex,
+    ) -> Option<ShardPeerSelection> {
+        let mut candidates: Vec<(AuthorityIndex, f64)> = {
+            let latencies = self.streaming_blocks.lock();
+            latencies
+                .iter()
+                .enumerate()
+                .filter_map(|(index, latency)| {
+                    let peer = AuthorityIndex::from(index as u8);
+                    (*latency).map(|latency| (peer, latency))
+                })
+                .filter(|(peer, _)| *peer != own_index && *peer != author)
+                .collect()
+        };
+        candidates.sort_by(|(left_peer, left_latency), (right_peer, right_latency)| {
+            left_latency
+                .total_cmp(right_latency)
+                .then_with(|| left_peer.cmp(right_peer))
+        });
+
+        let count_position = committee.info_length().checked_sub(1)?;
+        candidates.get(count_position)?;
+
+        let mut stake = 0;
+        let stake_position = candidates.iter().position(|(peer, _)| {
+            stake += committee.stake(*peer);
+            committee.reached_validity(stake)
+        })?;
+        let peer_count = count_position.max(stake_position) + 1;
+
+        Some(ShardPeerSelection {
+            required_latency_ms: candidates[peer_count - 1].1,
+            peers: candidates
+                .into_iter()
+                .take(peer_count)
+                .map(|(peer, _)| peer)
+                .collect(),
         })
     }
 
@@ -595,6 +678,11 @@ impl PeerResponsiveness {
             .get(peer.value())?
             .get(author.value())?
     }
+
+    #[cfg(test)]
+    pub(crate) fn streaming_block_latency_ms(&self, peer: AuthorityIndex) -> Option<f64> {
+        *self.streaming_blocks.lock().get(peer.value())?
+    }
 }
 
 #[cfg(test)]
@@ -788,6 +876,65 @@ mod tests {
         pr.record_streaming_header_deliveries(idx(200), 1_000, [(idx(1), 1, 900)]);
         pr.record_streaming_header_deliveries(idx(1), 1_000, [(idx(200), 1, 900)]);
         assert_eq!(pr.streaming_header_latency_ms(idx(1), idx(1)), None);
+    }
+
+    #[test]
+    fn streaming_block_delivery_seeds_then_smooths_ewma() {
+        let pr = responsiveness(4);
+        pr.record_streaming_block_delivery(idx(1), ms(100));
+        assert_eq!(pr.streaming_block_latency_ms(idx(1)), Some(100.0));
+
+        pr.record_streaming_block_delivery(idx(1), ms(200));
+        let latency = pr.streaming_block_latency_ms(idx(1)).unwrap();
+        assert!((latency - 130.0).abs() < 1e-6, "got {latency}");
+
+        pr.clear_streaming_block_delivery(idx(1));
+        assert_eq!(pr.streaming_block_latency_ms(idx(1)), None);
+    }
+
+    #[test]
+    fn shard_peers_meet_count_and_stake_thresholds() {
+        let (committee, _) = starfish_config::local_committee_and_keys(0, vec![1; 30]);
+        let pr = PeerResponsiveness::new(&committee, test_metrics());
+        let own_index = idx(0);
+        let author = idx(29);
+        for peer in 1..29u8 {
+            pr.record_streaming_block_delivery(idx(peer), ms(peer as u64));
+        }
+
+        let selection = pr
+            .select_shard_peers(&committee, own_index, author)
+            .unwrap();
+
+        assert_eq!(committee.info_length(), 12);
+        assert_eq!(selection.peers, (1..=12).map(idx).collect::<Vec<_>>());
+        assert_eq!(selection.required_latency_ms, 12.0);
+    }
+
+    #[test]
+    fn shard_peers_include_enough_stake() {
+        let (committee, _) =
+            starfish_config::local_committee_and_keys(0, vec![1, 1, 1, 1, 100, 100, 1]);
+        let pr = PeerResponsiveness::new(&committee, test_metrics());
+        for peer in 1..=5u8 {
+            pr.record_streaming_block_delivery(idx(peer), ms(peer as u64 * 10));
+        }
+
+        let selection = pr.select_shard_peers(&committee, idx(0), idx(6)).unwrap();
+
+        assert_eq!(committee.info_length(), 3);
+        assert_eq!(selection.peers, [1, 2, 3, 4].map(idx));
+        assert_eq!(selection.required_latency_ms, 40.0);
+    }
+
+    #[test]
+    fn shard_peer_selection_requires_enough_measurements() {
+        let (committee, _) = starfish_config::local_committee_and_keys(0, vec![1; 7]);
+        let pr = PeerResponsiveness::new(&committee, test_metrics());
+        pr.record_streaming_block_delivery(idx(1), ms(10));
+        pr.record_streaming_block_delivery(idx(2), ms(20));
+
+        assert!(pr.select_shard_peers(&committee, idx(0), idx(6)).is_none());
     }
 
     #[test]

--- a/crates/starfish/core/src/peer_responsiveness.rs
+++ b/crates/starfish/core/src/peer_responsiveness.rs
@@ -211,12 +211,22 @@ impl PeerResponsiveness {
         })
     }
 
-    /// Records the latency of a primary block received on `peer`'s stream. The
-    /// latency is measured from the block's own timestamp, so the peer's clock
-    /// offset is part of the sample and, unlike the per-author header latency,
-    /// does not cancel across peers.
-    pub(crate) fn record_streaming_block_delivery(&self, peer: AuthorityIndex, latency: Duration) {
-        let sample = (latency.as_secs_f64() * 1_000.0).max(MIN_LATENCY_MS);
+    /// Records the delivery of a primary block received on `peer`'s stream,
+    /// measured from the block's own timestamp to `now_ms`. The peer sets that
+    /// timestamp, so its clock offset is part of the sample and, unlike the
+    /// per-author header latency, does not cancel across peers. A timestamp
+    /// ahead of `now_ms` is dropped rather than floored, or a clock running
+    /// ahead would read as the fastest peer.
+    pub(crate) fn record_streaming_block_delivery(
+        &self,
+        peer: AuthorityIndex,
+        now_ms: BlockTimestampMs,
+        timestamp_ms: BlockTimestampMs,
+    ) {
+        if timestamp_ms > now_ms {
+            return;
+        }
+        let sample = ((now_ms - timestamp_ms) as f64).max(MIN_LATENCY_MS);
         let mut streaming_blocks = self.streaming_blocks.lock();
         let Some(previous) = streaming_blocks.get_mut(peer.value()) else {
             return;
@@ -881,15 +891,26 @@ mod tests {
     #[test]
     fn streaming_block_delivery_seeds_then_smooths_ewma() {
         let pr = responsiveness(4);
-        pr.record_streaming_block_delivery(idx(1), ms(100));
+        pr.record_streaming_block_delivery(idx(1), 100, 0);
         assert_eq!(pr.streaming_block_latency_ms(idx(1)), Some(100.0));
 
-        pr.record_streaming_block_delivery(idx(1), ms(200));
+        pr.record_streaming_block_delivery(idx(1), 200, 0);
         let latency = pr.streaming_block_latency_ms(idx(1)).unwrap();
         assert!((latency - 130.0).abs() < 1e-6, "got {latency}");
 
         pr.clear_streaming_block_delivery(idx(1));
         assert_eq!(pr.streaming_block_latency_ms(idx(1)), None);
+    }
+
+    #[test]
+    fn streaming_block_delivery_ahead_of_now_is_dropped() {
+        let pr = responsiveness(4);
+        pr.record_streaming_block_delivery(idx(1), 1_000, 1_001);
+        assert_eq!(pr.streaming_block_latency_ms(idx(1)), None);
+
+        pr.record_streaming_block_delivery(idx(1), 1_000, 900);
+        pr.record_streaming_block_delivery(idx(1), 1_000, 1_001);
+        assert_eq!(pr.streaming_block_latency_ms(idx(1)), Some(100.0));
     }
 
     #[test]
@@ -899,7 +920,7 @@ mod tests {
         let own_index = idx(0);
         let author = idx(29);
         for peer in 1..29u8 {
-            pr.record_streaming_block_delivery(idx(peer), ms(peer as u64));
+            pr.record_streaming_block_delivery(idx(peer), peer as u64, 0);
         }
 
         let selection = pr
@@ -917,7 +938,7 @@ mod tests {
             starfish_config::local_committee_and_keys(0, vec![1, 1, 1, 1, 100, 100, 1]);
         let pr = PeerResponsiveness::new(&committee, test_metrics());
         for peer in 1..=5u8 {
-            pr.record_streaming_block_delivery(idx(peer), ms(peer as u64 * 10));
+            pr.record_streaming_block_delivery(idx(peer), peer as u64 * 10, 0);
         }
 
         let selection = pr.select_shard_peers(&committee, idx(0), idx(6)).unwrap();
@@ -931,8 +952,8 @@ mod tests {
     fn shard_peer_selection_requires_enough_measurements() {
         let (committee, _) = starfish_config::local_committee_and_keys(0, vec![1; 7]);
         let pr = PeerResponsiveness::new(&committee, test_metrics());
-        pr.record_streaming_block_delivery(idx(1), ms(10));
-        pr.record_streaming_block_delivery(idx(2), ms(20));
+        pr.record_streaming_block_delivery(idx(1), 10, 0);
+        pr.record_streaming_block_delivery(idx(2), 20, 0);
 
         assert!(pr.select_shard_peers(&committee, idx(0), idx(6)).is_none());
     }

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -124,6 +124,9 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         if let Some(subscription) = subscription.take() {
             subscription.abort();
         }
+        self.context
+            .peer_responsiveness
+            .clear_streaming_block_delivery(peer);
         // There is a race between shutting down the subscription task and clearing the
         // metric here. TODO: fix the race when unsubscribe_locked() gets called
         // outside of stop().
@@ -160,6 +163,9 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let mut encoder = create_encoder(&context);
 
         'subscription: loop {
+            context
+                .peer_responsiveness
+                .clear_streaming_block_delivery(peer);
             context
                 .metrics
                 .node_metrics
@@ -544,6 +550,23 @@ mod test {
 
     fn header_for(peer: AuthorityIndex, round: Round) -> VerifiedBlockHeader {
         VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, peer.value() as u8).build())
+    }
+
+    #[test]
+    fn unsubscribe_clears_streaming_block_latency() {
+        let f = fixture(test_context(4), TestService::new(), StreamMode::Pending);
+        f.context
+            .peer_responsiveness
+            .record_streaming_block_delivery(f.peer, Duration::from_millis(10));
+
+        f.subscriber.unsubscribe(f.peer);
+
+        assert_eq!(
+            f.context
+                .peer_responsiveness
+                .streaming_block_latency_ms(f.peer),
+            None
+        );
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -552,8 +552,8 @@ mod test {
         VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, peer.value() as u8).build())
     }
 
-    #[test]
-    fn unsubscribe_clears_streaming_block_latency() {
+    #[tokio::test]
+    async fn unsubscribe_clears_streaming_block_latency() {
         let f = fixture(test_context(4), TestService::new(), StreamMode::Pending);
         f.context
             .peer_responsiveness

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -557,7 +557,7 @@ mod test {
         let f = fixture(test_context(4), TestService::new(), StreamMode::Pending);
         f.context
             .peer_responsiveness
-            .record_streaming_block_delivery(f.peer, Duration::from_millis(10));
+            .record_streaming_block_delivery(f.peer, 10, 0);
 
         f.subscriber.unsubscribe(f.peer);
 

--- a/dev-tools/grafana-local/dashboards/starfish-overview.json
+++ b/dev-tools/grafana-local/dashboards/starfish-overview.json
@@ -1858,7 +1858,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Distribution of the number of consensus commits coalesced into each checkpoint (`commits_per_checkpoint`). Each cell shows the rate of checkpoints whose commit count fell in the bucket on the Y axis. Buckets are 1..10 with a +Inf overflow (10+). At ~20 commits/s against the ~5 checkpoints/s cap, most checkpoints coalesce 3-5 commits (average ~4); a bimodal spread \u2014 many single-commit checkpoints plus a tail toward 10+ \u2014 indicates clustering.",
+      "description": "Distribution of the number of consensus commits coalesced into each checkpoint (`commits_per_checkpoint`). Each cell shows the rate of checkpoints whose commit count fell in the bucket on the Y axis. Buckets are 1..10 with a +Inf overflow (10+). At ~20 commits/s against the ~5 checkpoints/s cap, most checkpoints coalesce 3-5 commits (average ~4); a bimodal spread — many single-commit checkpoints plus a tail toward 10+ — indicates clustering.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -8658,7 +8658,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Rate at which validators request shards from each author.",
+          "description": "Peers each validator asks for one author's shards; 0 while no selection is active (too few measured peers or nothing missing).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -8714,11 +8714,11 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
+            "w": 6,
             "x": 12,
             "y": 334
           },
-          "id": 218,
+          "id": 435,
           "options": {
             "legend": {
               "calcs": [],
@@ -8727,8 +8727,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -8740,17 +8740,117 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by (author)(rate(consensus_cordial_knowledge_useful_shards_authors[2m]))",
+              "expr": "max by (host) (consensus_cordial_knowledge_selected_shard_peers)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "{{author}}",
+              "legendFormat": "{{host}}",
               "range": true,
               "refId": "A",
               "useBackend": false
             }
           ],
-          "title": "Useful shard authors over time",
+          "title": "Shard peers selected per author",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Block-stream latency of the slowest peer a validator had to include to cover shard count and stake for reconstruction.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 334
+          },
+          "id": 436,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "max by (host) (consensus_cordial_knowledge_shard_selection_latency_ms)",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Shard selection latency",
           "type": "timeseries"
         },
         {
@@ -16213,7 +16313,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Rate of counts instances where commit sync couldn\u2019t proceed due to a gap in block sequence",
+          "description": "Rate of counts instances where commit sync couldn’t proceed due to a gap in block sequence",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -16309,7 +16409,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Rate of counts instances where commit sync couldn\u2019t proceed due to a gap in block sequence",
+          "description": "Rate of counts instances where commit sync couldn’t proceed due to a gap in block sequence",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -21969,7 +22069,7 @@
               "refId": "A"
             }
           ],
-          "title": "Transaction synchronizer \u2014 expected fetch latency (uniform vs weighted)",
+          "title": "Transaction synchronizer — expected fetch latency (uniform vs weighted)",
           "type": "timeseries"
         },
         {
@@ -22097,7 +22197,7 @@
               "refId": "A"
             }
           ],
-          "title": "Commit syncer \u2014 expected fetch latency (uniform vs weighted)",
+          "title": "Commit syncer — expected fetch latency (uniform vs weighted)",
           "type": "timeseries"
         },
         {
@@ -22225,7 +22325,7 @@
               "refId": "A"
             }
           ],
-          "title": "Fast commit syncer \u2014 expected fetch latency (uniform vs weighted)",
+          "title": "Fast commit syncer — expected fetch latency (uniform vs weighted)",
           "type": "timeseries"
         },
         {
@@ -22353,7 +22453,7 @@
               "refId": "A"
             }
           ],
-          "title": "Header synchronizer \u2014 expected fetch latency (uniform vs weighted)",
+          "title": "Header synchronizer — expected fetch latency (uniform vs weighted)",
           "type": "timeseries"
         }
       ],


### PR DESCRIPTION
# Description of change

- Track smoothed primary block-stream latency per peer and clear it on disconnect.
- For each useful shard author, ask only the fastest peers needed to provide enough shards and stake for reconstruction.
- Treat authors of missing ancestors as useful shard authors too, as the header requests already do.
- Add two gauges for the latest selection: its peer count and the slowest selected peer's block-stream latency.
- Drop the per-author `cordial_knowledge_useful_shards_authors` counter (written per bundle under the connection lock; the new gauge covers it) and the dead `useful_shards_from_peer` field of `UsefulAuthors`.
- Replace the dashboard's "Useful shard authors over time" panel with panels for the two new gauges.

This limits shard traffic while leaving transaction synchronization unchanged as the fallback.

## Links to any relevant issues

Fixes #12793.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes



