### PR TITLE
upstream(core): Fix formal snapshot restore failures

### DIFF
--- a/crates/iota-indexer/src/restore/orchestration.rs
+++ b/crates/iota-indexer/src/restore/orchestration.rs
@@ -5,8 +5,9 @@ use std::{num::NonZeroUsize, path::Path};
 
 use futures::{TryFutureExt, future::AbortHandle};
 use iota_config::genesis::Genesis;
+use iota_snapshot::reader::StateAccumulatorSender;
 use iota_types::global_state_hash::GlobalStateHash;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::info;
 
 use super::{
@@ -56,13 +57,21 @@ pub async fn start(
     let (_abort_handle, abort_registration) = AbortHandle::new_pair();
     let (state_hash_tx, state_hash_rx) =
         mpsc::channel::<(GlobalStateHash, u64)>(num_parallel_downloads.get());
+    let (accumulation_done_tx, accumulation_done_rx) = oneshot::channel();
 
     let verified_epoch_info = verify_epoch_info(epoch_info, genesis, snapshot_chain_id).await?;
     let ((), num_objects) = tokio::try_join!(
         reader
-            .read_to_db(&pg_indexer_store, abort_registration, Some(state_hash_tx))
+            .read_to_db(
+                &pg_indexer_store,
+                abort_registration,
+                Some(StateAccumulatorSender {
+                    partials: state_hash_tx,
+                    completion: accumulation_done_tx,
+                }),
+            )
             .map_err(IndexerError::from),
-        verify_state_hash(state_hash_rx, &verified_epoch_info),
+        verify_state_hash(state_hash_rx, accumulation_done_rx, &verified_epoch_info),
     )?;
     populate_remaining_tables(&pg_indexer_store, verified_epoch_info, snapshot_chain_id).await?;
 

--- a/crates/iota-indexer/src/restore/verify.rs
+++ b/crates/iota-indexer/src/restore/verify.rs
@@ -53,6 +53,10 @@ pub(crate) async fn verify_state_hash(
     accumulation_done_rx: oneshot::Receiver<()>,
     verified_epoch_info: &VerifiedEpochInfo,
 ) -> IndexerResult<u64> {
+    // The partial hashes must be drained before the completion signal is
+    // awaited: the reader's accumulation tasks block on the bounded channel
+    // and only signal completion after the last of them, so awaiting
+    // completion first would deadlock the restore.
     let (root_state_hash, num_objects) = accumulate_state_hash(state_hash_rx).await;
     // A dropped completion sender means the restore failed before every
     // partial hash was sent — the accumulated hash is incomplete, and

--- a/crates/iota-indexer/src/restore/verify.rs
+++ b/crates/iota-indexer/src/restore/verify.rs
@@ -8,7 +8,7 @@ use iota_types::{
     digests::ChainIdentifier, global_state_hash::GlobalStateHash,
     messages_checkpoint::ECMHLiveObjectSetDigest,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{errors::IndexerError, types::IndexerResult};
 
@@ -45,13 +45,23 @@ pub(crate) async fn verify_epoch_info(
 /// Returns an error if:
 ///
 /// - State hash verification fails.
+/// - The restore stops before accumulation completes.
 /// - The verified checkpoint carries no end-of-epoch commitment.
 /// - The accumulated root state hash does not match that commitment.
 pub(crate) async fn verify_state_hash(
     state_hash_rx: mpsc::Receiver<(GlobalStateHash, u64)>,
+    accumulation_done_rx: oneshot::Receiver<()>,
     verified_epoch_info: &VerifiedEpochInfo,
 ) -> IndexerResult<u64> {
     let (root_state_hash, num_objects) = accumulate_state_hash(state_hash_rx).await;
+    // A dropped completion sender means the restore failed before every
+    // partial hash was sent — the accumulated hash is incomplete, and
+    // comparing it below would report a misleading mismatch.
+    if accumulation_done_rx.await.is_err() {
+        return Err(IndexerError::Restore(
+            "snapshot accumulation did not complete".to_string(),
+        ));
+    }
 
     let last_checkpoint_summary = &verified_epoch_info
         .entries()

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -23,7 +23,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
 use backoff::future::retry;
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
@@ -474,8 +474,15 @@ pub async fn copy_files_with_progress<S: ObjectStoreGetExt, D: ObjectStorePutExt
 ) -> Result<()> {
     futures::stream::iter(paths)
         .map(|path| async move {
-            let bytes = get_with_progress(src_store, path, progress).await?;
-            put(dest_store, path, bytes).await?;
+            let bytes = get_with_progress(src_store, path, progress)
+                .await
+                .with_context(|| format!("Failed to download {path}"))?;
+            if bytes.is_empty() {
+                return Err(anyhow!("Downloaded empty file {path}"));
+            }
+            put(dest_store, path, bytes)
+                .await
+                .with_context(|| format!("Failed to write {path}"))?;
             Ok::<_, anyhow::Error>(())
         })
         .boxed()
@@ -710,6 +717,29 @@ mod tests {
         assert_eq!(
             dest_store.get_bytes(&Path::from("a")).await?.to_vec(),
             b"12345"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_copy_files_with_progress_rejects_empty_file() -> anyhow::Result<()> {
+        let src_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let dest_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        src_store
+            .put_bytes(&Path::from("empty.ref"), Bytes::new())
+            .await?;
+        let paths = [Path::from("empty.ref")];
+
+        let progress = DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 1, None);
+        let error = copy_files_with_progress(&paths, &src_store, &dest_store, 1, &progress)
+            .await
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("Downloaded empty file empty.ref"));
+        assert!(
+            dest_store
+                .get_bytes(&Path::from("empty.ref"))
+                .await
+                .is_err()
         );
         Ok(())
     }

--- a/crates/iota-snapshot/src/progress.rs
+++ b/crates/iota-snapshot/src/progress.rs
@@ -23,9 +23,10 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, ensure};
 use backoff::future::retry;
 use bytes::Bytes;
+use fastcrypto::hash::{HashFunction, Sha3_256};
 use futures::{StreamExt, TryStreamExt};
 use indicatif::{
     FormattedDuration, HumanBytes, HumanCount, HumanDuration, MultiProgress, ProgressBar,
@@ -421,7 +422,9 @@ impl DownloadProgressBar {
 
 /// Download `src` from `store` with retries, recording received chunks on
 /// `progress` as they arrive. A failed attempt's bytes are rolled back so the
-/// retry doesn't count them twice.
+/// retry doesn't count them twice. An empty response counts as a failed
+/// attempt: no snapshot file is legitimately empty, and a store may serve one
+/// transiently.
 pub async fn get_with_progress<S: ObjectStoreGetExt>(
     store: &S,
     src: &Path,
@@ -435,6 +438,10 @@ pub async fn get_with_progress<S: ObjectStoreGetExt>(
                 progress.add_bytes(n);
             })
             .await
+            .and_then(|bytes| {
+                ensure!(!bytes.is_empty(), "Downloaded empty file {src}");
+                Ok(bytes)
+            })
             .map_err(|e| {
                 progress.remove_bytes(attempt_bytes.load(Ordering::Relaxed));
                 error!("Failed to read file {src} from object store with error: {e:?}");
@@ -462,24 +469,29 @@ pub async fn get_single_file_with_progress<S: ObjectStoreGetExt>(
     Ok(bytes)
 }
 
-/// Copy every path in `paths` from `src_store` to `dest_store` in parallel,
-/// recording downloaded chunks and each completed file on `progress` and
-/// failing on the first copy that fails.
+/// Copy every `(path, sha3_digest)` in `files` from `src_store` to
+/// `dest_store` in parallel, recording downloaded chunks and each completed
+/// file on `progress` and failing on the first copy that fails. A download
+/// whose bytes don't hash to its manifest digest — a truncated file, say — is
+/// rejected instead of being written to `dest_store`.
 pub async fn copy_files_with_progress<S: ObjectStoreGetExt, D: ObjectStorePutExt>(
-    paths: &[Path],
+    files: &[(Path, [u8; 32])],
     src_store: &S,
     dest_store: &D,
     concurrency: usize,
     progress: &DownloadProgressBar,
 ) -> Result<()> {
-    futures::stream::iter(paths)
-        .map(|path| async move {
+    futures::stream::iter(files)
+        .map(|(path, sha3_digest)| async move {
             let bytes = get_with_progress(src_store, path, progress)
                 .await
                 .with_context(|| format!("Failed to download {path}"))?;
-            if bytes.is_empty() {
-                return Err(anyhow!("Downloaded empty file {path}"));
-            }
+            let computed = Sha3_256::digest(&bytes).digest;
+            ensure!(
+                computed == *sha3_digest,
+                "Downloaded {path} does not match the manifest checksum: computed {computed:?}, \
+                 expected {sha3_digest:?}"
+            );
             put(dest_store, path, bytes)
                 .await
                 .with_context(|| format!("Failed to write {path}"))?;
@@ -508,6 +520,7 @@ mod tests {
     use anyhow::Result;
     use async_trait::async_trait;
     use bytes::Bytes;
+    use fastcrypto::hash::{HashFunction, Sha3_256};
     use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, TermLike};
     use iota_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
     use iota_storage::object_store::{ObjectStoreGetExt, ObjectStorePutExt};
@@ -521,6 +534,11 @@ mod tests {
 
     fn hidden_multi_progress() -> MultiProgress {
         MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
+    }
+
+    /// The manifest digest of a file with contents `bytes`.
+    fn sha3(bytes: &[u8]) -> [u8; 32] {
+        Sha3_256::digest(bytes).digest
     }
 
     /// A terminal that accepts every write, so that bars added to the
@@ -706,11 +724,14 @@ mod tests {
         src_store
             .put_bytes(&Path::from("b"), Bytes::from_static(b"123"))
             .await?;
-        let paths = [Path::from("a"), Path::from("b")];
+        let files = [
+            (Path::from("a"), sha3(b"12345")),
+            (Path::from("b"), sha3(b"123")),
+        ];
 
         let progress =
             DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 2, Some(8));
-        copy_files_with_progress(&paths, &src_store, &dest_store, 2, &progress).await?;
+        copy_files_with_progress(&files, &src_store, &dest_store, 2, &progress).await?;
         assert_eq!(progress.bar().length(), Some(8));
         assert_eq!(progress.bar().position(), 8);
         assert_eq!(progress.bar().message(), "2/2 files");
@@ -721,26 +742,49 @@ mod tests {
         Ok(())
     }
 
+    /// An empty response is retried like a failed attempt instead of failing
+    /// the whole copy, since a store may serve one transiently.
     #[tokio::test]
-    async fn test_copy_files_with_progress_rejects_empty_file() -> anyhow::Result<()> {
+    async fn test_copy_files_with_progress_retries_empty_download() -> anyhow::Result<()> {
+        let src_store = FlakyStore {
+            first_response: Some(Bytes::new()),
+            payload: Bytes::from_static(b"12345"),
+            failed_once: AtomicBool::new(false),
+        };
+        let dest_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let files = [(Path::from("a.ref"), sha3(b"12345"))];
+
+        let progress =
+            DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 1, Some(5));
+        copy_files_with_progress(&files, &src_store, &dest_store, 1, &progress).await?;
+        assert_eq!(
+            dest_store.get_bytes(&Path::from("a.ref")).await?.to_vec(),
+            b"12345"
+        );
+        assert_eq!(progress.bar().position(), 5);
+        Ok(())
+    }
+
+    /// A download whose bytes don't hash to the manifest digest — a truncated
+    /// file, say — is rejected and never written to the destination.
+    #[tokio::test]
+    async fn test_copy_files_with_progress_rejects_checksum_mismatch() -> anyhow::Result<()> {
         let src_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let dest_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         src_store
-            .put_bytes(&Path::from("empty.ref"), Bytes::new())
+            .put_bytes(&Path::from("a.ref"), Bytes::from_static(b"123"))
             .await?;
-        let paths = [Path::from("empty.ref")];
+        let files = [(Path::from("a.ref"), sha3(b"12345"))];
 
         let progress = DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 1, None);
-        let error = copy_files_with_progress(&paths, &src_store, &dest_store, 1, &progress)
+        let error = copy_files_with_progress(&files, &src_store, &dest_store, 1, &progress)
             .await
             .unwrap_err();
-        assert!(format!("{error:#}").contains("Downloaded empty file empty.ref"));
         assert!(
-            dest_store
-                .get_bytes(&Path::from("empty.ref"))
-                .await
-                .is_err()
+            format!("{error:#}").contains("does not match the manifest checksum"),
+            "{error:#}"
         );
+        assert!(dest_store.get_bytes(&Path::from("a.ref")).await.is_err());
         Ok(())
     }
 
@@ -754,19 +798,24 @@ mod tests {
         src_store
             .put_bytes(&Path::from("b"), Bytes::from_static(b"123"))
             .await?;
-        let paths = [Path::from("a"), Path::from("b")];
+        let files = [
+            (Path::from("a"), sha3(b"12345")),
+            (Path::from("b"), sha3(b"123")),
+        ];
 
         // An unknown total byte size means the bar counts files instead.
         let progress = DownloadProgressBar::new(&hidden_multi_progress(), "Downloading", 2, None);
-        copy_files_with_progress(&paths, &src_store, &dest_store, 2, &progress).await?;
+        copy_files_with_progress(&files, &src_store, &dest_store, 2, &progress).await?;
         assert_eq!(progress.bar().length(), Some(2));
         assert_eq!(progress.bar().position(), 2);
         Ok(())
     }
 
-    /// Store whose first download attempt emits a partial chunk and then
-    /// fails; every later attempt succeeds.
+    /// Store whose first download attempt goes wrong — it returns
+    /// `first_response` as is, or emits a partial chunk and then fails when
+    /// that is `None` — and whose every later attempt returns `payload`.
     struct FlakyStore {
+        first_response: Option<Bytes>,
         payload: Bytes,
         failed_once: AtomicBool,
     }
@@ -789,8 +838,12 @@ mod tests {
             on_bytes: &(dyn Fn(u64) + Send + Sync),
         ) -> Result<Bytes> {
             if !self.failed_once.swap(true, Ordering::Relaxed) {
-                on_bytes(3);
-                anyhow::bail!("transient failure after a partial chunk");
+                let Some(first_response) = &self.first_response else {
+                    on_bytes(3);
+                    anyhow::bail!("transient failure after a partial chunk");
+                };
+                on_bytes(first_response.len() as u64);
+                return Ok(first_response.clone());
             }
             on_bytes(self.payload.len() as u64);
             Ok(self.payload.clone())
@@ -810,6 +863,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_with_progress_rolls_back_failed_attempt() -> Result<()> {
         let store = FlakyStore {
+            first_response: None,
             payload: Bytes::from_static(b"12345"),
             failed_once: AtomicBool::new(false),
         };

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -40,7 +40,10 @@ use iota_storage::{
 };
 use iota_types::{digests::ChainIdentifier, global_state_hash::GlobalStateHash};
 use object_store::path::Path;
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::{
+    sync::{Mutex, mpsc, oneshot},
+    task::JoinHandle,
+};
 use tracing::info;
 
 use crate::{
@@ -56,6 +59,16 @@ use crate::{
 
 pub type SnapshotChecksums = (DigestByBucketAndPartition, GlobalStateHash);
 pub type DigestByBucketAndPartition = BTreeMap<u32, BTreeMap<u32, [u8; 32]>>;
+
+/// Channels through which the reader reports state accumulation: each
+/// partition's partial hash goes out on `partials`, and `completion` fires
+/// once every partition has been sent — so the receiving side can tell a
+/// finished accumulation apart from one whose sender was dropped by a failed
+/// restore.
+pub struct StateAccumulatorSender {
+    pub partials: mpsc::Sender<(GlobalStateHash, u64)>,
+    pub completion: oneshot::Sender<()>,
+}
 
 #[derive(Clone)]
 pub struct StateSnapshotReaderV1 {
@@ -265,9 +278,9 @@ impl StateSnapshotReaderV1 {
         &mut self,
         perpetual_db: &AuthorityPerpetualTables,
         abort_registration: AbortRegistration,
-        sender: Option<tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>>,
+        accumulator: Option<StateAccumulatorSender>,
     ) -> Result<()> {
-        self.read_to_db(perpetual_db, abort_registration, sender)
+        self.read_to_db(perpetual_db, abort_registration, accumulator)
             .await
     }
 
@@ -352,16 +365,16 @@ impl StateSnapshotReaderV1 {
     ///    directory.
     /// 2. Computing the partition checksums of the respective `*.ref` files.
     /// 3. Computing the partition elliptic-curve multiset hash (ECMH) in the
-    ///    background, and sending the result through the given `sender` to the
-    ///    caller. This allows to compute and verify the root hash of the live
-    ///    objects encoded in the snapshot. See [`GlobalStateHash`].
+    ///    background, and sending the result through the given `accumulator` to
+    ///    the caller. This allows to compute and verify the root hash of the
+    ///    live objects encoded in the snapshot. See [`GlobalStateHash`].
     /// 4. Reading, inserting, and verifying all encoded live objects to the
     ///    given `database`.
     pub async fn read_to_db(
         &mut self,
         database: &impl Restore,
         abort_registration: AbortRegistration,
-        sender: Option<tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>>,
+        accumulator: Option<StateAccumulatorSender>,
     ) -> Result<()> {
         // The reference files have to be local before their checksums can be
         // computed. Their download shares a bar with the object files, which
@@ -454,8 +467,8 @@ impl StateSnapshotReaderV1 {
 
         checksum_ticker.finish_with_message("Checksumming complete");
 
-        let accum_handle =
-            sender.map(|sender| self.spawn_accumulation_tasks(sender, num_part_files));
+        let accum_handle = accumulator
+            .map(|accumulator| self.spawn_accumulation_tasks(accumulator, num_part_files));
 
         // Downloads all object files from remote in parallel and inserts the objects
         // into the database of choice
@@ -477,9 +490,13 @@ impl StateSnapshotReaderV1 {
     /// then sends the accumulator to the sender.
     fn spawn_accumulation_tasks(
         &self,
-        sender: tokio::sync::mpsc::Sender<(GlobalStateHash, u64)>,
+        accumulator: StateAccumulatorSender,
         num_part_files: usize,
     ) -> JoinHandle<()> {
+        let StateAccumulatorSender {
+            partials: sender,
+            completion,
+        } = accumulator;
         // Spawns accumulation progress bar, whose position the ticker takes
         // from the counter the accumulation task below advances
         let concurrency = self.concurrency;
@@ -558,6 +575,7 @@ impl StateSnapshotReaderV1 {
                     .await;
             }
             accum_ticker.finish_with_message("Accumulation complete");
+            let _ = completion.send(());
         })
     }
 

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -65,6 +65,11 @@ pub type DigestByBucketAndPartition = BTreeMap<u32, BTreeMap<u32, [u8; 32]>>;
 /// once every partition has been sent — so the receiving side can tell a
 /// finished accumulation apart from one whose sender was dropped by a failed
 /// restore.
+///
+/// The receiving side must drain `partials` until the channel closes before
+/// awaiting `completion`: the accumulation tasks block on the bounded
+/// `partials` channel, and `completion` is only sent after the last of them,
+/// so awaiting it first deadlocks the restore.
 pub struct StateAccumulatorSender {
     pub partials: mpsc::Sender<(GlobalStateHash, u64)>,
     pub completion: oneshot::Sender<()>,
@@ -202,13 +207,18 @@ impl StateSnapshotReaderV1 {
     /// [`Self::sync_live_objects`] downloads onto the same bar.
     async fn download_reference_files(&self) -> Result<Arc<DownloadProgressBar>> {
         let epoch_dir_path = self.epoch_dir();
-        let ref_file_paths: Vec<Path> = self
+        // Each reference file is paired with its manifest digest, which the
+        // download checks the received bytes against.
+        let ref_files: Vec<(Path, [u8; 32])> = self
             .ref_files
             .values()
             .flat_map(|entry| {
-                entry
-                    .values()
-                    .map(|file_metadata| file_metadata.file_path(&epoch_dir_path))
+                entry.values().map(|file_metadata| {
+                    (
+                        file_metadata.file_path(&epoch_dir_path),
+                        file_metadata.sha3_digest,
+                    )
+                })
             })
             .collect();
 
@@ -221,15 +231,12 @@ impl StateSnapshotReaderV1 {
             while let Some(Ok(meta)) = list_stream.next().await {
                 existing_files.insert(meta.location);
             }
-            let mut missing_files = Vec::new();
-            for file in &ref_file_paths {
-                if !existing_files.contains(file) {
-                    missing_files.push(file.clone());
-                }
-            }
-            missing_files
+            ref_files
+                .into_iter()
+                .filter(|(file, _)| !existing_files.contains(file))
+                .collect()
         } else {
-            ref_file_paths
+            ref_files
         };
 
         let object_file_paths: Vec<Path> = self
@@ -246,7 +253,7 @@ impl StateSnapshotReaderV1 {
             &self.remote_object_store,
             files_to_download
                 .iter()
-                .cloned()
+                .map(|(path, _)| path.clone())
                 .chain(object_file_paths)
                 .collect(),
             self.concurrency.get(),
@@ -472,18 +479,26 @@ impl StateSnapshotReaderV1 {
 
         // Downloads all object files from remote in parallel and inserts the objects
         // into the database of choice
-        self.sync_live_objects(
-            database,
-            abort_registration,
-            sha3_digests,
-            download_progress,
-        )
-        .await?;
+        let sync_result = self
+            .sync_live_objects(
+                database,
+                abort_registration,
+                sha3_digests,
+                download_progress,
+            )
+            .await;
 
         if let Some(handle) = accum_handle {
-            handle.await?;
+            if sync_result.is_err() {
+                // Nobody is left to consume the partial hashes once the
+                // restore has failed; stop the accumulation rather than leave
+                // it running detached after this returns.
+                handle.abort();
+            } else {
+                handle.await?;
+            }
         }
-        Ok(())
+        sync_result
     }
 
     /// Spawns accumulation tasks to accumulate the sha3 digests of all objects
@@ -558,10 +573,10 @@ impl StateSnapshotReaderV1 {
                             let mut partial_acc = GlobalStateHash::default();
                             let num_objects = obj_digests.len();
                             partial_acc.insert_all(obj_digests);
-                            sender_clone
-                                .send((partial_acc, num_objects as u64))
-                                .await
-                                .expect("Unable to send accumulator from snapshot reader");
+                            // The receiver is only dropped once the caller
+                            // has given up on the restore, so a failed send
+                            // has nothing left to report to.
+                            let _ = sender_clone.send((partial_acc, num_objects as u64)).await;
                         })
                     })
                     .boxed()

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -45,12 +45,16 @@ use iota_types::{
     storage::EpochInfoV2,
 };
 use prometheus_filtered::Registry;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{
     EPOCH_INFO_FILE_MAGIC, EpochInfo, EpochInfoV1, EpochInfoV1Entry, FileCompression, FileMetadata,
     FileType, MAGIC_BYTES, MANIFEST_FILE_MAGIC, Manifest, ManifestV2, OBJECT_REF_BYTES,
-    reader::StateSnapshotReaderV1, restore::RestoreWithGrpcIndexes,
-    uploader::StateSnapshotUploader, verify_epoch_info_chain, writer::StateSnapshotWriterV1,
+    reader::{StateAccumulatorSender, StateSnapshotReaderV1},
+    restore::RestoreWithGrpcIndexes,
+    uploader::StateSnapshotUploader,
+    verify_epoch_info_chain,
+    writer::StateSnapshotWriterV1,
 };
 
 /// A fresh `CheckpointStore` seeded with fully-populated `epoch_info` rows for
@@ -381,9 +385,27 @@ async fn snapshot_round_trip(
     .await?;
     let restored_perpetual_db = AuthorityPerpetualTables::open(&tmp_dir.join("restored_db"), None);
     let (_abort_handle, abort_registration) = AbortHandle::new_pair();
+    let (partials_sender, mut partials_receiver) = mpsc::channel(1);
+    let (completion_sender, completion_receiver) = oneshot::channel();
+    let accumulator = tokio::spawn(async move {
+        let mut accumulated_objects = 0u64;
+        while let Some((_, partial_num_objects)) = partials_receiver.recv().await {
+            accumulated_objects += partial_num_objects;
+        }
+        accumulated_objects
+    });
     snapshot_reader
-        .read(&restored_perpetual_db, abort_registration, None)
+        .read(
+            &restored_perpetual_db,
+            abort_registration,
+            Some(StateAccumulatorSender {
+                partials: partials_sender,
+                completion: completion_sender,
+            }),
+        )
         .await?;
+    completion_receiver.await?;
+    assert_eq!(accumulator.await?, num_objects);
     compare_live_objects(&perpetual_db, &restored_perpetual_db)?;
 
     // Snapshot is at epoch 0, so EPOCH_INFO has exactly one entry, which must

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -959,6 +959,10 @@ pub async fn download_formal_snapshot(
 
         Ok::<(), anyhow::Error>(())
     });
+    // The partial hashes must be drained before the completion signal is
+    // awaited: the reader's accumulation tasks block on this bounded channel
+    // and only signal completion after the last of them, so awaiting
+    // completion first would deadlock the restore.
     let mut root_global_state_hash = GlobalStateHash::default();
     let mut num_live_objects = 0;
     while let Some((partial_hash, num_objects)) = receiver.recv().await {

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::ValueEnum;
 use fastcrypto::{hash::MultisetHash, traits::ToFromBytes};
 use futures::{
@@ -50,7 +50,7 @@ use iota_sdk_types::{
 use iota_snapshot::{
     VerifiedEpochInfo,
     progress::{ProgressTicker, ProgressUnit, make_multi_progress, println_or_log},
-    reader::StateSnapshotReaderV1,
+    reader::{StateAccumulatorSender, StateSnapshotReaderV1},
     restore::RestoreWithGrpcIndexes,
     setup_db_state,
 };
@@ -76,7 +76,10 @@ use iota_types::{
 use itertools::Itertools;
 use prometheus_filtered::Registry;
 use serde::{Deserialize, Serialize};
-use tokio::{sync::mpsc, time::Instant};
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::Instant,
+};
 use typed_store::rocks::bulk_ingestion_options;
 
 pub mod commands;
@@ -928,25 +931,30 @@ pub async fn download_formal_snapshot(
     // TODO if verify is false, we should skip generating these and
     // not pass in a channel to the reader
     let (sender, mut receiver) = mpsc::channel(num_parallel_downloads.get());
+    let (accumulation_done_sender, accumulation_done_receiver) = oneshot::channel();
     let grpc_indexes_clone = grpc_indexes.clone();
 
     let snapshot_handle = tokio::spawn(async move {
+        let accumulator = Some(StateAccumulatorSender {
+            partials: sender,
+            completion: accumulation_done_sender,
+        });
         if let Some(grpc_indexes) = &grpc_indexes_clone {
             let grpc_restorer =
                 grpc_indexes.live_object_restorer(bulk_ingestion_options().batch_size_limit);
             let restore_target = RestoreWithGrpcIndexes::new(&perpetual_db_clone, &grpc_restorer);
             reader
-                .read_to_db(&restore_target, abort_registration, Some(sender))
+                .read_to_db(&restore_target, abort_registration, accumulator)
                 .await
-                .unwrap_or_else(|err| panic!("Failed during read: {err}"));
+                .context("Failed to read snapshot")?;
             grpc_restorer
                 .finish()
-                .unwrap_or_else(|err| panic!("Failed to flush the gRPC coin index: {err}"));
+                .context("Failed to flush the gRPC coin index")?;
         } else {
             reader
-                .read(&perpetual_db_clone, abort_registration, Some(sender))
+                .read(&perpetual_db_clone, abort_registration, accumulator)
                 .await
-                .unwrap_or_else(|err| panic!("Failed during read: {err}"));
+                .context("Failed to read snapshot")?;
         }
 
         Ok::<(), anyhow::Error>(())
@@ -956,6 +964,16 @@ pub async fn download_formal_snapshot(
     while let Some((partial_hash, num_objects)) = receiver.recv().await {
         num_live_objects += num_objects;
         root_global_state_hash.union(&partial_hash);
+    }
+    // A dropped completion sender means the restore failed before every
+    // partial hash was sent, so the hash accumulated above is incomplete —
+    // surface the restore's own error rather than the digest mismatch its
+    // partial hash would produce below.
+    if accumulation_done_receiver.await.is_err() {
+        snapshot_handle
+            .await
+            .map_err(|error| anyhow!("Snapshot task failed: {error}"))??;
+        return Err(anyhow!("Snapshot accumulation did not complete"));
     }
 
     let last_checkpoint = checkpoint_store
@@ -1018,8 +1036,7 @@ pub async fn download_formal_snapshot(
 
     snapshot_handle
         .await
-        .expect("Task join failed")
-        .expect("Snapshot restore task failed");
+        .map_err(|error| anyhow!("Snapshot restore task failed: {error}"))??;
 
     setup_db_state(
         epoch,


### PR DESCRIPTION
## Description of change

- Port commit:
  - [MystenLabs/sui@0d645eb](https://github.com/MystenLabs/sui/commit/0d645eb8228f476f9d5482448b5f10489c0faec8)
- Description:

Fixes formal snapshot restores failing with misleading missing-file and root-digest errors:

- The snapshot reader reports state accumulation through a new `StateAccumulatorSender` (partial-hash channel + completion signal), so callers can tell a finished accumulation apart from a restore that failed mid-way.
- `iota-tool`'s `download-formal-snapshot` checks the completion signal before state-root verification and surfaces the restore task's own error instead of dying on a misleading root-digest mismatch; the spawned restore task returns errors instead of panicking.
- `copy_files_with_progress` rejects empty downloaded files instead of silently skipping the write, and names the file in copy failures.
- The indexer's snapshot restore gets the same completion check in `verify_state_hash`, reporting an incomplete accumulation instead of a bogus hash mismatch.

Differences from upstream:

- Download retries already exist here (backoff in `get`/`put`), so upstream's hand-rolled retry loop is not ported.
- Upstream's `copy_file_with_retry` and `sui-storage` `copy_files` hunks don't apply: we downloads ref files via `copy_files_with_progress` and no longer has `copy_files`.
- No summaries/backfill task handling: we restore seeds summaries from `EPOCH_INFO` synchronously.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes