### PR TITLE
fix(scripts): pin the rustfmt nightly in execution_layer.py to the CI version

### DIFF
--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -175,7 +175,7 @@ def do_generate_lib(args):
 
 def fmt_file(path):
     try:
-        subprocess.run(['cargo', '+nightly', 'fmt', '--', path, '--unstable-features', '--skip-children'],
+        subprocess.run(['cargo', '+nightly-2026-06-29', 'fmt', '--', path, '--unstable-features', '--skip-children'],
                        check=True)
     except subprocess.CalledProcessError as e:
         print(f"cargo fmt failed with error code {e.returncode}")


### PR DESCRIPTION
## Description of change

- `execution_layer.py` ran `cargo +nightly fmt` with the floating `nightly` toolchain, so any nightly rustfmt change could make `generate-lib` produce a diff and fail the generated-lib check.
- Pin it to `nightly-2026-06-29`, the nightly version we already use everywhere in CI, to avoid breaking it when nightly suddenly changes something.
- Fixes https://github.com/iotaledger/iota/actions/runs/33338415507/job/99329419201, where a rustfmt update (nightly 2026-08-29) changed comment wrapping and left the tree dirty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)