### PR TITLE
refactor(iota-kvstore): enable integration tests for the CI

### DIFF
--- a/crates/iota-kvstore/Cargo.toml
+++ b/crates/iota-kvstore/Cargo.toml
@@ -28,9 +28,6 @@ telemetry-subscribers.workspace = true
 [features]
 emulator = ["dep:futures", "tokio/process"]
 integration_tests = ["emulator"]
-# Keeps the emulator-backed tests ignored under `--all-features` (CI), which
-# would otherwise enable `integration_tests` on runners without the emulator.
-skip_integration_tests = []
 
 [dev-dependencies]
 # Self-dependency that enables the `emulator` feature for all dev targets,

--- a/crates/iota-kvstore/tests/kv_worker.rs
+++ b/crates/iota-kvstore/tests/kv_worker.rs
@@ -32,7 +32,7 @@ fn build_test_checkpoint() -> CheckpointData {
 /// transactions, and checkpoints data.
 #[tokio::test]
 #[cfg_attr(
-    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
+    not(feature = "integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn process_checkpoint_round_trips_objects_transactions_and_checkpoints() {
@@ -119,7 +119,7 @@ async fn process_checkpoint_round_trips_objects_transactions_and_checkpoints() {
 /// transactions.
 #[tokio::test]
 #[cfg_attr(
-    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
+    not(feature = "integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn readers_omit_not_found_keys() {

--- a/crates/iota-kvstore/tests/transactions_by_address.rs
+++ b/crates/iota-kvstore/tests/transactions_by_address.rs
@@ -75,7 +75,7 @@ fn affected_addresses_per_transaction() {
 
 #[tokio::test]
 #[cfg_attr(
-    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
+    not(feature = "integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn process_checkpoint() {
@@ -133,7 +133,7 @@ async fn process_checkpoint() {
 
 #[tokio::test]
 #[cfg_attr(
-    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
+    not(feature = "integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn paginates_newest_first() {
@@ -172,7 +172,7 @@ async fn paginates_newest_first() {
 
 #[tokio::test]
 #[cfg_attr(
-    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
+    not(feature = "integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn paginates_oldest_first() {
@@ -211,7 +211,7 @@ async fn paginates_oldest_first() {
 
 #[tokio::test]
 #[cfg_attr(
-    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
+    not(feature = "integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn order_flip_is_exact_reverse() {
@@ -264,7 +264,7 @@ async fn order_flip_is_exact_reverse() {
 
 #[tokio::test]
 #[cfg_attr(
-    any(not(feature = "integration_tests"), feature = "skip_integration_tests"),
+    not(feature = "integration_tests"),
     ignore = "requires the BigTable emulator; run with --features integration_tests"
 )]
 async fn empty_range_guards_return_ok_empty() {


### PR DESCRIPTION
# Description of change

This PR enables `iota-kvstore` integration tests in GitHub Runners CI.

## Links to any relevant issues

fixes #12393 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This PR does not affect the normal operations of the `iota-indexer`, thus, no further tests were conducted.