### PR TITLE
upstream(core): Reduce QUIC max_idle_timeout from 30s to 10s

### DIFF
--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1121,7 +1121,7 @@ impl IotaNode {
                 quic_config.crypto_buffer_size = Some(1 << 20);
             }
             if quic_config.max_idle_timeout_ms.is_none() {
-                quic_config.max_idle_timeout_ms = Some(30_000);
+                quic_config.max_idle_timeout_ms = Some(10_000);
             }
             if quic_config.keep_alive_interval_ms.is_none() {
                 quic_config.keep_alive_interval_ms = Some(5_000);


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.66.2, latest)
- Port commit:
  - [MystenLabs/sui@64a0aef](https://github.com/MystenLabs/sui/commit/64a0aef1839f595ff6f697f5ca64a0e4c22f8a08)
- Description:

Reduces the default QUIC `max_idle_timeout` from 30 seconds to 10 seconds for anemo peer connections, letting fullnodes detect dead validator connections ~3x faster after a correlated crash.

After a correlated validator crash, a fullnode's QUIC connections become stale but remain in `ActivePeers`: `open_bi()` and `write_request()` succeed locally on dead connections, `read_response()` hangs until the request timeout, and the QUIC idle timeout is the only mechanism that removes stale connections. At 30 seconds it races with the ~30s `CheckpointTimeout`, so fullnodes could get stuck at a stale checkpoint and clients see version mismatch errors on retry. At 10 seconds the fullnode detects dead connections, reconnects, and syncs missed checkpoints before the `CheckpointTimeout` fires.

The 5s `keep_alive_interval_ms` is unchanged, so active connections are unaffected.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Reduce the default QUIC idle timeout on the p2p network from 30s to 10s, so stale peer connections are detected and replaced faster.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: