### PR TITLE
chore: update SDK rev after the `*_opt` accessors were renamed to `opt_*`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7686,7 +7686,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "async-stream",
  "base64ct",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-graphql-client-build"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "cynic-codegen",
 ]
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -7686,7 +7686,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "base64ct",
  "bcs",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,9 +402,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "039eab606e498749e72f7d2f560e9246597a707b" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "039eab606e498749e72f7d2f560e9246597a707b" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -445,10 +445,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "039eab606e498749e72f7d2f560e9246597a707b", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "039eab606e498749e72f7d2f560e9246597a707b", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "039eab606e498749e72f7d2f560e9246597a707b", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "039eab606e498749e72f7d2f560e9246597a707b", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,9 +402,9 @@ iota-graphql-config = { path = "crates/iota-graphql-config" }
 iota-graphql-rpc = { path = "crates/iota-graphql-rpc" }
 iota-graphql-rpc-client = { path = "crates/iota-graphql-rpc-client" }
 iota-graphql-rpc-headers = { path = "crates/iota-graphql-rpc-headers" }
-iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f" }
+iota-grpc-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-client", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35" }
 iota-grpc-server = { path = "crates/iota-grpc-server" }
-iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f" }
+iota-grpc-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", package = "iota-sdk-grpc-types", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35" }
 iota-http = { path = "crates/iota-http" }
 iota-indexer = { path = "crates/iota-indexer" }
 iota-indexer-builder = { path = "crates/iota-indexer-builder" }
@@ -445,10 +445,10 @@ iota-replay = { path = "crates/iota-replay" }
 iota-rest-kv = { path = "crates/iota-rest-kv" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f", default-features = false }
-iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f", default-features = false }
-iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f", default-features = false }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f", default-features = false }
+iota-sdk-crypto = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35", default-features = false }
+iota-sdk-graphql-client = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35", default-features = false }
+iota-sdk-transaction-builder = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35", default-features = false }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35", default-features = false }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/object_handler.rs
@@ -203,8 +203,8 @@ impl ObjectHandler {
             previous_transaction: object.previous_transaction.to_base58(),
             storage_rebate: Some(object.storage_rebate),
             bcs: Some(object.to_base64()),
-            coin_type: object.coin_type_opt().map(|t| t.to_string()),
-            coin_balance: if object.coin_type_opt().is_some() {
+            coin_type: object.opt_coin_type().map(|t| t.to_string()),
+            coin_balance: if object.opt_coin_type().is_some() {
                 Some(object.get_coin_value_unchecked())
             } else {
                 None

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -519,7 +519,7 @@ impl IndexStore {
             .iter()
             .filter_map(|(owner, obj_id)| {
                 let object = input_coins.get(obj_id).or(written_coins.get(obj_id))?;
-                let coin_type_tag = object.coin_type_opt().unwrap_or_else(|| {
+                let coin_type_tag = object.opt_coin_type().unwrap_or_else(|| {
                     panic!(
                         "object_id: {obj_id} is not a coin type, input_coins: {input_coins:?}, written_coins: {written_coins:?}, tx_digest: {digest}"
                     )
@@ -556,7 +556,7 @@ impl IndexStore {
         .filter_map(|((owner, obj_id), obj_info)| {
             // If it's in written_coins, then it's not a coin. Skip it.
             let obj = written_coins.get(obj_id)?;
-            let coin_type_tag = obj.coin_type_opt().cloned().unwrap_or_else(|| {
+            let coin_type_tag = obj.opt_coin_type().cloned().unwrap_or_else(|| {
                 panic!(
                     "object_id: {obj_id} in written_coins is not a coin type, written_coins: {written_coins:?}, tx_digest: {digest}"
                 )

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -451,7 +451,7 @@ impl RegulatedCoinEnv {
             }
             if object.data.opt_object_type().unwrap().is_deny_cap_v1() {
                 deny_cap_id = Some(object.id());
-            } else if !object.is_gas_coin() && object.coin_type_opt().is_some() {
+            } else if !object.is_gas_coin() && object.opt_coin_type().is_some() {
                 coin_id = Some(object.id());
             }
         }

--- a/crates/iota-core/src/verify_indexes.rs
+++ b/crates/iota-core/src/verify_indexes.rs
@@ -38,7 +38,7 @@ pub fn verify_indexes(store: &dyn GlobalStateHashStore, indexes: Arc<IndexStore>
         owner_index.insert(owner_index_key, object_info);
 
         // Coin Index Calculation
-        if let Some(type_tag) = object.coin_type_opt() {
+        if let Some(type_tag) = object.opt_coin_type() {
             let info =
                 CoinInfo::from_object(object).expect("already checked that this is a coin type");
             let key = (owner, type_tag.to_string(), object.id());

--- a/crates/iota-e2e-tests/tests/per_epoch_config_stress_tests.rs
+++ b/crates/iota-e2e-tests/tests/per_epoch_config_stress_tests.rs
@@ -269,7 +269,7 @@ async fn create_test_env() -> TestEnv {
             continue;
         } else if object.is_coin() {
             coin_id = Some(object_id);
-            coin_type = object.coin_type_opt().cloned();
+            coin_type = object.opt_coin_type().cloned();
             coin_owner = Some(*created.owner.as_address());
         } else if object.data.opt_object_type().unwrap().is_deny_cap_v1() {
             deny_cap = Some(object_id);

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -77,7 +77,7 @@ impl TryFrom<IndexedObject> for StoredCheckpointedObject {
         })? as i64;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
-            .coin_type_opt()
+            .opt_coin_type()
             .map(|t| t.to_canonical_string(/* with_prefix */ true));
         let coin_balance = if coin_type.is_some() {
             Some(object.get_coin_value_unchecked())
@@ -266,7 +266,7 @@ impl TryFrom<IndexedObject> for StoredBackwardHistoryObject {
         })? as i64;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
-            .coin_type_opt()
+            .opt_coin_type()
             .map(|t| t.to_canonical_string(/* with_prefix */ true));
         let coin_balance = if coin_type.is_some() {
             Some(object.get_coin_value_unchecked())
@@ -348,7 +348,7 @@ impl From<IndexedObject> for StoredObject {
         } = o;
         let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
         let coin_type = object
-            .coin_type_opt()
+            .opt_coin_type()
             .map(|t| t.to_canonical_string(/* with_prefix */ true));
         let coin_balance = if coin_type.is_some() {
             Some(object.get_coin_value_unchecked())

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -131,7 +131,7 @@ impl CoinReadApiServer for CoinReadApi {
                     let obj = self.internal.get_object(&object_id).await?;
                     match obj {
                         Some(obj) => {
-                            if let Some(coin_type) = obj.coin_type_opt() {
+                            if let Some(coin_type) = obj.opt_coin_type() {
                                 Ok((coin_type.to_string(), object_id))
                             } else {
                                 Err(IotaRpcInputError::GenericInvalid(

--- a/crates/iota-types/src/coin.rs
+++ b/crates/iota-types/src/coin.rs
@@ -50,7 +50,7 @@ impl Coin {
         let ObjectData::Struct(obj) = &object.data else {
             return Ok(None);
         };
-        let Some(_) = obj.struct_tag().coin_type_opt() else {
+        let Some(_) = obj.struct_tag().opt_coin_type() else {
             return Ok(None);
         };
 

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -137,7 +137,7 @@ pub fn check_coin_deny_list_v1_during_execution(
         if obj.is_gas_coin() {
             continue;
         }
-        let Some(coin_type) = obj.coin_type_opt() else {
+        let Some(coin_type) = obj.opt_coin_type() else {
             continue;
         };
         let Some(owner) = obj.owner.as_opt_address() else {
@@ -301,7 +301,7 @@ fn input_object_coin_types_for_denylist_check(
             if obj.is_gas_coin() {
                 None
             } else {
-                obj.coin_type_opt()
+                obj.opt_coin_type()
                     .map(|type_tag| type_tag.to_canonical_string(false))
             }
         })

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -322,7 +322,7 @@ impl MoveStructExt for MoveStruct {
         layout_resolver: &mut dyn LayoutResolver,
     ) -> Result<BTreeMap<TypeTag, u64>, IotaError> {
         // Fast path without deserialization.
-        if let Some(type_tag) = self.object_type().coin_type_opt() {
+        if let Some(type_tag) = self.object_type().opt_coin_type() {
             let balance = self.get_coin_value_unchecked();
             Ok(if balance > 0 {
                 BTreeMap::from([(type_tag.clone(), balance)])

--- a/crates/iota-types/src/programmable_transaction_builder.rs
+++ b/crates/iota-types/src/programmable_transaction_builder.rs
@@ -69,7 +69,7 @@ impl ProgrammableTransactionBuilder {
     pub fn obj(&mut self, obj_arg: impl Into<CallArg>) -> anyhow::Result<Argument> {
         let obj_arg: CallArg = obj_arg.into();
         let id = *obj_arg
-            .object_id_opt()
+            .opt_object_id()
             .ok_or_else(|| anyhow::anyhow!("expected object CallArg, found pure argument"))?;
         let obj_arg = if let Some(old_value) = self.inputs.get(&BuilderArg::Object(id)) {
             match (old_value.as_opt_shared(), obj_arg.as_opt_shared()) {

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -295,7 +295,7 @@ impl TestCheckpointDataBuilder {
             .get(&object_id)
             .cloned()
             .expect("Mutating an object that does not exist");
-        let coin_type = object.coin_type_opt().cloned().unwrap();
+        let coin_type = object.opt_coin_type().cloned().unwrap();
         // Withdraw balance from coin object.
         let move_object = object.data.as_opt_mut_struct().unwrap();
         let old_balance = move_object.get_coin_value_unchecked();
@@ -1008,12 +1008,12 @@ mod tests {
 
         // Verify the original coin now has 90 balance after the transfer.
         assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id0
-            && obj.coin_type_opt() == Some(&type_tag)
+            && obj.opt_coin_type() == Some(&type_tag)
             && obj.data.as_opt_struct().unwrap().get_coin_value_unchecked() == 90));
 
         // Verify the split out coin has 10 balance, with the same type tag.
         assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id1
-            && obj.coin_type_opt() == Some(&type_tag)
+            && obj.opt_coin_type() == Some(&type_tag)
             && obj.data.as_opt_struct().unwrap().get_coin_value_unchecked() == 10));
     }
 

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3332,7 +3332,7 @@ async fn grpc_coin(
         .await?
         .ok_or_else(|| anyhow!("Coin {coin_id} does not exist"))?;
     let coin_type = object
-        .coin_type_opt()
+        .opt_coin_type()
         .ok_or_else(|| anyhow!("Object {coin_id} is not a coin"))?
         .clone();
 

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=039eab606e498749e72f7d2f560e9246597a707b#039eab606e498749e72f7d2f560e9246597a707b"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.lock
+++ b/docs/examples/rust/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-crypto"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-client"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-grpc-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-transaction-builder"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=0311cac8b35fa2301c40c2cb088765a2c6185e7f#0311cac8b35fa2301c40c2cb088765a2c6185e7f"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=56b8a133aa3fd20078cb10eff356d66c7630ea35#56b8a133aa3fd20078cb10eff356d66c7630ea35"
 dependencies = [
  "base64ct",
  "bcs",

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "039eab606e498749e72f7d2f560e9246597a707b" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "1.46.1"
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-move-build = { path = "../../../crates/iota-move-build" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35" }
 iota-types = { path = "../../../crates/iota-types" }
 move-binary-format = { path = "../../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
 

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "039eab606e498749e72f7d2f560e9246597a707b" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.49.0", features = ["time"] }
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }
 iota-sdk = { path = "../../../crates/iota-sdk" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "0311cac8b35fa2301c40c2cb088765a2c6185e7f" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "56b8a133aa3fd20078cb10eff356d66c7630ea35" }
 iota-types = { path = "../../../crates/iota-types" }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
## Description of change

- Bump `iota-rust-sdk` rev to `56b8a133aa3fd20078cb10eff356d66c7630ea35`.
- Rename all call sites of `coin_type_opt()` / `object_id_opt()` to the SDK's new `opt_coin_type()` / `opt_object_id()` names.

## Type of change

- Chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)