### PR TITLE
fix(ci): let paths-filter fetch the merge base with the job token

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -60,8 +60,6 @@ jobs:
       components: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -93,8 +91,6 @@ jobs:
       components: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:


### PR DESCRIPTION
Closes #12827.

`crates-changes` and `external-changes` check out at depth 1, so paths-filter always has to fetch `develop` to find the merge base. With `persist-credentials: false` that fetch is anonymous, and GitHub refuses anonymous fetches from the self-hosted runners often enough that a run — which needs both jobs' fetches accepted — rarely gets through: 2 of 8 fetches accepted across #12805's four queue attempts.

The flag came from #11342 as a workaround for a duplicate `Authorization` header in the `diffs` composite action, which checks out twice in one job. These two jobs check out once and never needed it; the composite action keeps it, and runs on GitHub-hosted runners where the anonymous fetch has not been refused.

Persisted credentials are known to work on these runners: the nightly `simtest` job fetches after a `persist-credentials: true` checkout on `github-runner-0`.

Passing `token:` to paths-filter is not an alternative — on `merge_group` it always shells out to plain `git fetch`; the token is only used for the API path on `pull_request`.

## Verification

Dispatched `hierarchy.yml` from a throwaway branch on top of this one (a copy plus a `workflow_dispatch` trigger, not for merging): [run 33740584557](https://github.com/iotaledger/iota/actions/runs/33740584557). Both `crates-changes` and `external-changes` checked out with `persist-credentials: true`, paths-filter ran its deepening fetch — `git fetch --no-tags --depth=100 origin develop <branch>`, the same command the merge queue runs — and it succeeded, with no `could not read Username` anywhere in either job. `external-changes` landed on `github-runner-5`, the runner that refused the anonymous fetch for #12805 at 08:18 the same morning. `rust-tests` then ran instead of being skipped.

YAML parses and `dprint check` passes.
