### PR TITLE
fix(iota-core,iota-grpc-server): don't lose a row when the pagination cursor row vanishes between pages

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4058,9 +4058,8 @@ impl AuthorityState {
         cursor: Option<ObjectId>,
         filter: Option<IotaObjectDataFilter>,
     ) -> IotaResult<impl Iterator<Item = ObjectInfo> + '_> {
-        let cursor_u = cursor.unwrap_or(ObjectId::ZERO);
         if let Some(indexes) = &self.indexes {
-            indexes.get_owner_objects_iterator(owner, cursor_u, filter)
+            indexes.get_owner_objects_iterator(owner, cursor, filter)
         } else {
             Err(IotaError::IndexStoreNotAvailable)
         }

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -858,10 +858,15 @@ impl IndexStoreTables {
         original_package_id: ObjectId,
         cursor: Option<u64>,
     ) -> Result<impl Iterator<Item = PackageVersionIteratorItem> + '_, TypedStoreError> {
-        Ok(self.package_version.safe_iter_with_prefix_from(
-            &original_package_id,
-            Bound::Included(&cursor.unwrap_or(0)),
-        ))
+        // The lower bound excludes the cursor position itself, so the scan
+        // resumes strictly after the last returned version.
+        let lower = match &cursor {
+            Some(version) => Bound::Excluded(version),
+            None => Bound::Unbounded,
+        };
+        Ok(self
+            .package_version
+            .safe_iter_with_prefix_from(&original_package_id, lower))
     }
 }
 
@@ -1391,7 +1396,7 @@ impl LiveObjectIndexer for GrpcLiveObjectIndexer<'_> {
 
 #[cfg(test)]
 mod tests {
-    use iota_sdk_types::{GasCostSummary, checkpoint::CheckpointSummary};
+    use iota_sdk_types::{GasCostSummary, MovePackage, checkpoint::CheckpointSummary};
     use iota_types::{
         crypto::AuthorityStrongQuorumSignInfo, iota_system_state::IotaSystemState,
         message_envelope::Envelope, messages_checkpoint::VerifiedCheckpoint,
@@ -1594,6 +1599,67 @@ mod tests {
             after_removal,
             all[1..],
             "the next live row must not be skipped",
+        );
+    }
+
+    /// Three versions of the same package (same `original_package_id`,
+    /// versions 1..=3), as the package-version index sees them.
+    fn package_versions() -> [MovePackage; 3] {
+        let module = move_binary_format::file_format::empty_module();
+        let v1 = Object::new_package_for_testing(&[module], TransactionDigest::GENESIS_MARKER, [])
+            .unwrap();
+        let v1 = v1.data.as_opt_package().unwrap().clone();
+        let mut v2 = v1.clone();
+        v2.id = ObjectId::random();
+        v2.version = Version::from_u64(2);
+        let mut v3 = v1.clone();
+        v3.id = ObjectId::random();
+        v3.version = Version::from_u64(3);
+        [v1, v2, v3]
+    }
+
+    /// The `cursor` of `package_versions_iter` is exclusive: the cursor row
+    /// itself is never returned again. Unlike `owner_iter` and
+    /// `dynamic_field_iter`, a package-version row is never deleted (version
+    /// keys are append-only), so there is no vanished-cursor-row case to
+    /// cover here.
+    #[tokio::test]
+    async fn package_versions_iter_cursor_is_exclusive() {
+        let tmp_dir = iota_common::tempdir();
+        let grpc = GrpcIndexesStore::new_without_init(tmp_dir.path().to_path_buf());
+
+        let versions = package_versions();
+        let original_package_id = versions[0].original_package_id();
+        let restorer = grpc.live_object_restorer(100);
+        let mut partition = restorer.begin_partition();
+        for package in versions {
+            partition
+                .index_object(Object::new_from_package(
+                    package,
+                    TransactionDigest::GENESIS_MARKER,
+                ))
+                .unwrap();
+        }
+        partition.finish().unwrap();
+        restorer.finish().unwrap();
+
+        let all: Vec<_> = grpc
+            .package_versions_iter(original_package_id, None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(all.len(), 3);
+        let cursor = all[0].0.version;
+
+        let after: Vec<_> = grpc
+            .package_versions_iter(original_package_id, Some(cursor))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            after,
+            all[1..],
+            "the cursor row itself must not be returned again",
         );
     }
 

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -228,25 +228,28 @@ fn hash_type_params(tag: &StructTag) -> u64 {
     hasher.finish()
 }
 
-/// Compute inclusive lower and upper `OwnerIndexKey` bounds for a
-/// `safe_iter_with_bounds` range scan, narrowed by `type_filter`.
+/// Compute lower and upper `OwnerIndexKey` bounds for a range scan,
+/// narrowed by `type_filter`. The upper bound is an exclusive sentinel past
+/// the last real key of the prefix.
 ///
-/// When `cursor` is `Some`, the lower bound is set to the cursor's exact
-/// position (inclusive) so that RocksDB can seek directly.
+/// When `cursor` is `Some`, the lower bound excludes the cursor position
+/// itself, so the scan resumes strictly after the last returned item — even
+/// when the cursor's index row no longer exists (e.g. the coin's balance
+/// changed, which moves its key).
 fn owner_bounds(
     owner: Address,
     cursor: Option<&OwnedObjectCursor>,
     filter: &OwnerTypeFilter,
-) -> (OwnerIndexKey, OwnerIndexKey) {
+) -> (Bound<OwnerIndexKey>, OwnerIndexKey) {
     let lower_bound = if let Some(c) = cursor {
-        // Resume from the exact cursor position.
-        OwnerIndexKey {
+        // Resume strictly after the cursor position.
+        Bound::Excluded(OwnerIndexKey {
             owner,
             object_type_identifier: c.object_type_identifier,
             object_type_params: c.object_type_params,
             inverted_balance: c.inverted_balance,
             object_id: c.object_id,
-        }
+        })
     } else {
         let (lower_id, _, lower_params, _) = match filter {
             OwnerTypeFilter::None => (0, u64::MAX, 0, u64::MAX),
@@ -257,13 +260,13 @@ fn owner_bounds(
                 ..
             } => (*id_hash, *id_hash, *params_hash, *params_hash),
         };
-        OwnerIndexKey {
+        Bound::Included(OwnerIndexKey {
             owner,
             object_type_identifier: lower_id,
             object_type_params: lower_params,
             inverted_balance: None,
             object_id: ObjectId::ZERO,
-        }
+        })
     };
 
     let (_, upper_bound_id, _, upper_bound_params) = match filter {
@@ -801,7 +804,7 @@ impl IndexStoreTables {
         let (lower_bound, upper_bound) = owner_bounds(owner, cursor, &type_filter);
         Ok(self
             .owner
-            .safe_iter_with_bounds(Some(lower_bound), Some(upper_bound))
+            .safe_range_iter((lower_bound, Bound::Excluded(upper_bound)))
             .filter(move |result| match result {
                 // Post-filter out hash collisions based on the full `StructTag` stored in the
                 // value.
@@ -1440,6 +1443,75 @@ mod tests {
             .unwrap();
         assert_eq!(owned.len(), 1, "restored object must be owner-indexed");
         assert_eq!(owned[0].0.object_id, object_id);
+    }
+
+    /// The `cursor` of `owner_iter` is exclusive: the cursor row itself is
+    /// never returned again, and when the cursor row no longer exists (the
+    /// coin's balance changed, which moves its index key) the scan resumes
+    /// at the next live row without skipping it.
+    #[tokio::test]
+    async fn owner_iter_cursor_is_exclusive() {
+        let tmp_dir = iota_common::tempdir();
+        let grpc = GrpcIndexesStore::new_without_init(tmp_dir.path().to_path_buf());
+
+        let owner = Address::from_u16(42);
+        let restorer = grpc.live_object_restorer(100);
+        let mut partition = restorer.begin_partition();
+        for balance in [300, 200, 100] {
+            partition
+                .index_object(Object::new_gas_with_balance_and_owner_for_testing(
+                    balance, owner,
+                ))
+                .unwrap();
+        }
+        partition.finish().unwrap();
+        restorer.finish().unwrap();
+
+        let all: Vec<_> = grpc
+            .owner_iter(owner, None, OwnerTypeFilter::None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(all.len(), 3);
+        let ids: Vec<_> = all.iter().map(|(key, _)| key.object_id).collect();
+        let first_key = &all[0].0;
+        let cursor = OwnedObjectCursor {
+            object_type_identifier: first_key.object_type_identifier,
+            object_type_params: first_key.object_type_params,
+            inverted_balance: first_key.inverted_balance,
+            object_id: first_key.object_id,
+        };
+
+        // Live cursor row: the scan starts strictly after it.
+        let after: Vec<_> = grpc
+            .owner_iter(owner, Some(&cursor), OwnerTypeFilter::None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            after
+                .iter()
+                .map(|(key, _)| key.object_id)
+                .collect::<Vec<_>>(),
+            ids[1..],
+            "the cursor row itself must not be returned again",
+        );
+
+        // Vanished cursor row: the scan resumes at the next live row.
+        grpc.tables.owner.remove(first_key).unwrap();
+        let after_removal: Vec<_> = grpc
+            .owner_iter(owner, Some(&cursor), OwnerTypeFilter::None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            after_removal
+                .iter()
+                .map(|(key, _)| key.object_id)
+                .collect::<Vec<_>>(),
+            ids[1..],
+            "the next live row must not be skipped",
+        );
     }
 
     /// `finalize_restore` must leave a store that `GrpcIndexesStore::new`

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -1597,6 +1597,86 @@ mod tests {
         );
     }
 
+    /// An address-owned non-coin `Object`, indexed with
+    /// `inverted_balance: None`.
+    fn non_coin_object(owner: Address) -> Object {
+        let id = ObjectId::random();
+        let move_struct = iota_sdk_types::MoveStruct::new(
+            "0x2::clock::Clock".parse::<StructTag>().unwrap().into(),
+            iota_types::object::OBJECT_START_VERSION,
+            id.as_bytes().to_vec(),
+        )
+        .unwrap();
+        Object::new_move(
+            move_struct,
+            Owner::Address(owner),
+            TransactionDigest::GENESIS_MARKER,
+        )
+    }
+
+    /// Walking `owner_iter` one row at a time over a mixed population —
+    /// non-coin rows (`inverted_balance: None`, shorter keys) next to coin
+    /// rows, including two coins with an equal balance — returns every row
+    /// exactly once, in the full listing's order: the exclusive-cursor seek
+    /// advances correctly across the `None`→`Some` key-layout boundary and
+    /// across equal-balance ties.
+    #[tokio::test]
+    async fn owner_iter_full_walk_returns_each_row_once() {
+        let tmp_dir = iota_common::tempdir();
+        let grpc = GrpcIndexesStore::new_without_init(tmp_dir.path().to_path_buf());
+
+        let owner = Address::from_u16(42);
+        let restorer = grpc.live_object_restorer(100);
+        let mut partition = restorer.begin_partition();
+        for _ in 0..3 {
+            partition.index_object(non_coin_object(owner)).unwrap();
+        }
+        // Two coins share a balance to exercise the object-id tie-break.
+        for balance in [300, 200, 200, 100] {
+            partition
+                .index_object(Object::new_gas_with_balance_and_owner_for_testing(
+                    balance, owner,
+                ))
+                .unwrap();
+        }
+        partition.finish().unwrap();
+        restorer.finish().unwrap();
+
+        let all: Vec<_> = grpc
+            .owner_iter(owner, None, OwnerTypeFilter::None)
+            .unwrap()
+            .map(|result| result.map(|(key, _)| key))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(all.len(), 7);
+
+        // Walk at most `len + 2` pages, so a cursor that stops advancing
+        // fails the assertion below instead of looping forever.
+        let mut walked = Vec::new();
+        let mut cursor: Option<OwnedObjectCursor> = None;
+        for _ in 0..all.len() + 2 {
+            let Some(item) = grpc
+                .owner_iter(owner, cursor.as_ref(), OwnerTypeFilter::None)
+                .unwrap()
+                .next()
+            else {
+                break;
+            };
+            let (key, _) = item.unwrap();
+            cursor = Some(OwnedObjectCursor {
+                object_type_identifier: key.object_type_identifier,
+                object_type_params: key.object_type_params,
+                inverted_balance: key.inverted_balance,
+                object_id: key.object_id,
+            });
+            walked.push(key);
+        }
+        assert_eq!(
+            walked, all,
+            "the one-row walk must return each row exactly once, in listing order",
+        );
+    }
+
     /// `finalize_restore` must leave a store that `GrpcIndexesStore::new`
     /// opens in place: `meta` is current and `Watermark::Indexed` matches the
     /// restore checkpoint, so `needs_to_do_initialization` is false and the

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -828,9 +828,17 @@ impl IndexStoreTables {
         cursor: Option<ObjectId>,
     ) -> Result<impl Iterator<Item = Result<DynamicFieldKey, TypedStoreError>> + '_, TypedStoreError>
     {
+        // When `cursor` is `Some`, the lower bound excludes the cursor
+        // position itself, so the scan resumes strictly after the last
+        // returned field — even when the cursor's index row no longer exists
+        // (e.g. the field was deleted between pages).
+        let lower = match &cursor {
+            Some(field_id) => Bound::Excluded(field_id),
+            None => Bound::Unbounded,
+        };
         let iter = self
             .dynamic_field
-            .safe_iter_with_prefix_from(&parent, Bound::Included(&cursor.unwrap_or(ObjectId::ZERO)))
+            .safe_iter_with_prefix_from(&parent, lower)
             .map(|r| r.map(|(key, ())| key));
         Ok(iter)
     }
@@ -1510,6 +1518,81 @@ mod tests {
                 .map(|(key, _)| key.object_id)
                 .collect::<Vec<_>>(),
             ids[1..],
+            "the next live row must not be skipped",
+        );
+    }
+
+    /// A `0x2::dynamic_field::Field<u64, u64>` object owned by `parent`, as
+    /// the dynamic-field index sees one.
+    fn dynamic_field_object(parent: ObjectId, field_id: ObjectId) -> Object {
+        let field = iota_types::dynamic_field::Field {
+            id: iota_types::id::UID::new(field_id),
+            name: 0u64,
+            value: 0u64,
+        };
+        let move_struct = iota_sdk_types::MoveStruct::new(
+            StructTag::new_dynamic_field(TypeTag::U64, TypeTag::U64).into(),
+            iota_types::object::OBJECT_START_VERSION,
+            bcs::to_bytes(&field).unwrap(),
+        )
+        .unwrap();
+        Object::new_move(
+            move_struct,
+            Owner::Object(parent),
+            TransactionDigest::GENESIS_MARKER,
+        )
+    }
+
+    /// The `cursor` of `dynamic_field_iter` is exclusive: the cursor row
+    /// itself is never returned again, and when the cursor row no longer
+    /// exists (the field was deleted or transferred between pages) the scan
+    /// resumes at the next live row without skipping it.
+    #[tokio::test]
+    async fn dynamic_field_iter_cursor_is_exclusive() {
+        let tmp_dir = iota_common::tempdir();
+        let grpc = GrpcIndexesStore::new_without_init(tmp_dir.path().to_path_buf());
+
+        let parent = ObjectId::random();
+        let restorer = grpc.live_object_restorer(100);
+        let mut partition = restorer.begin_partition();
+        for _ in 0..3 {
+            partition
+                .index_object(dynamic_field_object(parent, ObjectId::random()))
+                .unwrap();
+        }
+        partition.finish().unwrap();
+        restorer.finish().unwrap();
+
+        let all: Vec<_> = grpc
+            .dynamic_field_iter(parent, None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(all.len(), 3);
+        let cursor = all[0].field_id;
+
+        // Live cursor row: the scan starts strictly after it.
+        let after: Vec<_> = grpc
+            .dynamic_field_iter(parent, Some(cursor))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            after,
+            all[1..],
+            "the cursor row itself must not be returned again",
+        );
+
+        // Vanished cursor row: the scan resumes at the next live row.
+        grpc.tables.dynamic_field.remove(&all[0]).unwrap();
+        let after_removal: Vec<_> = grpc
+            .dynamic_field_iter(parent, Some(cursor))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            after_removal,
+            all[1..],
             "the next live row must not be skipped",
         );
     }

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -830,10 +830,7 @@ impl IndexStoreTables {
     {
         let iter = self
             .dynamic_field
-            .safe_iter_with_prefix_from(
-                &parent,
-                cursor.as_ref().map_or(Bound::Unbounded, Bound::Excluded),
-            )
+            .safe_iter_with_prefix_after(&parent, cursor.as_ref())
             .map(|r| r.map(|(key, ())| key));
         Ok(iter)
     }
@@ -853,10 +850,9 @@ impl IndexStoreTables {
         original_package_id: ObjectId,
         cursor: Option<u64>,
     ) -> Result<impl Iterator<Item = PackageVersionIteratorItem> + '_, TypedStoreError> {
-        Ok(self.package_version.safe_iter_with_prefix_from(
-            &original_package_id,
-            cursor.as_ref().map_or(Bound::Unbounded, Bound::Excluded),
-        ))
+        Ok(self
+            .package_version
+            .safe_iter_with_prefix_after(&original_package_id, cursor.as_ref()))
     }
 }
 

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -233,7 +233,7 @@ fn hash_type_params(tag: &StructTag) -> u64 {
 /// the last real key of the prefix.
 ///
 /// When `cursor` is `Some`, the lower bound excludes the cursor position
-/// itself, so the scan resumes strictly after the last returned item — even
+/// itself, so the scan resumes strictly after the last returned item, even
 /// when the cursor's index row no longer exists (e.g. the coin's balance
 /// changed, which moves its key).
 fn owner_bounds(
@@ -830,7 +830,7 @@ impl IndexStoreTables {
     {
         // When `cursor` is `Some`, the lower bound excludes the cursor
         // position itself, so the scan resumes strictly after the last
-        // returned field — even when the cursor's index row no longer exists
+        // returned field, even when the cursor's index row no longer exists
         // (e.g. the field was deleted between pages).
         let lower = match &cursor {
             Some(field_id) => Bound::Excluded(field_id),
@@ -1680,9 +1680,9 @@ mod tests {
         )
     }
 
-    /// Walking `owner_iter` one row at a time over a mixed population —
-    /// non-coin rows (`inverted_balance: None`, shorter keys) next to coin
-    /// rows, including two coins with an equal balance — returns every row
+    /// Walking `owner_iter` one row at a time over a mixed population of
+    /// non-coin rows (`inverted_balance: None`, shorter keys) and coin
+    /// rows, including two coins with an equal balance, returns every row
     /// exactly once, in the full listing's order: the exclusive-cursor seek
     /// advances correctly across the `None`→`Some` key-layout boundary and
     /// across equal-balance ties.

--- a/crates/iota-core/src/grpc_indexes.rs
+++ b/crates/iota-core/src/grpc_indexes.rs
@@ -828,17 +828,12 @@ impl IndexStoreTables {
         cursor: Option<ObjectId>,
     ) -> Result<impl Iterator<Item = Result<DynamicFieldKey, TypedStoreError>> + '_, TypedStoreError>
     {
-        // When `cursor` is `Some`, the lower bound excludes the cursor
-        // position itself, so the scan resumes strictly after the last
-        // returned field, even when the cursor's index row no longer exists
-        // (e.g. the field was deleted between pages).
-        let lower = match &cursor {
-            Some(field_id) => Bound::Excluded(field_id),
-            None => Bound::Unbounded,
-        };
         let iter = self
             .dynamic_field
-            .safe_iter_with_prefix_from(&parent, lower)
+            .safe_iter_with_prefix_from(
+                &parent,
+                cursor.as_ref().map_or(Bound::Unbounded, Bound::Excluded),
+            )
             .map(|r| r.map(|(key, ())| key));
         Ok(iter)
     }
@@ -858,15 +853,10 @@ impl IndexStoreTables {
         original_package_id: ObjectId,
         cursor: Option<u64>,
     ) -> Result<impl Iterator<Item = PackageVersionIteratorItem> + '_, TypedStoreError> {
-        // The lower bound excludes the cursor position itself, so the scan
-        // resumes strictly after the last returned version.
-        let lower = match &cursor {
-            Some(version) => Bound::Excluded(version),
-            None => Bound::Unbounded,
-        };
-        Ok(self
-            .package_version
-            .safe_iter_with_prefix_from(&original_package_id, lower))
+        Ok(self.package_version.safe_iter_with_prefix_from(
+            &original_package_id,
+            cursor.as_ref().map_or(Bound::Unbounded, Bound::Excluded),
+        ))
     }
 }
 

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1330,10 +1330,6 @@ impl IndexStore {
         limit: usize,
         filter: Option<IotaObjectDataFilter>,
     ) -> IotaResult<Vec<ObjectInfo>> {
-        let cursor = match cursor {
-            Some(cursor) => cursor,
-            None => ObjectId::ZERO,
-        };
         Ok(self
             .get_owner_objects_iterator(owner, cursor, filter)?
             .take(limit)
@@ -1399,23 +1395,20 @@ impl IndexStore {
             .map(|(_, ((_, coin_type, obj_id), coin))| (coin_type, obj_id, coin)))
     }
 
-    /// starting_object_id can be used to implement pagination, where a client
-    /// remembers the last object id of each page, and use it to query the
+    /// `cursor` can be used to implement pagination, where a client
+    /// remembers the last object id of each page, and uses it to query the
     /// next page.
     pub fn get_owner_objects_iterator(
         &self,
         owner: Address,
-        starting_object_id: ObjectId,
+        cursor: Option<ObjectId>,
         filter: Option<IotaObjectDataFilter>,
     ) -> IotaResult<impl Iterator<Item = ObjectInfo> + '_> {
         Ok(self
             .tables
             .owner_index
-            // The object id 0 is the smallest possible
-            .safe_iter_with_bounds(Some((owner, starting_object_id)), None)
+            .safe_iter_with_prefix_after(&owner, cursor.as_ref())
             .map(|result| result.expect("iterator db error"))
-            .skip(usize::from(starting_object_id != ObjectId::ZERO))
-            .take_while(move |((address_owner, _), _)| address_owner == &owner)
             .filter(move |(_, o)| {
                 if let Some(filter) = filter.as_ref() {
                     filter.matches(o)
@@ -1703,6 +1696,20 @@ mod tests {
             object_id: field_id,
             version: Version::from_u64(1),
             digest: ObjectDigest::random(),
+        }
+    }
+
+    /// An `ObjectInfo` for `object_id` owned by `owner`, with placeholder
+    /// metadata: the cursor tests below only care about the object's
+    /// identity, not its content.
+    fn owner_object_info(owner: Address, object_id: ObjectId) -> ObjectInfo {
+        ObjectInfo {
+            object_id,
+            version: Version::from_u64(1),
+            digest: ObjectDigest::random(),
+            object_type: ObjectType::Struct(StructTag::new_uid().into()),
+            owner: Owner::Address(owner),
+            previous_transaction: TransactionDigest::random(),
         }
     }
 
@@ -2011,6 +2018,98 @@ mod tests {
         assert_eq!(
             after_removal_ids,
             field_ids[1..],
+            "the next live row must not be skipped",
+        );
+    }
+
+    /// The `cursor` of `get_owner_objects_iterator` is exclusive: the cursor
+    /// row itself is never returned again, and when the cursor row no longer
+    /// exists (the object was deleted or transferred to a different owner)
+    /// the scan resumes at the next live row without skipping it.
+    #[tokio::test]
+    async fn get_owner_objects_iterator_cursor_is_exclusive() {
+        let tmp_dir = iota_common::tempdir();
+        let index_store = IndexStore::new(
+            tmp_dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+        );
+
+        let owner = Address::random();
+        let mut object_ids: Vec<ObjectId> = (0..3).map(|_| ObjectId::random()).collect();
+        object_ids.sort();
+
+        let new_owners = object_ids
+            .iter()
+            .map(|&id| ((owner, id), owner_object_info(owner, id)))
+            .collect();
+        index_store
+            .index_tx(
+                Address::random(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                &TransactionEvents(vec![]),
+                ObjectIndexChanges {
+                    deleted_owners: vec![],
+                    deleted_dynamic_fields: vec![],
+                    new_owners,
+                    new_dynamic_fields: vec![],
+                },
+                &TransactionDigest::random(),
+                0,
+                None,
+            )
+            .unwrap();
+
+        let all: Vec<_> = index_store
+            .get_owner_objects_iterator(owner, None, None)
+            .unwrap()
+            .map(|info| info.object_id)
+            .collect();
+        assert_eq!(all, object_ids);
+        let cursor = all[0];
+
+        // Live cursor row: the scan starts strictly after it.
+        let after: Vec<_> = index_store
+            .get_owner_objects_iterator(owner, Some(cursor), None)
+            .unwrap()
+            .map(|info| info.object_id)
+            .collect();
+        assert_eq!(
+            after,
+            object_ids[1..],
+            "the cursor row itself must not be returned again",
+        );
+
+        // Vanished cursor row: the scan resumes at the next live row instead
+        // of skipping it.
+        index_store
+            .index_tx(
+                Address::random(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                &TransactionEvents(vec![]),
+                ObjectIndexChanges {
+                    deleted_owners: vec![(owner, cursor)],
+                    deleted_dynamic_fields: vec![],
+                    new_owners: vec![],
+                    new_dynamic_fields: vec![],
+                },
+                &TransactionDigest::random(),
+                0,
+                None,
+            )
+            .unwrap();
+        let after_removal: Vec<_> = index_store
+            .get_owner_objects_iterator(owner, Some(cursor), None)
+            .unwrap()
+            .map(|info| info.object_id)
+            .collect();
+        assert_eq!(
+            after_removal,
+            object_ids[1..],
             "the next live row must not be skipped",
         );
     }

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1666,7 +1666,7 @@ impl IndexStore {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use iota_sdk_types::{
         Address, ObjectDigest, ObjectId, Owner, StructTag, TransactionDigest, TransactionEvents,
@@ -2022,6 +2022,129 @@ mod tests {
         );
     }
 
+    /// Walking `get_dynamic_fields_iterator` one field at a time, feeding
+    /// each page's last id back in as the next cursor, must visit every
+    /// field of the parent exactly once, in the same order as a single
+    /// unpaginated listing, without picking up another parent's fields, even
+    /// though every returned field is removed right after being read (the
+    /// next cursor always names a row that no longer exists).
+    #[tokio::test]
+    async fn get_dynamic_fields_iterator_walks_every_field() {
+        let tmp_dir = iota_common::tempdir();
+        let index_store = IndexStore::new(
+            tmp_dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+        );
+
+        let parent = ObjectId::random();
+        let mut field_ids: Vec<ObjectId> = (0..4).map(|_| ObjectId::random()).collect();
+        field_ids.sort();
+
+        let other_parent = ObjectId::random();
+        let other_field_ids: Vec<ObjectId> = (0..2).map(|_| ObjectId::random()).collect();
+
+        let mut new_dynamic_fields: Vec<_> = field_ids
+            .iter()
+            .map(|&id| ((parent, id), dynamic_field_info(id)))
+            .collect();
+        new_dynamic_fields.extend(
+            other_field_ids
+                .iter()
+                .map(|&id| ((other_parent, id), dynamic_field_info(id))),
+        );
+
+        index_store
+            .index_tx(
+                Address::random(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                &TransactionEvents(vec![]),
+                ObjectIndexChanges {
+                    deleted_owners: vec![],
+                    deleted_dynamic_fields: vec![],
+                    new_owners: vec![],
+                    new_dynamic_fields,
+                },
+                &TransactionDigest::random(),
+                0,
+                None,
+            )
+            .unwrap();
+
+        let expected_ids: Vec<_> = index_store
+            .get_dynamic_fields_iterator(parent, None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(expected_ids, field_ids);
+
+        let mut walked_ids = Vec::new();
+        let mut cursor = None;
+        let mut finished = false;
+        for _ in 0..field_ids.len() + 2 {
+            let Some(item) = index_store
+                .get_dynamic_fields_iterator(parent, cursor)
+                .unwrap()
+                .next()
+            else {
+                finished = true;
+                break;
+            };
+            let (id, _) = item.unwrap();
+            walked_ids.push(id);
+            cursor = Some(id);
+
+            // Remove the row just read before fetching the next page, as if
+            // another transaction had removed it concurrently.
+            index_store
+                .index_tx(
+                    Address::random(),
+                    vec![].into_iter(),
+                    vec![].into_iter(),
+                    vec![].into_iter(),
+                    &TransactionEvents(vec![]),
+                    ObjectIndexChanges {
+                        deleted_owners: vec![],
+                        deleted_dynamic_fields: vec![(parent, id)],
+                        new_owners: vec![],
+                        new_dynamic_fields: vec![],
+                    },
+                    &TransactionDigest::random(),
+                    0,
+                    None,
+                )
+                .unwrap();
+        }
+        if !finished {
+            panic!(
+                "cursor did not advance: exceeded {} pages for {} fields",
+                field_ids.len() + 2,
+                field_ids.len(),
+            );
+        }
+
+        assert_eq!(
+            walked_ids, expected_ids,
+            "the walk must return every field exactly once, in listing order, \
+             even though each row vanishes right after being read",
+        );
+        let unique: BTreeSet<_> = walked_ids.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            walked_ids.len(),
+            "every field must be returned exactly once",
+        );
+        assert!(
+            other_field_ids.iter().all(|id| !walked_ids.contains(id)),
+            "another parent's fields must not leak into the walk",
+        );
+    }
+
     /// The `cursor` of `get_owner_objects_iterator` is exclusive: the cursor
     /// row itself is never returned again, and when the cursor row no longer
     /// exists (the object was deleted or transferred to a different owner)
@@ -2111,6 +2234,125 @@ mod tests {
             after_removal,
             object_ids[1..],
             "the next live row must not be skipped",
+        );
+    }
+
+    /// Walking `get_owner_objects` one object at a time, feeding each page's
+    /// last id back in as the next cursor, must visit every object of the
+    /// owner exactly once, in the same order as a single unpaginated
+    /// listing, without picking up another owner's objects, even though
+    /// every returned object is removed right after being read (the next
+    /// cursor always names a row that no longer exists).
+    #[tokio::test]
+    async fn get_owner_objects_paginates_the_whole_listing() {
+        let tmp_dir = iota_common::tempdir();
+        let index_store = IndexStore::new(
+            tmp_dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+        );
+
+        let owner = Address::random();
+        let mut object_ids: Vec<ObjectId> = (0..5).map(|_| ObjectId::random()).collect();
+        object_ids.sort();
+
+        let other_owner = Address::random();
+        let other_object_ids: Vec<ObjectId> = (0..2).map(|_| ObjectId::random()).collect();
+
+        let mut new_owners: Vec<_> = object_ids
+            .iter()
+            .map(|&id| ((owner, id), owner_object_info(owner, id)))
+            .collect();
+        new_owners.extend(
+            other_object_ids
+                .iter()
+                .map(|&id| ((other_owner, id), owner_object_info(other_owner, id))),
+        );
+
+        index_store
+            .index_tx(
+                Address::random(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                &TransactionEvents(vec![]),
+                ObjectIndexChanges {
+                    deleted_owners: vec![],
+                    deleted_dynamic_fields: vec![],
+                    new_owners,
+                    new_dynamic_fields: vec![],
+                },
+                &TransactionDigest::random(),
+                0,
+                None,
+            )
+            .unwrap();
+
+        let expected_ids: Vec<_> = index_store
+            .get_owner_objects(owner, None, usize::MAX, None)
+            .unwrap()
+            .into_iter()
+            .map(|info| info.object_id)
+            .collect();
+        assert_eq!(expected_ids, object_ids);
+
+        let mut walked_ids = Vec::new();
+        let mut cursor = None;
+        let mut finished = false;
+        for _ in 0..object_ids.len() + 2 {
+            let page = index_store
+                .get_owner_objects(owner, cursor, 1, None)
+                .unwrap();
+            let Some(info) = page.into_iter().next() else {
+                finished = true;
+                break;
+            };
+            walked_ids.push(info.object_id);
+            cursor = Some(info.object_id);
+
+            // Remove the row just read before fetching the next page, as if
+            // another transaction had transferred or deleted it concurrently.
+            index_store
+                .index_tx(
+                    Address::random(),
+                    vec![].into_iter(),
+                    vec![].into_iter(),
+                    vec![].into_iter(),
+                    &TransactionEvents(vec![]),
+                    ObjectIndexChanges {
+                        deleted_owners: vec![(owner, info.object_id)],
+                        deleted_dynamic_fields: vec![],
+                        new_owners: vec![],
+                        new_dynamic_fields: vec![],
+                    },
+                    &TransactionDigest::random(),
+                    0,
+                    None,
+                )
+                .unwrap();
+        }
+        if !finished {
+            panic!(
+                "cursor did not advance: exceeded {} pages for {} objects",
+                object_ids.len() + 2,
+                object_ids.len(),
+            );
+        }
+
+        assert_eq!(
+            walked_ids, expected_ids,
+            "the walk must return every object exactly once, in listing order, \
+             even though each row vanishes right after being read",
+        );
+        let unique: BTreeSet<_> = walked_ids.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            walked_ids.len(),
+            "every object must be returned exactly once",
+        );
+        assert!(
+            other_object_ids.iter().all(|id| !walked_ids.contains(id)),
+            "another owner's objects must not leak into the walk",
         );
     }
 }

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1267,12 +1267,7 @@ impl IndexStore {
         Ok(self
             .tables
             .dynamic_field_index
-            .safe_iter_with_prefix_from(
-                &object,
-                cursor
-                    .as_ref()
-                    .map_or(std::ops::Bound::Unbounded, std::ops::Bound::Excluded),
-            )
+            .safe_iter_with_prefix_after(&object, cursor.as_ref())
             .map_ok(|((_, c), object_info)| (c, object_info)))
     }
 

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1264,15 +1264,18 @@ impl IndexStore {
     ) -> IotaResult<impl Iterator<Item = Result<(ObjectId, DynamicFieldInfo), TypedStoreError>> + '_>
     {
         debug!(?object, "get_dynamic_fields");
+        // The lower bound excludes the cursor position itself, so the scan
+        // resumes strictly after the last returned field — even when the
+        // cursor's index row no longer exists (e.g. the field was removed
+        // from its parent or transferred between pages).
+        let lower = match &cursor {
+            Some(field_id) => std::ops::Bound::Excluded(field_id),
+            None => std::ops::Bound::Unbounded,
+        };
         Ok(self
             .tables
             .dynamic_field_index
-            .safe_iter_with_prefix_from(
-                &object,
-                std::ops::Bound::Included(&cursor.unwrap_or(ObjectId::ZERO)),
-            )
-            // skip an extra b/c the cursor is exclusive
-            .skip(usize::from(cursor.is_some()))
+            .safe_iter_with_prefix_from(&object, lower)
             .map_ok(|((_, c), object_info)| (c, object_info)))
     }
 
@@ -1681,15 +1684,35 @@ mod tests {
     use std::collections::BTreeMap;
 
     use iota_sdk_types::{
-        Address, ObjectId, Owner, StructTag, TransactionDigest, TransactionEvents, TypeTag,
+        Address, ObjectDigest, ObjectId, Owner, StructTag, TransactionDigest, TransactionEvents,
+        TypeTag, Version,
     };
     use iota_types::{
         base_types::{ObjectInfo, ObjectType},
+        dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType},
         object,
     };
     use prometheus_filtered::Registry;
 
     use super::{IndexStore, ObjectIndexChanges};
+
+    /// A `DynamicFieldInfo` for `field_id`, with placeholder metadata: the
+    /// cursor tests below only care about the field's identity, not its
+    /// content.
+    fn dynamic_field_info(field_id: ObjectId) -> DynamicFieldInfo {
+        DynamicFieldInfo {
+            name: DynamicFieldName {
+                type_tag: TypeTag::U64,
+                value: serde_json::Value::Number(0.into()),
+            },
+            bcs_name: vec![],
+            type_: DynamicFieldType::DynamicField,
+            object_type: "0x2::dynamic_field::Field<u64, u64>".to_string(),
+            object_id: field_id,
+            version: Version::from_u64(1),
+            digest: ObjectDigest::random(),
+        }
+    }
 
     #[tokio::test]
     async fn test_index_cache() -> anyhow::Result<()> {
@@ -1903,5 +1926,100 @@ mod tests {
             .unwrap();
         v.reverse();
         assert_eq!(v, v_rev);
+    }
+
+    /// The `cursor` of `get_dynamic_fields_iterator` is exclusive: the cursor
+    /// row itself is never returned again, and when the cursor row no longer
+    /// exists (the field was removed from its parent or transferred between
+    /// pages) the scan resumes at the next live row without skipping it.
+    #[tokio::test]
+    async fn get_dynamic_fields_iterator_cursor_is_exclusive() {
+        let tmp_dir = iota_common::tempdir();
+        let index_store = IndexStore::new(
+            tmp_dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+        );
+
+        let parent = ObjectId::random();
+        let mut field_ids: Vec<ObjectId> = (0..3).map(|_| ObjectId::random()).collect();
+        field_ids.sort();
+
+        let new_dynamic_fields = field_ids
+            .iter()
+            .map(|&id| ((parent, id), dynamic_field_info(id)))
+            .collect();
+        index_store
+            .index_tx(
+                Address::random(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                &TransactionEvents(vec![]),
+                ObjectIndexChanges {
+                    deleted_owners: vec![],
+                    deleted_dynamic_fields: vec![],
+                    new_owners: vec![],
+                    new_dynamic_fields,
+                },
+                &TransactionDigest::random(),
+                0,
+                None,
+            )
+            .unwrap();
+
+        let all: Vec<_> = index_store
+            .get_dynamic_fields_iterator(parent, None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let all_ids: Vec<_> = all.iter().map(|(id, _)| *id).collect();
+        assert_eq!(all_ids, field_ids);
+        let cursor = all_ids[0];
+
+        // Live cursor row: the scan starts strictly after it.
+        let after: Vec<_> = index_store
+            .get_dynamic_fields_iterator(parent, Some(cursor))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let after_ids: Vec<_> = after.iter().map(|(id, _)| *id).collect();
+        assert_eq!(
+            after_ids,
+            field_ids[1..],
+            "the cursor row itself must not be returned again",
+        );
+
+        // Vanished cursor row: the scan resumes at the next live row instead
+        // of skipping it.
+        index_store
+            .index_tx(
+                Address::random(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                vec![].into_iter(),
+                &TransactionEvents(vec![]),
+                ObjectIndexChanges {
+                    deleted_owners: vec![],
+                    deleted_dynamic_fields: vec![(parent, cursor)],
+                    new_owners: vec![],
+                    new_dynamic_fields: vec![],
+                },
+                &TransactionDigest::random(),
+                0,
+                None,
+            )
+            .unwrap();
+        let after_removal: Vec<_> = index_store
+            .get_dynamic_fields_iterator(parent, Some(cursor))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let after_removal_ids: Vec<_> = after_removal.iter().map(|(id, _)| *id).collect();
+        assert_eq!(
+            after_removal_ids,
+            field_ids[1..],
+            "the next live row must not be skipped",
+        );
     }
 }

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1264,18 +1264,15 @@ impl IndexStore {
     ) -> IotaResult<impl Iterator<Item = Result<(ObjectId, DynamicFieldInfo), TypedStoreError>> + '_>
     {
         debug!(?object, "get_dynamic_fields");
-        // The lower bound excludes the cursor position itself, so the scan
-        // resumes strictly after the last returned field, even when the
-        // cursor's index row no longer exists (e.g. the field was removed
-        // from its parent or transferred between pages).
-        let lower = match &cursor {
-            Some(field_id) => std::ops::Bound::Excluded(field_id),
-            None => std::ops::Bound::Unbounded,
-        };
         Ok(self
             .tables
             .dynamic_field_index
-            .safe_iter_with_prefix_from(&object, lower)
+            .safe_iter_with_prefix_from(
+                &object,
+                cursor
+                    .as_ref()
+                    .map_or(std::ops::Bound::Unbounded, std::ops::Bound::Excluded),
+            )
             .map_ok(|((_, c), object_info)| (c, object_info)))
     }
 

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1265,7 +1265,7 @@ impl IndexStore {
     {
         debug!(?object, "get_dynamic_fields");
         // The lower bound excludes the cursor position itself, so the scan
-        // resumes strictly after the last returned field — even when the
+        // resumes strictly after the last returned field, even when the
         // cursor's index row no longer exists (e.g. the field was removed
         // from its parent or transferred between pages).
         let lower = match &cursor {

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -690,11 +690,10 @@ impl GrpcReader {
         let indexes = self
             .require_indexes()
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
-        let skip = usize::from(cursor.is_some());
         let iter = indexes
             .account_owned_objects_info_iter(owner, cursor, object_type)
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
-        Ok(Box::new(iter.map(|r| r.map_err(Into::into)).skip(skip)))
+        Ok(Box::new(iter.map(|r| r.map_err(Into::into))))
     }
 
     /// Iterate over dynamic fields of a parent object.

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -724,6 +724,9 @@ impl GrpcReader {
     }
 
     /// Iterate over all versions of a package by its original package ID.
+    ///
+    /// The cursor is exclusive: items *after* the cursor position are
+    /// returned.
     pub fn package_versions_iter(
         &self,
         original_package_id: ObjectId,
@@ -732,11 +735,10 @@ impl GrpcReader {
         let indexes = self
             .require_indexes()
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
-        let skip = usize::from(cursor.is_some());
         let iter = indexes
             .package_versions_iter(original_package_id, cursor)
             .map_err(|e| crate::error::RpcError::internal().with_context(e))?;
-        Ok(Box::new(iter.map(|r| r.map_err(Into::into)).skip(skip)))
+        Ok(Box::new(iter.map(|r| r.map_err(Into::into))))
     }
 
     /// Generic stream implementation for checkpoints

--- a/crates/iota-grpc-server/src/types.rs
+++ b/crates/iota-grpc-server/src/types.rs
@@ -698,16 +698,15 @@ impl GrpcReader {
 
     /// Iterate over dynamic fields of a parent object.
     ///
-    /// When `cursor` is `Some`, the cursor item itself is automatically skipped
-    /// so callers get items *after* the cursor (exclusive lower bound).
+    /// The cursor is exclusive: items *after* the cursor position are
+    /// returned.
     pub fn dynamic_field_iter(
         &self,
         parent: ObjectId,
         cursor: Option<ObjectId>,
     ) -> anyhow::Result<Box<dyn Iterator<Item = DynamicFieldIterItem> + '_>> {
-        let skip = usize::from(cursor.is_some());
         let iter = self.require_indexes()?.dynamic_field_iter(parent, cursor)?;
-        Ok(Box::new(iter.map(|r| r.map_err(Into::into)).skip(skip)))
+        Ok(Box::new(iter.map(|r| r.map_err(Into::into))))
     }
 
     /// Get unified coin info.

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -144,6 +144,11 @@ pub struct MockGrpcStateReader {
         iota_types::storage::OwnedObjectCursor,
     )>,
 
+    // -- Dynamic fields (for list_dynamic_fields pagination tests) --
+    /// Pre-sorted in dynamic-field index key order (`parent`, `field_id`).
+    /// The iterator respects cursor-based seeking.
+    pub dynamic_fields: Vec<iota_types::storage::DynamicFieldKey>,
+
     // -- Transactions --
     pub transactions: HashMap<TransactionDigest, Arc<VerifiedTransaction>>,
     pub effects: HashMap<TransactionDigest, TransactionEffects>,
@@ -468,8 +473,8 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
 
     fn dynamic_field_iter(
         &self,
-        _parent: ObjectId,
-        _cursor: Option<ObjectId>,
+        parent: ObjectId,
+        cursor: Option<ObjectId>,
     ) -> StorageResult<
         Box<
             dyn Iterator<
@@ -480,7 +485,13 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
                 > + '_,
         >,
     > {
-        Ok(Box::new(std::iter::empty()))
+        // Seek strictly past the cursor position (the cursor is exclusive).
+        let iter = self
+            .dynamic_fields
+            .iter()
+            .filter(move |key| key.parent == parent && cursor.is_none_or(|c| key.field_id > c))
+            .map(|key| Ok(*key));
+        Ok(Box::new(iter))
     }
 
     fn get_coin_info(

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -13,6 +13,7 @@ use std::{
 use iota_config::{local_ip_utils, node::GrpcApiConfig};
 use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
 use iota_grpc_types::v1::{
+    move_package_service::move_package_service_client::MovePackageServiceClient,
     state_service::state_service_client::StateServiceClient,
     types::{Address as ProtoAddress, ObjectId as ProtoObjectId},
 };
@@ -153,6 +154,14 @@ pub struct MockGrpcStateReader {
     /// Pre-sorted in dynamic-field index key order (`parent`, `field_id`).
     /// The iterator respects cursor-based seeking.
     pub dynamic_fields: Vec<iota_types::storage::DynamicFieldKey>,
+
+    // -- Package versions (for list_package_versions pagination tests) --
+    /// Pre-sorted in package-version index key order (`original_package_id`,
+    /// `version`). The iterator respects cursor-based seeking.
+    pub package_versions: Vec<(
+        iota_types::storage::PackageVersionKey,
+        iota_types::storage::PackageVersionInfo,
+    )>,
 
     // -- Transactions --
     pub transactions: HashMap<TransactionDigest, Arc<VerifiedTransaction>>,
@@ -510,11 +519,20 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
 
     fn package_versions_iter(
         &self,
-        _original_package_id: ObjectId,
-        _cursor: Option<u64>,
+        original_package_id: ObjectId,
+        cursor: Option<u64>,
     ) -> StorageResult<Box<dyn Iterator<Item = iota_types::storage::PackageVersionIteratorItem> + '_>>
     {
-        Ok(Box::new(std::iter::empty()))
+        // Seek strictly past the cursor position (the cursor is exclusive).
+        let iter = self
+            .package_versions
+            .iter()
+            .filter(move |(key, _)| {
+                key.original_package_id == original_package_id
+                    && cursor.is_none_or(|c| key.version > c)
+            })
+            .map(|(key, info)| Ok((key.clone(), info.clone())));
+        Ok(Box::new(iter))
     }
 }
 
@@ -604,4 +622,16 @@ pub async fn connect_state_client(handle: &GrpcServerHandle) -> StateServiceClie
         .await
         .unwrap();
     StateServiceClient::new(channel)
+}
+
+/// Connect a move-package-service client to the test server.
+pub async fn connect_move_package_service_client(
+    handle: &GrpcServerHandle,
+) -> MovePackageServiceClient<Channel> {
+    let channel = Channel::from_shared(format!("http://{}", handle.address()))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    MovePackageServiceClient::new(channel)
 }

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -440,7 +440,7 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
     ) -> StorageResult<Box<dyn Iterator<Item = iota_types::storage::OwnedObjectIteratorItem> + '_>>
     {
         // Find the start index: if a cursor is provided, seek strictly past
-        // its position (the cursor is exclusive) within this owner's rows —
+        // its position (the cursor is exclusive) within this owner's rows:
         // in the real index the owner is the leading key component.
         let start = if let Some(c) = cursor {
             self.owned_objects

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -12,6 +12,10 @@ use std::{
 
 use iota_config::{local_ip_utils, node::GrpcApiConfig};
 use iota_grpc_server::{GrpcReader, GrpcServerHandle, start_grpc_server};
+use iota_grpc_types::v1::{
+    state_service::state_service_client::StateServiceClient,
+    types::{Address as ProtoAddress, ObjectId as ProtoObjectId},
+};
 use iota_node_storage::GrpcStateReader;
 use iota_sdk_types::{
     Address, CheckpointContentsDigest, CheckpointDigest, MoveStruct, ObjectId, Owner, StructTag,
@@ -30,6 +34,7 @@ use iota_types::{
     storage::error::Result as StorageResult,
     transaction::VerifiedTransaction,
 };
+use tonic::transport::Channel;
 
 // ---------------------------------------------------------------------------
 // Stream invariant helpers
@@ -426,22 +431,24 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
     ) -> StorageResult<Box<dyn Iterator<Item = iota_types::storage::OwnedObjectIteratorItem> + '_>>
     {
         // Find the start index: if a cursor is provided, seek strictly past
-        // its position (the cursor is exclusive).
+        // its position (the cursor is exclusive) within this owner's rows —
+        // in the real index the owner is the leading key component.
         let start = if let Some(c) = cursor {
             self.owned_objects
                 .iter()
-                .position(|(_, oc)| {
-                    (
-                        oc.object_type_identifier,
-                        oc.object_type_params,
-                        oc.inverted_balance,
-                        oc.object_id,
-                    ) > (
-                        c.object_type_identifier,
-                        c.object_type_params,
-                        c.inverted_balance,
-                        c.object_id,
-                    )
+                .position(|(info, oc)| {
+                    info.owner == owner
+                        && (
+                            oc.object_type_identifier,
+                            oc.object_type_params,
+                            oc.inverted_balance,
+                            oc.object_id,
+                        ) > (
+                            c.object_type_identifier,
+                            c.object_type_params,
+                            c.inverted_balance,
+                            c.object_id,
+                        )
                 })
                 .unwrap_or(self.owned_objects.len())
         } else {
@@ -573,4 +580,28 @@ pub async fn start_test_server_with_traffic_controller(
     executor: Option<Arc<dyn iota_types::transaction_executor::TransactionExecutor>>,
 ) -> (GrpcServerHandle, Arc<GrpcReader>) {
     start_test_server_with(state_reader, executor, Some(traffic_controller), |_| {}).await
+}
+
+// ---------------------------------------------------------------------------
+// Client helpers
+// ---------------------------------------------------------------------------
+
+/// Convert an [`Address`] to its gRPC proto message.
+pub fn owner_proto(addr: Address) -> ProtoAddress {
+    ProtoAddress::default().with_address(addr.into_bytes().to_vec())
+}
+
+/// Convert an [`ObjectId`] to its gRPC proto message.
+pub fn object_id_proto(id: ObjectId) -> ProtoObjectId {
+    ProtoObjectId::default().with_object_id(id.into_bytes().to_vec())
+}
+
+/// Connect a state-service client to the test server.
+pub async fn connect_state_client(handle: &GrpcServerHandle) -> StateServiceClient<Channel> {
+    let channel = Channel::from_shared(format!("http://{}", handle.address()))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    StateServiceClient::new(channel)
 }

--- a/crates/iota-grpc-server/tests/common/mod.rs
+++ b/crates/iota-grpc-server/tests/common/mod.rs
@@ -420,8 +420,8 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
         object_type: Option<StructTag>,
     ) -> StorageResult<Box<dyn Iterator<Item = iota_types::storage::OwnedObjectIteratorItem> + '_>>
     {
-        // Find the start index: if cursor is provided, seek to its position
-        // (inclusive — the GrpcReader wrapper handles skip(1)).
+        // Find the start index: if a cursor is provided, seek strictly past
+        // its position (the cursor is exclusive).
         let start = if let Some(c) = cursor {
             self.owned_objects
                 .iter()
@@ -431,7 +431,7 @@ impl iota_node_storage::GrpcIndexes for MockGrpcStateReader {
                         oc.object_type_params,
                         oc.inverted_balance,
                         oc.object_id,
-                    ) >= (
+                    ) > (
                         c.object_type_identifier,
                         c.object_type_params,
                         c.inverted_balance,

--- a/crates/iota-grpc-server/tests/list_dynamic_fields.rs
+++ b/crates/iota-grpc-server/tests/list_dynamic_fields.rs
@@ -10,41 +10,18 @@ mod common;
 
 use std::sync::Arc;
 
-use common::{MockGrpcStateReader, start_test_server};
+use common::{MockGrpcStateReader, connect_state_client, object_id_proto, start_test_server};
 use iota_grpc_types::{
     field::FieldMaskUtil,
-    v1::{
-        state_service::{
-            ListDynamicFieldsRequest, ListDynamicFieldsResponse,
-            state_service_client::StateServiceClient,
-        },
-        types::ObjectId as ProtoObjectId,
-    },
+    v1::state_service::{ListDynamicFieldsRequest, ListDynamicFieldsResponse},
 };
 use iota_sdk_types::ObjectId;
 use iota_types::storage::DynamicFieldKey;
 use prost_types::FieldMask;
-use tonic::transport::Channel;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn object_id_proto(id: ObjectId) -> ProtoObjectId {
-    ProtoObjectId::default().with_object_id(id.into_bytes().to_vec())
-}
-
-/// Connect a state-service client to the test server.
-async fn connect_state_client(
-    handle: &iota_grpc_server::GrpcServerHandle,
-) -> StateServiceClient<Channel> {
-    let channel = Channel::from_shared(format!("http://{}", handle.address()))
-        .unwrap()
-        .connect()
-        .await
-        .unwrap();
-    StateServiceClient::new(channel)
-}
 
 /// Extract the returned field IDs (as raw bytes) from a response.
 fn returned_field_ids(resp: &ListDynamicFieldsResponse) -> Vec<Vec<u8>> {
@@ -93,7 +70,15 @@ async fn paginate_one_at_a_time() {
 
     let mut returned: Vec<Vec<u8>> = Vec::new();
     let mut page_token = None;
+    // Walk at most `len + 2` pages, so a regression where the cursor stops
+    // advancing fails the test instead of hanging it.
+    let mut pages_left = expected_ids.len() + 2;
     loop {
+        assert!(
+            pages_left > 0,
+            "cursor did not advance: page budget exhausted"
+        );
+        pages_left -= 1;
         let mut request = base.clone();
         if let Some(token) = page_token.take() {
             request = request.with_page_token(token);
@@ -171,8 +156,9 @@ async fn cursor_row_removed_between_pages_loses_no_field() {
         .unwrap()
         .into_inner();
 
-    assert!(
-        returned_field_ids(&page2).contains(&index_ids[1].as_bytes().to_vec()),
+    assert_eq!(
+        returned_field_ids(&page2),
+        [index_ids[1].as_bytes().to_vec()],
         "the unchanged second row must not be skipped when the cursor row is gone",
     );
 }

--- a/crates/iota-grpc-server/tests/list_dynamic_fields.rs
+++ b/crates/iota-grpc-server/tests/list_dynamic_fields.rs
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pagination edge-case tests for `ListDynamicFields`.
+//!
+//! Uses `MockGrpcStateReader` populated with controlled data so we can
+//! exercise cursor-based seeking without a full validator cluster.
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{MockGrpcStateReader, start_test_server};
+use iota_grpc_types::{
+    field::FieldMaskUtil,
+    v1::{
+        state_service::{
+            ListDynamicFieldsRequest, ListDynamicFieldsResponse,
+            state_service_client::StateServiceClient,
+        },
+        types::ObjectId as ProtoObjectId,
+    },
+};
+use iota_sdk_types::ObjectId;
+use iota_types::storage::DynamicFieldKey;
+use prost_types::FieldMask;
+use tonic::transport::Channel;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn object_id_proto(id: ObjectId) -> ProtoObjectId {
+    ProtoObjectId::default().with_object_id(id.into_bytes().to_vec())
+}
+
+/// Connect a state-service client to the test server.
+async fn connect_state_client(
+    handle: &iota_grpc_server::GrpcServerHandle,
+) -> StateServiceClient<Channel> {
+    let channel = Channel::from_shared(format!("http://{}", handle.address()))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    StateServiceClient::new(channel)
+}
+
+/// Extract the returned field IDs (as raw bytes) from a response.
+fn returned_field_ids(resp: &ListDynamicFieldsResponse) -> Vec<Vec<u8>> {
+    resp.dynamic_fields
+        .iter()
+        .map(|f| f.field_id.as_ref().unwrap().object_id.to_vec())
+        .collect()
+}
+
+/// Set up a mock with `count` dynamic fields under a single parent.
+///
+/// Returns the mock and the field IDs in index key order.
+fn make_field_mock(parent: ObjectId, count: usize) -> (MockGrpcStateReader, Vec<ObjectId>) {
+    let mut ids: Vec<ObjectId> = (0..count).map(|_| ObjectId::random()).collect();
+    // Sort IDs so they match the dynamic-field index key ordering.
+    ids.sort();
+
+    let mock = MockGrpcStateReader {
+        dynamic_fields: ids
+            .iter()
+            .map(|&id| DynamicFieldKey::new(parent, id))
+            .collect(),
+        ..Default::default()
+    };
+    (mock, ids)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Walk through all items with page_size=1 and verify every field is returned
+/// exactly once, in the expected order, with no duplicates or gaps.
+#[tokio::test]
+async fn paginate_one_at_a_time() {
+    let parent = ObjectId::random();
+    let (mock, expected_ids) = make_field_mock(parent, 5);
+
+    let (handle, _reader) = start_test_server(Arc::new(mock), |_| {}).await;
+    let mut client = connect_state_client(&handle).await;
+
+    let base = ListDynamicFieldsRequest::default()
+        .with_parent(object_id_proto(parent))
+        .with_page_size(1)
+        .with_read_mask(FieldMask::from_str("field_id"));
+
+    let mut returned: Vec<Vec<u8>> = Vec::new();
+    let mut page_token = None;
+    loop {
+        let mut request = base.clone();
+        if let Some(token) = page_token.take() {
+            request = request.with_page_token(token);
+        }
+        let resp = client
+            .list_dynamic_fields(request)
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(
+            resp.dynamic_fields.len() <= 1,
+            "page_size=1 but got {} fields",
+            resp.dynamic_fields.len()
+        );
+        returned.extend(returned_field_ids(&resp));
+
+        match resp.next_page_token {
+            Some(token) => page_token = Some(token),
+            None => break,
+        }
+    }
+
+    let expected: Vec<Vec<u8>> = expected_ids
+        .iter()
+        .map(|id| id.as_bytes().to_vec())
+        .collect();
+    assert_eq!(
+        returned, expected,
+        "every field must be returned exactly once, in index order",
+    );
+}
+
+/// A cursor row that vanishes between pages (e.g. the field was deleted from
+/// its parent) must not cause the next live row to be skipped: a field that
+/// did not change is always returned.
+#[tokio::test]
+async fn cursor_row_removed_between_pages_loses_no_field() {
+    let parent = ObjectId::random();
+    let (mock, index_ids) = make_field_mock(parent, 3);
+    // Derive the state where the first row (the future cursor row) is gone
+    // from the index.
+    let mut fields_after = mock.dynamic_fields.clone();
+    fields_after.remove(0);
+
+    // Page 1 against the full state returns the first row and a token
+    // pointing at it.
+    let (handle, _reader) = start_test_server(Arc::new(mock), |_| {}).await;
+    let mut client = connect_state_client(&handle).await;
+    let base = ListDynamicFieldsRequest::default()
+        .with_parent(object_id_proto(parent))
+        .with_page_size(1)
+        .with_read_mask(FieldMask::from_str("field_id"));
+    let page1 = client
+        .list_dynamic_fields(base.clone())
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        returned_field_ids(&page1),
+        [index_ids[0].as_bytes().to_vec()],
+    );
+    let token = page1.next_page_token.clone().expect("more rows exist");
+
+    // Page 2 against the state without the cursor row.
+    let mock_after = MockGrpcStateReader {
+        dynamic_fields: fields_after,
+        ..Default::default()
+    };
+    let (handle_after, _reader_after) = start_test_server(Arc::new(mock_after), |_| {}).await;
+    let mut client_after = connect_state_client(&handle_after).await;
+    let page2 = client_after
+        .list_dynamic_fields(base.with_page_token(token))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(
+        returned_field_ids(&page2).contains(&index_ids[1].as_bytes().to_vec()),
+        "the unchanged second row must not be skipped when the cursor row is gone",
+    );
+}

--- a/crates/iota-grpc-server/tests/list_owned_objects.rs
+++ b/crates/iota-grpc-server/tests/list_owned_objects.rs
@@ -571,3 +571,83 @@ async fn type_filter_with_pagination() {
     // This validates that type filtering + pagination work together.
     assert_eq!(total_filtered, 5);
 }
+
+/// A cursor row that vanishes between pages (e.g. the cursor coin's balance
+/// changed, which moves its index key) must not cause the next live row to
+/// be skipped: an object that did not change is always returned.
+#[tokio::test]
+async fn cursor_row_removed_between_pages_loses_no_object() {
+    let owner = Address::random();
+    let (mock, _ids) = make_coin_mock(owner, 3);
+    // `owned_objects` is sorted in index order; remember it and derive the
+    // state where the first row (the future cursor row) is gone from the
+    // index while the object store is unchanged.
+    let index_ids: Vec<ObjectId> = mock
+        .owned_objects
+        .iter()
+        .map(|(info, _)| info.object_id)
+        .collect();
+    let objects_after = mock.objects.clone();
+    let mut owned_after = mock.owned_objects.clone();
+    owned_after.remove(0);
+
+    // Page 1 against the full state returns the first row and a token
+    // pointing at it.
+    let (handle, _reader) = start_test_server(Arc::new(mock), |_| {}).await;
+    let mut client = connect_state_client(&handle).await;
+    let base = ListOwnedObjectsRequest::default()
+        .with_owner(owner_proto(owner))
+        .with_page_size(1)
+        .with_read_mask(FieldMask::from_str("reference.object_id"));
+    let page1 = client
+        .list_owned_objects(base.clone())
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        page1.objects[0]
+            .reference
+            .as_ref()
+            .unwrap()
+            .object_id
+            .as_ref()
+            .unwrap()
+            .object_id
+            .to_vec(),
+        index_ids[0].as_bytes().to_vec(),
+    );
+    let token = page1.next_page_token.clone().expect("more rows exist");
+
+    // Page 2 against the state without the cursor row.
+    let mock_after = MockGrpcStateReader {
+        objects: objects_after,
+        owned_objects: owned_after,
+        ..Default::default()
+    };
+    let (handle_after, _reader_after) = start_test_server(Arc::new(mock_after), |_| {}).await;
+    let mut client_after = connect_state_client(&handle_after).await;
+    let page2 = client_after
+        .list_owned_objects(base.with_page_token(token))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let returned: Vec<Vec<u8>> = page2
+        .objects
+        .iter()
+        .map(|o| {
+            o.reference
+                .as_ref()
+                .unwrap()
+                .object_id
+                .as_ref()
+                .unwrap()
+                .object_id
+                .to_vec()
+        })
+        .collect();
+    assert!(
+        returned.contains(&index_ids[1].as_bytes().to_vec()),
+        "the unchanged second row must not be skipped when the cursor row is gone",
+    );
+}

--- a/crates/iota-grpc-server/tests/list_owned_objects.rs
+++ b/crates/iota-grpc-server/tests/list_owned_objects.rs
@@ -11,15 +11,11 @@ mod common;
 
 use std::{collections::HashMap, sync::Arc};
 
-use common::{MockGrpcStateReader, start_test_server};
+use common::{MockGrpcStateReader, connect_state_client, owner_proto, start_test_server};
 use iota_grpc_types::{
     field::FieldMaskUtil,
-    v1::{
-        state_service::{
-            ListOwnedObjectsRequest, ListOwnedObjectsResponse,
-            state_service_client::StateServiceClient,
-        },
-        types::Address as ProtoAddress,
+    v1::state_service::{
+        ListOwnedObjectsRequest, ListOwnedObjectsResponse, state_service_client::StateServiceClient,
     },
 };
 use iota_sdk_types::{
@@ -103,31 +99,19 @@ fn make_owned_entry(
     (info, cursor)
 }
 
-fn owner_proto(addr: Address) -> ProtoAddress {
-    ProtoAddress::default().with_address(addr.into_bytes().to_vec())
-}
-
-/// Connect a state-service client to the test server.
-async fn connect_state_client(
-    handle: &iota_grpc_server::GrpcServerHandle,
-) -> StateServiceClient<Channel> {
-    let channel = Channel::from_shared(format!("http://{}", handle.address()))
-        .unwrap()
-        .connect()
-        .await
-        .unwrap();
-    StateServiceClient::new(channel)
-}
-
-/// Paginate through `ListOwnedObjects` collecting all object IDs.
+/// Paginate through `ListOwnedObjects` collecting all responses.
+///
+/// Walks at most `expected_count + 2` pages, so a regression where the
+/// cursor stops advancing fails the test instead of hanging it.
 async fn paginate_all(
     client: &mut StateServiceClient<Channel>,
     base_request: ListOwnedObjectsRequest,
+    expected_count: usize,
 ) -> Vec<ListOwnedObjectsResponse> {
     let mut responses = Vec::new();
     let mut page_token = None;
 
-    loop {
+    for _ in 0..expected_count + 2 {
         let mut request = base_request.clone();
         if let Some(token) = page_token.take() {
             request = request.with_page_token(token);
@@ -145,11 +129,14 @@ async fn paginate_all(
         responses.push(resp);
 
         if !has_next {
-            break;
+            return responses;
         }
     }
 
-    responses
+    panic!(
+        "cursor did not advance: exceeded {} pages for {expected_count} items",
+        expected_count + 2
+    );
 }
 
 /// Set up a mock with `count` gas-coin objects for a single owner.
@@ -226,7 +213,7 @@ async fn paginate_one_at_a_time() {
         .with_page_size(1)
         .with_read_mask(FieldMask::from_str("reference.object_id"));
 
-    let responses = paginate_all(&mut client, base).await;
+    let responses = paginate_all(&mut client, base, expected_count).await;
 
     // Collect all returned object IDs.
     let mut returned_ids: Vec<Vec<u8>> = Vec::new();
@@ -457,7 +444,7 @@ async fn message_size_triggers_pagination() {
         .with_max_message_size_bytes(iota_grpc_server::constants::MIN_MESSAGE_SIZE_BYTES as u32)
         .with_read_mask(FieldMask::from_str("reference,bcs"));
 
-    let responses = paginate_all(&mut client, base).await;
+    let responses = paginate_all(&mut client, base, 3).await;
 
     // Collect total objects across all pages.
     let total: usize = responses.iter().map(|r| r.objects.len()).sum();
@@ -552,7 +539,7 @@ async fn type_filter_with_pagination() {
         .with_owner(owner_proto(owner))
         .with_page_size(2) // force multiple pages
         .with_read_mask(FieldMask::from_str("reference.object_id"));
-    let all_responses = paginate_all(&mut client, all_base).await;
+    let all_responses = paginate_all(&mut client, all_base, 5).await;
     let total_all: usize = all_responses.iter().map(|r| r.objects.len()).sum();
     assert_eq!(total_all, 5, "unfiltered should return all 5 objects");
 
@@ -562,7 +549,7 @@ async fn type_filter_with_pagination() {
         .with_page_size(2)
         .with_object_type(StructTag::new_gas_coin().to_canonical_string(true))
         .with_read_mask(FieldMask::from_str("reference.object_id"));
-    let filtered_responses = paginate_all(&mut client, filtered_base).await;
+    let filtered_responses = paginate_all(&mut client, filtered_base, 5).await;
     let total_filtered: usize = filtered_responses.iter().map(|r| r.objects.len()).sum();
 
     // The mock's type filter works on MoveObjectType equality. All 5 objects
@@ -646,8 +633,9 @@ async fn cursor_row_removed_between_pages_loses_no_object() {
                 .to_vec()
         })
         .collect();
-    assert!(
-        returned.contains(&index_ids[1].as_bytes().to_vec()),
+    assert_eq!(
+        returned,
+        [index_ids[1].as_bytes().to_vec()],
         "the unchanged second row must not be skipped when the cursor row is gone",
     );
 }

--- a/crates/iota-grpc-server/tests/list_package_versions.rs
+++ b/crates/iota-grpc-server/tests/list_package_versions.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pagination edge-case tests for `ListPackageVersions`.
+//!
+//! Uses `MockGrpcStateReader` populated with controlled data so we can
+//! exercise cursor-based seeking without a full validator cluster.
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{
+    MockGrpcStateReader, connect_move_package_service_client, object_id_proto, start_test_server,
+};
+use iota_grpc_types::v1::move_package_service::{
+    ListPackageVersionsRequest, ListPackageVersionsResponse,
+};
+use iota_sdk_types::ObjectId;
+use iota_types::storage::{PackageVersionInfo, PackageVersionKey};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the returned version numbers from a response.
+fn returned_versions(resp: &ListPackageVersionsResponse) -> Vec<u64> {
+    resp.versions.iter().map(|v| v.version.unwrap()).collect()
+}
+
+/// Set up a mock with sequential versions `1..=count` of a single package.
+fn make_package_version_mock(original_package_id: ObjectId, count: u64) -> MockGrpcStateReader {
+    let package_versions = (1..=count)
+        .map(|version| {
+            (
+                PackageVersionKey {
+                    original_package_id,
+                    version,
+                },
+                PackageVersionInfo {
+                    storage_id: ObjectId::random(),
+                },
+            )
+        })
+        .collect();
+    MockGrpcStateReader {
+        package_versions,
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Walk through all versions with page_size=1 and verify every version is
+/// returned exactly once, in order, with no duplicates or gaps: a regression
+/// that skips an extra item on top of the exclusive-cursor store (e.g. the
+/// old inclusive-cursor-plus-skip pattern applied twice) would drop every
+/// other version.
+#[tokio::test]
+async fn paginate_one_at_a_time() {
+    let original_package_id = ObjectId::random();
+    let version_count = 5u64;
+    let mock = make_package_version_mock(original_package_id, version_count);
+
+    let (handle, _reader) = start_test_server(Arc::new(mock), |_| {}).await;
+    let mut client = connect_move_package_service_client(&handle).await;
+
+    let base = ListPackageVersionsRequest::default()
+        .with_package_id(object_id_proto(original_package_id))
+        .with_page_size(1);
+
+    let mut returned: Vec<u64> = Vec::new();
+    let mut page_token = None;
+    // Walk at most `version_count + 2` pages, so a cursor that stops
+    // advancing fails the test instead of hanging it.
+    let mut pages_left = version_count + 2;
+    loop {
+        assert!(
+            pages_left > 0,
+            "cursor did not advance: page budget exhausted"
+        );
+        pages_left -= 1;
+        let mut request = base.clone();
+        if let Some(token) = page_token.take() {
+            request = request.with_page_token(token);
+        }
+        let resp = client
+            .list_package_versions(request)
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(
+            resp.versions.len() <= 1,
+            "page_size=1 but got {} versions",
+            resp.versions.len()
+        );
+        returned.extend(returned_versions(&resp));
+
+        match resp.next_page_token {
+            Some(token) => page_token = Some(token),
+            None => break,
+        }
+    }
+
+    let expected: Vec<u64> = (1..=version_count).collect();
+    assert_eq!(
+        returned, expected,
+        "every version must be returned exactly once, in order",
+    );
+}

--- a/crates/iota-node-storage/src/lib.rs
+++ b/crates/iota-node-storage/src/lib.rs
@@ -85,8 +85,7 @@ pub trait GrpcIndexes: Send + Sync {
     /// `object_type`.
     ///
     /// Each item includes an [`OwnedObjectCursor`] for seek-based pagination.
-    /// The `cursor` is **exclusive**: only items strictly after the cursor
-    /// position are returned, even when the cursor's row no longer exists.
+    /// The `cursor` is **exclusive**.
     fn account_owned_objects_info_iter(
         &self,
         owner: Address,
@@ -96,8 +95,7 @@ pub trait GrpcIndexes: Send + Sync {
 
     /// Iterate over the dynamic fields of `parent`.
     ///
-    /// The `cursor` is **exclusive**: only fields strictly after the cursor
-    /// position are returned, even when the cursor's row no longer exists.
+    /// The `cursor` is **exclusive**.
     /// Only the `DynamicFieldKey` is returned; field metadata is loaded on
     /// demand from the object store.
     fn dynamic_field_iter(
@@ -111,9 +109,7 @@ pub trait GrpcIndexes: Send + Sync {
 
     /// Iterate over all versions of a package by its original package ID.
     ///
-    /// The `cursor` is **exclusive**: only versions strictly after the
-    /// cursor position are returned. Version keys are append-only, so a
-    /// cursor row never vanishes between pages.
+    /// The `cursor` is **exclusive**.
     fn package_versions_iter(
         &self,
         original_package_id: ObjectId,

--- a/crates/iota-node-storage/src/lib.rs
+++ b/crates/iota-node-storage/src/lib.rs
@@ -111,9 +111,9 @@ pub trait GrpcIndexes: Send + Sync {
 
     /// Iterate over all versions of a package by its original package ID.
     ///
-    /// The `cursor` bound is **inclusive** (the `GrpcReader` wrapper skips
-    /// the cursor item itself); version keys are append-only, so a cursor
-    /// row never vanishes between pages.
+    /// The `cursor` is **exclusive**: only versions strictly after the
+    /// cursor position are returned. Version keys are append-only, so a
+    /// cursor row never vanishes between pages.
     fn package_versions_iter(
         &self,
         original_package_id: ObjectId,

--- a/crates/iota-node-storage/src/lib.rs
+++ b/crates/iota-node-storage/src/lib.rs
@@ -96,8 +96,10 @@ pub trait GrpcIndexes: Send + Sync {
 
     /// Iterate over the dynamic fields of `parent`.
     ///
-    /// The `cursor` bound is **inclusive**.  Only the `DynamicFieldKey` is
-    /// returned; field metadata is loaded on demand from the object store.
+    /// The `cursor` is **exclusive**: only fields strictly after the cursor
+    /// position are returned, even when the cursor's row no longer exists.
+    /// Only the `DynamicFieldKey` is returned; field metadata is loaded on
+    /// demand from the object store.
     fn dynamic_field_iter(
         &self,
         parent: ObjectId,

--- a/crates/iota-node-storage/src/lib.rs
+++ b/crates/iota-node-storage/src/lib.rs
@@ -85,7 +85,8 @@ pub trait GrpcIndexes: Send + Sync {
     /// `object_type`.
     ///
     /// Each item includes an [`OwnedObjectCursor`] for seek-based pagination.
-    /// The `cursor` bound is **inclusive**.
+    /// The `cursor` is **exclusive**: only items strictly after the cursor
+    /// position are returned, even when the cursor's row no longer exists.
     fn account_owned_objects_info_iter(
         &self,
         owner: Address,

--- a/crates/iota-node-storage/src/lib.rs
+++ b/crates/iota-node-storage/src/lib.rs
@@ -110,6 +110,10 @@ pub trait GrpcIndexes: Send + Sync {
     fn get_coin_info(&self, coin_type: &StructTag) -> Result<Option<CoinInfo>>;
 
     /// Iterate over all versions of a package by its original package ID.
+    ///
+    /// The `cursor` bound is **inclusive** (the `GrpcReader` wrapper skips
+    /// the cursor item itself); version keys are append-only, so a cursor
+    /// row never vanishes between pages.
     fn package_versions_iter(
         &self,
         original_package_id: ObjectId,

--- a/crates/iota-node-transaction-builder/src/lib.rs
+++ b/crates/iota-node-transaction-builder/src/lib.rs
@@ -158,12 +158,8 @@ impl TransactionBuilderLedgerClient for NodeTransactionBuilderLedgerClient {
             .transpose()?;
 
         let indexes = self.reader.grpc_indexes().ok_or(Error::IndexesDisabled)?;
-        // The index iterator's cursor bound is inclusive, so skip the cursor
-        // item itself to advance past the previous page.
-        let skip = usize::from(cursor.is_some());
-        let mut iter = indexes
-            .account_owned_objects_info_iter(owner, cursor.as_ref(), struct_tag.clone())?
-            .skip(skip);
+        let mut iter =
+            indexes.account_owned_objects_info_iter(owner, cursor.as_ref(), struct_tag.clone())?;
 
         let mut data = Vec::with_capacity(limit);
         let mut last_cursor = None;


### PR DESCRIPTION
# Description of change

Both paginated index scans behind `ListOwnedObjects` and `ListDynamicFields` resume from the page token with an inclusive seek followed by `skip(1)`, assuming the row the token points at still exists. It does not have to: an owned-object row moves whenever the coin's balance changes (the balance is part of the key) or the object changes owner; a dynamic-field row disappears when the field is removed from its parent. When the token row is gone between two pages, the inclusive seek lands on the *next* live row (an object or field that was never returned), and `skip(1)` silently drops it. The `skip` also swallows a storage error yielded as the first item.

The fix makes the cursor exclusive at the index level: `owner_iter` and `dynamic_field_iter` take the token position as an exclusive lower bound (`Bound::Excluded`, or `safe_iter_with_prefix_after` from #12831 for prefix scans), so resuming is "strictly after the token" by construction whether or not the row still exists. The gRPC readers and the node transaction builder client drop their `skip(1)`. The token keeps its meaning (last returned row) and its bytes; nothing changes on the wire.

Cursor schemes compared:

- **Before**: token = last returned row; inclusive seek + `skip(1)`. If the token's row vanished, the seek lands on the next live row and `skip(1)` drops it: an unchanged row is silently lost.
- **Upstream Sui**: token = first row of the *next* page; no skip. Fixes the loss, but silently changes what an already-issued token means while keeping its byte format: during a rolling upgrade a token issued by a new node and consumed by an old one loses one never-returned row at every page boundary: deterministic silent loss on a released API, undetectable from the token itself.
- **This PR**: token = last returned row, unchanged in meaning and bytes; the seek becomes exclusive. Same guarantee as Sui's scheme, no mixed-version hazard, one producer-side change, and `skip(1)`'s error-swallowing disappears with it.

On the choice of scheme: Sui's is simpler in the store: a plain inclusive seek, no exclusive-bound machinery. Ours buys compatibility of in-flight tokens across a mixed-version fleet. If that window is judged not worth protecting, the Sui scheme is the alternative; with #12831 in place both are now equally cheap to implement here.

The three remaining readers with the same shape get the same treatment. JSON-RPC `IndexStore::get_dynamic_fields_iterator` (behind `iotax_getDynamicFields`) and `IndexStore::get_owner_objects_iterator` (behind `iotax_getOwnedObjects`) scan the same kind of table and had the same bug; the owner listing also used `ObjectId::ZERO` as a stand-in for "no cursor", which is gone with the cursor now being an `Option`. `package_versions_iter` has append-only keys, so no row can vanish there, but its `skip(1)` still swallowed a storage error, and the `GrpcIndexes` trait now states one cursor contract (exclusive) for all three methods. `get_newer_object_keys` in the authority store is left as is.

## Links to any relevant issues

Review comment on #12411 (client side); the server side predates that PR. Split out of #12806. Builds on the prefix scan API from #12831; both are now merged.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

All new tests fail on the pre-fix code and pass after (verified locally, both axes: restoring `skip(1)` in `GrpcReader` turns the handler tests red; restoring the inclusive seek in the store turns the store tests red).

- Store (`iota-core`, real RocksDB, rows produced through the production indexing path): `owner_iter_cursor_is_exclusive`, `dynamic_field_iter_cursor_is_exclusive`: the token row is never returned again, and a vanished token row does not shift the scan past the next live row; `owner_iter_full_walk_returns_each_row_once`: mixed coin / non-coin population walked one row per page, covers the key-length boundary between the two.
- JSON-RPC index (`iota-core`, real RocksDB, rows written through `index_tx`): `get_dynamic_fields_iterator_cursor_is_exclusive` and `get_owner_objects_iterator_cursor_is_exclusive`: a field or object removed between pages does not hide the next one. `get_dynamic_fields_iterator_walks_every_field` and `get_owner_objects_paginates_the_whole_listing` repeat that for a whole listing: every page is read one row at a time and that row is deleted before the next page is requested, so each cursor names a row that is already gone. `package_versions_iter_cursor_is_exclusive` pins the new contract of the third method.
- Handler (`iota-grpc-server`, real `ListOwnedObjects` / `ListDynamicFields` / `ListPackageVersions` handlers over the test reader): a token whose index row is gone must not skip the unchanged next row; a full walk returns every row exactly once, with the loop bounded so a non-advancing cursor fails an assertion instead of hanging.

### Release Notes

- [x] gRPC: Fixed `ListOwnedObjects` and `ListDynamicFields` pagination that could permanently skip an unchanged row when the index row referenced by the page token vanished between pages (e.g. the cursor coin's balance changed, or the cursor field was removed).
- [x] JSON-RPC: Fixed `iotax_getDynamicFields` and `iotax_getOwnedObjects` pagination that could permanently skip an unchanged row when the field or object referenced by the cursor was removed, transferred or otherwise left the index between pages.

