### PR TITLE
feat(iota-vm-sdk): report what a consumer needs to assemble a node-shaped response

### DIFF
--- a/crates/iota-vm-sdk/src/executor/local_vm.rs
+++ b/crates/iota-vm-sdk/src/executor/local_vm.rs
@@ -40,19 +40,6 @@ use crate::{
     store::{Store, StoreBackend},
 };
 
-/// Adapts the SDK [`Store`] to the [`GetModule`] interface that
-/// [`TypeLayoutBuilder`] needs to resolve struct layouts from packages.
-struct StoreModuleResolver<'a>(StoreBackend<'a>);
-
-impl GetModule for StoreModuleResolver<'_> {
-    type Error = iota_types::error::IotaError;
-    type Item = move_binary_format::CompiledModule;
-
-    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
-        iota_types::storage::get_module_by_id(&self.0, id)
-    }
-}
-
 /// The local Move VM executor. Owns a [`Store`] and the execution engine for a
 /// single [`ChainContext`].
 pub struct LocalVm {
@@ -69,6 +56,19 @@ pub struct LocalVm {
     /// across calls; a profiled run builds its own executor via
     /// [`ExecutionEnv`].
     cached_executor: OnceLock<Arc<dyn Executor + Send + Sync>>,
+}
+
+/// Resolves Move modules from the store, as [`TypeLayoutBuilder`] needs to
+/// build struct layouts. Packages a run published are not in the store; use
+/// [`ExecutionResult::module_resolver`](crate::ExecutionResult::module_resolver)
+/// to resolve those as well.
+impl GetModule for LocalVm {
+    type Error = iota_types::error::IotaError;
+    type Item = move_binary_format::CompiledModule;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
+        iota_types::storage::get_module_by_id(&StoreBackend::new(self.store.as_ref()), id)
+    }
 }
 
 impl LocalVm {
@@ -98,6 +98,13 @@ impl LocalVm {
             store: Box::new(store),
             cached_executor: OnceLock::new(),
         })
+    }
+
+    /// The protocol config the VM runs under, resolved from the
+    /// [`ChainContext`] it was built with. Read it for protocol limits a
+    /// caller has to honour, such as the maximum gas a transaction may use.
+    pub fn protocol_config(&self) -> &ProtocolConfig {
+        &self.protocol_config
     }
 
     /// A shared reference to the underlying store, for read-only lookups.
@@ -142,14 +149,20 @@ impl LocalVm {
                 opts.check_coin_deny_list,
             )?
         };
-        let sim = {
+        let (sim, transaction) = {
             let backend = StoreBackend::new(self.store.as_ref());
             execute_prepared(&env, &backend, prepared, opts.mode)?
         };
         // The dev-inspect entry point accepts no `MoveTraceBuilder`, so this path
         // never captures a trace; pass `None`. See `DebugConfig::with_tracing`.
         let artifacts = env.collect_artifacts(None)?;
-        self.finish(sim, opts.mode, SignatureStatus::NotChecked, artifacts)
+        self.finish(
+            sim,
+            transaction,
+            opts.mode,
+            SignatureStatus::NotChecked,
+            artifacts,
+        )
     }
 
     /// Run a signed transaction, verifying signatures first.
@@ -220,23 +233,20 @@ impl LocalVm {
                 opts.check_coin_deny_list,
             )?
         };
-        let (sim, signature_status, trace) = {
+        let (sim, executed, signature_status, trace) = {
             let backend = StoreBackend::new(self.store.as_ref());
             if move_authenticators.is_empty() {
                 // Standard schemes were verified cryptographically above; the
                 // run's outcome cannot retroactively invalidate them. Runs
                 // through the dev-inspect entry point, so no trace is captured.
-                (
-                    execute_prepared(&env, &backend, prepared, opts.mode)?,
-                    SignatureStatus::Verified,
-                    None,
-                )
+                let (sim, executed) = execute_prepared(&env, &backend, prepared, opts.mode)?;
+                (sim, executed, SignatureStatus::Verified, None)
             } else {
                 // Only the authenticator path threads a `MoveTraceBuilder`
                 // through the engine, so a trace is built only here.
                 let mut trace_builder = env.trace_enabled().then(MoveTraceBuilder::new);
 
-                let (sim, authenticator_outcome) = execute_with_move_authenticators(
+                let (sim, authenticator_outcome, executed) = execute_with_move_authenticators(
                     &env,
                     &backend,
                     prepared,
@@ -247,6 +257,7 @@ impl LocalVm {
                 )?;
                 (
                     sim,
+                    executed,
                     SignatureStatus::from_authentication(authenticator_outcome),
                     trace_builder.map(ExecutionTrace::from_builder),
                 )
@@ -254,7 +265,7 @@ impl LocalVm {
         };
         let artifacts = env.collect_artifacts(trace)?;
 
-        self.finish(sim, opts.mode, signature_status, artifacts)
+        self.finish(sim, executed, opts.mode, signature_status, artifacts)
     }
 
     /// Check whether the transaction's `MoveAuthenticator`(s) would be admitted
@@ -392,8 +403,7 @@ impl LocalVm {
         type_tag: &iota_sdk_types::TypeTag,
     ) -> Result<move_core_types::annotated_value::MoveValue, VmSdkError> {
         let core_tag = iota_types::iota_sdk_types_conversions::type_tag_sdk_to_core(type_tag);
-        let resolver = StoreModuleResolver(StoreBackend::new(self.store.as_ref()));
-        let layout = TypeLayoutBuilder::build_with_types(&core_tag, &resolver)
+        let layout = TypeLayoutBuilder::build_with_types(&core_tag, self)
             .map_err(|e| ExecutionError::new(format!("build layout for {type_tag}: {e}")))?;
         // `BoundedVisitor` bounds the deserialized value's depth and
         // allocation, like every node-side decoder of externally-sourced
@@ -427,6 +437,7 @@ impl LocalVm {
     fn finish(
         &mut self,
         sim: SimulateTransactionResult,
+        transaction: Transaction,
         mode: ExecutionMode,
         signature_status: SignatureStatus,
         artifacts: Option<DebugArtifacts>,
@@ -439,13 +450,30 @@ impl LocalVm {
             self.apply_effects(&sim);
         }
 
+        // Without a mutable shared input there is no congestion to price in, so
+        // a node suggests exactly the reference gas price; with one, the
+        // suggestion depends on congestion only a node observes.
+        let suggested_gas_price = (!transaction
+            .shared_input_objects()
+            .iter()
+            .any(|object| object.mutable))
+        .then_some(self.reference_gas_price);
+
+        let (command_results, execution_error) = match sim.execution_result {
+            Ok(results) => (results, None),
+            Err(error) => (Vec::new(), Some(error)),
+        };
+
         Ok(ExecutionResult {
+            transaction,
             effects: sim.effects,
             events: sim.events,
-            command_results: sim.execution_result.unwrap_or_default(),
+            command_results,
+            execution_error,
             input_objects: sim.input_objects.into_values().collect(),
             output_objects: sim.output_objects.into_values().collect(),
             gas_summary,
+            suggested_gas_price,
             mock_gas_id: sim.mock_gas_id,
             status,
             signature_status,

--- a/crates/iota-vm-sdk/src/executor/mod.rs
+++ b/crates/iota-vm-sdk/src/executor/mod.rs
@@ -30,5 +30,5 @@ mod types;
 pub use local_vm::LocalVm;
 pub use types::{
     ChainContext, CommandResult, DecodedEvent, ExecuteOptions, ExecutionMode, ExecutionResult,
-    SignatureStatus,
+    RunModuleResolver, SignatureStatus,
 };

--- a/crates/iota-vm-sdk/src/executor/mod.rs
+++ b/crates/iota-vm-sdk/src/executor/mod.rs
@@ -29,6 +29,6 @@ mod types;
 
 pub use local_vm::LocalVm;
 pub use types::{
-    ChainContext, CommandResult, DecodedEvent, ExecuteOptions, ExecutionMode, ExecutionResult,
-    RunModuleResolver, SignatureStatus,
+    ChainContext, CommandResult, DecodedEvent, ExecuteOptions, ExecutionMode,
+    ExecutionModuleResolver, ExecutionResult, SignatureStatus,
 };

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -252,7 +252,7 @@ pub(super) fn execute_prepared(
     store: &dyn BackingStore,
     prepared: PreparedTransaction,
     mode: ExecutionMode,
-) -> Result<SimulateTransactionResult, VmSdkError> {
+) -> Result<(SimulateTransactionResult, Transaction), VmSdkError> {
     let PreparedTransaction {
         transaction,
         gas_status,
@@ -281,13 +281,16 @@ pub(super) fn execute_prepared(
         dev_inspect,
     );
 
-    Ok(simulation_result(
-        store,
-        inner_temp_store,
-        effects,
-        execution_result,
-        mock_gas_id,
-        transaction.gas_data().clone(),
+    Ok((
+        simulation_result(
+            store,
+            inner_temp_store,
+            effects,
+            execution_result,
+            mock_gas_id,
+            transaction.gas_data().clone(),
+        ),
+        transaction,
     ))
 }
 
@@ -343,6 +346,7 @@ pub(super) fn execute_with_move_authenticators(
     (
         SimulateTransactionResult,
         Result<(), iota_types::error::ExecutionError>,
+        Transaction,
     ),
     VmSdkError,
 > {
@@ -474,6 +478,7 @@ pub(super) fn execute_with_move_authenticators(
             transaction.gas_data().clone(),
         ),
         authenticator_outcome,
+        transaction,
     ))
 }
 

--- a/crates/iota-vm-sdk/src/executor/types.rs
+++ b/crates/iota-vm-sdk/src/executor/types.rs
@@ -3,13 +3,27 @@
 
 //! Public input / output types for the [`LocalVm`](super::LocalVm) surface.
 
+use std::collections::BTreeMap;
+
 use iota_config::transaction_deny_config::TransactionDenyConfig;
 use iota_protocol_config::{Chain, ProtocolVersion};
-use iota_sdk_types::{Event, ObjectId, TransactionEffects, TransactionEvents, gas::GasCostSummary};
-use iota_types::object::Object;
-use move_core_types::annotated_value::MoveValue;
+use iota_sdk_types::{
+    BalanceChange, DeriveChangesError, Event, ObjectChange, ObjectId, Transaction,
+    TransactionEffects, TransactionEvents, gas::GasCostSummary,
+};
+use iota_types::{
+    error::{ExecutionError, IotaError},
+    object::Object,
+    transaction::TransactionAPI as _,
+};
+use move_binary_format::CompiledModule;
+use move_bytecode_utils::module_cache::GetModule;
+use move_core_types::{annotated_value::MoveValue, language_storage::ModuleId};
 
-use crate::debug::{DebugArtifacts, DebugConfig};
+use crate::{
+    debug::{DebugArtifacts, DebugConfig},
+    executor::LocalVm,
+};
 
 /// The chain parameters a [`LocalVm`](super::LocalVm) needs.
 ///
@@ -197,6 +211,11 @@ pub type CommandResult = iota_types::execution::ExecutionResult;
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct ExecutionResult {
+    /// The transaction as it ran, with whatever it left unset filled in — in
+    /// particular the gas payment, which is the mock coin of
+    /// [`mock_gas_id`](Self::mock_gas_id) for a gas-less run. Callers reporting
+    /// the transaction back should use this rather than the one they passed in.
+    pub transaction: Transaction,
     /// The transaction effects (object changes, gas, status digest).
     pub effects: TransactionEffects,
     /// Emitted events, if the run produced any.
@@ -207,12 +226,25 @@ pub struct ExecutionResult {
     /// entry point does not return per-command results) and for failed runs
     /// (the engine reports them only for a successful execution).
     pub command_results: Vec<CommandResult>,
-    /// Objects read as inputs to the run.
+    /// Why the run failed, with more detail than
+    /// [`status`](Self::status) carries — in particular its
+    /// [`source`](iota_types::error::ExecutionError::source), which is what a
+    /// node reports as a dry run's execution error source. `None` for a run
+    /// that succeeded.
+    pub execution_error: Option<ExecutionError>,
+    /// Objects read as inputs to the run: the transaction's own inputs, plus
+    /// the pre-transaction versions of objects the run loaded at runtime
+    /// (dynamic fields, received objects) where the store still holds them.
     pub input_objects: Vec<Object>,
     /// Objects written by the run (created or mutated).
     pub output_objects: Vec<Object>,
     /// Gas ledger for the run (computation / storage / rebate).
     pub gas_summary: GasCostSummary,
+    /// The gas price a node would suggest: the epoch's reference gas price for
+    /// a transaction with no mutable shared inputs, where no congestion can
+    /// apply. `None` when it has one — their congestion is tracked only by a
+    /// node, so no suggestion can be derived here.
+    pub suggested_gas_price: Option<u64>,
     /// Id of the mock gas coin minted for a gas-less transaction, if any.
     pub mock_gas_id: Option<ObjectId>,
     /// The Move-level execution status (success or abort).
@@ -224,6 +256,83 @@ pub struct ExecutionResult {
     pub committed: bool,
     /// Captured debug artifacts (profile / trace), if requested.
     pub debug: Option<DebugArtifacts>,
+}
+
+impl ExecutionResult {
+    /// The run's balance changes per owner and coin type, in the shape a node
+    /// reports them: only the gas charge for a failed run, and the mock gas
+    /// coin of a gas-less run excluded.
+    pub fn balance_changes(&self) -> Result<Vec<BalanceChange>, DeriveChangesError> {
+        self.effects.as_v1().balance_changes(
+            self.input_objects.iter().map(|o| &**o),
+            self.output_objects.iter().map(|o| &**o),
+            self.mock_gas_id,
+        )
+    }
+
+    /// The run's object changes, in the shape a node reports them.
+    pub fn object_changes(&self) -> Result<Vec<ObjectChange>, DeriveChangesError> {
+        self.effects.as_v1().object_changes(
+            self.transaction.sender(),
+            self.input_objects.iter().map(|o| &**o),
+            self.output_objects.iter().map(|o| &**o),
+        )
+    }
+
+    /// Resolves Move modules as this run saw them: packages the run published
+    /// first, then `vm`'s store. A run that is not committed leaves what it
+    /// published out of the store, so resolving through `vm` alone cannot
+    /// decode events or inputs typed by a package the run created.
+    ///
+    /// Published packages are matched by storage id. A package the run
+    /// upgraded keeps its original runtime address, so its modules resolve
+    /// from the store's earlier version instead.
+    pub fn module_resolver<'a>(&'a self, vm: &'a LocalVm) -> RunModuleResolver<'a> {
+        RunModuleResolver {
+            published: self
+                .output_objects
+                .iter()
+                .filter(|object| object.data.as_opt_package().is_some())
+                .map(|object| (object.id(), object))
+                .collect(),
+            vm,
+        }
+    }
+}
+
+/// Module resolver for one run, built with
+/// [`ExecutionResult::module_resolver`].
+pub struct RunModuleResolver<'a> {
+    published: BTreeMap<ObjectId, &'a Object>,
+    vm: &'a LocalVm,
+}
+
+impl GetModule for RunModuleResolver<'_> {
+    type Error = IotaError;
+    type Item = CompiledModule;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
+        let package_id = ObjectId::new(id.address().into_bytes());
+        let published = self
+            .published
+            .get(&package_id)
+            .and_then(|object| object.data.as_opt_package());
+        let Some(package) = published else {
+            return self.vm.get_module_by_id(id);
+        };
+        let name = iota_types::iota_sdk_types_conversions::identifier_core_to_sdk(id.name());
+        package
+            .serialized_module_map()
+            .get(&name)
+            .map(|bytes| {
+                CompiledModule::deserialize_with_defaults(bytes).map_err(|e| {
+                    IotaError::ModuleDeserializationFailure {
+                        error: e.to_string(),
+                    }
+                })
+            })
+            .transpose()
+    }
 }
 
 /// A Move event paired with its decoded payload.

--- a/crates/iota-vm-sdk/src/executor/types.rs
+++ b/crates/iota-vm-sdk/src/executor/types.rs
@@ -287,8 +287,8 @@ impl ExecutionResult {
     /// Published packages are matched by storage id. A package the run
     /// upgraded keeps its original runtime address, so its modules resolve
     /// from the store's earlier version instead.
-    pub fn module_resolver<'a>(&'a self, vm: &'a LocalVm) -> RunModuleResolver<'a> {
-        RunModuleResolver {
+    pub fn module_resolver<'a>(&'a self, vm: &'a LocalVm) -> ExecutionModuleResolver<'a> {
+        ExecutionModuleResolver {
             published: self
                 .output_objects
                 .iter()
@@ -300,14 +300,14 @@ impl ExecutionResult {
     }
 }
 
-/// Module resolver for one run, built with
+/// Module resolver for one execution, built with
 /// [`ExecutionResult::module_resolver`].
-pub struct RunModuleResolver<'a> {
+pub struct ExecutionModuleResolver<'a> {
     published: BTreeMap<ObjectId, &'a Object>,
     vm: &'a LocalVm,
 }
 
-impl GetModule for RunModuleResolver<'_> {
+impl GetModule for ExecutionModuleResolver<'_> {
     type Error = IotaError;
     type Item = CompiledModule;
 

--- a/crates/iota-vm-sdk/src/lib.rs
+++ b/crates/iota-vm-sdk/src/lib.rs
@@ -55,13 +55,13 @@ pub use error::{
 };
 pub use executor::{
     ChainContext, CommandResult, DecodedEvent, ExecuteOptions, ExecutionMode, ExecutionResult,
-    LocalVm, SignatureStatus,
+    LocalVm, RunModuleResolver, SignatureStatus,
 };
 // Upstream types re-exported in the public API.
 pub use iota_config::transaction_deny_config::{
     TransactionDenyConfig, TransactionDenyConfigBuilder,
 };
-pub use iota_protocol_config::{Chain, ProtocolVersion};
+pub use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 pub use iota_sdk_types::{
     Address, MoveAuthenticator, ObjectId, SenderSignedTransaction, StructTag, Transaction,
     TransactionEffects, TransactionEvents, TypeTag, UserSignature, Version,

--- a/crates/iota-vm-sdk/src/lib.rs
+++ b/crates/iota-vm-sdk/src/lib.rs
@@ -54,8 +54,8 @@ pub use error::{
     ExecutionError, SignatureError, StoreError, TraceError, ValidationError, VmError, VmSdkError,
 };
 pub use executor::{
-    ChainContext, CommandResult, DecodedEvent, ExecuteOptions, ExecutionMode, ExecutionResult,
-    LocalVm, RunModuleResolver, SignatureStatus,
+    ChainContext, CommandResult, DecodedEvent, ExecuteOptions, ExecutionMode,
+    ExecutionModuleResolver, ExecutionResult, LocalVm, SignatureStatus,
 };
 // Upstream types re-exported in the public API.
 pub use iota_config::transaction_deny_config::{

--- a/crates/iota-vm-sdk/tests/execute_commit.rs
+++ b/crates/iota-vm-sdk/tests/execute_commit.rs
@@ -15,7 +15,7 @@ use iota_types::{
     error::{IotaError, UserInputError},
     object::{MoveStructExt, OBJECT_START_VERSION, Object},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TransactionAPI},
+    transaction::{CallArg, TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TransactionAPI},
 };
 use iota_vm_sdk::{
     Address, Chain, ChainContext, ExecuteOptions, InMemoryStore, LocalVm, ProtocolVersion, Store,
@@ -533,4 +533,221 @@ fn deny_config_rejects_denied_sender() {
         )
         .expect_err("a denied sender must be rejected");
     assert!(matches!(err, VmSdkError::Validation(_)), "got {err:?}");
+}
+
+/// A committed run must report the pre-transaction versions of the objects it
+/// loaded at runtime, such as a dynamic-field child, even though committing
+/// replaces those versions in the store.
+#[test]
+fn execute_reports_runtime_loaded_inputs_at_their_pre_transaction_versions() {
+    use iota_sdk_types::{
+        Argument, ObjectChange, TypeTag,
+        transaction::{Command, SplitCoins},
+    };
+    use iota_types::IOTA_FRAMEWORK_PACKAGE_ID;
+
+    let sender = Address::ZERO;
+    let gas = gas_coin(sender);
+    let coin_type =
+        MoveStruct::new_gas_coin(OBJECT_START_VERSION, ObjectId::random(), 0).type_tag();
+    let key_type = TypeTag::U64;
+    let object_bag = Identifier::from_static("object_bag");
+
+    let mut store = InMemoryStore::with_framework();
+    store.insert(gas.clone());
+    let mut vm = LocalVm::new(chain_context(), store).expect("build LocalVm");
+
+    // Store a coin in an object bag owned by the sender.
+    let mut b = ProgrammableTransactionBuilder::new();
+    let bag = b.programmable_move_call(
+        IOTA_FRAMEWORK_PACKAGE_ID,
+        object_bag.clone(),
+        Identifier::from_static("new"),
+        vec![],
+        vec![],
+    );
+    let amount = b.pure(TRANSFER_AMOUNT).expect("pure amount");
+    let coin = b.command(Command::SplitCoins(SplitCoins {
+        coin: Argument::Gas,
+        amounts: vec![amount],
+    }));
+    let key = b.pure(7u64).expect("pure key");
+    b.programmable_move_call(
+        IOTA_FRAMEWORK_PACKAGE_ID,
+        object_bag.clone(),
+        Identifier::from_static("add"),
+        vec![key_type.clone(), coin_type.clone()],
+        vec![bag, key, coin],
+    );
+    b.transfer_arg(sender, bag);
+    let result = vm
+        .execute(
+            Transaction::new_programmable(
+                sender,
+                vec![gas.object_ref()],
+                b.finish(),
+                TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE * GAS_PRICE,
+                GAS_PRICE,
+            ),
+            ExecuteOptions::execute(),
+        )
+        .expect("execute must succeed");
+    assert!(result.status.is_success(), "got {:?}", result.status);
+
+    let created = result.effects.created();
+    let bag_ref = created
+        .iter()
+        .find(|created| created.owner == Owner::Address(sender))
+        .expect("the bag is created and owned by the sender");
+    // A dynamic object field child is owned by its `Field` wrapper, which the
+    // bag owns.
+    let field = created
+        .iter()
+        .find(|created| created.owner == Owner::Object(bag_ref.reference.object_id))
+        .expect("the field wrapper is created as a child of the bag");
+    let stored_coin = created
+        .iter()
+        .find(|created| created.owner == Owner::Object(field.reference.object_id))
+        .expect("the coin is created as a child of the field wrapper")
+        .reference;
+
+    // Take the coin back out: the bag is an input, the coin is loaded at
+    // runtime.
+    let gas = vm
+        .store()
+        .get_object(&gas.id(), None)
+        .expect("store lookup")
+        .expect("gas coin remains");
+    let bag = vm
+        .store()
+        .get_object(&bag_ref.reference.object_id, None)
+        .expect("store lookup")
+        .expect("bag is committed");
+    let mut b = ProgrammableTransactionBuilder::new();
+    let bag = b
+        .obj(CallArg::ImmutableOrOwned(bag.object_ref()))
+        .expect("bag input");
+    let key = b.pure(7u64).expect("pure key");
+    let coin = b.programmable_move_call(
+        IOTA_FRAMEWORK_PACKAGE_ID,
+        object_bag,
+        Identifier::from_static("remove"),
+        vec![key_type, coin_type],
+        vec![bag, key],
+    );
+    b.transfer_arg(sender, coin);
+    let result = vm
+        .execute(
+            Transaction::new_programmable(
+                sender,
+                vec![gas.object_ref()],
+                b.finish(),
+                TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE * GAS_PRICE,
+                GAS_PRICE,
+            ),
+            ExecuteOptions::execute(),
+        )
+        .expect("execute must succeed");
+    assert!(result.status.is_success(), "got {:?}", result.status);
+    assert!(result.committed);
+
+    assert!(
+        result
+            .input_objects
+            .iter()
+            .any(|object| object.object_ref() == stored_coin),
+        "the coin must be reported at the version it was loaded at, got {:?}",
+        result
+            .input_objects
+            .iter()
+            .map(|object| object.object_ref())
+            .collect::<Vec<_>>()
+    );
+    let changes = result.object_changes().expect("derive object changes");
+    assert!(
+        changes.iter().any(|change| matches!(
+            change,
+            ObjectChange::Mutated { object_id, previous_version, .. }
+                if *object_id == stored_coin.object_id && *previous_version == stored_coin.version
+        )),
+        "the coin must be reported as mutated from its stored version, got {changes:#?}"
+    );
+}
+
+/// A dry run never commits, so a package it publishes is not in the store. The
+/// run's module resolver still resolves its modules, and falls back to the
+/// store for everything else.
+#[test]
+fn module_resolver_resolves_modules_a_dry_run_published() {
+    use move_binary_format::file_format::empty_module;
+    use move_bytecode_utils::module_cache::GetModule;
+    use move_core_types::{
+        account_address::AccountAddress, identifier::Identifier as MoveIdentifier,
+        language_storage::ModuleId,
+    };
+
+    let sender = Address::ZERO;
+    let gas = gas_coin(sender);
+    let mut store = InMemoryStore::with_framework();
+    store.insert(gas.clone());
+    let mut vm = LocalVm::new(chain_context(), store).expect("build LocalVm");
+
+    let mut module = empty_module();
+    module.identifiers[0] = MoveIdentifier::new("published").unwrap();
+    let mut bytes = Vec::new();
+    module
+        .serialize_with_version(module.version, &mut bytes)
+        .expect("serialize module");
+
+    let mut b = ProgrammableTransactionBuilder::new();
+    b.publish_immutable(vec![bytes], vec![]);
+    let result = vm
+        .execute(
+            Transaction::new_programmable(
+                sender,
+                vec![gas.object_ref()],
+                b.finish(),
+                TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE * GAS_PRICE,
+                GAS_PRICE,
+            ),
+            ExecuteOptions::dry_run(),
+        )
+        .expect("dry run must succeed");
+    assert!(result.status.is_success(), "got {:?}", result.status);
+    assert!(!result.committed);
+
+    let package_id = result
+        .effects
+        .created()
+        .iter()
+        .find(|created| created.owner == Owner::Immutable)
+        .expect("the package is created immutable")
+        .reference
+        .object_id;
+    let published = ModuleId::new(
+        AccountAddress::new(package_id.into_bytes()),
+        MoveIdentifier::new("published").unwrap(),
+    );
+    let framework = ModuleId::new(AccountAddress::TWO, MoveIdentifier::new("coin").unwrap());
+
+    assert!(
+        vm.get_module_by_id(&published)
+            .expect("store lookup")
+            .is_none(),
+        "an uncommitted package must not be in the store"
+    );
+
+    let resolver = result.module_resolver(&vm);
+    let module = resolver
+        .get_module_by_id(&published)
+        .expect("resolve")
+        .expect("the published module must resolve through the run's resolver");
+    assert_eq!(module.self_id(), published);
+    assert!(
+        resolver
+            .get_module_by_id(&framework)
+            .expect("resolve")
+            .is_some(),
+        "framework modules must still resolve from the store"
+    );
 }


### PR DESCRIPTION
# Description of change

Split out of #12478 so the `iota-vm-sdk` part can merge on its own; #12478 will be rebased onto it and then only contain the CLI changes.

A local simulation is only useful if its result renders like a node's. `ExecutionResult` withheld several things needed for that, leaving each consumer to re-derive them from node internals:

- `transaction`: the transaction as it ran, with the mock gas coin filled in for a gas-less run.
- `balance_changes()` / `object_changes()`: derived via the SDK's `TransactionEffectsV1` methods, so a failed run reports only its gas charge and the mock coin stays out.
- `execution_error`: previously dropped; its source is what a node reports as a dry run's error source.
- `suggested_gas_price`: the reference gas price where no mutable shared input can make congestion apply.
- `LocalVm` implements `GetModule`, so a consumer resolves modules by passing the VM. `ExecutionResult::module_resolver(&vm)` layers the packages a run published over it, so types a non-committed run defines still resolve.

Part of #12310.

## Links to any relevant issues

Part of #12310, prerequisite for #12478.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo clippy -p iota-vm-sdk --all-targets -- -D warnings`, the crate's tests including two new ones: a committed run reports runtime-loaded objects at their pre-transaction versions, and `module_resolver` resolves a module a dry run published while the store does not, and `cargo check -p iota-e2e-tests --tests` (the other consumer). End-to-end coverage against a node is in #12478 (`test_local_dry_run_matches_node_dry_run*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
