### PR TITLE
backport(core): Bump anemo version and reduce QUIC max_idle_timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=f8b708601d002a75955dafebae4f75628c6f42b4#f8b708601d002a75955dafebae4f75628c6f42b4"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=68adc31d4ea1f4573f08c2c75317fcb205b823de#68adc31d4ea1f4573f08c2c75317fcb205b823de"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -213,7 +213,7 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=f8b708601d002a75955dafebae4f75628c6f42b4#f8b708601d002a75955dafebae4f75628c6f42b4"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=68adc31d4ea1f4573f08c2c75317fcb205b823de#68adc31d4ea1f4573f08c2c75317fcb205b823de"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "anemo-cli"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=f8b708601d002a75955dafebae4f75628c6f42b4#f8b708601d002a75955dafebae4f75628c6f42b4"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=68adc31d4ea1f4573f08c2c75317fcb205b823de#68adc31d4ea1f4573f08c2c75317fcb205b823de"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=f8b708601d002a75955dafebae4f75628c6f42b4#f8b708601d002a75955dafebae4f75628c6f42b4"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=68adc31d4ea1f4573f08c2c75317fcb205b823de#68adc31d4ea1f4573f08c2c75317fcb205b823de"
 dependencies = [
  "anemo",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,9 +231,9 @@ uninlined_format_args = "warn"
 [workspace.dependencies]
 # external dependencies
 # anemo dependencies
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "f8b708601d002a75955dafebae4f75628c6f42b4" }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "f8b708601d002a75955dafebae4f75628c6f42b4" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "f8b708601d002a75955dafebae4f75628c6f42b4" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d4ea1f4573f08c2c75317fcb205b823de" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d4ea1f4573f08c2c75317fcb205b823de" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d4ea1f4573f08c2c75317fcb205b823de" }
 anyhow = "1.0.103"
 arc-swap = { version = "1.7.1", features = ["serde"] }
 async-graphql = { version = "7.1.0", default-features = false }

--- a/crates/iota-network-stack/src/codec.rs
+++ b/crates/iota-network-stack/src/codec.rs
@@ -10,6 +10,25 @@ use tonic::{
     codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder},
 };
 
+/// Default upper bound on total decompressed payload size.
+const MAX_DECOMPRESSED_SIZE: u64 = 128 << 20;
+
+/// Decompress a snappy-framed stream, bounding output at
+/// [`MAX_DECOMPRESSED_SIZE`].
+fn decompress_snappy<R: Read>(src: R) -> std::io::Result<Vec<u8>> {
+    decompress_snappy_bounded(src, MAX_DECOMPRESSED_SIZE)
+}
+
+/// Decompress a snappy-framed stream, bounding total output at
+/// `max_allowed` bytes. Exposed separately from [`decompress_snappy`] so
+/// tests can exercise the bound directly.
+fn decompress_snappy_bounded<R: Read>(src: R, max_allowed: u64) -> std::io::Result<Vec<u8>> {
+    let mut snappy_decoder = snap::read::FrameDecoder::new(src).take(max_allowed);
+    let mut bytes = Vec::new();
+    snappy_decoder.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
 #[derive(Debug)]
 pub struct BcsEncoder<T>(PhantomData<T>);
 
@@ -94,13 +113,10 @@ impl<U: serde::de::DeserializeOwned> Decoder for BcsSnappyDecoder<U> {
     type Error = Status;
 
     fn decode(&mut self, buf: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
-        let compressed_size = buf.remaining();
-        if compressed_size == 0 {
+        if !buf.has_remaining() {
             return Ok(None);
         }
-        let mut snappy_decoder = snap::read::FrameDecoder::new(buf.reader());
-        let mut bytes = Vec::with_capacity(compressed_size);
-        snappy_decoder.read_to_end(&mut bytes)?;
+        let bytes = decompress_snappy(buf.reader()).map_err(|e| Status::internal(e.to_string()))?;
         let item =
             bcs::from_bytes(bytes.as_slice()).map_err(|e| Status::internal(e.to_string()))?;
         Ok(Some(item))
@@ -139,7 +155,7 @@ where
 
 // Anemo variant of BCS codec using Snappy for compression.
 pub mod anemo {
-    use std::{io::Read, marker::PhantomData};
+    use std::marker::PhantomData;
 
     use ::anemo::rpc::codec::{Codec, Decoder, Encoder};
     use bytes::Buf;
@@ -168,10 +184,7 @@ pub mod anemo {
         type Error = bcs::Error;
 
         fn decode(&mut self, buf: bytes::Bytes) -> Result<Self::Item, Self::Error> {
-            let compressed_size = buf.len();
-            let mut snappy_decoder = snap::read::FrameDecoder::new(buf.reader()).take(1 << 30);
-            let mut bytes = Vec::with_capacity(compressed_size);
-            snappy_decoder.read_to_end(&mut bytes)?;
+            let bytes = super::decompress_snappy(buf.reader())?;
             bcs::from_bytes(bytes.as_slice())
         }
     }
@@ -207,6 +220,104 @@ pub mod anemo {
 
         fn format_name(&self) -> &'static str {
             "bcs"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ::anemo::rpc::codec::{
+        Codec as AnemoCodec, Decoder as AnemoDecoder, Encoder as AnemoEncoder,
+    };
+
+    use super::*;
+
+    fn snappy_compress(raw: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut encoder = snap::write::FrameEncoder::new(&mut out);
+        std::io::Write::write_all(&mut encoder, raw).unwrap();
+        drop(encoder);
+        out
+    }
+
+    #[test]
+    fn anemo_roundtrip() {
+        let mut codec: anemo::BcsSnappyCodec<Vec<u64>, Vec<u64>> = anemo::BcsSnappyCodec::default();
+        let value = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let encoded = codec.encoder().encode(value.clone()).unwrap();
+        let decoded = codec.decoder().decode(encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn bounded_helper_respects_output_limit() {
+        // With `max_allowed` set below the stream's decompressed size,
+        // `decompress_snappy_bounded` returns exactly `max_allowed` bytes.
+        let raw = vec![0u8; 2 * 1024 * 1024];
+        let compressed = snappy_compress(&raw);
+        let limit = 1024u64;
+        let out = decompress_snappy_bounded(&compressed[..], limit).unwrap();
+        assert_eq!(out.len() as u64, limit);
+        assert!((out.len() as u64) < raw.len() as u64);
+    }
+
+    // Tonic-variant round trip via a bespoke HttpBody. Building a real
+    // `DecodeBuf` requires tonic's internal API, so we drive the decoder
+    // through `tonic::codec::Streaming::new_request`, which is the path used
+    // by the gRPC server. This exercises the real `BcsSnappyDecoder::decode`.
+    mod tonic_via_streaming {
+        use std::{
+            pin::Pin,
+            task::{Context, Poll},
+        };
+
+        use bytes::{BufMut, Bytes, BytesMut};
+        use futures::StreamExt;
+        use http_body::{Body as HttpBody, Frame};
+
+        use super::{super::*, snappy_compress};
+
+        /// Minimal HttpBody yielding a single gRPC-framed payload. gRPC length-
+        /// prefixed frames are `[compression:u8][length:u32 BE][payload]`.
+        struct OneFrameBody(Option<Bytes>);
+
+        impl OneFrameBody {
+            fn new(payload: Bytes) -> Self {
+                let mut framed = BytesMut::with_capacity(5 + payload.len());
+                framed.put_u8(0);
+                framed.put_u32(payload.len() as u32);
+                framed.put_slice(&payload);
+                Self(Some(framed.freeze()))
+            }
+        }
+
+        impl HttpBody for OneFrameBody {
+            type Data = Bytes;
+            type Error = std::convert::Infallible;
+
+            fn poll_frame(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+                Poll::Ready(self.0.take().map(|b| Ok(Frame::data(b))))
+            }
+
+            fn is_end_stream(&self) -> bool {
+                self.0.is_none()
+            }
+        }
+
+        #[tokio::test]
+        async fn tonic_roundtrip() {
+            let mut codec: BcsSnappyCodec<Vec<u64>, Vec<u64>> = BcsSnappyCodec::default();
+            let value = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            let raw = bcs::to_bytes(&value).unwrap();
+            let compressed = snappy_compress(&raw);
+            let body = OneFrameBody::new(Bytes::from(compressed));
+            let mut stream =
+                tonic::codec::Streaming::new_request(codec.decoder(), body, None, None);
+            let decoded = stream.next().await.unwrap().unwrap();
+            assert_eq!(decoded, value);
         }
     }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1085,9 +1085,12 @@ impl IotaNode {
                 .into_inner();
 
             let mut anemo_config = config.p2p_config.anemo_config.clone().unwrap_or_default();
-            // Set the max_frame_size to be 1 GB to work around the issue of there being too
-            // many staking events in the epoch change txn.
-            anemo_config.max_frame_size = Some(1 << 30);
+            // Inbound requests on this network are small (signatures, queries, summaries).
+            // Cap request frames at 1 MiB.
+            anemo_config.max_request_frame_size = Some(1 << 20);
+            // Responses can be larger (checkpoint contents).
+            // Cap response frames at 128 MiB.
+            anemo_config.max_response_frame_size = Some(128 << 20);
 
             // Set a higher default value for socket send/receive buffers if not already
             // configured.
@@ -1121,7 +1124,7 @@ impl IotaNode {
                 quic_config.crypto_buffer_size = Some(1 << 20);
             }
             if quic_config.max_idle_timeout_ms.is_none() {
-                quic_config.max_idle_timeout_ms = Some(30_000);
+                quic_config.max_idle_timeout_ms = Some(10_000);
             }
             if quic_config.keep_alive_interval_ms.is_none() {
                 quic_config.keep_alive_interval_ms = Some(5_000);

--- a/crates/iota-tool/Cargo.toml
+++ b/crates/iota-tool/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 # external dependencies
 anemo.workspace = true
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "f8b708601d002a75955dafebae4f75628c6f42b4" }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d4ea1f4573f08c2c75317fcb205b823de" }
 anyhow.workspace = true
 camino.workspace = true
 clap.workspace = true


### PR DESCRIPTION
## Description of change

- Upstream range: [v1.66.2, latest)
- Port commits:
  - [MystenLabs/sui@255e614](https://github.com/MystenLabs/sui/commit/255e614f4fd3faccb9812b90b29337c15c5e515a)
  - [MystenLabs/sui@64a0aef](https://github.com/MystenLabs/sui/commit/64a0aef1839f595ff6f697f5ca64a0e4c22f8a08)
- Description:

Set new `max_request_frame_size` config to 1 MiB on the p2p network. Lower existing max (now applies only to responses) to 128 MiB, still plenty of headroom over max observed message sizes. Factor the snappy decode path in `iota-network-stack::codec` into a shared helper bounded at 128 MiB (previously 1 GiB in the anemo decoder, unbounded in the tonic decoder), and add codec tests.

Also reduce the default QUIC `max_idle_timeout` from 30 seconds to 10 seconds for anemo peer connections. The QUIC idle timeout is the only mechanism that removes stale connections after a correlated validator crash, and at 30 seconds it races with the ~30s `CheckpointTimeout`, so fullnodes could get stuck at a stale checkpoint until reconnect. The 5s `keep_alive_interval_ms` is unchanged, so active connections are unaffected.

Differences from upstream:

- anemo is pinned to [`68adc31`](https://github.com/MystenLabs/anemo/commit/68adc31d4ea1f4573f08c2c75317fcb205b823de), two commits past upstream's target `487f8bc` (which this fork's previous bump already included).
- The `randomness/builder.rs` hunks were already applied by the previous anemo bump (#11813).
- The `state_sync/builder.rs` hunks don't apply: this fork's state-sync builder doesn't assemble the anemo `Router`, and the `SizeLimitLayer` feature the hunk reorders was never ported.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Cap p2p request frames at 1 MiB and response frames at 128 MiB (previously 1 GiB for both), and reduce the default QUIC idle timeout on the p2p network from 30s to 10s so stale peer connections are detected and replaced faster.
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: