### PR TITLE
fix(iota-core,iota-protocol-config): use protocol config verifier limits in post-consensus validation

### DIFF
--- a/crates/iota-config/src/verifier_signing_config.rs
+++ b/crates/iota-config/src/verifier_signing_config.rs
@@ -19,6 +19,12 @@ pub const DEFAULT_SANITY_CHECK_WITH_REGEX_REFERENCE_SAFETY_UNITS: usize = 2_200_
 /// _only_. There are additional limits in the `MeterConfig` and
 /// `VerifierConfig` that are used during both signing and execution, however
 /// those limits cannot be set here and must be protocol versioned.
+///
+/// Post-consensus validation has to reach the same verdict on every validator,
+/// so it meters published packages with the protocol config's limits instead;
+/// see `ProtocolConfig::meter_config` and
+/// `ProtocolConfig::verifier_signing_limits`. The defaults here equal those
+/// protocol values.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct VerifierSigningConfig {
@@ -86,5 +92,42 @@ impl VerifierSigningConfig {
             max_per_mod_meter_units: Some(self.max_per_mod_meter_units() as u128),
             max_per_pkg_meter_units: Some(self.max_per_pkg_meter_units() as u128),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_protocol_config::ProtocolConfig;
+
+    use super::*;
+
+    /// A validator that leaves its `VerifierSigningConfig` at the defaults must
+    /// reach the same verdict at admission as post-consensus validation
+    /// does with the protocol config's limits, so the two sets of defaults
+    /// have to agree.
+    #[test]
+    fn defaults_match_protocol_config() {
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        let signing_config = VerifierSigningConfig::default();
+
+        assert_eq!(
+            signing_config.limits_for_signing(),
+            protocol_config.verifier_signing_limits()
+        );
+
+        let from_node = signing_config.meter_config_for_signing();
+        let from_protocol = protocol_config.meter_config();
+        assert_eq!(
+            from_node.max_per_fun_meter_units,
+            from_protocol.max_per_fun_meter_units
+        );
+        assert_eq!(
+            from_node.max_per_mod_meter_units,
+            from_protocol.max_per_mod_meter_units
+        );
+        assert_eq!(
+            from_node.max_per_pkg_meter_units,
+            from_protocol.max_per_pkg_meter_units
+        );
     }
 }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -55,6 +55,7 @@ use iota_storage::{
     key_value_store_metrics::KeyValueStoreMetrics,
 };
 use iota_traffic_controller::{TrafficController, metrics::TrafficControllerMetrics};
+use iota_transaction_checks::VerifierLimitsSource;
 #[cfg(msim)]
 use iota_types::committee::CommitteeTrait;
 use iota_types::{
@@ -1017,6 +1018,12 @@ impl AuthorityState {
     ///   losers, for example), and validators that skip admission can put such
     ///   transactions into their blocks anyway, so no admission policy can
     ///   limit how many deterministically-dropped transactions reach consensus.
+    ///
+    /// `verifier_limits_source` says where the metered bytecode verifier takes
+    /// its limits for the packages the transaction publishes. Validator-local
+    /// admission passes this validator's own `VerifierSigningConfig`;
+    /// post-consensus validation passes the protocol config, because every
+    /// validator must reach the same verdict there.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
     pub(crate) async fn handle_transaction_validation_checks(
         &self,
@@ -1024,6 +1031,7 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
         deny_config: &dyn DenyRuleConfig,
         epoch_gated_coin_deny_list: bool,
+        verifier_limits_source: VerifierLimitsSource<'_>,
     ) -> IotaResult<Vec<ObjectReference>> {
         let protocol_config = epoch_store.protocol_config();
         let reference_gas_price = epoch_store.reference_gas_price();
@@ -1067,6 +1075,7 @@ impl AuthorityState {
                 &tx_receiving_objects,
                 &move_authenticators,
                 per_authenticator_inputs,
+                verifier_limits_source,
             )?;
 
         // Get the input objects for the authenticators, if there are
@@ -1226,6 +1235,7 @@ impl AuthorityState {
                 // submission path, no post-consensus re-check follows - this is
                 // the only sender-side coin deny check in the certificate flow.
                 false,
+                VerifierLimitsSource::NodeConfig(&self.config.verifier_signing_config),
             )
             .await?;
 
@@ -2344,7 +2354,7 @@ impl AuthorityState {
                 input_objects,
                 &receiving_objects,
                 &self.metrics.bytecode_verifier_metrics,
-                &self.config.verifier_signing_config,
+                VerifierLimitsSource::NodeConfig(&self.config.verifier_signing_config),
                 authenticator_gas_budget,
             )?
         } else {
@@ -5823,6 +5833,7 @@ impl AuthorityState {
         tx_receiving_objects: &ReceivingObjects,
         move_authenticators: &Vec<&MoveAuthenticator>,
         per_authenticator_inputs: Vec<(InputObjects, ObjectReadResult)>,
+        verifier_limits_source: VerifierLimitsSource<'_>,
     ) -> IotaResult<(
         IotaGasStatus,
         CheckedInputObjects,
@@ -5891,7 +5902,7 @@ impl AuthorityState {
                 tx_input_objects,
                 tx_receiving_objects,
                 &self.metrics.bytecode_verifier_metrics,
-                &self.config.verifier_signing_config,
+                verifier_limits_source,
                 authenticator_gas_budget,
             )?;
 

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -11,6 +11,7 @@ use iota_config::{
     genesis::Genesis,
     node::{AuthorityOverloadConfig, AuthorityStorePruningConfig, ExpensiveSafetyCheckConfig},
     transaction_deny_config::TransactionDenyConfig,
+    verifier_signing_config::VerifierSigningConfig,
 };
 use iota_network::randomness;
 use iota_protocol_config::{Chain, ProtocolConfig};
@@ -54,6 +55,7 @@ pub struct TestAuthorityBuilder<'a> {
     store: Option<Arc<AuthorityStore>>,
     transaction_deny_config: Option<TransactionDenyConfig>,
     certificate_deny_config: Option<CertificateDenyConfig>,
+    verifier_signing_config: Option<VerifierSigningConfig>,
     protocol_config: Option<ProtocolConfig>,
     reference_gas_price: Option<u64>,
     node_keypair: Option<&'a AuthorityKeyPair>,
@@ -98,6 +100,11 @@ impl<'a> TestAuthorityBuilder<'a> {
 
     pub fn with_certificate_deny_config(mut self, config: CertificateDenyConfig) -> Self {
         assert!(self.certificate_deny_config.replace(config).is_none());
+        self
+    }
+
+    pub fn with_verifier_signing_config(mut self, config: VerifierSigningConfig) -> Self {
+        assert!(self.verifier_signing_config.replace(config).is_none());
         self
     }
 
@@ -355,11 +362,13 @@ impl<'a> TestAuthorityBuilder<'a> {
 
         let transaction_deny_config = self.transaction_deny_config.unwrap_or_default();
         let certificate_deny_config = self.certificate_deny_config.unwrap_or_default();
+        let verifier_signing_config = self.verifier_signing_config.unwrap_or_default();
         let authority_overload_config = self.authority_overload_config.unwrap_or_default();
         let pruning_config = AuthorityStorePruningConfig::default();
 
         config.transaction_deny_config = transaction_deny_config;
         config.certificate_deny_config = certificate_deny_config;
+        config.verifier_signing_config = verifier_signing_config;
         config.authority_overload_config = authority_overload_config;
         config.authority_store_pruning_config = pruning_config;
 

--- a/crates/iota-core/src/authority_server/validator_v2.rs
+++ b/crates/iota-core/src/authority_server/validator_v2.rs
@@ -324,6 +324,9 @@ impl ValidatorService {
                 // differs from the epoch-gated post-consensus read; see the
                 // read-mode notes on `handle_transaction_validation_checks`.
                 false,
+                iota_transaction_checks::VerifierLimitsSource::NodeConfig(
+                    &state.config.verifier_signing_config,
+                ),
             )
             .await
         {

--- a/crates/iota-core/src/post_consensus_validation.rs
+++ b/crates/iota-core/src/post_consensus_validation.rs
@@ -50,6 +50,7 @@ use std::{
 
 use iota_common::fatal;
 use iota_sdk_types::{ObjectReference, TransactionDigest};
+use iota_transaction_checks::VerifierLimitsSource;
 use iota_types::{
     deny_rule_governance::DenyRuleConfig,
     effects::TransactionEffectsAPI,
@@ -134,6 +135,19 @@ pub async fn validate_and_resolve_conflicts(
         governance_deny_rules.as_ref()
     } else {
         &authority_state.config.transaction_deny_config
+    };
+
+    // Same concern as the deny rules above: the verifier limits decide whether
+    // a transaction that publishes a package stays in the commit, so with the
+    // flag set they come from the protocol config, not from this validator's
+    // own `VerifierSigningConfig`.
+    let verifier_limits_source = if epoch_store
+        .protocol_config()
+        .pcool_verifier_limits_from_protocol_config()
+    {
+        VerifierLimitsSource::ProtocolConfig
+    } else {
+        VerifierLimitsSource::NodeConfig(&authority_state.config.verifier_signing_config)
     };
 
     // Read once for the whole commit: the protocol config is fixed for the epoch.
@@ -315,6 +329,7 @@ pub async fn validate_and_resolve_conflicts(
                 // the transaction stays in the committed set, so it must not depend
                 // on this validator's execution progress.
                 true,
+                verifier_limits_source,
             )
             .await
         {

--- a/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/iota-core/src/unit_tests/coin_deny_list_tests.rs
@@ -10,6 +10,7 @@ use iota_sdk_types::{
     TransactionDigest, TransactionEffects, TypeTag, Version,
 };
 use iota_test_transaction_builder::TestTransactionBuilder;
+use iota_transaction_checks::VerifierLimitsSource;
 use iota_types::{
     base_types::dbg_addr,
     crypto::{AccountPrivateKey, get_account_private_key},
@@ -593,6 +594,9 @@ impl RegulatedCoinEnv {
                 &epoch_store,
                 &self.env.authority.config.transaction_deny_config,
                 epoch_gated_coin_deny_list,
+                VerifierLimitsSource::NodeConfig(
+                    &self.env.authority.config.verifier_signing_config,
+                ),
             )
             .await
     }

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -4,14 +4,17 @@
 //! Unit tests for post-consensus transaction validation and owned-object
 //! conflict resolution.
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
+use iota_config::verifier_signing_config::VerifierSigningConfig;
 use iota_macros::sim_test;
 use iota_protocol_config::{OverrideGuard, ProtocolConfig};
 use iota_sdk_types::{
     Address, Command, Identifier, ObjectId, ObjectReference, Owner, Transaction, TransactionDigest,
     Version,
 };
+use iota_test_transaction_builder::TestTransactionBuilder;
+use iota_transaction_checks::VerifierLimitsSource;
 use iota_types::{
     crypto::{AccountPrivateKey, get_key_pair},
     error::{IotaError, UserInputError},
@@ -20,17 +23,18 @@ use iota_types::{
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
-        CallArg, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS, TransactionAPI, TransactionKey,
-        VerifiedTransaction,
+        CallArg, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS, TransactionAPI, TransactionEnvelope,
+        TransactionKey, VerifiedTransaction,
     },
     utils::to_sender_signed_transaction,
 };
 
 use crate::{
     authority::{
-        ExecutionEnv,
+        AuthorityState, ExecutionEnv,
         authority_per_epoch_store::{LockDetails, consensus_quarantine::ConsensusCommitOutput},
         authority_tests::init_state_with_objects_and_object_basics,
+        test_authority_builder::TestAuthorityBuilder,
     },
     checkpoints::CheckpointServiceNoop,
     consensus_handler::{SequencedConsensusTransaction, VerifiedSequencedConsensusTransaction},
@@ -2239,4 +2243,147 @@ async fn test_already_executed_tx_does_not_lock_immutable_input() {
         "an owned input the Move call never mutated is still consumed, so it \
          is still locked"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Verifier limits for published packages
+// ---------------------------------------------------------------------------
+
+/// An authority whose own `VerifierSigningConfig` rejects every package, and
+/// a transaction that publishes the `object_basics` test package.
+struct PublishSetup {
+    authority: Arc<AuthorityState>,
+    tx: TransactionEnvelope,
+}
+
+/// What an operator would write in the node YAML to tighten the signing-time
+/// verifier. A one-tick meter limit fails the first function it meters.
+const ONE_TICK_VERIFIER_SIGNING_CONFIG_YAML: &str = concat!(
+    "max-per-fun-meter-units: 1\n",
+    "max-per-mod-meter-units: 1\n",
+    "max-per-pkg-meter-units: 1\n",
+);
+
+/// Builds an authority from `ONE_TICK_VERIFIER_SIGNING_CONFIG_YAML` and a
+/// signed transaction publishing `object_basics` from a fresh sender's gas
+/// coin. Nothing is executed or validated here; each test drives the checks
+/// itself after setting the protocol flags.
+async fn setup_publish_with_one_tick_node_limits() -> PublishSetup {
+    let node_limits: VerifierSigningConfig =
+        serde_yaml::from_str(ONE_TICK_VERIFIER_SIGNING_CONFIG_YAML).unwrap();
+    let authority = TestAuthorityBuilder::new()
+        .with_verifier_signing_config(node_limits)
+        .build()
+        .await;
+
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    authority.insert_genesis_object(Object::with_id_owner_for_testing(gas_id, sender));
+
+    let gas_ref = authority.get_object(&gas_id).unwrap().object_ref();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/unit_tests/data/object_basics");
+    let tx_data = TestTransactionBuilder::new(sender, gas_ref, rgp)
+        .publish(path)
+        .build();
+
+    PublishSetup {
+        authority,
+        tx: to_sender_signed_transaction(tx_data, &sender_key),
+    }
+}
+
+/// Admission on this authority rejects the package under its own limits, so
+/// the post-consensus verdict below is decided by where the limits come from.
+async fn assert_node_limits_reject(setup: &PublishSetup) {
+    let epoch_store = setup.authority.epoch_store_for_testing();
+    let admission = setup
+        .authority
+        .handle_transaction_validation_checks(
+            &VerifiedTransaction::new_unchecked(setup.tx.clone()),
+            &epoch_store,
+            &setup.authority.config.transaction_deny_config,
+            false,
+            VerifierLimitsSource::NodeConfig(&setup.authority.config.verifier_signing_config),
+        )
+        .await;
+
+    assert!(
+        matches!(
+            admission,
+            Err(IotaError::UserInput {
+                error: UserInputError::PackageVerificationTimedout { .. }
+            })
+        ),
+        "the node's own limits must reject the package: {admission:?}"
+    );
+}
+
+/// With `pcool_verifier_limits_from_protocol_config` set, post-consensus
+/// validation meters a published package with the protocol config's limits.
+/// A validator whose own `VerifierSigningConfig` would reject the package
+/// keeps it, as every validator on default settings does.
+#[tokio::test]
+async fn post_consensus_validation_meters_packages_with_protocol_limits() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config.set_pcool_verifier_limits_from_protocol_config_for_testing(true);
+        config
+    });
+    let setup = setup_publish_with_one_tick_node_limits().await;
+    assert_node_limits_reject(&setup).await;
+
+    let epoch_store = setup.authority.epoch_store_for_testing();
+    let mut transactions = vec![make_user_tx_v1(setup.tx.clone())];
+    let (dropped, locks, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &setup.authority,
+        &epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        dropped.is_empty(),
+        "post-consensus validation dropped the package even though the protocol \
+            config's limits should accept it: {dropped:?}"
+    );
+    assert_eq!(transactions.len(), 1);
+    assert_eq!(locks.len(), 1, "only the gas coin is locked");
+}
+
+/// Without the flag, post-consensus validation still meters with this
+/// validator's own `VerifierSigningConfig`: the package is dropped here
+/// while validators on default settings keep it.
+#[tokio::test]
+async fn post_consensus_validation_meters_packages_with_node_limits_when_flag_disabled() {
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_pcool_flow_for_testing(true);
+        config.set_pcool_verifier_limits_from_protocol_config_for_testing(false);
+        config
+    });
+    let setup = setup_publish_with_one_tick_node_limits().await;
+    assert_node_limits_reject(&setup).await;
+
+    let epoch_store = setup.authority.epoch_store_for_testing();
+    let digest = *setup.tx.digest();
+    let mut transactions = vec![make_user_tx_v1(setup.tx.clone())];
+    let (dropped, locks, _) = post_consensus_validation::validate_and_resolve_conflicts(
+        &setup.authority,
+        &epoch_store,
+        &mut transactions,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(dropped.len(), 1);
+    assert_eq!(dropped[0].0, digest);
+    assert!(matches!(
+        &dropped[0].1,
+        IotaError::UserInput {
+            error: UserInputError::PackageVerificationTimedout { .. }
+        }
+    ));
+    assert!(transactions.is_empty());
+    assert!(locks.is_empty(), "dropped transaction must not take locks");
 }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1346,6 +1346,7 @@
                 "pass_validator_scores_to_advance_epoch": true,
                 "passkey_auth": true,
                 "pcool_skip_immutable_object_locks": true,
+                "pcool_verifier_limits_from_protocol_config": true,
                 "pre_consensus_sponsor_only_move_authentication": true,
                 "protocol_defined_base_fee": true,
                 "publish_package_metadata": true,
@@ -1939,10 +1940,13 @@
                   "u64": "5"
                 },
                 "max_meter_ticks_per_module": {
-                  "u64": "16000000"
+                  "u64": "2200000"
                 },
                 "max_meter_ticks_per_package": {
-                  "u64": "16000000"
+                  "u64": "2200000"
+                },
+                "max_meter_ticks_regex_reference_safety": {
+                  "u64": "2200000"
                 },
                 "max_modules_in_publish": {
                   "u32": "64"
@@ -2048,7 +2052,7 @@
                   "u64": "1024"
                 },
                 "max_verifier_meter_ticks_per_function": {
-                  "u64": "16000000"
+                  "u64": "2200000"
                 },
                 "min_checkpoint_interval_ms": {
                   "u64": "200"

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -12,7 +12,7 @@ use clap::*;
 use iota_protocol_config_macros::{
     ProtocolConfigAccessors, ProtocolConfigFeatureFlagsGetters, ProtocolConfigOverride,
 };
-use move_vm_config::verifier::VerifierConfig;
+use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use tracing::{info, warn};
@@ -218,6 +218,10 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             the max object size limit.
 //             Enable the optimistic commit rule (StarfishSpeed) in Starfish
 //             consensus on mainnet.
+//             Meter the packages a transaction publishes with the protocol
+//             config's verifier limits in post-consensus validation, and set
+//             those limits to the node config's defaults on all chains
+//             (inert where the P-COOL flow is off).
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -592,6 +596,13 @@ struct FeatureFlags {
     // unless `enable_pcool_flow` is set.
     #[serde(skip_serializing_if = "is_false")]
     pcool_skip_immutable_object_locks: bool,
+
+    // If true, post-consensus validation meters the packages a transaction
+    // publishes with the verifier limits from this config instead of each
+    // validator's own `VerifierSigningConfig`, so every validator reaches
+    // the same verdict. Has no effect unless `enable_pcool_flow` is set.
+    #[serde(skip_serializing_if = "is_false")]
+    pcool_verifier_limits_from_protocol_config: bool,
 
     // If true perform consistent verification of metadata
     #[serde(skip_serializing_if = "is_false")]
@@ -969,25 +980,32 @@ pub struct ProtocolConfig {
     /// at signing.
     max_move_enum_variants: Option<u64>,
 
-    /// Maximum number of back edges in Move function. Enforced by the bytecode
-    /// verifier at signing.
+    // === Metered bytecode verifier limits ===
+    // Enforced on the packages a transaction publishes when post-consensus
+    // validation checks them (via `pcool_verifier_limits_from_protocol_config`).
+    // Signing, admission and simulation are validator-local decisions and use
+    // each validator's own `VerifierSigningConfig` instead.
+
+    //
+    /// Maximum number of back edges in a Move function.
     max_back_edges_per_function: Option<u64>,
 
-    /// Maximum number of back edges in Move module. Enforced by the bytecode
-    /// verifier at signing.
+    /// Maximum number of back edges in a Move module.
     max_back_edges_per_module: Option<u64>,
 
     /// Maximum number of meter `ticks` spent verifying a Move function.
-    /// Enforced by the bytecode verifier at signing.
     max_verifier_meter_ticks_per_function: Option<u64>,
 
-    /// Maximum number of meter `ticks` spent verifying a Move function.
-    /// Enforced by the bytecode verifier at signing.
+    /// Maximum number of meter `ticks` spent verifying a Move module.
     max_meter_ticks_per_module: Option<u64>,
 
-    /// Maximum number of meter `ticks` spent verifying a Move package. Enforced
-    /// by the bytecode verifier at signing.
+    /// Maximum number of meter `ticks` spent verifying a Move package.
     max_meter_ticks_per_package: Option<u64>,
+
+    /// Maximum number of meter `ticks` the regex-based reference safety check
+    /// may spend per function, module and package. The check rejects a module
+    /// it cannot finish within the limit.
+    max_meter_ticks_regex_reference_safety: Option<u64>,
 
     // === Object runtime internal operation limits ====
     // These affect dynamic fields
@@ -1965,6 +1983,13 @@ impl ProtocolConfig {
         self.feature_flags.pcool_skip_immutable_object_locks
     }
 
+    /// Effective only with its prerequisite `enable_pcool_flow`: a config
+    /// missing the prerequisite reads as disabled.
+    pub fn pcool_verifier_limits_from_protocol_config(&self) -> bool {
+        self.feature_flags
+            .pcool_verifier_limits_from_protocol_config
+    }
+
     pub fn validator_metadata_verify_v2(&self) -> bool {
         self.feature_flags.validator_metadata_verify_v2
     }
@@ -2151,6 +2176,16 @@ impl ProtocolConfig {
             !ret.feature_flags.deny_rule_governance_on_chain
                 || ret.feature_flags.deny_rule_governance,
             "deny_rule_governance_on_chain requires deny_rule_governance"
+        );
+        // Post-consensus validation reads the regex check budget through the
+        // panicking accessor once the flag is set, so the constant must exist
+        // wherever the flag does, including when an override sets the flag on
+        // an earlier version.
+        assert!(
+            !ret.feature_flags.pcool_verifier_limits_from_protocol_config
+                || ret.max_meter_ticks_regex_reference_safety.is_some(),
+            "pcool_verifier_limits_from_protocol_config requires \
+                max_meter_ticks_regex_reference_safety"
         );
         // The injection cannot chunk updates or gate removals without its
         // knobs.
@@ -2344,6 +2379,7 @@ impl ProtocolConfig {
 
             max_meter_ticks_per_module: Some(16_000_000),
             max_meter_ticks_per_package: Some(16_000_000),
+            max_meter_ticks_regex_reference_safety: None,
 
             object_runtime_max_num_cached_objects: Some(1000),
             object_runtime_max_num_cached_objects_system_tx: Some(1000 * 16),
@@ -3399,9 +3435,22 @@ impl ProtocolConfig {
                     cfg.feature_flags.max_ptb_value_size_v2 = true;
                     // Let system objects grow past the per-object size bound.
                     cfg.feature_flags.allow_unbounded_system_objects = true;
+
                     // Enable the optimistic commit rule (StarfishSpeed) in
                     // Starfish consensus.
                     cfg.feature_flags.consensus_starfish_speed = true;
+
+                    // Post-consensus validation meters published packages with
+                    // the limits below instead of each validator's own
+                    // `VerifierSigningConfig`. The values are that config's
+                    // defaults, so a validator that leaves it alone reaches
+                    // the same verdict at admission and post-consensus. Set on
+                    // all chains; inert where the P-COOL flow is off.
+                    cfg.max_verifier_meter_ticks_per_function = Some(2_200_000);
+                    cfg.max_meter_ticks_per_module = Some(2_200_000);
+                    cfg.max_meter_ticks_per_package = Some(2_200_000);
+                    cfg.max_meter_ticks_regex_reference_safety = Some(2_200_000);
+                    cfg.feature_flags.pcool_verifier_limits_from_protocol_config = true;
                 }
                 // Use this template when making changes:
                 //
@@ -3476,6 +3525,31 @@ impl ProtocolConfig {
             additional_borrow_checks,
             sanity_check_with_regex_reference_safety: sanity_check_with_regex_reference_safety
                 .map(|limit| limit as u128),
+        }
+    }
+
+    /// The sign-time verifier limits as protocol parameters, in the shape
+    /// `verifier_config` takes: back edges per function, back edges per module,
+    /// and the meter limit of the regex-based reference safety check.
+    /// `VerifierSigningConfig::limits_for_signing` is the validator-local
+    /// counterpart. Defined from the protocol version that sets
+    /// `pcool_verifier_limits_from_protocol_config`.
+    pub fn verifier_signing_limits(&self) -> (usize, usize, usize) {
+        (
+            self.max_back_edges_per_function() as usize,
+            self.max_back_edges_per_module() as usize,
+            self.max_meter_ticks_regex_reference_safety() as usize,
+        )
+    }
+
+    /// The meter limits for verifying the packages a transaction publishes, as
+    /// protocol parameters. `VerifierSigningConfig::meter_config_for_signing`
+    /// is the validator-local counterpart.
+    pub fn meter_config(&self) -> MeterConfig {
+        MeterConfig {
+            max_per_fun_meter_units: Some(self.max_verifier_meter_ticks_per_function() as u128),
+            max_per_mod_meter_units: Some(self.max_meter_ticks_per_module() as u128),
+            max_per_pkg_meter_units: Some(self.max_meter_ticks_per_package() as u128),
         }
     }
 
@@ -3656,6 +3730,11 @@ impl ProtocolConfig {
 
     pub fn set_pcool_skip_immutable_object_locks_for_testing(&mut self, val: bool) {
         self.feature_flags.pcool_skip_immutable_object_locks = val;
+    }
+
+    pub fn set_pcool_verifier_limits_from_protocol_config_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .pcool_verifier_limits_from_protocol_config = val;
     }
 
     pub fn set_commits_per_schedule_for_testing(&mut self, val: u32) {

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
@@ -45,6 +45,7 @@ feature_flags:
   consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
   pcool_skip_immutable_object_locks: true
+  pcool_verifier_limits_from_protocol_config: true
   validator_metadata_verify_v2: true
   report_move_authentication_error: true
   max_ptb_value_size_v2: true
@@ -112,9 +113,10 @@ max_move_identifier_len: 128
 max_move_value_depth: 128
 max_back_edges_per_function: 10000
 max_back_edges_per_module: 10000
-max_verifier_meter_ticks_per_function: 16000000
-max_meter_ticks_per_module: 16000000
-max_meter_ticks_per_package: 16000000
+max_verifier_meter_ticks_per_function: 2200000
+max_meter_ticks_per_module: 2200000
+max_meter_ticks_per_package: 2200000
+max_meter_ticks_regex_reference_safety: 2200000
 object_runtime_max_num_cached_objects: 1000
 object_runtime_max_num_cached_objects_system_tx: 16000
 object_runtime_max_num_store_entries: 1000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_35.snap
@@ -48,6 +48,7 @@ feature_flags:
   consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
   pcool_skip_immutable_object_locks: true
+  pcool_verifier_limits_from_protocol_config: true
   validator_metadata_verify_v2: true
   package_metadata_with_dynamic_module_metadata: true
   report_move_authentication_error: true
@@ -118,9 +119,10 @@ max_move_identifier_len: 128
 max_move_value_depth: 128
 max_back_edges_per_function: 10000
 max_back_edges_per_module: 10000
-max_verifier_meter_ticks_per_function: 16000000
-max_meter_ticks_per_module: 16000000
-max_meter_ticks_per_package: 16000000
+max_verifier_meter_ticks_per_function: 2200000
+max_meter_ticks_per_module: 2200000
+max_meter_ticks_per_package: 2200000
+max_meter_ticks_regex_reference_safety: 2200000
 object_runtime_max_num_cached_objects: 1000
 object_runtime_max_num_cached_objects_system_tx: 16000
 object_runtime_max_num_store_entries: 1000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_35.snap
@@ -56,6 +56,7 @@ feature_flags:
   always_advance_dkg_to_resolution: true
   enable_pcool_flow: true
   pcool_skip_immutable_object_locks: true
+  pcool_verifier_limits_from_protocol_config: true
   validator_metadata_verify_v2: true
   package_metadata_with_dynamic_module_metadata: true
   report_move_authentication_error: true
@@ -126,9 +127,10 @@ max_move_identifier_len: 128
 max_move_value_depth: 128
 max_back_edges_per_function: 10000
 max_back_edges_per_module: 10000
-max_verifier_meter_ticks_per_function: 16000000
-max_meter_ticks_per_module: 16000000
-max_meter_ticks_per_package: 16000000
+max_verifier_meter_ticks_per_function: 2200000
+max_meter_ticks_per_module: 2200000
+max_meter_ticks_per_package: 2200000
+max_meter_ticks_regex_reference_safety: 2200000
 object_runtime_max_num_cached_objects: 1000
 object_runtime_max_num_cached_objects_system_tx: 16000
 object_runtime_max_num_store_entries: 1000

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -73,6 +73,21 @@ mod checked {
         }
     }
 
+    /// Where the metered bytecode verifier takes its limits from when
+    /// it checks the packages a transaction publishes.
+    #[derive(Clone, Copy, Debug)]
+    pub enum VerifierLimitsSource<'a> {
+        /// The validator's own `VerifierSigningConfig`. Operators may set it
+        /// differently on each validator, so this is only for decisions that
+        /// stay local to one validator: signing, admission, and simulation.
+        NodeConfig(&'a VerifierSigningConfig),
+
+        /// The protocol config, which is the same on every validator. Required
+        /// wherever the verdict has to agree across validators, as in
+        /// post-consensus validation.
+        ProtocolConfig,
+    }
+
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
     pub fn check_transaction_input(
         protocol_config: &ProtocolConfig,
@@ -81,7 +96,7 @@ mod checked {
         input_objects: InputObjects,
         receiving_objects: &ReceivingObjects,
         metrics: &Arc<BytecodeVerifierMetrics>,
-        verifier_signing_config: &VerifierSigningConfig,
+        verifier_limits_source: VerifierLimitsSource<'_>,
         authentication_gas_budget: u64,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_status = check_transaction_input_inner(
@@ -99,7 +114,7 @@ mod checked {
             transaction,
             protocol_config,
             metrics,
-            verifier_signing_config,
+            verifier_limits_source,
         )?;
 
         Ok((gas_status, input_objects.into_checked()))
@@ -114,7 +129,7 @@ mod checked {
         receiving_objects: ReceivingObjects,
         gas_object: Object,
         metrics: &Arc<BytecodeVerifierMetrics>,
-        verifier_signing_config: &VerifierSigningConfig,
+        verifier_limits_source: VerifierLimitsSource<'_>,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_object_ref = gas_object.object_ref();
         input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));
@@ -134,7 +149,7 @@ mod checked {
             transaction,
             protocol_config,
             metrics,
-            verifier_signing_config,
+            verifier_limits_source,
         )?;
 
         Ok((gas_status, input_objects.into_checked()))
@@ -905,7 +920,7 @@ mod checked {
         transaction: &Transaction,
         protocol_config: &ProtocolConfig,
         metrics: &Arc<BytecodeVerifierMetrics>,
-        verifier_signing_config: &VerifierSigningConfig,
+        verifier_limits_source: VerifierLimitsSource<'_>,
     ) -> UserInputResult<()> {
         // Only meter non-system programmable transaction blocks
         if transaction.is_system_tx() {
@@ -916,11 +931,19 @@ mod checked {
             return Ok(());
         };
 
-        // Use the same verifier and meter for all packages, custom configured for
-        // signing.
-        let signing_limits = Some(verifier_signing_config.limits_for_signing());
-        let mut verifier = iota_execution::verifier(protocol_config, signing_limits, metrics);
-        let mut meter = verifier.meter(verifier_signing_config.meter_config_for_signing());
+        // Use the same verifier and meter for all packages.
+        let (signing_limits, meter_config) = match verifier_limits_source {
+            VerifierLimitsSource::NodeConfig(config) => (
+                config.limits_for_signing(),
+                config.meter_config_for_signing(),
+            ),
+            VerifierLimitsSource::ProtocolConfig => (
+                protocol_config.verifier_signing_limits(),
+                protocol_config.meter_config(),
+            ),
+        };
+        let mut verifier = iota_execution::verifier(protocol_config, Some(signing_limits), metrics);
+        let mut meter = verifier.meter(meter_config);
 
         // Measure time for verifying all packages in the PTB
         let shared_meter_verifier_timer = metrics

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -218,7 +218,7 @@ pub(super) fn prepare_transaction(
             input_objects,
             &receiving_objects,
             &env.bytecode_verifier_metrics,
-            &verifier_signing_config,
+            iota_transaction_checks::VerifierLimitsSource::NodeConfig(&verifier_signing_config),
             0,
         )
         .map_err(|e| ValidationError::new("transaction input check", e))?;

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -11,6 +11,7 @@ use iota_config::{
 use iota_execution::Executor;
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_sdk_types::{Transaction, TransactionEffects};
+use iota_transaction_checks::VerifierLimitsSource;
 use iota_types::{
     committee::{Committee, EpochId},
     effects::TransactionEffectsAPI,
@@ -160,7 +161,7 @@ impl EpochState {
             input_objects,
             &receiving_objects,
             &self.bytecode_verifier_metrics,
-            verifier_signing_config,
+            VerifierLimitsSource::NodeConfig(verifier_signing_config),
             authenticator_gas_budget,
         )?;
 
@@ -261,7 +262,7 @@ impl EpochState {
                 input_objects,
                 &receiving_objects,
                 &self.bytecode_verifier_metrics,
-                verifier_signing_config,
+                VerifierLimitsSource::NodeConfig(verifier_signing_config),
                 authenticator_gas_budget,
             )?
         } else {


### PR DESCRIPTION
# Description of change

### Why

Post-consensus validation (P-COOL, Check #5) ran the metered bytecode verifier with each validator's own `verifier-signing-config` from its node YAML. A validator with a non-default setting drops a package publish that the other validators keep, so it builds a different checkpoint and halts on fork detection.

### Changes

This PR adds and enables the feature flag `pcool_verifier_limits_from_protocol_config` in protocol version 35 on all chains: when the flag is set (_and the P-COOL flow is on_), post-consensus validation meters published packages with the protocol config's verifier limits instead of the node's own config. The flag is read only by post-consensus validation, which runs only under the P-COOL flow, so it needs no chain condition: it is inert on `mainnet` and `testnet`, where the flow is off, and takes effect on any chain that enables the flow later.

The protocol constants `max_verifier_meter_ticks_per_function`, `max_meter_ticks_per_module` and `max_meter_ticks_per_package` have been 16M since version 1, but nothing read them: signing meters packages with the node config, whose defaults are 2.2M. This PR makes these constants the post-consensus limits and sets them to 2.2M, so post-consensus validation enforces the same limits signing enforces on a validator with the default `verifier-signing-config`. It also adds `max_meter_ticks_regex_reference_safety` (2.2M) for the one node config limit that had no protocol constant. **Nothing changes below version 35.**

> [!NOTE]
> Signing, admission, dry-run, and the simulators keep using the node config; only post-consensus validation passes the protocol config.

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-private/issues/504. Part of https://github.com/iotaledger/iota-private/issues/502.

## How the change has been tested

```shell
# iota-config: node-config defaults equal the protocol-config values
cargo nextest run -p iota-config -E 'test(defaults_match_protocol_config)'

# iota-core: flag set, protocol limits keep the package
cargo nextest run -p iota-core -E 'test(post_consensus_validation_meters_packages_with_protocol_limits)'

# iota-core: flag not set, node limits drop the package
cargo nextest run -p iota-core -E 'test(post_consensus_validation_meters_packages_with_node_limits_when_flag_disabled)'
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Protocol version 35 adds `max_meter_ticks_regex_reference_safety` and sets the meter tick limits to 2.2M on all chains, and enables `pcool_verifier_limits_from_protocol_config` on all chains, where it takes effect only under the P-COOL flow (`devnet` today). With the flag set, post-consensus validation meters published packages with these limits instead of each validator's verifier-signing-config.
- [x] Nodes (Validators and Full nodes): Under the P-COOL flow, a validator's `verifier-signing-config` no longer affects which package publishes the network accepts. It still applies to signing, admission, dry-run, and simulation on that node.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---