### PR TITLE
fix(move-package): keep git's stdout out of the CLI's output

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
@@ -279,6 +279,7 @@ fn full_clone<Progress: Write>(
             git_path.as_os_str(),
         ])
         .stdin(Stdio::null())
+        .stdout(Stdio::null())
         .spawn()
     {
         output.wait().map_err(|_| {
@@ -516,13 +517,16 @@ fn update_dependency<Progress: Write>(
     Ok(())
 }
 
-/// Runs `git` with `args`, inheriting stdio so progress is shown, and reports
-/// whether it exited successfully. A spawn failure (e.g. `git` missing) is
-/// treated as a non-successful run.
+/// Runs `git` with `args` and reports whether it exited successfully. Stderr is
+/// inherited so progress is shown; stdout is discarded, since git writes
+/// messages such as `branch 'x' set up to track 'origin/x'` there and the
+/// caller's stdout may be machine-readable output. A spawn failure (e.g. `git`
+/// missing) is treated as a non-successful run.
 fn git_status(args: &[&OsStr]) -> bool {
     Command::new("git")
         .args(args)
         .stdin(Stdio::null())
+        .stdout(Stdio::null())
         .status()
         .map(|status| status.success())
         .unwrap_or(false)


### PR DESCRIPTION
# Description of change

The Move dependency fetch runs `git` with inherited stdio so its progress is shown. Progress goes to stderr, but git also writes messages such as `Branch 'framework/mainnet' set up to track remote branch …` to stdout — and that lands inside whatever the CLI prints there, including the JSON of `iota move build --dump-bytecode-as-base64`, which then fails to parse for any caller that reads it. It only shows when a dependency is cloned during the build, so a warm `~/.move` cache hides it; the ts-packages Kiosk e2e tests hit it the first time a clone got through on CI ([run](https://github.com/iotaledger/ts-packages/actions/runs/33735875644)).

Stderr stays inherited; stdout is discarded for the git children.

Inheriting stdio is deliberate — upstream switched `clone`/`fetch` to it in MystenLabs/sui#18636 so users see `Cloning into …` and network errors — but upstream never runs `checkout` that way: it captures its output, and where it does use `.status()` (`reset --hard`, MystenLabs/sui#21556) it nulls stdout, because `move-analyzer` speaks its protocol over stdout. Routing `checkout` through an inheriting `.status()` came with the sparse-clone change (#12111), which is IOTA-only. This brings it back in line: progress on stderr, nothing on stdout.

## Links to any relevant issues

Surfaced while fixing iotaledger/ts-packages#323 (same root as #12827: the clones used to fail before reaching this point).

## How the change has been tested

`cargo test -p move-package dependency_cache` (8 tests) in `external-crates/move`, plus fmt and clippy. The failure itself is only reproducible with a cold dependency cache and a caller parsing the CLI's stdout; the ts-packages run above is that reproduction, and the nightly there picks up the next develop binary.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: `iota move build --dump-bytecode-as-base64` no longer mixes git's output into its JSON when a dependency is cloned during the build.
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---
