### PR TITLE
fix(state-sync): bound peer sync by the execution gap

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1228,10 +1228,6 @@ fn default_checkpoint_archive_verify_concurrency() -> NonZeroUsize {
     std::thread::available_parallelism().unwrap_or(NonZeroUsize::new(4).unwrap())
 }
 
-fn default_checkpoint_archive_max_checkpoints_ahead_of_execution() -> NonZeroUsize {
-    NonZeroUsize::new(100_000).unwrap()
-}
-
 /// Configuration for backfilling checkpoint contents from the
 /// checkpoint archive when peers no longer serve the required range.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1246,13 +1242,6 @@ pub struct CheckpointArchiveConfig {
     /// Defaults to the number of CPU cores.
     #[serde(default = "default_checkpoint_archive_verify_concurrency")]
     pub verify_concurrency: NonZeroUsize,
-    /// Pause downloading from the archive while the synced watermark is this
-    /// many checkpoints ahead of the executed watermark, and resume once
-    /// execution catches up. Bounds the disk space held by checkpoints that
-    /// are synced but not yet executed, since only executed checkpoints can
-    /// be pruned.
-    #[serde(default = "default_checkpoint_archive_max_checkpoints_ahead_of_execution")]
-    pub max_checkpoints_ahead_of_execution: NonZeroUsize,
 }
 
 /// Configuration for the per-epoch state-snapshot publisher.

--- a/crates/iota-config/src/p2p.rs
+++ b/crates/iota-config/src/p2p.rs
@@ -2,7 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::SocketAddr, num::NonZeroU32, time::Duration};
+use std::{
+    net::SocketAddr,
+    num::{NonZeroU32, NonZeroU64},
+    time::Duration,
+};
 
 use iota_multiaddr::Multiaddr;
 use iota_sdk_types::CheckpointDigest;
@@ -196,6 +200,17 @@ pub struct StateSyncConfig {
     /// content from. If unspecified, this will set to default value
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wait_interval_when_no_peer_to_sync_content_ms: Option<u64>,
+
+    /// Pause syncing checkpoint contents while the synced watermark is this
+    /// many checkpoints ahead of the executed watermark, and resume once
+    /// execution catches up. Bounds the disk space held by checkpoints that
+    /// are synced but not yet executed, since only executed checkpoints can
+    /// be pruned. Applies to sync from peers and from the checkpoint archive
+    /// alike.
+    ///
+    /// If unspecified, this will default to `100,000`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_checkpoints_ahead_of_execution: Option<NonZeroU64>,
 }
 
 impl StateSyncConfig {
@@ -253,6 +268,14 @@ impl StateSyncConfig {
         self.checkpoint_content_timeout_ms
             .map(Duration::from_millis)
             .unwrap_or(DEFAULT_TIMEOUT)
+    }
+
+    pub fn max_checkpoints_ahead_of_execution(&self) -> u64 {
+        const MAX_CHECKPOINTS_AHEAD_OF_EXECUTION: u64 = 100_000;
+
+        self.max_checkpoints_ahead_of_execution
+            .map(NonZeroU64::get)
+            .unwrap_or(MAX_CHECKPOINTS_AHEAD_OF_EXECUTION)
     }
 
     pub fn wait_interval_when_no_peer_to_sync_content(&self) -> Duration {

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -529,6 +529,7 @@ where
         let task = sync_checkpoint_contents_from_checkpoint_archive(
             self.network.clone(),
             self.checkpoint_archive_config.clone(),
+            self.config.max_checkpoints_ahead_of_execution(),
             self.store.clone(),
             self.peer_heights.clone(),
             self.metrics.clone(),
@@ -1306,6 +1307,7 @@ async fn setup_data_ingestion_executor<W: Worker + 'static>(
 async fn sync_checkpoint_contents_from_checkpoint_archive<S>(
     network: anemo::Network,
     checkpoint_archive_config: Option<CheckpointArchiveConfig>,
+    max_checkpoints_ahead_of_execution: u64,
     store: S,
     peer_heights: Arc<RwLock<PeerHeights>>,
     metrics: Metrics,
@@ -1316,6 +1318,7 @@ async fn sync_checkpoint_contents_from_checkpoint_archive<S>(
         sync_checkpoint_contents_from_checkpoint_archive_iteration(
             &network,
             &checkpoint_archive_config,
+            max_checkpoints_ahead_of_execution,
             store.clone(),
             peer_heights.clone(),
             metrics.clone(),
@@ -1328,6 +1331,7 @@ async fn sync_checkpoint_contents_from_checkpoint_archive<S>(
 async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
     network: &anemo::Network,
     checkpoint_archive_config: &Option<CheckpointArchiveConfig>,
+    max_checkpoints_ahead_of_execution: u64,
     store: S,
     peer_heights: Arc<RwLock<PeerHeights>>,
     metrics: Metrics,
@@ -1400,9 +1404,7 @@ async fn sync_checkpoint_contents_from_checkpoint_archive_iteration<S>(
             StateSyncReducer {
                 store,
                 metrics,
-                max_checkpoints_ahead_of_execution: checkpoint_archive_config
-                    .max_checkpoints_ahead_of_execution
-                    .get() as u64,
+                max_checkpoints_ahead_of_execution,
             },
         );
         let setup_result = setup_data_ingestion_executor(

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -50,7 +50,10 @@
 //! Once we've ratcheted up our highest_verified_checkpoint, and if it is higher
 //! than highest_synced_checkpoint, StateSync will then kick off a task to
 //! synchronize the contents of all of the checkpoints from
-//! highest_synced_checkpoint..=highest_verified_checkpoint. After the
+//! highest_synced_checkpoint..=highest_verified_checkpoint. Contents are only
+//! synced up to `max_checkpoints_ahead_of_execution` checkpoints above the
+//! executed watermark, since synced contents can only be pruned once
+//! executed; the range resumes as execution catches up. After the
 //! contents of each checkpoint is fully downloaded, StateSync will update our
 //! highest_synced_checkpoint watermark and send out a notification on a
 //! broadcast channel indicating that a new checkpoint has been fully
@@ -904,10 +907,9 @@ where
         }
     }
 
-    /// Triggers the checkpoint contents sync task if
-    /// highest_verified_checkpoint > highest_synced_checkpoint and there
-    /// are peers that have highest_known_checkpoint >
-    /// highest_synced_checkpoint.
+    /// Triggers the checkpoint contents sync task if the sync target is above
+    /// highest_synced_checkpoint and there are peers that have
+    /// highest_known_checkpoint > highest_synced_checkpoint.
     fn maybe_trigger_checkpoint_contents_sync_task(
         &mut self,
         target_sequence_channel: &watch::Sender<CheckpointSequenceNumber>,
@@ -920,8 +922,17 @@ where
             .store
             .try_get_highest_synced_checkpoint_seq_number()
             .expect("store operation should not fail");
+        let highest_executed_checkpoint = self
+            .store
+            .try_get_highest_executed_checkpoint_seq_number()
+            .expect("store operation should not fail");
+        let target = checkpoint_contents_sync_target(
+            highest_verified_checkpoint,
+            highest_executed_checkpoint,
+            self.config.max_checkpoints_ahead_of_execution(),
+        );
 
-        if highest_verified_checkpoint > highest_synced_checkpoint
+        if target > highest_synced_checkpoint
             // Skip if we aren't connected to any peers that can help
             && self
                 .peer_heights
@@ -931,7 +942,7 @@ where
                 > Some(highest_synced_checkpoint)
         {
             let _ = target_sequence_channel.send_if_modified(|num| {
-                let new_num = highest_verified_checkpoint;
+                let new_num = target;
                 if *num == new_num {
                     return false;
                 }
@@ -1446,6 +1457,25 @@ fn checkpoint_archive_sync_end(
 ) -> Option<CheckpointSequenceNumber> {
     let last = lowest_checkpoint_on_peers.checked_sub(1)?;
     (start <= last).then_some(last)
+}
+
+/// The highest checkpoint whose contents may be synced from peers: the highest
+/// verified one, held back to `max_ahead_of_execution` checkpoints above the
+/// executed watermark.
+///
+/// Synced contents can only be pruned once executed, so syncing far ahead of
+/// execution grows disk usage without bound. `None` for `highest_executed`
+/// means the store does not track execution, and there is nothing to hold the
+/// target back against.
+fn checkpoint_contents_sync_target(
+    highest_verified: CheckpointSequenceNumber,
+    highest_executed: Option<CheckpointSequenceNumber>,
+    max_ahead_of_execution: u64,
+) -> CheckpointSequenceNumber {
+    let Some(highest_executed) = highest_executed else {
+        return highest_verified;
+    };
+    highest_verified.min(highest_executed.saturating_add(max_ahead_of_execution))
 }
 
 /// Syncs checkpoint contents from peers if the target sequence cursor, which is

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -2,7 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, num::NonZeroUsize, time::Duration};
+use std::{
+    collections::HashMap,
+    num::{NonZeroU64, NonZeroUsize},
+    time::Duration,
+};
 
 use anemo::{PeerId, Request};
 use anyhow::anyhow;
@@ -337,7 +341,6 @@ async fn test_state_sync_using_checkpoint_archive() -> anyhow::Result<()> {
     let checkpoint_archive_config = CheckpointArchiveConfig {
         download_concurrency: NonZeroUsize::new(1).unwrap(),
         verify_concurrency: NonZeroUsize::new(2).unwrap(),
-        max_checkpoints_ahead_of_execution: NonZeroUsize::new(1_000_000).unwrap(),
         url: format!("file://{}", temp_dir.path().display()),
     };
     // Build and connect two nodes where Node 1 will be given access to an archive
@@ -354,6 +357,8 @@ async fn test_state_sync_using_checkpoint_archive() -> anyhow::Result<()> {
             // Shorten the retry delay so pruned-checkpoint tasks quickly discover
             // that the archive has already advanced highest_synced past them.
             wait_interval_when_no_peer_to_sync_content_ms: Some(10),
+            // Keep sync unbounded: this store does not execute checkpoints.
+            max_checkpoints_ahead_of_execution: NonZeroU64::new(1_000_000),
             ..StateSyncConfig::randomized_for_testing()
         })
         .checkpoint_archive_config(Some(checkpoint_archive_config))

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -1107,3 +1107,106 @@ fn test_required_executed_checkpoint() {
     assert_eq!(required_executed_checkpoint(31, 30), 1);
     assert_eq!(required_executed_checkpoint(51, 30), 21);
 }
+
+#[tokio::test]
+async fn peer_sync_pauses_while_too_far_ahead_of_execution() {
+    telemetry_subscribers::init_for_testing();
+    let (committee, (ordered_checkpoints, contents, _, _)) =
+        make_committee_and_checkpoints(0, 4, 4, None, random_contents);
+    let genesis_checkpoint = ordered_checkpoints.first().cloned().unwrap();
+    let genesis_contents = contents.first().cloned().unwrap();
+
+    // Node 1 has every checkpoint and serves node 2.
+    let store_1 = store_with_genesis_state(
+        genesis_checkpoint.clone(),
+        genesis_contents.clone(),
+        committee.committee().to_owned(),
+    );
+    let (builder, server) = Builder::new().store(store_1).build();
+    let network_1 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_1, handle_1) = builder.build(network_1.clone());
+    let store_1 = event_loop_1.store.clone();
+
+    // Node 2 may sync at most 2 checkpoints past its executed watermark, which
+    // stays at genesis until this test moves it.
+    let store_2 = store_with_genesis_state(
+        genesis_checkpoint,
+        genesis_contents,
+        committee.committee().to_owned(),
+    );
+    store_2.inner_mut().set_highest_executed_checkpoint(0);
+    let (builder, server) = Builder::new()
+        .store(store_2)
+        .config(StateSyncConfig {
+            max_checkpoints_ahead_of_execution: NonZeroU64::new(2),
+            // Sync resumes on the next tick once execution advances.
+            interval_period_ms: Some(50),
+            ..Default::default()
+        })
+        .build();
+    let network_2 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_2, _handle_2) = builder.build(network_2.clone());
+    let store_2 = event_loop_2.store.clone();
+
+    tokio::spawn(event_loop_1.start());
+    tokio::spawn(event_loop_2.start());
+    network_1.connect(network_2.local_addr()).await.unwrap();
+
+    // Hand node 1 every checkpoint, which it announces to node 2.
+    for (checkpoint, contents) in ordered_checkpoints
+        .iter()
+        .zip(contents.iter())
+        .skip(1)
+        .map(|(checkpoint, contents)| (checkpoint.clone(), contents.clone()))
+    {
+        store_1
+            .try_insert_checkpoint_contents(&checkpoint, contents)
+            .unwrap();
+        store_1.insert_certified_checkpoint(&checkpoint);
+        handle_1.send_checkpoint(checkpoint).await;
+    }
+
+    // Node 2 verifies every summary, but stops syncing contents at the bound.
+    timeout(Duration::from_secs(10), async {
+        while store_2.get_highest_verified_checkpoint_seq_number()
+            != ordered_checkpoints.last().unwrap().sequence_number()
+        {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("node 2 failed to verify all checkpoint summaries");
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_eq!(store_2.get_highest_synced_checkpoint_seq_number(), 2);
+
+    // Execution catches up, and sync continues to the end.
+    store_2.inner_mut().set_highest_executed_checkpoint(2);
+    timeout(Duration::from_secs(10), async {
+        while store_2.get_highest_synced_checkpoint_seq_number()
+            != ordered_checkpoints.last().unwrap().sequence_number()
+        {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("node 2 failed to resume syncing after execution caught up");
+}
+
+#[test]
+fn test_checkpoint_contents_sync_target() {
+    use crate::state_sync::checkpoint_contents_sync_target;
+
+    // Within the bound: sync all the way up to the verified watermark.
+    assert_eq!(checkpoint_contents_sync_target(30, Some(10), 100), 30);
+    assert_eq!(checkpoint_contents_sync_target(30, Some(0), 30), 30);
+
+    // Past the bound: hold the target at the bound above execution.
+    assert_eq!(checkpoint_contents_sync_target(1_000, Some(10), 100), 110);
+    assert_eq!(checkpoint_contents_sync_target(1_000, Some(0), 1), 1);
+
+    // A store that does not track execution has nothing to hold back against.
+    assert_eq!(checkpoint_contents_sync_target(1_000, None, 100), 1_000);
+
+    // The bound must not run past the end of the sequence space.
+    assert_eq!(checkpoint_contents_sync_target(30, Some(u64::MAX), 100), 30);
+}

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -215,6 +215,12 @@ impl WriteStore for SharedInMemoryStore {
         self.inner_mut().insert_committee(new_committee);
         Ok(())
     }
+
+    fn try_get_highest_executed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>> {
+        Ok(self.inner().get_highest_executed_checkpoint_seq_number())
+    }
 }
 
 impl SharedInMemoryStore {
@@ -227,6 +233,7 @@ impl SharedInMemoryStore {
 pub struct InMemoryStore {
     highest_verified_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
     highest_synced_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
+    highest_executed_checkpoint: Option<CheckpointSequenceNumber>,
     checkpoints: HashMap<CheckpointDigest, VerifiedCheckpoint>,
     full_checkpoint_contents: HashMap<CheckpointSequenceNumber, FullCheckpointContents>,
     contents_digest_to_sequence_number: HashMap<CheckpointContentsDigest, CheckpointSequenceNumber>,
@@ -330,6 +337,16 @@ impl InMemoryStore {
     pub fn get_highest_synced_checkpoint_seq_number(&self) -> Option<CheckpointSequenceNumber> {
         self.highest_synced_checkpoint
             .map(|(sequence_number, _digest)| sequence_number)
+    }
+
+    pub fn get_highest_executed_checkpoint_seq_number(&self) -> Option<CheckpointSequenceNumber> {
+        self.highest_executed_checkpoint
+    }
+
+    /// Moves the executed watermark, which nothing in this store advances on
+    /// its own since it does not execute checkpoints.
+    pub fn set_highest_executed_checkpoint(&mut self, sequence_number: CheckpointSequenceNumber) {
+        self.highest_executed_checkpoint = Some(sequence_number);
     }
 
     pub fn get_lowest_available_checkpoint(&self) -> CheckpointSequenceNumber {


### PR DESCRIPTION
# Description of change

Only archive sync was bounded against execution lag.
`CheckpointArchiveConfig::max_checkpoints_ahead_of_execution` (default 100,000)
is enforced by the archive ingestion reducer; peer sync published
`highest_verified_checkpoint` as its contents target and inserted whatever
peers served, with nothing tying it to execution. A node that syncs faster than
it executes therefore grows its database without bound — a testnet fullnode
reached 20.1M checkpoints (~50 epochs, 200x the archive limit) ahead of
execution, holding 274M synced-but-unexecuted `transactions` and `effects` rows
that cannot be pruned, on a 1.2 TB database.

- Hold the peer contents-sync target at `max_checkpoints_ahead_of_execution`
  above the executed watermark. The target is recomputed on every event-loop
  iteration, so sync resumes on its own as execution advances, and the executor
  always has the whole bound's worth of checkpoints to work through. Stores that
  do not track execution stay unbounded, as they already are on the archive
  path.
- Move the knob from `CheckpointArchiveConfig` to `StateSyncConfig`, as an
  optional `NonZeroU64`. It bounds the disk held by synced-but-unexecuted
  checkpoints, which is a property of the store rather than of one download
  source, and on the archive config it was unreadable by peer sync and
  unsettable on a node with no archive configured.
- Let the in-memory store report an executed watermark, so a test can model a
  node whose execution lags behind sync.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

- `peer_sync_pauses_while_too_far_ahead_of_execution`: a node with a bound of 2
  verifies every checkpoint summary but stops syncing contents at checkpoint 2,
  and finishes once the test advances its executed watermark. It fails without
  the fix, syncing everything on offer.
- `test_checkpoint_contents_sync_target`: the bound, a store that does not track
  execution, and saturation at the end of the sequence space.
- `cargo nextest run -p iota-network -p iota-config -p iota-types` and
  `-p iota-e2e-tests --test full_node_tests --test checkpoint_tests` pass,
  including `test_full_node_cold_sync`, which drives a real fullnode through
  state sync. Two failures reproduce unchanged on `develop`:
  `discovery::tests::test_address_verification_cooldown_and_cleanup` and
  `test_checkpoint_split_brain` (which needs the simulator, not the
  `#[tokio::test]` fallback).

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Sync from peers now pauses while the synced watermark is more than `max-checkpoints-ahead-of-execution` (default 100,000) checkpoints ahead of the executed watermark, bounding the disk held by checkpoints that are synced but not yet executed. The setting moved from `checkpoint-archive-config` to the `state-sync` section of `p2p-config`, and now governs sync from peers and from the archive alike.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

#### Breaking Changes Rollout

Affected Crates:

- iota-config

Required User Actions:

- Operators who set `checkpoint-archive-config.max-checkpoints-ahead-of-execution`
  must move it to `p2p-config.state-sync.max-checkpoints-ahead-of-execution`; it
  is silently ignored in its old place. None of the node templates in `setups/`
  set it, and leaving it unset keeps the 100,000 default on both sync paths.
