### PR TITLE
fix(state-sync): bound checkpoint summary sync by the execution gap

### DIFF
--- a/crates/iota-config/src/p2p.rs
+++ b/crates/iota-config/src/p2p.rs
@@ -201,11 +201,11 @@ pub struct StateSyncConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wait_interval_when_no_peer_to_sync_content_ms: Option<u64>,
 
-    /// Pause syncing checkpoint contents while the synced watermark is this
-    /// many checkpoints ahead of the executed watermark, and resume once
-    /// execution catches up. Bounds the disk space held by checkpoints that
-    /// are synced but not yet executed, since only executed checkpoints can
-    /// be pruned. Applies to sync from peers and from the checkpoint archive
+    /// Stop syncing checkpoints more than this many above the executed
+    /// watermark, and resume as execution catches up. Bounds the disk space
+    /// held by checkpoints that are synced but not yet executed, since only
+    /// executed checkpoints can be pruned. Applies to checkpoint summaries and
+    /// contents, and to sync from peers and from the checkpoint archive
     /// alike.
     ///
     /// If unspecified, this will default to `100,000`.

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1117,13 +1117,11 @@ async fn query_peers_for_their_latest_checkpoint(
     }
 }
 
-/// Queries connected peers for checkpoints from sequence
-/// current+1 to the target. The received checkpoints will be verified and
-/// stored in the store. Checkpoints in temporary store (peer_heights) will be
-/// cleaned up after syncing.
-/// Verifies and inserts the checkpoint summaries from the highest verified one
-/// up to `highest_checkpoint_to_sync`, downloading them from peers. The caller
-/// holds that bound back to keep the store within reach of execution.
+/// Queries connected peers for the checkpoint summaries from the highest
+/// verified one up to `highest_checkpoint_to_sync`, verifies them, inserts
+/// them in the store, and cleans the ones it took out of `peer_heights` as it
+/// goes. The caller holds `highest_checkpoint_to_sync` back to keep the store
+/// within reach of execution.
 async fn sync_to_checkpoint<S>(
     network: anemo::Network,
     store: S,

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -872,18 +872,58 @@ where
         );
         self.tasks.spawn(task);
 
+        if let Some(highest_known_checkpoint) = self
+            .peer_heights
+            .read()
+            .unwrap()
+            .highest_known_checkpoint_sequence_number()
+        {
+            self.metrics
+                .set_highest_known_checkpoint(highest_known_checkpoint);
+        }
+
+        // Peers push their latest checkpoint as they sync it, and nothing
+        // reads the ones above the sync target until execution advances. Drop
+        // them here rather than next to the gate, which does not run while a
+        // summary sync task is in flight — and one of those can run for a
+        // whole bound's worth of checkpoints.
+        if let Some(highest_checkpoint_to_sync) = self.highest_checkpoint_to_sync() {
+            self.peer_heights
+                .write()
+                .unwrap()
+                .cleanup_checkpoints_above(highest_checkpoint_to_sync);
+        }
+
         if let Some(layer) = self.download_limit_layer.as_ref() {
             layer.maybe_prune_map();
         }
+    }
+
+    /// The highest checkpoint state sync may take on right now: the highest
+    /// one known to be on peers, held back to
+    /// `max_checkpoints_ahead_of_execution` above the executed watermark.
+    /// `None` when no peer on our chain is known.
+    fn highest_checkpoint_to_sync(&self) -> Option<CheckpointSequenceNumber> {
+        let highest_known_checkpoint = self
+            .peer_heights
+            .read()
+            .unwrap()
+            .highest_known_checkpoint_sequence_number()?;
+        let highest_executed_checkpoint = self
+            .store
+            .try_get_highest_executed_checkpoint_seq_number()
+            .expect("store operation should not fail");
+        Some(checkpoint_sync_target(
+            highest_known_checkpoint,
+            highest_executed_checkpoint,
+            self.config.max_checkpoints_ahead_of_execution(),
+        ))
     }
 
     /// Starts syncing checkpoint summaries if there are peers that have a
     /// higher known checkpoint than us, up to
     /// `max_checkpoints_ahead_of_execution` above the executed watermark. Only
     /// one sync task is allowed to run at a time.
-    ///
-    /// Also drops the summaries peers pushed above that point, since nothing
-    /// reads them until execution advances.
     fn maybe_start_checkpoint_summary_sync_task(&mut self) {
         // Only run one sync task at a time
         if self.sync_checkpoint_summaries_task.is_some() {
@@ -895,29 +935,9 @@ where
             .try_get_highest_verified_checkpoint()
             .expect("store operation should not fail");
 
-        let highest_known_checkpoint = self
-            .peer_heights
-            .read()
-            .unwrap()
-            .highest_known_checkpoint_sequence_number();
-        let Some(highest_known_checkpoint) = highest_known_checkpoint else {
+        let Some(target) = self.highest_checkpoint_to_sync() else {
             return;
         };
-        self.metrics
-            .set_highest_known_checkpoint(highest_known_checkpoint);
-        let highest_executed_checkpoint = self
-            .store
-            .try_get_highest_executed_checkpoint_seq_number()
-            .expect("store operation should not fail");
-        let target = checkpoint_sync_target(
-            highest_known_checkpoint,
-            highest_executed_checkpoint,
-            self.config.max_checkpoints_ahead_of_execution(),
-        );
-        self.peer_heights
-            .write()
-            .unwrap()
-            .cleanup_checkpoints_above(target);
 
         if highest_processed_checkpoint.sequence_number() < target {
             // Start sync job

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -50,10 +50,10 @@
 //! Once we've ratcheted up our highest_verified_checkpoint, and if it is higher
 //! than highest_synced_checkpoint, StateSync will then kick off a task to
 //! synchronize the contents of all of the checkpoints from
-//! highest_synced_checkpoint..=highest_verified_checkpoint. Contents are only
-//! synced up to `max_checkpoints_ahead_of_execution` checkpoints above the
-//! executed watermark, since synced contents can only be pruned once
-//! executed; the range resumes as execution catches up. After the
+//! highest_synced_checkpoint..=highest_verified_checkpoint. Neither watermark
+//! is moved more than `max_checkpoints_ahead_of_execution` checkpoints above
+//! the executed one, since synced checkpoints can only be pruned once
+//! executed; both resume as execution catches up. After the
 //! contents of each checkpoint is fully downloaded, StateSync will update our
 //! highest_synced_checkpoint watermark and send out a notification on a
 //! broadcast channel indicating that a new checkpoint has been fully
@@ -856,8 +856,9 @@ where
     }
 
     /// Starts syncing checkpoint summaries if there are peers that have a
-    /// higher known checkpoint than us. Only one sync task is allowed to
-    /// run at a time.
+    /// higher known checkpoint than us, up to
+    /// `max_checkpoints_ahead_of_execution` above the executed watermark. Only
+    /// one sync task is allowed to run at a time.
     fn maybe_start_checkpoint_summary_sync_task(&mut self) {
         // Only run one sync task at a time
         if self.sync_checkpoint_summaries_task.is_some() {
@@ -875,12 +876,20 @@ where
             .unwrap()
             .highest_known_checkpoint()
             .cloned();
+        let Some(highest_known_checkpoint) = highest_known_checkpoint else {
+            return;
+        };
+        let highest_executed_checkpoint = self
+            .store
+            .try_get_highest_executed_checkpoint_seq_number()
+            .expect("store operation should not fail");
+        let target = checkpoint_sync_target(
+            highest_known_checkpoint.sequence_number(),
+            highest_executed_checkpoint,
+            self.config.max_checkpoints_ahead_of_execution(),
+        );
 
-        if Some(highest_processed_checkpoint.sequence_number())
-            < highest_known_checkpoint
-                .as_ref()
-                .map(|x| x.sequence_number())
-        {
+        if highest_processed_checkpoint.sequence_number() < target {
             // Start sync job
             let concurrency =
                 NonZeroUsize::new(self.config.checkpoint_header_download_concurrency())
@@ -893,8 +902,8 @@ where
                 self.config.pinned_checkpoints.clone(),
                 concurrency,
                 self.config.timeout(),
-                // The if condition should ensure that this is Some
-                highest_known_checkpoint.unwrap(),
+                highest_known_checkpoint,
+                target,
             )
             .map(|result| match result {
                 Ok(()) => {}
@@ -926,7 +935,7 @@ where
             .store
             .try_get_highest_executed_checkpoint_seq_number()
             .expect("store operation should not fail");
-        let target = checkpoint_contents_sync_target(
+        let target = checkpoint_sync_target(
             highest_verified_checkpoint,
             highest_executed_checkpoint,
             self.config.max_checkpoints_ahead_of_execution(),
@@ -1083,6 +1092,13 @@ async fn query_peers_for_their_latest_checkpoint(
 /// current+1 to the target. The received checkpoints will be verified and
 /// stored in the store. Checkpoints in temporary store (peer_heights) will be
 /// cleaned up after syncing.
+/// Verifies and inserts the checkpoint summaries from the highest verified one
+/// up to `highest_checkpoint_to_sync`, downloading them from peers.
+///
+/// `checkpoint` is the highest checkpoint known to be on peers, which is
+/// reported as such and must not be below `highest_checkpoint_to_sync`; the
+/// walk stops at `highest_checkpoint_to_sync`, which the caller holds back to
+/// keep the store within reach of execution.
 async fn sync_to_checkpoint<S>(
     network: anemo::Network,
     store: S,
@@ -1092,6 +1108,7 @@ async fn sync_to_checkpoint<S>(
     checkpoint_header_download_concurrency: NonZeroUsize,
     timeout: Duration,
     checkpoint: Checkpoint,
+    highest_checkpoint_to_sync: CheckpointSequenceNumber,
 ) -> Result<()>
 where
     S: WriteStore,
@@ -1116,7 +1133,7 @@ where
     );
     // Range of the next sequence_numbers to fetch
     let mut request_stream = (current.sequence_number().checked_add(1).unwrap()
-        ..=checkpoint.sequence_number())
+        ..=highest_checkpoint_to_sync)
         .map(|next| {
             let peers = peer_balancer.clone().with_checkpoint(next);
             let peer_heights = peer_heights.clone();
@@ -1279,7 +1296,7 @@ where
     peer_heights
         .write()
         .unwrap()
-        .cleanup_old_checkpoints(checkpoint.sequence_number());
+        .cleanup_old_checkpoints(highest_checkpoint_to_sync);
 
     Ok(())
 }
@@ -1459,20 +1476,20 @@ fn checkpoint_archive_sync_end(
     (start <= last).then_some(last)
 }
 
-/// The highest checkpoint whose contents may be synced from peers: the highest
-/// verified one, held back to `max_ahead_of_execution` checkpoints above the
-/// executed watermark.
+/// The highest checkpoint state sync may take on: the highest one available,
+/// held back to `max_ahead_of_execution` checkpoints above the executed
+/// watermark.
 ///
-/// Synced contents can only be pruned once executed, so syncing far ahead of
-/// execution grows disk usage without bound. `None` for `highest_executed`
+/// Synced checkpoints can only be pruned once executed, so syncing far ahead
+/// of execution grows disk usage without bound. `None` for `highest_executed`
 /// means nothing has been executed yet, not even genesis, and the bound counts
 /// from checkpoint 0.
-fn checkpoint_contents_sync_target(
-    highest_verified: CheckpointSequenceNumber,
+fn checkpoint_sync_target(
+    highest_available: CheckpointSequenceNumber,
     highest_executed: Option<CheckpointSequenceNumber>,
     max_ahead_of_execution: u64,
 ) -> CheckpointSequenceNumber {
-    highest_verified.min(
+    highest_available.min(
         highest_executed
             .unwrap_or(0)
             .saturating_add(max_ahead_of_execution),

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1465,17 +1465,18 @@ fn checkpoint_archive_sync_end(
 ///
 /// Synced contents can only be pruned once executed, so syncing far ahead of
 /// execution grows disk usage without bound. `None` for `highest_executed`
-/// means the store does not track execution, and there is nothing to hold the
-/// target back against.
+/// means nothing has been executed yet, not even genesis, and the bound counts
+/// from checkpoint 0.
 fn checkpoint_contents_sync_target(
     highest_verified: CheckpointSequenceNumber,
     highest_executed: Option<CheckpointSequenceNumber>,
     max_ahead_of_execution: u64,
 ) -> CheckpointSequenceNumber {
-    let Some(highest_executed) = highest_executed else {
-        return highest_verified;
-    };
-    highest_verified.min(highest_executed.saturating_add(max_ahead_of_execution))
+    highest_verified.min(
+        highest_executed
+            .unwrap_or(0)
+            .saturating_add(max_ahead_of_execution),
+    )
 }
 
 /// Syncs checkpoint contents from peers if the target sequence cursor, which is

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -283,6 +283,28 @@ impl PeerHeights {
         self.sequence_number_to_digest.shrink_to_fit();
     }
 
+    /// Drops cached summaries above `sequence_number`. Peers push their
+    /// latest checkpoint as they sync it, and the periodic query records each
+    /// peer's tip, so without this the ones state sync is not going to
+    /// process yet pile up for as long as it holds back.
+    pub fn cleanup_checkpoints_above(&mut self, sequence_number: CheckpointSequenceNumber) {
+        if !self
+            .sequence_number_to_digest
+            .keys()
+            .any(|s| *s > sequence_number)
+        {
+            return;
+        }
+        // `retain` leaves tombstones that count toward the load factor; see
+        // `cleanup_old_checkpoints`.
+        self.unprocessed_checkpoints
+            .retain(|_digest, checkpoint| checkpoint.sequence_number() <= sequence_number);
+        self.unprocessed_checkpoints.shrink_to_fit();
+        self.sequence_number_to_digest
+            .retain(|&s, _digest| s <= sequence_number);
+        self.sequence_number_to_digest.shrink_to_fit();
+    }
+
     // TODO: also record who gives this checkpoint info for peer quality
     // measurement?
     pub fn insert_checkpoint(&mut self, checkpoint: Checkpoint) {
@@ -859,6 +881,9 @@ where
     /// higher known checkpoint than us, up to
     /// `max_checkpoints_ahead_of_execution` above the executed watermark. Only
     /// one sync task is allowed to run at a time.
+    ///
+    /// Also drops the summaries peers pushed above that point, since nothing
+    /// reads them until execution advances.
     fn maybe_start_checkpoint_summary_sync_task(&mut self) {
         // Only run one sync task at a time
         if self.sync_checkpoint_summaries_task.is_some() {
@@ -874,20 +899,25 @@ where
             .peer_heights
             .read()
             .unwrap()
-            .highest_known_checkpoint()
-            .cloned();
+            .highest_known_checkpoint_sequence_number();
         let Some(highest_known_checkpoint) = highest_known_checkpoint else {
             return;
         };
+        self.metrics
+            .set_highest_known_checkpoint(highest_known_checkpoint);
         let highest_executed_checkpoint = self
             .store
             .try_get_highest_executed_checkpoint_seq_number()
             .expect("store operation should not fail");
         let target = checkpoint_sync_target(
-            highest_known_checkpoint.sequence_number(),
+            highest_known_checkpoint,
             highest_executed_checkpoint,
             self.config.max_checkpoints_ahead_of_execution(),
         );
+        self.peer_heights
+            .write()
+            .unwrap()
+            .cleanup_checkpoints_above(target);
 
         if highest_processed_checkpoint.sequence_number() < target {
             // Start sync job
@@ -902,7 +932,6 @@ where
                 self.config.pinned_checkpoints.clone(),
                 concurrency,
                 self.config.timeout(),
-                highest_known_checkpoint,
                 target,
             )
             .map(|result| match result {
@@ -1093,12 +1122,8 @@ async fn query_peers_for_their_latest_checkpoint(
 /// stored in the store. Checkpoints in temporary store (peer_heights) will be
 /// cleaned up after syncing.
 /// Verifies and inserts the checkpoint summaries from the highest verified one
-/// up to `highest_checkpoint_to_sync`, downloading them from peers.
-///
-/// `checkpoint` is the highest checkpoint known to be on peers, which is
-/// reported as such and must not be below `highest_checkpoint_to_sync`; the
-/// walk stops at `highest_checkpoint_to_sync`, which the caller holds back to
-/// keep the store within reach of execution.
+/// up to `highest_checkpoint_to_sync`, downloading them from peers. The caller
+/// holds that bound back to keep the store within reach of execution.
 async fn sync_to_checkpoint<S>(
     network: anemo::Network,
     store: S,
@@ -1107,21 +1132,18 @@ async fn sync_to_checkpoint<S>(
     pinned_checkpoints: Vec<(CheckpointSequenceNumber, CheckpointDigest)>,
     checkpoint_header_download_concurrency: NonZeroUsize,
     timeout: Duration,
-    checkpoint: Checkpoint,
     highest_checkpoint_to_sync: CheckpointSequenceNumber,
 ) -> Result<()>
 where
     S: WriteStore,
 {
-    metrics.set_highest_known_checkpoint(checkpoint.sequence_number());
-
     let mut current = store
         .try_get_highest_verified_checkpoint()
         .expect("store operation should not fail");
-    if current.sequence_number() >= checkpoint.sequence_number() {
+    if current.sequence_number() >= highest_checkpoint_to_sync {
         bail!(
-            "target checkpoint {} is older than highest verified checkpoint {}",
-            checkpoint.sequence_number(),
+            "target checkpoint {highest_checkpoint_to_sync} is older than highest verified \
+             checkpoint {}",
             current.sequence_number(),
         );
     }

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -27,7 +27,9 @@ use iota_swarm_config::test_utils::{
 use iota_types::{
     committee::{Committee, EpochId},
     full_checkpoint_content::CheckpointData,
-    messages_checkpoint::{VerifiedCheckpoint, VerifiedCheckpointContents},
+    messages_checkpoint::{
+        CheckpointSequenceNumber, VerifiedCheckpoint, VerifiedCheckpointContents,
+    },
     storage::{ReadStore, SharedInMemoryStore, WriteStore},
 };
 use tokio::time::{Instant, timeout};
@@ -1112,7 +1114,8 @@ fn test_required_executed_checkpoint() {
 async fn peer_sync_pauses_while_too_far_ahead_of_execution() {
     telemetry_subscribers::init_for_testing();
     let (committee, (ordered_checkpoints, contents, _, _)) =
-        make_committee_and_checkpoints(0, 4, 4, None, random_contents);
+        make_committee_and_checkpoints(0, 4, 6, None, random_contents);
+    let last_checkpoint_seq = ordered_checkpoints.last().unwrap().sequence_number();
     let genesis_checkpoint = ordered_checkpoints.first().cloned().unwrap();
     let genesis_contents = contents.first().cloned().unwrap();
 
@@ -1166,47 +1169,133 @@ async fn peer_sync_pauses_while_too_far_ahead_of_execution() {
         handle_1.send_checkpoint(checkpoint).await;
     }
 
-    // Node 2 verifies every summary, but stops syncing contents at the bound.
-    timeout(Duration::from_secs(10), async {
-        while store_2.get_highest_verified_checkpoint_seq_number()
-            != ordered_checkpoints.last().unwrap().sequence_number()
-        {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-    })
-    .await
-    .expect("node 2 failed to verify all checkpoint summaries");
+    // Node 2 stops at the bound: it neither verifies summaries nor syncs
+    // contents beyond it, though node 1 offers everything up to the last
+    // checkpoint.
+    wait_for_watermarks(&store_2, 2, 2).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_eq!(store_2.get_highest_verified_checkpoint_seq_number(), 2);
+    assert_eq!(store_2.get_highest_synced_checkpoint_seq_number(), 2);
+    assert_eq!(
+        store_1.get_highest_synced_checkpoint_seq_number(),
+        last_checkpoint_seq
+    );
+
+    // Both watermarks follow execution as it advances.
+    store_2.inner_mut().set_highest_executed_checkpoint(3);
+    wait_for_watermarks(&store_2, last_checkpoint_seq, last_checkpoint_seq).await;
+}
+
+#[tokio::test]
+async fn peer_content_sync_pauses_when_summaries_run_ahead() {
+    telemetry_subscribers::init_for_testing();
+    let (committee, (ordered_checkpoints, contents, _, _)) =
+        make_committee_and_checkpoints(0, 4, 6, None, random_contents);
+    let last_checkpoint_seq = ordered_checkpoints.last().unwrap().sequence_number();
+    let genesis_checkpoint = ordered_checkpoints.first().cloned().unwrap();
+    let genesis_contents = contents.first().cloned().unwrap();
+
+    // Node 1 has every checkpoint and serves node 2.
+    let store_1 = store_with_genesis_state(
+        genesis_checkpoint.clone(),
+        genesis_contents.clone(),
+        committee.committee().to_owned(),
+    );
+    let (builder, server) = Builder::new().store(store_1).build();
+    let network_1 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_1, handle_1) = builder.build(network_1.clone());
+    let store_1 = event_loop_1.store.clone();
+    for (checkpoint, contents) in ordered_checkpoints
+        .iter()
+        .zip(contents.iter())
+        .skip(1)
+        .map(|(checkpoint, contents)| (checkpoint.clone(), contents.clone()))
+    {
+        store_1
+            .try_insert_checkpoint_contents(&checkpoint, contents)
+            .unwrap();
+        store_1.insert_certified_checkpoint(&checkpoint);
+    }
+
+    // Node 2 already holds every summary, the way consensus or archive sync
+    // leaves them, so its verified watermark is at the last checkpoint before
+    // contents sync starts. Only the contents are missing.
+    let store_2 = store_with_genesis_state(
+        genesis_checkpoint,
+        genesis_contents,
+        committee.committee().to_owned(),
+    );
+    for checkpoint in ordered_checkpoints.iter().skip(1) {
+        store_2.inner_mut().insert_checkpoint(checkpoint);
+    }
+    store_2.inner_mut().set_highest_executed_checkpoint(0);
+    let (builder, server) = Builder::new()
+        .store(store_2)
+        .config(StateSyncConfig {
+            max_checkpoints_ahead_of_execution: NonZeroU64::new(2),
+            interval_period_ms: Some(50),
+            ..Default::default()
+        })
+        .build();
+    let network_2 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_2, _handle_2) = builder.build(network_2.clone());
+    let store_2 = event_loop_2.store.clone();
+
+    tokio::spawn(event_loop_1.start());
+    tokio::spawn(event_loop_2.start());
+    network_1.connect(network_2.local_addr()).await.unwrap();
+    for checkpoint in ordered_checkpoints.iter().skip(1).cloned() {
+        handle_1.send_checkpoint(checkpoint).await;
+    }
+
+    // Contents stop at the bound even though every summary is already there.
+    wait_for_watermarks(&store_2, last_checkpoint_seq, 2).await;
     tokio::time::sleep(Duration::from_secs(1)).await;
     assert_eq!(store_2.get_highest_synced_checkpoint_seq_number(), 2);
 
-    // Execution catches up, and sync continues to the end.
+    // And follow execution as it advances.
     store_2.inner_mut().set_highest_executed_checkpoint(2);
-    timeout(Duration::from_secs(10), async {
-        while store_2.get_highest_synced_checkpoint_seq_number()
-            != ordered_checkpoints.last().unwrap().sequence_number()
+    wait_for_watermarks(&store_2, last_checkpoint_seq, 4).await;
+}
+
+/// Waits for a store to reach the given verified and synced watermarks,
+/// panicking with both watermarks if it does not get there in time.
+async fn wait_for_watermarks(
+    store: &SharedInMemoryStore,
+    verified: CheckpointSequenceNumber,
+    synced: CheckpointSequenceNumber,
+) {
+    let reached = timeout(Duration::from_secs(10), async {
+        while store.get_highest_verified_checkpoint_seq_number() != verified
+            || store.get_highest_synced_checkpoint_seq_number() != synced
         {
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
     })
-    .await
-    .expect("node 2 failed to resume syncing after execution caught up");
+    .await;
+    assert!(
+        reached.is_ok(),
+        "expected to reach verified {verified} and synced {synced}, got verified {} and synced {}",
+        store.get_highest_verified_checkpoint_seq_number(),
+        store.get_highest_synced_checkpoint_seq_number(),
+    );
 }
 
 #[test]
-fn test_checkpoint_contents_sync_target() {
-    use crate::state_sync::checkpoint_contents_sync_target;
+fn test_checkpoint_sync_target() {
+    use crate::state_sync::checkpoint_sync_target;
 
-    // Within the bound: sync all the way up to the verified watermark.
-    assert_eq!(checkpoint_contents_sync_target(30, Some(10), 100), 30);
-    assert_eq!(checkpoint_contents_sync_target(30, Some(0), 30), 30);
+    // Within the bound: sync all the way up to what is available.
+    assert_eq!(checkpoint_sync_target(30, Some(10), 100), 30);
+    assert_eq!(checkpoint_sync_target(30, Some(0), 30), 30);
 
     // Past the bound: hold the target at the bound above execution.
-    assert_eq!(checkpoint_contents_sync_target(1_000, Some(10), 100), 110);
-    assert_eq!(checkpoint_contents_sync_target(1_000, Some(0), 1), 1);
+    assert_eq!(checkpoint_sync_target(1_000, Some(10), 100), 110);
+    assert_eq!(checkpoint_sync_target(1_000, Some(0), 1), 1);
 
     // Nothing executed yet, not even genesis: the bound counts from 0.
-    assert_eq!(checkpoint_contents_sync_target(1_000, None, 100), 100);
+    assert_eq!(checkpoint_sync_target(1_000, None, 100), 100);
 
     // The bound must not run past the end of the sequence space.
-    assert_eq!(checkpoint_contents_sync_target(30, Some(u64::MAX), 100), 30);
+    assert_eq!(checkpoint_sync_target(30, Some(u64::MAX), 100), 30);
 }

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -1293,8 +1293,10 @@ fn test_checkpoint_sync_target() {
     assert_eq!(checkpoint_sync_target(1_000, Some(10), 100), 110);
     assert_eq!(checkpoint_sync_target(1_000, Some(0), 1), 1);
 
-    // Nothing executed yet, not even genesis: the bound counts from 0.
+    // Nothing executed yet, not even genesis: the bound counts from 0, and
+    // still never targets more than is available.
     assert_eq!(checkpoint_sync_target(1_000, None, 100), 100);
+    assert_eq!(checkpoint_sync_target(30, None, 100), 30);
 
     // The bound must not run past the end of the sequence space.
     assert_eq!(checkpoint_sync_target(30, Some(u64::MAX), 100), 30);

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -1258,6 +1258,93 @@ async fn peer_content_sync_pauses_when_summaries_run_ahead() {
     wait_for_watermarks(&store_2, last_checkpoint_seq, 4).await;
 }
 
+#[tokio::test]
+async fn pushed_summaries_above_the_sync_target_are_dropped() {
+    telemetry_subscribers::init_for_testing();
+    let (committee, (ordered_checkpoints, contents, _, _)) =
+        make_committee_and_checkpoints(0, 4, 6, None, random_contents);
+    let last_checkpoint_seq = ordered_checkpoints.last().unwrap().sequence_number();
+    let genesis_checkpoint = ordered_checkpoints.first().cloned().unwrap();
+    let genesis_contents = contents.first().cloned().unwrap();
+
+    // Node 1 serves node 2, and is given its checkpoints in two rounds below.
+    let store_1 = store_with_genesis_state(
+        genesis_checkpoint.clone(),
+        genesis_contents.clone(),
+        committee.committee().to_owned(),
+    );
+    let (builder, server) = Builder::new().store(store_1).build();
+    let network_1 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_1, handle_1) = builder.build(network_1.clone());
+    let store_1 = event_loop_1.store.clone();
+
+    // Node 2 holds at 2 checkpoints past its executed watermark.
+    let store_2 = store_with_genesis_state(
+        genesis_checkpoint,
+        genesis_contents,
+        committee.committee().to_owned(),
+    );
+    store_2.inner_mut().set_highest_executed_checkpoint(0);
+    let (builder, server) = Builder::new()
+        .store(store_2)
+        .config(StateSyncConfig {
+            max_checkpoints_ahead_of_execution: NonZeroU64::new(2),
+            interval_period_ms: Some(50),
+            ..Default::default()
+        })
+        .build();
+    let network_2 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_2, _handle_2) = builder.build(network_2.clone());
+    let store_2 = event_loop_2.store.clone();
+    let peer_heights_2 = event_loop_2.peer_heights.clone();
+
+    tokio::spawn(event_loop_1.start());
+    tokio::spawn(event_loop_2.start());
+    network_1.connect(network_2.local_addr()).await.unwrap();
+
+    let give_to_node_1 = |sequence_numbers: std::ops::RangeInclusive<usize>| {
+        let (store_1, handle_1) = (store_1.clone(), handle_1.clone());
+        let (ordered_checkpoints, contents) = (ordered_checkpoints.clone(), contents.clone());
+        async move {
+            for i in sequence_numbers {
+                store_1
+                    .try_insert_checkpoint_contents(&ordered_checkpoints[i], contents[i].clone())
+                    .unwrap();
+                store_1.insert_certified_checkpoint(&ordered_checkpoints[i]);
+                handle_1
+                    .send_checkpoint(ordered_checkpoints[i].clone())
+                    .await;
+            }
+        }
+    };
+
+    // Node 2 syncs up to the bound and stops there, which also means it has
+    // node 1 registered as a peer.
+    give_to_node_1(1..=2).await;
+    wait_for_watermarks(&store_2, 2, 2).await;
+
+    // Node 1 now produces the rest and pushes each summary to node 2, which is
+    // not going to process any of them until execution advances. Node 2 must
+    // not hold them for the whole wait. The peers' tip is exempt: the periodic
+    // peer query keeps putting it back.
+    give_to_node_1(3..=last_checkpoint_seq as usize).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    for sequence_number in 3..last_checkpoint_seq {
+        assert!(
+            peer_heights_2
+                .read()
+                .unwrap()
+                .get_checkpoint_by_sequence_number(sequence_number)
+                .is_none(),
+            "summary {sequence_number} is above the sync target and should not be cached",
+        );
+    }
+
+    // Dropping them does not cost node 2 the peers' height, so sync resumes.
+    store_2.inner_mut().set_highest_executed_checkpoint(3);
+    wait_for_watermarks(&store_2, last_checkpoint_seq, last_checkpoint_seq).await;
+}
+
 /// Waits for a store to reach the given verified and synced watermarks,
 /// panicking with both watermarks if it does not get there in time.
 async fn wait_for_watermarks(

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -1204,8 +1204,8 @@ fn test_checkpoint_contents_sync_target() {
     assert_eq!(checkpoint_contents_sync_target(1_000, Some(10), 100), 110);
     assert_eq!(checkpoint_contents_sync_target(1_000, Some(0), 1), 1);
 
-    // A store that does not track execution has nothing to hold back against.
-    assert_eq!(checkpoint_contents_sync_target(1_000, None, 100), 1_000);
+    // Nothing executed yet, not even genesis: the bound counts from 0.
+    assert_eq!(checkpoint_contents_sync_target(1_000, None, 100), 100);
 
     // The bound must not run past the end of the sequence space.
     assert_eq!(checkpoint_contents_sync_target(30, Some(u64::MAX), 100), 30);

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -639,6 +639,12 @@ impl ReadStore for SingleCheckpointSharedInMemoryStore {
 }
 
 impl WriteStore for SingleCheckpointSharedInMemoryStore {
+    fn try_get_highest_executed_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>> {
+        self.0.try_get_highest_executed_checkpoint_seq_number()
+    }
+
     fn try_insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
         {
             let mut locked = self.0.0.write().unwrap();

--- a/crates/iota-types/src/storage/write_store.rs
+++ b/crates/iota-types/src/storage/write_store.rs
@@ -63,14 +63,13 @@ pub trait WriteStore: ReadStore {
             .expect("storage access failed")
     }
 
-    /// The highest checkpoint whose transactions have been executed, when the
-    /// store tracks execution progress. `None` when nothing has been executed
-    /// yet or the store does not track execution (the default).
+    /// The highest checkpoint whose transactions have been executed, or `None`
+    /// when no checkpoint has been executed yet. State sync counts how far it
+    /// may run ahead of execution from checkpoint 0 while this is `None`, so a
+    /// store that never advances it holds sync at that distance.
     fn try_get_highest_executed_checkpoint_seq_number(
         &self,
-    ) -> Result<Option<CheckpointSequenceNumber>> {
-        Ok(None)
-    }
+    ) -> Result<Option<CheckpointSequenceNumber>>;
 
     /// Non-fallible version of
     /// `try_get_highest_executed_checkpoint_seq_number`.
@@ -80,8 +79,9 @@ pub trait WriteStore: ReadStore {
     }
 
     /// Resolves once the store's executed watermark has reached the given
-    /// sequence number. Returns right away for stores that don't track
-    /// execution (the default), since their watermark never advances.
+    /// sequence number. The default resolves right away, so a store that
+    /// executes checkpoints must override it or its callers will not wait for
+    /// execution at all.
     fn wait_for_executed_checkpoint(
         &self,
         _sequence_number: CheckpointSequenceNumber,


### PR DESCRIPTION
# Description of change

Follow-up to #12836, which bounded checkpoint contents but left summary sync
walking to the peers' tip. A node that syncs faster than it executes therefore
kept verifying and storing summaries for checkpoints whose contents it had
deliberately declined to fetch — 20M rows on the testnet database that
motivated #12836. There is no reason to prefetch summaries past the point
contents may reach.

- Bound summary sync by the same rule and the same knob, anchored to the same
  executed watermark: `verified <= executed + max_checkpoints_ahead_of_execution`.
  Enforced at both ends of the summary path —
  `maybe_start_checkpoint_summary_sync_task` starts a run only while the
  verified watermark is below the target, and `sync_to_checkpoint` walks to the
  target rather than to the peers' tip. Both are needed: the gate keeps a run
  that stopped at the bound from restarting on its own completion (`join_next`
  is a select branch, and a bare restart would fire up to
  `checkpoint-header-download-concurrency` summary requests before stopping
  again), and the walk stops a run that was started while there was still room.
- Read `None` from the executed watermark as "nothing executed yet, not even
  genesis" and count the bound from checkpoint 0. #12836 read it as "this store
  does not track execution" and left sync unbounded, so the bound did not apply
  until the node had executed its first checkpoint. `bump_highest_executed_checkpoint`
  asserts the first checkpoint it bumps to is 0, which is what settles the
  reading.
- Drop the summaries peers push above the target. Holding the walk back left
  them with nothing to remove them — every cleanup call sits inside
  `sync_to_checkpoint`, which does not run while the walk is held back — so a
  node at the bound kept one `Checkpoint` in the heap per checkpoint the
  network produced, trading disk growth for heap growth of the same shape
  (caught in review). The trim runs where the target is computed, and the gate
  now reads the peers' height from `PeerHeights::peers` instead of looking the
  tip summary up in the cache the trim empties. `sync_to_checkpoint` therefore
  takes only the target — it used its `Checkpoint` argument for nothing but the
  sequence number — and the highest known checkpoint is reported as a metric
  from the event loop, where it is now read on every pass rather than only when
  a walk starts.
- Give the executed watermark one meaning in `WriteStore`. Its doc read `None`
  as either "nothing executed yet" or "does not track execution", defaulting to
  the latter; only the first is actionable now that state sync counts from
  checkpoint 0, so the default is gone and every store answers.
- The contents bound from #12836 stays. On a fullnode in steady state it now
  follows from the summary bound, but it is still what holds contents back on a
  node that already has a large gap on disk, and on a validator, where
  `handle_checkpoint_from_consensus` advances the verified watermark outside
  state sync's control.

Deadlock is not reachable: holding at the bound leaves the executor the whole
bound's worth of checkpoints to work through, and the knob is a `NonZeroU64`,
so it cannot be configured to 0.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

- `peer_sync_pauses_while_too_far_ahead_of_execution` now asserts both
  watermarks hold at the bound and then follow execution as it advances. Its
  previous form asserted the node verified every summary while contents
  stopped, which is exactly the behaviour this PR removes; without the fix it
  fails with `verified 5 and synced 2`.
- `peer_content_sync_pauses_when_summaries_run_ahead` keeps the contents bound
  covered on its own: every summary is in the store up front, the way consensus
  or archive sync leaves them, and contents still stop at the bound.
- `pushed_summaries_above_the_sync_target_are_dropped` holds a node at the
  bound, has its peer produce and push the rest, and asserts none of those
  summaries stay cached — and that sync still resumes once execution advances,
  which is what proves the trim did not cost the node the peers' height. It
  fails without the trim on `summary 3 is above the sync target and should not
  be cached`.
- `test_checkpoint_sync_target` covers the bound, the "nothing executed yet"
  case, and saturation at the end of the sequence space.
- `cargo nextest run -p iota-network -p iota-config -p iota-types` (287 passed)
  and `-p iota-e2e-tests --test full_node_tests --test checkpoint_tests`
  (23 passed), including `test_full_node_cold_sync`, which drives a real
  fullnode through state sync. Two failures reproduce unchanged on `develop`:
  `test_checkpoint_split_brain` (which needs the simulator, not the
  `#[tokio::test]` fallback) and, intermittently,
  `discovery::tests::test_address_verification_cooldown_and_cleanup`.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): `max-checkpoints-ahead-of-execution` now bounds checkpoint summaries as well as contents, so a node that syncs faster than it executes no longer stores summaries for checkpoints it has declined to fetch contents for. The bound also applies before the node has executed its first checkpoint.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
